### PR TITLE
Fixed the sidebar state issue when switching between Chat and Agent.

### DIFF
--- a/Packages/OsaurusCore/Managers/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/ChatWindowState.swift
@@ -30,6 +30,7 @@ final class ChatWindowState: ObservableObject {
     // MARK: - Mode State
 
     @Published var mode: ChatMode = .chat
+    @Published var showSidebar: Bool = false
 
     /// When non-nil, ChatView should present a close confirmation for active agent execution.
     @Published var agentCloseConfirmation: AgentCloseConfirmation?

--- a/Packages/OsaurusCore/Views/AgentView.swift
+++ b/Packages/OsaurusCore/Views/AgentView.swift
@@ -13,7 +13,6 @@ struct AgentView: View {
     @ObservedObject var windowState: ChatWindowState
     @ObservedObject var session: AgentSession
 
-    @State private var showSidebar: Bool = false
     @State private var isPinnedToBottom: Bool = true
 
     @State private var progressSidebarWidth: CGFloat = 280
@@ -28,11 +27,11 @@ struct AgentView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let sidebarWidth: CGFloat = showSidebar ? 240 : 0
+            let sidebarWidth: CGFloat = windowState.showSidebar ? 240 : 0
             let mainWidth = proxy.size.width - sidebarWidth
 
             HStack(alignment: .top, spacing: 0) {
-                if showSidebar {
+                if windowState.showSidebar {
                     AgentTaskSidebar(
                         tasks: windowState.agentTasks,
                         currentTaskId: session.currentTask?.id,
@@ -96,7 +95,7 @@ struct AgentView: View {
             windowControls
         }
         .ignoresSafeArea()
-        .animation(theme.springAnimation(responseMultiplier: 0.9), value: showSidebar)
+        .animation(theme.springAnimation(responseMultiplier: 0.9), value: windowState.showSidebar)
         .environment(\.theme, windowState.theme)
         .tint(theme.accentColor)
         .sheet(item: $selectedArtifact) { artifact in
@@ -220,8 +219,8 @@ struct AgentView: View {
             if theme.glassEnabled {
                 ThemedGlassSurface(
                     cornerRadius: 24,
-                    topLeadingRadius: showSidebar ? 0 : nil,
-                    bottomLeadingRadius: showSidebar ? 0 : nil
+                    topLeadingRadius: windowState.showSidebar ? 0 : nil,
+                    bottomLeadingRadius: windowState.showSidebar ? 0 : nil
                 )
                 .allowsHitTesting(false)
 
@@ -251,8 +250,8 @@ struct AgentView: View {
 
     private var backgroundShape: UnevenRoundedRectangle {
         UnevenRoundedRectangle(
-            topLeadingRadius: showSidebar ? 0 : 24,
-            bottomLeadingRadius: showSidebar ? 0 : 24,
+            topLeadingRadius: windowState.showSidebar ? 0 : 24,
+            bottomLeadingRadius: windowState.showSidebar ? 0 : 24,
             bottomTrailingRadius: 24,
             topTrailingRadius: 24,
             style: .continuous
@@ -306,10 +305,10 @@ struct AgentView: View {
                 // Sidebar toggle - far left
                 HeaderActionButton(
                     icon: "sidebar.left",
-                    help: showSidebar ? "Hide sidebar" : "Show sidebar",
+                    help: windowState.showSidebar ? "Hide sidebar" : "Show sidebar",
                     action: {
                         withAnimation(theme.animationQuick()) {
-                            showSidebar.toggle()
+                            windowState.showSidebar.toggle()
                         }
                     }
                 )

--- a/Packages/OsaurusCore/Views/ChatView.swift
+++ b/Packages/OsaurusCore/Views/ChatView.swift
@@ -1266,7 +1266,6 @@ struct ChatView: View {
     @State private var hostWindow: NSWindow?
     @State private var keyMonitor: Any?
     @State private var isHeaderHovered: Bool = false
-    @State private var showSidebar: Bool = false
 
     /// Convenience accessor for the window's theme
     private var theme: ThemeProtocol { windowState.theme }
@@ -1367,12 +1366,12 @@ struct ChatView: View {
     @ViewBuilder
     private var chatModeContent: some View {
         GeometryReader { proxy in
-            let sidebarWidth: CGFloat = showSidebar ? 240 : 0
+            let sidebarWidth: CGFloat = windowState.showSidebar ? 240 : 0
             let chatWidth = proxy.size.width - sidebarWidth
 
             HStack(alignment: .top, spacing: 0) {
                 // Sidebar
-                if showSidebar {
+                if windowState.showSidebar {
                     VStack(alignment: .leading, spacing: 0) {
                         ChatSessionSidebar(
                             sessions: windowState.filteredSessions,
@@ -1517,7 +1516,7 @@ struct ChatView: View {
         }
         .ignoresSafeArea()
         .animation(theme.animationMedium(), value: session.turns.isEmpty)
-        .animation(theme.springAnimation(responseMultiplier: 0.9), value: showSidebar)
+        .animation(theme.springAnimation(responseMultiplier: 0.9), value: windowState.showSidebar)
         .background(WindowAccessor(window: $hostWindow))
         .onReceive(NotificationCenter.default.publisher(for: .chatOverlayActivated)) { _ in
             // Lightweight state updates only - refreshAll() removed to prevent excessive re-renders
@@ -1565,8 +1564,8 @@ struct ChatView: View {
             if theme.glassEnabled {
                 ThemedGlassSurface(
                     cornerRadius: 24,
-                    topLeadingRadius: showSidebar ? 0 : nil,
-                    bottomLeadingRadius: showSidebar ? 0 : nil
+                    topLeadingRadius: windowState.showSidebar ? 0 : nil,
+                    bottomLeadingRadius: windowState.showSidebar ? 0 : nil
                 )
                 .allowsHitTesting(false)
 
@@ -1598,8 +1597,8 @@ struct ChatView: View {
 
     private var backgroundShape: UnevenRoundedRectangle {
         UnevenRoundedRectangle(
-            topLeadingRadius: showSidebar ? 0 : 24,
-            bottomLeadingRadius: showSidebar ? 0 : 24,
+            topLeadingRadius: windowState.showSidebar ? 0 : 24,
+            bottomLeadingRadius: windowState.showSidebar ? 0 : 24,
             bottomTrailingRadius: 24,
             topTrailingRadius: 24,
             style: .continuous
@@ -1712,10 +1711,10 @@ struct ChatView: View {
                 // Sidebar toggle - far left
                 HeaderActionButton(
                     icon: "sidebar.left",
-                    help: showSidebar ? "Hide sidebar" : "Show sidebar",
+                    help: windowState.showSidebar ? "Hide sidebar" : "Show sidebar",
                     action: {
                         withAnimation(theme.animationQuick()) {
-                            showSidebar.toggle()
+                            windowState.showSidebar.toggle()
                         }
                     }
                 )


### PR DESCRIPTION
## Summary

Fixed the sidebar state issue when switching between Chat and Agent. Moved "showSidebar" to the file ChatWindowState.swift.

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Screenshots

before

https://github.com/user-attachments/assets/819644e1-571d-40a5-897b-f97a338bb472

after

https://github.com/user-attachments/assets/f7f86590-6fbe-4440-bcc9-03a9e83f8bbf

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
