### PR TITLE
fixed minor issue with jinja and surface better errors

### DIFF
--- a/Packages/OsaurusCore/Models/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/OpenAIAPI.swift
@@ -635,7 +635,10 @@ public enum JSONValue: Codable, Sendable {
 // MARK: - JSONValue Conversions
 
 extension JSONValue {
-    /// Convert JSONValue to Sendable-compatible value (for MLXLMCommon.ToolSpec)
+    /// Convert JSONValue to Sendable-compatible value for Jinja chat templates.
+    /// Null values are dropped from dictionaries because Jinja's `Value(any:)` cannot
+    /// handle `NSNull` and throws a runtime error. JSON Schema treats a missing key
+    /// the same as `null`, so this is semantically lossless for tool specs.
     var sendableValue: any Sendable {
         switch self {
         case .null:
@@ -650,13 +653,35 @@ extension JSONValue {
             return arr.map { $0.sendableValue }
         case .object(let obj):
             var dict: [String: any Sendable] = [:]
-            for (k, v) in obj { dict[k] = v.sendableValue }
+            for (k, v) in obj {
+                if case .null = v { continue }
+                dict[k] = v.sendableValue
+            }
             return dict
         }
     }
 
-    /// Convert JSONValue to Foundation JSON-compatible Any (for JSONSerialization)
-    var anyValue: Any { sendableValue }
+    /// Convert JSONValue to Foundation JSON-compatible Any (for JSONSerialization).
+    /// Unlike `sendableValue`, this preserves null as `NSNull` in dictionaries
+    /// since `JSONSerialization` handles it correctly.
+    var anyValue: Any {
+        switch self {
+        case .null:
+            return NSNull()
+        case .bool(let b):
+            return b
+        case .number(let n):
+            return n
+        case .string(let s):
+            return s
+        case .array(let arr):
+            return arr.map { $0.anyValue }
+        case .object(let obj):
+            var dict: [String: Any] = [:]
+            for (k, v) in obj { dict[k] = v.anyValue }
+            return dict
+        }
+    }
 }
 
 extension ToolFunction {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
@@ -33,7 +33,19 @@ struct MLXGenerationEngine {
                 prefillStep: runtime.prefillStep
             )
             let fullInput = MLXLMCommon.UserInput(chat: chat, processing: .init(), tools: toolsSpec)
-            let fullLMInput = try await context.processor.prepare(input: fullInput)
+            let fullLMInput: LMInput
+            do {
+                fullLMInput = try await context.processor.prepare(input: fullInput)
+            } catch {
+                let detail =
+                    (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+                throw NSError(
+                    domain: "MLXGenerationEngine",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Chat template error: \(detail)"]
+                )
+            }
 
             var contextWithEOS = context
             let existing = context.configuration.extraEOSTokens

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
-        "version" : "2.3.1"
+        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
+        "version" : "2.3.2"
       }
     },
     {


### PR DESCRIPTION
## Summary

Related to #567 , null values in JSON Schema dictionaries are now skipped during sendableValue conversion, preventing `NSNull()` from reaching `Jinja.Value(any:)` which can't handle it.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
