### PR TITLE
removed thinking wrapper for smaller qwen3_5 models

### DIFF
--- a/Packages/OsaurusCore/Utils/StreamingMiddleware.swift
+++ b/Packages/OsaurusCore/Utils/StreamingMiddleware.swift
@@ -40,7 +40,7 @@ enum StreamingMiddlewareResolver {
             return PrependThinkTagMiddleware()
         }
 
-        if lower.contains("qwen") && lower.contains("3.5") {
+        if lower.contains("qwen") && lower.contains("3.5") && (lower.contains("4b") || lower.contains("9b")) {
             return PrependThinkTagMiddleware()
         }
 


### PR DESCRIPTION
## Summary

smaller models doesn't have thinking cap

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
