### PR TITLE
fixed the warning: "Modifying state during view update"

### DIFF
--- a/Packages/OsaurusCore/Views/Components/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Components/EditableTextView.swift
@@ -113,14 +113,16 @@ struct EditableTextView: NSViewRepresentable {
         }
 
         func textViewDidChangeSelection(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
-            parent.text = textView.string
-            // Invalidate intrinsic size to trigger resize
-            if let customTextView = textView as? CustomNSTextView {
-                customTextView.invalidateIntrinsicContentSize()
-            }
-            if let scrollView = textView.enclosingScrollView {
-                scrollView.invalidateIntrinsicContentSize()
+            DispatchQueue.main.async {
+                guard let textView = notification.object as? NSTextView else { return }
+                self.parent.text = textView.string
+                // Invalidate intrinsic size to trigger resize
+                if let customTextView = textView as? CustomNSTextView {
+                    customTextView.invalidateIntrinsicContentSize()
+                }
+                if let scrollView = textView.enclosingScrollView {
+                    scrollView.invalidateIntrinsicContentSize()
+                }
             }
         }
 


### PR DESCRIPTION

## Summary

After commit "fixed the placeholder display issue when using a Chinese input method #371", a warning in EditableTextView.swift on line 117: "Modifying state during view update, this will cause undefined behavior.".

To avoid modifying state directly during view update, defer the state change until after the current update cycle.

## Changes

- [ ] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
