### PR TITLE
fix: auto-enable MCP and sandbox plugin tools on first registration

### DIFF
--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -349,12 +349,20 @@ final class ToolRegistry: ObservableObject {
     // MARK: - Sandbox Tool Registration
 
     /// Register a tool that requires the sandbox container.
+    /// Non-runtime-managed tools are auto-enabled on first registration so they
+    /// are immediately usable; subsequent registrations preserve the user's choice.
     func registerSandboxTool(_ tool: OsaurusTool, runtimeManaged: Bool = false) {
+        let firstTime =
+            toolsByName[tool.name] == nil
+            && !configuration.enabled.keys.contains(tool.name)
         toolsByName[tool.name] = tool
         sandboxToolNames.insert(tool.name)
         if runtimeManaged {
             builtInSandboxToolNames.insert(tool.name)
         } else {
+            if firstTime {
+                setEnabled(true, for: tool.name)
+            }
             builtInSandboxToolNames.remove(tool.name)
             Task {
                 await ToolIndexService.shared.onToolRegistered(
@@ -418,9 +426,17 @@ final class ToolRegistry: ObservableObject {
     // MARK: - MCP Tool Registration
 
     /// Register a tool from a remote MCP provider.
+    /// Auto-enables the tool on first registration so it is immediately usable;
+    /// subsequent registrations preserve the user's choice.
     func registerMCPTool(_ tool: OsaurusTool) {
+        let firstTime =
+            toolsByName[tool.name] == nil
+            && !configuration.enabled.keys.contains(tool.name)
         toolsByName[tool.name] = tool
         mcpToolNames.insert(tool.name)
+        if firstTime {
+            setEnabled(true, for: tool.name)
+        }
         Task {
             await ToolIndexService.shared.onToolRegistered(
                 name: tool.name,


### PR DESCRIPTION
## Summary

- MCP tools and sandbox plugin tools were registered but defaulted to disabled, making them invisible to the model even after users granted permissions
- Applied the same `firstTime` auto-enable pattern already used by `registerPluginTool()` and `registerBuiltInTools()` to `registerMCPTool()` and `registerSandboxTool()`
- Existing users who previously disabled a tool manually will NOT be affected — the `firstTime` guard checks both `toolsByName` and persisted config

## Details

The root cause of #823: Osaurus has two separate concepts — **enabled** (tool is discoverable by the model) and **permission policy** (what happens when the model tries to use it). Users were setting permissions to "auto" but tools remained disabled because `registerMCPTool()` and `registerSandboxTool()` never called `setEnabled(true)` on first registration, unlike plugin and built-in tools which already did.

All downstream consumers (`ToolSearchService`, `PreflightCapabilitySearch`, `ToolIndexService`, `CapabilityTools.loadTool()`, `MCPServerManager`, `HTTPHandler /tools` endpoint) filter by enabled status — so a disabled-by-default tool was completely invisible across every surface.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` passes clean
- [x] Pre-existing test failure (`SpeechService.swift` AsrManager API mismatch) confirmed identical on `main` — not introduced by this change
- [x] Verified `Package.resolved` is unchanged from `main`
- [x] Only one file changed: `Packages/OsaurusCore/Tools/ToolRegistry.swift` (+16 lines)

Closes #823