### PR TITLE
fix sandbox plugin modal overflow

### DIFF
--- a/Packages/OsaurusCore/Views/SandboxView.swift
+++ b/Packages/OsaurusCore/Views/SandboxView.swift
@@ -1051,6 +1051,7 @@ private struct SandboxProvisionSheet: View {
                     .buttonStyle(.plain)
                     .foregroundColor(theme.secondaryText)
                     .font(.system(size: 13, weight: .medium))
+                    .keyboardShortcut(.escape, modifiers: [])
 
                 Spacer()
 
@@ -1069,6 +1070,7 @@ private struct SandboxProvisionSheet: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .keyboardShortcut(.return, modifiers: .command)
             }
             .padding(20)
         }
@@ -1779,37 +1781,37 @@ private struct SandboxInstallSheet: View {
 
             Divider().foregroundColor(theme.cardBorder)
 
-            VStack(alignment: .leading, spacing: 20) {
-                SandboxPluginHeader(plugin: plugin)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    SandboxPluginHeader(plugin: plugin)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("SELECT AGENTS")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(theme.secondaryText)
-                        .tracking(0.5)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("SELECT AGENTS")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundColor(theme.secondaryText)
+                            .tracking(0.5)
 
-                    VStack(spacing: 0) {
-                        ForEach(agents, id: \.id) { agent in
-                            agentRow(agent: agent, isInstalled: installedAgentIds.contains(agent.id))
-                            if agent.id != agents.last?.id {
-                                Divider().foregroundColor(theme.cardBorder)
+                        VStack(spacing: 0) {
+                            ForEach(agents, id: \.id) { agent in
+                                agentRow(agent: agent, isInstalled: installedAgentIds.contains(agent.id))
+                                if agent.id != agents.last?.id {
+                                    Divider().foregroundColor(theme.cardBorder)
+                                }
                             }
                         }
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(theme.inputBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(theme.inputBorder, lineWidth: 1)
+                                )
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                     }
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.inputBackground)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(theme.inputBorder, lineWidth: 1)
-                            )
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
+                .padding(20)
             }
-            .padding(20)
-
-            Spacer()
 
             Divider().foregroundColor(theme.cardBorder)
 
@@ -1818,6 +1820,7 @@ private struct SandboxInstallSheet: View {
                     .buttonStyle(.plain)
                     .foregroundColor(theme.secondaryText)
                     .font(.system(size: 13, weight: .medium))
+                    .keyboardShortcut(.escape, modifiers: [])
 
                 Spacer()
 
@@ -1843,6 +1846,7 @@ private struct SandboxInstallSheet: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(newSelectionCount == 0)
+                .keyboardShortcut(.return, modifiers: .command)
             }
             .padding(20)
         }
@@ -1937,58 +1941,58 @@ private struct SandboxManageInstallsSheet: View {
 
             Divider().foregroundColor(theme.cardBorder)
 
-            VStack(alignment: .leading, spacing: 20) {
-                SandboxPluginHeader(plugin: plugin)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    SandboxPluginHeader(plugin: plugin)
 
-                if let error = errorMessage {
-                    HStack(spacing: 6) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 11))
-                        Text(error)
-                            .font(.system(size: 11))
-                            .lineLimit(2)
+                    if let error = errorMessage {
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 11))
+                            Text(error)
+                                .font(.system(size: 11))
+                                .lineLimit(2)
+                        }
+                        .foregroundColor(theme.warningColor)
                     }
-                    .foregroundColor(theme.warningColor)
-                }
 
-                if agentInstalls.isEmpty {
-                    VStack(spacing: 8) {
-                        Text("Not installed on any agents")
-                            .font(.system(size: 13))
-                            .foregroundColor(theme.secondaryText)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 20)
-                } else {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("INSTALLED ON")
-                            .font(.system(size: 11, weight: .bold))
-                            .foregroundColor(theme.secondaryText)
-                            .tracking(0.5)
+                    if agentInstalls.isEmpty {
+                        VStack(spacing: 8) {
+                            Text("Not installed on any agents")
+                                .font(.system(size: 13))
+                                .foregroundColor(theme.secondaryText)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 20)
+                    } else {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("INSTALLED ON")
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundColor(theme.secondaryText)
+                                .tracking(0.5)
 
-                        VStack(spacing: 0) {
-                            ForEach(agentInstalls, id: \.0.id) { agent, installed, outdated in
-                                manageRow(agent: agent, installed: installed, isOutdated: outdated)
-                                if agent.id != agentInstalls.last?.0.id {
-                                    Divider().foregroundColor(theme.cardBorder)
+                            VStack(spacing: 0) {
+                                ForEach(agentInstalls, id: \.0.id) { agent, installed, outdated in
+                                    manageRow(agent: agent, installed: installed, isOutdated: outdated)
+                                    if agent.id != agentInstalls.last?.0.id {
+                                        Divider().foregroundColor(theme.cardBorder)
+                                    }
                                 }
                             }
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(theme.inputBackground)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .stroke(theme.inputBorder, lineWidth: 1)
+                                    )
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
                         }
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.inputBackground)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(theme.inputBorder, lineWidth: 1)
-                                )
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
                     }
                 }
+                .padding(20)
             }
-            .padding(20)
-
-            Spacer()
 
             Divider().foregroundColor(theme.cardBorder)
 
@@ -2006,6 +2010,7 @@ private struct SandboxManageInstallsSheet: View {
                             )
                     }
                     .buttonStyle(.plain)
+                    .keyboardShortcut(.return, modifiers: .command)
                 }
 
                 Spacer()
@@ -2014,6 +2019,7 @@ private struct SandboxManageInstallsSheet: View {
                     .buttonStyle(.plain)
                     .foregroundColor(theme.secondaryText)
                     .font(.system(size: 13, weight: .medium))
+                    .keyboardShortcut(.escape, modifiers: [])
             }
             .padding(20)
         }


### PR DESCRIPTION
## Summary

This PR fixes a UI bug which is causing the Install button and header elements to be inaccessible in the "Select Agents" modal when there are 8 or more agents. Fixes #653 

## Changes
  - Wrapped agent lists in `SandboxInstallSheet` and `SandboxManageInstallsSheet` with a ScrollView
  - Pinned the header to ensure they remain visible regardless of list length
  - Added cmd+return keyboard shortcut for primary actions (Install/Reinstall) and escape for dismissal across all sandbox sheets

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

   - Create 8+ agents and verify that the `SandboxInstallSheet` now displays a scrollbar and the "Install" button remains visible at the bottom.
   - Confirm that the "X" button and "Cancel" buttons are always accessible and functional even when scrolling the agent list.
   - Verify that pressing cmd+return triggers the installation and closes the modal.
   - Verify that pressing escape dismisses the modal immediately.
   - Verify "Manage Installations" and "Sandbox Provision" sheets also correctly handle their content and respect the new keyboard shortcuts.

## Screenshots

Before

<img width="493" height="495" alt="SELECT AGENTS" src="https://github.com/user-attachments/assets/767f1059-afbf-43f1-8e41-1a7ff815623f" />

After

https://github.com/user-attachments/assets/e3c798aa-7209-449a-8aa4-d9704712f292

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
