### PR TITLE
Fix UI freeze during streaming with tool-enabled models

### DIFF
--- a/Packages/OsaurusCore/Views/ChatView.swift
+++ b/Packages/OsaurusCore/Views/ChatView.swift
@@ -952,6 +952,9 @@ struct ChatView: View {
     @State private var keyMonitor: Any?
     @State private var isHeaderHovered: Bool = false
     @State private var showSidebar: Bool = false
+    @State private var lastScrollTime: Date = .distantPast
+    
+    private static let scrollThrottleInterval: TimeInterval = 0.15
 
     private var theme: ThemeProtocol { themeManager.chatTheme }
 
@@ -1428,11 +1431,10 @@ struct ChatView: View {
                 }
             }
             .onChange(of: session.scrollTick) { _, _ in
-                if isPinnedToBottom {
-                    // No animation during streaming to prevent UI jumpiness
-                    // The scrollTick is updated during streaming buffer flushes
-                    proxy.scrollTo("BOTTOM", anchor: .bottom)
-                }
+                guard isPinnedToBottom,
+                      Date().timeIntervalSince(lastScrollTime) >= Self.scrollThrottleInterval else { return }
+                lastScrollTime = .now
+                proxy.scrollTo("BOTTOM", anchor: .bottom)
             }
             .onReceive(NotificationCenter.default.publisher(for: .chatOverlayActivated)) { _ in
                 proxy.scrollTo("BOTTOM", anchor: .bottom)


### PR DESCRIPTION
Note: This fix was developed with assistance from Claude Code. I've reviewed the changes and kept them minimal.

---

Fixes main thread hang when streaming responses with tool-calling models.

Reproduced with Qwen 4B + fetch/search tools enabled, asking about the weather. The app would beach ball and become unresponsive during streaming.

Root cause: Each streaming buffer flush incremented `scrollTick`, triggering `scrollTo("BOTTOM")`. This caused SwiftUI to recalculate layout for the entire view hierarchy on every flush. Combined with unstable ForEach IDs (using array offset), views were being recreated unnecessarily, compounding the layout cost.

Fix:
- Throttle scroll-to-bottom to 150ms intervals during streaming
- Use stable content-based IDs for message group ForEach instead of enumeration offset