### PR TITLE
keep mcp process alive

### DIFF
--- a/Packages/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/OsaurusCLI.swift
@@ -1211,8 +1211,11 @@ extension OsaurusCLI {
         do {
             let transport = MCP.StdioTransport()
             try await server.start(transport: transport)
-            // Returned when stdio closes
-            exit(EXIT_SUCCESS)
+
+            // Keep the process alive
+            while true {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            }
         } catch {
             fputs("MCP server error: \(error.localizedDescription)\n", stderr)
             exit(EXIT_FAILURE)


### PR DESCRIPTION
## Summary

currently `osaurus mcp` closes prematurely, need to keep process alive

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
