### PR TITLE
Fixes CLI directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ This installs `Osaurus.app`. The CLI (`osaurus`) is embedded inside the app and 
 
 ```bash
 # One-liner: symlink the embedded CLI into your Homebrew bin
-ln -sf "/Applications/Osaurus.app/Contents/Helpers/osaurus" "$(brew --prefix)/bin/osaurus" || \
-ln -sf "$HOME/Applications/Osaurus.app/Contents/Helpers/osaurus" "$(brew --prefix)/bin/osaurus"
+ln -sf "/Applications/Osaurus.app/Contents/MacOS/osaurus" "$(brew --prefix)/bin/osaurus" || \
+ln -sf "$HOME/Applications/Osaurus.app/Contents/MacOS/osaurus" "$(brew --prefix)/bin/osaurus"
 
 # Or use the helper script (auto-detects paths and Homebrew prefix)
 curl -fsSL https://raw.githubusercontent.com/dinoki-ai/osaurus/main/scripts/install_cli_symlink.sh | bash

--- a/osaurus/Views/ContentView.swift
+++ b/osaurus/Views/ContentView.swift
@@ -776,7 +776,7 @@ extension ConfigurationView {
   private func resolveCLIExecutableURL() -> URL? {
     let fm = FileManager.default
     let appURL = Bundle.main.bundleURL
-    let embedded = appURL.appendingPathComponent("Contents/Helpers/osaurus", isDirectory: false)
+    let embedded = appURL.appendingPathComponent("Contents/MacOS/osaurus", isDirectory: false)
     if fm.fileExists(atPath: embedded.path), fm.isExecutableFile(atPath: embedded.path) {
       return embedded
     }
@@ -797,7 +797,7 @@ extension ConfigurationView {
 
     // Also try if the app got embedded but we ran before copy phase: check inside the app that lives in Products/Release
     let releaseEmbedded = productsDir.deletingLastPathComponent()
-      .appendingPathComponent("Release/osaurus.app/Contents/Helpers/osaurus", isDirectory: false)
+      .appendingPathComponent("Release/osaurus.app/Contents/MacOS/osaurus", isDirectory: false)
     if fm.fileExists(atPath: releaseEmbedded.path),
       fm.isExecutableFile(atPath: releaseEmbedded.path)
     {

--- a/scripts/install_cli_symlink.sh
+++ b/scripts/install_cli_symlink.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # install_cli_symlink.sh
 # Creates/updates a convenient `osaurus` symlink to either:
-#   1) the app's embedded CLI at Osaurus.app/Contents/Helpers/osaurus, or
+#   1) the app's embedded CLI at Osaurus.app/Contents/MacOS/osaurus, or
 #   2) a locally built CLI binary in DerivedData (dev mode).
 #
 # Usage:
@@ -44,7 +44,7 @@ done
 resolve_cli_from_app() {
   local app_path="$1"
   local cli_path
-  cli_path="$app_path/Contents/Helpers/osaurus"
+  cli_path="$app_path/Contents/MacOS/osaurus"
   if [[ -x "$cli_path" ]]; then
     echo "$cli_path"
     return 0
@@ -58,7 +58,7 @@ resolve_cli_from_dev() {
   for candidate in \
     "$base/osaurus" \
     "$base/osaurus-cli" \
-    "$base/osaurus.app/Contents/Helpers/osaurus" \
+    "$base/osaurus.app/Contents/MacOS/osaurus" \
     "$REPO_ROOT/build/DerivedData/Build/Products/Debug/osaurus" \
     "$REPO_ROOT/build/DerivedData/Build/Products/Debug/osaurus-cli"
   do
@@ -118,7 +118,7 @@ else
   else
     if CLI_SRC="$(resolve_cli_from_app "$APP_PATH")"; then :; else
       echo "CLI binary not found in: $APP_PATH" >&2
-      echo "Expected at: $APP_PATH/Contents/Helpers/osaurus" >&2
+      echo "Expected at: $APP_PATH/Contents/MacOS/osaurus" >&2
       exit 1
     fi
   fi

--- a/scripts/osaurus
+++ b/scripts/osaurus
@@ -54,7 +54,7 @@ resolve_app_path() {
 
 resolve_cli_from_app() {
   local app_path="$1"
-  local cli="$app_path/Contents/Helpers/osaurus"
+  local cli="$app_path/Contents/MacOS/osaurus"
   if [[ -x "$cli" ]]; then
     echo "$cli"
     return 0
@@ -67,7 +67,7 @@ resolve_cli_from_dev() {
   local candidates=(
     "$base/Release/osaurus"
     "$base/Release/osaurus-cli"
-    "$base/Release/osaurus.app/Contents/Helpers/osaurus"
+    "$base/Release/osaurus.app/Contents/MacOS/osaurus"
     "$base/Debug/osaurus"
     "$base/Debug/osaurus-cli"
   )


### PR DESCRIPTION
## Summary

Update references to use Contents/MacOS/osaurus instead of Contents/Helpers, fixing CLI path and symlink issues

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [x] Docs

## Test Plan

Ensure CLI works when Osaurus is installed via homebrew

## Screenshots

N/A

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
