### PR TITLE
Add InferenceProgressManager for tracking MLX prefill/generation progress

### DIFF
--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -1,0 +1,57 @@
+//
+//  InferenceProgressManager.swift
+//  osaurus
+//
+//  Observable singleton that broadcasts prefill progress so the UI can show
+//  "Processing N tokens…" while the GPU is doing its initial prompt forward pass.
+//
+
+import Foundation
+
+/// Singleton observable that tracks in-flight prefill progress.
+///
+/// Stored-property mutations are always dispatched to the MainActor so that
+/// SwiftUI bindings are updated correctly.  Call sites that are NOT on the
+/// MainActor use the fire-and-forget `*Async` variants.
+final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
+    static let shared = InferenceProgressManager()
+
+    /// Non-nil while a prefill is in progress.  Set to the prompt token count
+    /// just before `prepareAndGenerate` is called; cleared as soon as the first
+    /// generated token arrives (or on error / cancellation).
+    @MainActor @Published var prefillTokenCount: Int? = nil
+
+    /// Wall-clock time when the current prefill started.
+    @MainActor @Published var prefillStartedAt: Date? = nil
+
+    init() {}
+
+    #if DEBUG
+        /// Test-only factory: creates an isolated instance so tests don't share
+        /// state with the `shared` singleton.
+        static func _testMake() -> InferenceProgressManager { InferenceProgressManager() }
+    #endif
+
+    /// Called from the MainActor just before prefill begins.
+    @MainActor func prefillWillStart(tokenCount: Int) {
+        if prefillTokenCount == nil { prefillStartedAt = Date() }
+        prefillTokenCount = tokenCount
+    }
+
+    /// Called from the MainActor when the first token is generated (prefill done)
+    /// or on error / cancellation.
+    @MainActor func prefillDidFinish() {
+        prefillTokenCount = nil
+        prefillStartedAt = nil
+    }
+
+    /// Fire-and-forget variant for call sites that are not on MainActor.
+    func prefillWillStartAsync(tokenCount: Int) {
+        Task { @MainActor in self.prefillWillStart(tokenCount: tokenCount) }
+    }
+
+    /// Fire-and-forget variant for call sites that are not on MainActor.
+    func prefillDidFinishAsync() {
+        Task { @MainActor in self.prefillDidFinish() }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
@@ -1,0 +1,105 @@
+//
+//  InferenceProgressManagerTests.swift
+//  osaurusTests
+//
+//  Tests for InferenceProgressManager — the observable singleton that
+//  broadcasts prefill progress to the typing indicator UI.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Tests
+
+@MainActor
+struct InferenceProgressManagerTests {
+
+    // Each test creates an isolated InferenceProgressManager via _testMake() so
+    // tests don't share state with the global .shared singleton.
+
+    // MARK: prefillWillStart
+
+    @Test func prefillWillStart_setsPrefillTokenCount() {
+        let state = InferenceProgressManager._testMake()
+        state.prefillWillStart(tokenCount: 42)
+        #expect(state.prefillTokenCount == 42)
+    }
+
+    @Test func prefillWillStart_setsPrefillStartedAt() {
+        let state = InferenceProgressManager._testMake()
+        let before = Date()
+        state.prefillWillStart(tokenCount: 10)
+        let after = Date()
+        guard let startedAt = state.prefillStartedAt else {
+            Issue.record("prefillStartedAt should be non-nil after prefillWillStart")
+            return
+        }
+        #expect(startedAt >= before)
+        #expect(startedAt <= after)
+    }
+
+    @Test func prefillWillStart_withZeroCount_showsIndeterminate() {
+        let state = InferenceProgressManager._testMake()
+        state.prefillWillStart(tokenCount: 0)
+        #expect(state.prefillTokenCount == 0)
+        #expect(state.prefillStartedAt != nil)
+    }
+
+    // MARK: prefillWillStart (second call — count update, preserve startedAt)
+
+    @Test func prefillWillStart_secondCall_updatesCountButPreservesStartedAt() {
+        let state = InferenceProgressManager._testMake()
+        state.prefillWillStart(tokenCount: 0)
+        let firstStartedAt = state.prefillStartedAt
+
+        // Call again with the real count (simulating post-prepareAndGenerate update).
+        state.prefillWillStart(tokenCount: 1234)
+
+        #expect(state.prefillTokenCount == 1234)
+        // startedAt must not have been reset on the second call.
+        #expect(state.prefillStartedAt == firstStartedAt)
+    }
+
+    // MARK: prefillDidFinish
+
+    @Test func prefillDidFinish_clearsPrefillTokenCount() {
+        let state = InferenceProgressManager._testMake()
+        state.prefillWillStart(tokenCount: 99)
+        state.prefillDidFinish()
+        #expect(state.prefillTokenCount == nil)
+    }
+
+    @Test func prefillDidFinish_clearsPrefillStartedAt() {
+        let state = InferenceProgressManager._testMake()
+        state.prefillWillStart(tokenCount: 99)
+        state.prefillDidFinish()
+        #expect(state.prefillStartedAt == nil)
+    }
+
+    @Test func prefillDidFinish_isIdempotent() {
+        let state = InferenceProgressManager._testMake()
+        // Called without a prior prefillWillStart — must not crash.
+        state.prefillDidFinish()
+        #expect(state.prefillTokenCount == nil)
+        #expect(state.prefillStartedAt == nil)
+    }
+
+    // MARK: round-trip
+
+    @Test func roundTrip_startThenFinishThenStartAgain() {
+        let state = InferenceProgressManager._testMake()
+
+        state.prefillWillStart(tokenCount: 100)
+        #expect(state.prefillTokenCount == 100)
+
+        state.prefillDidFinish()
+        #expect(state.prefillTokenCount == nil)
+
+        // Second round — startedAt should be reset on a fresh start.
+        state.prefillWillStart(tokenCount: 200)
+        #expect(state.prefillTokenCount == 200)
+        #expect(state.prefillStartedAt != nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `InferenceProgressManager` — a shared `@MainActor`-safe observable singleton in `Managers/` that `StreamAccumulator` updates during MLX inference and `TypingIndicator` observes for its progress bar UI.

This is a prerequisite for PRs #710 and #711.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Test Plan

```bash
xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug build-for-testing \
  CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

xcrun xctest .../OsaurusCoreTests.xctest 2>&1 | grep "InferenceProgressManager"
```

8 tests in `InferenceProgressManagerTests` covering: `prefillWillStart`, `prefillDidFinish`, state preservation across calls, idempotency, and round-trip transitions.

## Screenshots

N/A — no UI change.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+