### PR TITLE
docs: add native plugin file import contract

### DIFF
--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -253,7 +253,7 @@ The manifest JSON returned by `get_manifest` describes the plugin's capabilities
 }
 ```
 
-All v2 capabilities (`routes`, `config`, `web`, `artifact_handler`, `docs`) are optional. A v2 plugin can declare any combination of them.
+All v2 capabilities (`routes`, `config`, `web`, `artifact_handler`, `file_importers`, `docs`) are optional. A v2 plugin can declare any combination of them.
 
 **Top-level fields:**
 
@@ -263,7 +263,7 @@ All v2 capabilities (`routes`, `config`, `web`, `artifact_handler`, `docs`) are 
 | `version`      | string | No       | Semver version string                          |
 | `description`  | string | No       | Short description of the plugin                |
 | `instructions` | string | No       | Default system prompt instructions appended during plugin-initiated inference; users can override per-agent in agent settings |
-| `capabilities` | object | Yes      | Tools, routes, config, web, artifact_handler   |
+| `capabilities` | object | Yes      | Tools, routes, config, web, artifact_handler, file_importers |
 | `secrets`      | array  | No       | API key / credential declarations              |
 | `docs`         | object | No       | README, changelog, external links              |
 
@@ -306,6 +306,7 @@ New in v2:
 - **`on_task_event`**: Set this on `osr_plugin_api` to receive lifecycle events for dispatched tasks. Set to `NULL` to opt out.
 - **Host API callbacks**: The `osr_host_api` now provides 20 callbacks across 9 capability groups — config, data store, logging, agent dispatch (core + extended), inference, models, HTTP client, and file I/O. All are available from the moment `osaurus_plugin_entry_v2` returns.
 - **Artifact handling**: Plugins can declare `"artifact_handler": true` in their manifest capabilities to intercept shared artifacts. See [Artifact Handling](#artifact-handling).
+- **File importers**: Plugins can declare `"file_importers"` in the manifest to normalize host-selected files into existing document attachments. See [File Import Plugin Contract](development/file-import-plugin-contract.md).
 
 ---
 

--- a/docs/development/file-import-plugin-contract.md
+++ b/docs/development/file-import-plugin-contract.md
@@ -1,0 +1,95 @@
+# File Import Plugin Contract
+
+This document defines the native plugin manifest and tool contract for
+plugin-backed file importers.
+
+## Manifest
+
+Native plugins can declare importer descriptors in `capabilities.file_importers`:
+
+```json
+{
+  "plugin_id": "com.example.office",
+  "capabilities": {
+    "tools": [
+      {
+        "id": "import_xlsx",
+        "description": "Normalize spreadsheet content to text",
+        "parameters": {
+          "type": "object"
+        }
+      }
+    ],
+    "file_importers": [
+      {
+        "id": "xlsx",
+        "tool_id": "import_xlsx",
+        "extensions": ["xlsx", "xls"],
+        "ut_types": ["org.openxmlformats.spreadsheetml.sheet"],
+        "mime_types": ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+        "max_bytes": 10485760,
+        "output_mode": "normalized_text",
+        "output_schema_version": 1
+      }
+    ]
+  }
+}
+```
+
+## Tool Request
+
+Osaurus invokes the referenced `tool_id` with a JSON payload:
+
+```json
+{
+  "path": "/absolute/path/to/file.xlsx",
+  "filename": "file.xlsx",
+  "file_extension": "xlsx",
+  "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "max_bytes": 10485760,
+  "max_chars": 500000,
+  "output_mode": "normalized_text",
+  "output_schema_version": 1
+}
+```
+
+Rules:
+
+- `path` is always a host-local absolute file path.
+- Importers must fail closed on unreadable, malformed, or oversized inputs.
+- Importers should not shell out unless that behavior is explicitly part of the plugin design and security review.
+
+## Tool Response
+
+Preferred response shape:
+
+```json
+{
+  "attachments": [
+    {
+      "filename": "file.xlsx",
+      "content": "Normalized text summary here",
+      "file_size": 12345
+    }
+  ]
+}
+```
+
+Also accepted:
+
+- `{"documents":[...]}`
+- `{"content":"Normalized text summary","filename":"file.xlsx","file_size":12345}`
+- Raw plain text, which Osaurus wraps into a `.document` attachment
+
+All responses are normalized into the existing chat document attachment path and continue to render as:
+
+```xml
+<attached_document name="...">...</attached_document>
+```
+
+## Current Host Limits
+
+- Built-in document text is truncated to `500000` characters.
+- Built-in PDF image fallback is capped at `20` rendered pages.
+- Most built-in host importers are capped at `25 MB`.
+- Built-in PDF import is capped at `50 MB`.


### PR DESCRIPTION
## Summary

This PR adds a documented contract for native plugin-backed file importers and links it from the main plugin authoring guide.

Changes:
- add `docs/development/file-import-plugin-contract.md`
- update `docs/PLUGIN_AUTHORING.md` to mention `capabilities.file_importers`
- link plugin authors to the new request/response contract

## Why This Helps

### Business value

Osaurus is already positioned as a plugin-extensible desktop AI product. File understanding is one of the highest-leverage extension surfaces because it directly affects whether Osaurus can participate in real business workflows across office, technical, scientific, and industry-specific documents.

Right now, plugin authors can build tools, routes, config, and artifact handlers, but there is no documented contract for plugin-owned file readers. That creates friction in three places:
- plugin authors have to guess how file import should work
- maintainers have to review ad hoc proposals instead of a stable interface
- roadmap discussions around office/mining/scientific coverage stay strategic rather than implementation-ready

A documented contract lowers time-to-market for ecosystem coverage. It lets Osaurus expand into new verticals through plugins instead of forcing every format into `OsaurusCore`, which is the more scalable business model:
- faster partner and community contributions
- clearer separation between core product stability and domain-specific experimentation
- better path to broad format coverage without turning core into a dependency-heavy monolith

### Programming value

From an engineering point of view, this PR reduces ambiguity before implementation work lands.

It defines:
- the manifest capability name: `capabilities.file_importers`
- the host-to-plugin request payload
- accepted plugin response shapes
- normalization rules into the existing document attachment path
- baseline host limits and fail-closed expectations

That matters because later PRs can now be reviewed against a concrete interface instead of against implied behavior. It improves:
- API stability: plugin packs can target one documented contract
- review quality: maintainers can reject deviations from the contract early
- implementation safety: oversized, malformed, and shell-backed importers are called out explicitly
- phase isolation: docs and contract review can happen before host/runtime and plugin-pack PRs

This is intentionally small and docs-only, but it unlocks cleaner follow-on PRs for:
- host import foundation
- office import/export plugins
- data/database readers
- technical/mining/scientific format packs

## Scope

This PR is documentation only. It does not change runtime behavior.

## Validation

- reviewed relative links and manifest examples locally
- no code or package changes
