### PR TITLE
set up default context for remote models

### DIFF
--- a/Packages/OsaurusCore/Models/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/ChatConfiguration.swift
@@ -32,6 +32,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     public var temperature: Float?
     /// Optional per-chat override for maximum response tokens (nil uses app default)
     public var maxTokens: Int?
+    /// Optional default context length for models with unknown limits (e.g. remote)
+    public var contextLength: Int?
     /// Optional per-chat override for top_p sampling (nil uses server default)
     public var topPOverride: Float?
     /// Optional per-chat limit on consecutive tool attempts (nil uses default)
@@ -46,6 +48,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         systemPrompt: String,
         temperature: Float? = nil,
         maxTokens: Int? = nil,
+        contextLength: Int? = nil,
         topPOverride: Float? = nil,
         maxToolAttempts: Int? = nil,
         alwaysOnTop: Bool = false,
@@ -55,6 +58,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         self.systemPrompt = systemPrompt
         self.temperature = temperature
         self.maxTokens = maxTokens
+        self.contextLength = contextLength
         self.topPOverride = topPOverride
         self.maxToolAttempts = maxToolAttempts
         self.alwaysOnTop = alwaysOnTop
@@ -71,6 +75,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
             systemPrompt: "",
             temperature: nil,
             maxTokens: 16384,  // High default to support long generations (essays, code, etc.)
+            contextLength: 128000,  // Default to 128k for modern remote models
             topPOverride: nil,
             maxToolAttempts: 15,  // Increased from 3 to support longer agentic workflows
             alwaysOnTop: false

--- a/Packages/OsaurusCore/Views/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/ConfigurationView.swift
@@ -23,6 +23,7 @@ struct ConfigurationView: View {
     @State private var tempSystemPrompt: String = ""
     @State private var tempChatTemperature: String = ""
     @State private var tempChatMaxTokens: String = ""
+    @State private var tempChatContextLength: String = ""
     @State private var tempChatTopP: String = ""
     @State private var tempChatMaxToolAttempts: String = ""
     @State private var tempChatAlwaysOnTop: Bool = false
@@ -76,6 +77,7 @@ struct ConfigurationView: View {
                         "System Prompt",
                         "Temperature",
                         "Max Tokens",
+                        "Context Length",
                         "Top P",
                         "Tools",
                         "Tool Call",
@@ -135,6 +137,12 @@ struct ConfigurationView: View {
                                             text: $tempChatMaxTokens,
                                             placeholder: "16384",
                                             help: "Maximum response tokens. Empty uses default 16384"
+                                        )
+                                        settingsTextField(
+                                            label: "Context Length",
+                                            text: $tempChatContextLength,
+                                            placeholder: "128000",
+                                            help: "Assumed context window for remote models. Empty uses default 128k"
                                         )
                                         settingsTextField(
                                             label: "Top P Override",
@@ -546,6 +554,7 @@ struct ConfigurationView: View {
         tempSystemPrompt = chat.systemPrompt
         tempChatTemperature = chat.temperature.map { String($0) } ?? ""
         tempChatMaxTokens = chat.maxTokens.map(String.init) ?? ""
+        tempChatContextLength = chat.contextLength.map(String.init) ?? ""
         tempChatTopP = chat.topPOverride.map { String($0) } ?? ""
         tempChatMaxToolAttempts = chat.maxToolAttempts.map(String.init) ?? ""
         tempChatAlwaysOnTop = chat.alwaysOnTop
@@ -590,6 +599,7 @@ struct ConfigurationView: View {
         tempSystemPrompt = ""
         tempChatTemperature = ""
         tempChatMaxTokens = ""
+        tempChatContextLength = ""
         tempChatTopP = ""
         tempChatMaxToolAttempts = ""
         tempChatAlwaysOnTop = chatDefaults.alwaysOnTop
@@ -706,6 +716,12 @@ struct ConfigurationView: View {
             return max(1, v)
         }()
 
+        let trimmedContext = tempChatContextLength.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsedContext: Int? = {
+            guard !trimmedContext.isEmpty, let v = Int(trimmedContext) else { return nil }
+            return max(2048, v)
+        }()
+
         let trimmedTopPChat = tempChatTopP.trimmingCharacters(in: .whitespacesAndNewlines)
         let parsedTopP: Float? = {
             guard !trimmedTopPChat.isEmpty, let v = Float(trimmedTopPChat) else { return nil }
@@ -723,6 +739,7 @@ struct ConfigurationView: View {
             systemPrompt: tempSystemPrompt,
             temperature: parsedTemp,
             maxTokens: parsedMax,
+            contextLength: parsedContext,
             topPOverride: parsedTopP,
             maxToolAttempts: parsedMaxToolAttempts,
             alwaysOnTop: tempChatAlwaysOnTop,


### PR DESCRIPTION
## Summary

remote models have very small default context window, getting unexpected side effects

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
