### PR TITLE
perf: tiered KV cache store, O(1) streaming decode, eval fix

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -228,6 +228,23 @@ actor ModelRuntime {
     }
 
     private func storeSessionCache(sessionId: String, cache: [any KVCache], promptTokens: [Int], modelName: String) {
+        // Materialize all lazy MLXArrays before storing.
+        //
+        // During generation, TokenIterator uses asyncEval() to keep the GPU pipeline full.
+        // Each in-place key/value write (`keys[..., prev..<offset, ...] = newKeys`) adds a
+        // graph node.  After generateLoopTask completes and Stream().synchronize() returns,
+        // the GPU is finished — but the MLXArray objects in the cache may still hold
+        // unevaluated computation-graph references rather than concrete GPU buffers.  On the
+        // next turn, MLX walks those graphs from scratch, triggering a full re-prefill even
+        // though offset and token counts are correct.
+        //
+        // eval() forces the arrays to concrete buffers right now, so subsequent reads are
+        // O(1) buffer accesses instead of O(n) graph replays.
+        let arraysToEval = cache.flatMap { $0.state }
+        if !arraysToEval.isEmpty {
+            eval(arraysToEval)
+        }
+
         kvCacheStore.putCache(sessionId: sessionId, cache: cache, tokens: promptTokens, modelName: modelName)
         let budget = currentKVBudget()
         kvCacheStore.ensureBudget(budget)
@@ -235,6 +252,7 @@ actor ModelRuntime {
         debugLog(
             "[ModelRuntime] stored session cache sessionId=\(sessionId.prefix(8)) promptTokens=\(promptTokens.count) effectiveCacheOffset=\(offset) budget=\(budget / 1024 / 1024)MB"
         )
+        print("[ModelRuntime] storeSessionCache: evaled \(arraysToEval.count) arrays, offset=\(offset)")
     }
 
     // MARK: - Internals
@@ -371,7 +389,7 @@ actor ModelRuntime {
         let params = GenerationParameters(temperature: 0.0, maxTokens: 1)
 
         do {
-            let (stream, _, cache, newTokens, genTask, _) = try await MLXGenerationEngine.prepareAndGenerate(
+            let prefixResult = try await MLXGenerationEngine.prepareAndGenerate(
                 container: holder.container,
                 buildChat: { messages },
                 buildToolsSpec: { tokenizerTools },
@@ -379,6 +397,9 @@ actor ModelRuntime {
                 runtime: runtimeConfig,
                 existingCache: nil,
                 cachedTokens: nil
+            )
+            let (stream, cache, newTokens, genTask) = (
+                prefixResult.stream, prefixResult.cache, prefixResult.promptTokens, prefixResult.genTask
             )
             // Only track this as the active generation task when called from a foreground
             // (non-background) context. When called from a fire-and-forget background Task,
@@ -395,6 +416,10 @@ actor ModelRuntime {
                 print("[ModelRuntime] Prefix cache incomplete, skipping persistence")
                 return
             }
+
+            // Materialize cache arrays before storing (same reason as storeSessionCache).
+            let prefixArrays = cache.flatMap { $0.state }
+            if !prefixArrays.isEmpty { eval(prefixArrays) }
 
             kvCacheStore.putPrefixCache(cache, tokens: newTokens, modelName: modelName, hash: hash)
             print("[ModelRuntime] Prefix cached for \(modelName) (hash: \(hash.prefix(8)))")
@@ -488,6 +513,8 @@ actor ModelRuntime {
         var newTokens: [Int]
         var genTask: Task<Void, Never>
         var toolCallFormat: ToolCallFormat
+        // Two-phase prefill sets this to the stable-boundary snapshot instead of the full-prompt snapshot.
+        nonisolated(unsafe) var snapshotCacheOverride: ([any KVCache], [Int])? = nil
 
         debugLog(
             "[ModelRuntime] generateEventStream: calling prepareAndGenerate existingCache=\(existingCache != nil) cachedTokens=\(cachedTokens?.count ?? 0) sessionId=\(sessionId?.prefix(8) ?? "nil")"
@@ -504,8 +531,7 @@ actor ModelRuntime {
         InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
 
         do {
-            (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) =
-                try await MLXGenerationEngine.prepareAndGenerate(
+            let genResult = try await MLXGenerationEngine.prepareAndGenerate(
                     container: holder.container,
                     buildChat: buildChat,
                     buildToolsSpec: buildTools,
@@ -514,6 +540,14 @@ actor ModelRuntime {
                     existingCache: existingCache,
                     cachedTokens: cachedTokens
                 )
+            (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) = (
+                genResult.stream, genResult.tokenizer, genResult.cache,
+                genResult.promptTokens, genResult.genTask, genResult.toolCallFormat
+            )
+            // For two-phase prefill, override snapshot with the stable-boundary snapshot.
+            if let snapCache = genResult.snapshotCache, let snapTokens = genResult.snapshotTokens {
+                snapshotCacheOverride = (snapCache, snapTokens)
+            }
         } catch {
             genLog.error(
                 "generateEventStream: prepareAndGenerate failed (cache retry): \(error.localizedDescription, privacy: .public)"
@@ -527,8 +561,7 @@ actor ModelRuntime {
             // Re-signal for the retry prefill (still unknown count).
             InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
             do {
-                (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) =
-                    try await MLXGenerationEngine.prepareAndGenerate(
+                let retryResult = try await MLXGenerationEngine.prepareAndGenerate(
                         container: holder.container,
                         buildChat: buildChat,
                         buildToolsSpec: buildTools,
@@ -537,6 +570,13 @@ actor ModelRuntime {
                         existingCache: nil,
                         cachedTokens: nil
                     )
+                (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) = (
+                    retryResult.stream, retryResult.tokenizer, retryResult.cache,
+                    retryResult.promptTokens, retryResult.genTask, retryResult.toolCallFormat
+                )
+                if let snapCache = retryResult.snapshotCache, let snapTokens = retryResult.snapshotTokens {
+                    snapshotCacheOverride = (snapCache, snapTokens)
+                }
             } catch {
                 InferenceProgressManager.shared.prefillDidFinishAsync()
                 throw error
@@ -550,11 +590,40 @@ actor ModelRuntime {
 
         activeGenerationTask = genTask
 
+        // Store a pre-generation snapshot of the cache immediately after prefill.
+        //
+        // Standard (single-phase) path: snapshot the full-prompt cache keyed by `newTokens`.
+        // Two-phase path: use the stable-boundary snapshot from prepareAndGenerate (keyed by
+        // stableTokens, before gen-prefix). This ensures the next turn's common-prefix check
+        // hits exactly at cacheOffset, with toTrim == 0, even for MambaCache models.
+        if let sid = sessionId {
+            let (snapCacheToStore, snapTokensToStore): ([any KVCache], [Int])
+            if let override = snapshotCacheOverride {
+                // Two-phase: store the stable-boundary snapshot already deep-copied inside engine.
+                snapCacheToStore = override.0
+                snapTokensToStore = override.1
+                debugLog(
+                    "[ModelRuntime] twoPhase snapshot override: stableTokens=\(snapTokensToStore.count)"
+                )
+                print("[ModelRuntime] twoPhase snapshot: using stable-boundary snapshot tokens=\(snapTokensToStore.count)")
+            } else {
+                // Single-phase: snapshot full-prompt cache now.
+                snapCacheToStore = KVCacheStore.deepCopyCache(cache)
+                snapTokensToStore = newTokens
+            }
+            let arraysToEval = snapCacheToStore.flatMap { $0.state }
+            if !arraysToEval.isEmpty { eval(arraysToEval) }
+            kvCacheStore.putCache(sessionId: sid, cache: snapCacheToStore, tokens: snapTokensToStore, modelName: modelName)
+            let budget = currentKVBudget()
+            kvCacheStore.ensureBudget(budget)
+            let snapshotOffset = effectiveCacheOffset(snapCacheToStore)
+            debugLog(
+                "[ModelRuntime] pre-gen snapshot stored sessionId=\(sid.prefix(8)) tokens=\(snapTokensToStore.count) offset=\(snapshotOffset)"
+            )
+            print("[ModelRuntime] pre-gen snapshot: evaled \(arraysToEval.count) arrays, offset=\(snapshotOffset)")
+        }
+
         // Thread the tokenizer into StreamAccumulator so it can decode token IDs to text.
-        // The onGeneratedTokenIds callback captures the generated IDs so wrapWithCacheStore
-        // can store promptTokens + generatedTokenIds as the complete cached token sequence.
-        let capturedPromptTokens = newTokens
-        nonisolated(unsafe) var generatedTokenIds: [Int] = []
         let capturedToolsSpec = buildTools()
         let eventStream = StreamAccumulator.accumulate(
             events: rawStream,
@@ -564,22 +633,15 @@ actor ModelRuntime {
             toolCallFormat: toolCallFormat,
             toolsSpec: capturedToolsSpec,
             generationTask: genTask,
-            onGeneratedTokenIds: { ids in generatedTokenIds = ids }
+            onGeneratedTokenIds: { _ in }
         ).asAsyncThrowingStream()
 
-        // Compose wrappers: cache-store on success (innermost), then cache-invalidation on error.
-        // Cache must be stored after the stream drains so `cache.offset` reflects all processed tokens.
+        // Compose wrappers: cache-invalidation on error.
+        // The pre-generation snapshot is already stored above; no post-generation re-store
+        // is needed (and would be harmful: it would overwrite the snapshot with a cache at
+        // offset = promptTokens + generatedIds, which diverges from the next-turn prompt by
+        // exactly the number of generated tokens, requiring trim that MambaCache cannot do).
         var wrappedStream = eventStream
-        if let sid = sessionId {
-            wrappedStream = wrapWithCacheStore(
-                wrappedStream,
-                sessionId: sid,
-                cache: cache,
-                promptTokens: capturedPromptTokens,
-                generatedTokenIdsBox: { generatedTokenIds },
-                modelName: modelName
-            )
-        }
         guard existingCache != nil else { return wrappedStream }
         return wrapWithCacheInvalidation(
             wrappedStream,

--- a/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
@@ -10,6 +10,10 @@
 import Foundation
 import MLX
 @preconcurrency import MLXLMCommon
+import os.log
+
+private let kvSignposter = OSSignposter(subsystem: "ai.osaurus", category: "KVCache")
+private let kvLog = Logger(subsystem: "ai.osaurus", category: "KVCache")
 
 /// Manages per-session KV caches across a hot RAM tier and cold SSD tier.
 /// Must be used from within the `ModelRuntime` actor (not independently thread-safe).
@@ -103,6 +107,10 @@ struct KVCacheStore {
 
         // Cold hit: restore from SSD
         if entry.ssdPath != nil {
+            let spID = kvSignposter.makeSignpostID()
+            let spState = kvSignposter.beginInterval("ssdLoad", id: spID, "session restore")
+            let t0ssd = CFAbsoluteTimeGetCurrent()
+            defer { kvSignposter.endInterval("ssdLoad", spState) }
             do {
                 let (cache, metadata) = try loadPromptCache(url: entry.ssdPath!)
                 guard Self.isValidCache(cache) else {
@@ -121,6 +129,8 @@ struct KVCacheStore {
                 totalHotBytes += bytes
                 entry.lastAccess = Date()
                 touchLRU(sessionId)
+                let loadMs = Int((CFAbsoluteTimeGetCurrent() - t0ssd) * 1000)
+                kvLog.info("[perf] ssdLoad kind=session durationMs=\(loadMs, privacy: .public) kb=\(bytes / 1024, privacy: .public)")
                 print("[KVCacheStore] Restored session \(sessionId.prefix(8)) from SSD (\(bytes / 1024)KB)")
                 return (cache, entry.tokens)
             } catch {
@@ -191,10 +201,14 @@ struct KVCacheStore {
 
         let box = CacheBox(cache)
 
-        // Optimistically set the SSD path so we don't try to save it again
+        // Optimistically set the SSD path so we don't try to save it again.
+        // If the write fails, we log the error; the entry retains a stale ssdPath
+        // until it is re-put or evicted, at which point a fresh write will be attempted.
         self.entries[sessionId]?.ssdPath = url
 
         let task = Task.detached(priority: .background) {
+            let spID = kvSignposter.makeSignpostID()
+            let spState = kvSignposter.beginInterval("ssdSave", id: spID, "\(bytes / 1024, privacy: .public) KB")
             do {
                 var metadata = ["model": modelName]
                 if let tokens = tokens, let data = try? JSONEncoder().encode(tokens),
@@ -204,11 +218,15 @@ struct KVCacheStore {
                 }
                 try savePromptCache(url: url, cache: box.cache, metadata: metadata)
                 let durationMs = Date().timeIntervalSince(start) * 1000
+                kvSignposter.endInterval("ssdSave", spState, "\(Int(durationMs), privacy: .public)ms ok")
+                kvLog.info("[perf] ssdSave durationMs=\(Int(durationMs), privacy: .public) kb=\(bytes / 1024, privacy: .public) ok=true")
                 print(
                     "[KVCacheStore] [BENCHMARK] Saved session \(sessionId.prefix(8)) to SSD (\(bytes / 1024)KB) asynchronously in \(String(format: "%.1f", durationMs))ms"
                 )
             } catch {
                 let durationMs = Date().timeIntervalSince(start) * 1000
+                kvSignposter.endInterval("ssdSave", spState, "\(Int(durationMs), privacy: .public)ms error")
+                kvLog.error("[perf] ssdSave failed session=\(sessionId.prefix(8), privacy: .public) durationMs=\(Int(durationMs), privacy: .public) error=\(error, privacy: .public)")
                 print(
                     "[KVCacheStore] [BENCHMARK] SSD save failed for \(sessionId.prefix(8)) after \(String(format: "%.1f", durationMs))ms: \(error)"
                 )
@@ -293,12 +311,36 @@ struct KVCacheStore {
     }
 
     /// Returns a **fresh copy** of the prefix cache for this model + content hash.
-    /// Always loads from SSD so each caller gets independent KVCache objects
-    /// that won't corrupt the stored prefix when mutated during generation.
+    ///
+    /// Hot-tier path: if the prefix cache is resident in RAM (entry.cache != nil), deep-copy
+    /// all KVCache objects in-memory and return immediately — no SSD I/O.  Each caller gets
+    /// independent objects whose MLXArrays are shared via copy-on-write until generation
+    /// mutates them, keeping the stored hot-tier copy pristine.
+    ///
+    /// Cold-tier fallback: if only an SSD path is recorded, load from disk as before.
     mutating func getPrefixCache(modelName: String, hash: String) -> ([any KVCache]?, [Int]?) {
         let key = Self.prefixKey(modelName: modelName, hash: hash)
         guard let entry = entries[key], entry.modelName == modelName else { return (nil, nil) }
+
+        // ── Hot-tier path (RAM hit) ──────────────────────────────────────────
+        if let hotCache = entry.cache {
+            let t0 = CFAbsoluteTimeGetCurrent()
+            let copied = Self.deepCopyCache(hotCache)
+            touchLRU(key)
+            entry.lastAccess = Date()
+            let copyMs = Int((CFAbsoluteTimeGetCurrent() - t0) * 1000)
+            let kb = Self.cacheBytes(copied) / 1024
+            kvLog.info("[perf] ramCopy kind=prefix durationMs=\(copyMs, privacy: .public) kb=\(kb, privacy: .public)")
+            print("[KVCacheStore] Prefix cache RAM hit for \(key.prefix(24)) (\(kb)KB, copy \(copyMs)ms)")
+            return (copied, entry.tokens)
+        }
+
+        // ── Cold-tier path (SSD fallback) ────────────────────────────────────
         guard let ssdPath = entry.ssdPath else { return (nil, nil) }
+        let spID = kvSignposter.makeSignpostID()
+        let spState = kvSignposter.beginInterval("ssdLoad", id: spID, "prefix cache load")
+        let t0prefix = CFAbsoluteTimeGetCurrent()
+        defer { kvSignposter.endInterval("ssdLoad", spState) }
         do {
             let (cache, metadata) = try loadPromptCache(url: ssdPath)
             guard Self.isValidCache(cache) else {
@@ -309,11 +351,88 @@ struct KVCacheStore {
             if entry.tokens == nil, let tokensStr = metadata["tokens"], let data = tokensStr.data(using: .utf8) {
                 entry.tokens = try? JSONDecoder().decode([Int].self, from: data)
             }
-            return (cache, entry.tokens)
+            // Promote the loaded cache to the hot tier so subsequent calls avoid SSD I/O.
+            let bytes = Self.cacheBytes(cache)
+            entry.cache = cache
+            entry.sizeBytes = bytes
+            totalHotBytes += bytes
+            touchLRU(key)
+            let loadMs = Int((CFAbsoluteTimeGetCurrent() - t0prefix) * 1000)
+            let kb = bytes / 1024
+            kvLog.info("[perf] ssdLoad kind=prefix durationMs=\(loadMs, privacy: .public) kb=\(kb, privacy: .public)")
+            print("[KVCacheStore] Prefix cache SSD load (promoted to RAM) \(key.prefix(24)) (\(kb)KB, \(loadMs)ms)")
+            // Return a deep copy so the hot-tier entry stays pristine.
+            return (Self.deepCopyCache(cache), entry.tokens)
         } catch {
             print("[KVCacheStore] Failed to load prefix cache from SSD: \(error)")
             evictEntry(sessionId: key, saveSSD: false)
             return (nil, nil)
+        }
+    }
+
+    /// Returns an independent copy of `source` where every KVCache layer is a new
+    /// object of the same concrete type.  The underlying MLXArrays are shared via
+    /// copy-on-write until generation mutates the new copy, so this is very cheap.
+    static func deepCopyCache(_ source: [any KVCache]) -> [any KVCache] {
+        source.map { layer -> any KVCache in
+            let copy: any KVCache
+
+            switch layer {
+            case let src as ChunkedKVCache:
+                // ChunkedKVCache must precede KVCacheSimple (subclass relationship).
+                // metaState restores chunkSize + startPosition; state restores keys/values/offset.
+                let dst = ChunkedKVCache()
+                dst.state = src.state
+                dst.metaState = src.metaState
+                copy = dst
+
+            case let src as KVCacheSimple:
+                let dst = KVCacheSimple()
+                let st = src.state
+                if !st.isEmpty { dst.state = st }
+                copy = dst
+
+            case let src as RotatingKVCache:
+                // RotatingKVCache requires maxSize at construction; read it from metaState[1].
+                // Guard against empty state (fresh cache that hasn't processed any tokens yet).
+                let meta = src.metaState
+                let maxSize = meta.count >= 2 ? (Int(meta[1]) ?? 4096) : 4096
+                let dst = RotatingKVCache(maxSize: maxSize)
+                let st = src.state
+                if !st.isEmpty { dst.state = st }
+                dst.metaState = meta
+                copy = dst
+
+            case let src as QuantizedKVCache:
+                // groupSize/bits are restored via metaState setter; offset is restored too.
+                let dst = QuantizedKVCache()
+                dst.state = src.state
+                dst.metaState = src.metaState
+                copy = dst
+
+            case let src as MambaCache:
+                // MambaCache is ArraysCache(size:2); state setter replaces the array list.
+                let dst = MambaCache()
+                dst.state = src.state
+                copy = dst
+
+            case let src as ArraysCache:
+                // Generic ArraysCache: state count tells us the real size.
+                let st = src.state
+                let dst = ArraysCache(size: st.count)
+                dst.state = st
+                copy = dst
+
+            default:
+                // Unknown concrete type: fall back to state/metaState round-trip.
+                // This will fatalError only if the unknown type has incompatible state.
+                assertionFailure("[KVCacheStore] deepCopyCache: unhandled KVCache subtype \(type(of: layer)) — add an explicit case")
+                let dst = KVCacheSimple()
+                dst.state = layer.state
+                copy = dst
+            }
+
+            return copy
         }
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/StreamAccumulator.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/StreamAccumulator.swift
@@ -17,6 +17,10 @@
 import Foundation
 import MLXLMCommon
 import Tokenizers
+import os.log
+
+private let accumSignposter = OSSignposter(subsystem: "ai.osaurus", category: "Generation")
+private let accumLog = Logger(subsystem: "ai.osaurus", category: "Generation")
 
 /// An AsyncSequence that transforms a raw `TokenGeneration` stream into
 /// typed `ModelRuntimeEvent` values.  All processing happens synchronously
@@ -130,6 +134,10 @@ struct StreamAccumulator: AsyncSequence, Sendable {
         private var decodedSoFar = ""
         private var finished = false
         private var pendingEvents: [ModelRuntimeEvent] = []
+        // Signpost state for the generation interval (first-token → stream-end)
+        private var generationSpState: OSSignpostIntervalState? = nil
+        private var generationSpStarted = false
+        private var generationT0: CFAbsoluteTime = 0
 
         private var maxStopLen: Int
         private var shouldCheckStop: Bool
@@ -137,6 +145,13 @@ struct StreamAccumulator: AsyncSequence, Sendable {
         // Tracks how many tool calls the processor has emitted so far so we
         // can detect when processChunk() produces a new one.
         private var knownToolCallCount = 0
+
+        /// Sliding context window used for incremental O(1) token decode.
+        /// BPE and byte-level tokenizers may need a few preceding tokens to
+        /// correctly decode the newest token (e.g. multi-byte UTF-8 splits
+        /// across token boundaries).  8 tokens is enough for any known tokeniser.
+        private static let decodeContextSize = 8
+        private var decodeContextIds: [Int] = []
 
         init(
             eventIterator: AsyncStream<TokenGeneration>.AsyncIterator,
@@ -201,26 +216,55 @@ struct StreamAccumulator: AsyncSequence, Sendable {
                             info.generateTime
                         )
                     )
+                    // Emit GPU-accurate stats as a signpost event so they appear in
+                    // Instruments and can be captured by `log stream --type signpost`.
+                    accumSignposter.emitEvent(
+                        "mlxStats",
+                        id: .exclusive,
+                        "prompt: \(info.promptTokenCount, privacy: .public) tok \(info.promptTokensPerSecond, privacy: .public) tok/s \(info.promptTime, privacy: .public)s | gen: \(info.generationTokenCount, privacy: .public) tok \(info.tokensPerSecond, privacy: .public) tok/s \(info.generateTime, privacy: .public)s"
+                    )
+                    // Also emit as a Logger.info so it appears in `log stream`.
+                    accumLog.info(
+                        "[perf] mlxStats promptTokens=\(info.promptTokenCount, privacy: .public) promptTps=\(info.promptTokensPerSecond, privacy: .public) promptMs=\(Int(info.promptTime * 1000), privacy: .public) genTokens=\(info.generationTokenCount, privacy: .public) genTps=\(info.tokensPerSecond, privacy: .public) genMs=\(Int(info.generateTime * 1000), privacy: .public)"
+                    )
                     continue
                 }
 
                 guard let tokenId = event.token else { continue }
 
-                // Signal prefill complete on first token.
+                // Signal prefill complete on first token; start generation interval.
                 if firstToken {
                     firstToken = false
+                    generationT0 = CFAbsoluteTimeGetCurrent()
+                    generationSpState = accumSignposter.beginInterval("generation", id: accumSignposter.makeSignpostID())
+                    generationSpStarted = true
                     InferenceProgressManager.shared.prefillDidFinishAsync()
                 }
 
                 generatedTokenIds.append(tokenId)
 
-                // Incremental decode.
-                let newDecoded = tokenizer.decode(tokens: generatedTokenIds)
-                let token =
-                    newDecoded.count > decodedSoFar.count
-                    ? String(newDecoded.dropFirst(decodedSoFar.count))
-                    : ""
-                decodedSoFar = newDecoded
+                // Incremental decode — O(1) per token regardless of sequence length.
+                // Decode [context ++ newToken] minus [context] to isolate the new text.
+                // The context window handles BPE / byte-level tokenisers that need a
+                // few preceding tokens to correctly decode the newest one.
+                let contextWithNew = decodeContextIds + [tokenId]
+                let withNewDecoded  = tokenizer.decode(tokens: contextWithNew)
+                let contextDecoded  = decodeContextIds.isEmpty
+                    ? ""
+                    : tokenizer.decode(tokens: decodeContextIds)
+                let token: String
+                if withNewDecoded.count > contextDecoded.count {
+                    token = String(withNewDecoded.dropFirst(contextDecoded.count))
+                } else {
+                    token = ""
+                }
+                decodedSoFar += token
+
+                // Advance the sliding context window.
+                decodeContextIds.append(tokenId)
+                if decodeContextIds.count > Self.decodeContextSize {
+                    decodeContextIds.removeFirst()
+                }
 
                 guard !token.isEmpty else { continue }
 
@@ -377,6 +421,19 @@ struct StreamAccumulator: AsyncSequence, Sendable {
         private mutating func finish(cancelled: Bool) async {
             guard !finished else { return }
             finished = true
+
+            if generationSpStarted, let spState = generationSpState {
+                let tokenCount = generatedTokenIds.count
+                let durationMs = Int((CFAbsoluteTimeGetCurrent() - generationT0) * 1000)
+                let suffix = cancelled ? " (cancelled)" : ""
+                accumSignposter.endInterval(
+                    "generation", spState,
+                    "\(tokenCount, privacy: .public) tokens\(suffix, privacy: .public)"
+                )
+                accumLog.info(
+                    "[perf] generation durationMs=\(durationMs, privacy: .public) tokenCount=\(tokenCount, privacy: .public) cancelled=\(cancelled, privacy: .public)"
+                )
+            }
 
             if cancelled {
                 InferenceProgressManager.shared.prefillDidFinishAsync()

--- a/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
@@ -176,14 +176,14 @@ struct KVCacheStoreTests {
         #expect(store.hasPrefixCache(modelName: "llama", hash: "hash1"))
     }
 
-    @Test func getPrefixCacheReturnsNilWithoutSSD() {
+    @Test func getPrefixCacheReturnsHotCacheWhenResident() {
         var store = KVCacheStore()
         seedPrefixCache(&store, modelName: "llama", hash: "hash1")
 
-        // getPrefixCache always loads from SSD to avoid shared-reference mutation;
-        // seeded entries have no ssdPath so it returns nil.
+        // Hot-tier path: entry.cache != nil → deepCopyCache returns an independent copy,
+        // no SSD path required.
         let retrieved = store.getPrefixCache(modelName: "llama", hash: "hash1")
-        #expect(retrieved.0 == nil)
+        #expect(retrieved.0 != nil)
     }
 
     @Test func hasPrefixCacheReturnsFalseOnMiss() {
@@ -494,5 +494,77 @@ struct KVCacheStoreTests {
         let hybrid: [any KVCache] = [mamba, attn]
         // attn.state is empty, so allSatisfy { !state.isEmpty } fails → invalid.
         #expect(!KVCacheStore._testIsValidCache(hybrid))
+    }
+
+    // MARK: - deepCopyCache branch coverage
+
+    /// KVCacheSimple: deep copy produces an independent instance with same offset.
+    @Test func deepCopyCache_kvCacheSimple() {
+        let src = KVCacheSimple()
+        let fakeKeys = MLX.zeros([1, 1, 4, 1])
+        let fakeValues = MLX.zeros([1, 1, 4, 1])
+        src.state = [fakeKeys, fakeValues]
+
+        let copies = KVCacheStore.deepCopyCache([src])
+        #expect(copies.count == 1)
+        guard let copy = copies[0] as? KVCacheSimple else {
+            Issue.record("Expected KVCacheSimple copy")
+            return
+        }
+        // Independent instance (not the same object)
+        #expect(copy !== src)
+        // Same offset preserved
+        #expect(copy.offset == src.offset)
+    }
+
+    /// RotatingKVCache: deep copy preserves state without crashing.
+    @Test func deepCopyCache_rotatingKVCache() {
+        let src = RotatingKVCache(maxSize: 4)
+        let copies = KVCacheStore.deepCopyCache([src])
+        #expect(copies.count == 1)
+        guard let copy = copies[0] as? RotatingKVCache else {
+            Issue.record("Expected RotatingKVCache copy")
+            return
+        }
+        #expect(copy !== src)
+    }
+
+    /// MambaCache (ArraysCache subtype): deep copy produces MambaCache (not KVCacheSimple).
+    @Test func deepCopyCache_mambaCache() {
+        let src = MambaCache()
+        src.state = [MLX.zeros([2, 4]), MLX.zeros([2, 4])]
+
+        let copies = KVCacheStore.deepCopyCache([src])
+        #expect(copies.count == 1)
+        guard let copy = copies[0] as? MambaCache else {
+            Issue.record("Expected MambaCache copy, got \(type(of: copies[0]))")
+            return
+        }
+        #expect(copy !== src)
+    }
+
+    /// Mixed cache: all branches exercised in a single call.
+    @Test func deepCopyCache_mixedTypes() {
+        let simple = KVCacheSimple()
+        let mamba = MambaCache()
+        mamba.state = [MLX.zeros([1]), MLX.zeros([1])]
+
+        let copies = KVCacheStore.deepCopyCache([simple, mamba])
+        #expect(copies.count == 2)
+        #expect(copies[0] is KVCacheSimple)
+        #expect(copies[1] is MambaCache)
+    }
+
+    // MARK: - saveToDisk: no crash for missing session
+
+    /// Calling saveToDisk for a session that was never put silently no-ops.
+    @Test func saveToDisk_noopForMissingSession() async {
+        var store = KVCacheStore()
+        // Session "ghost" was never put — no entry exists.
+        store.saveToDisk(sessionId: "ghost", cache: makeCache(), tokens: nil, modelName: "m")
+        // No crash, and a background task was still dispatched (for the disk write).
+        if let task = store.lastSaveTask {
+            await task.value  // drain to avoid test leaks
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three coordinated improvements to inference latency and correctness:

**1. Tiered KV cache store (RAM + SSD)**

`KVCacheStore` gains a two-tier architecture. Hot sessions are kept in RAM up to a model-size-derived budget (≈ ¼ of model weights, capped at 8 GB). Sessions evicted from RAM are serialised to SSD in a background task and rehydrated on the next turn. An O(1) doubly-linked LRU list drives eviction so no O(n) scans occur on every put. `os_signpost` intervals bracket SSD load/save for easy Instruments profiling.

**2. O(1) streaming decode in StreamAccumulator**

The previous decode path re-decoded the entire token history on every new token, giving O(n²) total work for a response of n tokens. The new path decodes only the net-new suffix per step (O(n) total). `os_signpost` intervals wrap each `accumulate()` call.

**3. MLXArray materialisation fix (correctness)**

`TokenIterator` uses `asyncEval()` to keep the GPU pipeline full, leaving graph nodes inside the KV cache arrays. When the cache is stored and later read for the next turn, MLX re-walks those graphs from scratch — effectively triggering a full re-prefill even though `offset` and token counts are correct.

Fix: call `eval()` on all cache arrays immediately after prefill in both `storeSessionCache` and `buildPrefixCache`. Subsequent reads are then O(1) buffer accesses.

**4. Pre-generation snapshot (correctness)**

The previous approach stored the cache post-generation, keyed by `promptTokens + generatedIds`. On the next turn, the common prefix diverges by exactly `len(generatedIds)` tokens, requiring trim. `MambaCache` is not trimmable, so this caused a full re-prefill on every turn for hybrid SSM models.

Fix: snapshot the cache immediately after prefill (before any tokens are generated) and store it keyed by `promptTokens` only. The post-generation `wrapWithCacheStore` wrapper is removed.

Also adds `KVCacheStore.deepCopyCache` (used by the pre-generation snapshot and by PR #perf/two-phase-prefill) with test coverage for all three cache types (`KVCacheSimple`, `RotatingKVCache`, `MambaCache`), including a fix for a latent crash when deep-copying an empty `RotatingKVCache`.

## Changes

- [x] Behavior change
- [x] Refactor / chore
- [x] Tests

## Test Plan

```
swift test --package-path Packages/OsaurusCore
```

New tests: `KVCacheStoreTests` — `deepCopyCache_kvCacheSimple`, `deepCopyCache_rotatingKVCache`, `deepCopyCache_mambaCache`, `deepCopyCache_mixedTypes`, `saveToDisk_noopForMissingSession`.

Integration: run a 3-turn conversation with any local model and observe:
- T2/T3 TTFT is shorter than T1 (cache reused).
- SSD eviction log lines appear after the RAM budget is exceeded.
- Instruments → os_signpost shows `ssdLoad`/`ssdSave`/`accumulate` intervals.

Benchmark (M4 Pro 64GB, non-hybrid models, 3 turns):
- Phi-4-mini-reasoning T2 TTFT: 513 ms
- GLM-4.7-Flash T2 TTFT: 843 ms

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+