### PR TITLE
Toggle Always on Top

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -469,7 +469,8 @@ extension AppDelegate {
             win.titleVisibility = .hidden
             win.titlebarAppearsTransparent = true
             win.isMovableByWindowBackground = true
-            win.level = .normal
+            let chatConfig = ChatConfigurationStore.load()
+            win.level = chatConfig.alwaysOnTop ? .floating : .normal
             win.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
             win.contentViewController = controller
             win.delegate = self
@@ -497,6 +498,12 @@ extension AppDelegate {
 
     @MainActor func closeChatOverlay() {
         chatWindow?.orderOut(nil)
+    }
+
+    @MainActor func applyChatWindowLevel() {
+        guard let win = chatWindow else { return }
+        let chatConfig = ChatConfigurationStore.load()
+        win.level = chatConfig.alwaysOnTop ? .floating : .normal
     }
 }
 

--- a/Packages/OsaurusCore/Models/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/ChatConfiguration.swift
@@ -36,6 +36,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     public var topPOverride: Float?
     /// Optional per-chat limit on consecutive tool attempts (nil uses default)
     public var maxToolAttempts: Int?
+    /// Whether the chat window should float above other windows
+    public var alwaysOnTop: Bool
 
     public init(
         hotkey: Hotkey?,
@@ -43,7 +45,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         temperature: Float? = nil,
         maxTokens: Int? = nil,
         topPOverride: Float? = nil,
-        maxToolAttempts: Int? = nil
+        maxToolAttempts: Int? = nil,
+        alwaysOnTop: Bool = false
     ) {
         self.hotkey = hotkey
         self.systemPrompt = systemPrompt
@@ -51,6 +54,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         self.maxTokens = maxTokens
         self.topPOverride = topPOverride
         self.maxToolAttempts = maxToolAttempts
+        self.alwaysOnTop = alwaysOnTop
     }
 
     public static var `default`: ChatConfiguration {
@@ -64,7 +68,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
             temperature: 0.7,
             maxTokens: 1024,
             topPOverride: nil,
-            maxToolAttempts: nil
+            maxToolAttempts: nil,
+            alwaysOnTop: false
         )
     }
 }

--- a/Packages/OsaurusCore/Views/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/ConfigurationView.swift
@@ -21,6 +21,7 @@ struct ConfigurationView: View {
     @State private var tempChatMaxTokens: String = ""
     @State private var tempChatTopP: String = ""
     @State private var tempChatMaxToolAttempts: String = ""
+    @State private var tempChatAlwaysOnTop: Bool = false
 
     // Server settings state
     @State private var tempAllowedOrigins: String = ""
@@ -116,6 +117,16 @@ struct ConfigurationView: View {
                                     help: "Max consecutive tool calls (1–10). Empty uses no limit"
                                 )
                             }
+
+                            Divider()
+                                .background(theme.primaryBorder)
+
+                            // Window Settings
+                            SettingsToggle(
+                                title: "Always on Top",
+                                description: "Keep chat window above other windows",
+                                isOn: $tempChatAlwaysOnTop
+                            )
                         }
                     }
 
@@ -470,6 +481,7 @@ struct ConfigurationView: View {
         tempChatMaxTokens = chat.maxTokens.map(String.init) ?? ""
         tempChatTopP = chat.topPOverride.map { String($0) } ?? ""
         tempChatMaxToolAttempts = chat.maxToolAttempts.map(String.init) ?? ""
+        tempChatAlwaysOnTop = chat.alwaysOnTop
 
         let defaults = ServerConfiguration.default
         tempTopP = configuration.genTopP == defaults.genTopP ? "" : String(configuration.genTopP)
@@ -508,6 +520,7 @@ struct ConfigurationView: View {
         tempChatMaxTokens = ""
         tempChatTopP = ""
         tempChatMaxToolAttempts = ""
+        tempChatAlwaysOnTop = chatDefaults.alwaysOnTop
 
         // Performance settings - clear to use defaults
         tempTopP = ""
@@ -617,12 +630,16 @@ struct ConfigurationView: View {
             temperature: parsedTemp,
             maxTokens: parsedMax,
             topPOverride: parsedTopP,
-            maxToolAttempts: parsedMaxToolAttempts
+            maxToolAttempts: parsedMaxToolAttempts,
+            alwaysOnTop: tempChatAlwaysOnTop
         )
         ChatConfigurationStore.save(chatCfg)
 
         // Apply hotkey without relaunch
         AppDelegate.shared?.applyChatHotkey()
+
+        // Apply chat window level immediately
+        AppDelegate.shared?.applyChatWindowLevel()
 
         // Apply login item state
         LoginItemService.shared.applyStartAtLogin(configuration.startAtLogin)


### PR DESCRIPTION
## Summary

chat UI is always on top which could be annoying

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
