### PR TITLE
batch embedding for context index rebuilds

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -159,7 +159,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             }
         }
 
-        // Initialize context management (sequential to avoid concurrent CoreML model loads).
+        // Context indexes: open DBs and construct VecturaKit instances in order so only one
+        // SwiftEmbedder-backed init runs at a time (see EmbeddingService.sharedEmbedder).
+        // Rebuild paths batch documents into a single embed call per index, not N serial adds.
         Task {
             try? MethodDatabase.shared.open()
             await MethodSearchService.shared.initialize()

--- a/Packages/OsaurusCore/Services/Method/MethodSearchService.swift
+++ b/Packages/OsaurusCore/Services/Method/MethodSearchService.swift
@@ -131,11 +131,17 @@ public actor MethodSearchService {
             let toolDescs = Self.loadToolDescriptions()
 
             let methods = try MethodDatabase.shared.loadAllMethods()
+            var texts: [String] = []
+            var ids: [UUID] = []
+            texts.reserveCapacity(methods.count)
+            ids.reserveCapacity(methods.count)
             for method in methods {
                 let id = deterministicUUID(for: method.id)
-                let text = buildIndexText(for: method, toolDescriptions: toolDescs)
-                _ = try await db.addDocument(text: text, id: id)
-                reverseIdMap[id.uuidString] = method.id
+                texts.append(buildIndexText(for: method, toolDescriptions: toolDescs))
+                ids.append(id)
+            }
+            if !texts.isEmpty {
+                _ = try await db.addDocuments(texts: texts, ids: ids)
             }
             MethodLogger.search.info("Method index rebuilt with \(methods.count) methods")
         } catch {

--- a/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
+++ b/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
@@ -143,10 +143,17 @@ public actor SkillSearchService {
             reverseIdMap.removeAll()
 
             let allSkills = await MainActor.run { SkillManager.shared.skills }
+            var texts: [String] = []
+            var ids: [UUID] = []
+            texts.reserveCapacity(allSkills.count)
+            ids.reserveCapacity(allSkills.count)
             for skill in allSkills {
                 let id = deterministicUUID(for: skill.id)
-                let text = buildIndexText(for: skill)
-                _ = try await db.addDocument(text: text, id: id)
+                texts.append(buildIndexText(for: skill))
+                ids.append(id)
+            }
+            if !texts.isEmpty {
+                _ = try await db.addDocuments(texts: texts, ids: ids)
             }
             SkillSearchLogger.search.info("Skill index rebuilt with \(allSkills.count) skills")
         } catch {

--- a/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
@@ -52,7 +52,6 @@ public actor ToolIndexService {
 
             do {
                 try ToolDatabase.shared.upsertEntry(entry)
-                await ToolSearchService.shared.indexEntry(entry, parameters: tool.parameters)
             } catch {
                 ToolIndexLogger.service.error("Failed to sync tool '\(tool.name)' to index: \(error)")
             }
@@ -66,7 +65,6 @@ public actor ToolIndexService {
             for stale in staleSystemEntries {
                 do {
                     try ToolDatabase.shared.deleteEntry(id: stale.id)
-                    await ToolSearchService.shared.removeEntry(id: stale.id)
                     ToolIndexLogger.service.info("Pruned stale tool index entry: \(stale.id)")
                 } catch {
                     ToolIndexLogger.service.error("Failed to prune stale entry '\(stale.id)': \(error)")
@@ -75,6 +73,8 @@ public actor ToolIndexService {
         } catch {
             ToolIndexLogger.service.error("Failed to load entries for pruning: \(error)")
         }
+
+        await ToolSearchService.shared.rebuildIndex()
 
         let count = (try? ToolDatabase.shared.entryCount()) ?? 0
         ToolIndexLogger.service.info("Tool index synced: \(count) entries from registry")

--- a/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
@@ -158,14 +158,23 @@ public actor ToolSearchService {
             }
 
             let entries = try ToolDatabase.shared.loadAllEntries()
+            var texts: [String] = []
+            var ids: [UUID] = []
+            texts.reserveCapacity(entries.count)
+            ids.reserveCapacity(entries.count)
             for entry in entries {
                 let id = deterministicUUID(for: entry.id)
-                let text = buildIndexText(
-                    name: entry.name,
-                    description: entry.description,
-                    parameters: toolParams[entry.name]
+                texts.append(
+                    buildIndexText(
+                        name: entry.name,
+                        description: entry.description,
+                        parameters: toolParams[entry.name]
+                    )
                 )
-                _ = try await db.addDocument(text: text, id: id)
+                ids.append(id)
+            }
+            if !texts.isEmpty {
+                _ = try await db.addDocuments(texts: texts, ids: ids)
             }
             ToolIndexLogger.search.info("Tool index rebuilt with \(entries.count) entries")
         } catch {


### PR DESCRIPTION
## Summary

rebuild and tool registry sync no longer call addDocument once per row. they use addDocuments so the embedder runs in fewer, larger batches. startup ordering for DB open and Vectura init is unchanged.

## Changes

- `SkillSearchService`, `MethodSearchService`, `ToolSearchService` rebuildIndex collects texts/IDs and calls `addDocuments(texts:ids:)` instead of looping addDocument
- `ToolIndexService.syncFromRegistry` upserts SQLite (and prunes stale rows) then calls `ToolSearchService.rebuildIndex() `once instead of per tool `indexEntry`
- `AppDelegate` comment clarifies ordered init vs batched rebuild embedding

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
