### PR TITLE
fix(security): add private key and certificate patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,5 +124,13 @@ ggml-*.metal
 .env
 Packages/**/Package.resolved
 
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.cer
+*.pfx
+private_key.txt
+
 # Benchmarks (cloned repos — setup via `make bench-setup`)
 benchmarks/


### PR DESCRIPTION
## Summary

- Adds `.gitignore` patterns for common private key and certificate file extensions (`*.pem`, `*.key`, `*.p12`, `*.cer`, `*.pfx`, `private_key.txt`)
- Defense-in-depth measure to prevent accidental commits of cryptographic material
- The `generate_and_deploy_appcast.sh` script writes `private_key.txt` during CI; this pattern ensures it can never be accidentally committed

Closes #520