### PR TITLE
Fix sidebar missing glass blur effect

### DIFF
--- a/Packages/OsaurusCore/Views/Components/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Components/ChatSessionSidebar.swift
@@ -60,7 +60,13 @@ struct ChatSessionSidebar: View {
         }
         .frame(width: 240, alignment: .top)
         .frame(maxHeight: .infinity, alignment: .top)
-        .background(theme.secondaryBackground.opacity(colorScheme == .dark ? 0.85 : 0.9))
+        .background {
+            if theme.glassEnabled {
+                ThemedGlassSurface(cornerRadius: 0)
+            } else {
+                theme.secondaryBackground
+            }
+        }
     }
 
     private func dismissEditing() {


### PR DESCRIPTION
Note: This fix was developed with assistance from Claude Code. I've reviewed the changes and kept them minimal.

---

The chat history sidebar had semi-transparency but no blur effect. It was using a solid color with opacity instead of the glass material.

<img width="839" height="623" alt="1-before-sidebar-fix" src="https://github.com/user-attachments/assets/9ccccfbc-1962-437f-95d3-d75bce60bccb" />
<img width="837" height="615" alt="2-after-sidebar-fix" src="https://github.com/user-attachments/assets/6b94bc77-4db3-421e-b057-bc396c99d93e" />


Fix: Use `ThemedGlassSurface` for the sidebar background when `theme.glassEnabled` is true, with `cornerRadius: 0` since it sits inside the window frame.