### PR TITLE
added automation permission granularity with calendar

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm",
       "state" : {
-        "revision" : "01852971866b17889f7aff27500cc62d9148b0df",
-        "version" : "2.29.2"
+        "revision" : "74f85d9505032ec3403c94ba159472244fe78767"
       }
     },
     {

--- a/App/osaurus/Info.plist
+++ b/App/osaurus/Info.plist
@@ -10,6 +10,12 @@
 	<string>HBRBQ8QQOhmvMKnSxQxqb3upTjyirdx0xkHSSRqn7aI=</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Osaurus plugins may use automation to control other applications on your behalf.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Osaurus plugins may access your calendar to read and create events.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Osaurus plugins may access your calendar to read and create events.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>Osaurus plugins may access your reminders to read and create tasks.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Packages/OsaurusCore/Models/SystemPermission.swift
+++ b/Packages/OsaurusCore/Models/SystemPermission.swift
@@ -10,8 +10,10 @@ import Foundation
 /// System-level macOS permissions that plugins can declare as requirements.
 /// These are checked at the OS level, not per-tool grants.
 enum SystemPermission: String, CaseIterable, Codable, Sendable {
-    /// AppleScript / Apple Events automation permission
+    /// AppleScript / Apple Events automation permission (System Events)
     case automation
+    /// AppleScript automation permission for Calendar.app specifically
+    case automationCalendar = "automation_calendar"
     /// Accessibility API access (AXIsProcessTrusted)
     case accessibility
     /// Full Disk Access permission
@@ -22,6 +24,8 @@ enum SystemPermission: String, CaseIterable, Codable, Sendable {
         switch self {
         case .automation:
             return "Automation"
+        case .automationCalendar:
+            return "Automation (Calendar)"
         case .accessibility:
             return "Accessibility"
         case .disk:
@@ -34,6 +38,8 @@ enum SystemPermission: String, CaseIterable, Codable, Sendable {
         switch self {
         case .automation:
             return "Allows plugins to control other applications using AppleScript and Apple Events."
+        case .automationCalendar:
+            return "Allows plugins to read and create events in Calendar.app via AppleScript."
         case .accessibility:
             return "Allows plugins to interact with UI elements, simulate input, and control the computer."
         case .disk:
@@ -46,6 +52,8 @@ enum SystemPermission: String, CaseIterable, Codable, Sendable {
         switch self {
         case .automation:
             return "applescript"
+        case .automationCalendar:
+            return "calendar"
         case .accessibility:
             return "accessibility"
         case .disk:
@@ -58,6 +66,8 @@ enum SystemPermission: String, CaseIterable, Codable, Sendable {
         switch self {
         case .automation:
             return "gearshape.2"
+        case .automationCalendar:
+            return "calendar"
         case .accessibility:
             return "figure.stand"
         case .disk:
@@ -70,6 +80,9 @@ enum SystemPermission: String, CaseIterable, Codable, Sendable {
         switch self {
         case .automation:
             // Opens Privacy & Security > Automation
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
+        case .automationCalendar:
+            // Opens Privacy & Security > Automation (Calendar is listed under the app)
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
         case .accessibility:
             // Opens Privacy & Security > Accessibility

--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -28,6 +28,8 @@ final class SystemPermissionService: ObservableObject {
         switch permission {
         case .automation:
             return checkAutomationPermission()
+        case .automationCalendar:
+            return checkCalendarAutomationPermission()
         case .accessibility:
             return checkAccessibilityPermission()
         case .disk:
@@ -46,10 +48,28 @@ final class SystemPermissionService: ObservableObject {
     func startPeriodicRefresh(interval: TimeInterval = 2.0) {
         stopPeriodicRefresh()
         refreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshAllPermissions()
+            // Use DispatchQueue.main.async to avoid "Publishing changes from within view updates" warning
+            DispatchQueue.main.async {
+                self?.refreshNonDisruptivePermissions()
             }
         }
+    }
+
+    /// Refresh only permissions that don't require launching apps or disrupting user flow
+    /// Calendar automation check is excluded because it launches Calendar.app
+    private func refreshNonDisruptivePermissions() {
+        for permission in SystemPermission.allCases {
+            // Skip Calendar automation - it requires launching Calendar which is disruptive
+            if permission == .automationCalendar {
+                continue
+            }
+            permissionStates[permission] = isGranted(permission)
+        }
+    }
+
+    /// Update the Calendar automation permission state directly (used after diagnostic test)
+    func updateCalendarPermissionState(_ isGranted: Bool) {
+        permissionStates[.automationCalendar] = isGranted
     }
 
     /// Stop periodic refresh
@@ -65,6 +85,8 @@ final class SystemPermissionService: ObservableObject {
         switch permission {
         case .automation:
             requestAutomationPermission()
+        case .automationCalendar:
+            requestCalendarAutomationPermission()
         case .accessibility:
             requestAccessibilityPermission()
         case .disk:
@@ -159,6 +181,95 @@ final class SystemPermissionService: ObservableObject {
         }
     }
 
+    // MARK: - Calendar Automation Permission
+
+    private func checkCalendarAutomationPermission() -> Bool {
+        // For periodic checks, just return the last known state to avoid launching Calendar
+        // The accurate check happens when user clicks "Test Calendar AppleScript" button
+        // or when the permission is explicitly requested
+        return permissionStates[.automationCalendar] ?? false
+    }
+
+    /// Perform a full Calendar automation check (may launch Calendar.app)
+    /// This is called only on explicit user request, not during periodic refresh
+    nonisolated private func performFullCalendarAutomationCheck() -> Bool {
+        // Ensure Calendar is running using NSWorkspace
+        let workspace = NSWorkspace.shared
+        let calendarRunning = workspace.runningApplications.contains {
+            $0.bundleIdentifier == "com.apple.iCal"
+        }
+
+        if !calendarRunning {
+            if let calendarURL = workspace.urlForApplication(withBundleIdentifier: "com.apple.iCal") {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = false
+
+                let semaphore = DispatchSemaphore(value: 0)
+                workspace.openApplication(at: calendarURL, configuration: config) { _, _ in
+                    semaphore.signal()
+                }
+                _ = semaphore.wait(timeout: .now() + 5.0)
+                Thread.sleep(forTimeInterval: 2.0)
+            }
+        }
+
+        // Use NSAppleScript directly (not osascript) to ensure attribution to host app
+        let script = NSAppleScript(
+            source: """
+                tell application id "com.apple.iCal"
+                    return name of calendars as string
+                end tell
+                """
+        )
+
+        var errorInfo: NSDictionary?
+        script?.executeAndReturnError(&errorInfo)
+
+        if let error = errorInfo,
+            let errorNumber = error[NSAppleScript.errorNumber] as? Int
+        {
+            // -1743 = permission denied (not authorized to send Apple events)
+            if errorNumber == -1743 {
+                return false
+            }
+            // -600 = app not responding, treat as unknown/failed
+            if errorNumber == -600 {
+                return false
+            }
+        }
+
+        // If execution succeeded, we have permission
+        return errorInfo == nil
+    }
+
+    private func requestCalendarAutomationPermission() {
+        // Run on MainActor to ensure TCC prompts attach correctly
+        Task { @MainActor in
+            // First, check if we already have permission
+            let alreadyGranted = checkCalendarAutomationPermission()
+            if alreadyGranted {
+                refreshAllPermissions()
+                return
+            }
+
+            // Perform full check which will launch Calendar and trigger permission prompt
+            // running on main thread/queue is safer for TCC triggers
+            // We use a detached task to avoid blocking the main thread during the 5s timeout
+            let granted: Bool = await Task.detached { [weak self] in
+                guard let self = self else { return false }
+                return self.performFullCalendarAutomationCheck()
+            }.value
+
+            updateCalendarPermissionState(granted)
+
+            // If not granted, the dialog likely didn't appear (already shown before)
+            // Open System Settings so the user can manually grant the permission
+            if !granted {
+                self.openSystemSettings(for: .automationCalendar)
+            }
+        }
+    }
+
     // MARK: - Full Disk Access Permission
 
     private func checkDiskPermission() -> Bool {
@@ -216,5 +327,109 @@ final class SystemPermissionService: ObservableObject {
     /// Check if a requirement string represents a system permission
     static func isSystemPermission(_ requirement: String) -> Bool {
         return SystemPermission(rawValue: requirement) != nil
+    }
+
+    // MARK: - Debug: Test Calendar AppleScript
+
+    /// Debug function to test if Calendar AppleScript works from this process.
+    /// This will launch Calendar.app if not running.
+    /// Marked nonisolated so it can be called from background threads.
+    nonisolated static func debugTestCalendarAccess() -> String {
+        // Ensure Calendar is running using NSWorkspace
+        let workspace = NSWorkspace.shared
+        let calendarRunning = workspace.runningApplications.contains {
+            $0.bundleIdentifier == "com.apple.iCal"
+        }
+
+        var diagnostics = ""
+
+        if !calendarRunning {
+            if let calendarURL = workspace.urlForApplication(withBundleIdentifier: "com.apple.iCal") {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = false
+                let semaphore = DispatchSemaphore(value: 0)
+                workspace.openApplication(at: calendarURL, configuration: config) { _, _ in
+                    semaphore.signal()
+                }
+                // Wait up to 5 seconds for launch
+                _ = semaphore.wait(timeout: .now() + 5.0)
+                // Give it a moment to fully initialize
+                Thread.sleep(forTimeInterval: 2.0)
+            } else {
+                diagnostics += " | Calendar.app not found"
+            }
+        }
+
+        // Use bundle ID for reliable resolution
+        let script = NSAppleScript(
+            source: """
+                tell application id "com.apple.iCal"
+                    return name of calendars as string
+                end tell
+                """
+        )
+
+        var errorInfo: NSDictionary?
+        let result = script?.executeAndReturnError(&errorInfo)
+
+        if let error = errorInfo {
+            let errorNumber = error[NSAppleScript.errorNumber] as? Int ?? -1
+            let errorMessage = error[NSAppleScript.errorMessage] as? String ?? "Unknown error"
+
+            var guidance = ""
+            if errorNumber == -1743 {
+                guidance = " → Permission denied. Grant in System Settings → Privacy & Security → Automation"
+            } else if errorNumber == -600 {
+                guidance = " → App communication failed. Try restarting your Mac if this persists."
+            }
+
+            return "ERROR [\(errorNumber)]: \(errorMessage)\(guidance)\(diagnostics.isEmpty ? "" : " | \(diagnostics)")"
+        }
+
+        if let resultValue = result?.stringValue {
+            return "SUCCESS: \(resultValue)"
+        }
+
+        return "NO RESULT"
+    }
+
+    /// Simple error wrapper for osascript results
+    private struct OsascriptError: Error {
+        let message: String
+    }
+
+    /// Run an AppleScript using osascript command
+    private nonisolated static func runOsascript(_ script: String) -> Result<String, OsascriptError> {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+            let output =
+                String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let errorOutput =
+                String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            if process.terminationStatus == 0 {
+                return .success(output)
+            } else {
+                return .failure(
+                    OsascriptError(message: errorOutput.isEmpty ? "exit \(process.terminationStatus)" : errorOutput)
+                )
+            }
+        } catch {
+            return .failure(OsascriptError(message: error.localizedDescription))
+        }
     }
 }

--- a/Packages/OsaurusCore/Views/ChatView.swift
+++ b/Packages/OsaurusCore/Views/ChatView.swift
@@ -721,11 +721,26 @@ final class ChatSession: ObservableObject {
                         // Execute tool and append hidden tool result turn
                         let resultText: String
                         do {
+                            // Log tool execution start
+                            let truncatedArgs = inv.jsonArguments.prefix(200)
+                            print(
+                                "[Osaurus][Tool] Executing: \(inv.toolName) with args: \(truncatedArgs)\(inv.jsonArguments.count > 200 ? "..." : "")"
+                            )
+
                             resultText = try await ToolRegistry.shared.execute(
                                 name: inv.toolName,
                                 argumentsJSON: inv.jsonArguments
                             )
+
+                            // Log tool success (truncated result)
+                            let truncatedResult = resultText.prefix(500)
+                            print(
+                                "[Osaurus][Tool] Success: \(inv.toolName) returned \(resultText.count) chars: \(truncatedResult)\(resultText.count > 500 ? "..." : "")"
+                            )
                         } catch {
+                            // Log tool error
+                            print("[Osaurus][Tool] Error: \(inv.toolName) failed: \(error.localizedDescription)")
+
                             // Store rejection/error as the result so UI shows "Rejected" instead of hanging
                             let rejectionMessage = "[REJECTED] \(error.localizedDescription)"
                             assistantTurn.toolResults[callId] = rejectionMessage


### PR DESCRIPTION
## Summary

currently debugging calendar permissions. need to test on production build

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
