### PR TITLE
perf: sort alwaysLoadedSpecs() for deterministic tool ordering

### DIFF
--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -547,6 +547,7 @@ final class ToolRegistry: ObservableObject {
                 builtInNames.contains(tool.name) || runtimeNames.contains(tool.name)
             }
             .filter { !excluded.contains($0.name) }
+            .sorted { $0.name < $1.name }
             .map { $0.asOpenAITool() }
     }
 }


### PR DESCRIPTION
## Summary

`ToolRegistry.alwaysLoadedSpecs()` previously returned tools in insertion order, which varies across app launches (e.g. depends on plugin discovery timing). Non-deterministic ordering means the tool list in the system prompt changes between sessions, causing KV-cache divergence even when the conversation content is identical.

Sort the returned specs by `name` so the tool section of the prompt is always byte-identical for the same set of loaded tools, maximising prefix cache reuse.

## Changes

- [x] Behavior change
- [x] Refactor / chore

## Test Plan

```
swift test --package-path Packages/OsaurusCore
```

No behavioral regressions. Tool specs are returned in alphabetical order by name.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+