### PR TITLE
ensure menu bar panel and windows are visible over full screen apps

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -654,6 +654,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         self.popover = popover
 
         popover.show(relativeTo: statusButton.bounds, of: statusButton, preferredEdge: .minY)
+
+        // ensure popover window can join all spaces and appear over full screen apps
+        if let popoverWindow = popover.contentViewController?.view.window {
+            popoverWindow.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        }
+
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -885,6 +891,7 @@ extension AppDelegate {
         window.contentViewController = hostingController
         window.center()
         window.isReleasedWhenClosed = false
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         Self.acknowledgementsWindow = window
 
@@ -958,6 +965,7 @@ extension AppDelegate {
         window.standardWindowButton(.zoomButton)?.isHidden = true
         window.backgroundColor = NSColor(themeManager.currentTheme.primaryBackground)
         window.isMovableByWindowBackground = true
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         Self.onboardingWindow = window
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -470,6 +470,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         panel.hidesOnDeactivate = false
         panel.worksWhenModal = true
         panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
         panel.titleVisibility = .hidden
         panel.titlebarAppearsTransparent = true


### PR DESCRIPTION
## Summary

This PR fixes a bug where the osaurus menu bar popover was restricted to the standard desktop space and did not appear in full screen mode.  Closes #696.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

- Maximize any app (like Safari or Xcode) into Full Screen mode
- Reveal the macOS menu bar and click the Osaurus icon
- Verify the osaurus status panel opens on top of the full screen app instead of remaining hidden on the desktop space

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
