### PR TITLE
fixed the placeholder display issue when using a Chinese input method

### DIFF
--- a/Packages/OsaurusCore/Views/Components/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Components/EditableTextView.swift
@@ -112,6 +112,18 @@ struct EditableTextView: NSViewRepresentable {
             }
         }
 
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+            // Invalidate intrinsic size to trigger resize
+            if let customTextView = textView as? CustomNSTextView {
+                customTextView.invalidateIntrinsicContentSize()
+            }
+            if let scrollView = textView.enclosingScrollView {
+                scrollView.invalidateIntrinsicContentSize()
+            }
+        }
+
         func textDidBeginEditing(_ notification: Notification) {
             parent.isFocused = true
         }


### PR DESCRIPTION
## Summary

fixed the placeholder display issue when using a Chinese input method

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

Steps to verify locally (commands, screenshots, recordings). Include model used.

## Screenshots

before

<img width="803" height="613" alt="before" src="https://github.com/user-attachments/assets/c21a2b4e-a52d-4386-987d-5d485f9a5d8b" />

after

<img width="808" height="612" alt="after" src="https://github.com/user-attachments/assets/bc4762ac-91ba-4fbb-99ca-b0c0f345e33b" />


## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
