### PR TITLE
added image resize config for MLX vision input

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
@@ -8,8 +8,38 @@
 import Foundation
 import MLXLLM
 import MLXLMCommon
+import CoreImage
+import MLXVLM
 
 struct MLXGenerationEngine {
+    
+    private static let maxImageSize = CGSize(width: 1024, height: 1024)
+    
+    private static func downscaleIfNeeded(_ image: CIImage) -> CIImage {
+        let scale = min(MediaProcessing.bestFitScale(image.extent.size, in: maxImageSize), 1.0)
+        guard scale < 1.0 else { return image }
+        return image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+    }
+    
+    private static func preprocessImages(in chat: [MLXLMCommon.Chat.Message]) -> [MLXLMCommon.Chat.Message] {
+        chat.map { message in
+            let processedImages = message.images.map { userInputImage -> UserInput.Image in
+                switch userInputImage {
+                case .ciImage(let ciImage):
+                    return .ciImage(downscaleIfNeeded(ciImage))
+                default:
+                    return userInputImage
+                }
+            }
+            return MLXLMCommon.Chat.Message(
+                role: message.role,
+                content: message.content,
+                images: processedImages,
+                videos: message.videos
+            )
+        }
+    }
+    
     static func prepareAndGenerate(
         container: ModelContainer,
         buildChat: @Sendable () -> [MLXLMCommon.Chat.Message],
@@ -19,7 +49,7 @@ struct MLXGenerationEngine {
     ) async throws -> AsyncStream<MLXLMCommon.Generation> {
         let stream: AsyncStream<MLXLMCommon.Generation> = try await container.perform {
             (context: MLXLMCommon.ModelContext) in
-            let chat = buildChat()
+            let chat = preprocessImages(in: buildChat())
             let toolsSpec = buildToolsSpec()
             let parameters = ModelRuntime.makeGenerateParameters(
                 temperature: generation.temperature ?? 0.7,
@@ -32,8 +62,7 @@ struct MLXGenerationEngine {
                 maxKV: runtime.maxKV,
                 prefillStep: runtime.prefillStep
             )
-            let imageResizeConfig: UserInput.Processing = .init(resize: CGSize(width: 1024, height: 1024))
-            let fullInput = MLXLMCommon.UserInput(chat: chat, processing: imageResizeConfig, tools: toolsSpec)
+            let fullInput = MLXLMCommon.UserInput(chat: chat, processing: .init(), tools: toolsSpec)
             let fullLMInput: LMInput
             do {
                 fullLMInput = try await context.processor.prepare(input: fullInput)


### PR DESCRIPTION
## Summary

enforce a fixed image resize config for MLX vision models to avoid fatal crash due to maximum allowed buffer size. fixes [#634](https://github.com/osaurus-ai/osaurus/issues/632)

## Test Plan
1. Select an MLX vision model
2. Select a high resolution image and tap send
3. The app must run without crashing

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
