### PR TITLE
prioritize custom auth headers & prevent automatic overwrite in remote providers

### DIFF
--- a/Packages/OsaurusCore/Models/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/RemoteProviderConfiguration.swift
@@ -230,15 +230,21 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         if authType == .apiKey, let apiKey = getAPIKey(), !apiKey.isEmpty {
             switch providerType {
             case .anthropic:
-                headers["x-api-key"] = apiKey
+                if headers["x-api-key"] == nil {
+                    headers["x-api-key"] = apiKey
+                }
                 // Add required Anthropic version header if not already set
                 if headers["anthropic-version"] == nil {
                     headers["anthropic-version"] = "2023-06-01"
                 }
             case .gemini:
-                headers["x-goog-api-key"] = apiKey
+                if headers["x-goog-api-key"] == nil {
+                    headers["x-goog-api-key"] = apiKey
+                }
             case .openai, .openResponses:
-                headers["Authorization"] = "Bearer \(apiKey)"
+                if headers["Authorization"] == nil {
+                    headers["Authorization"] = "Bearer \(apiKey)"
+                }
             }
         }
 

--- a/Packages/OsaurusCore/Services/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Services/RemoteProviderManager.swift
@@ -348,15 +348,21 @@ public final class RemoteProviderManager: ObservableObject {
         if authType == .apiKey, let apiKey = apiKey, !apiKey.isEmpty {
             switch providerType {
             case .anthropic:
-                testHeaders["x-api-key"] = apiKey
+                if testHeaders["x-api-key"] == nil {
+                    testHeaders["x-api-key"] = apiKey
+                }
                 // Add required Anthropic version header if not already set
                 if testHeaders["anthropic-version"] == nil {
                     testHeaders["anthropic-version"] = "2023-06-01"
                 }
             case .gemini:
-                testHeaders["x-goog-api-key"] = apiKey
+                if testHeaders["x-goog-api-key"] == nil {
+                    testHeaders["x-goog-api-key"] = apiKey
+                }
             case .openai, .openResponses:
-                testHeaders["Authorization"] = "Bearer \(apiKey)"
+                if testHeaders["Authorization"] == nil {
+                    testHeaders["Authorization"] = "Bearer \(apiKey)"
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes an authentication bug where manually provided Authorization headers (defined in Advanced > Custom Headers) were being silently overwritten by the automatic Bearer token generation during chat requests. This was causing HTTP 401 errors for providers like OpenRouter that require specific header configurations.

## Changes
  - Updated `RemoteProvider.resolvedHeaders()` to only apply default authentication headers if the user hasn't already provided a custom override for that specific header.
  - Applied the same prioritization logic to the "Test Connection" method in `RemoteProviderManager` to ensure the settings test accurately reflects actual chat behavior.
  - Also improved compatibility for Anthropic (x-api-key) and Gemini (x-goog-api-key) by ensuring their automatic headers also respect manual overrides.

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

- Add OpenRouter as a provider and specify a custom Authorization header in Advanced > Custom Headers. Verify the request uses the manual header instead of the default Bearer format.
- Confirm that both the "Test Connection" button in Settings and actual Chat completions succeed with the same custom header configuration.
- Verify that custom x-api-key (Anthropic) and x-goog-api-key (Gemini) headers are also respected as manual overrides
- Ensure that custom headers marked as "Secret" are correctly retrieved and applied during chat sessions.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+