### PR TITLE
add support for cron expression scheduling

### DIFF
--- a/Packages/OsaurusCore/Models/Schedule.swift
+++ b/Packages/OsaurusCore/Models/Schedule.swift
@@ -25,6 +25,8 @@ public enum ScheduleFrequency: Codable, Sendable, Equatable, Hashable {
     case monthly(dayOfMonth: Int, hour: Int, minute: Int)
     /// Run yearly on a specific month and day at a specific time
     case yearly(month: Int, day: Int, hour: Int, minute: Int)
+    /// Run based on a cron expression (e.g., "15 0,7 * * 1-5")
+    case cron(expression: String)
 
     // MARK: - Display Helpers
 
@@ -60,6 +62,9 @@ public enum ScheduleFrequency: Codable, Sendable, Equatable, Hashable {
             let monthName = calendar.monthSymbols[month - 1]
             let suffix = daySuffix(day)
             return "Yearly on \(monthName) \(day)\(suffix) at \(timeString(hour: hour, minute: minute))"
+
+        case .cron(let expression):
+            return "Cron: \(expression)"
         }
     }
 
@@ -80,6 +85,8 @@ public enum ScheduleFrequency: Codable, Sendable, Equatable, Hashable {
             return "Monthly"
         case .yearly:
             return "Yearly"
+        case .cron:
+            return "Cron"
         }
     }
 
@@ -93,6 +100,7 @@ public enum ScheduleFrequency: Codable, Sendable, Equatable, Hashable {
         case .weekly: return .weekly
         case .monthly: return .monthly
         case .yearly: return .yearly
+        case .cron: return .cron
         }
     }
 
@@ -220,6 +228,9 @@ public enum ScheduleFrequency: Codable, Sendable, Equatable, Hashable {
                 return calendar.date(from: components)
             }
             return candidate
+
+        case .cron(let expression):
+            return CronParser(expression)?.nextDate(after: referenceDate)
         }
     }
 
@@ -277,6 +288,7 @@ public enum ScheduleFrequencyType: String, CaseIterable, Sendable {
     case weekly = "Weekly"
     case monthly = "Monthly"
     case yearly = "Yearly"
+    case cron = "Cron Expression"
 
     public var icon: String {
         switch self {
@@ -287,6 +299,7 @@ public enum ScheduleFrequencyType: String, CaseIterable, Sendable {
         case .weekly: return "calendar.badge.clock"
         case .monthly: return "calendar"
         case .yearly: return "calendar.badge.exclamationmark"
+        case .cron: return "terminal"
         }
     }
 }

--- a/Packages/OsaurusCore/Utils/CronParser.swift
+++ b/Packages/OsaurusCore/Utils/CronParser.swift
@@ -1,0 +1,189 @@
+//
+//  CronParser.swift
+//  osaurus
+//
+//  A simple, dependency-free cron expression parser for Osaurus.
+//  Supports: * , - / and standard 5-field format.
+//
+
+import Foundation
+
+public struct CronParser: Sendable {
+    private let minute: Set<Int>
+    private let hour: Set<Int>
+    private let dayOfMonth: Set<Int>
+    private let month: Set<Int>
+    private let dayOfWeek: Set<Int>
+    
+    // whether dayOfMonth or dayOfWeek are restricted (not '*')
+    private let domRestricted: Bool
+    private let dowRestricted: Bool
+
+    /// initialize with a standard 5-field cron expression
+    /// format: minute hour day-of-month month day-of-week
+    public init?(_ expression: String) {
+        let components = expression.split(separator: " ").map(String.init)
+        guard components.count == 5 else { return nil }
+
+        guard let m = Self.parseField(components[0], min: 0, max: 59),
+              let h = Self.parseField(components[1], min: 0, max: 23),
+              let dom = Self.parseField(components[2], min: 1, max: 31),
+              let mon = Self.parseField(components[3], min: 1, max: 12),
+              let dow = Self.parseField(components[4], min: 0, max: 6) else { // 0=Sunday, 6=Saturday
+            return nil
+        }
+
+        self.minute = m
+        self.hour = h
+        self.dayOfMonth = dom
+        self.month = mon
+        self.dayOfWeek = dow
+        
+        self.domRestricted = components[2] != "*"
+        self.dowRestricted = components[4] != "*"
+    }
+
+    /// calculate the next matching date after the reference date
+    public func nextDate(after referenceDate: Date) -> Date? {
+        let calendar = Calendar.current
+        
+        // start checking from the next minute
+        guard let start = calendar.date(byAdding: .minute, value: 1, to: referenceDate) else { return nil }
+        
+        // truncate to the minute
+        var components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: start)
+        components.second = 0
+        guard var current = calendar.date(from: components) else { return nil }
+        
+        // limit search to 5 years to prevent infinite loops
+        let limit = calendar.date(byAdding: .year, value: 5, to: current)!
+        
+        while current < limit {
+            let comps = calendar.dateComponents([.month, .day, .hour, .minute, .weekday], from: current)
+            
+            // 1. check Month
+            guard let m = comps.month, month.contains(m) else {
+                guard let next = calendar.date(byAdding: .month, value: 1, to: current) else { return nil }
+                current = firstOfNextMonth(next, calendar: calendar)
+                continue
+            }
+            
+            // 2. check Day (standard cron logic: if both DOM and DOW are restricted, it's an OR)
+            let d = comps.day!
+            // calendar weekday is 1-7 (sun-sat), cron is 0-6
+            let w = comps.weekday! - 1
+            
+            let domMatch = dayOfMonth.contains(d)
+            let dowMatch = dayOfWeek.contains(w)
+            
+            let dayMatch: Bool
+            if domRestricted && dowRestricted {
+                dayMatch = domMatch || dowMatch
+            } else {
+                dayMatch = domMatch && dowMatch
+            }
+            
+            if !dayMatch {
+                guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { return nil }
+                current = firstOfNextDay(next, calendar: calendar)
+                continue
+            }
+            
+            // 3. check Hour
+            guard let h = comps.hour, hour.contains(h) else {
+                guard let next = calendar.date(byAdding: .hour, value: 1, to: current) else { return nil }
+                current = firstOfNextHour(next, calendar: calendar)
+                continue
+            }
+            
+            // 4. check Minute
+            guard let minVal = comps.minute, minute.contains(minVal) else {
+                guard let next = calendar.date(byAdding: .minute, value: 1, to: current) else { return nil }
+                current = next
+                continue
+            }
+            
+            return current
+        }
+        
+        return nil
+    }
+
+    // MARK: - Helper Methods for Jumping
+
+    private func firstOfNextMonth(_ date: Date, calendar: Calendar) -> Date {
+        var comps = calendar.dateComponents([.year, .month], from: date)
+        comps.day = 1
+        comps.hour = 0
+        comps.minute = 0
+        comps.second = 0
+        return calendar.date(from: comps)!
+    }
+
+    private func firstOfNextDay(_ date: Date, calendar: Calendar) -> Date {
+        var comps = calendar.dateComponents([.year, .month, .day], from: date)
+        comps.hour = 0
+        comps.minute = 0
+        comps.second = 0
+        return calendar.date(from: comps)!
+    }
+
+    private func firstOfNextHour(_ date: Date, calendar: Calendar) -> Date {
+        var comps = calendar.dateComponents([.year, .month, .day, .hour], from: date)
+        comps.minute = 0
+        comps.second = 0
+        return calendar.date(from: comps)!
+    }
+
+    // MARK: - Parser Logic
+
+    private static func parseField(_ field: String, min: Int, max: Int) -> Set<Int>? {
+        var result = Set<Int>()
+        let parts = field.split(separator: ",")
+        
+        for part in parts {
+            let partStr = String(part)
+            if partStr == "*" {
+                for i in min...max { result.insert(i) }
+            } else if partStr.contains("/") {
+                let stepParts = partStr.split(separator: "/")
+                guard stepParts.count == 2 else { return nil }
+                let rangeStr = String(stepParts[0])
+                guard let step = Int(stepParts[1]) else { return nil }
+                
+                let range: ClosedRange<Int>
+                if rangeStr == "*" {
+                    range = min...max
+                } else {
+                    guard let r = parseRange(rangeStr, min: min, max: max) else { return nil }
+                    range = r
+                }
+                
+                var i = range.lowerBound
+                while i <= range.upperBound {
+                    result.insert(i)
+                    i += step
+                }
+            } else if let range = parseRange(partStr, min: min, max: max) {
+                for i in range { result.insert(i) }
+            } else {
+                return nil
+            }
+        }
+        
+        return result.isEmpty ? nil : result
+    }
+
+    private static func parseRange(_ rangeStr: String, min: Int, max: Int) -> ClosedRange<Int>? {
+        let parts = rangeStr.split(separator: "-")
+        if parts.count == 1 {
+            guard let val = Int(parts[0]), val >= min, val <= max else { return nil }
+            return val...val
+        } else if parts.count == 2 {
+            guard let start = Int(parts[0]), let end = Int(parts[1]),
+                  start >= min, end <= max, start <= end else { return nil }
+            return start...end
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Views/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/SchedulesView.swift
@@ -1512,6 +1512,7 @@ struct ScheduleEditorSheet: View {
     @State private var selectedMonth = 1
     @State private var selectedDay = 1
     @State private var selectedDate = Date()
+    @State private var cronExpression = "0 9 * * *"
     @State private var hasAppeared = false
     @Namespace private var modeNamespace
 
@@ -1961,7 +1962,46 @@ struct ScheduleEditorSheet: View {
             monthlyOptions
         case .yearly:
             yearlyOptions
+        case .cron:
+            cronOptions
         }
+    }
+
+    private var cronOptions: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Cron Expression")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+
+                ScheduleTextField(
+                    placeholder: "e.g., 15 0,7 * * 1-5",
+                    text: $cronExpression,
+                    icon: "terminal"
+                )
+            }
+
+            Text("Format: minute hour day-of-month month day-of-week")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+
+            Text("Supports standard 5 field format with * , - and / operators")
+                .font(.system(size: 10))
+                .foregroundColor(theme.tertiaryText)
+
+            if let nextRun = CronParser(cronExpression)?.nextDate(after: Date()) {
+                schedulePreview(text: "Next run: \(formattedDate(nextRun))")
+            } else {
+                schedulePreview(text: "Invalid cron expression", isError: true)
+            }
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
     }
 
     private var onceOptions: some View {
@@ -2301,19 +2341,19 @@ struct ScheduleEditorSheet: View {
     }
 
     // Helper view for schedule preview
-    private func schedulePreview(text: String) -> some View {
+    private func schedulePreview(text: String, isError: Bool = false) -> some View {
         HStack(spacing: 10) {
-            Image(systemName: "repeat")
+            Image(systemName: isError ? "exclamationmark.triangle.fill" : "repeat")
                 .font(.system(size: 14, weight: .medium))
-                .foregroundColor(theme.accentColor)
+                .foregroundColor(isError ? theme.errorColor : theme.accentColor)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("Schedule")
+                Text(isError ? "Error" : "Schedule")
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(theme.tertiaryText)
+                    .foregroundColor(isError ? theme.errorColor : theme.tertiaryText)
                 Text(text)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(theme.primaryText)
+                    .foregroundColor(isError ? theme.errorColor : theme.primaryText)
             }
 
             Spacer()
@@ -2321,10 +2361,10 @@ struct ScheduleEditorSheet: View {
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 10)
-                .fill(theme.accentColor.opacity(0.08))
+                .fill((isError ? theme.errorColor : theme.accentColor).opacity(0.08))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
-                        .stroke(theme.accentColor.opacity(0.2), lineWidth: 1)
+                        .stroke((isError ? theme.errorColor : theme.accentColor).opacity(0.2), lineWidth: 1)
                 )
         )
     }
@@ -2415,9 +2455,11 @@ struct ScheduleEditorSheet: View {
             selectedDay = day
             selectedHour = hour
             selectedMinute = minute
+        case .cron(let expression):
+            cronExpression = expression
         }
     }
-
+    
     private func buildFrequency() -> ScheduleFrequency {
         switch frequencyType {
         case .once:
@@ -2434,6 +2476,8 @@ struct ScheduleEditorSheet: View {
             return .monthly(dayOfMonth: selectedDayOfMonth, hour: selectedHour, minute: selectedMinute)
         case .yearly:
             return .yearly(month: selectedMonth, day: selectedDay, hour: selectedHour, minute: selectedMinute)
+        case .cron:
+            return .cron(expression: cronExpression)
         }
     }
 


### PR DESCRIPTION
## Summary

This PR introduces a cron based frequency option (standard 5-field cron syntax with all common operators) for automated tasks to consolidate recurring schedules into a single entry. Closes #672 

## Changes

- Added a native `CronParser` utility supporting minute, hour, day-of-month, month, and day-of-week fields with *, ,, -, and / operators.
- Extended `ScheduleFrequency` and `ScheduleFrequencyType` to support the new cron case (backward compatibility for existing schedules has been ensured)
-  Updated the Schedule Editor with a dedicated Cron Expression field with a live "Next run" preview and validation warnings for invalid expressions
- `ScheduleManager` ensures that cron-based tasks respect system timezone changes and app sleep/wake cycles

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Screenshots

<img width="531" height="375" alt="• FREQUENCY" src="https://github.com/user-attachments/assets/cd729879-4840-4c26-9134-da3d5b580006" />


## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
