### PR TITLE
fix(tests): update PreflightCapabilitySearch topKValues expectations after #730

### DIFF
--- a/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
@@ -68,8 +68,8 @@ struct PreflightCapabilitySearchTests {
 
     @Test func topKValuesAreCorrect() {
         #expect(PreflightSearchMode.off.topKValues == (0, 0, 0))
-        #expect(PreflightSearchMode.narrow.topKValues == (1, 2, 1))
-        #expect(PreflightSearchMode.balanced.topKValues == (3, 5, 2))
-        #expect(PreflightSearchMode.wide.topKValues == (5, 8, 4))
+        #expect(PreflightSearchMode.narrow.topKValues == (1, 2, 0))
+        #expect(PreflightSearchMode.balanced.topKValues == (3, 5, 1))
+        #expect(PreflightSearchMode.wide.topKValues == (5, 8, 2))
     }
 }


### PR DESCRIPTION
## Summary

Closes a test regression introduced when #730 changed the skill `topK` values in `PreflightSearchMode` but did not update the corresponding test expectations.

## Changes

- [ ] Behavior change
- [ ] UI change
- [x] Refactor / chore
- [x] Tests
- [ ] Docs

## What changed

**`Tests/Context/PreflightCapabilitySearchTests.swift`** — `topKValuesAreCorrect` expectations updated to match the values now in `PreflightCapabilitySearch.swift`:

| Mode | Before (stale) | After (correct) |
|---|---|---|
| `.narrow` | `skills: 1` | `skills: 0` |
| `.balanced` | `skills: 2` | `skills: 1` |
| `.wide` | `skills: 4` | `skills: 2` |

No source behaviour changed.

## Test Plan

```bash
swift test --package-path Packages/OsaurusCore
```

`topKValuesAreCorrect` now passes. All other tests pass (two known pre-existing failures: `toolLoadBuffersSpec` requires a loaded model; `prefillDidFinish_calledAfterFirstToken` is flaky under concurrent execution).

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+