### PR TITLE
switch tabs after pasting from hugging face

### DIFF
--- a/osaurus/Controllers/ModelManager.swift
+++ b/osaurus/Controllers/ModelManager.swift
@@ -950,7 +950,7 @@ extension ModelManager {
 
 extension ModelManager {
   /// Parse a user-provided text into a Hugging Face repo id ("org/repo") if possible.
-  fileprivate static func parseHuggingFaceRepoId(from input: String) -> String? {
+  static func parseHuggingFaceRepoId(from input: String) -> String? {
     let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
     if let url = URL(string: trimmed), let host = url.host?.lowercased(), host == "huggingface.co" {

--- a/osaurus/Views/ModelDownloadView.swift
+++ b/osaurus/Views/ModelDownloadView.swift
@@ -66,6 +66,10 @@ struct ModelDownloadView: View {
       modelManager.fetchRemoteMLXModels(searchText: searchText)
     }
     .onChange(of: searchText) { _, newValue in
+      // If input looks like a Hugging Face repo, switch to All so it's visible
+      if ModelManager.parseHuggingFaceRepoId(from: newValue) != nil, selectedTab != .all {
+        selectedTab = .all
+      }
       // Debounce remote search to avoid spamming the API
       searchDebounceTask?.cancel()
       searchDebounceTask = Task { @MainActor in


### PR DESCRIPTION
## Summary

When a user pastes a hugging face URL in the input, it should switch tabs so they can see it.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
