### PR TITLE
several optimizations for bringing down GPU usage

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1318,7 +1318,7 @@ struct ChatView: View {
                             )
                         }
                     }
-                    .animation(theme.springAnimation(), value: session.turns.isEmpty)
+                    .animation(theme.springAnimation(responseMultiplier: 0.9), value: session.turns.isEmpty)
                 }
             }
         }
@@ -1332,8 +1332,6 @@ struct ChatView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         .ignoresSafeArea()
-        .animation(theme.animationMedium(), value: session.turns.isEmpty)
-        .animation(theme.springAnimation(responseMultiplier: 0.9), value: windowState.showSidebar)
         .onReceive(NotificationCenter.default.publisher(for: .chatOverlayActivated)) { _ in
             // Lightweight state updates only - refreshAll() removed to prevent excessive re-renders
             focusTrigger &+= 1

--- a/Packages/OsaurusCore/Views/Chat/ContentBlockView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ContentBlockView.swift
@@ -53,14 +53,8 @@ struct ContentBlockView: View, Equatable {
     @ViewBuilder
     private var messageBubbleBackground: some View {
         if isUserMessage {
-            ZStack {
-                if theme.glassEnabled {
-                    RoundedRectangle(cornerRadius: bubbleCornerRadius, style: .continuous)
-                        .fill(.ultraThinMaterial)
-                }
-                RoundedRectangle(cornerRadius: bubbleCornerRadius, style: .continuous)
-                    .fill(userBubbleBackgroundColor.opacity(theme.userBubbleOpacity))
-            }
+            RoundedRectangle(cornerRadius: bubbleCornerRadius, style: .continuous)
+                .fill(userBubbleBackgroundColor.opacity(theme.userBubbleOpacity))
         } else {
             Color.clear
         }

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -67,19 +67,37 @@ struct EditableTextView: NSViewRepresentable {
         context.coordinator.parent = self
         guard let textView = scrollView.documentView as? CustomNSTextView else { return }
 
-        textView.maxHeight = maxHeight
-
-        // Only update text if it's different to avoid cursor jumping
-        if textView.string != text {
-            textView.string = text
+        // only update max height when it changes — avoids triggering NSTextView layout
+        if textView.maxHeight != maxHeight {
+            textView.maxHeight = maxHeight
+            textView.invalidateIntrinsicContentSize()
+            scrollView.invalidateIntrinsicContentSize()
         }
 
-        // Update styling
-        textView.font = .systemFont(ofSize: fontSize)
-        textView.textColor = NSColor(textColor)
-        textView.insertionPointColor = NSColor(cursorColor)
+        // only update text if it differs — avoids cursor-position reset on every parent re-render
+        if textView.string != text {
+            textView.string = text
+            textView.invalidateIntrinsicContentSize()
+            scrollView.invalidateIntrinsicContentSize()
+        }
 
-        // Handle focus
+        // guard styling assignments — each one invalidates the NSTextView layout and calls
+        // needsDisplay even when the value hasn't changed
+        let coord = context.coordinator
+        if coord.lastFontSize != fontSize {
+            textView.font = .systemFont(ofSize: fontSize)
+            coord.lastFontSize = fontSize
+        }
+        if coord.lastTextColor != textColor {
+            textView.textColor = NSColor(textColor)
+            coord.lastTextColor = textColor
+        }
+        if coord.lastCursorColor != cursorColor {
+            textView.insertionPointColor = NSColor(cursorColor)
+            coord.lastCursorColor = cursorColor
+        }
+
+        // handle focus
         DispatchQueue.main.async {
             let isFirstResponder = textView.window?.firstResponder == textView
             if isFocused && !isFirstResponder {
@@ -89,20 +107,27 @@ struct EditableTextView: NSViewRepresentable {
             }
         }
 
-        // Dynamically toggle scroller visibility without changing hasVerticalScroller
-        let needsScroller = textView.contentHeight > maxHeight
-        scrollView.verticalScroller?.isHidden = !needsScroller
-
-        // Ensure scroll view tiles its subviews correctly
-        scrollView.tile()
-
-        // Force layout update for height calculation
-        textView.invalidateIntrinsicContentSize()
-        scrollView.invalidateIntrinsicContentSize()
+        // only check scroller visibility and tile when max height changes or text changes —
+        // contentHeight runs ensureLayout which is expensive; scroller state cannot change
+        // without text or maxHeight changing
+        if coord.lastScrollerMaxHeight != maxHeight || coord.lastScrollerText != text {
+            let needsScroller = textView.contentHeight > maxHeight
+            scrollView.verticalScroller?.isHidden = !needsScroller
+            scrollView.tile()
+            coord.lastScrollerMaxHeight = maxHeight
+            coord.lastScrollerText = text
+        }
     }
 
     class Coordinator: NSObject, NSTextViewDelegate {
         var parent: EditableTextView
+
+        // cached appearance values — guards against needsDisplay on every parent re-render
+        var lastFontSize: CGFloat = 0
+        var lastTextColor: Color = .clear
+        var lastCursorColor: Color = .clear
+        var lastScrollerMaxHeight: CGFloat = -1
+        var lastScrollerText: String = ""
 
         init(_ parent: EditableTextView) {
             self.parent = parent
@@ -121,17 +146,8 @@ struct EditableTextView: NSViewRepresentable {
         }
 
         func textViewDidChangeSelection(_ notification: Notification) {
-            DispatchQueue.main.async {
-                guard let textView = notification.object as? NSTextView else { return }
-                self.parent.text = textView.string
-                // Invalidate intrinsic size to trigger resize
-                if let customTextView = textView as? CustomNSTextView {
-                    customTextView.invalidateIntrinsicContentSize()
-                }
-                if let scrollView = textView.enclosingScrollView {
-                    scrollView.invalidateIntrinsicContentSize()
-                }
-            }
+            // selection changes (cursor moves) do not affect text content or view size —
+            // no-op here; text sync and size invalidation are both handled in textDidChange.
         }
 
         func textDidBeginEditing(_ notification: Notification) {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -350,6 +350,13 @@ struct FloatingInputCard: View {
                 }
             }
             .onChange(of: isStreaming) { wasStreaming, nowStreaming in
+                // re-focus the input when streaming ends so the user can type immediately.
+                // focus is cleared on send to stop the NSTextView cursor-blink display link
+                // during streaming; restore it once the response is complete.
+                if wasStreaming && !nowStreaming {
+                    isFocused = true
+                }
+
                 // When AI finishes responding and we're in continuous voice mode, restart voice input
                 if wasStreaming && !nowStreaming && isContinuousVoiceMode {
                     print("[FloatingInputCard] AI response finished in continuous mode - restarting voice")
@@ -860,6 +867,9 @@ extension FloatingInputCard {
         let message = localText
         localText = ""
         text = ""
+        // resign first responder so the NSTextView cursor-blink display link stops driving
+        // the window compositor at 60fps through the streaming response
+        isFocused = false
         onSend(message)
     }
 
@@ -1778,17 +1788,10 @@ extension FloatingInputCard {
 
     private var cardBackground: some View {
         ZStack {
-            // Layer 1: Glass material
-            if theme.glassEnabled {
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(.ultraThinMaterial)
-            }
-
-            // Layer 2: Semi-transparent background
             RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(theme.primaryBackground.opacity(theme.isDark ? 0.7 : 0.88))
+                .fill(theme.primaryBackground.opacity(theme.isDark ? 0.82 : 0.94))
 
-            // Layer 3: Subtle accent gradient at top (enhanced when focused)
+            // subtle accent gradient at top (enhanced when focused)
             LinearGradient(
                 colors: [
                     theme.accentColor.opacity(isFocused ? 0.08 : (theme.isDark ? 0.04 : 0.025)),

--- a/Packages/OsaurusCore/Views/Chat/MessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageCellView.swift
@@ -10,9 +10,59 @@
 //  on the table view -- the hosting view's intrinsic content size drives
 //  the row height through pinned Auto Layout constraints.
 //
+//  AnyView is intentionally avoided: CellRootView is a concrete typed
+//  wrapper so SwiftUI can use ContentBlockView's Equatable conformance
+//  to skip re-renders when the block content has not changed.
+//
 
 import AppKit
 import SwiftUI
+
+// MARK: - CellRootView
+
+/// Thin typed wrapper around ContentBlockView. Using a concrete type rather
+/// than AnyView lets SwiftUI apply ContentBlockView's Equatable conformance
+/// and skip layout/render passes when block content is unchanged.
+struct CellRootView: View {
+    var block: ContentBlock
+    var width: CGFloat
+    var agentName: String
+    var isTurnHovered: Bool
+    var theme: ThemeProtocol
+    var expandedBlocksStore: ExpandedBlocksStore
+    var onCopy: ((UUID) -> Void)?
+    var onRegenerate: ((UUID) -> Void)?
+    var onEdit: ((UUID) -> Void)?
+    var onDelete: ((UUID) -> Void)?
+    var editingTurnId: UUID?
+    var editText: Binding<String>?
+    var onConfirmEdit: (() -> Void)?
+    var onCancelEdit: (() -> Void)?
+
+    private let horizontalPadding: CGFloat = 12
+
+    var body: some View {
+        ContentBlockView(
+            block: block,
+            width: width - (horizontalPadding * 2),
+            agentName: agentName,
+            isTurnHovered: isTurnHovered,
+            onCopy: onCopy,
+            onRegenerate: onRegenerate,
+            onEdit: onEdit,
+            onDelete: onDelete,
+            editingTurnId: editingTurnId,
+            editText: editText,
+            onConfirmEdit: onConfirmEdit,
+            onCancelEdit: onCancelEdit
+        )
+        .environment(\.theme, theme)
+        .environmentObject(expandedBlocksStore)
+        .padding(.horizontal, horizontalPadding)
+    }
+}
+
+// MARK: - MessageCellView
 
 @MainActor
 final class MessageCellView: NSTableCellView {
@@ -22,12 +72,12 @@ final class MessageCellView: NSTableCellView {
     // MARK: - Private State
 
     /// The embedded hosting view rendering the SwiftUI content.
-    private var hostingView: NSHostingView<AnyView>?
+    private var hostingView: NSHostingView<CellRootView>?
 
     /// Block ID currently displayed; used to detect reuse externally.
     private(set) var blockId: String?
 
-    /// Horizontal padding (mirrors the original `.padding(.horizontal, 12)`).
+    /// Horizontal padding stored so CellRootView can reference the same value.
     private let horizontalPadding: CGFloat = 12
 
     // MARK: - Initialization
@@ -48,6 +98,9 @@ final class MessageCellView: NSTableCellView {
     ///
     /// If a hosting view already exists it updates `rootView` in place,
     /// which is significantly cheaper than recreating the view hierarchy.
+    /// Because `CellRootView` holds a typed `ContentBlockView` (not `AnyView`),
+    /// SwiftUI can use `ContentBlockView`'s `Equatable` conformance to skip
+    /// the layout pass entirely when the block content has not changed.
     func configure(
         block: ContentBlock,
         width: CGFloat,
@@ -66,11 +119,13 @@ final class MessageCellView: NSTableCellView {
     ) {
         blockId = block.id
 
-        let contentView = ContentBlockView(
+        let rootView = CellRootView(
             block: block,
-            width: width - (horizontalPadding * 2),
+            width: width,
             agentName: agentName,
             isTurnHovered: isTurnHovered,
+            theme: theme,
+            expandedBlocksStore: expandedBlocksStore,
             onCopy: onCopy,
             onRegenerate: onRegenerate,
             onEdit: onEdit,
@@ -80,16 +135,11 @@ final class MessageCellView: NSTableCellView {
             onConfirmEdit: onConfirmEdit,
             onCancelEdit: onCancelEdit
         )
-        .environment(\.theme, theme)
-        .environmentObject(expandedBlocksStore)
-        .padding(.horizontal, horizontalPadding)
-
-        let wrapped = AnyView(contentView)
 
         if let hostingView {
-            hostingView.rootView = wrapped
+            hostingView.rootView = rootView
         } else {
-            createHostingView(rootView: wrapped)
+            createHostingView(rootView: rootView)
         }
     }
 
@@ -98,22 +148,19 @@ final class MessageCellView: NSTableCellView {
     override func prepareForReuse() {
         super.prepareForReuse()
         blockId = nil
-        // Intentionally keep the hosting view alive -- updating rootView
-        // on the next configure() is much cheaper than teardown + rebuild.
     }
 
     // MARK: - Private Helpers
 
-    private func createHostingView(rootView: AnyView) {
+    private func createHostingView(rootView: CellRootView) {
         let hv = NSHostingView(rootView: rootView)
         hv.translatesAutoresizingMaskIntoConstraints = false
         hv.layer?.backgroundColor = NSColor.clear.cgColor
 
         addSubview(hv)
 
-        // Pin all four edges. The table's `usesAutomaticRowHeights` derives
-        // row height from these constraints + the hosting view's intrinsic
-        // content size, so the row is always exactly as tall as its content.
+        // pin all four edges; usesAutomaticRowHeights derives row height from
+        // these constraints + the hosting view's intrinsic content size.
         NSLayoutConstraint.activate([
             hv.topAnchor.constraint(equalTo: topAnchor),
             hv.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -210,25 +210,29 @@ struct SelectableTextView: NSViewRepresentable {
     }
 
     func updateNSView(_ textView: SelectableNSTextView, context: Context) {
-        // Update container width
-        textView.textContainer?.containerSize = NSSize(width: baseWidth, height: CGFloat.greatestFiniteMagnitude)
-
-        // Update selection color for theme changes
-        textView.selectedTextAttributes = [
-            .backgroundColor: NSColor(theme.selectionColor)
-        ]
-
-        // Update theme colors for custom drawing
-        textView.accentColor = NSColor(theme.accentColor)
-        textView.blockquoteBarColor = NSColor(theme.accentColor).withAlphaComponent(0.6)
-        textView.secondaryBackgroundColor = NSColor(theme.secondaryBackground)
-
-        // Fast path: Direct comparison instead of expensive O(n) hashing every update
-        // Swift's Equatable for arrays uses optimized comparison that short-circuits early
+        // compute change flags first so every guard below can reference them cheaply
         let themeFingerprint = makeThemeFingerprint()
         let widthChanged = abs(context.coordinator.lastWidth - baseWidth) > 0.1
         let themeChanged = context.coordinator.lastThemeFingerprint != themeFingerprint
         let blocksChanged = context.coordinator.lastBlocks != blocks
+
+        // setting containerSize calls textContainerChangedGeometry, which invalidates the
+        // entire NSLayoutManager even when the value hasn't changed — guard it so we only
+        // pay the layout cost when the width actually differs.
+        if widthChanged {
+            textView.textContainer?.containerSize = NSSize(width: baseWidth, height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        // selectedTextAttributes triggers needsDisplay; accent colors are only used during
+        // custom drawing — only push these when the theme actually changes.
+        if themeChanged {
+            textView.selectedTextAttributes = [
+                .backgroundColor: NSColor(theme.selectionColor)
+            ]
+            textView.accentColor = NSColor(theme.accentColor)
+            textView.blockquoteBarColor = NSColor(theme.accentColor).withAlphaComponent(0.6)
+            textView.secondaryBackgroundColor = NSColor(theme.secondaryBackground)
+        }
 
         if blocksChanged || widthChanged || themeChanged {
             if !widthChanged && !themeChanged && !context.coordinator.lastBlocks.isEmpty {

--- a/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - Animated Orb
@@ -44,6 +45,7 @@ struct AnimatedOrb: View {
     @State private var floatOffset: CGFloat = 0
     @State private var glowPulse: CGFloat = 1.0
     @State private var isHovered = false
+    @State private var isAppActive = true
 
     // MARK: - Seed Hashing
 
@@ -77,6 +79,23 @@ struct AnimatedOrb: View {
             }
         }
         .onAppear(perform: startAnimations)
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.willResignActiveNotification)
+        ) { _ in
+            isAppActive = false
+            var t = Transaction()
+            t.animation = nil
+            withTransaction(t) {
+                floatOffset = 0
+                glowPulse = 1.0
+            }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        ) { _ in
+            isAppActive = true
+            startAnimations()
+        }
     }
 
     // MARK: - Computed Properties
@@ -131,10 +150,20 @@ private struct OrbShaderContent: View {
     let seedHash: Float
 
     @State private var startTime = Date.now
+    /// time value frozen at the moment the app resigned active
+    @State private var frozenTime: Float = 0
+    @State private var isAppActive = true
 
     var body: some View {
-        TimelineView(.periodic(from: .now, by: 1.0 / 30.0)) { timeline in
-            let time = Float(timeline.date.timeIntervalSince(startTime))
+        // .animation(minimumInterval:, paused:) is display-link driven and actually stops
+        // the display link when paused — .periodic fires at the given interval regardless
+        // of app state, still submitting CA draw calls that keep the compositor busy.
+        // paused: !isAppActive ensures zero CA updates when the app is not in the foreground.
+        TimelineView(.animation(minimumInterval: 1.0 / 15.0, paused: !isAppActive)) { timeline in
+            let elapsed = Float(timeline.date.timeIntervalSince(startTime))
+            // when paused, timeline.date stops advancing, but on resume it jumps to wall-clock
+            // time; use frozenTime to preserve the shader's animation phase across pause/resume.
+            let time = isAppActive ? elapsed : frozenTime
 
             ZStack {
                 Rectangle()
@@ -149,6 +178,19 @@ private struct OrbShaderContent: View {
 
                 particleCanvas(time: time)
             }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.willResignActiveNotification)
+        ) { _ in
+            frozenTime = Float(Date.now.timeIntervalSince(startTime))
+            isAppActive = false
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        ) { _ in
+            // shift startTime forward so the shader resumes from exactly the frozen phase
+            startTime = Date.now - TimeInterval(frozenTime)
+            isAppActive = true
         }
     }
 

--- a/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
+++ b/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
@@ -122,14 +122,22 @@ struct CodeContentView: NSViewRepresentable {
     func updateNSView(_ textView: CodeNSTextView, context: Context) {
         let coord = context.coordinator
         let themeId = "\(theme.monoFontName)|\(theme.bodySize)"
-        textView.textContainer?.containerSize = NSSize(width: baseWidth, height: .greatestFiniteMagnitude)
-        textView.selectedTextAttributes = [.backgroundColor: NSColor(theme.selectionColor)]
-        textView.lineNumberColor = NSColor(theme.tertiaryText.opacity(0.4))
 
         let codeChanged = coord.lastCode != code
         let langChanged = coord.lastLanguage != language
         let widthChanged = abs(coord.lastWidth - baseWidth) > 0.1
         let themeChanged = coord.lastThemeId != themeId
+
+        // guard containerSize — setting it always invalidates NSLayoutManager even when unchanged
+        if widthChanged {
+            textView.textContainer?.containerSize = NSSize(width: baseWidth, height: .greatestFiniteMagnitude)
+        }
+
+        // selectedTextAttributes triggers needsDisplay; only push on theme changes
+        if themeChanged {
+            textView.selectedTextAttributes = [.backgroundColor: NSColor(theme.selectionColor)]
+            textView.lineNumberColor = NSColor(theme.tertiaryText.opacity(0.4))
+        }
 
         if codeChanged || langChanged || widthChanged || themeChanged {
             let attrStr = buildAttributedString()

--- a/Packages/OsaurusCore/Views/Common/GlassBackground.swift
+++ b/Packages/OsaurusCore/Views/Common/GlassBackground.swift
@@ -27,6 +27,15 @@ final class GlassContainerView: NSView {
             || bottomTrailingRadius != nil
     }
 
+    // cached values used to skip redundant CAShapeLayer creation
+    private var _lastHasCustomCorners = false
+    private var _lastCornerRadius: CGFloat = -1
+    private var _lastMaskBounds: CGRect = .zero
+    private var _lastTopLeading: CGFloat? = nil
+    private var _lastBottomLeading: CGFloat? = nil
+    private var _lastTopTrailing: CGFloat? = nil
+    private var _lastBottomTrailing: CGFloat? = nil
+
     init(baseGlassView: NSVisualEffectView, edgeLightingView: NSView, tintOverlayView: NSView) {
         self.baseGlassView = baseGlassView
         self.edgeLightingView = edgeLightingView
@@ -44,33 +53,59 @@ final class GlassContainerView: NSView {
     }
 
     func updateMaskIfNeeded() {
-        guard hasCustomCorners else {
-            // Use native cornerRadius
+        if hasCustomCorners {
+            // custom-corner path: use CAShapeLayer masks
+            guard bounds.width > 0 && bounds.height > 0 else { return }
+
+            let tl = topLeadingRadius
+            let bl = bottomLeadingRadius
+            let tt = topTrailingRadius
+            let bt = bottomTrailingRadius
+
+            // skip if nothing has changed since last pass
+            guard !_lastHasCustomCorners
+                || bounds != _lastMaskBounds
+                || tl != _lastTopLeading
+                || bl != _lastBottomLeading
+                || tt != _lastTopTrailing
+                || bt != _lastBottomTrailing
+            else { return }
+
+            _lastHasCustomCorners = true
+            _lastMaskBounds = bounds
+            _lastTopLeading = tl
+            _lastBottomLeading = bl
+            _lastTopTrailing = tt
+            _lastBottomTrailing = bt
+
+            baseGlassView.layer?.cornerRadius = 0
+            baseGlassView.layer?.masksToBounds = false
+            edgeLightingView.layer?.cornerRadius = 0
+            edgeLightingView.layer?.masksToBounds = false
+            tintOverlayView.layer?.cornerRadius = 0
+            tintOverlayView.layer?.masksToBounds = false
+
+            baseGlassView.layer?.mask = createMaskLayer(for: bounds)
+            edgeLightingView.layer?.mask = createMaskLayer(for: bounds)
+            tintOverlayView.layer?.mask = createMaskLayer(for: bounds)
+        } else {
+            // uniform corner-radius path: use native CA cornerRadius
+            let r = cornerRadius
+            guard r != _lastCornerRadius || _lastHasCustomCorners else { return }
+
+            _lastCornerRadius = r
+            _lastHasCustomCorners = false
+
             baseGlassView.layer?.mask = nil
             edgeLightingView.layer?.mask = nil
             tintOverlayView.layer?.mask = nil
-            baseGlassView.layer?.cornerRadius = cornerRadius
+            baseGlassView.layer?.cornerRadius = r
             baseGlassView.layer?.masksToBounds = true
-            edgeLightingView.layer?.cornerRadius = cornerRadius
+            edgeLightingView.layer?.cornerRadius = r
             edgeLightingView.layer?.masksToBounds = true
-            tintOverlayView.layer?.cornerRadius = cornerRadius
+            tintOverlayView.layer?.cornerRadius = r
             tintOverlayView.layer?.masksToBounds = true
-            return
         }
-
-        // Use mask for custom corners
-        baseGlassView.layer?.cornerRadius = 0
-        baseGlassView.layer?.masksToBounds = false
-        edgeLightingView.layer?.cornerRadius = 0
-        edgeLightingView.layer?.masksToBounds = false
-        tintOverlayView.layer?.cornerRadius = 0
-        tintOverlayView.layer?.masksToBounds = false
-
-        guard bounds.width > 0 && bounds.height > 0 else { return }
-
-        baseGlassView.layer?.mask = createMaskLayer(for: bounds)
-        edgeLightingView.layer?.mask = createMaskLayer(for: bounds)
-        tintOverlayView.layer?.mask = createMaskLayer(for: bounds)
     }
 
     private func effectiveRadius(for corner: CGFloat?) -> CGFloat {
@@ -148,7 +183,9 @@ struct GlassBackground: NSViewRepresentable {
         let baseGlassView = NSVisualEffectView()
         baseGlassView.material = material
         baseGlassView.blendingMode = .behindWindow
-        baseGlassView.state = .active
+        // .followsWindowActiveState deactivates the behind-window desktop capture when the window
+        // is not key, eliminating compositor sampling cost while the app is backgrounded.
+        baseGlassView.state = .followsWindowActiveState
         baseGlassView.wantsLayer = true
 
         // Edge lighting layer (disabled - using single clean edge)

--- a/Packages/OsaurusCore/Views/Management/SharedSidebarComponents.swift
+++ b/Packages/OsaurusCore/Views/Management/SharedSidebarComponents.swift
@@ -487,9 +487,15 @@ struct SidebarRowBackground: View {
 
 // MARK: - Utilities
 
+// shared instance — initialised once; only localizedString(for:relativeTo:) is called on it,
+// which does not mutate the formatter. nonisolated(unsafe) silences the Sendable warning.
+nonisolated(unsafe) private let _sharedRelativeDateFormatter: RelativeDateTimeFormatter = {
+    let f = RelativeDateTimeFormatter()
+    f.unitsStyle = .abbreviated
+    return f
+}()
+
 /// Formats a date as a relative time string (e.g., "2h ago", "yesterday").
 func formatRelativeDate(_ date: Date) -> String {
-    let formatter = RelativeDateTimeFormatter()
-    formatter.unitsStyle = .abbreviated
-    return formatter.localizedString(for: date, relativeTo: Date())
+    _sharedRelativeDateFormatter.localizedString(for: date, relativeTo: Date())
 }


### PR DESCRIPTION
## Changes

- reduced the tick rate of `AnimatedOrb` to 15 fps and also added lifecycle aware start/stop for the animation
- removed multiple `NSVisualEffectView` in `.behindWindow` mode in `GlassBackground`
- reuse a single formatter instance of `RelativeDateTimeFormatter`(as it is also expensive to initialize) instead of a new one for every `SessionRow` render
- added cached-value guards before the mask creation paths in `GlassContainerView.updateMaskIfNeeded`
- added concrete type instead of `NSHostingView<AnyView>`  in `MessageCellView` to take advantage of SwiftUI's diffing through Equatable
- removed `.ultraThinMaterial` from `ContentBlockView.messageBubbleBackground`
- both `SelectableTextView` and `CodeContentView` have been updated to prevent unconditional NSTextView property assignments in `updateNSView`

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
