### PR TITLE
fix app window focus and activation on launch

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -249,20 +249,21 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
                 showOnboardingWindow()
             }
         } else {
-            // fesh launch from terminated state: explicitly activate and show window
+            // Fresh launch from terminated state: explicitly activate and show window
             Task { @MainActor in
-                // delay slightly to ensure services are ready
-                try? await Task.sleep(nanoseconds: 300_000_000)
-                
-                // ensure app is unhidden and active
+                // Delay slightly to ensure services are ready
+                try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms
+
+                // Ensure app is unhidden and active
                 NSApp.unhide(nil)
-                NSApp.activate()
-                _ = NSRunningApplication.current.activate(options: .activateAllWindows)
-                
-                if ChatWindowManager.shared.windowCount == 0 && !WindowManager.shared.isVisible(.management) {
-                    showChatOverlay()
-                } else {
+                _ = NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+
+                if ChatWindowManager.shared.windowCount > 0 {
                     ChatWindowManager.shared.focusAllWindows()
+                } else if WindowManager.shared.isVisible(.management) {
+                    WindowManager.shared.show(.management, center: false)
+                } else {
+                    showChatOverlay()
                 }
             }
         }
@@ -453,8 +454,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
                 self.showChatOverlay()
             }
         }
-        
-        return false
+
+        return true
     }
 
     // MARK: - Dock Menu

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -182,13 +182,11 @@ public final class ChatWindowManager: NSObject, ObservableObject {
             window.deminiaturize(nil)
         }
 
-        // Activate app and yank focus
-        NSApp.activate()
-        _ = NSRunningApplication.current.activate(options: .activateAllWindows)
+        // Activate app and pull focus forward
+        _ = NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
 
+        // Bring the window forward and make it key
         window.makeKeyAndOrderFront(nil)
-        window.orderFrontRegardless()
-        window.makeKey()
 
         // Update last focused
         lastFocusedWindowId = id
@@ -291,25 +289,21 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         guard !windows.isEmpty else { return }
 
         NSApp.unhide(nil)
-        NSApp.activate()
-        _ = NSRunningApplication.current.activate(options: .activateAllWindows)
+        _ = NSRunningApplication.current.activate(options: [.activateAllWindows])
 
-        // Bring all windows to front
+        // Bring all windows to front without churn on key window state
         for (_, window) in nsWindows {
             if window.isMiniaturized {
                 window.deminiaturize(nil)
             }
             window.orderFrontRegardless()
-            window.makeKey()
         }
 
-        // Make the last focused window key
+        // Make the intended window key once
         if let lastId = lastFocusedWindowId, let window = nsWindows[lastId] {
             window.makeKeyAndOrderFront(nil)
-            window.makeKey()
         } else if let firstWindow = nsWindows.values.first {
             firstWindow.makeKeyAndOrderFront(nil)
-            firstWindow.makeKey()
         }
 
         print("[ChatWindowManager] Focused all \(windows.count) windows")


### PR DESCRIPTION
## Summary

- Implements explicit app activation and window presentation in `applicationDidFinishLaunching` to ensure the UI appears when launched from a terminated state.
- Enhances window management with `NSRunningApplication` activation to reliably bring the app to the front.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
