### PR TITLE
feat: add Disable Tools toggle to chat configuration

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
@@ -57,6 +57,12 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     /// Controls how aggressively pre-flight capability search loads context (nil defaults to .balanced)
     public var preflightSearchMode: PreflightSearchMode?
 
+    // MARK: - Tool Settings
+    /// When true, no tools or preflight context are passed to the model. The raw message is sent
+    /// directly, keeping the prompt stable across turns for maximum KV-cache reuse. Recommended
+    /// when osaurus is acting as a plain LLM backend for an external agent (e.g. Claude via API).
+    public var disableTools: Bool
+
     public init(
         hotkey: Hotkey?,
         systemPrompt: String,
@@ -71,7 +77,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         workTopPOverride: Float? = nil,
         workMaxIterations: Int? = nil,
         defaultAutonomousExec: AutonomousExecConfig? = nil,
-        preflightSearchMode: PreflightSearchMode? = nil
+        preflightSearchMode: PreflightSearchMode? = nil,
+        disableTools: Bool = false
     ) {
         self.hotkey = hotkey
         self.systemPrompt = systemPrompt
@@ -87,6 +94,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         self.workMaxIterations = workMaxIterations
         self.defaultAutonomousExec = defaultAutonomousExec
         self.preflightSearchMode = preflightSearchMode
+        self.disableTools = disableTools
     }
 
     public init(from decoder: Decoder) throws {
@@ -111,6 +119,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
             PreflightSearchMode.self,
             forKey: .preflightSearchMode
         )
+        disableTools = try container.decodeIfPresent(Bool.self, forKey: .disableTools) ?? false
     }
 
     public static var `default`: ChatConfiguration {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -787,9 +787,16 @@ final class ChatSession: ObservableObject {
                 guard isRunActive(runId) else { return }
                 updateMemoryTokens(fromContext: memoryContext)
 
-                // Pre-flight RAG: search capabilities based on user's message
-                let preflightMode = chatCfg.preflightSearchMode ?? .balanced
-                let preflight = await PreflightCapabilitySearch.search(query: trimmed, mode: preflightMode)
+                // Pre-flight RAG: search capabilities based on user's message.
+                // Skipped when disableTools is set — raw message goes directly to the model.
+                let toolsDisabled = chatCfg.disableTools
+                let preflight: PreflightResult
+                if !toolsDisabled {
+                    let preflightMode = chatCfg.preflightSearchMode ?? .balanced
+                    preflight = await PreflightCapabilitySearch.search(query: trimmed, mode: preflightMode)
+                } else {
+                    preflight = PreflightResult(toolSpecs: [], contextSnippet: "", items: [])
+                }
                 guard isRunActive(runId) else { return }
 
                 if !preflight.items.isEmpty {
@@ -809,11 +816,13 @@ final class ChatSession: ObservableObject {
                 }
 
                 sys = SystemPromptBuilder.prependMemoryContext(memoryContext, to: sys)
-                var toolSpecs = buildToolSpecs(executionMode: executionMode)
+                var toolSpecs = toolsDisabled ? [] : buildToolSpecs(executionMode: executionMode)
 
-                for spec in preflight.toolSpecs
-                where !toolSpecs.contains(where: { $0.function.name == spec.function.name }) {
-                    toolSpecs.append(spec)
+                if !toolsDisabled {
+                    for spec in preflight.toolSpecs
+                    where !toolSpecs.contains(where: { $0.function.name == spec.function.name }) {
+                        toolSpecs.append(spec)
+                    }
                 }
 
                 budgetTracker.snapshot(

--- a/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
@@ -25,6 +25,7 @@ struct ConfigurationView: View {
     @State private var tempChatTopP: String = ""
     @State private var tempChatMaxToolAttempts: String = ""
     @State private var tempPreflightSearchMode: PreflightSearchMode = .balanced
+    @State private var tempDisableTools: Bool = false
 
     // Work generation settings state
     @State private var tempAgentTemperature: String = ""
@@ -251,8 +252,23 @@ struct ConfigurationView: View {
                                             }
                                             .pickerStyle(.segmented)
                                             .labelsHidden()
+                                            .disabled(tempDisableTools)
 
                                             Text(tempPreflightSearchMode.helpText)
+                                                .font(.system(size: 11))
+                                                .foregroundColor(theme.tertiaryText)
+                                        }
+                                    }
+
+                                    SettingsDivider()
+
+                                    SettingsSubsection(label: "Tools") {
+                                        VStack(alignment: .leading, spacing: 8) {
+                                            Toggle(isOn: $tempDisableTools) {
+                                                Text("Disable tools")
+                                                    .font(.system(size: 12))
+                                            }
+                                            Text("Send messages directly to the model with no tool specs or capability injection. Keeps the prompt stable across turns for maximum KV-cache reuse. Recommended when osaurus is acting as a backend for an external agent.")
                                                 .font(.system(size: 11))
                                                 .foregroundColor(theme.tertiaryText)
                                         }
@@ -598,6 +614,7 @@ struct ConfigurationView: View {
         tempChatTopP = chat.topPOverride.map { String($0) } ?? ""
         tempChatMaxToolAttempts = chat.maxToolAttempts.map(String.init) ?? ""
         tempPreflightSearchMode = chat.preflightSearchMode ?? .balanced
+        tempDisableTools = chat.disableTools
 
         // Work generation settings
         tempAgentTemperature = chat.workTemperature.map { String($0) } ?? ""
@@ -658,8 +675,7 @@ struct ConfigurationView: View {
         tempChatTopP = ""
         tempChatMaxToolAttempts = ""
         tempPreflightSearchMode = .balanced
-
-        // Work generation settings - clear to use defaults
+        tempDisableTools = false
         tempAgentTemperature = ""
         tempAgentMaxTokens = ""
         tempAgentTopP = ""
@@ -781,7 +797,7 @@ struct ConfigurationView: View {
         let parsedMaxToolAttempts: Int? = {
             let s = tempChatMaxToolAttempts.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !s.isEmpty, let v = Int(s) else { return nil }
-            return max(1, min(10, v))
+            return max(1, min(50, v))
         }()
 
         // Parse work generation settings
@@ -824,7 +840,8 @@ struct ConfigurationView: View {
             workMaxTokens: parsedAgentMax,
             workTopPOverride: parsedAgentTopP,
             workMaxIterations: parsedAgentMaxIterations,
-            preflightSearchMode: tempPreflightSearchMode
+            preflightSearchMode: tempPreflightSearchMode,
+            disableTools: tempDisableTools
         )
         ChatConfigurationStore.save(chatCfg)
 


### PR DESCRIPTION
## Summary

Adds a **Disable Tools** toggle to the Chat section of Settings. When enabled, no tool specs, preflight RAG results, or capability context snippets are injected into the request — the raw message goes directly to the model.

**Why:** When osaurus is acting as a plain LLM backend for an external agent (e.g. Claude via the OpenAI-compatible API), the caller manages its own tool routing. Injecting osaurus's tool list into every request:
- Changes the system-prompt token sequence, preventing KV-cache reuse across turns.
- Adds tokens that the external caller does not want.

With Disable Tools on, the prompt is stable across all turns in a session, maximising KV-cache hit rate.

Also fixes the `maxToolAttempts` clamp in `ConfigurationView` from `min(10, v)` to `min(50, v)`, matching the UI's 1–50 allowed range and the default value of 15.

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)

## Test Plan

1. Open Settings → Chat.
2. Enable "Disable tools".
3. Start a conversation with a local model.
4. Verify no tool specs appear in the request payload (check app logs or use the Server Explorer to inspect the enriched inference object).
5. Disable the toggle; confirm tools re-appear on the next message.

```
swift test --package-path Packages/OsaurusCore
```

## Screenshots

_UI change: new "Tools" subsection below "Capability Search" in the Chat settings panel with a "Disable tools" toggle and descriptive help text. The Capability Search mode picker is greyed out when Disable Tools is on._

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+