### PR TITLE
added toggle for phased context loading

### DIFF
--- a/Packages/OsaurusCore/Models/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/ChatConfiguration.swift
@@ -40,6 +40,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     public var maxToolAttempts: Int?
     /// Default model for new chat sessions (nil uses first available)
     public var defaultModel: String?
+    /// Load capabilities in two phases (catalog, then select_capabilities) to reduce token usage
+    public var phasedContextLoading: Bool
 
     // MARK: - Work Generation Settings
     /// Work-specific temperature override (nil uses default 0.3)
@@ -60,6 +62,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         topPOverride: Float? = nil,
         maxToolAttempts: Int? = nil,
         defaultModel: String? = nil,
+        phasedContextLoading: Bool = true,
         workTemperature: Float? = nil,
         workMaxTokens: Int? = nil,
         workTopPOverride: Float? = nil,
@@ -73,10 +76,28 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         self.topPOverride = topPOverride
         self.maxToolAttempts = maxToolAttempts
         self.defaultModel = defaultModel
+        self.phasedContextLoading = phasedContextLoading
         self.workTemperature = workTemperature
         self.workMaxTokens = workMaxTokens
         self.workTopPOverride = workTopPOverride
         self.workMaxIterations = workMaxIterations
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hotkey = try container.decodeIfPresent(Hotkey.self, forKey: .hotkey)
+        systemPrompt = try container.decode(String.self, forKey: .systemPrompt)
+        temperature = try container.decodeIfPresent(Float.self, forKey: .temperature)
+        maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
+        contextLength = try container.decodeIfPresent(Int.self, forKey: .contextLength)
+        topPOverride = try container.decodeIfPresent(Float.self, forKey: .topPOverride)
+        maxToolAttempts = try container.decodeIfPresent(Int.self, forKey: .maxToolAttempts)
+        defaultModel = try container.decodeIfPresent(String.self, forKey: .defaultModel)
+        phasedContextLoading = try container.decodeIfPresent(Bool.self, forKey: .phasedContextLoading) ?? true
+        workTemperature = try container.decodeIfPresent(Float.self, forKey: .workTemperature)
+        workMaxTokens = try container.decodeIfPresent(Int.self, forKey: .workMaxTokens)
+        workTopPOverride = try container.decodeIfPresent(Float.self, forKey: .workTopPOverride)
+        workMaxIterations = try container.decodeIfPresent(Int.self, forKey: .workMaxIterations)
     }
 
     public static var `default`: ChatConfiguration {

--- a/Packages/OsaurusCore/Views/Components/CapabilitiesTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Components/CapabilitiesTableRepresentable.swift
@@ -642,7 +642,11 @@ private struct ToolRowCell: View {
 
             if !isAgentRestricted {
                 TokenBadge(count: catalogTokens)
-                    .help("Catalog: ~\(catalogTokens), Full: ~\(estimatedTokens) tokens")
+                    .help(
+                        catalogTokens == estimatedTokens
+                            ? "~\(estimatedTokens) tokens"
+                            : "Catalog: ~\(catalogTokens), Full: ~\(estimatedTokens) tokens"
+                    )
             }
         }
         .padding(.leading, 32)
@@ -703,7 +707,7 @@ private struct SkillRowCell: View {
             Spacer()
 
             TokenBadge(count: estimatedTokens)
-                .help("Catalog entry tokens")
+                .help("~\(estimatedTokens) tokens")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)

--- a/Packages/OsaurusCore/Views/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/ConfigurationView.swift
@@ -24,6 +24,7 @@ struct ConfigurationView: View {
     @State private var tempChatContextLength: String = ""
     @State private var tempChatTopP: String = ""
     @State private var tempChatMaxToolAttempts: String = ""
+    @State private var tempPhasedContextLoading: Bool = true
 
     // Work generation settings state
     @State private var tempAgentTemperature: String = ""
@@ -173,7 +174,8 @@ struct ConfigurationView: View {
                             "Context Length",
                             "Top P",
                             "Max Tool Attempts",
-                            "Generation"
+                            "Generation",
+                            "Phased Context Loading"
                         ) {
                             SettingsSection(title: "Chat", icon: "message") {
                                 VStack(alignment: .leading, spacing: 20) {
@@ -236,6 +238,15 @@ struct ConfigurationView: View {
                                             )
                                         }
                                     }
+
+                                    SettingsDivider()
+
+                                    SettingsToggle(
+                                        title: "Phased Context Loading",
+                                        description:
+                                            "Load tools and skills in two phases to reduce token usage. When disabled, all capabilities are loaded upfront.",
+                                        isOn: $tempPhasedContextLoading
+                                    )
 
                                 }
                             }
@@ -571,6 +582,7 @@ struct ConfigurationView: View {
         tempChatContextLength = chat.contextLength.map(String.init) ?? ""
         tempChatTopP = chat.topPOverride.map { String($0) } ?? ""
         tempChatMaxToolAttempts = chat.maxToolAttempts.map(String.init) ?? ""
+        tempPhasedContextLoading = chat.phasedContextLoading
 
         // Work generation settings
         tempAgentTemperature = chat.workTemperature.map { String($0) } ?? ""
@@ -632,6 +644,7 @@ struct ConfigurationView: View {
         tempChatContextLength = ""
         tempChatTopP = ""
         tempChatMaxToolAttempts = ""
+        tempPhasedContextLoading = true
 
         // Work generation settings - clear to use defaults
         tempAgentTemperature = ""
@@ -798,6 +811,7 @@ struct ConfigurationView: View {
             topPOverride: parsedTopP,
             maxToolAttempts: parsedMaxToolAttempts,
             defaultModel: existingDefaultModel,
+            phasedContextLoading: tempPhasedContextLoading,
             workTemperature: parsedAgentTemp,
             workMaxTokens: parsedAgentMax,
             workTopPOverride: parsedAgentTopP,


### PR DESCRIPTION
## Summary

Fixes #532 .

<img width="1012" height="784" alt="Screenshot 2026-02-27 at 5 34 43 AM" src="https://github.com/user-attachments/assets/68a46cf5-0b93-41ba-82a3-b13b05dfb952" />

You can disable it here.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
