### PR TITLE
fix: PDF attachment 'Document appears to be empty' error

### DIFF
--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -189,7 +189,7 @@ enum DocumentParser {
         return pages.joined(separator: "\n\n")
     }
 
-    private static let maxPixelsPerPage = 4000 * 4000  // ~64MP cap per page
+    private static let maxPixelsPerPage = 4000 * 4000  // ~16MP cap per page
 
     private static func renderPDFPagesAsImages(document: PDFDocument, maxPages: Int) -> [Data] {
         let pageCount = min(document.pageCount, maxPages)
@@ -204,7 +204,7 @@ enum DocumentParser {
             let intWidth = Int(bounds.width * scale)
             let intHeight = Int(bounds.height * scale)
 
-            guard intWidth > 0, intHeight > 0, intWidth * intHeight <= maxPixelsPerPage else { continue }
+            guard intWidth > 0, intHeight > 0, intWidth <= maxPixelsPerPage / intHeight else { continue }
 
             guard let context = CGContext(
                 data: nil,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1580,11 +1580,12 @@ extension FloatingInputCard {
                     }
                 }
             } else if DocumentParser.canParse(url: url) {
+                let animation = theme.springAnimation()
                 Task.detached(priority: .userInitiated) {
                     do {
                         let attachments = try DocumentParser.parseAll(url: url)
                         await MainActor.run {
-                            withAnimation {
+                            withAnimation(animation) {
                                 self.pendingAttachments.append(contentsOf: attachments)
                                 self.clipboardService.markAsRead()
                             }
@@ -1793,12 +1794,13 @@ extension FloatingInputCard {
 
     private func parseAndAttach(url: URL) {
         let filename = url.lastPathComponent
+        let animation = theme.springAnimation()
         Task.detached(priority: .userInitiated) {
             do {
                 let attachments = try DocumentParser.parseAll(url: url)
                 await MainActor.run {
-                    for attachment in attachments {
-                        self.appendAttachment(attachment)
+                    withAnimation(animation) {
+                        self.pendingAttachments.append(contentsOf: attachments)
                     }
                 }
             } catch {


### PR DESCRIPTION
## Summary

Fixes PDF attachment throwing "Document appears to be empty" for scanned/image-based PDFs (reported by Specter in Discord).

- `DocumentParser.parsePDF()` used `page.string` for text extraction, which returns nil for scanned PDFs with no text layer
- Now falls back to rendering PDF pages as images via CGContext when text extraction yields nothing
- Uses sRGB color space, 2x scale for readability, 64MP/page cap to prevent memory spikes
- Rendering runs on `Task.detached` background thread to avoid blocking the UI
- Added `parseAll()` returning `[Attachment]` so multi-page PDFs attach all rendered pages
- Text-based PDFs still attach as document text (no behavior change)

**Per-chat tool selection**: Removed from this PR per tpae's feedback — the removal was intentional, tool selection now lives in agent settings.

## Test plan

- [ ] Attach a scanned PDF (image-based, no text layer) — should attach as page images instead of erroring
- [ ] Attach a text-based PDF — should still attach as document text (no change)
- [ ] Attach a large multi-page scanned PDF — should render on background thread without UI freeze
- [ ] Drag-and-drop a PDF — should work the same as file picker
- [ ] Paste a PDF from clipboard — should work the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)