### PR TITLE
fix UI Freeze by making skill related I/O and processing asynchronous

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -111,7 +111,7 @@ final class PluginManager {
             for loaded in plugins {
                 ToolRegistry.shared.unregister(names: loaded.tools.map { $0.name })
                 if !loaded.skills.isEmpty {
-                    SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
+                    await SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
                 }
                 await loaded.plugin.shutdown()
                 PluginHostContext.getContext(for: loaded.plugin.id)?.teardown()
@@ -149,7 +149,7 @@ final class PluginManager {
             } else {
                 ToolRegistry.shared.unregister(names: loaded.tools.map { $0.name })
                 if !loaded.skills.isEmpty {
-                    SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
+                    await SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
                 }
                 await loaded.plugin.shutdown()
                 PluginHostContext.getContext(for: loaded.plugin.id)?.teardown()
@@ -178,7 +178,7 @@ final class PluginManager {
 
                 // Register plugin skills
                 for skill in loaded.skills {
-                    SkillManager.shared.registerPluginSkill(skill)
+                    await SkillManager.shared.registerPluginSkill(skill)
                 }
 
                 // Clear any previous failure for this plugin

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -33,15 +33,18 @@ public final class SkillManager {
     public static let shared = SkillManager()
 
     public private(set) var skills: [Skill] = []
+    public private(set) var isRefreshing = false
 
     private init() {
-        refresh()
+        Task { await refresh() }
     }
 
     // MARK: - CRUD
 
-    public func refresh() {
-        skills = SkillStore.loadAll()
+    public func refresh() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+        skills = await SkillStore.loadAll()
     }
 
     @discardableResult
@@ -52,7 +55,7 @@ public final class SkillManager {
         author: String? = nil,
         category: String? = nil,
         instructions: String = ""
-    ) -> Skill {
+    ) async -> Skill {
         let skill = Skill(
             name: name,
             description: description,
@@ -61,30 +64,30 @@ public final class SkillManager {
             category: category,
             instructions: instructions
         )
-        SkillStore.save(skill)
-        refresh()
+        await SkillStore.save(skill)
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
         return skill
     }
 
-    public func update(_ skill: Skill) {
+    public func update(_ skill: Skill) async {
         guard !skill.isBuiltIn && !skill.isFromPlugin else { return }
         var updated = skill
         updated.updatedAt = Date()
-        SkillStore.save(updated)
-        refresh()
+        await SkillStore.save(updated)
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(updated) }
     }
 
     @discardableResult
-    public func delete(id: UUID) -> Bool {
+    public func delete(id: UUID) async -> Bool {
         // Prevent deleting plugin-provided skills
         if let skill = skill(for: id), skill.isFromPlugin { return false }
-        let result = SkillStore.delete(id: id)
+        let result = await SkillStore.delete(id: id)
         if result {
-            refresh()
+            await refresh()
 
             Task { await SkillSearchService.shared.removeSkill(id: id) }
         }
@@ -94,30 +97,30 @@ public final class SkillManager {
     // MARK: - Plugin Skills
 
     /// Register a skill from a plugin. If a skill with the same pluginId and name already exists, update it.
-    public func registerPluginSkill(_ skill: Skill) {
+    public func registerPluginSkill(_ skill: Skill) async {
         // Check if we already have a skill from this plugin with the same name
         if let existing = skills.first(where: { $0.pluginId == skill.pluginId && $0.name == skill.name }) {
             // Update existing skill but preserve enabled state
             var updated = skill
             updated.enabled = existing.enabled
-            SkillStore.save(updated)
+            await SkillStore.save(updated)
         } else {
-            SkillStore.save(skill)
+            await SkillStore.save(skill)
         }
-        refresh()
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
     }
 
     /// Remove all skills associated with a plugin
-    public func unregisterPluginSkills(pluginId: String) {
+    public func unregisterPluginSkills(pluginId: String) async {
         let pluginSkillIds = skills.filter { $0.pluginId == pluginId }.map { $0.id }
         for id in pluginSkillIds {
-            _ = SkillStore.delete(id: id)
+            _ = await SkillStore.delete(id: id)
             Task { await SkillSearchService.shared.removeSkill(id: id) }
         }
         if !pluginSkillIds.isEmpty {
-            refresh()
+            await refresh()
 
         }
     }
@@ -127,7 +130,7 @@ public final class SkillManager {
         skills.filter { $0.pluginId == pluginId }
     }
 
-    public func setEnabled(_ enabled: Bool, for id: UUID) {
+    public func setEnabled(_ enabled: Bool, for id: UUID) async {
         guard var skill = skill(for: id) else { return }
         skill.enabled = enabled
         skill.updatedAt = Date()
@@ -147,12 +150,12 @@ public final class SkillManager {
                 createdAt: skill.createdAt,
                 updatedAt: Date()
             )
-            SkillStore.save(saveable)
+            await SkillStore.save(saveable)
         } else {
-            SkillStore.save(skill)
+            await SkillStore.save(skill)
         }
 
-        refresh()
+        await refresh()
 
     }
 
@@ -169,7 +172,7 @@ public final class SkillManager {
     // MARK: - Import/Export
 
     @discardableResult
-    public func importSkill(from data: Data) throws -> Skill {
+    public func importSkill(from data: Data) async throws -> Skill {
         var skill = try Skill.importFromJSON(data)
         skill = Skill(
             name: skill.name,
@@ -179,15 +182,15 @@ public final class SkillManager {
             category: skill.category,
             instructions: skill.instructions
         )
-        SkillStore.save(skill)
-        refresh()
+        await SkillStore.save(skill)
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
         return skill
     }
 
     @discardableResult
-    public func importSkillFromMarkdown(_ content: String) throws -> Skill {
+    public func importSkillFromMarkdown(_ content: String) async throws -> Skill {
         var skill = try Skill.parseAnyFormat(from: content)
         skill = Skill(
             name: skill.name,
@@ -197,8 +200,8 @@ public final class SkillManager {
             category: skill.category,
             instructions: skill.instructions
         )
-        SkillStore.save(skill)
-        refresh()
+        await SkillStore.save(skill)
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
         return skill
@@ -206,7 +209,7 @@ public final class SkillManager {
 
     /// Import multiple skills at once (batch import from GitHub)
     @discardableResult
-    public func importSkillsFromMarkdown(_ skills: [Skill]) -> [Skill] {
+    public func importSkillsFromMarkdown(_ skills: [Skill]) async -> [Skill] {
         var imported: [Skill] = []
         for parsedSkill in skills {
             let skill = Skill(
@@ -217,11 +220,11 @@ public final class SkillManager {
                 category: parsedSkill.category,
                 instructions: parsedSkill.instructions
             )
-            SkillStore.save(skill)
+            await SkillStore.save(skill)
             imported.append(skill)
         }
         if !imported.isEmpty {
-            refresh()
+            await refresh()
 
             Task {
                 await EmbeddingService.awaitStartupInit()
@@ -243,38 +246,38 @@ public final class SkillManager {
 
     // MARK: - File Management
 
-    public func addReference(to skillId: UUID, name: String, content: Data) throws {
+    public func addReference(to skillId: UUID, name: String, content: Data) async throws {
         guard let skill = skill(for: skillId), !skill.isBuiltIn else {
             throw SkillFileError.cannotModifyBuiltIn
         }
-        try SkillStore.addReference(to: skill, name: name, content: content)
-        refresh()
+        try await SkillStore.addReference(to: skill, name: name, content: content)
+        await refresh()
 
     }
 
-    public func addAsset(to skillId: UUID, name: String, content: Data) throws {
+    public func addAsset(to skillId: UUID, name: String, content: Data) async throws {
         guard let skill = skill(for: skillId), !skill.isBuiltIn else {
             throw SkillFileError.cannotModifyBuiltIn
         }
-        try SkillStore.addAsset(to: skill, name: name, content: content)
-        refresh()
+        try await SkillStore.addAsset(to: skill, name: name, content: content)
+        await refresh()
 
     }
 
-    public func removeFile(from skillId: UUID, relativePath: String) throws {
+    public func removeFile(from skillId: UUID, relativePath: String) async throws {
         guard let skill = skill(for: skillId), !skill.isBuiltIn else {
             throw SkillFileError.cannotModifyBuiltIn
         }
-        try SkillStore.removeFile(from: skill, relativePath: relativePath)
-        refresh()
+        try await SkillStore.removeFile(from: skill, relativePath: relativePath)
+        await refresh()
 
     }
 
-    public func readFile(from skillId: UUID, relativePath: String) throws -> Data {
+    public func readFile(from skillId: UUID, relativePath: String) async throws -> Data {
         guard let skill = skill(for: skillId) else {
             throw SkillFileError.skillNotFound
         }
-        return try SkillStore.readFile(from: skill, relativePath: relativePath)
+        return try await SkillStore.readFile(from: skill, relativePath: relativePath)
     }
 
     public func skillDirectory(for skillId: UUID) -> URL? {
@@ -284,13 +287,13 @@ public final class SkillManager {
 
     // MARK: - ZIP Export/Import
 
-    public func exportSkillAsZip(_ skill: Skill) throws -> URL {
+    public func exportSkillAsZip(_ skill: Skill) async throws -> URL {
         let skillDir = SkillStore.skillDirectory(for: skill)
         let zipURL = FileManager.default.temporaryDirectory.appendingPathComponent(
             "\(skill.xplaceholder_agentSkillsNamex).zip"
         )
         try? FileManager.default.removeItem(at: zipURL)
-        try FileManager.default.zipItem(at: skillDir, to: zipURL)
+        try await FileManager.default.zipItem(at: skillDir, to: zipURL)
         guard FileManager.default.fileExists(atPath: zipURL.path) else {
             throw SkillFileError.exportFailed
         }
@@ -298,12 +301,16 @@ public final class SkillManager {
     }
 
     @discardableResult
-    public func importSkillFromZip(_ zipURL: URL) throws -> Skill {
+    public func importSkillFromZip(_ zipURL: URL) async throws -> Skill {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
+        defer {
+            Task.detached {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+        }
 
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        try FileManager.default.unzipItem(at: zipURL, to: tempDir)
+        try await FileManager.default.unzipItem(at: zipURL, to: tempDir)
 
         guard let skillMdURL = findSkillMd(in: tempDir) else {
             throw SkillFileError.invalidSkillArchive
@@ -324,7 +331,7 @@ public final class SkillManager {
             directoryName: skill.xplaceholder_agentSkillsNamex
         )
 
-        SkillStore.save(skill)
+        await SkillStore.save(skill)
 
         // Copy associated files
         let destDir = SkillStore.skillDirectory(for: skill)
@@ -348,7 +355,7 @@ public final class SkillManager {
             }
         }
 
-        refresh()
+        await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
         return skill
@@ -380,31 +387,31 @@ public final class SkillManager {
 
     // MARK: - Catalog & Instructions
 
-    public func loadInstructions(for skillNames: [String]) -> [String: String] {
+    public func loadInstructions(for skillNames: [String]) async -> [String: String] {
         var result: [String: String] = [:]
         for name in skillNames {
             if let skill = skill(named: name), skill.enabled {
-                result[name] = buildFullInstructions(for: skill)
+                result[name] = await buildFullInstructions(for: skill)
             }
         }
         return result
     }
 
-    public func loadInstructions(forIds ids: [UUID]) -> [UUID: String] {
+    public func loadInstructions(forIds ids: [UUID]) async -> [UUID: String] {
         var result: [UUID: String] = [:]
         for id in ids {
             if let skill = skill(for: id), skill.enabled {
-                result[id] = buildFullInstructions(for: skill)
+                result[id] = await buildFullInstructions(for: skill)
             }
         }
         return result
     }
 
-    private func buildFullInstructions(for skill: Skill) -> String {
+    private func buildFullInstructions(for skill: Skill) async -> String {
         var sections = [skill.instructions]
 
         if !skill.references.isEmpty {
-            let refs = loadReferenceContents(for: skill)
+            let refs = await loadReferenceContents(for: skill)
             if !refs.isEmpty {
                 sections.append("\n## Reference Materials\n\n\(refs)")
             }
@@ -413,7 +420,7 @@ public final class SkillManager {
         return sections.joined(separator: "\n")
     }
 
-    private func loadReferenceContents(for skill: Skill) -> String {
+    private func loadReferenceContents(for skill: Skill) async -> String {
         let textExtensions: Set<String> = [
             "md", "txt", "json", "yaml", "yml", "xml", "html", "css", "js", "ts",
             "swift", "py", "rb", "go", "rs", "java", "kt", "c", "cpp", "h", "hpp",
@@ -430,7 +437,7 @@ public final class SkillManager {
             }
 
             do {
-                let data = try SkillStore.readFile(from: skill, relativePath: file.relativePath)
+                let data = try await SkillStore.readFile(from: skill, relativePath: file.relativePath)
                 if let text = String(data: data, encoding: .utf8) {
                     contents.append("### \(file.name)\n\n```\n\(text)\n```\n")
                 }
@@ -457,48 +464,52 @@ public final class SkillManager {
 // MARK: - FileManager ZIP Extension
 
 extension FileManager {
-    func unzipItem(at sourceURL: URL, to destinationURL: URL) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-o", "-q", sourceURL.path, "-d", destinationURL.path]
+    func unzipItem(at sourceURL: URL, to destinationURL: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+            process.arguments = ["-o", "-q", sourceURL.path, "-d", destinationURL.path]
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
 
-        try process.run()
-        process.waitUntilExit()
+            try process.run()
+            process.waitUntilExit()
 
-        if process.terminationStatus != 0 {
-            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            throw NSError(
-                domain: "FileManager",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(output)"]
-            )
-        }
+            if process.terminationStatus != 0 {
+                let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                throw NSError(
+                    domain: "FileManager",
+                    code: Int(process.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "Unzip failed: \(output)"]
+                )
+            }
+        }.value
     }
 
-    func zipItem(at sourceURL: URL, to destinationURL: URL) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-        process.currentDirectoryURL = sourceURL.deletingLastPathComponent()
-        process.arguments = ["-r", "-q", destinationURL.path, sourceURL.lastPathComponent]
+    func zipItem(at sourceURL: URL, to destinationURL: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+            process.currentDirectoryURL = sourceURL.deletingLastPathComponent()
+            process.arguments = ["-r", "-q", destinationURL.path, sourceURL.lastPathComponent]
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
 
-        try process.run()
-        process.waitUntilExit()
+            try process.run()
+            process.waitUntilExit()
 
-        if process.terminationStatus != 0 {
-            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            throw NSError(
-                domain: "FileManager",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(output)"]
-            )
-        }
+            if process.terminationStatus != 0 {
+                let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                throw NSError(
+                    domain: "FileManager",
+                    code: Int(process.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: "Zip failed: \(output)"]
+                )
+            }
+        }.value
     }
 }

--- a/Packages/OsaurusCore/Models/Agent/SkillStore.swift
+++ b/Packages/OsaurusCore/Models/Agent/SkillStore.swift
@@ -8,13 +8,12 @@
 
 import Foundation
 
-@MainActor
 public enum SkillStore {
 
     // MARK: - Public API
 
     /// Load all skills sorted by name, including built-ins
-    public static func loadAll() -> [Skill] {
+    public static func loadAll() async -> [Skill] {
         let directory = skillsDirectory()
         OsaurusPaths.ensureExistsSilent(directory)
         migrateOldFormat()
@@ -95,7 +94,7 @@ public enum SkillStore {
     }
 
     /// Load a specific skill by ID
-    public static func load(id: UUID) -> Skill? {
+    public static func load(id: UUID) async -> Skill? {
         if let builtIn = Skill.builtInSkills.first(where: { $0.id == id }) {
             return builtIn
         }
@@ -126,7 +125,7 @@ public enum SkillStore {
     }
 
     /// Save a skill to disk
-    public static func save(_ skill: Skill) {
+    public static func save(_ skill: Skill) async {
         if skill.isBuiltIn {
             saveBuiltInState(skill)
             return
@@ -163,7 +162,7 @@ public enum SkillStore {
 
     /// Delete a skill by ID
     @discardableResult
-    public static func delete(id: UUID) -> Bool {
+    public static func delete(id: UUID) async -> Bool {
         guard !Skill.builtInSkills.contains(where: { $0.id == id }) else {
             return false
         }
@@ -199,8 +198,11 @@ public enum SkillStore {
     }
 
     /// Check if a skill exists
-    public static func exists(id: UUID) -> Bool {
-        Skill.builtInSkills.contains(where: { $0.id == id }) || load(id: id) != nil
+    public static func exists(id: UUID) async -> Bool {
+        if Skill.builtInSkills.contains(where: { $0.id == id }) {
+            return true
+        }
+        return await load(id: id) != nil
     }
 
     /// Get the directory URL for a skill
@@ -215,27 +217,27 @@ public enum SkillStore {
     // MARK: - File Operations
 
     /// Add a reference file to a skill
-    public static func addReference(to skill: Skill, name: String, content: Data) throws {
+    public static func addReference(to skill: Skill, name: String, content: Data) async throws {
         let refsDir = skillDirectory(for: skill).appendingPathComponent("references")
         try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
         try content.write(to: refsDir.appendingPathComponent(name))
     }
 
     /// Add an asset file to a skill
-    public static func addAsset(to skill: Skill, name: String, content: Data) throws {
+    public static func addAsset(to skill: Skill, name: String, content: Data) async throws {
         let assetsDir = skillDirectory(for: skill).appendingPathComponent("assets")
         try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
         try content.write(to: assetsDir.appendingPathComponent(name))
     }
 
     /// Remove a file from a skill
-    public static func removeFile(from skill: Skill, relativePath: String) throws {
+    public static func removeFile(from skill: Skill, relativePath: String) async throws {
         let fileURL = skillDirectory(for: skill).appendingPathComponent(relativePath)
         try FileManager.default.removeItem(at: fileURL)
     }
 
     /// Read content of a skill file
-    public static func readFile(from skill: Skill, relativePath: String) throws -> Data {
+    public static func readFile(from skill: Skill, relativePath: String) async throws -> Data {
         let fileURL = skillDirectory(for: skill).appendingPathComponent(relativePath)
         return try Data(contentsOf: fileURL)
     }

--- a/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
@@ -176,7 +176,7 @@ final class PluginRepositoryService: ObservableObject {
 
         ToolSecretsKeychain.deleteAllSecretsAllAgents(for: pluginId)
         ToolSecretsKeychain.deleteAllSecrets(for: pluginId)
-        SkillManager.shared.unregisterPluginSkills(pluginId: pluginId)
+        await SkillManager.shared.unregisterPluginSkills(pluginId: pluginId)
 
         // Update state immediately so the UI reflects uninstallation
         if let index = plugins.firstIndex(where: { $0.pluginId == pluginId }) {

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -24,6 +24,8 @@ struct SkillsView: View {
     @State private var showImportPicker = false
     @State private var showGitHubImport = false
     @State private var exportingSkill: Skill?
+    @State private var isProcessing = false
+    @State private var showProgress = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -33,9 +35,19 @@ struct SkillsView: View {
                 .offset(y: hasAppeared ? 0 : -10)
                 .animation(.spring(response: 0.4, dampingFraction: 0.8), value: hasAppeared)
 
+            // Progress bar
+            if showProgress {
+                ProgressView()
+                    .progressViewStyle(LinearProgressViewStyle())
+                    .frame(height: 2)
+                    .transition(.opacity)
+            } else {
+                Spacer().frame(height: 2)
+            }
+
             // Content
             ZStack {
-                if skillManager.skills.isEmpty {
+                if skillManager.skills.isEmpty && !skillManager.isRefreshing {
                     SettingsEmptyState(
                         icon: "sparkles",
                         title: "Create Your First Skill",
@@ -69,7 +81,11 @@ struct SkillsView: View {
                                     animationDelay: Double(index) * 0.03,
                                     hasAppeared: hasAppeared,
                                     onToggle: { enabled in
-                                        skillManager.setEnabled(enabled, for: skill.id)
+                                        Task {
+                                            isProcessing = true
+                                            defer { isProcessing = false }
+                                            await skillManager.setEnabled(enabled, for: skill.id)
+                                        }
                                     },
                                     onEdit: {
                                         editingSkill = skill
@@ -78,8 +94,12 @@ struct SkillsView: View {
                                         exportingSkill = skill
                                     },
                                     onDelete: {
-                                        skillManager.delete(id: skill.id)
-                                        showToast("Deleted \"\(skill.name)\"")
+                                        Task {
+                                            isProcessing = true
+                                            defer { isProcessing = false }
+                                            await skillManager.delete(id: skill.id)
+                                            showToast("Deleted \"\(skill.name)\"")
+                                        }
                                     }
                                 )
                             }
@@ -107,16 +127,20 @@ struct SkillsView: View {
             SkillEditorSheet(
                 mode: .create,
                 onSave: { skill in
-                    skillManager.create(
-                        name: skill.name,
-                        description: skill.description,
-                        version: skill.version,
-                        author: skill.author,
-                        category: skill.category,
-                        instructions: skill.instructions
-                    )
-                    isCreating = false
-                    showToast("Created \"\(skill.name)\"")
+                    Task {
+                        isProcessing = true
+                        defer { isProcessing = false }
+                        await skillManager.create(
+                            name: skill.name,
+                            description: skill.description,
+                            version: skill.version,
+                            author: skill.author,
+                            category: skill.category,
+                            instructions: skill.instructions
+                        )
+                        isCreating = false
+                        showToast("Created \"\(skill.name)\"")
+                    }
                 },
                 onCancel: {
                     isCreating = false
@@ -127,9 +151,13 @@ struct SkillsView: View {
             SkillEditorSheet(
                 mode: .edit(skill),
                 onSave: { updated in
-                    skillManager.update(updated)
-                    editingSkill = nil
-                    showToast("Updated \"\(updated.name)\"")
+                    Task {
+                        isProcessing = true
+                        defer { isProcessing = false }
+                        await skillManager.update(updated)
+                        editingSkill = nil
+                        showToast("Updated \"\(updated.name)\"")
+                    }
                 },
                 onCancel: {
                     editingSkill = nil
@@ -139,12 +167,16 @@ struct SkillsView: View {
         .sheet(isPresented: $showGitHubImport) {
             GitHubImportSheet(
                 onImport: { skills in
-                    let imported = skillManager.importSkillsFromMarkdown(skills)
-                    showGitHubImport = false
-                    if imported.count == 1 {
-                        showToast("Imported \"\(imported[0].name)\"")
-                    } else {
-                        showToast("Imported \(imported.count) skills")
+                    Task {
+                        isProcessing = true
+                        defer { isProcessing = false }
+                        let imported = await skillManager.importSkillsFromMarkdown(skills)
+                        showGitHubImport = false
+                        if imported.count == 1 {
+                            showToast("Imported \"\(imported[0].name)\"")
+                        } else {
+                            showToast("Imported \(imported.count) skills")
+                        }
                     }
                 },
                 onCancel: {
@@ -152,10 +184,29 @@ struct SkillsView: View {
                 }
             )
         }
+        .onChange(of: isProcessing || skillManager.isRefreshing) { _, newValue in
+            if newValue {
+                // Delay showing the progress bar to avoid flickering for fast operations
+                Task {
+                    try? await Task.sleep(nanoseconds: 2_500_000_000) // 2.5 seconds
+                    if isProcessing || skillManager.isRefreshing {
+                        withAnimation(.easeIn(duration: 0.2)) {
+                            showProgress = true
+                        }
+                    }
+                }
+            } else {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    showProgress = false
+                }
+            }
+        }
         .onAppear {
-            skillManager.refresh()
-            withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
-                hasAppeared = true
+            Task {
+                await skillManager.refresh()
+                withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
+                    hasAppeared = true
+                }
             }
         }
         .fileImporter(
@@ -168,18 +219,24 @@ struct SkillsView: View {
             ],
             allowsMultipleSelection: false
         ) { result in
-            handleImport(result)
+            Task {
+                await handleImport(result)
+            }
         }
         .onChange(of: exportingSkill) { _, skill in
             if let skill = skill {
-                exportSkill(skill)
+                Task {
+                    await exportSkill(skill)
+                }
             }
         }
     }
 
     // MARK: - Import/Export
 
-    private func handleImport(_ result: Result<[URL], Error>) {
+    private func handleImport(_ result: Result<[URL], Error>) async {
+        isProcessing = true
+        defer { isProcessing = false }
         switch result {
         case .success(let urls):
             guard let url = urls.first else { return }
@@ -196,7 +253,7 @@ struct SkillsView: View {
 
                 if ext == "zip" {
                     // Import from ZIP archive (Agent Skills compatible)
-                    let skill = try skillManager.importSkillFromZip(url)
+                    let skill = try await skillManager.importSkillFromZip(url)
                     let fileCount = skill.totalFileCount
                     if fileCount > 0 {
                         showToast("Imported \"\(skill.name)\" with \(fileCount) files")
@@ -210,12 +267,12 @@ struct SkillsView: View {
                         showToast("Invalid file content", isError: true)
                         return
                     }
-                    let skill = try skillManager.importSkill(from: data)
+                    let skill = try await skillManager.importSkill(from: data)
                     showToast("Imported \"\(skill.name)\"")
                 } else {
                     // Import from Markdown (SKILL.md or .md)
                     let content = try String(contentsOf: url, encoding: .utf8)
-                    let skill = try skillManager.importSkillFromMarkdown(content)
+                    let skill = try await skillManager.importSkillFromMarkdown(content)
                     showToast("Imported \"\(skill.name)\"")
                 }
             } catch {
@@ -227,7 +284,7 @@ struct SkillsView: View {
         }
     }
 
-    private func exportSkill(_ skill: Skill) {
+    private func exportSkill(_ skill: Skill) async {
         let panel = NSSavePanel()
 
         // If skill has associated files, export as ZIP; otherwise just SKILL.md
@@ -245,26 +302,30 @@ struct SkillsView: View {
 
         panel.begin { response in
             if response == .OK, let url = panel.url {
-                do {
-                    if skill.hasAssociatedFiles {
-                        // Export as ZIP
-                        let zipURL = try skillManager.exportSkillAsZip(skill)
-                        try FileManager.default.copyItem(at: zipURL, to: url)
-                        try? FileManager.default.removeItem(at: zipURL)
-                        DispatchQueue.main.async {
-                            self.showToast("Exported \"\(skill.name)\" as ZIP")
+                Task {
+                    self.isProcessing = true
+                    defer { self.isProcessing = false }
+                    do {
+                        if skill.hasAssociatedFiles {
+                            // export as ZIP
+                            let zipURL = try await skillManager.exportSkillAsZip(skill)
+                            try FileManager.default.copyItem(at: zipURL, to: url)
+                            try? FileManager.default.removeItem(at: zipURL)
+                            DispatchQueue.main.async {
+                                self.showToast("Exported \"\(skill.name)\" as ZIP")
+                            }
+                        } else {
+                            // export as SKILL.md
+                            let content = skillManager.exportSkillAsAgentSkills(skill)
+                            try content.write(to: url, atomically: true, encoding: .utf8)
+                            DispatchQueue.main.async {
+                                self.showToast("Exported \"\(skill.name)\" as SKILL.md")
+                            }
                         }
-                    } else {
-                        // Export as SKILL.md
-                        let content = skillManager.exportSkillAsAgentSkills(skill)
-                        try content.write(to: url, atomically: true, encoding: .utf8)
+                    } catch {
                         DispatchQueue.main.async {
-                            self.showToast("Exported \"\(skill.name)\" as SKILL.md")
+                            self.showToast("Export failed: \(error.localizedDescription)", isError: true)
                         }
-                    }
-                } catch {
-                    DispatchQueue.main.async {
-                        self.showToast("Export failed: \(error.localizedDescription)", isError: true)
                     }
                 }
             }
@@ -282,16 +343,21 @@ struct SkillsView: View {
             subtitle: "Specialized knowledge and guidance for the AI",
             count: skillManager.skills.isEmpty ? nil : skillManager.enabledCount
         ) {
-            HeaderIconButton("arrow.clockwise", help: "Refresh skills") {
-                skillManager.refresh()
+            HeaderIconButton("arrow.clockwise", isLoading: skillManager.isRefreshing, help: "Refresh skills") {
+                Task {
+                    await skillManager.refresh()
+                }
             }
             ImportDropdownButton(
                 onGitHub: { showGitHubImport = true },
                 onLocal: { showImportPicker = true }
             )
+            .disabled(isProcessing || skillManager.isRefreshing)
+
             HeaderPrimaryButton("Create Skill", icon: "plus") {
                 isCreating = true
             }
+            .disabled(isProcessing || skillManager.isRefreshing)
         }
     }
 


### PR DESCRIPTION
## Summary

Migrated all skill related file operations and ZIP processing to asynchronous background tasks to prevent main thread blocking. Also added explicit loading indicators and progress bars to provide visual feedback during long running tasks like imports and exports

## Changes

- Converted skill persistence to asynchronous methods
- Offloaded ZIP operations to background tasks
- Implemented loading states and progress indicators
- Updated dependent services for async compatibility
- Added UI safeguards during active processing

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
