### PR TITLE
fix: harden MLX cache reuse under long-context pressure

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -57,6 +57,8 @@ actor ModelRuntime {
     private var currentModelName: String?
     private var kvCacheStore = KVCacheStore()
     private var cachedConfig: RuntimeConfig?
+    private var learnedMaxKVCaps: [String: Int] = [:]
+    private var learnedPrefillStepCaps: [String: Int] = [:]
     private var activeGenerationTask: Task<Void, Never>?
     // modelName:taskHash -> Task
     private var prefixCacheTasks: [String: Task<Void, Never>] = [:]
@@ -141,6 +143,16 @@ actor ModelRuntime {
     /// Invalidates the cached RuntimeConfig so the next request reads fresh values.
     func invalidateConfig() {
         cachedConfig = nil
+        learnedMaxKVCaps.removeAll()
+        learnedPrefillStepCaps.removeAll()
+    }
+
+    func effectiveRuntimeMaxKV(for modelName: String) async -> Int? {
+        let cfg = await getConfig()
+        return cfg.capped(
+            maxKVCap: learnedMaxKVCaps[modelName],
+            prefillStepCap: learnedPrefillStepCaps[modelName]
+        ).maxKV
     }
 
     /// Invalidates the KV cache for a specific session (e.g., on window close).
@@ -280,6 +292,22 @@ actor ModelRuntime {
         guard !modelCache.isEmpty else { return 0 }
         let modelBytes = modelCache.values.reduce(Int64(0)) { $0 + $1.weightsSizeBytes }
         return KVCacheStore.computeBudget(modelWeightsBytes: modelBytes)
+    }
+
+    private func rememberLearnedMaxKV(_ maxKV: Int, for modelName: String) {
+        if let existing = learnedMaxKVCaps[modelName] {
+            learnedMaxKVCaps[modelName] = min(existing, maxKV)
+        } else {
+            learnedMaxKVCaps[modelName] = maxKV
+        }
+    }
+
+    private func rememberLearnedPrefillStep(_ prefillStep: Int, for modelName: String) {
+        if let existing = learnedPrefillStepCaps[modelName] {
+            learnedPrefillStepCaps[modelName] = min(existing, prefillStep)
+        } else {
+            learnedPrefillStepCaps[modelName] = prefillStep
+        }
     }
 
     /// MLX freed-buffer cache limit sized for intermediate activation reuse.
@@ -471,7 +499,10 @@ actor ModelRuntime {
         genLog.info("generateEventStream: start model=\(modelName, privacy: .public)")
 
         let effectiveStopSequences = stopSequences
-        let cfg = await getConfig()
+        let cfg = (await getConfig()).capped(
+            maxKVCap: learnedMaxKVCaps[modelName],
+            prefillStepCap: learnedPrefillStepCaps[modelName]
+        )
         let holder = try await loadContainer(id: modelId, name: modelName)
 
         let wiredPolicy = MLXLMCommon.WiredSumPolicy()
@@ -512,15 +543,15 @@ actor ModelRuntime {
 
         var rawStream: AsyncStream<MLXLMCommon.TokenGeneration>
         var tokenizer: any Tokenizer
-        var cache: [any KVCache]
         var newTokens: [Int]
         var genTask: Task<Void, Never>
         var toolCallFormat: ToolCallFormat
-        // Two-phase prefill sets this to the stable-boundary snapshot instead of the full-prompt snapshot.
-        nonisolated(unsafe) var snapshotCacheOverride: ([any KVCache], [Int])? = nil
+        // `prepareAndGenerate` now always returns a pre-generation snapshot.
+        nonisolated(unsafe) var snapshotCacheToStore: [any KVCache] = []
+        var snapshotTokensToStore: [Int] = []
 
         genLog.info(
-            "generateEventStream: prepareAndGenerate existingCache=\(existingCache != nil, privacy: .public) cachedTokens=\(cachedTokens?.count ?? 0, privacy: .public)"
+            "generateEventStream: prepareAndGenerate existingCache=\(existingCache != nil, privacy: .public) cachedTokens=\(cachedTokens?.count ?? 0, privacy: .public) maxKV=\(cfg.maxKV ?? -1, privacy: .public) prefillStep=\(cfg.prefillStep, privacy: .public)"
         )
 
         // Acquire exclusive Metal access after all throwing setup is complete.
@@ -535,60 +566,99 @@ actor ModelRuntime {
         // The UI shows a spinner; once the first generated token arrives prefillDidFinish() clears it.
         InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
 
-        do {
-            let genResult = try await MLXGenerationEngine.prepareAndGenerate(
-                container: holder.container,
-                buildChat: buildChat,
-                buildToolsSpec: buildTools,
-                generation: parameters,
-                runtime: cfg,
-                existingCache: existingCache,
-                cachedTokens: cachedTokens,
-                wiredMemoryTicket: wiredTicket
-            )
-            (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) = (
-                genResult.stream, genResult.tokenizer, genResult.cache,
-                genResult.promptTokens, genResult.genTask, genResult.toolCallFormat
-            )
-            // For two-phase prefill, override snapshot with the stable-boundary snapshot.
-            if let snapCache = genResult.snapshotCache, let snapTokens = genResult.snapshotTokens {
-                snapshotCacheOverride = (snapCache, snapTokens)
-            }
-        } catch {
-            genLog.error(
-                "generateEventStream: prepareAndGenerate failed (cache retry): \(error.localizedDescription, privacy: .public)"
-            )
-            guard existingCache != nil else {
-                InferenceProgressManager.shared.prefillDidFinishAsync()
-                await MetalGate.shared.exitGeneration()
-                throw error
-            }
-            genLog.warning("Cache incompatible, retrying: \(error.localizedDescription, privacy: .public)")
-            invalidateCaches(sessionId: sessionId, modelName: modelName, prefixHash: prefixHash)
-            // Re-signal for the retry prefill (still unknown count).
-            InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
+        var runtimeConfig = cfg
+        nonisolated(unsafe) var attemptCache = existingCache
+        let initialCachedTokens = cachedTokens
+        var attemptCachedTokens = initialCachedTokens
+        var retriedWithoutCache = false
+        var lastMetalAllocationRequestedBytes: Int64?
+
+        while true {
             do {
-                let retryResult = try await MLXGenerationEngine.prepareAndGenerate(
+                let genResult = try await MLXGenerationEngine.prepareAndGenerate(
                     container: holder.container,
                     buildChat: buildChat,
                     buildToolsSpec: buildTools,
                     generation: parameters,
-                    runtime: cfg,
-                    existingCache: nil,
-                    cachedTokens: nil,
+                    runtime: runtimeConfig,
+                    existingCache: attemptCache,
+                    cachedTokens: attemptCachedTokens,
                     wiredMemoryTicket: wiredTicket
                 )
-                (rawStream, tokenizer, cache, newTokens, genTask, toolCallFormat) = (
-                    retryResult.stream, retryResult.tokenizer, retryResult.cache,
-                    retryResult.promptTokens, retryResult.genTask, retryResult.toolCallFormat
-                )
-                if let snapCache = retryResult.snapshotCache, let snapTokens = retryResult.snapshotTokens {
-                    snapshotCacheOverride = (snapCache, snapTokens)
-                }
+                rawStream = genResult.stream
+                tokenizer = genResult.tokenizer
+                newTokens = genResult.promptTokens
+                genTask = genResult.genTask
+                toolCallFormat = genResult.toolCallFormat
+                snapshotCacheToStore = genResult.snapshotCache
+                snapshotTokensToStore = genResult.snapshotTokens
+                break
             } catch {
-                InferenceProgressManager.shared.prefillDidFinishAsync()
-                await MetalGate.shared.exitGeneration()
-                throw error
+                let description = error.localizedDescription
+                let requestedBytes = Self.metalAllocationFailureBytes(from: description)?.requestedBytes
+                let shouldPreferPrefillStep = Self.metalAllocationRetryShouldPreferPrefillStep(
+                    previousRequestedBytes: lastMetalAllocationRequestedBytes,
+                    currentRequestedBytes: requestedBytes
+                )
+                if let reducedMaxKV = Self.adaptiveMaxKVForMetalAllocationFailure(
+                    currentMaxKV: runtimeConfig.maxKV,
+                    errorDescription: description
+                ), !shouldPreferPrefillStep {
+                    let previousMaxKV = runtimeConfig.maxKV ?? -1
+                    runtimeConfig = runtimeConfig.capped(
+                        maxKVCap: reducedMaxKV,
+                        prefillStepCap: runtimeConfig.prefillStep
+                    )
+                    rememberLearnedMaxKV(reducedMaxKV, for: modelName)
+                    invalidateCaches(sessionId: sessionId, modelName: modelName, prefixHash: prefixHash)
+                    attemptCache = nil
+                    attemptCachedTokens = nil
+                    retriedWithoutCache = true
+                    lastMetalAllocationRequestedBytes = requestedBytes
+                    genLog.warning(
+                        "generateEventStream: metal allocation failed for maxKV=\(previousMaxKV, privacy: .public), retrying with maxKV=\(reducedMaxKV, privacy: .public): \(description, privacy: .public)"
+                    )
+                    InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
+                    continue
+                }
+
+                if let reducedPrefillStep = Self.adaptivePrefillStepForMetalAllocationFailure(
+                    currentPrefillStep: runtimeConfig.prefillStep,
+                    errorDescription: description
+                ) {
+                    let previousPrefillStep = runtimeConfig.prefillStep
+                    runtimeConfig = runtimeConfig.capped(
+                        maxKVCap: runtimeConfig.maxKV,
+                        prefillStepCap: reducedPrefillStep
+                    )
+                    rememberLearnedPrefillStep(reducedPrefillStep, for: modelName)
+                    invalidateCaches(sessionId: sessionId, modelName: modelName, prefixHash: prefixHash)
+                    attemptCache = nil
+                    attemptCachedTokens = nil
+                    retriedWithoutCache = true
+                    lastMetalAllocationRequestedBytes = requestedBytes
+                    genLog.warning(
+                        "generateEventStream: metal allocation failed for prefillStep=\(previousPrefillStep, privacy: .public), retrying with prefillStep=\(reducedPrefillStep, privacy: .public): \(description, privacy: .public)"
+                    )
+                    InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
+                    continue
+                }
+
+                lastMetalAllocationRequestedBytes = requestedBytes
+                genLog.error(
+                    "generateEventStream: prepareAndGenerate failed: \(description, privacy: .public)"
+                )
+                guard attemptCache != nil, !retriedWithoutCache else {
+                    InferenceProgressManager.shared.prefillDidFinishAsync()
+                    await MetalGate.shared.exitGeneration()
+                    throw error
+                }
+                genLog.warning("Cache incompatible, retrying: \(description, privacy: .public)")
+                invalidateCaches(sessionId: sessionId, modelName: modelName, prefixHash: prefixHash)
+                attemptCache = nil
+                attemptCachedTokens = nil
+                retriedWithoutCache = true
+                InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
             }
         }
         genLog.info("generateEventStream: stream created tokenCount=\(newTokens.count, privacy: .public)")
@@ -610,38 +680,24 @@ actor ModelRuntime {
         }
         activeGenerationTask = gatedGenTask
 
-        // Store a pre-generation snapshot of the cache immediately after prefill.
-        //
-        // Standard (single-phase) path: snapshot the full-prompt cache keyed by `newTokens`.
-        // Two-phase path: use the stable-boundary snapshot from prepareAndGenerate (keyed by
-        // stableTokens, before gen-prefix). This ensures the next turn's common-prefix check
-        // hits exactly at cacheOffset, with toTrim == 0, even for MambaCache models.
-        if let sid = sessionId {
-            let (snapCacheToStore, snapTokensToStore): ([any KVCache], [Int])
-            if let override = snapshotCacheOverride {
-                // Two-phase: store the stable-boundary snapshot already deep-copied inside engine.
-                snapCacheToStore = override.0
-                snapTokensToStore = override.1
-                genLog.info("twoPhase snapshot override: stableTokens=\(snapTokensToStore.count, privacy: .public)")
-            } else {
-                // Single-phase: snapshot full-prompt cache now.
-                snapCacheToStore = KVCacheStore.deepCopyCache(cache)
-                snapTokensToStore = newTokens
-            }
-            let arraysToEval = snapCacheToStore.flatMap { $0.state }
-            if !arraysToEval.isEmpty { try? withError { eval(arraysToEval) } }
+        // Store the pre-generation snapshot returned by prepareAndGenerate.
+        // In the standard path this is keyed by `newTokens`; in the two-phase
+        // path it is keyed by the stable boundary before the generation prefix.
+        if let sid = sessionId, !snapshotCacheToStore.isEmpty, !snapshotTokensToStore.isEmpty {
             kvCacheStore.putCache(
                 sessionId: sid,
-                cache: snapCacheToStore,
-                tokens: snapTokensToStore,
+                cache: snapshotCacheToStore,
+                tokens: snapshotTokensToStore,
                 modelName: modelName
             )
             let budget = currentKVBudget()
             kvCacheStore.ensureBudget(budget)
-            let snapshotOffset = effectiveCacheOffset(snapCacheToStore)
+            let snapshotOffset = effectiveCacheOffset(snapshotCacheToStore)
             genLog.info(
-                "pre-gen snapshot stored session=\(sid.prefix(8), privacy: .public) tokens=\(snapTokensToStore.count, privacy: .public) offset=\(snapshotOffset, privacy: .public)"
+                "pre-gen snapshot stored session=\(sid.prefix(8), privacy: .public) tokens=\(snapshotTokensToStore.count, privacy: .public) offset=\(snapshotOffset, privacy: .public)"
             )
+        } else if let sid = sessionId {
+            genLog.warning("pre-gen snapshot skipped session=\(sid.prefix(8), privacy: .public)")
         }
 
         // Thread the tokenizer into StreamAccumulator so it can decode token IDs to text.
@@ -800,6 +856,81 @@ actor ModelRuntime {
         let combined = systemContent + "\0" + tools
         let digest = SHA256.hash(data: Data(combined.utf8))
         return digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+    }
+
+    nonisolated static func adaptiveMaxKVForMetalAllocationFailure(
+        currentMaxKV: Int?,
+        errorDescription: String
+    ) -> Int? {
+        guard let currentMaxKV, currentMaxKV > 4096 else { return nil }
+
+        let normalized = errorDescription.lowercased()
+        guard
+            normalized.contains("metal::malloc"),
+            normalized.contains("maximum allowed buffer size")
+        else {
+            return nil
+        }
+
+        let targetMaxKV: Int
+        if let allocation = metalAllocationFailureBytes(from: errorDescription) {
+            let safetyFactor = Double(allocation.allowedBytes) / Double(allocation.requestedBytes) * 0.9
+            targetMaxKV = Int(Double(currentMaxKV) * safetyFactor)
+        } else {
+            targetMaxKV = currentMaxKV / 2
+        }
+
+        let rounded = max(4096, (targetMaxKV / 1024) * 1024)
+        guard rounded < currentMaxKV else {
+            let halved = max(4096, ((currentMaxKV / 2) / 1024) * 1024)
+            return halved < currentMaxKV ? halved : nil
+        }
+        return rounded
+    }
+
+    nonisolated static func adaptivePrefillStepForMetalAllocationFailure(
+        currentPrefillStep: Int,
+        errorDescription: String
+    ) -> Int? {
+        let minimumPrefillStep = 256
+        guard currentPrefillStep > minimumPrefillStep else { return nil }
+
+        let normalized = errorDescription.lowercased()
+        guard
+            normalized.contains("metal::malloc"),
+            normalized.contains("maximum allowed buffer size")
+        else {
+            return nil
+        }
+
+        let halved = max(minimumPrefillStep, ((currentPrefillStep / 2) / 256) * 256)
+        return halved < currentPrefillStep ? halved : nil
+    }
+
+    nonisolated static func metalAllocationRetryShouldPreferPrefillStep(
+        previousRequestedBytes: Int64?,
+        currentRequestedBytes: Int64?
+    ) -> Bool {
+        guard let previousRequestedBytes, let currentRequestedBytes else { return false }
+        return currentRequestedBytes >= Int64(Double(previousRequestedBytes) * 0.98)
+    }
+
+    nonisolated static func metalAllocationFailureBytes(
+        from errorDescription: String
+    ) -> (requestedBytes: Int64, allowedBytes: Int64)? {
+        let pattern =
+            #"Attempting to allocate ([0-9]+) bytes which is greater than the maximum allowed buffer size of ([0-9]+) bytes"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(errorDescription.startIndex..., in: errorDescription)
+        guard let match = regex.firstMatch(in: errorDescription, range: range), match.numberOfRanges == 3,
+            let requestedRange = Range(match.range(at: 1), in: errorDescription),
+            let allowedRange = Range(match.range(at: 2), in: errorDescription),
+            let requestedBytes = Int64(errorDescription[requestedRange]),
+            let allowedBytes = Int64(errorDescription[allowedRange])
+        else {
+            return nil
+        }
+        return (requestedBytes, allowedBytes)
     }
 
     nonisolated static func makeGenerateParameters(

--- a/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/KVCacheStore.swift
@@ -319,9 +319,9 @@ struct KVCacheStore {
     /// Returns a **fresh copy** of the prefix cache for this model + content hash.
     ///
     /// Hot-tier path: if the prefix cache is resident in RAM (entry.cache != nil), deep-copy
-    /// all KVCache objects in-memory and return immediately — no SSD I/O.  Each caller gets
-    /// independent objects whose MLXArrays are shared via copy-on-write until generation
-    /// mutates them, keeping the stored hot-tier copy pristine.
+    /// all KVCache objects in-memory and return immediately — no SSD I/O. Each caller gets
+    /// detached MLXArray storage so live generation cannot alias Metal-backed buffers owned by
+    /// the cached entry.
     ///
     /// Cold-tier fallback: if only an SSD path is recorded, load from disk as before.
     mutating func getPrefixCache(modelName: String, hash: String) -> ([any KVCache]?, [Int]?) {
@@ -367,7 +367,7 @@ struct KVCacheStore {
             let kb = bytes / 1024
             kvLog.info("[perf] ssdLoad kind=prefix durationMs=\(loadMs, privacy: .public) kb=\(kb, privacy: .public)")
             print("[KVCacheStore] Prefix cache SSD load (promoted to RAM) \(key.prefix(24)) (\(kb)KB, \(loadMs)ms)")
-            // Return a deep copy so the hot-tier entry stays pristine.
+            // Return a detached copy so the hot-tier entry stays pristine.
             return (Self.deepCopyCache(cache), entry.tokens)
         } catch {
             print("[KVCacheStore] Failed to load prefix cache from SSD: \(error)")
@@ -376,11 +376,73 @@ struct KVCacheStore {
         }
     }
 
-    /// Returns an independent copy of `source` where every KVCache layer is a new
-    /// object of the same concrete type.  The underlying MLXArrays are shared via
-    /// copy-on-write until generation mutates the new copy, so this is very cheap.
+    /// Returns an independent copy of `source`.
+    ///
+    /// Transformer-style KV caches are rebuilt with detached MLXArray storage to
+    /// avoid aliasing live Metal resources between cached snapshots and active
+    /// generation. Other cache families currently fall back to upstream `copy()`
+    /// because the generic MLX readback path is not stable across all cache types.
     static func deepCopyCache(_ source: [any KVCache]) -> [any KVCache] {
-        source.map { $0.copy() }
+        source.map { detachedCloneCache($0) }
+    }
+
+    private static func detachedCloneCache(_ source: any KVCache) -> any KVCache {
+        if let cacheList = source as? CacheList {
+            return detachedCloneCacheList(cacheList)
+        }
+
+        // The crash signature implicated transformer KV caches (`RotatingKVCache`)
+        // whose upstream `copy()` implementation aliases the underlying MLX
+        // storage. Scope the expensive detached clone to that family only.
+        guard var clone = instantiateCacheLike(source) else {
+            return source.copy()
+        }
+
+        let detachedState = source.state.map(detachedCloneArray)
+        if !detachedState.isEmpty {
+            clone.state = detachedState
+        }
+        clone.metaState = source.metaState
+        return clone
+    }
+
+    private static func detachedCloneCacheList(_ source: CacheList) -> any KVCache {
+        if let subcaches = Mirror(reflecting: source).descendant("caches") as? [any KVCache] {
+            return CacheList(subcaches.map { detachedCloneCache($0) })
+        }
+        return source.copy()
+    }
+
+    private static func instantiateCacheLike(_ source: any KVCache) -> (any KVCache)? {
+        switch source {
+        case let chunked as ChunkedKVCache:
+            let chunkSize = chunked.metaState.first.flatMap { $0 == "None" ? nil : Int($0) }
+            return ChunkedKVCache(chunkSize: chunkSize)
+        case is KVCacheSimple:
+            return KVCacheSimple()
+        case let rotating as RotatingKVCache:
+            let maxSize = Int(rotating.metaState.dropFirst().first ?? "") ?? rotating.maxSize
+            guard let maxSize else { return nil }
+            return RotatingKVCache(maxSize: maxSize)
+        case let quantized as any QuantizedKVCacheProtocol:
+            return QuantizedKVCache(
+                groupSize: quantized.groupSize,
+                bits: quantized.bits,
+                mode: quantized.mode
+            )
+        default:
+            return nil
+        }
+    }
+
+    private static func detachedCloneArray(_ source: MLXArray) -> MLXArray {
+        if source.nbytes == 0 || source.size == 0 {
+            // Zero-length cache slices can be represented by null-backed MLX views.
+            // Return a shape-preserving view without touching `asData()` so MLX
+            // never dereferences a missing Metal buffer during snapshot cloning.
+            return source[.ellipsis]
+        }
+        return MLXArray(data: source.asData(access: .copy))
     }
 
     private static let maxPrefixCachesPerModel = 2

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
@@ -36,9 +36,21 @@ func effectiveCacheOffset(_ cache: [any KVCache]) -> Int {
     return cache.first?.offset ?? 0
 }
 
+/// Prefix-based cache reuse is unsafe once a rotating cache has wrapped past its
+/// window because the retained state corresponds to a suffix of the prompt, not a
+/// true prefix. In that case callers must rebuild the cache from scratch.
+func hasWrappedRotatingCache(_ cache: [any KVCache], cachedTokenCount: Int) -> Bool {
+    cache.contains { layer in
+        guard layer is RotatingKVCache, let maxSize = layer.maxSize else { return false }
+        return cachedTokenCount > maxSize
+    }
+}
+
 struct MLXGenerationEngine {
 
     private static let maxImageSize = CGSize(width: 1024, height: 1024)
+    private static let minimumSnapshotCopyBytes = Int64(512 * 1024 * 1024)
+    private static let maximumSnapshotCopyBytes = Int64(8 * 1024 * 1024 * 1024)
 
     private static func downscaleIfNeeded(_ image: CIImage) -> CIImage {
         let scale = min(MediaProcessing.bestFitScale(image.extent.size, in: maxImageSize), 1.0)
@@ -63,6 +75,34 @@ struct MLXGenerationEngine {
                 videos: message.videos
             )
         }
+    }
+
+    static func snapshotCopyByteLimit(physicalMemory: UInt64 = ProcessInfo.processInfo.physicalMemory) -> Int64 {
+        let adaptiveLimit = Int64(physicalMemory / 8)
+        return max(minimumSnapshotCopyBytes, min(adaptiveLimit, maximumSnapshotCopyBytes))
+    }
+
+    static func shouldSkipSnapshotCopy(
+        cacheBytes: Int64,
+        physicalMemory: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Bool {
+        cacheBytes > snapshotCopyByteLimit(physicalMemory: physicalMemory)
+    }
+
+    private static func snapshotCacheIfAffordable(
+        _ cache: [any KVCache],
+        tokens: [Int]
+    ) -> ([any KVCache], [Int]) {
+        let cacheBytes = Int64(KVCacheStore.cacheBytes(cache))
+        guard cacheBytes > 0 else { return ([], []) }
+        let byteLimit = snapshotCopyByteLimit()
+        guard !shouldSkipSnapshotCopy(cacheBytes: cacheBytes) else {
+            engineLog.warning(
+                "prepareAndGenerate: skipping snapshot copy cacheBytes=\(cacheBytes, privacy: .public) byteLimit=\(byteLimit, privacy: .public) tokens=\(tokens.count, privacy: .public)"
+            )
+            return ([], [])
+        }
+        return (KVCacheStore.deepCopyCache(cache), tokens)
     }
 
     /// Holds the generation stream plus the caller-owned KV cache that was
@@ -91,16 +131,12 @@ struct MLXGenerationEngine {
         promptTokens: [Int],
         genTask: Task<Void, Never>,
         toolCallFormat: ToolCallFormat,
-        /// Non-nil when a two-phase prefill was performed.  The snapshot cache
-        /// and its corresponding token array are at the *stable boundary* —
-        /// i.e. after all history tokens have been processed but BEFORE the
-        /// generation-prefix tokens (e.g. `<|im_start|>assistant\n<think>\n`).
-        /// Storing the session cache keyed by these tokens instead of
-        /// `promptTokens` means the next turn's common-prefix check will hit
-        /// exactly at `snapshotTokens.count` == `cacheOffset`, requiring zero
-        /// trim even on non-trimmable (MambaCache) models.
-        snapshotCache: [any KVCache]?,
-        snapshotTokens: [Int]?
+        /// Snapshot taken before the generation task starts mutating the live
+        /// cache. In the single-phase path this is keyed by `promptTokens`; in
+        /// the two-phase path it is keyed by the stable boundary (before any
+        /// generation-prefix tokens).
+        snapshotCache: [any KVCache],
+        snapshotTokens: [Int]
     ) {
         let spState = engineSignposter.beginInterval("prepareAndGenerate", id: engineSignposter.makeSignpostID())
         let t0 = CFAbsoluteTimeGetCurrent()
@@ -114,8 +150,8 @@ struct MLXGenerationEngine {
             let promptTokens: [Int]
             let genTask: Task<Void, Never>
             let toolCallFormat: ToolCallFormat
-            let snapshotCache: CacheBox?
-            let snapshotTokens: [Int]?
+            let snapshotCache: CacheBox
+            let snapshotTokens: [Int]
             init(
                 _ stream: AsyncStream<MLXLMCommon.TokenGeneration>,
                 _ tokenizer: any Tokenizer,
@@ -123,8 +159,8 @@ struct MLXGenerationEngine {
                 _ promptTokens: [Int],
                 _ genTask: Task<Void, Never>,
                 _ toolCallFormat: ToolCallFormat,
-                _ snapshotCache: CacheBox?,
-                _ snapshotTokens: [Int]?
+                _ snapshotCache: CacheBox,
+                _ snapshotTokens: [Int]
             ) {
                 self.stream = stream; self.tokenizer = tokenizer; self.cache = cache
                 self.promptTokens = promptTokens; self.genTask = genTask
@@ -147,6 +183,9 @@ struct MLXGenerationEngine {
                 maxKV: runtime.maxKV,
                 prefillStep: runtime.prefillStep,
                 turboQuant: runtime.turboQuant
+            )
+            engineLog.info(
+                "runtimeConfig: turboQuant=\(runtime.turboQuant, privacy: .public) kvBits=\(String(describing: runtime.kvBits), privacy: .public) kvGroup=\(runtime.kvGroup, privacy: .public) quantStart=\(runtime.quantStart, privacy: .public) maxKV=\(String(describing: runtime.maxKV), privacy: .public) prefillStep=\(runtime.prefillStep, privacy: .public)"
             )
             let additionalContext: [String: any Sendable]? =
                 generation.modelOptions["disableThinking"]?.boolValue == true
@@ -193,6 +232,12 @@ struct MLXGenerationEngine {
             if let existingCache = existingCache, let cachedTokens = cachedTokens, fullLMInput.image == nil,
                 fullLMInput.video == nil
             {
+                if hasWrappedRotatingCache(existingCache, cachedTokenCount: cachedTokens.count) {
+                    cache = makePromptCache(model: context.model, parameters: parameters)
+                    debugLog(
+                        "[MLXGenerationEngine] wrapped rotating cache detected (cachedTokens=\(cachedTokens.count)); skipping prefix reuse"
+                    )
+                } else {
                 // Find common prefix length
                 var commonPrefixLength = zip(newPromptTokens, cachedTokens).prefix(while: { $0 == $1 }).count
 
@@ -254,6 +299,7 @@ struct MLXGenerationEngine {
                         video: fullLMInput.video
                     )
                     debugLog("[MLXGenerationEngine] sliced input to \(newTokens.shape) new tokens")
+                }
                 }
             } else {
                 // Cannot reuse cache (e.g. VLM with images, or no cached tokens)
@@ -317,11 +363,9 @@ struct MLXGenerationEngine {
             }
 
             let genPrefixLen = newPromptTokens.count - stableTokenCount
-            // existingCache != nil guard: on turn 1 there is no prior cache to reuse,
-            // so deep-copying the full prefill cache would double peak RAM and OOM on large
-            // system prompts (~3700+ tokens with Qwen3.5-9B-4bit).  On turn 1 the single-phase
-            // path already stores a snapshot via snapshotCacheOverride after generation, so turn 2
-            // will find a cache hit and use two-phase correctly.
+            // Only switch to the more complex two-phase path once we have a
+            // prior session snapshot. Turn 1 still stores the standard prompt
+            // snapshot and gives turn 2 the signal needed to upgrade.
             let useTwoPhase =
                 canAttemptTwoPhase && genPrefixLen > 0 && modelCacheIsNonTrimmable
                 && existingCache != nil
@@ -361,9 +405,13 @@ struct MLXGenerationEngine {
                     try withError { eval(cache) }
                 }
 
-                // Deep-copy cache at stable boundary for snapshot storage.
-                let snapCache = KVCacheStore.deepCopyCache(cache)
-                let snapTokens = Array(newPromptTokens[0 ..< stableTokenCount])
+                // Snapshotting a very large Gemma/VLM cache can require tens of GB
+                // of extra Metal buffers. Skip persistence for oversized caches and
+                // fall back to a full prefill on the next turn instead of crashing.
+                let (snapCache, snapTokens) = snapshotCacheIfAffordable(
+                    cache,
+                    tokens: Array(newPromptTokens[0 ..< stableTokenCount])
+                )
                 debugLog(
                     "[MLXGenerationEngine] twoPhase phase1 done: stableOffset=\(effectiveCacheOffset(cache)) snapTokens=\(snapTokens.count)"
                 )
@@ -533,6 +581,10 @@ struct MLXGenerationEngine {
                 id: engineSignposter.makeSignpostID(),
                 "promptTokens: \(newPromptTokens.count, privacy: .public), effectiveTokens: \(effectiveInput.text.tokens.dim(0), privacy: .public), cacheOffset: \(postPrefillOffset, privacy: .public)"
             )
+            // Snapshot the prompt cache before generateTokenTask() launches its
+            // background Task. Calling deepCopyCache() after generateTokenTask()
+            // races TokenIterator.next() on the same MLX buffers.
+            let (snapCache, snapTokens) = snapshotCacheIfAffordable(cache, tokens: newPromptTokens)
             let (stream, genTask) = MLXLMCommon.generateTokenTask(
                 promptTokenCount: newPromptTokens.count,
                 modelConfiguration: contextWithEOS.configuration,
@@ -550,8 +602,8 @@ struct MLXGenerationEngine {
                 newPromptTokens,
                 genTask,
                 toolCallFormat,
-                nil,
-                nil
+                CacheBox(snapCache),
+                snapTokens
             )
         }
         let durationMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000
@@ -560,7 +612,7 @@ struct MLXGenerationEngine {
         )
         return (
             result.stream, result.tokenizer, result.cache.cache, result.promptTokens, result.genTask,
-            result.toolCallFormat, result.snapshotCache?.cache, result.snapshotTokens
+            result.toolCallFormat, result.snapshotCache.cache, result.snapshotTokens
         )
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
@@ -46,6 +46,40 @@ struct RuntimeConfig: Sendable {
         )
     }
 
+    func capped(to maxKVCap: Int?) -> RuntimeConfig {
+        capped(maxKVCap: maxKVCap, prefillStepCap: nil)
+    }
+
+    func capped(maxKVCap: Int?, prefillStepCap: Int?) -> RuntimeConfig {
+        let resolvedMaxKV: Int?
+        if let maxKVCap {
+            if let maxKV {
+                resolvedMaxKV = min(maxKV, maxKVCap)
+            } else {
+                resolvedMaxKV = maxKVCap
+            }
+        } else {
+            resolvedMaxKV = maxKV
+        }
+
+        let resolvedPrefillStep: Int
+        if let prefillStepCap {
+            resolvedPrefillStep = min(prefillStep, prefillStepCap)
+        } else {
+            resolvedPrefillStep = prefillStep
+        }
+
+        return RuntimeConfig(
+            topP: topP,
+            kvBits: kvBits,
+            kvGroup: kvGroup,
+            quantStart: quantStart,
+            maxKV: resolvedMaxKV,
+            prefillStep: resolvedPrefillStep,
+            turboQuant: turboQuant
+        )
+    }
+
     /// Auto-enable 8-bit KV cache quantization when the headroom after model
     /// weights is less than 16 GB. Only kicks in when the user hasn't
     /// explicitly configured genKVBits.

--- a/Packages/OsaurusCore/Tests/Model/MLXGenerationEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MLXGenerationEngineTests.swift
@@ -76,4 +76,59 @@ struct MLXGenerationEngineTests {
         let layers: [any KVCache] = [mamba, kv]
         #expect(effectiveCacheOffset(layers) == 0)
     }
+
+    @Test func hasWrappedRotatingCache_returnsTrueWhenPromptExceedsWindow() {
+        let rotating = RotatingKVCache(maxSize: 1024, keep: 4)
+        let layers: [any KVCache] = [rotating]
+
+        #expect(hasWrappedRotatingCache(layers, cachedTokenCount: 2048))
+    }
+
+    @Test func hasWrappedRotatingCache_returnsFalseWhenPromptFitsWindow() {
+        let rotating = RotatingKVCache(maxSize: 1024, keep: 4)
+        let layers: [any KVCache] = [rotating]
+
+        #expect(!hasWrappedRotatingCache(layers, cachedTokenCount: 1024))
+    }
+
+    @Test func hasWrappedRotatingCache_ignoresNonRotatingLayers() {
+        let kv = KVCacheSimple()
+        let layers: [any KVCache] = [kv]
+
+        #expect(!hasWrappedRotatingCache(layers, cachedTokenCount: 4096))
+    }
+
+    @Test func snapshotCopyByteLimit_capsAtEightGiB() {
+        let limit = MLXGenerationEngine.snapshotCopyByteLimit(
+            physicalMemory: 128 * 1024 * 1024 * 1024
+        )
+
+        #expect(limit == 8 * 1024 * 1024 * 1024)
+    }
+
+    @Test func snapshotCopyByteLimit_reservesOneEighthOfSystemMemory() {
+        let limit = MLXGenerationEngine.snapshotCopyByteLimit(
+            physicalMemory: 32 * 1024 * 1024 * 1024
+        )
+
+        #expect(limit == 4 * 1024 * 1024 * 1024)
+    }
+
+    @Test func shouldSkipSnapshotCopy_trueWhenCacheExceedsLimit() {
+        let skip = MLXGenerationEngine.shouldSkipSnapshotCopy(
+            cacheBytes: 9 * 1024 * 1024 * 1024,
+            physicalMemory: 128 * 1024 * 1024 * 1024
+        )
+
+        #expect(skip)
+    }
+
+    @Test func shouldSkipSnapshotCopy_falseWhenCacheFitsLimit() {
+        let skip = MLXGenerationEngine.shouldSkipSnapshotCopy(
+            cacheBytes: 3 * 1024 * 1024 * 1024,
+            physicalMemory: 32 * 1024 * 1024 * 1024
+        )
+
+        #expect(!skip)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelRuntimeAdaptiveKVTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelRuntimeAdaptiveKVTests.swift
@@ -1,0 +1,104 @@
+//
+//  ModelRuntimeAdaptiveKVTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ModelRuntimeAdaptiveKVTests {
+
+    @Test
+    func metalAllocationFailureBytes_parsesRequestedAndAllowedSizes() {
+        let description =
+            "MLX Error: [metal::malloc] Attempting to allocate 95901702400 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes."
+
+        let parsed = ModelRuntime.metalAllocationFailureBytes(from: description)
+
+        #expect(parsed?.requestedBytes == 95_901_702_400)
+        #expect(parsed?.allowedBytes == 86_586_540_032)
+    }
+
+    @Test
+    func adaptiveMaxKVForMetalAllocationFailure_scalesDownUsingReportedBufferLimit() {
+        let description =
+            "MLX Error: [metal::malloc] Attempting to allocate 95901702400 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes."
+
+        let reduced = ModelRuntime.adaptiveMaxKVForMetalAllocationFailure(
+            currentMaxKV: 65_536,
+            errorDescription: description
+        )
+
+        #expect(reduced == 53_248)
+    }
+
+    @Test
+    func adaptiveMaxKVForMetalAllocationFailure_halvesWhenBytesCannotBeParsed() {
+        let description = "MLX Error: [metal::malloc] maximum allowed buffer size exceeded"
+
+        let reduced = ModelRuntime.adaptiveMaxKVForMetalAllocationFailure(
+            currentMaxKV: 65_536,
+            errorDescription: description
+        )
+
+        #expect(reduced == 32_768)
+    }
+
+    @Test
+    func adaptiveMaxKVForMetalAllocationFailure_ignoresNonMetalErrors() {
+        let reduced = ModelRuntime.adaptiveMaxKVForMetalAllocationFailure(
+            currentMaxKV: 65_536,
+            errorDescription: "Tokenizer produced no tokens for the given input"
+        )
+
+        #expect(reduced == nil)
+    }
+
+    @Test
+    func adaptivePrefillStepForMetalAllocationFailure_halvesUntilFloor() {
+        let description =
+            "MLX Error: [metal::malloc] Attempting to allocate 95901702400 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes."
+
+        let reduced = ModelRuntime.adaptivePrefillStepForMetalAllocationFailure(
+            currentPrefillStep: 4096,
+            errorDescription: description
+        )
+
+        #expect(reduced == 2048)
+    }
+
+    @Test
+    func adaptivePrefillStepForMetalAllocationFailure_stopsAtFloor() {
+        let description =
+            "MLX Error: [metal::malloc] Attempting to allocate 95901702400 bytes which is greater than the maximum allowed buffer size of 86586540032 bytes."
+
+        let reduced = ModelRuntime.adaptivePrefillStepForMetalAllocationFailure(
+            currentPrefillStep: 256,
+            errorDescription: description
+        )
+
+        #expect(reduced == nil)
+    }
+
+    @Test
+    func metalAllocationRetryShouldPreferPrefillStep_whenRequestedBytesDoNotShrink() {
+        let shouldPrefer = ModelRuntime.metalAllocationRetryShouldPreferPrefillStep(
+            previousRequestedBytes: 95_881_883_904,
+            currentRequestedBytes: 95_881_883_904
+        )
+
+        #expect(shouldPrefer)
+    }
+
+    @Test
+    func metalAllocationRetryShouldPreferPrefillStep_falseWhenRequestShrinksMeaningfully() {
+        let shouldPrefer = ModelRuntime.metalAllocationRetryShouldPreferPrefillStep(
+            previousRequestedBytes: 95_881_883_904,
+            currentRequestedBytes: 82_000_000_000
+        )
+
+        #expect(!shouldPrefer)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KVCacheStoreTests.swift
@@ -529,6 +529,31 @@ struct KVCacheStoreTests {
         #expect(copy !== src)
     }
 
+    /// RotatingKVCache with an explicit zero-length state should still deep copy
+    /// without touching MLX's raw-byte bridge.
+    @Test func deepCopyCache_rotatingKVCacheWithZeroLengthState() {
+        let src = RotatingKVCache(maxSize: 4)
+        let fullKeys = MLX.zeros([1, 1, 1, 1])
+        let fullValues = MLX.zeros([1, 1, 1, 1])
+        src.state = [
+            fullKeys[.ellipsis, ..<0, 0...],
+            fullValues[.ellipsis, ..<0, 0...],
+        ]
+
+        let copies = KVCacheStore.deepCopyCache([src])
+        #expect(copies.count == 1)
+        guard let copy = copies[0] as? RotatingKVCache else {
+            Issue.record("Expected RotatingKVCache copy")
+            return
+        }
+
+        #expect(copy !== src)
+        #expect(copy.offset == 0)
+        #expect(copy.state.count == 2)
+        #expect(copy.state[0].shape == [1, 1, 0, 1])
+        #expect(copy.state[1].shape == [1, 1, 0, 1])
+    }
+
     /// MambaCache (ArraysCache subtype): deep copy produces MambaCache (not KVCacheSimple).
     @Test func deepCopyCache_mambaCache() {
         let src = MambaCache()
@@ -553,6 +578,21 @@ struct KVCacheStoreTests {
         #expect(copies.count == 2)
         #expect(copies[0] is KVCacheSimple)
         #expect(copies[1] is MambaCache)
+    }
+
+    @Test func deepCopyCache_cacheListPreservesNestedTypes() {
+        let mamba = MambaCache()
+        let rotating = RotatingKVCache(maxSize: 8)
+        let composite = CacheList(mamba, rotating)
+        let copies = KVCacheStore.deepCopyCache([composite])
+
+        guard let copiedList = copies[0] as? CacheList else {
+            Issue.record("Expected CacheList copy")
+            return
+        }
+
+        #expect(copiedList[0] is MambaCache)
+        #expect(copiedList[1] is RotatingKVCache)
     }
 
     // MARK: - saveToDisk: no crash for missing session


### PR DESCRIPTION
## Summary
- harden local MLX generation against long-context cache corruption and Metal allocation failures
- stop reusing wrapped rotating caches as if they were valid prefix caches
- make pre-generation snapshotting adaptive so oversized cache copies are skipped instead of crashing
- add focused regression tests for adaptive KV retry logic and rotating-cache guards

## What changed
- `ModelRuntime` now learns lower `maxKV` / `prefillStep` caps from Metal allocation failures and retries with tighter settings
- `MLXGenerationEngine` now:
  - logs effective KV/runtime settings
  - skips prefix reuse when a `RotatingKVCache` has already wrapped
  - snapshots caches before generation starts mutating them
  - skips snapshot copies when cache size exceeds a machine-scaled byte limit
- `KVCacheStore` now uses detached MLX array copies for transformer-style cache snapshots to avoid aliasing cached Metal buffers into live generation
- `RuntimeConfig` now supports capped runtime variants used by adaptive retries

## Why this matters
This isolates the local-runtime failure class behind recent Gemma 4 regressions:
- crashes during large prefills
- garbage output after rotating-cache wrap
- snapshot-related pressure spikes during long sessions

## Validation
Passing deterministic coverage in the compatibility-fixed local environment:
- `swift test --package-path /Users/mmeding/Documents/Claude/Projects/osaurus/.local-worktrees/workmode-all-local/Packages/OsaurusCore --filter ModelRuntimeAdaptiveKVTests`
- `swift test --package-path /Users/mmeding/Documents/Claude/Projects/osaurus/.local-worktrees/workmode-all-local/Packages/OsaurusCore --filter 'hasWrappedRotatingCache|snapshotCopyByteLimit|shouldSkipSnapshotCopy'`

Additional note:
- Clean-branch validation against `upstream/main` is currently blocked by an unrelated repo-head compile break in `Packages/OsaurusCore/Managers/SpeechService.swift` (`AsrManager.initialize(models:)` no longer exists in the current FluidAudio API).
- That compatibility fix is intentionally not folded into this PR.

## Out of scope
- prompt hygiene / stale-history filtering
- attached-document retrieval changes
- UI or settings changes
