### PR TITLE
build: pin MLX dependencies and fix current FluidAudio compatibility

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6d825c4d68c47e18f5d4607729be796d583f1ad7ace433a900815fdb0bf43c67",
+  "originHash" : "d22ff3a751a5cfed0fc3949c0b920f3b8b245231d1fcbb5bb8084cb8c2d8ff45",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "2fc4652fb4689eb24af10e55cabaa61d8ba774fd",
-        "version" : "1.32.0"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "636eef0eff00e451de6d5d426e6a6785b90b44e2",
-        "version" : "0.26.5"
+        "revision" : "72432f148c9cb35d6a7e7c0ad61d6f9d226cbef7",
+        "version" : "0.30.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
-        "version" : "1.3.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
-        "version" : "0.13.4"
+        "revision" : "57551cd90e0bbec342766244358bcf08afb05290",
+        "version" : "0.13.6"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "956259f65a34c58dd76ae5df4511712e1087726b",
-        "version" : "1.27.3"
+        "revision" : "ac715c584bb1e2e5cdfb7684ccb46fab8dafc641",
+        "version" : "1.27.4"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orlandos-nl/IkigaJSON",
       "state" : {
-        "revision" : "fad099f256e4b8d4c67a386a13d176b1f5910a8b",
-        "version" : "2.4.1"
+        "revision" : "937ee3b14b34688787e4549de026b4292fddf6f4",
+        "version" : "2.4.2"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
-        "version" : "1.4.0"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jkrukowski/swift-embeddings.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33"
+        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33",
+        "version" : "0.0.26"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "2039e9760ba1694f9962ccd2c616403983d46895",
-        "version" : "2.3.3"
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
-        "version" : "1.9.1"
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "9b92dcd5c22ae17016ad867852e0850f1f9f93ed",
-        "version" : "2.94.1"
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
-        "version" : "1.32.1"
+        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
+        "version" : "1.33.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
-        "version" : "1.40.0"
+        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
+        "version" : "1.42.0"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
+        "version" : "2.36.1"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "5596511fce902e649c403cd4d6d5da1254f142b7",
-        "version" : "1.35.1"
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
       }
     },
     {
@@ -301,7 +301,7 @@
     {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/modelcontextprotocol/swift-sdk",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
         "version" : "0.12.0"
@@ -364,7 +364,7 @@
     {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
         "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
         "version" : "1.2.1"
@@ -385,7 +385,7 @@
       "location" : "https://github.com/rryam/VecturaKit",
       "state" : {
         "branch" : "main",
-        "revision" : "a1b93774d16d8a6e7fc39b7cda9449b719f07f48"
+        "revision" : "5fed66f3700bee561326e719250aa01c49fc53d5"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/SpeechService.swift
+++ b/Packages/OsaurusCore/Managers/SpeechService.swift
@@ -661,7 +661,7 @@ public final class SpeechService: ObservableObject {
             }.value
 
             let manager = AsrManager(config: .default)
-            try await manager.initialize(models: models)
+            try await manager.loadModels(models)
             self.sendableAsrManager = SendableAsrManager(manager)
 
             let vad = try await VadManager(

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -9,26 +9,30 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
     .package(
         url: "https://github.com/osaurus-ai/mlx-swift",
-        revision: "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"),
+        revision: "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"
+    ),
     .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
     .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
     .package(
         url: "https://github.com/rryam/VecturaKit",
-        revision: "5fed66f3700bee561326e719250aa01c49fc53d5"),
+        revision: "5fed66f3700bee561326e719250aa01c49fc53d5"
+    ),
     .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.21.1"),
     .package(path: "../OsaurusRepository"),
     .package(url: "https://github.com/mgriebling/SwiftMath", from: "1.7.3"),
 ]
 
 if let localMLXSwiftLMPath = Context.environment["LOCAL_MLX_SWIFT_LM_PATH"],
-   !localMLXSwiftLMPath.isEmpty
+    !localMLXSwiftLMPath.isEmpty
 {
     dependencies.append(.package(path: localMLXSwiftLMPath))
 } else {
     dependencies.append(
         .package(
             url: "https://github.com/osaurus-ai/mlx-swift-lm",
-            revision: "10d547ee65e16e9e9c20197623b29ab7c4952100"))
+            revision: "10d547ee65e16e9e9c20197623b29ab7c4952100"
+        )
+    )
 }
 
 let package = Package(

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -1,33 +1,43 @@
 // swift-tools-version: 6.2
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/apple/swift-nio.git", from: "2.88.0"),
+    .package(url: "https://github.com/apple/containerization.git", from: "0.26.0"),
+    .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
+    .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
+    .package(
+        url: "https://github.com/osaurus-ai/mlx-swift",
+        revision: "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"),
+    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
+    .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
+    .package(
+        url: "https://github.com/rryam/VecturaKit",
+        revision: "5fed66f3700bee561326e719250aa01c49fc53d5"),
+    .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.21.1"),
+    .package(path: "../OsaurusRepository"),
+    .package(url: "https://github.com/mgriebling/SwiftMath", from: "1.7.3"),
+]
+
+if let localMLXSwiftLMPath = Context.environment["LOCAL_MLX_SWIFT_LM_PATH"],
+   !localMLXSwiftLMPath.isEmpty
+{
+    dependencies.append(.package(path: localMLXSwiftLMPath))
+} else {
+    dependencies.append(
+        .package(
+            url: "https://github.com/osaurus-ai/mlx-swift-lm",
+            revision: "10d547ee65e16e9e9c20197623b29ab7c4952100"))
+}
+
 let package = Package(
     name: "OsaurusCore",
     platforms: [.macOS(.v15)],
     products: [
         .library(name: "OsaurusCore", targets: ["OsaurusCore"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.88.0"),
-        .package(url: "https://github.com/apple/containerization.git", from: "0.26.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
-        .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
-        .package(
-            url: "https://github.com/osaurus-ai/mlx-swift",
-            revision: "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"),
-        .package(
-            url: "https://github.com/osaurus-ai/mlx-swift-lm",
-            revision: "10d547ee65e16e9e9c20197623b29ab7c4952100"),
-        .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
-        .package(
-            url: "https://github.com/rryam/VecturaKit",
-            revision: "5fed66f3700bee561326e719250aa01c49fc53d5"),
-        .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.21.1"),
-        .package(path: "../OsaurusRepository"),
-        .package(url: "https://github.com/mgriebling/SwiftMath", from: "1.7.3"),
-    ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "OsaurusCore",

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -13,15 +13,20 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
-        .package(url: "https://github.com/osaurus-ai/mlx-swift", branch: "osaurus-0.31.3"),
-        .package(url: "https://github.com/osaurus-ai/mlx-swift-lm", branch: "main"),
+        .package(
+            url: "https://github.com/osaurus-ai/mlx-swift",
+            revision: "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"),
+        .package(
+            url: "https://github.com/osaurus-ai/mlx-swift-lm",
+            revision: "10d547ee65e16e9e9c20197623b29ab7c4952100"),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.13.4"),
-        .package(url: "https://github.com/rryam/VecturaKit", branch: "main"),
+        .package(
+            url: "https://github.com/rryam/VecturaKit",
+            revision: "5fed66f3700bee561326e719250aa01c49fc53d5"),
         .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", exact: "0.21.1"),
         .package(path: "../OsaurusRepository"),
         .package(url: "https://github.com/mgriebling/SwiftMath", from: "1.7.3"),
-        .package(url: "https://github.com/raspu/Highlightr", from: "2.3.0"),
     ],
     targets: [
         .target(
@@ -45,11 +50,9 @@ let package = Package(
                 .product(name: "SwiftMath", package: "SwiftMath"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
-                .product(name: "Highlightr", package: "Highlightr"),
             ],
             path: ".",
-            exclude: ["Tests"],
-            resources: [.process("Resources")]
+            exclude: ["Tests"]
         ),
         .testTarget(
             name: "OsaurusCoreTests",

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "aff0b0b3cc1e49b83530d7c7e310a795ecc138855e759bdd328ca8bebbbcf0a8",
+  "originHash" : "d22ff3a751a5cfed0fc3949c0b920f3b8b245231d1fcbb5bb8084cb8c2d8ff45",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "2fc4652fb4689eb24af10e55cabaa61d8ba774fd",
-        "version" : "1.32.0"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "636eef0eff00e451de6d5d426e6a6785b90b44e2",
-        "version" : "0.26.5"
+        "revision" : "72432f148c9cb35d6a7e7c0ad61d6f9d226cbef7",
+        "version" : "0.30.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
-        "version" : "1.3.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
-        "version" : "0.13.4"
+        "revision" : "57551cd90e0bbec342766244358bcf08afb05290",
+        "version" : "0.13.6"
       }
     },
     {
@@ -42,17 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "956259f65a34c58dd76ae5df4511712e1087726b",
-        "version" : "1.27.3"
-      }
-    },
-    {
-      "identity" : "highlightr",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/raspu/Highlightr",
-      "state" : {
-        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
-        "version" : "2.3.0"
+        "revision" : "ac715c584bb1e2e5cdfb7684ccb46fab8dafc641",
+        "version" : "1.27.4"
       }
     },
     {
@@ -60,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orlandos-nl/IkigaJSON",
       "state" : {
-        "revision" : "fad099f256e4b8d4c67a386a13d176b1f5910a8b",
-        "version" : "2.4.1"
+        "revision" : "937ee3b14b34688787e4549de026b4292fddf6f4",
+        "version" : "2.4.2"
       }
     },
     {
@@ -87,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {
@@ -105,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {
@@ -114,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
       }
     },
     {
@@ -150,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
       }
     },
     {
@@ -177,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
-        "version" : "1.4.0"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -186,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jkrukowski/swift-embeddings.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33"
+        "revision" : "66994e3b3ed172a9b691b59d11bd0702c3f5eb33",
+        "version" : "0.0.26"
       }
     },
     {
@@ -222,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "2039e9760ba1694f9962ccd2c616403983d46895",
-        "version" : "2.3.3"
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
       }
     },
     {
@@ -231,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
-        "version" : "1.9.1"
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
       }
     },
     {
@@ -240,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "9b92dcd5c22ae17016ad867852e0850f1f9f93ed",
-        "version" : "2.94.1"
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
       }
     },
     {
@@ -249,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
-        "version" : "1.32.1"
+        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
+        "version" : "1.33.0"
       }
     },
     {
@@ -258,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
-        "version" : "1.40.0"
+        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
+        "version" : "1.42.0"
       }
     },
     {
@@ -267,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
+        "version" : "2.36.1"
       }
     },
     {
@@ -294,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "5596511fce902e649c403cd4d6d5da1254f142b7",
-        "version" : "1.35.1"
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
       }
     },
     {
@@ -310,7 +301,7 @@
     {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/modelcontextprotocol/swift-sdk",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
         "version" : "0.12.0"
@@ -373,7 +364,7 @@
     {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
         "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
         "version" : "1.2.1"
@@ -394,7 +385,7 @@
       "location" : "https://github.com/rryam/VecturaKit",
       "state" : {
         "branch" : "main",
-        "revision" : "a1b93774d16d8a6e7fc39b7cda9449b719f07f48"
+        "revision" : "5fed66f3700bee561326e719250aa01c49fc53d5"
       }
     },
     {


### PR DESCRIPTION
## Scope
- fix speech model initialization to match the current FluidAudio API
- pin MLX-related dependencies to exact revisions
- sync the Xcode/workspace lockfiles to the pinned dependency set
- add an optional `LOCAL_MLX_SWIFT_LM_PATH` override for coordinated local MLX development

## Resulting Improvements
- Build resolution becomes reproducible instead of depending on mutable MLX-related refs.
- The current speech-service path works again against the FluidAudio API this branch targets.
- Xcode and SwiftPM dependency state stay aligned more reliably.
- Cross-repo MLX development becomes easier to validate locally without repeated manifest edits.

## Detailed Improvement Explanation
This PR makes the repository behave more like a controlled product build instead of an ad hoc local setup. Pinning the MLX-related graph removes a class of failures where the same checkout resolves differently over time or between machines. Syncing the Xcode lockfiles closes the gap between command-line and IDE package state. The FluidAudio fix restores the currently expected speech initialization path, so the branch is not only more reproducible but also compatible with the dependency versions it declares.

## Why This PR Exists
This branch addresses two concrete problems:
1. `SpeechService` was calling an outdated FluidAudio initialization path.
2. MLX-related dependencies were being resolved from mutable refs, which made local and CI builds harder to reason about.

## Validation
- validated a Release app build against a local MLX checkout
- confirmed the branch stays scoped to build compatibility and dependency reproducibility
- cleaned and audited the published diff for local-path and temp-file leakage

## Merge Notes
- This is the build/reproducibility base for the local MLX and Work Mode follow-up work.
- `.mov` / broader media forwarding stays intentionally out of this PR.
- MLX-specific hardening and VLM changes are proposed separately in `osaurus-ai/mlx-swift-lm`.
