### PR TITLE
chore: bump swift-jinja 2.3.2 → 2.3.3

### DIFF
--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
-        "version" : "2.3.2"
+        "revision" : "2039e9760ba1694f9962ccd2c616403983d46895",
+        "version" : "2.3.3"
       }
     },
     {


### PR DESCRIPTION
## Summary

Bump the `swift-jinja` dependency from 2.3.2 to 2.3.3. Picks up upstream fixes and keeps the resolved snapshot consistent with the latest patch release.

## Changes

- [x] Refactor / chore

## Test Plan

```
swift test --package-path Packages/OsaurusCore
```

All pre-existing tests pass. No behavioral changes.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+