### PR TITLE
smart toggle logic for global chat hotkey

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -200,7 +200,11 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     /// Toggle the last focused window (or create new if none exist)
     public func toggleLastFocused() {
         if let lastId = lastFocusedWindowId, let window = nsWindows[lastId] {
-            if window.isVisible {
+            // smart toggle: only hide if the window is already visible, frontmost, and the app is active
+            // otherwise, toggling should just bring it to the front
+            let isFrontmost = window.isVisible && window.isKeyWindow && NSApp.isActive
+
+            if isFrontmost {
                 hideWindow(id: lastId)
             } else {
                 showWindow(id: lastId)


### PR DESCRIPTION
## Summary

Improved the behavior of the global chat hotkey to be state aware. Instead of a simple visibility toggle, the hotkey now ensures the chat window is brought to the front if it is currently buried or inactive. The window will only be hidden if it is already the frontmost active window so that accidental closures are prevented when the user intended to simply focus the app. Closes #686.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

- Press hotkey when closed → verify window opens and focuses
- Open window, then focus another app → press hotkey → verify window comes to front/focuses
- Press hotkey while window is already frontmost and active → verify window hides
- Switch to a different desktop space → press hotkey → verify window follows to current space and focuses

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
