### PR TITLE
inline data visualization

### DIFF
--- a/App/osaurus/Acknowledgements.json
+++ b/App/osaurus/Acknowledgements.json
@@ -129,6 +129,14 @@
         "repository": "https://github.com/raspu/Highlightr",
         "license": "MIT",
         "licenseUrl": "https://github.com/raspu/Highlightr/blob/master/LICENSE"
+    },
+    {
+        "name": "AAChartKit",
+        "identity": "AAChartKit-Swift",
+        "version": "9.5.0",
+        "repository": "https://github.com/AAChartModel/AAChartKit-Swift",
+        "license": "MIT",
+        "licenseUrl": "https://github.com/AAChartModel/AAChartKit-Swift/blob/master/LICENSE"
     }
   ]
 }

--- a/Packages/OsaurusCore/Models/Agent/Skill.swift
+++ b/Packages/OsaurusCore/Models/Agent/Skill.swift
@@ -405,6 +405,69 @@ public struct Skill: Codable, Identifiable, Sendable, Equatable {
                 createdAt: Date.distantPast,
                 updatedAt: Date.distantPast
             ),
+
+            // Data Visualization
+            Skill(
+                id: UUID(uuidString: "00000001-0000-0000-0000-000000000007")!,
+                name: "Data Visualizer",
+                description: "Render charts and graphs from data inline or from file attachments",
+                version: "1.0.0",
+                author: "Osaurus",
+                category: "productivity",
+                keywords: ["chart", "graph", "plot", "visualize", "bar", "line", "pie", "data", "table", "csv"],
+                enabled: false,
+                instructions: """
+                    When the user's message contains data suitable for visualization:
+
+                    ## Choosing the right path
+
+                    **If the data is in a file attachment:** call the `render_chart` tool.
+                    Pass the full raw file content in the `data` field and use `xColumn` /
+                    `series` to specify which columns to plot. The tool handles all parsing
+                    and downsampling — you never need to format individual data points. Example:
+                    ```
+                    render_chart(
+                      data: "<full raw CSV/TSV/JSON content>",
+                      format: "csv",
+                      chartType: "line",
+                      xColumn: "Month",
+                      series: ["Revenue", "Expenses"],
+                      title: "Monthly Financials"
+                    )
+                    ```
+
+                    **If the data is small and inline** (pasted table, computed values, fewer
+                    than ~50 data points): emit a ```chart fenced block with the full spec:
+                    ```chart
+                    {
+                      "chartType": "line",
+                      "title": "...",
+                      "categories": [...],
+                      "series": [{ "name": "...", "data": [...] }]
+                    }
+                    ```
+
+                    ## Chart type selection
+                    - **column / bar**: comparisons between categories
+                    - **line / spline**: trends over time or ordered sequences
+                    - **area / areaspline**: trends where cumulative volume matters
+                    - **pie**: proportions (use only with ≤8 slices)
+                    - **scatter**: correlations between two numeric variables
+                    - **bubble**: correlations with a third size dimension
+                    - **gauge**: single KPI value with a target range
+                    - **waterfall**: cumulative effect of sequential values
+
+                    ## Quality guidelines
+                    - Always set a meaningful `title`
+                    - Set `tooltipSuffix` when data has units (USD, %, ms, kg, etc.)
+                    - Use `stacking: "percent"` for part-to-whole comparisons across categories
+                    - Keep series count ≤ 8 for readability
+                    - For time series, put dates/times as `categories` on the x-axis
+                    """,
+                isBuiltIn: true,
+                createdAt: Date.distantPast,
+                updatedAt: Date.distantPast
+            ),
         ]
     }
 

--- a/Packages/OsaurusCore/Models/Chat/ChartSpec.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChartSpec.swift
@@ -1,0 +1,135 @@
+//
+//  ChartSpec.swift
+//  osaurus
+//
+//  Data model for chart rendering. Used by both the fenced block path (Path A)
+//  and the render_chart tool path (Path B).
+//
+
+import Foundation
+
+public struct ChartSeries: Codable, Equatable, Sendable {
+    public var name: String
+    public var data: [Double?]  // nil emits gaps in AAChartKit
+}
+
+public struct ChartSpec: Codable, Equatable, Sendable {
+    public var chartType: String
+    public var title: String?
+    public var subtitle: String?
+    public var categories: [String]?
+    public var series: [ChartSeries]
+    public var colorsTheme: [String]?
+    public var tooltipSuffix: String?
+    public var stacking: String?        // "normal", "percent", or nil
+    public var dataLabelsEnabled: Bool?
+    public var note: String?            // set by RenderChartTool when downsampling occurs
+
+    public static let validChartTypes: Set<String> = [
+        "column", "bar", "line", "spline", "area", "areaspline",
+        "pie", "scatter", "bubble", "gauge", "waterfall", "boxplot",
+    ]
+
+    /// Returns a copy with chartType coerced to a known value
+    public var normalized: ChartSpec {
+        guard !Self.validChartTypes.contains(chartType) else { return self }
+        var copy = self
+        copy.chartType = "column"
+        return copy
+    }
+
+    // MARK: - Forgiving decode
+
+    enum CodingKeys: String, CodingKey {
+        case chartType, title, subtitle, categories, series
+        case colorsTheme, tooltipSuffix, stacking, dataLabelsEnabled, note
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        chartType         = (try? c.decode(String.self, forKey: .chartType)) ?? "column"
+        title             = try? c.decode(String.self, forKey: .title)
+        subtitle          = try? c.decode(String.self, forKey: .subtitle)
+        categories        = try? c.decode([String].self, forKey: .categories)
+        tooltipSuffix     = try? c.decode(String.self, forKey: .tooltipSuffix)
+        stacking          = try? c.decode(String.self, forKey: .stacking)
+        dataLabelsEnabled = try? c.decode(Bool.self, forKey: .dataLabelsEnabled)
+        note              = try? c.decode(String.self, forKey: .note)
+        colorsTheme       = try? c.decode([String].self, forKey: .colorsTheme)
+
+        // Coerce series data: some quantized models emit numbers as strings or omit nulls
+        if let rawSeries = try? c.decode([RawSeries].self, forKey: .series) {
+            series = rawSeries.map { raw in
+                ChartSeries(
+                    name: raw.name,
+                    data: raw.data.map { v in
+                        switch v {
+                        case .double(let d): return d
+                        case .string(let s): return Double(s)
+                        case .null:          return nil
+                        }
+                    }
+                )
+            }
+        } else {
+            series = []
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(chartType, forKey: .chartType)
+        try c.encodeIfPresent(title, forKey: .title)
+        try c.encodeIfPresent(subtitle, forKey: .subtitle)
+        try c.encodeIfPresent(categories, forKey: .categories)
+        try c.encodeIfPresent(tooltipSuffix, forKey: .tooltipSuffix)
+        try c.encodeIfPresent(stacking, forKey: .stacking)
+        try c.encodeIfPresent(dataLabelsEnabled, forKey: .dataLabelsEnabled)
+        try c.encodeIfPresent(note, forKey: .note)
+        try c.encodeIfPresent(colorsTheme, forKey: .colorsTheme)
+        try c.encode(series, forKey: .series)
+    }
+
+    public init(
+        chartType: String,
+        title: String? = nil,
+        subtitle: String? = nil,
+        categories: [String]? = nil,
+        series: [ChartSeries],
+        colorsTheme: [String]? = nil,
+        tooltipSuffix: String? = nil,
+        stacking: String? = nil,
+        dataLabelsEnabled: Bool? = nil,
+        note: String? = nil
+    ) {
+        self.chartType         = chartType
+        self.title             = title
+        self.subtitle          = subtitle
+        self.categories        = categories
+        self.series            = series
+        self.colorsTheme       = colorsTheme
+        self.tooltipSuffix     = tooltipSuffix
+        self.stacking          = stacking
+        self.dataLabelsEnabled = dataLabelsEnabled
+        self.note              = note
+    }
+
+    // MARK: - Internal lenient series parser
+
+    private struct RawSeries: Decodable {
+        let name: String
+        let data: [FlexDouble]
+    }
+
+    private enum FlexDouble: Decodable {
+        case double(Double), string(String), null
+
+        init(from decoder: Decoder) throws {
+            let s = try decoder.singleValueContainer()
+            if s.decodeNil()                             { self = .null }
+            else if let d = try? s.decode(Double.self)  { self = .double(d) }
+            else if let str = try? s.decode(String.self) { self = .string(str) }
+            else                                         { self = .null }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -38,6 +38,7 @@ enum ContentBlockKind: Equatable {
     case generationStats(ttft: TimeInterval?, tokensPerSecond: Double?, tokenCount: Int?)
     case typingIndicator
     case groupSpacer
+    case chart(spec: ChartSpec)
 
     /// Custom Equatable optimized for performance during streaming.
     /// Uses text length comparison as a cheap proxy for content change detection.
@@ -85,6 +86,9 @@ enum ContentBlockKind: Equatable {
         case (.groupSpacer, .groupSpacer):
             return true
 
+        case let (.chart(lSpec), .chart(rSpec)):
+            return lSpec == rSpec
+
         default:
             return false
         }
@@ -105,7 +109,7 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         case let .header(role, _, _): return role
         case let .paragraph(_, _, _, role): return role
         case .toolCallGroup, .thinking, .sharedArtifact, .pendingToolCall, .preflightCapabilities,
-            .generationStats, .typingIndicator, .groupSpacer:
+            .generationStats, .typingIndicator, .groupSpacer, .chart:
             return .assistant
         case .userMessage: return .user
         }
@@ -248,6 +252,15 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         let turnId = associatedWithTurnId ?? afterTurnId
         return ContentBlock(id: "spacer-\(afterTurnId.uuidString)", turnId: turnId, kind: .groupSpacer, position: .only)
     }
+
+    static func chart(turnId: UUID, spec: ChartSpec, position: BlockPosition) -> ContentBlock {
+        ContentBlock(
+            id: "chart-\(turnId.uuidString)",
+            turnId: turnId,
+            kind: .chart(spec: spec),
+            position: position
+        )
+    }
 }
 
 // MARK: - Block Generation
@@ -329,16 +342,13 @@ extension ContentBlock {
                 // during streaming, skip the regex-based metadata strip (O(n) on every sync).
                 // visibleContent is used for the final render once streaming ends.
                 let text = isStreaming ? turn.content : turn.visibleContent
-                turnBlocks.append(
-                    .paragraph(
-                        turnId: turn.id,
-                        index: 0,
-                        text: text,
-                        isStreaming: isStreaming && turn.pendingToolName == nil,
-                        role: turn.role,
-                        position: .middle
-                    )
+                let chartBlocks = Self.extractChartBlocks(
+                    from: text,
+                    turnId: turn.id,
+                    isStreaming: isStreaming && turn.pendingToolName == nil,
+                    role: turn.role
                 )
+                turnBlocks.append(contentsOf: chartBlocks)
             }
 
             if isStreaming && turn.contentIsEmpty && !turn.hasThinking
@@ -375,6 +385,15 @@ extension ContentBlock {
                             regularItems = []
                         }
                         turnBlocks.append(.sharedArtifact(turnId: turn.id, artifact: artifact, position: .middle))
+                    } else if call.function.name == "render_chart",
+                        let result,
+                        let spec = Self.parseChartSpecFromResult(result)
+                    {
+                        if !regularItems.isEmpty {
+                            turnBlocks.append(.toolCallGroup(turnId: turn.id, calls: regularItems, position: .middle))
+                            regularItems = []
+                        }
+                        turnBlocks.append(.chart(turnId: turn.id, spec: spec.normalized, position: .middle))
                     } else {
                         regularItems.append(ToolCallItem(call: call, result: result))
                     }
@@ -421,6 +440,88 @@ extension ContentBlock {
     /// Reconstructs a SharedArtifact from an enriched share_artifact tool result.
     private static func parseSharedArtifactFromResult(_ result: String) -> SharedArtifact? {
         SharedArtifact.fromEnrichedToolResult(result)
+    }
+
+    /// Parses a ChartSpec from a render_chart tool result marker.
+    private static func parseChartSpecFromResult(_ result: String) -> ChartSpec? {
+        guard let start = result.range(of: "---CHART_START---\n"),
+              let end   = result.range(of: "\n---CHART_END---")
+        else { return nil }
+        let json = String(result[start.upperBound..<end.lowerBound])
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ChartSpec.self, from: data)
+    }
+
+    /// Splits text into paragraph and chart blocks by detecting ```chart fenced blocks.
+    /// During streaming, incomplete fences (no closing ```) are left as plain paragraphs
+    /// and re-evaluated on the next sync once the closing fence arrives.
+    private static func extractChartBlocks(
+        from text: String,
+        turnId: UUID,
+        isStreaming: Bool,
+        role: MessageRole
+    ) -> [ContentBlock] {
+        let fence = "```chart"
+        guard text.contains(fence) else {
+            return [.paragraph(turnId: turnId, index: 0, text: text,
+                               isStreaming: isStreaming, role: role, position: .middle)]
+        }
+
+        var blocks: [ContentBlock] = []
+        var remaining = text
+        var paraIndex = 0
+
+        while let fenceStart = remaining.range(of: fence) {
+            let before = String(remaining[..<fenceStart.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !before.isEmpty {
+                blocks.append(.paragraph(turnId: turnId, index: paraIndex,
+                                         text: before, isStreaming: false,
+                                         role: role, position: .middle))
+                paraIndex += 1
+            }
+
+            let afterFence = remaining[fenceStart.upperBound...]
+            if let closeRange = afterFence.range(of: "```") {
+                let json = String(afterFence[..<closeRange.lowerBound])
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                remaining = String(afterFence[closeRange.upperBound...])
+
+                if let data = json.data(using: .utf8),
+                   let spec = try? JSONDecoder().decode(ChartSpec.self, from: data)
+                {
+                    blocks.append(.chart(turnId: turnId, spec: spec.normalized, position: .middle))
+                } else {
+                    // Malformed JSON — show as readable code block so user can see what was emitted
+                    let errText = "⚠️ Could not render chart — invalid spec:\n```\n\(json)\n```"
+                    blocks.append(.paragraph(turnId: turnId, index: paraIndex,
+                                             text: errText, isStreaming: false,
+                                             role: role, position: .middle))
+                    paraIndex += 1
+                }
+            } else {
+                // No closing fence yet — streaming in progress; leave as plain text for now
+                let partialText = fence + String(afterFence)
+                blocks.append(.paragraph(turnId: turnId, index: paraIndex,
+                                         text: partialText, isStreaming: isStreaming,
+                                         role: role, position: .middle))
+                paraIndex += 1
+                remaining = ""
+                break
+            }
+        }
+
+        let tail = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tail.isEmpty {
+            blocks.append(.paragraph(turnId: turnId, index: paraIndex,
+                                     text: tail, isStreaming: isStreaming,
+                                     role: role, position: .middle))
+        }
+
+        return blocks.isEmpty
+            ? [.paragraph(turnId: turnId, index: 0, text: text,
+                           isStreaming: isStreaming, role: role, position: .middle)]
+            : blocks
     }
 
     private static func assignPositions(to blocks: [ContentBlock]) -> [ContentBlock] {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(path: "../OsaurusRepository"),
         .package(url: "https://github.com/mgriebling/SwiftMath", from: "1.7.3"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.3.0"),
+        .package(url: "https://github.com/AAChartModel/AAChartKit-Swift.git", from: "9.5.0"),
     ],
     targets: [
         .target(
@@ -46,6 +47,7 @@ let package = Package(
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
                 .product(name: "Highlightr", package: "Highlightr"),
+                .product(name: "AAInfographics", package: "AAChartKit-Swift"),
             ],
             path: ".",
             exclude: ["Tests"],

--- a/Packages/OsaurusCore/Tools/RenderChartTool.swift
+++ b/Packages/OsaurusCore/Tools/RenderChartTool.swift
@@ -1,0 +1,230 @@
+//
+//  RenderChartTool.swift
+//  osaurus
+//
+//  Builds a ChartSpec from attachment content passed directly by the model.
+//  The model passes the raw file content + column references — the tool does
+//  all parsing, type coercion, and downsampling so the model never has to
+//  format individual data points.
+//
+
+import Foundation
+
+struct RenderChartTool: OsaurusTool {
+    let name = "render_chart"
+    let description =
+        "Render a chart from attachment data. Use when the user has attached a data file (CSV, TSV, JSON). Pass the raw file content and column names — the tool handles all parsing and downsampling."
+
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "required": .array([.string("data"), .string("chartType"), .string("series")]),
+        "properties": .object([
+            "data": .object([
+                "type": .string("string"),
+                "description": .string("The raw content of the attached file (CSV, TSV, or JSON array of objects)"),
+            ]),
+            "format": .object([
+                "type": .string("string"),
+                "description": .string("File format: csv, tsv, or json. Defaults to csv."),
+            ]),
+            "chartType": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Chart type: column, bar, line, spline, area, areaspline, pie, scatter, bubble, gauge, waterfall, boxplot"
+                ),
+            ]),
+            "xColumn": .object([
+                "type": .string("string"),
+                "description": .string("Column name to use as x-axis labels / categories"),
+            ]),
+            "series": .object([
+                "type": .string("array"),
+                "items": .object(["type": .string("string")]),
+                "description": .string("Column names to plot as data series"),
+            ]),
+            "title": .object([
+                "type": .string("string"),
+                "description": .string("Chart title"),
+            ]),
+            "tooltipSuffix": .object([
+                "type": .string("string"),
+                "description": .string("Unit suffix shown in tooltips (e.g. USD, %, ms)"),
+            ]),
+        ]),
+    ])
+
+    private static let maxRows = 500
+
+    func execute(argumentsJSON: String) async throws -> String {
+        guard let args = parseArguments(argumentsJSON) else {
+            return errorResult("Invalid arguments JSON")
+        }
+
+        guard let raw = args["data"] as? String else {
+            return errorResult("data is required — pass the full raw file content")
+        }
+
+        // chartType may be top-level or nested inside a "properties" object (model schema confusion)
+        let chartType: String
+        if let ct = args["chartType"] as? String {
+            chartType = ct
+        } else if let props = args["properties"] as? [String: Any],
+                  let ct = props["chartType"] as? String {
+            chartType = ct
+        } else if let propsStr = args["properties"] as? String,
+                  let data = propsStr.data(using: .utf8),
+                  let props = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let ct = props["chartType"] as? String {
+            chartType = ct
+        } else {
+            return errorResult("chartType is required (e.g. \"line\", \"column\", \"pie\")")
+        }
+
+        // series may be a proper array or a JSON-encoded string array
+        guard let seriesCols = coerceStringArray(args["series"]) ?? parseStringArrayFromJSON(args["series"]) else {
+            return errorResult("series is required — pass an array of column names to plot")
+        }
+
+        let format    = (args["format"] as? String)?.lowercased() ?? "csv"
+        let xColumn   = args["xColumn"]       as? String
+        let title     = args["title"]         as? String
+        let tipSuffix = args["tooltipSuffix"] as? String
+
+        let headers: [String]
+        let rows: [[String]]
+        do {
+            switch format {
+            case "json":
+                (headers, rows) = try parseJSON(raw)
+            case "tsv":
+                (headers, rows) = parseDelimited(raw, separator: "\t")
+            default:
+                (headers, rows) = parseDelimited(raw, separator: ",")
+            }
+        } catch {
+            return errorResult(error.localizedDescription)
+        }
+
+        guard !headers.isEmpty else {
+            return errorResult("Could not parse any columns from the provided data")
+        }
+
+        // Validate columns
+        var missingColumns: [String] = []
+        for col in seriesCols where !headers.contains(col) {
+            missingColumns.append(col)
+        }
+        if let x = xColumn, !headers.contains(x) {
+            missingColumns.append(x)
+        }
+        if !missingColumns.isEmpty {
+            return errorResult(
+                "Column(s) not found: \(missingColumns.joined(separator: ", ")). Available columns: \(headers.joined(separator: ", "))"
+            )
+        }
+
+        // Downsample if needed
+        var note: String? = nil
+        var dataRows = rows
+        if rows.count > Self.maxRows {
+            dataRows = downsample(rows, to: Self.maxRows)
+            note = "Downsampled from \(rows.count) to \(Self.maxRows) rows for rendering"
+        }
+
+        // Build categories from xColumn
+        var categories: [String]? = nil
+        if let xCol = xColumn, let xIdx = headers.firstIndex(of: xCol) {
+            categories = dataRows.map { row in xIdx < row.count ? row[xIdx] : "" }
+        }
+
+        // Build series, skipping non-numeric columns
+        var chartSeries: [ChartSeries] = []
+        var skippedColumns: [String] = []
+
+        for col in seriesCols {
+            guard let idx = headers.firstIndex(of: col) else { continue }
+            let data: [Double?] = dataRows.map { row in
+                idx < row.count ? Double(row[idx].trimmingCharacters(in: .whitespaces)) : nil
+            }
+            if data.allSatisfy({ $0 == nil }) {
+                skippedColumns.append(col)
+                continue
+            }
+            chartSeries.append(ChartSeries(name: col, data: data))
+        }
+
+        if !skippedColumns.isEmpty {
+            let skipNote = "Column(s) '\(skippedColumns.joined(separator: ", "))' had no numeric data and were skipped"
+            note = note.map { $0 + "; " + skipNote } ?? skipNote
+        }
+
+        if chartSeries.isEmpty {
+            return errorResult("No numeric series could be extracted from the specified columns")
+        }
+
+        let spec = ChartSpec(
+            chartType: chartType,
+            title: title,
+            categories: categories,
+            series: chartSeries,
+            tooltipSuffix: tipSuffix,
+            note: note
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let jsonData = try encoder.encode(spec)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+        return "---CHART_START---\n\(jsonString)\n---CHART_END---"
+    }
+
+    // MARK: - Parsing
+
+    private func parseDelimited(_ raw: String, separator: Character) -> ([String], [[String]]) {
+        var lines = raw.components(separatedBy: .newlines).filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return ([], []) }
+        let headers = lines.removeFirst()
+            .components(separatedBy: String(separator))
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        let rows = lines.map {
+            $0.components(separatedBy: String(separator))
+              .map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+        return (headers, rows)
+    }
+
+    private func parseJSON(_ raw: String) throws -> ([String], [[String]]) {
+        guard let data = raw.data(using: .utf8),
+              let array = try JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+              let first = array.first
+        else {
+            throw NSError(
+                domain: "RenderChartTool", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "JSON must be an array of objects"]
+            )
+        }
+        let headers = Array(first.keys).sorted()
+        let rows: [[String]] = array.map { obj in headers.map { key in "\(obj[key] ?? "")" } }
+        return (headers, rows)
+    }
+
+    private func downsample(_ rows: [[String]], to maxCount: Int) -> [[String]] {
+        guard rows.count > maxCount else { return rows }
+        let step = Double(rows.count) / Double(maxCount)
+        return (0..<maxCount).map { i in rows[Int(Double(i) * step)] }
+    }
+
+    /// Fallback for when the model serializes an array as a JSON string e.g. "[\"Apple\",\"Google\"]"
+    private func parseStringArrayFromJSON(_ value: Any?) -> [String]? {
+        guard let str = value as? String,
+              let data = str.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [String]
+        else { return nil }
+        return arr.isEmpty ? nil : arr
+    }
+
+    private func errorResult(_ message: String) -> String {
+        let escaped = message.replacingOccurrences(of: "\"", with: "'")
+        return "{\"error\": \"\(escaped)\"}"
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -97,6 +97,7 @@ final class ToolRegistry: ObservableObject {
             SearchConversationsTool(),
             SearchSummariesTool(),
             SearchGraphTool(),
+            RenderChartTool(),
         ]
         var configChanged = false
         for tool in builtIns {

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -1,0 +1,147 @@
+//
+//  NativeChartView.swift
+//  osaurus
+//
+//  AppKit view wrapping AAChartView in a styled card. Rendered by
+//  NativeMessageCellView for .chart(spec:) content blocks.
+//
+
+import AppKit
+import AAInfographics
+
+final class NativeChartView: NSView {
+
+    private let card       = NSView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let noteLabel  = NSTextField(labelWithString: "")
+    private let chartView  = AAChartView()
+
+    private static let chartHeight: CGFloat = 260
+    private static let cardPadding: CGFloat = 12
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
+
+    // MARK: - Layout
+
+    private func setupLayout() {
+        wantsLayer = true
+
+        card.wantsLayer = true
+        card.layer?.cornerRadius = 12
+        card.layer?.borderWidth  = 0.5
+        card.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(card)
+        NSLayoutConstraint.activate([
+            card.topAnchor.constraint(equalTo: topAnchor),
+            card.leadingAnchor.constraint(equalTo: leadingAnchor),
+            card.trailingAnchor.constraint(equalTo: trailingAnchor),
+            card.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        titleLabel.font          = .systemFont(ofSize: 13, weight: .semibold)
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(titleLabel)
+
+        chartView.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(chartView)
+
+        noteLabel.font      = .systemFont(ofSize: 11)
+        noteLabel.isHidden  = true
+        noteLabel.lineBreakMode = .byWordWrapping
+        noteLabel.maximumNumberOfLines = 2
+        noteLabel.translatesAutoresizingMaskIntoConstraints = false
+        card.addSubview(noteLabel)
+
+        let p = Self.cardPadding
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: p),
+            titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
+            titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
+
+            chartView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            chartView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            chartView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            chartView.heightAnchor.constraint(equalToConstant: Self.chartHeight),
+
+            noteLabel.topAnchor.constraint(equalTo: chartView.bottomAnchor, constant: 6),
+            noteLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
+            noteLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
+            noteLabel.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -p),
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(spec: ChartSpec, theme: any ThemeProtocol) {
+        card.layer?.backgroundColor = NSColor(theme.cardBackground).cgColor
+        card.layer?.borderColor     = NSColor(theme.cardBorder).cgColor
+        titleLabel.textColor        = NSColor(theme.primaryText)
+        noteLabel.textColor         = NSColor(theme.secondaryText)
+
+        titleLabel.stringValue = spec.title ?? ""
+        titleLabel.isHidden    = (spec.title ?? "").isEmpty
+
+        if let note = spec.note, !note.isEmpty {
+            noteLabel.stringValue = "ⓘ \(note)"
+            noteLabel.isHidden    = false
+        } else {
+            noteLabel.isHidden = true
+        }
+
+        let model = buildChartModel(from: spec, theme: theme)
+        // Refresh if already rendered to get a smooth animated update; draw on first render
+        if chartView.bounds.width > 0 {
+            chartView.aa_refreshChartWholeContentWithChartModel(model)
+        } else {
+            chartView.aa_drawChartWithChartModel(model)
+        }
+    }
+
+    func measuredCardHeight() -> CGFloat {
+        let p = Self.cardPadding
+        var h = p                                        // top padding
+        h += titleLabel.isHidden ? 0 : (20 + 8)         // title + gap below
+        h += Self.chartHeight                            // chart
+        h += noteLabel.isHidden ? 0 : (6 + 16)          // gap + note
+        h += p                                           // bottom padding
+        return h
+    }
+
+    // MARK: - AAChartModel Builder
+
+    private func buildChartModel(from spec: ChartSpec, theme: any ThemeProtocol) -> AAChartModel {
+        let seriesElements: [Any] = spec.series.map { s in
+            AASeriesElement()
+                .name(s.name)
+                .data(s.data.map { v -> Any in v.map { $0 as Any } ?? NSNull() } as [Any])
+        }
+
+        let model = AAChartModel()
+            .chartType(AAChartType(rawValue: spec.chartType) ?? .column)
+            .animationType(.easeInOutQuart)
+            .animationDuration(400)
+            .dataLabelsEnabled(spec.dataLabelsEnabled ?? false)
+            .tooltipValueSuffix(spec.tooltipSuffix ?? "")
+            .series(seriesElements)
+
+        if let categories = spec.categories {
+            model.categories(categories)
+        }
+        if let stacking = spec.stacking,
+           let stackingType = AAChartStackingType(rawValue: stacking)
+        {
+            model.stacking(stackingType)
+        }
+        if let colors = spec.colorsTheme {
+            model.colorsTheme(colors)
+        }
+
+        return model
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -24,7 +24,7 @@ final class NativeChartView: NSView {
     private var lastBgHex: String = "#000000"
 
     // Chart height gives Highcharts enough vertical room for the plot + legend.
-    static let chartHeight: CGFloat = 300
+    static let chartHeight: CGFloat = 320
     static let cardPadding: CGFloat = 12
 
     override init(frame: CGRect) {
@@ -57,7 +57,8 @@ final class NativeChartView: NSView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(titleLabel)
 
-        // Transparent WKWebView so AAChartKit's chart.backgroundColor controls the background
+        // Suppress WKWebView's white background before JS renders
+        chartView.setValue(false, forKey: "drawsBackground")
         chartView.underPageBackgroundColor = .clear
         chartView.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(chartView)
@@ -80,11 +81,9 @@ final class NativeChartView: NSView {
             chartView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
             chartView.heightAnchor.constraint(equalToConstant: Self.chartHeight),
 
-            // noteLabel anchors to chartView bottom and defines card bottom
             noteLabel.topAnchor.constraint(equalTo: chartView.bottomAnchor, constant: 6),
             noteLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
             noteLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
-            noteLabel.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -p),
         ])
     }
 
@@ -95,7 +94,6 @@ final class NativeChartView: NSView {
         let bgHex     = bgColor.hexString
         let textColor = NSColor(theme.primaryText)
 
-        // Card chrome
         card.layer?.backgroundColor = bgColor.cgColor
         // Subtle gray border — slightly lighter than the card background
         card.layer?.borderColor = NSColor(theme.primaryBorder).withAlphaComponent(0.25).cgColor
@@ -133,7 +131,11 @@ final class NativeChartView: NSView {
         var h = p
         h += titleLabel.isHidden ? 0 : (20 + 4)   // title + gap
         h += Self.chartHeight
-        h += noteLabel.isHidden ? p : (6 + 16 + p) // bottom padding or note + bottom padding
+        if noteLabel.isHidden {
+            h += p                      // chartView → card bottom
+        } else {
+            h += 6 + 16 + p            // gap + note + bottom padding
+        }
         return h
     }
 

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -16,8 +16,16 @@ final class NativeChartView: NSView {
     private let noteLabel  = NSTextField(labelWithString: "")
     private let chartView  = AAChartView()
 
-    private static let chartHeight: CGFloat = 260
-    private static let cardPadding: CGFloat = 12
+    /// Animation runs only on first draw; subsequent spec changes skip animation.
+    private var hasDrawn = false
+    /// Skip redundant redraws (window focus, resize) when spec hasn't changed.
+    private var lastSpec: ChartSpec?
+    /// Cached theme background hex — used to re-apply after WebView loads.
+    private var lastBgHex: String = "#000000"
+
+    // Chart height gives Highcharts enough vertical room for the plot + legend.
+    static let chartHeight: CGFloat = 300
+    static let cardPadding: CGFloat = 12
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,7 +41,8 @@ final class NativeChartView: NSView {
 
         card.wantsLayer = true
         card.layer?.cornerRadius = 12
-        card.layer?.borderWidth  = 0.5
+        // Subtle border for elevation
+        card.layer?.borderWidth  = 1
         card.translatesAutoresizingMaskIntoConstraints = false
         addSubview(card)
         NSLayoutConstraint.activate([
@@ -48,12 +57,14 @@ final class NativeChartView: NSView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(titleLabel)
 
+        // Transparent WKWebView so AAChartKit's chart.backgroundColor controls the background
+        chartView.underPageBackgroundColor = .clear
         chartView.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(chartView)
 
-        noteLabel.font      = .systemFont(ofSize: 11)
-        noteLabel.isHidden  = true
-        noteLabel.lineBreakMode = .byWordWrapping
+        noteLabel.font                 = .systemFont(ofSize: 11)
+        noteLabel.isHidden             = true
+        noteLabel.lineBreakMode        = .byWordWrapping
         noteLabel.maximumNumberOfLines = 2
         noteLabel.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(noteLabel)
@@ -64,11 +75,12 @@ final class NativeChartView: NSView {
             titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
             titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
 
-            chartView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            chartView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
             chartView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
             chartView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
             chartView.heightAnchor.constraint(equalToConstant: Self.chartHeight),
 
+            // noteLabel anchors to chartView bottom and defines card bottom
             noteLabel.topAnchor.constraint(equalTo: chartView.bottomAnchor, constant: 6),
             noteLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
             noteLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
@@ -79,10 +91,16 @@ final class NativeChartView: NSView {
     // MARK: - Configure
 
     func configure(spec: ChartSpec, theme: any ThemeProtocol) {
-        card.layer?.backgroundColor = NSColor(theme.cardBackground).cgColor
-        card.layer?.borderColor     = NSColor(theme.cardBorder).cgColor
-        titleLabel.textColor        = NSColor(theme.primaryText)
-        noteLabel.textColor         = NSColor(theme.secondaryText)
+        let bgColor   = NSColor(theme.cardBackground)
+        let bgHex     = bgColor.hexString
+        let textColor = NSColor(theme.primaryText)
+
+        // Card chrome
+        card.layer?.backgroundColor = bgColor.cgColor
+        // Subtle gray border — slightly lighter than the card background
+        card.layer?.borderColor = NSColor(theme.primaryBorder).withAlphaComponent(0.25).cgColor
+        titleLabel.textColor    = textColor
+        noteLabel.textColor     = NSColor(theme.secondaryText)
 
         titleLabel.stringValue = spec.title ?? ""
         titleLabel.isHidden    = (spec.title ?? "").isEmpty
@@ -94,40 +112,56 @@ final class NativeChartView: NSView {
             noteLabel.isHidden = true
         }
 
-        let model = buildChartModel(from: spec, theme: theme)
-        // Refresh if already rendered to get a smooth animated update; draw on first render
-        if chartView.bounds.width > 0 {
-            chartView.aa_refreshChartWholeContentWithChartModel(model)
+        lastBgHex = bgHex
+
+        // Skip chart redraw when spec hasn't changed (handles window focus / resize)
+        guard spec != lastSpec else { return }
+        lastSpec = spec
+
+        let (options, seriesElements) = buildChartModel(from: spec, bgHex: bgHex, textHex: textColor.hexString, theme: theme)
+
+        if !hasDrawn {
+            hasDrawn = true
+            chartView.aa_drawChartWithChartOptions(options)
         } else {
-            chartView.aa_drawChartWithChartModel(model)
+            chartView.aa_onlyRefreshTheChartDataWithChartModelSeries(seriesElements, animation: false)
         }
     }
 
     func measuredCardHeight() -> CGFloat {
         let p = Self.cardPadding
-        var h = p                                        // top padding
-        h += titleLabel.isHidden ? 0 : (20 + 8)         // title + gap below
-        h += Self.chartHeight                            // chart
-        h += noteLabel.isHidden ? 0 : (6 + 16)          // gap + note
-        h += p                                           // bottom padding
+        var h = p
+        h += titleLabel.isHidden ? 0 : (20 + 4)   // title + gap
+        h += Self.chartHeight
+        h += noteLabel.isHidden ? p : (6 + 16 + p) // bottom padding or note + bottom padding
         return h
     }
 
     // MARK: - AAChartModel Builder
 
-    private func buildChartModel(from spec: ChartSpec, theme: any ThemeProtocol) -> AAChartModel {
-        let seriesElements: [Any] = spec.series.map { s in
+    private func buildChartModel(
+        from spec: ChartSpec,
+        bgHex: String,
+        textHex: String,
+        theme: any ThemeProtocol
+    ) -> (AAOptions, [AASeriesElement]) {
+        let gridHex = NSColor(theme.primaryBorder).withAlphaComponent(0.2).hexString
+
+        let seriesElements: [AASeriesElement] = spec.series.map { s in
             AASeriesElement()
                 .name(s.name)
-                .data(s.data.map { v -> Any in v.map { $0 as Any } ?? NSNull() } as [Any])
+                .data(s.data.map { v -> Any in v.map { $0 as Any } ?? NSNull() } as [AnyObject])
         }
 
         let model = AAChartModel()
             .chartType(AAChartType(rawValue: spec.chartType) ?? .column)
+            .backgroundColor(bgHex)
             .animationType(.easeInOutQuart)
-            .animationDuration(400)
+            .animationDuration(600)
             .dataLabelsEnabled(spec.dataLabelsEnabled ?? false)
+            .dataLabelsStyle(AAStyle().color(textHex).fontSize(11))
             .tooltipValueSuffix(spec.tooltipSuffix ?? "")
+            .legendEnabled(true)
             .series(seriesElements)
 
         if let categories = spec.categories {
@@ -142,6 +176,30 @@ final class NativeChartView: NSView {
             model.colorsTheme(colors)
         }
 
-        return model
+        // Apply axis label and legend text colors via AAOptions (AAChartModel has no axesTextColor)
+        let options = model.aa_toAAOptions()
+        let labelStyle = AAStyle().color(textHex).fontSize(11)
+        options.xAxis?.labels(AALabels().style(labelStyle))
+            .gridLineColor(gridHex)
+            .lineColor(gridHex)
+        options.yAxis?.labels(AALabels().style(labelStyle))
+            .gridLineColor(gridHex)
+            .lineColor(gridHex)
+        options.legend?.itemStyle(AAStyle().color(textHex).fontSize(12).fontWeight(.regular))
+
+        return (options, seriesElements)
+    }
+}
+
+// MARK: - NSColor hex helper
+
+private extension NSColor {
+    /// Returns a CSS hex string (#rrggbb) suitable for passing to AAChartKit
+    var hexString: String {
+        guard let color = usingColorSpace(.sRGB) else { return "#000000" }
+        let r = Int((color.redComponent   * 255).rounded())
+        let g = Int((color.greenComponent * 255).rounded())
+        let b = Int((color.blueComponent  * 255).rounded())
+        return String(format: "#%02x%02x%02x", r, g, b)
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -11,21 +11,45 @@ import AAInfographics
 
 final class NativeChartView: NSView {
 
-    private let card       = NSView()
-    private let titleLabel = NSTextField(labelWithString: "")
-    private let noteLabel  = NSTextField(labelWithString: "")
-    private let chartView  = AAChartView()
+    private let card         = NSView()
+    private let titleLabel   = NSTextField(labelWithString: "")
+    private let typePicker   = NSPopUpButton()
+    private let noteLabel    = NSTextField(labelWithString: "")
+    private let chartView    = AAChartView()
 
     /// Animation runs only on first draw; subsequent spec changes skip animation.
     private var hasDrawn = false
     /// Skip redundant redraws (window focus, resize) when spec hasn't changed.
     private var lastSpec: ChartSpec?
-    /// Cached theme background hex — used to re-apply after WebView loads.
-    private var lastBgHex: String = "#000000"
+    /// Chart type chosen by the user via the picker; overrides spec.chartType until a new spec arrives.
+    private var chartTypeOverride: String?
+    /// Cached theme so the picker action can trigger a redraw with the same theme.
+    private var lastTheme: (any ThemeProtocol)?
 
     // Chart height gives Highcharts enough vertical room for the plot + legend.
     static let chartHeight: CGFloat = 320
     static let cardPadding: CGFloat = 12
+
+    private static let chartTypes: [String] = [
+        "line", "spline", "column", "bar", "area", "areaspline",
+        "pie", "scatter", "bubble", "waterfall",
+    ]
+
+    private static func symbol(for chartType: String) -> String {
+        switch chartType {
+        case "line":       return "chart.xyaxis.line"
+        case "spline":     return "chart.line.uptrend.xyaxis"
+        case "column":     return "chart.bar.fill"
+        case "bar":        return "chart.bar.xaxis.ascending"
+        case "area":       return "chart.line.flattrend.xyaxis.circle.fill"
+        case "areaspline": return "chart.line.uptrend.xyaxis.circle.fill"
+        case "pie":        return "chart.pie.fill"
+        case "scatter":    return "chart.dots.scatter"
+        case "bubble":     return "circle.grid.3x3.fill"
+        case "waterfall":  return "chart.bar.doc.horizontal.fill"
+default:           return "chart.bar.fill"
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -41,7 +65,6 @@ final class NativeChartView: NSView {
 
         card.wantsLayer = true
         card.layer?.cornerRadius = 12
-        // Subtle border for elevation
         card.layer?.borderWidth  = 1
         card.translatesAutoresizingMaskIntoConstraints = false
         addSubview(card)
@@ -56,6 +79,22 @@ final class NativeChartView: NSView {
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         card.addSubview(titleLabel)
+
+        // Chart type picker
+        typePicker.removeAllItems()
+        for type in Self.chartTypes {
+            let item = NSMenuItem()
+            item.title = type.capitalized
+            item.image = NSImage(systemSymbolName: Self.symbol(for: type), accessibilityDescription: nil)
+            typePicker.menu?.addItem(item)
+        }
+        typePicker.font = .systemFont(ofSize: 11)
+        typePicker.controlSize = .small
+        typePicker.bezelStyle = .roundRect
+        typePicker.translatesAutoresizingMaskIntoConstraints = false
+        typePicker.target = self
+        typePicker.action = #selector(chartTypeChanged)
+        card.addSubview(typePicker)
 
         // Suppress WKWebView's white background before JS renders
         chartView.setValue(false, forKey: "drawsBackground")
@@ -74,9 +113,13 @@ final class NativeChartView: NSView {
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: p),
             titleLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: p),
-            titleLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: typePicker.leadingAnchor, constant: -8),
+            titleLabel.centerYAnchor.constraint(equalTo: typePicker.centerYAnchor),
 
-            chartView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            typePicker.topAnchor.constraint(equalTo: card.topAnchor, constant: p - 2),
+            typePicker.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -p),
+
+            chartView.topAnchor.constraint(equalTo: typePicker.bottomAnchor, constant: 4),
             chartView.leadingAnchor.constraint(equalTo: card.leadingAnchor),
             chartView.trailingAnchor.constraint(equalTo: card.trailingAnchor),
             chartView.heightAnchor.constraint(equalToConstant: Self.chartHeight),
@@ -95,7 +138,6 @@ final class NativeChartView: NSView {
         let textColor = NSColor(theme.primaryText)
 
         card.layer?.backgroundColor = bgColor.cgColor
-        // Subtle gray border — slightly lighter than the card background
         card.layer?.borderColor = NSColor(theme.primaryBorder).withAlphaComponent(0.25).cgColor
         titleLabel.textColor    = textColor
         noteLabel.textColor     = NSColor(theme.secondaryText)
@@ -110,33 +152,59 @@ final class NativeChartView: NSView {
             noteLabel.isHidden = true
         }
 
-        lastBgHex = bgHex
+        lastTheme = theme
 
         // Skip chart redraw when spec hasn't changed (handles window focus / resize)
         guard spec != lastSpec else { return }
         lastSpec = spec
+        chartTypeOverride = nil   // new spec from model — reset any user override
 
-        let (options, seriesElements) = buildChartModel(from: spec, bgHex: bgHex, textHex: textColor.hexString, theme: theme)
+        // Sync picker to the spec's chart type
+        if let idx = Self.chartTypes.firstIndex(of: spec.chartType) {
+            typePicker.selectItem(at: idx)
+        }
 
-        if !hasDrawn {
+        redraw(spec: spec, bgHex: bgHex, textHex: textColor.hexString, theme: theme)
+    }
+
+    func measuredCardHeight() -> CGFloat {
+        let p = Self.cardPadding
+        let headerH: CGFloat = 24    // picker height + 4pt gap
+        var h = p + headerH
+        h += Self.chartHeight
+        if noteLabel.isHidden {
+            h += p
+        } else {
+            h += 6 + 16 + p
+        }
+        return h
+    }
+
+    // MARK: - Picker action
+
+    @objc private func chartTypeChanged() {
+        guard let spec = lastSpec, let theme = lastTheme else { return }
+        chartTypeOverride = Self.chartTypes[typePicker.indexOfSelectedItem]
+
+        var updated = spec
+        updated.chartType = chartTypeOverride!
+
+        let bgHex   = NSColor(theme.cardBackground).hexString
+        let textHex = NSColor(theme.primaryText).hexString
+        redraw(spec: updated, bgHex: bgHex, textHex: textHex, theme: theme, forceFullRedraw: true)
+    }
+
+    // MARK: - Draw / Refresh
+
+    private func redraw(spec: ChartSpec, bgHex: String, textHex: String, theme: any ThemeProtocol, forceFullRedraw: Bool = false) {
+        let (options, seriesElements) = buildChartModel(from: spec, bgHex: bgHex, textHex: textHex, theme: theme)
+
+        if !hasDrawn || forceFullRedraw {
             hasDrawn = true
             chartView.aa_drawChartWithChartOptions(options)
         } else {
             chartView.aa_onlyRefreshTheChartDataWithChartModelSeries(seriesElements, animation: false)
         }
-    }
-
-    func measuredCardHeight() -> CGFloat {
-        let p = Self.cardPadding
-        var h = p
-        h += titleLabel.isHidden ? 0 : (20 + 4)   // title + gap
-        h += Self.chartHeight
-        if noteLabel.isHidden {
-            h += p                      // chartView → card bottom
-        } else {
-            h += 6 + 16 + p            // gap + note + bottom padding
-        }
-        return h
     }
 
     // MARK: - AAChartModel Builder
@@ -178,7 +246,6 @@ final class NativeChartView: NSView {
             model.colorsTheme(colors)
         }
 
-        // Apply axis label and legend text colors via AAOptions (AAChartModel has no axesTextColor)
         let options = model.aa_toAAOptions()
         let labelStyle = AAStyle().color(textHex).fontSize(11)
         options.xAxis?.labels(AALabels().style(labelStyle))

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1885,10 +1885,11 @@ enum NativeCellHeightEstimator {
             return h + 12 + 24
 
         case let .chart(spec):
-            // cardPadding(12) + title(20+8) + chart(260) + note(6+16) + cardPadding(12) + cell insets(12)
-            var h: CGFloat = 12 + 260 + 12 + 12   // paddings + chart + cell insets
-            if !(spec.title ?? "").isEmpty { h += 20 + 8 }
-            if !(spec.note  ?? "").isEmpty { h += 6 + 16 }
+            var h: CGFloat = NativeChartView.cardPadding + NativeChartView.chartHeight + 12 // top pad + chart + cell insets
+            h += (spec.title ?? "").isEmpty ? 0 : (20 + 4)   // title + gap
+            h += (spec.note  ?? "").isEmpty
+                ? NativeChartView.cardPadding                  // bottom padding only
+                : (6 + 16 + NativeChartView.cardPadding)      // note + bottom padding
             return h
         }
     }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -719,6 +719,7 @@ final class NativeMessageCellView: NSTableCellView {
     private var nativePendingView: NativePendingToolCallView?
     private var nativeTypingView: NativeTypingIndicatorView?
     private var nativeArtifactView: NativeArtifactCardView?
+    private var nativeChartView: NativeChartView?
     private var nativePreflightView: NativePreflightCapabilitiesView?
     private var nativeStatsView: NativeStatsView?
 
@@ -863,6 +864,9 @@ final class NativeMessageCellView: NSTableCellView {
 
         case let .sharedArtifact(artifact):
             configureAsArtifact(block: block, artifact: artifact, context: context, sameKind: sameKind)
+
+        case let .chart(spec):
+            configureAsChart(block: block, spec: spec, context: context, sameKind: sameKind)
 
         case let .preflightCapabilities(items):
             configureAsPreflight(block: block, items: items, context: context, sameKind: sameKind)
@@ -1479,6 +1483,38 @@ final class NativeMessageCellView: NSTableCellView {
         }
     }
 
+    // MARK: - Chart
+
+    private func configureAsChart(
+        block: ContentBlock,
+        spec: ChartSpec,
+        context: CellRenderingContext,
+        sameKind: Bool
+    ) {
+        if !sameKind || nativeChartView == nil {
+            removeAllContentViews()
+            let cv = NativeChartView()
+            cv.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(cv)
+            let bottomToCell = cv.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6)
+            bottomToCell.priority = NSLayoutConstraint.Priority(250)
+            NSLayoutConstraint.activate([
+                cv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                cv.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+                cv.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+                bottomToCell,
+            ])
+            nativeChartView = cv
+        }
+        let blockId = block.id
+        nativeChartView?.configure(spec: spec, theme: context.theme)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let cv = self.nativeChartView else { return }
+            guard self.currentBlockId == blockId else { return }
+            context.onHeightMeasured?(cv.measuredCardHeight() + 12, blockId)
+        }
+    }
+
     // MARK: - PreflightCapabilities
 
     private func configureAsPreflight(
@@ -1717,7 +1753,7 @@ private final class UserDocumentChipView: NSView {
 /// Lightweight discriminator used to detect kind changes without comparing full associated values.
 enum ContentBlockKindTag: Equatable {
     case header, paragraph, toolCallGroup, thinking, userMessage, pendingToolCall
-    case generationStats, typingIndicator, groupSpacer, sharedArtifact, preflightCapabilities, other
+    case generationStats, typingIndicator, groupSpacer, sharedArtifact, preflightCapabilities, chart, other
 }
 
 extension ContentBlockKind {
@@ -1734,6 +1770,7 @@ extension ContentBlockKind {
         case .groupSpacer: return .groupSpacer
         case .sharedArtifact: return .sharedArtifact
         case .preflightCapabilities: return .preflightCapabilities
+        case .chart: return .chart
         }
     }
 }
@@ -1846,6 +1883,13 @@ enum NativeCellHeightEstimator {
             // configureAsArtifact reports measuredCardHeight() + 12 for cell top/bottom inset — match that here
             // extra slack: intrinsic footer + deferred layout can exceed this; too-small row clips Open in Finder
             return h + 12 + 24
+
+        case let .chart(spec):
+            // cardPadding(12) + title(20+8) + chart(260) + note(6+16) + cardPadding(12) + cell insets(12)
+            var h: CGFloat = 12 + 260 + 12 + 12   // paddings + chart + cell insets
+            if !(spec.title ?? "").isEmpty { h += 20 + 8 }
+            if !(spec.note  ?? "").isEmpty { h += 6 + 16 }
+            return h
         }
     }
 }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "aff0b0b3cc1e49b83530d7c7e310a795ecc138855e759bdd328ca8bebbbcf0a8",
+  "originHash" : "d39503d2331612893b8c86af835aac916e397042eb933ef5ed054c817e0a324b",
   "pins" : [
+    {
+      "identity" : "aachartkit-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AAChartModel/AAChartKit-Swift.git",
+      "state" : {
+        "revision" : "b51e53c3b04372c1ed1906b0ec3ba45733953ef4",
+        "version" : "9.5.0"
+      }
+    },
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",


### PR DESCRIPTION
## Summary

  - Added native chart rendering inline in the chat via AAChartKit using a hybrid approach to handle both     
  inline data and file attachments reliably                                                                   
  - Uses fenced block path for small/inline datasets. the model emits a JSON `ChartSpecinside` a     
  fenced block and the parser extracts it upstream of the markdown renderer and renders it as a `NativeChartView`  
  - Tool call path (render_chart) for file attachments. the app passes the raw file content to the tool which
   handles all CSV/TSV/JSON parsing, column extraction and downsampling (capped at 500 rows). the model only
   specifies column names and chart intent, never individual data points. result is returned as a  ---CHART_START--- marker that the message pipeline converts to a .chart content block                       
  - The tool call path is preferred for attachments because re-emitting large datasets through the model is 
  unreliable especially with quantized local models                                                          
  - `ChartSpec` uses a forgiving decoder (FlexDouble) to coerce string encoded numbers produced by local
  models                                                                                                      
  - Adds a DataVisualizer built-in skill that instructs the model on when to use each path and how to select
  appropriate chart types  
  - Users can switch between chart types (line, column, bar, area, pie, scatter etc) via a dropdown on the chart card without re-prompting the model

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Screenshots

https://github.com/user-attachments/assets/923fc094-a2e9-48d9-84ba-57394d23585f

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
