### PR TITLE
set default genMaxKVSize to 8192

### DIFF
--- a/Packages/OsaurusCore/Models/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/ServerConfiguration.swift
@@ -156,7 +156,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
             genKVBits: nil,
             genKVGroupSize: 64,
             genQuantizedKVStart: 0,
-            genMaxKVSize: nil,
+            genMaxKVSize: 8192,
             genPrefillStepSize: 512,
             allowedOrigins: []
         )

--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
@@ -22,7 +22,7 @@ struct RuntimeConfig: Sendable {
             kvBits: cfg?.genKVBits,
             kvGroup: cfg?.genKVGroupSize ?? 64,
             quantStart: cfg?.genQuantizedKVStart ?? 0,
-            maxKV: cfg?.genMaxKVSize,
+            maxKV: cfg?.genMaxKVSize ?? 8192,
             prefillStep: cfg?.genPrefillStepSize ?? 512
         )
     }

--- a/Packages/OsaurusCore/Views/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/ConfigurationView.swift
@@ -371,8 +371,8 @@ struct ConfigurationView: View {
                                 settingsTextField(
                                     label: "Max KV Size",
                                     text: $tempMaxKV,
-                                    placeholder: "",
-                                    help: "Maximum KV cache size in tokens. Empty uses unlimited"
+                                    placeholder: "8192",
+                                    help: "Maximum KV cache size in tokens. Empty uses default 8192"
                                 )
                                 settingsTextField(
                                     label: "Prefill Step Size",


### PR DESCRIPTION
## Summary

Based on #192 , seems like the user is running out of memory when calling a large context request. this is happening because we have `genMaxKVSize` set as `nil` which means unlimited. Generally there's a rolling eviction policy for KV Caches, but if it's set to nil, it will keep growing until out of memory.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
