### PR TITLE
fix(TypingIndicator): fix shimmer overflow into "Processing prompt…" text

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/TypingIndicator.swift
+++ b/Packages/OsaurusCore/Views/Chat/TypingIndicator.swift
@@ -53,7 +53,7 @@ struct TypingIndicator: View {
 
         return HStack(spacing: 8) {
             // Indeterminate shimmer bar
-            PrefillShimmerBar()
+            IndeterminateShimmerProgress(color: theme.accentColor, height: 4)
                 .frame(width: 80, height: 4)
 
             Text(label)
@@ -144,38 +144,6 @@ struct TypingIndicator: View {
     private func stopElapsedTimer() {
         elapsedTimer?.cancel()
         elapsedTimer = nil
-    }
-}
-
-// MARK: - Indeterminate shimmer bar for prefill
-
-private struct PrefillShimmerBar: View {
-    @State private var phase: CGFloat = 0
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(theme.tertiaryText.opacity(0.15))
-
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(
-                        LinearGradient(
-                            colors: [.clear, theme.accentColor.opacity(0.6), .clear],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: geo.size.width * 0.4)
-                    .offset(x: phase * (geo.size.width + geo.size.width * 0.4) - geo.size.width * 0.4)
-            }
-        }
-        .onAppear {
-            withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
-                phase = 1
-            }
-        }
     }
 }
 

--- a/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedProgressComponents.swift
@@ -97,46 +97,36 @@ struct ShimmerProgressBar: View {
 
 /// Animated indeterminate progress indicator with flowing gradient
 struct IndeterminateShimmerProgress: View {
-    @Environment(\.theme) private var theme
-
     let color: Color
     var height: CGFloat = 4
 
-    @State private var animationOffset: CGFloat = -0.3
+    // Animate the gradient's start/end points from off-left (-0.7…-0.3)
+    // to off-right (1.0…1.4), keeping the sweep block at 40% of the bar width
+    // without needing a GeometryReader or pixel math.
+    @State private var phase: CGFloat = 0
+
+    private var gradient: LinearGradient {
+        LinearGradient(
+            colors: [.clear, color.opacity(0.6), color, color.opacity(0.6), .clear],
+            startPoint: UnitPoint(x: phase - 0.4, y: 0.5),
+            endPoint:   UnitPoint(x: phase + 0.4, y: 0.5)
+        )
+    }
 
     var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                // Background track
+        RoundedRectangle(cornerRadius: height / 2)
+            .fill(color.opacity(0.15))
+            .frame(height: height)
+            .overlay(
                 RoundedRectangle(cornerRadius: height / 2)
-                    .fill(color.opacity(0.15))
-                    .frame(height: height)
-
-                // Animated flowing bar
-                RoundedRectangle(cornerRadius: height / 2)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                color.opacity(0),
-                                color,
-                                color,
-                                color.opacity(0),
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
-                    .frame(width: geometry.size.width * 0.4, height: height)
-                    .offset(x: animationOffset * geometry.size.width)
-            }
-        }
-        .frame(height: height)
+                    .fill(gradient)
+            )
         .onAppear {
             withAnimation(
                 .easeInOut(duration: 1.2)
                     .repeatForever(autoreverses: true)
             ) {
-                animationOffset = 0.9
+                phase = 1
             }
         }
     }


### PR DESCRIPTION
## Summary

The animated shimmer bar in the \"Processing prompt…\" / \"Processing N tokens…\" typing indicator was rendering outside its 80×4 pt frame and visually bleeding into the adjacent status text.

**Root cause:** `PrefillShimmerBar` (and `IndeterminateShimmerProgress`) used a `GeometryReader` to measure the container width, then swept a fixed-pixel-width block across using `.offset(x:)`. SwiftUI's `.offset` moves a view visually without affecting layout, so the animated block rendered outside the declared frame with no clipping boundary.

**Fix:** Animate a `LinearGradient`'s `startPoint`/`endPoint` in unit-coordinate space instead. The sweep block is expressed as `phase ± 0.4` on the x-axis (UnitPoint), which keeps it naturally bounded by the shape it fills. No `GeometryReader`, no pixel math, no `.clipped()` workaround required.

`PrefillShimmerBar` was also a private duplicate of the existing shared `IndeterminateShimmerProgress` component. It is removed entirely; `TypingIndicator` now uses `IndeterminateShimmerProgress(color: theme.accentColor, height: 4)` directly.

## Changes

- [x] UI change (screenshots below)
- [x] Refactor / chore

## Test Plan

1. Load any model in the app
2. Send a message long enough to trigger a visible prefill phase (a long system prompt or large context helps)
3. Observe the \"Processing prompt… (Xs)\" or \"Processing N tokens… (Xs)\" indicator in the chat bubble area
4. **Before:** the shimmer sweep visually overlapped the status text on entry/exit
5. **After:** the shimmer is contained within the 80 pt bar; the text is always fully legible

No model-specific behaviour is needed — any locally-loaded MLX model will show the prefill indicator.

## Screenshots

_Screenshots cannot be attached from a CLI environment. The change is fully observable by running the app and sending a message with a locally-loaded model. The before state shows the shimmer gradient extending into the text; the after state shows it contained within the bar._

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable — animation-only UI change; no unit-testable logic
- [x] I updated docs/README as needed — no behaviour or API change
- [x] I verified build on macOS with Xcode 16.4+