### PR TITLE
feat: add attached-document retrieval for local chat

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AttachedDocumentStore.swift
+++ b/Packages/OsaurusCore/Services/Chat/AttachedDocumentStore.swift
@@ -503,7 +503,8 @@ actor AttachedDocumentStore {
             let excerptEnd = squashed.index(squashed.startIndex, offsetBy: end)
             let prefix = start > 0 ? "..." : ""
             let suffix = end < squashed.count ? "..." : ""
-            return prefix + squashed[excerptStart ..< excerptEnd] + suffix
+            let excerpt = String(squashed[excerptStart ..< excerptEnd])
+            return prefix + excerpt + suffix
         }
 
         return preview(for: squashed, maxCharacters: maxCharacters)

--- a/Packages/OsaurusCore/Services/Chat/AttachedDocumentStore.swift
+++ b/Packages/OsaurusCore/Services/Chat/AttachedDocumentStore.swift
@@ -1,0 +1,572 @@
+//
+//  AttachedDocumentStore.swift
+//  osaurus
+//
+//  Session-scoped registry for document attachments so local models can
+//  search and page through full document contents via tools instead of
+//  forcing the entire raw document into a single prompt prefill.
+//
+
+import Foundation
+
+struct AttachedDocumentReference: Sendable, Equatable {
+    let attachmentId: String
+    let filename: String
+    let characterCount: Int
+    let chunkCount: Int
+    let preview: String
+}
+
+struct AttachedDocumentSearchHit: Sendable, Equatable {
+    let attachmentId: String
+    let filename: String
+    let chunkIndex: Int
+    let chunkCount: Int
+    let excerpt: String
+    let score: Int
+}
+
+struct AttachedDocumentChunkRead: Sendable, Equatable {
+    let attachmentId: String
+    let filename: String
+    let chunkIndex: Int
+    let chunkCount: Int
+    let content: String
+}
+
+actor AttachedDocumentStore {
+    static let shared = AttachedDocumentStore()
+
+    private struct StoredDocument: Sendable {
+        let attachmentId: String
+        let filename: String
+        let content: String
+        let chunks: [String]
+        let looksLikeMultiProfile: Bool
+        let updatedAt: Date
+        var chunkEmbeddings: [[Float]]?
+    }
+
+    private static let previewLength = 240
+    private static let chunkSize = 2_400
+    private static let chunkOverlap = 240
+    private static let maxRegisteredDocuments = 512
+    private static let minimumSemanticScore: Float = 0.10
+    private static let ignoredQueryTokens: Set<String> = [
+        "a", "an", "and", "are", "at", "be", "by", "can", "describe", "do", "for", "from", "how", "i",
+        "in", "is", "it", "me", "my", "of", "on", "or", "see", "that", "the", "there", "this", "to",
+        "what", "where", "who", "why", "you", "your",
+    ]
+
+    private var documents: [String: StoredDocument] = [:]
+
+    func register(attachments: [Attachment]) -> [AttachedDocumentReference] {
+        var references: [AttachedDocumentReference] = []
+
+        for attachment in attachments where attachment.isDocument {
+            guard let filename = attachment.filename, let content = attachment.documentContent else { continue }
+            let attachmentId = attachment.id.uuidString
+            let chunks = Self.chunk(content)
+            let document = StoredDocument(
+                attachmentId: attachmentId,
+                filename: filename,
+                content: content,
+                chunks: chunks,
+                looksLikeMultiProfile: Self.looksLikeMultiProfileDocument(content),
+                updatedAt: Date(),
+                chunkEmbeddings: nil
+            )
+            documents[attachmentId] = document
+            references.append(
+                AttachedDocumentReference(
+                    attachmentId: attachmentId,
+                    filename: filename,
+                    characterCount: content.count,
+                    chunkCount: chunks.count,
+                    preview: Self.preview(for: content)
+                )
+            )
+        }
+
+        trimIfNeeded()
+
+        return references.sorted { lhs, rhs in
+            lhs.filename.localizedCaseInsensitiveCompare(rhs.filename) == .orderedAscending
+        }
+    }
+
+    func search(
+        attachmentIds: [String],
+        query: String,
+        maxResults: Int
+    ) async -> [AttachedDocumentSearchHit] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedAttachmentIds = Self.sanitizeAttachmentIds(attachmentIds)
+        guard !normalizedAttachmentIds.isEmpty, !trimmedQuery.isEmpty else { return [] }
+
+        let limit = max(1, min(maxResults, 8))
+        let lexicalHits = lexicalSearch(
+            attachmentIds: normalizedAttachmentIds,
+            query: trimmedQuery
+        )
+        if !lexicalHits.isEmpty {
+            return Array(lexicalHits.prefix(limit))
+        }
+
+        return await semanticSearch(
+            attachmentIds: normalizedAttachmentIds,
+            query: trimmedQuery,
+            maxResults: limit
+        )
+    }
+
+    func read(attachmentId: String, chunkIndex: Int) -> AttachedDocumentChunkRead? {
+        let normalizedAttachmentId = Self.sanitizeAttachmentIds([attachmentId]).first ?? attachmentId
+        guard let document = documents[normalizedAttachmentId] else { return nil }
+        let normalizedIndex = max(1, chunkIndex)
+        guard normalizedIndex <= document.chunks.count else { return nil }
+
+        return AttachedDocumentChunkRead(
+            attachmentId: document.attachmentId,
+            filename: document.filename,
+            chunkIndex: normalizedIndex,
+            chunkCount: document.chunks.count,
+            content: document.chunks[normalizedIndex - 1]
+        )
+    }
+
+    func buildPromptContext(
+        attachmentIds: [String],
+        query: String,
+        maxResults: Int,
+        maxTotalCharacters: Int,
+        allowFallback: Bool = false
+    ) async -> String {
+        let normalizedAttachmentIds = Self.sanitizeAttachmentIds(attachmentIds)
+        guard !normalizedAttachmentIds.isEmpty else { return "" }
+
+        let requestedHits = await search(
+            attachmentIds: normalizedAttachmentIds,
+            query: query,
+            maxResults: maxResults
+        )
+        let canUseFallback =
+            allowFallback
+            && !normalizedAttachmentIds.contains { attachmentId in
+                documents[attachmentId]?.looksLikeMultiProfile == true
+            }
+        let hits =
+            requestedHits.isEmpty && canUseFallback
+            ? fallbackPromptHits(attachmentIds: normalizedAttachmentIds, maxResults: maxResults)
+            : requestedHits
+        guard !hits.isEmpty else { return "" }
+
+        var lines = [
+            "<attached_document_context>",
+            requestedHits.isEmpty
+                ? "Representative excerpts from the attached documents are included below because no strong direct match was found for the current request."
+                : "These excerpts were selected from the attached documents for the current user request.",
+        ]
+
+        var remainingCharacters = max(1_024, maxTotalCharacters)
+        for hit in hits {
+            guard let document = documents[hit.attachmentId] else { continue }
+            let chunkOffset = hit.chunkIndex - 1
+            guard document.chunks.indices.contains(chunkOffset) else { continue }
+
+            let excerptBudget = min(1_400, max(420, remainingCharacters))
+            let excerpt = Self.preview(for: document.chunks[chunkOffset], maxCharacters: excerptBudget)
+            guard !excerpt.isEmpty else { continue }
+
+            lines.append(
+                "<attached_document_excerpt id=\"\(hit.attachmentId)\" name=\"\(hit.filename)\" chunk=\"\(hit.chunkIndex)/\(hit.chunkCount)\" score=\"\(hit.score)\">"
+            )
+            lines.append(excerpt)
+            lines.append("</attached_document_excerpt>")
+
+            remainingCharacters -= excerpt.count
+            if remainingCharacters <= 420 {
+                break
+            }
+        }
+
+        lines.append("</attached_document_context>")
+        return lines.joined(separator: "\n")
+    }
+
+    private func trimIfNeeded() {
+        guard documents.count > Self.maxRegisteredDocuments else { return }
+
+        let overflow = documents.count - Self.maxRegisteredDocuments
+        let oldestIds = documents.values
+            .sorted { $0.updatedAt < $1.updatedAt }
+            .prefix(overflow)
+            .map(\.attachmentId)
+
+        for id in oldestIds {
+            documents.removeValue(forKey: id)
+        }
+    }
+
+    private static func preview(for text: String, maxCharacters: Int = previewLength) -> String {
+        let squashed = squashWhitespace(text)
+        guard squashed.count > maxCharacters else { return squashed }
+        return String(squashed.prefix(maxCharacters)) + "..."
+    }
+
+    private static func looksLikeMultiProfileDocument(_ text: String) -> Bool {
+        let normalized = text.lowercased()
+
+        let repeatedHeadingSignals = [
+            "executive summary",
+            "relevant experience",
+            "areas of expertise",
+            "role and responsibilities",
+            "languages",
+            "education",
+        ]
+        .reduce(into: 0) { count, heading in
+            if occurrenceCount(of: heading, in: normalized) >= 3 {
+                count += 1
+            }
+        }
+
+        let structuralSignals = [
+            occurrenceCount(of: "volver", in: normalized) >= 2,
+            occurrenceCount(of: "los azules ·", in: normalized) >= 3,
+        ]
+        .filter { $0 }
+        .count
+
+        return repeatedHeadingSignals >= 2 || (repeatedHeadingSignals >= 1 && structuralSignals >= 1)
+    }
+
+    private static func occurrenceCount(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty, !haystack.isEmpty else { return 0 }
+
+        var count = 0
+        var searchRange: Range<String.Index>? = haystack.startIndex ..< haystack.endIndex
+        while let range = haystack.range(of: needle, options: [], range: searchRange) {
+            count += 1
+            searchRange = range.upperBound ..< haystack.endIndex
+        }
+        return count
+    }
+
+    private func lexicalSearch(
+        attachmentIds: [String],
+        query: String
+    ) -> [AttachedDocumentSearchHit] {
+        let normalizedQuery = query.lowercased()
+        let queryTokens = Self.meaningfulQueryTokens(from: query)
+
+        var hits: [AttachedDocumentSearchHit] = []
+        for attachmentId in attachmentIds {
+            guard let document = documents[attachmentId] else { continue }
+
+            for (chunkIndex, chunk) in document.chunks.enumerated() {
+                let score = Self.score(chunk: chunk, normalizedQuery: normalizedQuery, queryTokens: queryTokens)
+                guard score > 0 else { continue }
+
+                hits.append(
+                    AttachedDocumentSearchHit(
+                        attachmentId: document.attachmentId,
+                        filename: document.filename,
+                        chunkIndex: chunkIndex + 1,
+                        chunkCount: document.chunks.count,
+                        excerpt: Self.excerpt(
+                            from: chunk,
+                            query: normalizedQuery,
+                            queryTokens: queryTokens,
+                            maxCharacters: 420
+                        ),
+                        score: score
+                    )
+                )
+            }
+        }
+
+        return hits.sorted { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            if lhs.filename != rhs.filename {
+                return lhs.filename.localizedCaseInsensitiveCompare(rhs.filename) == .orderedAscending
+            }
+            return lhs.chunkIndex < rhs.chunkIndex
+        }
+    }
+
+    private static func score(
+        chunk: String,
+        normalizedQuery: String,
+        queryTokens: [String]
+    ) -> Int {
+        let normalizedChunk = chunk.lowercased()
+        var score = 0
+
+        if normalizedChunk.contains(normalizedQuery) {
+            score += 12
+        }
+
+        for token in queryTokens {
+            if normalizedChunk.contains(token) {
+                score += 3
+            }
+        }
+
+        return score
+    }
+
+    private static func meaningfulQueryTokens(from query: String) -> [String] {
+        Array(Set(SearchService.tokenize(query))).filter { token in
+            token.count >= 3 && !ignoredQueryTokens.contains(token)
+        }
+    }
+
+    private func semanticSearch(
+        attachmentIds: [String],
+        query: String,
+        maxResults: Int
+    ) async -> [AttachedDocumentSearchHit] {
+        guard let queryEmbedding = try? await EmbeddingService.shared.embed(texts: [query]).first else {
+            return []
+        }
+
+        let normalizedQuery = query.lowercased()
+        let queryTokens = Self.meaningfulQueryTokens(from: query)
+        var hits: [AttachedDocumentSearchHit] = []
+
+        for attachmentId in attachmentIds {
+            guard var document = documents[attachmentId] else { continue }
+            let embeddings = await ensureChunkEmbeddings(for: &document)
+            documents[attachmentId] = document
+
+            for (chunkIndex, chunk) in document.chunks.enumerated() {
+                guard embeddings.indices.contains(chunkIndex) else { continue }
+                let cosineScore = Self.cosineSimilarity(queryEmbedding, embeddings[chunkIndex])
+                guard cosineScore >= Self.minimumSemanticScore else { continue }
+
+                let lexicalScore = Self.score(
+                    chunk: chunk,
+                    normalizedQuery: normalizedQuery,
+                    queryTokens: queryTokens
+                )
+                let combinedScore = Int((cosineScore * 1_000).rounded()) + (lexicalScore * 25)
+
+                hits.append(
+                    AttachedDocumentSearchHit(
+                        attachmentId: document.attachmentId,
+                        filename: document.filename,
+                        chunkIndex: chunkIndex + 1,
+                        chunkCount: document.chunks.count,
+                        excerpt: Self.excerpt(
+                            from: chunk,
+                            query: normalizedQuery,
+                            queryTokens: queryTokens,
+                            maxCharacters: 420
+                        ),
+                        score: combinedScore
+                    )
+                )
+            }
+        }
+
+        return
+            hits
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                if lhs.filename != rhs.filename {
+                    return lhs.filename.localizedCaseInsensitiveCompare(rhs.filename) == .orderedAscending
+                }
+                return lhs.chunkIndex < rhs.chunkIndex
+            }
+            .prefix(maxResults)
+            .map { $0 }
+    }
+
+    private func ensureChunkEmbeddings(for document: inout StoredDocument) async -> [[Float]] {
+        if let cachedEmbeddings = document.chunkEmbeddings, cachedEmbeddings.count == document.chunks.count {
+            return cachedEmbeddings
+        }
+
+        guard let embeddings = try? await EmbeddingService.shared.embed(texts: document.chunks),
+            embeddings.count == document.chunks.count
+        else {
+            document.chunkEmbeddings = []
+            return []
+        }
+
+        document.chunkEmbeddings = embeddings
+        return embeddings
+    }
+
+    private func fallbackPromptHits(
+        attachmentIds: [String],
+        maxResults: Int
+    ) -> [AttachedDocumentSearchHit] {
+        var hits: [AttachedDocumentSearchHit] = []
+
+        for attachmentId in attachmentIds {
+            guard let document = documents[attachmentId], !document.chunks.isEmpty else { continue }
+
+            let firstIndex = 0
+            let middleIndex = document.chunks.count > 2 ? document.chunks.count / 2 : nil
+            let lastIndex = document.chunks.count - 1
+            let candidateIndices = [firstIndex, middleIndex, lastIndex]
+                .compactMap { $0 }
+                .reduce(into: [Int]()) { indices, index in
+                    if !indices.contains(index) {
+                        indices.append(index)
+                    }
+                }
+
+            for chunkIndex in candidateIndices {
+                let chunk = document.chunks[chunkIndex]
+                hits.append(
+                    AttachedDocumentSearchHit(
+                        attachmentId: document.attachmentId,
+                        filename: document.filename,
+                        chunkIndex: chunkIndex + 1,
+                        chunkCount: document.chunks.count,
+                        excerpt: Self.preview(for: chunk, maxCharacters: 420),
+                        score: 1
+                    )
+                )
+            }
+        }
+
+        return hits.prefix(maxResults).map { $0 }
+    }
+
+    private static func chunk(_ text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+
+        let characters = Array(text)
+        var chunks: [String] = []
+        var start = 0
+
+        while start < characters.count {
+            let hardEnd = min(characters.count, start + chunkSize)
+            var end = hardEnd
+
+            if hardEnd < characters.count,
+                let newlineIndex = characters[start ..< hardEnd].lastIndex(where: { $0 == "\n" })
+            {
+                let candidateEnd = newlineIndex + 1
+                if candidateEnd > start + (chunkSize / 2) {
+                    end = candidateEnd
+                }
+            }
+
+            let chunk = String(characters[start ..< end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !chunk.isEmpty {
+                chunks.append(chunk)
+            }
+
+            guard end < characters.count else { break }
+            start = max(end - chunkOverlap, start + 1)
+        }
+
+        return chunks.isEmpty ? [text] : chunks
+    }
+
+    private static func squashWhitespace(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .joined(separator: " ")
+    }
+
+    private static func excerpt(
+        from text: String,
+        query: String,
+        queryTokens: [String],
+        maxCharacters: Int
+    ) -> String {
+        let squashed = squashWhitespace(text)
+        guard squashed.count > maxCharacters else { return squashed }
+
+        let lowered = squashed.lowercased()
+        let candidates = [query].filter { !$0.isEmpty } + queryTokens
+
+        for candidate in candidates {
+            guard let range = lowered.range(of: candidate) else { continue }
+            let matchStart = lowered.distance(from: lowered.startIndex, to: range.lowerBound)
+            let matchEnd = lowered.distance(from: lowered.startIndex, to: range.upperBound)
+            let matchCenter = (matchStart + matchEnd) / 2
+            let halfWindow = maxCharacters / 2
+            let start = max(0, matchCenter - halfWindow)
+            let end = min(squashed.count, start + maxCharacters)
+            let excerptStart = squashed.index(squashed.startIndex, offsetBy: start)
+            let excerptEnd = squashed.index(squashed.startIndex, offsetBy: end)
+            let prefix = start > 0 ? "..." : ""
+            let suffix = end < squashed.count ? "..." : ""
+            return prefix + squashed[excerptStart ..< excerptEnd] + suffix
+        }
+
+        return preview(for: squashed, maxCharacters: maxCharacters)
+    }
+
+    private static func sanitizeAttachmentIds(_ rawIds: [String]) -> [String] {
+        var sanitized: [String] = []
+        var seen = Set<String>()
+
+        for rawId in rawIds {
+            let trimmed = rawId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            if let data = trimmed.data(using: .utf8),
+                let parsed = try? JSONSerialization.jsonObject(with: data) as? [String]
+            {
+                for nestedId in sanitizeAttachmentIds(parsed) where seen.insert(nestedId).inserted {
+                    sanitized.append(nestedId)
+                }
+                continue
+            }
+
+            let matches = trimmed.matches(
+                of: /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/
+            )
+            if !matches.isEmpty {
+                for match in matches.map(\.output) {
+                    let id = String(match)
+                    if seen.insert(id).inserted {
+                        sanitized.append(id)
+                    }
+                }
+                continue
+            }
+
+            let cleaned =
+                trimmed
+                .replacingOccurrences(of: "<|\\\"|>", with: "")
+                .trimmingCharacters(in: CharacterSet(charactersIn: "[]\"' "))
+            if !cleaned.isEmpty, seen.insert(cleaned).inserted {
+                sanitized.append(cleaned)
+            }
+        }
+
+        return sanitized
+    }
+
+    private static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Float {
+        guard lhs.count == rhs.count, !lhs.isEmpty else { return 0 }
+
+        var dot: Float = 0
+        var lhsMagnitude: Float = 0
+        var rhsMagnitude: Float = 0
+
+        for index in lhs.indices {
+            let left = lhs[index]
+            let right = rhs[index]
+            dot += left * right
+            lhsMagnitude += left * left
+            rhsMagnitude += right * right
+        }
+
+        guard lhsMagnitude > 0, rhsMagnitude > 0 else { return 0 }
+        return dot / (sqrt(lhsMagnitude) * sqrt(rhsMagnitude))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -169,6 +169,189 @@ struct ChatViewSandboxTests {
             #expect(sandboxToolTokens == ToolRegistry.shared.totalEstimatedTokens(for: sandboxTools))
         }
     }
+
+    @Test
+    func selectedModelIsLocal_treatsSlashStyleLocalPickerIdsAsLocal() {
+        let session = ChatSession()
+        let modelId = "TheCluster/Gemma-4-31B-Heretic-MLX-mxfp4"
+        session.pickerItems = [
+            ModelPickerItem(
+                id: modelId,
+                displayName: "Gemma 4 31B",
+                source: .local
+            )
+        ]
+        session.selectedModel = modelId
+
+        #expect(session.selectedModelIsLocal)
+    }
+
+    @Test
+    func buildUserMessageText_truncatesOversizedDocumentsWhenBudgetProvided() {
+        let repeated = String(repeating: "line 1234567890\n", count: 300)
+        let attachment = Attachment.document(
+            filename: "_chat.txt",
+            content: repeated,
+            fileSize: repeated.utf8.count
+        )
+
+        let built = ChatSession.buildUserMessageText(
+            content: "Analyze this closely.",
+            attachments: [attachment],
+            maxInputTokens: 200
+        )
+
+        #expect(built.contains("<attached_document name=\"_chat.txt\">"))
+        #expect(built.contains("Document truncated to fit local model context"))
+        #expect(built.contains("Analyze this closely."))
+        #expect(built.count < repeated.count)
+    }
+
+    @Test
+    func buildUserMessageText_truncatesOversizedDocumentsWhenOnlyCapProvided() {
+        let repeated = String(repeating: "transcript line 1234567890\n", count: 600)
+        let attachment = Attachment.document(
+            filename: "_chat.txt",
+            content: repeated,
+            fileSize: repeated.utf8.count
+        )
+
+        let built = ChatSession.buildUserMessageText(
+            content: "What matters here?",
+            attachments: [attachment],
+            documentTokenCap: 256
+        )
+
+        #expect(built.contains("<attached_document name=\"_chat.txt\">"))
+        #expect(built.contains("Document truncated to fit local model context"))
+        #expect(built.contains("What matters here?"))
+        #expect(built.count < repeated.count)
+    }
+
+    @Test
+    func buildUserMessageText_rendersDocumentManifestWhenReferencesProvided() {
+        let attachment = Attachment.document(
+            filename: "_chat.txt",
+            content: "alpha beta gamma",
+            fileSize: 16
+        )
+
+        let built = ChatSession.buildUserMessageText(
+            content: "Analyze the transcript.",
+            attachments: [attachment],
+            documentReferences: [
+                AttachedDocumentReference(
+                    attachmentId: attachment.id.uuidString,
+                    filename: "_chat.txt",
+                    characterCount: 16,
+                    chunkCount: 1,
+                    preview: "alpha beta gamma"
+                )
+            ]
+        )
+
+        #expect(built.contains("<attached_documents>"))
+        #expect(built.contains("search_attached_documents"))
+        #expect(built.contains("read_attached_document"))
+        #expect(built.contains(attachment.id.uuidString))
+        #expect(built.contains("Analyze the transcript."))
+        #expect(!built.contains("<attached_document name=\"_chat.txt\">\nalpha beta gamma"))
+    }
+
+    @Test
+    func buildUserMessageText_prefersPromptContextBlockOverRawDocumentInlining() {
+        let attachment = Attachment.document(
+            filename: "_chat.txt",
+            content: "alpha beta gamma delta epsilon",
+            fileSize: 32
+        )
+
+        let built = ChatSession.buildUserMessageText(
+            content: "Summarize the transcript.",
+            attachments: [attachment],
+            documentPromptBlock:
+                "<attached_document_context>\n<attached_document_excerpt id=\"1\" name=\"_chat.txt\" chunk=\"1/1\" score=\"42\">gamma delta</attached_document_excerpt>\n</attached_document_context>"
+        )
+
+        #expect(built.contains("<attached_document_context>"))
+        #expect(built.contains("gamma delta"))
+        #expect(built.contains("Summarize the transcript."))
+        #expect(!built.contains("<attached_document name=\"_chat.txt\">"))
+    }
+
+    @Test
+    func buildUserMessageText_combinesManifestAndPromptContextForLocalDocuments() {
+        let attachment = Attachment.document(
+            filename: "_chat.txt",
+            content: "alpha beta gamma delta epsilon",
+            fileSize: 32
+        )
+
+        let built = ChatSession.buildUserMessageText(
+            content: "Please analyze the full file, not just one excerpt.",
+            attachments: [attachment],
+            documentPromptBlock:
+                "<attached_document_context>\n<attached_document_excerpt id=\"doc-1\" name=\"_chat.txt\" chunk=\"2/4\" score=\"42\">gamma delta</attached_document_excerpt>\n</attached_document_context>",
+            documentReferences: [
+                AttachedDocumentReference(
+                    attachmentId: attachment.id.uuidString,
+                    filename: "_chat.txt",
+                    characterCount: 32,
+                    chunkCount: 4,
+                    preview: "alpha beta gamma"
+                )
+            ]
+        )
+
+        #expect(built.contains("<attached_documents>"))
+        #expect(built.contains("<attached_document_context>"))
+        #expect(built.contains("search_attached_documents"))
+        #expect(built.contains("read_attached_document"))
+        #expect(built.contains(attachment.id.uuidString))
+        #expect(built.contains("Please analyze the full file"))
+    }
+
+    @Test
+    func isFailedAttachedDocumentProbe_detectsStaleNoMatchToolLoops() {
+        let turn = ChatTurn(role: .assistant, content: "")
+        turn.toolCalls = [
+            ToolCall(
+                id: "call_123",
+                type: "function",
+                function: ToolCallFunction(
+                    name: "search_attached_documents",
+                    arguments: "{}"
+                )
+            )
+        ]
+        turn.toolResults = [
+            "call_123": "No matching excerpts found in the requested attached documents."
+        ]
+
+        #expect(ChatSession.isFailedAttachedDocumentProbe(turn))
+    }
+
+    @Test
+    func isStaleExcerptOnlyAttachedDocumentAnswer_detectsOldExcerptBoundResponses() {
+        let turn = ChatTurn(
+            role: .assistant,
+            content:
+                "Since I only have access to the specific excerpts provided in the prompt, my previous analysis was limited to those snippets. Based on the provided excerpts, here is a focused summary."
+        )
+
+        #expect(ChatSession.isStaleExcerptOnlyAttachedDocumentAnswer(turn))
+    }
+
+    @Test
+    func shouldInjectHistoricalDocumentContext_disablesForImageOnlyTurns() {
+        let turn = ChatTurn(
+            role: .user,
+            content: "What do you see in this photo?",
+            attachments: [.image(Data([0x89, 0x50, 0x4E, 0x47]))]
+        )
+
+        #expect(!ChatSession.shouldInjectHistoricalDocumentContext(for: turn))
+    }
 }
 
 @MainActor

--- a/Packages/OsaurusCore/Tests/Tool/AttachedDocumentToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AttachedDocumentToolsTests.swift
@@ -1,0 +1,180 @@
+//
+//  AttachedDocumentToolsTests.swift
+//  osaurus
+//
+//  Verifies that large attached documents remain searchable and readable
+//  through the incremental retrieval tools instead of being reduced to the
+//  prompt preview only.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct AttachedDocumentToolsTests {
+
+    @MainActor
+    @Test func registerIfNeeded_exposesAttachedDocumentToolSpecs() {
+        AttachedDocumentTools.registerIfNeeded()
+
+        let specs = ToolRegistry.shared.specs(forTools: AttachedDocumentTools.toolNames)
+        #expect(specs.count == AttachedDocumentTools.toolNames.count)
+        #expect(specs.contains(where: { $0.function.name == "search_attached_documents" }))
+        #expect(specs.contains(where: { $0.function.name == "read_attached_document" }))
+    }
+
+    @Test func searchAndReadExposeContentBeyondPromptPreview() async throws {
+        let repeatedPrefix = String(repeating: "intro filler ", count: 260)
+        let marker = "needle-phrase-314159"
+        let content =
+            repeatedPrefix
+            + "\nSection A\n"
+            + String(repeating: "middle filler ", count: 120)
+            + "\n\(marker) appears deep in the file.\n"
+            + String(repeating: "tail filler ", count: 160)
+        let attachment = Attachment.document(
+            filename: "deep-context.txt",
+            content: content,
+            fileSize: content.utf8.count
+        )
+
+        let references = await AttachedDocumentStore.shared.register(attachments: [attachment])
+        #expect(references.count == 1)
+        #expect(references[0].preview.contains(marker) == false)
+
+        let searchTool = SearchAttachedDocumentsTool()
+        let searchResult = try await searchTool.execute(
+            argumentsJSON:
+                "{\"attachment_ids\":[\"\(attachment.id.uuidString)\"],\"query\":\"\(marker)\",\"max_results\":2}"
+        )
+        #expect(searchResult.contains("matching attached-document excerpt"))
+        #expect(searchResult.contains(attachment.id.uuidString))
+        #expect(searchResult.contains(marker))
+
+        let hits = await AttachedDocumentStore.shared.search(
+            attachmentIds: [attachment.id.uuidString],
+            query: marker,
+            maxResults: 2
+        )
+        let hit = try #require(hits.first)
+        #expect(hit.chunkIndex > 1)
+
+        let readTool = ReadAttachedDocumentTool()
+        let readResult = try await readTool.execute(
+            argumentsJSON:
+                "{\"attachment_id\":\"\(attachment.id.uuidString)\",\"chunk_index\":\(hit.chunkIndex)}"
+        )
+        #expect(readResult.contains("chunk \(hit.chunkIndex)/\(hit.chunkCount)"))
+        #expect(readResult.contains(marker))
+        #expect(readResult.contains("appears deep in the file"))
+    }
+
+    @Test func readAttachedDocumentRejectsMissingChunk() async throws {
+        let tool = ReadAttachedDocumentTool()
+        let result = try await tool.execute(argumentsJSON: "{\"attachment_id\":\"missing\",\"chunk_index\":0}")
+        #expect(result.contains("chunk_index"))
+        #expect(result.contains("positive integer"))
+    }
+
+    @Test func searchAcceptsMangledAttachmentIdArraysFromLocalToolCalls() async throws {
+        let marker = "needled-deep-271828"
+        let content =
+            String(repeating: "preface filler ", count: 180)
+            + "\n\(marker) appears in the middle.\n"
+            + String(repeating: "tail filler ", count: 120)
+        let attachment = Attachment.document(
+            filename: "mangled-id.txt",
+            content: content,
+            fileSize: content.utf8.count
+        )
+
+        _ = await AttachedDocumentStore.shared.register(attachments: [attachment])
+
+        let tool = SearchAttachedDocumentsTool()
+        let result = try await tool.execute(
+            argumentsJSON:
+                "{\"attachment_ids\":\"[<|\\\"|>\(attachment.id.uuidString)<|\\\"|>]\",\"query\":\"\(marker)\"}"
+        )
+
+        #expect(result.contains(marker))
+        #expect(result.contains(attachment.id.uuidString))
+    }
+
+    @Test func buildPromptContext_onlyUsesRepresentativeFallbackWhenExplicitlyAllowed() async {
+        let content =
+            String(repeating: "conversation context ", count: 220)
+            + "\nCarola says buen viaje and asks how you are.\n"
+            + String(repeating: "more context ", count: 180)
+        let attachment = Attachment.document(
+            filename: "history.txt",
+            content: content,
+            fileSize: content.utf8.count
+        )
+
+        _ = await AttachedDocumentStore.shared.register(attachments: [attachment])
+
+        let withoutFallback = await AttachedDocumentStore.shared.buildPromptContext(
+            attachmentIds: [attachment.id.uuidString],
+            query: "   ",
+            maxResults: 3,
+            maxTotalCharacters: 2_400,
+            allowFallback: false
+        )
+        let withFallback = await AttachedDocumentStore.shared.buildPromptContext(
+            attachmentIds: [attachment.id.uuidString],
+            query: "   ",
+            maxResults: 3,
+            maxTotalCharacters: 2_400,
+            allowFallback: true
+        )
+
+        #expect(withoutFallback.isEmpty)
+        #expect(withFallback.contains("<attached_document_context>"))
+    }
+
+    @Test func buildPromptContext_suppressesFallbackForMultiProfileDocuments() async {
+        let content = """
+            MICHAEL MEDING
+            EXECUTIVE SUMMARY
+            AREAS OF EXPERTISE
+            RELEVANT EXPERIENCE
+            LANGUAGES
+            LOS AZULES · ROLE AND RESPONSIBILITIES
+            VOLVER
+
+            EMILIO MIRANDA
+            EXECUTIVE SUMMARY
+            AREAS OF EXPERTISE
+            RELEVANT EXPERIENCE
+            LANGUAGES
+            LOS AZULES · ROLE AND RESPONSIBILITIES
+            VOLVER
+
+            MARK NOTHAFT
+            EXECUTIVE SUMMARY
+            AREAS OF EXPERTISE
+            RELEVANT EXPERIENCE
+            LANGUAGES
+            LOS AZULES · ROLE AND RESPONSIBILITIES
+            VOLVER
+            """
+        let attachment = Attachment.document(
+            filename: "Consolidated Resumes.pdf",
+            content: content,
+            fileSize: content.utf8.count
+        )
+
+        _ = await AttachedDocumentStore.shared.register(attachments: [attachment])
+
+        let promptContext = await AttachedDocumentStore.shared.buildPromptContext(
+            attachmentIds: [attachment.id.uuidString],
+            query: "please recheck",
+            maxResults: 3,
+            maxTotalCharacters: 2_400,
+            allowFallback: true
+        )
+
+        #expect(promptContext.isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Tools/AttachedDocumentTools.swift
+++ b/Packages/OsaurusCore/Tools/AttachedDocumentTools.swift
@@ -1,0 +1,131 @@
+//
+//  AttachedDocumentTools.swift
+//  osaurus
+//
+//  Tools that expose full attached-document contents incrementally to local
+//  models, avoiding giant inline prompts while preserving attachment access.
+//
+
+import Foundation
+
+enum AttachedDocumentTools {
+    static let toolNames = ["search_attached_documents", "read_attached_document"]
+
+    @MainActor
+    static func registerIfNeeded() {
+        ToolRegistry.shared.register(SearchAttachedDocumentsTool())
+        ToolRegistry.shared.register(ReadAttachedDocumentTool())
+    }
+}
+
+final class SearchAttachedDocumentsTool: OsaurusTool, @unchecked Sendable {
+    let name = "search_attached_documents"
+    let description =
+        "Search attached document contents by keyword or phrase. Use this to locate relevant excerpts in user-attached documents before answering."
+
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "attachment_ids": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Attachment IDs to search. Use the IDs shown in the attached document manifest."
+                ),
+                "items": .object([
+                    "type": .string("string")
+                ]),
+            ]),
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("Keyword, phrase, or concept to find in the attached documents."),
+            ]),
+            "max_results": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum number of matching excerpts to return (1-8). Default: 3."),
+            ]),
+        ]),
+        "required": .array([.string("attachment_ids"), .string("query")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let args = parseArguments(argumentsJSON)
+        let attachmentIds = coerceStringArray(args?["attachment_ids"]) ?? []
+        let query = (args?["query"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let maxResults = coerceInt(args?["max_results"]) ?? 3
+
+        guard !attachmentIds.isEmpty else {
+            return "Error: 'attachment_ids' is required."
+        }
+        guard !query.isEmpty else {
+            return "Error: 'query' is required."
+        }
+
+        let hits = await AttachedDocumentStore.shared.search(
+            attachmentIds: attachmentIds,
+            query: query,
+            maxResults: maxResults
+        )
+
+        guard !hits.isEmpty else {
+            return "No matching excerpts found in the requested attached documents."
+        }
+
+        var lines: [String] = ["Found \(hits.count) matching attached-document excerpt(s):"]
+        for hit in hits {
+            lines.append("")
+            lines.append(
+                "- attachment_id: \(hit.attachmentId) | name: \(hit.filename) | chunk: \(hit.chunkIndex)/\(hit.chunkCount) | score: \(hit.score)"
+            )
+            lines.append(hit.excerpt)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+final class ReadAttachedDocumentTool: OsaurusTool, @unchecked Sendable {
+    let name = "read_attached_document"
+    let description =
+        "Read a specific chunk from an attached document. Use after search_attached_documents or when you need to inspect a document sequentially."
+
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "attachment_id": .object([
+                "type": .string("string"),
+                "description": .string("Attachment ID to read from."),
+            ]),
+            "chunk_index": .object([
+                "type": .string("integer"),
+                "description": .string("1-based chunk index to read."),
+            ]),
+        ]),
+        "required": .array([.string("attachment_id"), .string("chunk_index")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let args = parseArguments(argumentsJSON)
+        let attachmentId = (args?["attachment_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let chunkIndex = coerceInt(args?["chunk_index"]) ?? 0
+
+        guard !attachmentId.isEmpty else {
+            return "Error: 'attachment_id' is required."
+        }
+        guard chunkIndex > 0 else {
+            return "Error: 'chunk_index' must be a positive integer."
+        }
+
+        guard let chunk = await AttachedDocumentStore.shared.read(attachmentId: attachmentId, chunkIndex: chunkIndex)
+        else {
+            return "Error: attached document or chunk not found."
+        }
+
+        return """
+            Attached document chunk \(chunk.chunkIndex)/\(chunk.chunkCount)
+            attachment_id: \(chunk.attachmentId)
+            name: \(chunk.filename)
+
+            \(chunk.content)
+            """
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -214,6 +214,21 @@ final class ChatSession: ObservableObject {
         return pickerItems.first { $0.id == model }
     }
 
+    var selectedModelIsLocal: Bool {
+        guard let model = selectedModel else { return true }
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if trimmed.isEmpty || trimmed == "default" || trimmed == "foundation" {
+            return true
+        }
+        if let selectedPickerItem {
+            if case .remote = selectedPickerItem.source {
+                return false
+            }
+            return true
+        }
+        return ModelInfo.load(modelId: model) != nil
+    }
+
     /// Flattened content blocks for NSTableView rendering.
     /// Stored and updated explicitly (not recomputed on every body pass).
     /// Call `rebuildVisibleBlocks()` after any turn mutation to refresh.
@@ -329,22 +344,203 @@ final class ChatSession: ObservableObject {
     }
 
     /// Builds the full user message text, prepending any attached document contents wrapped in XML tags.
-    static func buildUserMessageText(content: String, attachments: [Attachment]) -> String {
+    /// When a token budget is supplied, attached documents are truncated conservatively because
+    /// structured logs and XML wrappers tokenize denser than plain prose on local models.
+    static func buildUserMessageText(
+        content: String,
+        attachments: [Attachment],
+        maxInputTokens: Int? = nil,
+        documentTokenCap: Int? = nil,
+        documentPromptBlock: String? = nil,
+        documentReferences: [AttachedDocumentReference] = [],
+        includeDocumentPreviews: Bool = true
+    ) -> String {
         let docs = attachments.filter(\.isDocument)
-        guard !docs.isEmpty else { return content }
+        guard !docs.isEmpty else {
+            guard let maxInputTokens, maxInputTokens > 0 else { return content }
+            return trimFreeformText(content, maxCharacters: max(256, maxInputTokens * 2))
+        }
+
+        if !documentReferences.isEmpty {
+            var parts: [String] = []
+            parts.append(
+                buildAttachedDocumentReferenceBlock(
+                    references: documentReferences,
+                    includePreviews: includeDocumentPreviews
+                )
+            )
+            if let documentPromptBlock, !documentPromptBlock.isEmpty {
+                parts.append(documentPromptBlock)
+            }
+            if !content.isEmpty {
+                parts.append(content)
+            }
+            return parts.joined(separator: "\n\n")
+        }
+
+        if let documentPromptBlock, !documentPromptBlock.isEmpty {
+            var parts = [documentPromptBlock]
+            if !content.isEmpty {
+                parts.append(content)
+            }
+            return parts.joined(separator: "\n\n")
+        }
+
+        let effectiveDocumentTokenBudget: Int? = {
+            switch (maxInputTokens, documentTokenCap) {
+            case let (input?, cap?):
+                return min(input, cap)
+            case let (input?, nil):
+                return input
+            case let (nil, cap?):
+                return cap
+            default:
+                return nil
+            }
+        }()
+
+        guard let effectiveDocumentTokenBudget, effectiveDocumentTokenBudget > 0 else {
+            var parts: [String] = []
+            for doc in docs {
+                if let name = doc.filename, let text = doc.documentContent {
+                    parts.append("<attached_document name=\"\(name)\">\n\(text)\n</attached_document>")
+                }
+            }
+
+            if !content.isEmpty {
+                parts.append(content)
+            }
+
+            return parts.joined(separator: "\n\n")
+        }
 
         var parts: [String] = []
-        for doc in docs {
+        let maxCharacters = max(512, effectiveDocumentTokenBudget * 2)
+        let reservedContentChars = content.isEmpty ? 0 : min(content.count, max(256, maxCharacters / 6))
+        var remainingDocumentChars = max(256, maxCharacters - reservedContentChars)
+
+        for (index, doc) in docs.enumerated() {
             if let name = doc.filename, let text = doc.documentContent {
-                parts.append("<attached_document name=\"\(name)\">\n\(text)\n</attached_document>")
+                let docsRemaining = max(1, docs.count - index)
+                let perDocumentBudget = max(512, remainingDocumentChars / docsRemaining)
+                parts.append(
+                    buildDocumentBlock(
+                        filename: name,
+                        content: text,
+                        maxCharacters: perDocumentBudget
+                    )
+                )
+                remainingDocumentChars = max(0, remainingDocumentChars - perDocumentBudget)
             }
         }
 
         if !content.isEmpty {
-            parts.append(content)
+            let usedCharacters = parts.joined(separator: "\n\n").count
+            let remainingContentChars = max(256, maxCharacters - usedCharacters)
+            parts.append(trimFreeformText(content, maxCharacters: remainingContentChars))
         }
 
         return parts.joined(separator: "\n\n")
+    }
+
+    private static func buildDocumentBlock(
+        filename: String,
+        content: String,
+        maxCharacters: Int
+    ) -> String {
+        let full = "<attached_document name=\"\(filename)\">\n\(content)\n</attached_document>"
+        guard content.count > maxCharacters else { return full }
+
+        let note =
+            "[Document truncated to fit local model context. Showing the beginning and end of \(content.count) characters.]"
+        let wrapperOverhead = filename.count + note.count + 64
+        let excerptBudget = max(256, maxCharacters - wrapperOverhead)
+        let headBudget = max(160, Int(Double(excerptBudget) * 0.7))
+        let tailBudget = max(96, excerptBudget - headBudget)
+        let excerpt = String(content.prefix(headBudget)) + "\n...\n" + String(content.suffix(tailBudget))
+        return "<attached_document name=\"\(filename)\">\n\(note)\n\(excerpt)\n</attached_document>"
+    }
+
+    private static func trimFreeformText(_ text: String, maxCharacters: Int) -> String {
+        guard !text.isEmpty, text.count > maxCharacters else { return text }
+
+        let note = "[Text truncated to fit local model context.]"
+        let excerptBudget = max(128, maxCharacters - note.count - 6)
+        let headBudget = max(96, Int(Double(excerptBudget) * 0.75))
+        let tailBudget = max(32, excerptBudget - headBudget)
+        return String(text.prefix(headBudget)) + "\n\(note)\n" + String(text.suffix(tailBudget))
+    }
+
+    private static func buildAttachedDocumentReferenceBlock(
+        references: [AttachedDocumentReference],
+        includePreviews: Bool
+    ) -> String {
+        var lines = [
+            "<attached_documents>",
+            "The full contents of these attached documents are available through tools.",
+            "Use `search_attached_documents` to find relevant excerpts and `read_attached_document` to inspect specific chunks.",
+            "For documents containing multiple people or sections, do not infer a person's profile from previews or one excerpt alone. Search by the exact name or role and read the matching chunk before answering.",
+        ]
+
+        for reference in references {
+            if includePreviews {
+                lines.append(
+                    "<attached_document id=\"\(reference.attachmentId)\" name=\"\(reference.filename)\" characters=\"\(reference.characterCount)\" chunks=\"\(reference.chunkCount)\">"
+                )
+                lines.append(reference.preview)
+                lines.append("</attached_document>")
+            } else {
+                lines.append(
+                    "<attached_document_ref id=\"\(reference.attachmentId)\" name=\"\(reference.filename)\" characters=\"\(reference.characterCount)\" chunks=\"\(reference.chunkCount)\" />"
+                )
+            }
+        }
+
+        lines.append("</attached_documents>")
+        return lines.joined(separator: "\n")
+    }
+
+    private static let localCurrentDocumentTokenCap = 2_048
+    private static let localHistoricalDocumentTokenCap = 768
+
+    private static func localDocumentTokenCap(
+        attachments: [Attachment],
+        isCurrentTurn: Bool
+    ) -> Int? {
+        guard attachments.hasDocuments else { return nil }
+        return isCurrentTurn ? localCurrentDocumentTokenCap : localHistoricalDocumentTokenCap
+    }
+
+    static func shouldInjectHistoricalDocumentContext(for currentTurn: ChatTurn?) -> Bool {
+        guard let currentTurn else { return true }
+        return !(currentTurn.attachments.hasImages && !currentTurn.attachments.hasDocuments)
+    }
+
+    static func isFailedAttachedDocumentProbe(_ turn: ChatTurn) -> Bool {
+        guard turn.role == .assistant, turn.contentIsEmpty, let toolCalls = turn.toolCalls, !toolCalls.isEmpty else {
+            return false
+        }
+
+        let attachedDocumentToolNames = Set(AttachedDocumentTools.toolNames)
+        let toolNames = Set(toolCalls.map(\.function.name))
+        guard toolNames.isSubset(of: attachedDocumentToolNames) else { return false }
+
+        let results = Array(turn.toolResults.values)
+        guard !results.isEmpty else { return false }
+        return results.allSatisfy { result in
+            result.contains("No matching excerpts found")
+                || result.contains("attached document or chunk not found")
+                || result.contains("attachment_ids")
+                || result.contains("attachment_id")
+        }
+    }
+
+    static func isStaleExcerptOnlyAttachedDocumentAnswer(_ turn: ChatTurn) -> Bool {
+        guard turn.role == .assistant, !turn.contentIsEmpty else { return false }
+
+        let normalized = turn.content.lowercased()
+        return normalized.contains("i only have access to the specific excerpts provided in the prompt")
+            || normalized.contains("based on the provided excerpts")
     }
 
     /// Format token count for display (e.g., "1.2K", "15K")
@@ -793,6 +989,7 @@ final class ChatSession: ObservableObject {
 
         let memoryAgentId = (agentId ?? Agent.defaultId).uuidString
         let memoryConversationId = (sessionId ?? UUID()).uuidString
+        let currentUserTurnId = hasContent ? turns.last(where: { $0.role == .user })?.id : nil
         if hasContent {
             ActivityTracker.shared.recordActivity(agentId: memoryAgentId)
         }
@@ -868,9 +1065,60 @@ final class ChatSession: ObservableObject {
                     assistantTurn.preflightCapabilities = context.preflightItems
                 }
 
+                var documentReferencesByTurnId: [UUID: [AttachedDocumentReference]] = [:]
+                var documentPromptBlocksByTurnId: [UUID: String] = [:]
+                if selectedModelIsLocal {
+                    let currentTurn = turns.first { $0.id == currentUserTurnId }
+                    let injectHistoricalDocumentContext = Self.shouldInjectHistoricalDocumentContext(
+                        for: currentTurn
+                    )
+
+                    for turn in turns where turn.attachments.hasDocuments {
+                        let isCurrentTurn = turn.id == currentUserTurnId
+                        if !isCurrentTurn && !injectHistoricalDocumentContext {
+                            continue
+                        }
+
+                        let references = await AttachedDocumentStore.shared.register(
+                            attachments: turn.attachments.documents
+                        )
+                        documentReferencesByTurnId[turn.id] = references
+
+                        let promptContext = await AttachedDocumentStore.shared.buildPromptContext(
+                            attachmentIds: references.map(\.attachmentId),
+                            query: trimmed,
+                            maxResults: isCurrentTurn ? 6 : 3,
+                            maxTotalCharacters: isCurrentTurn ? 8_000 : 2_400,
+                            allowFallback: isCurrentTurn && !turn.attachments.hasImages
+                        )
+                        if !promptContext.isEmpty {
+                            documentPromptBlocksByTurnId[turn.id] = promptContext
+                        }
+                    }
+                }
+
+                if selectedModelIsLocal, !documentReferencesByTurnId.isEmpty {
+                    AttachedDocumentTools.registerIfNeeded()
+                    for tool in ToolRegistry.shared.specs(forTools: AttachedDocumentTools.toolNames)
+                    where !toolSpecs.contains(where: { $0.function.name == tool.function.name }) {
+                        toolSpecs.append(tool)
+                    }
+
+                    let attachedDocumentRefs = documentReferencesByTurnId.values.flatMap { $0 }
+                    let totalCharacters = attachedDocumentRefs.reduce(0) { $0 + $1.characterCount }
+                    debugLog(
+                        "[AttachedDocuments] manifest+tools enabled turns=\(documentReferencesByTurnId.count) excerptBlocks=\(documentPromptBlocksByTurnId.count) docs=\(attachedDocumentRefs.count) chars=\(totalCharacters) tools=\(AttachedDocumentTools.toolNames.joined(separator: ","))"
+                    )
+                }
+
                 budgetTracker.snapshot(context: context)
 
                 let effectiveMaxTokensForAgent = AgentManager.shared.effectiveMaxTokens(for: effectiveAgentId)
+                let suppressedAttachedDocumentToolCallIds = Set(
+                    turns.flatMap { turn in
+                        Self.isFailedAttachedDocumentProbe(turn) ? (turn.toolCalls?.map(\.id) ?? []) : []
+                    }
+                )
 
                 /// Convert a single turn to a ChatMessage (returns nil if should be skipped)
                 @MainActor
@@ -886,6 +1134,10 @@ final class ChatSession: ObservableObject {
                             return nil
                         }
 
+                        if Self.isFailedAttachedDocumentProbe(t) || Self.isStaleExcerptOnlyAttachedDocumentAnswer(t) {
+                            return nil
+                        }
+
                         let content: String? = t.contentIsEmpty ? nil : t.content
 
                         return ChatMessage(
@@ -895,6 +1147,11 @@ final class ChatSession: ObservableObject {
                             tool_call_id: nil
                         )
                     case .tool:
+                        if let toolCallId = t.toolCallId,
+                            suppressedAttachedDocumentToolCallIds.contains(toolCallId)
+                        {
+                            return nil
+                        }
                         return ChatMessage(
                             role: "tool",
                             content: t.content,
@@ -902,7 +1159,20 @@ final class ChatSession: ObservableObject {
                             tool_call_id: t.toolCallId
                         )
                     case .user:
-                        let messageText = Self.buildUserMessageText(content: t.content, attachments: t.attachments)
+                        let isCurrentUserTurn = t.id == currentUserTurnId
+                        let messageText = Self.buildUserMessageText(
+                            content: t.content,
+                            attachments: t.attachments,
+                            documentTokenCap:
+                                selectedModelIsLocal && documentPromptBlocksByTurnId[t.id] == nil
+                                ? Self.localDocumentTokenCap(
+                                    attachments: t.attachments,
+                                    isCurrentTurn: isCurrentUserTurn
+                                ) : nil,
+                            documentPromptBlock: selectedModelIsLocal ? documentPromptBlocksByTurnId[t.id] : nil,
+                            documentReferences: selectedModelIsLocal ? (documentReferencesByTurnId[t.id] ?? []) : [],
+                            includeDocumentPreviews: isCurrentUserTurn
+                        )
                         let imageData = selectedModelSupportsImages ? t.attachments.images : []
                         if !imageData.isEmpty {
                             return ChatMessage(role: "user", text: messageText, imageData: imageData)


### PR DESCRIPTION
## Summary
- register attached documents in a session-scoped store instead of forcing full-file inline prompts
- expose `search_attached_documents` and `read_attached_document` so local models can retrieve content incrementally
- add safeguards for multi-profile documents and stale excerpt-only history

## Why This Matters
### Business reason
Large local documents are a common real-world workflow. This change makes document-heavy chats materially more useful by letting the model work through attached files without blowing up the prompt budget or falling back to shallow excerpt-only answers.

### Programming reason
The implementation moves document access off the prompt body and into explicit tools. That keeps the prompt smaller, makes retrieval behavior testable, and limits access to registered attachment IDs instead of ad hoc file reads.

## Scope
Included:
- session-scoped attached-document registry
- chunked search and read tools for attached documents
- prompt-context integration for local attached documents
- tests for chunk retrieval, prompt construction, and stale-answer handling

Deliberately excluded:
- arbitrary filesystem browsing
- new dependency or lockfile changes
- unrelated speech or model-runtime fixes

## Validation
Validated on rewritten branch head `87b47f89`.

Results:
- branch-local formatting passed
- 22 focused tests passed across `AttachedDocumentToolsTests` and `ChatViewSandboxTests`
- workspace build succeeded
- launch smoke check passed
- worktree remained clean after validation

Exact commands and evidence are in the validation comments on the PR.
