### PR TITLE
Add native Anthropic API support

### DIFF
--- a/Packages/OsaurusCore/Views/Components/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Components/RemoteProviderEditSheet.swift
@@ -10,6 +10,7 @@ import SwiftUI
 // MARK: - Provider Presets
 
 enum ProviderPreset: String, CaseIterable, Identifiable {
+    case anthropic = "Anthropic"
     case openai = "OpenAI"
     case ollama = "Ollama"
     case lmstudio = "LM Studio"
@@ -20,6 +21,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
 
     var icon: String {
         switch self {
+        case .anthropic: return "brain.head.profile"
         case .openai: return "sparkles"
         case .ollama: return "cube.fill"
         case .lmstudio: return "desktopcomputer"
@@ -30,6 +32,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
 
     var description: String {
         switch self {
+        case .anthropic: return "Claude models"
         case .openai: return "GPT-4o, o1, etc."
         case .ollama: return "Local models"
         case .lmstudio: return "Local inference"
@@ -40,6 +43,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
 
     var gradient: [Color] {
         switch self {
+        case .anthropic: return [Color(red: 0.85, green: 0.55, blue: 0.35), Color(red: 0.75, green: 0.4, blue: 0.25)]
         case .openai: return [Color(red: 0.0, green: 0.65, blue: 0.52), Color(red: 0.0, green: 0.5, blue: 0.4)]
         case .ollama: return [Color(red: 0.3, green: 0.5, blue: 0.9), Color(red: 0.2, green: 0.35, blue: 0.7)]
         case .lmstudio: return [Color(red: 0.7, green: 0.45, blue: 0.9), Color(red: 0.5, green: 0.3, blue: 0.7)]
@@ -55,10 +59,21 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
         let port: Int?
         let basePath: String
         let authType: RemoteProviderAuthType
+        let providerType: RemoteProviderType
     }
 
     var configuration: Configuration {
         switch self {
+        case .anthropic:
+            return Configuration(
+                name: "Anthropic",
+                host: "api.anthropic.com",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/v1",
+                authType: .apiKey,
+                providerType: .anthropic
+            )
         case .openai:
             return Configuration(
                 name: "OpenAI",
@@ -66,7 +81,8 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 providerProtocol: .https,
                 port: nil,
                 basePath: "/v1",
-                authType: .apiKey
+                authType: .apiKey,
+                providerType: .openai
             )
         case .ollama:
             return Configuration(
@@ -75,7 +91,8 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 providerProtocol: .http,
                 port: 11434,
                 basePath: "/v1",
-                authType: .none
+                authType: .none,
+                providerType: .openai
             )
         case .lmstudio:
             return Configuration(
@@ -84,7 +101,8 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 providerProtocol: .http,
                 port: 1234,
                 basePath: "/v1",
-                authType: .none
+                authType: .none,
+                providerType: .openai
             )
         case .openrouter:
             return Configuration(
@@ -93,7 +111,8 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 providerProtocol: .https,
                 port: nil,
                 basePath: "/api/v1",
-                authType: .apiKey
+                authType: .apiKey,
+                providerType: .openai
             )
         case .custom:
             return Configuration(
@@ -102,7 +121,8 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 providerProtocol: .https,
                 port: nil,
                 basePath: "/v1",
-                authType: .none
+                authType: .none,
+                providerType: .openai
             )
         }
     }
@@ -130,6 +150,9 @@ struct RemoteProviderEditSheet: View {
     // Authentication
     @State private var authType: RemoteProviderAuthType = .none
     @State private var apiKey: String = ""
+
+    // Provider type
+    @State private var providerType: RemoteProviderType = .openai
 
     // Custom headers
     @State private var customHeaders: [HeaderEntry] = []
@@ -673,6 +696,7 @@ struct RemoteProviderEditSheet: View {
         portString = config.port.map { String($0) } ?? ""
         basePath = config.basePath
         authType = config.authType
+        providerType = config.providerType
         testResult = nil
     }
 
@@ -686,6 +710,7 @@ struct RemoteProviderEditSheet: View {
         }
         basePath = provider.basePath
         authType = provider.authType
+        providerType = provider.providerType
         timeout = provider.timeout
         customHeaders = provider.customHeaders.map { HeaderEntry(key: $0.key, value: $0.value, isSecret: false) }
         for key in provider.secretHeaderKeys {
@@ -711,6 +736,7 @@ struct RemoteProviderEditSheet: View {
                     port: port,
                     basePath: trimmedBasePath,
                     authType: authType,
+                    providerType: providerType,
                     apiKey: testApiKey,
                     headers: headers
                 )
@@ -752,6 +778,7 @@ struct RemoteProviderEditSheet: View {
             basePath: basePath,
             customHeaders: regularHeaders,
             authType: authType,
+            providerType: providerType,
             enabled: provider?.enabled ?? true,
             autoConnect: true,
             timeout: timeout,


### PR DESCRIPTION
  Summary

  Adds native Anthropic API support as a remote provider option, enabling users to connect directly to Anthropic's Claude models alongside existing OpenAI-compatible providers.

  Motivation: Currently Osaurus only supports OpenAI-compatible APIs. This adds first-class support for Anthropic's Messages API, allowing users to use Claude models directly without needing an OpenAI-compatible proxy.

  Changes

  - Behavior change
  - UI change (screenshots below)
  - Refactor / chore
  - Tests
  - Docs

  Details

  - Added RemoteProviderType enum to distinguish OpenAI vs Anthropic API formats
  - Added Anthropic preset to the provider selection dropdown
  - Implemented Anthropic Messages API request/response transformation
  - Added Anthropic SSE streaming event parsing (content_block_delta, message_stop, etc.)
  - Handle Anthropic-specific auth headers (x-api-key, anthropic-version)
  - Use /messages endpoint for connection testing (Anthropic has no /models endpoint)
  - Added hardcoded list of Anthropic models using official aliases
  - Fixed Accept: text/event-stream header for streaming requests

  Test Plan

  1. Open Osaurus → Settings → Remote Providers
  2. Click "Add Provider"
  3. Select "Anthropic" from the preset dropdown
  4. Enter your Anthropic API key
  5. Click "Test Connection" - should show available models
  6. Save and enable the provider
  7. Select an Anthropic model (e.g., anthropic/claude-sonnet-4-5)
  8. Send a message and verify streaming response works

  Model tested: claude-sonnet-4-5, claude-opus-4-5

  Screenshots

  Added Anthropic button to Models selector

  Checklist

  - I have read CONTRIBUTING.md
  - I added/updated tests where reasonable
  - I updated docs/README as needed
  - I verified build on macOS with Xcode 26.2