### PR TITLE
support array parts content

### DIFF
--- a/osaurus/Views/ChatView.swift
+++ b/osaurus/Views/ChatView.swift
@@ -192,10 +192,10 @@ struct ChatView: View {
           if isReturn {
             let hasShift = event.modifierFlags.contains(.shift)
             if hasShift {
-              return event // allow newline
+              return event  // allow newline
             } else {
               session.sendCurrent()
-              return nil // consume
+              return nil  // consume
             }
           }
           return event

--- a/osaurus/Views/Components/ChatTextEditor.swift
+++ b/osaurus/Views/Components/ChatTextEditor.swift
@@ -45,5 +45,3 @@ struct ChatTextEditor: View {
     .frame(minHeight: 48, maxHeight: 120)
   }
 }
-
-

--- a/osaurusTests/osaurusTests.swift
+++ b/osaurusTests/osaurusTests.swift
@@ -18,6 +18,30 @@ struct osaurusTests {
     #expect(1 + 1 == 2)
   }
 
+  @Test func openAI_decodes_arrayOfParts_content() async throws {
+    let json = """
+    {
+      "model": "test-model",
+      "messages": [
+        {"role": "system", "content": "You are a test."},
+        {"role": "user", "content": [
+          {"type": "text", "text": "Hel"},
+          {"type": "text", "text": "lo"}
+        ]}
+      ],
+      "stream": false
+    }
+    """.data(using: .utf8)!
+
+    let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: json)
+    #expect(req.messages.count == 2)
+    #expect(req.messages[1].role == "user")
+    #expect(req.messages[1].content == "Hello")
+
+    let internalMessages = req.toInternalMessages()
+    #expect(internalMessages[1].content == "Hello")
+  }
+
   @Test func serverConfiguration_portValidation() async throws {
     var cfg = ServerConfiguration.default
     cfg.port = 0


### PR DESCRIPTION
## Summary

Issue reported from #99 , updated `content` to support arrays.

Request:
```
{
  "model": "llama-3.2-3b-instruct-4bit",
  "messages": [
    {
      "role": "system",
      "content": "You are a large language model living in Emacs and a helpful assistant. Respond concisely."
    },
    {
      "role": "user",
      "content": [
        { "type": "text", "text": "Hello" }
      ]
    }
  ],
  "temperature": 1.0,
  "stream": false
}
```

Response:
```
{
  "id": "chatcmpl-5A02FFC5",
  "object": "chat.completion",
  "created": 1761857008,
  "model": "llama-3.2-3b-instruct-4bit",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Welcome to Emacs. How can I assist you today?"
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 30,
    "completion_tokens": 11,
    "total_tokens": 41
  }
}
```

## Changes

- [ ] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
