### PR TITLE
fix race condition

### DIFF
--- a/App/osaurus/OrbShader.metal
+++ b/App/osaurus/OrbShader.metal
@@ -30,7 +30,12 @@ static float orbFbm(float2 p) {
 
 [[ stitchable ]]
 half4 orbEffect(float2 position, half4 currentColor, float time, float seed, float4 bounds) {
+    if (bounds.z <= 0.0 || bounds.w <= 0.0) {
+        return half4(0.0);
+    }
     float2 uv = position / bounds.zw;
+    // Guard against potential NaN/Inf by clamping uv to a reasonable range
+    uv = clamp(uv, -1.0, 2.0);
     float3 base = float3(currentColor.rgb);
 
     float n1 = orbFbm(uv * 3.0 + float2(time * 0.18 + seed * 10.0, time * 0.14));

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -60,6 +60,8 @@ actor ModelRuntime {
     private var kvCacheStore = KVCacheStore()
     private var cachedConfig: RuntimeConfig?
     private var activeGenerationTask: Task<Void, Never>?
+    // modelName:taskHash -> Task
+    private var prefixCacheTasks: [String: Task<Void, Never>] = [:]
 
     private init() {}
 
@@ -87,11 +89,26 @@ actor ModelRuntime {
         activeGenerationTask?.cancel()
         _ = await activeGenerationTask?.value
         activeGenerationTask = nil
+
+        // also cancel and await all background prefix cache tasks
+        for task in prefixCacheTasks.values {
+            task.cancel()
+            _ = await task.value
+        }
+        prefixCacheTasks.removeAll()
     }
 
     func unload(name: String) async {
         await cancelActiveGeneration()
         kvCacheStore.invalidateModel(name)
+
+        // cancel any specific prefix tasks for this model
+        let modelTasks = prefixCacheTasks.filter { $0.key.hasPrefix("\(name):") }
+        for (key, task) in modelTasks {
+            task.cancel()
+            _ = await task.value
+            prefixCacheTasks.removeValue(forKey: key)
+        }
 
         autoreleasepool {
             _ = modelCache.removeValue(forKey: name)
@@ -368,6 +385,10 @@ actor ModelRuntime {
         }
     }
 
+    private func removePrefixTask(key: String) async {
+        prefixCacheTasks.removeValue(forKey: key)
+    }
+
     /// Builds and persists a prefix KV cache for the given system content and
     /// tools via a minimal 1-token generation.  Called lazily on the first real
     /// query when no persisted prefix cache is found on disk.
@@ -408,8 +429,14 @@ actor ModelRuntime {
             // model unloading and cancel-on-new-message.
             if !background { activeGenerationTask = genTask }
 
-            for await _ in stream {}
-            await genTask.value
+            for await _ in stream {
+                if Task.isCancelled { break }
+            }
+            if !Task.isCancelled {
+                await genTask.value
+            } else {
+                genTask.cancel()
+            }
 
             guard !Task.isCancelled else { return }
             guard cache.contains(where: { $0.offset > 0 }) else {
@@ -471,17 +498,23 @@ actor ModelRuntime {
             // actor-isolated Task. This natively prevents the entire generation engine
             // from synchronously sitting dead waiting for Apple's MLX framework to execute and
             // serialize the system-prompt's initial AST block when booting up completely new chats.
-            Task {
-                await buildPrefixCache(
-                    holder: holder,
-                    systemContent: systemContent,
-                    tools: tools,
-                    toolChoice: toolChoice,
-                    modelName: modelName,
-                    hash: prefixHash,
-                    runtimeConfig: cfg,
-                    background: true
-                )
+            let taskKey = "\(modelName):\(prefixHash)"
+            if prefixCacheTasks[taskKey] == nil {
+                let task = Task {
+                    await buildPrefixCache(
+                        holder: holder,
+                        systemContent: systemContent,
+                        tools: tools,
+                        toolChoice: toolChoice,
+                        modelName: modelName,
+                        hash: prefixHash,
+                        runtimeConfig: cfg,
+                        background: true
+                    )
+                    // Remove from tracking when done
+                    await removePrefixTask(key: taskKey)
+                }
+                prefixCacheTasks[taskKey] = task
             }
         }
 

--- a/Packages/OsaurusCore/Services/Voice/VADService.swift
+++ b/Packages/OsaurusCore/Services/Voice/VADService.swift
@@ -111,6 +111,10 @@ public final class VADService: ObservableObject {
 
         print("[VADService] Starting with \(configuration.enabledAgentIds.count) enabled agents")
 
+        // brief delay of 2s to avoid GPU contention during app startup/prefix-caching
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        guard !Task.isCancelled else { return }
+
         state = .starting
 
         // Ensure model is loaded

--- a/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
@@ -155,28 +155,33 @@ private struct OrbShaderContent: View {
     @State private var isAppActive = true
 
     var body: some View {
-        // .animation(minimumInterval:, paused:) is display-link driven and actually stops
-        // the display link when paused — .periodic fires at the given interval regardless
-        // of app state, still submitting CA draw calls that keep the compositor busy.
-        // paused: !isAppActive ensures zero CA updates when the app is not in the foreground.
-        TimelineView(.animation(minimumInterval: 1.0 / 15.0, paused: !isAppActive)) { timeline in
-            let elapsed = Float(timeline.date.timeIntervalSince(startTime))
-            // when paused, timeline.date stops advancing, but on resume it jumps to wall-clock
-            // time; use frozenTime to preserve the shader's animation phase across pause/resume.
-            let time = isAppActive ? elapsed : frozenTime
+        GeometryReader { geometry in
+            let size = geometry.size
+            if size.width > 0 && size.height > 0 {
+                // .animation(minimumInterval:, paused:) is display-link driven and actually stops
+                // the display link when paused — .periodic fires at the given interval regardless
+                // of app state, still submitting CA draw calls that keep the compositor busy.
+                // paused: !isAppActive ensures zero CA updates when the app is not in the foreground.
+                TimelineView(.animation(minimumInterval: 1.0 / 15.0, paused: !isAppActive)) { timeline in
+                    let elapsed = Float(timeline.date.timeIntervalSince(startTime))
+                    // when paused, timeline.date stops advancing, but on resume it jumps to wall-clock
+                    // time; use frozenTime to preserve the shader's animation phase across pause/resume.
+                    let time = isAppActive ? elapsed : frozenTime
 
-            ZStack {
-                Rectangle()
-                    .fill(color)
-                    .colorEffect(
-                        ShaderLibrary.orbEffect(
-                            .float(time),
-                            .float(seedHash),
-                            .boundingRect
-                        )
-                    )
+                    ZStack {
+                        Rectangle()
+                            .fill(color)
+                            .colorEffect(
+                                ShaderLibrary.orbEffect(
+                                    .float(time),
+                                    .float(seedHash),
+                                    .boundingRect
+                                )
+                            )
 
-                particleCanvas(time: time)
+                        particleCanvas(time: time)
+                    }
+                }
             }
         }
         .onReceive(


### PR DESCRIPTION
Addresses #744 

## Changes

- track and await all background prefix cache tasks before model unloading to prevent null pointer dereference
- synchronize command queue explicitly before clearing MLX memory
- delay VADService startup by 2s to reduce initial resource contention

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
