### PR TITLE
fix: Telegram plugin not working after restart

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -158,7 +158,34 @@ final class PluginManager {
         }
 
         migrateGlobalConfigToPerAgent()
+        notifyNewPluginsWithAgentConfig(from: scanResult)
         observeTunnelStatus()
+    }
+
+    /// For each newly loaded plugin, re-deliver its config under the primary
+    /// agent context. `initPlugin` runs before any agent is wired up, so
+    /// `configGet` falls back to `Agent.defaultId` and misses secrets stored
+    /// under custom agents. Sending the batch here corrects that.
+    private func notifyNewPluginsWithAgentConfig(from scanResult: PluginScanResult) {
+        for entry in scanResult.loadResults {
+            guard case .success(let loaded) = entry.result else { continue }
+            let pluginId = loaded.plugin.id
+            guard let agentId = AgentManager.shared.primaryAgent(forPlugin: pluginId),
+                let configSpec = loaded.plugin.manifest.capabilities.config,
+                let hostCtx = PluginHostContext.getContext(for: pluginId)
+            else { continue }
+
+            hostCtx.currentAgentId = agentId
+            let changes: [(key: String, value: String)] = configSpec.sections
+                .flatMap { $0.fields }
+                .compactMap { field in
+                    guard let value = ToolSecretsKeychain.getSecret(
+                        id: field.key, for: pluginId, agentId: agentId),
+                        !value.isEmpty else { return nil }
+                    return (key: field.key, value: value)
+                }
+            loaded.plugin.notifyConfigBatch(changes)
+        }
     }
 
     // MARK: - One-Time Migration (global config → per-agent)


### PR DESCRIPTION

## Summary
initPlugin() in the plugin runs with no agent context, any configuration loaded is from Default agent, so botToken stays nill.

We set the Agent context properly and re-notify all plugins

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

Set up Telegram plugin, check if Plugin works, restart Osaurus, check if Telegram works

## Screenshots

If UI updated, add before/after.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
