### PR TITLE
perf(KVCacheStore): Phase 1 - make saveToDisk async to unblock inference

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
@@ -13,6 +13,12 @@ import MLX
 
 /// Manages per-session KV caches across a hot RAM tier and cold SSD tier.
 /// Must be used from within the `ModelRuntime` actor (not independently thread-safe).
+
+private final class CacheBox: @unchecked Sendable {
+    let cache: [any KVCache]
+    init(_ cache: [any KVCache]) { self.cache = cache }
+}
+
 struct KVCacheStore {
 
     // MARK: - Entry
@@ -60,6 +66,9 @@ struct KVCacheStore {
 
     /// Maximum total SSD cache size in bytes (default 4 GB)
     private let maxSSDBytes: Int = 4 * 1024 * 1024 * 1024
+
+    /// For tracking background disk writes in tests
+    var lastSaveTask: Task<Void, Never>?
 
     // MARK: - Budget
 
@@ -161,48 +170,48 @@ struct KVCacheStore {
             return
         }
 
-        // Save to SSD if not already persisted
+        // Save to SSD if not already persisted (saveToDisk calls pruneSSDIfNeeded internally)
         if entry.ssdPath == nil {
-            let url = ssdCacheDir.appendingPathComponent("\(sessionId).safetensors")
-            do {
-                var metadata = ["model": entry.modelName]
-                if let tokens = entry.tokens, let data = try? JSONEncoder().encode(tokens),
-                    let str = String(data: data, encoding: .utf8)
-                {
-                    metadata["tokens"] = str
-                }
-                try savePromptCache(url: url, cache: cache, metadata: metadata)
-                entry.ssdPath = url
-                print("[KVCacheStore] Saved session \(sessionId.prefix(8)) to SSD (\(entry.sizeBytes / 1024)KB)")
-            } catch {
-                print("[KVCacheStore] Failed to save SSD cache: \(error)")
-            }
+            saveToDisk(sessionId: sessionId, cache: cache, tokens: entry.tokens, modelName: entry.modelName)
         }
 
         totalHotBytes -= entry.sizeBytes
         entry.cache = nil
         entry.sizeBytes = 0
         lruOrder.removeAll { $0 == sessionId }
-
-        pruneSSDIfNeeded()
     }
 
-    /// Saves the given session's cache to SSD synchronously.
+    /// Saves the given session's cache to SSD asynchronously in a background task.
+    /// Sets `ssdPath` optimistically before the write completes so duplicate saves are avoided.
+    /// Also calls `pruneSSDIfNeeded()` synchronously after scheduling the write.
     mutating func saveToDisk(sessionId: String, cache: [any KVCache], tokens: [Int]?, modelName: String) {
         let url = ssdCacheDir.appendingPathComponent("\(sessionId).safetensors")
-        do {
-            var metadata = ["model": modelName]
-            if let tokens = tokens, let data = try? JSONEncoder().encode(tokens),
-                let str = String(data: data, encoding: .utf8)
-            {
-                metadata["tokens"] = str
+        let bytes = Self.cacheBytes(cache)
+        let start = Date()
+        
+        let box = CacheBox(cache)
+        
+        // Optimistically set the SSD path so we don't try to save it again
+        self.entries[sessionId]?.ssdPath = url
+        
+        let task = Task.detached(priority: .background) {
+            do {
+                var metadata = ["model": modelName]
+                if let tokens = tokens, let data = try? JSONEncoder().encode(tokens),
+                    let str = String(data: data, encoding: .utf8)
+                {
+                    metadata["tokens"] = str
+                }
+                try savePromptCache(url: url, cache: box.cache, metadata: metadata)
+                let durationMs = Date().timeIntervalSince(start) * 1000
+                print("[KVCacheStore] [BENCHMARK] Saved session \(sessionId.prefix(8)) to SSD (\(bytes / 1024)KB) asynchronously in \(String(format: "%.1f", durationMs))ms")
+            } catch {
+                let durationMs = Date().timeIntervalSince(start) * 1000
+                print("[KVCacheStore] [BENCHMARK] SSD save failed for \(sessionId.prefix(8)) after \(String(format: "%.1f", durationMs))ms: \(error)")
             }
-            try savePromptCache(url: url, cache: cache, metadata: metadata)
-            entries[sessionId]?.ssdPath = url
-            pruneSSDIfNeeded()
-        } catch {
-            print("[KVCacheStore] SSD save failed for \(sessionId.prefix(8)): \(error)")
         }
+        self.lastSaveTask = task
+        pruneSSDIfNeeded()
     }
 
     // MARK: - Invalidation
@@ -397,12 +406,7 @@ struct KVCacheStore {
         guard let entry = entries[sessionId] else { return }
 
         if saveSSD, entry.cache != nil, entry.ssdPath == nil {
-            let url = ssdCacheDir.appendingPathComponent("\(sessionId).safetensors")
-            do {
-                try savePromptCache(url: url, cache: entry.cache!, metadata: ["model": entry.modelName])
-            } catch {
-                // best-effort
-            }
+            saveToDisk(sessionId: sessionId, cache: entry.cache!, tokens: entry.tokens, modelName: entry.modelName)
         }
 
         if entry.cache != nil {

--- a/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
@@ -217,6 +217,28 @@ struct KVCacheStoreTests {
         #expect(!store.hasPrefixCache(modelName: "llama", hash: "h1"))
     }
 
+    // MARK: - Async behavior TDD
+
+    @Test func saveToDiskIsNonBlocking() async throws {
+        var store = KVCacheStore()
+        let cache = makeCache()
+        
+        let start = Date()
+        store.saveToDisk(sessionId: "testAsync", cache: cache, tokens: nil, modelName: "llama")
+        let duration = Date().timeIntervalSince(start)
+        
+        // Assert it returns immediately (much faster than a safetensors disk write)
+        #expect(duration < 0.05)
+        
+        // Confirm a background task was dispatched
+        #expect(store.lastSaveTask != nil)
+        
+        // Await the background task so we don't leak it across tests
+        if let task = store.lastSaveTask {
+            await task.value
+        }
+    }
+
     // MARK: - Budget computation
 
     @Test func computeBudgetFloor() {


### PR DESCRIPTION
## Summary

Implements **Phase 1** of our core architecture optimization plan. SSD writes (`savePromptCache`) inside `KVCacheStore` were historically synchronous. Writing large context buffer models to disk could take 50ms+ on slower tiers, effectively blocking `ModelRuntime` logic and stalling subsequent streams. 

This PR offloads SSD `.safetensors` eviction and caching to a `Task.detached(priority: .background)`, eliminating actor queue contention.

## Changes

- [x] Behavior change (backgrounds disk IO)
- [ ] UI change
- [x] Refactor / chore (Performance scaling)
- [x] Tests (Added async duration validations)
- [ ] Docs

## Test Plan

- Ran `swift test --filter KVCacheStoreTests.saveToDiskIsNonBlocking` to verify execution yields back within < 50ms boundaries.
- The prefill progression and hot-cache metrics correctly resume generation logic without being preempted by synchronous `.safetensors` operations. 

## Screenshots

N/A - backend telemetry only.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
