### PR TITLE
fix: VLM classification false positives and image persistence across model switches

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -8,7 +8,6 @@
 import Combine
 import Foundation
 import MLXLLM
-import MLXVLM
 import SwiftUI
 
 extension Notification.Name {
@@ -1313,8 +1312,7 @@ extension ModelManager {
     ///
     /// Reads config.json from the local model directory and checks:
     /// 1. Structural keys (vision_config, image_processor, etc.)
-    /// 2. model_type against `VLMTypeRegistry.supportedModelTypes` from mlx-swift-lm
-    /// 3. preprocessor_config.json as a final fallback
+    /// 2. preprocessor_config.json as a final fallback
     nonisolated static func isVisionModel(modelId: String) -> Bool {
         guard let localDir = findLocalModelDirectory(forModelId: modelId) else {
             return false
@@ -1332,8 +1330,9 @@ extension ModelManager {
         }
 
         // Structural keys that indicate vision capability in config.json.
-        // Checked first to disambiguate dual-registered model types (e.g. gemma4
-        // appears in both VLM and LLM registries; vision_config distinguishes them).
+        // This is the primary signal — it correctly disambiguates dual-registered
+        // model types (e.g. gemma4 appears in both VLM and LLM registries, but only
+        // the VLM variant has vision_config).
         let visionKeys: Set<String> = [
             "vision_config",
             "image_processor",
@@ -1346,13 +1345,6 @@ extension ModelManager {
         ]
 
         if json.keys.contains(where: { visionKeys.contains($0) }) {
-            return true
-        }
-
-        // model_type check against the library's canonical VLM type registry.
-        if let modelType = json["model_type"] as? String,
-            VLMTypeRegistry.supportedModelTypes.contains(modelType)
-        {
             return true
         }
 
@@ -1391,13 +1383,6 @@ extension ModelManager {
         return nil
     }
 
-    /// Check if the currently selected model (by name) supports vision
-    nonisolated static func isVisionModel(named name: String) -> Bool {
-        guard let found = findInstalledModel(named: name) else {
-            return false
-        }
-        return isVisionModel(modelId: found.id)
-    }
 }
 
 // MARK: - Direct file downloader with session-level delegate

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -106,7 +106,9 @@ extension ModelPickerItem {
         )
     }
 
-    /// Create a local MLX model picker item from an MLXModel
+    /// Create a local MLX model picker item from an MLXModel.
+    /// Uses config.json-based detection for downloaded models; falls back to name
+    /// heuristics for models not yet on disk.
     static func fromMLXModel(_ model: MLXModel) -> ModelPickerItem {
         ModelPickerItem(
             id: model.id,
@@ -114,7 +116,7 @@ extension ModelPickerItem {
             source: .local,
             parameterCount: model.parameterCount,
             quantization: model.quantization,
-            isVLM: model.isLikelyVLM,
+            isVLM: ModelManager.isVisionModel(modelId: model.id) || model.isLikelyVLM,
             description: model.description
         )
     }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -113,6 +113,17 @@ final class ChatSession: ObservableObject {
                     self.activeModelOptions = ModelProfileRegistry.defaults(for: model)
                 }
 
+                // Clear pending image attachments when switching to a non-VLM model
+                let newModelSupportsImages: Bool = {
+                    if model.lowercased() == "foundation" { return false }
+                    guard let option = self.pickerItems.first(where: { $0.id == model }) else { return false }
+                    if case .remote = option.source { return true }
+                    return option.isVLM
+                }()
+                if !newModelSupportsImages {
+                    self.pendingAttachments = []
+                }
+
                 Task { @MainActor in
                     let active = ChatWindowManager.shared.activeLocalModelNames()
                     await ModelRuntime.shared.unloadModelsNotIn(active)
@@ -946,7 +957,7 @@ final class ChatSession: ObservableObject {
                         )
                     case .user:
                         let messageText = Self.buildUserMessageText(content: t.content, attachments: t.attachments)
-                        let imageData = t.attachments.images
+                        let imageData = selectedModelSupportsImages ? t.attachments.images : []
                         if !imageData.isEmpty {
                             return ChatMessage(role: "user", text: messageText, imageData: imageData)
                         } else {


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs in VLM/LLM model switching:

**Bug 1 — Image persistence across model switches (High severity)**
When a user sends a message with an image while using a VLM, then switches to a text-only LLM, the old image data persists in conversation history and gets sent to the text-only model. This causes crashes in `processor.prepare(input:)` when image content reaches models without vision encoders. No guard existed anywhere in the pipeline (`turnToMessage` → `buildMessages` → `mapOpenAIChatToMLX` → `extractImageSources` → `prepareAndGenerate`).

**Bug 2 — VLM classification false positives for dual-registered models (Medium severity)**
`isVisionModel(at:)` used `VLMTypeRegistry.supportedModelTypes` as a standalone signal. For dual-registered model types that exist in **both** VLM and LLM registries (`gemma4`, `gemma3`, `mistral3`, `qwen3_5`, `qwen3_5_moe`), text-only variants were misclassified as VLM. This caused incorrect "VLM" badges in model info, wrong vision capability in the `/v1/models` API, and compounded Bug 1 by encouraging image attachment to non-VLM models.

## Changes

### `ModelManager.swift`
- **Removed `VLMTypeRegistry` standalone check** from `isVisionModel(at:)` — structural keys in `config.json` (`vision_config`, `image_processor`, etc.) and `preprocessor_config.json` are sufficient. Every real VLM has one or both; the registry check only added false positives for dual-registered types.
- **Deleted dead `isVisionModel(named:)`** — zero call sites confirmed via grep.
- **Removed unused `import MLXVLM`** — only consumer was `VLMTypeRegistry`.

### `ModelPickerItem.swift`
- **Unified VLM classification** in `fromMLXModel()` — now calls `ModelManager.isVisionModel(modelId:)` (reads actual `config.json`) with `|| model.isLikelyVLM` as fallback for non-downloaded models. Previously used only name heuristics (`isLikelyVLM`), which couldn't detect dual-registered types.

### `ChatView.swift`
- **Conditional image stripping in `turnToMessage`** — when `selectedModelSupportsImages` is `false`, image data from historical turns is excluded from the message array. Images remain in `ChatTurn.attachments` (no data loss) and are re-included when switching back to a VLM.
- **Clear `pendingAttachments` on model switch** — when the user switches to a non-VLM model, any pending (unsent) image attachments are cleared. Uses the incoming model ID (not `self.selectedModel`) to correctly evaluate against the new model despite Combine `willSet` timing.

## Dual-registration coverage

All 5 dual-registered types in current `mlx-swift-lm` are fixed:

| model_type | VLM registry | LLM registry | Text-only variant now correctly returns `false` |
|---|---|---|---|
| `gemma4` | yes | yes | yes |
| `gemma3` | yes | yes | yes |
| `mistral3` | yes | yes | yes |
| `qwen3_5` | yes | yes | yes |
| `qwen3_5_moe` | yes | yes | yes |

## Test plan

- [ ] Download a text-only gemma4 model (e.g. `gemma-4-31b-it-4bit`) — verify it shows "LLM" badge, not "VLM"
- [ ] Send an image message with a VLM model, then switch to a text-only model and send a text message — verify no crash
- [ ] Switch back to VLM — verify images from history are re-included
- [ ] Attach an image, switch to text-only model before sending — verify pending attachments are cleared
- [ ] Verify `/v1/models` API reports correct capabilities for dual-registered models
- [ ] Verify VLM-only models (paligemma, qwen2_vl, pixtral, etc.) still correctly classified as VLM