### PR TITLE
removed version requirement in manifest for plugins

### DIFF
--- a/Packages/OsaurusCore/Models/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/ExternalPlugin.swift
@@ -40,12 +40,12 @@ typealias osr_plugin_entry_t = @convention(c) () -> UnsafeRawPointer?
 
 public struct PluginManifest: Decodable, Sendable {
     public let plugin_id: String
-    public let version: String
     public let description: String?
     public let capabilities: Capabilities
 
     // Optional fields for registry
     public let name: String?
+    public let version: String?
     public let license: String?
     public let authors: [String]?
     public let min_macos: String?


### PR DESCRIPTION
## Summary

removed unused `version` field in the plugin manifest. it's actually in the podspec

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
