### PR TITLE
feat: add registry-backed file import foundation

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -110,6 +110,7 @@ final class PluginManager {
         if forceReload {
             for loaded in plugins {
                 ToolRegistry.shared.unregister(names: loaded.tools.map { $0.name })
+                FileImportService.unregisterPluginImporters(pluginId: loaded.plugin.id)
                 if !loaded.skills.isEmpty {
                     await SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
                 }
@@ -148,6 +149,7 @@ final class PluginManager {
                 remaining.append(loaded)
             } else {
                 ToolRegistry.shared.unregister(names: loaded.tools.map { $0.name })
+                FileImportService.unregisterPluginImporters(pluginId: loaded.plugin.id)
                 if !loaded.skills.isEmpty {
                     await SkillManager.shared.unregisterPluginSkills(pluginId: loaded.plugin.id)
                 }
@@ -175,6 +177,8 @@ final class PluginManager {
                 for tool in loaded.tools {
                     ToolRegistry.shared.registerPluginTool(tool)
                 }
+
+                FileImportService.registerPluginImporters(from: loaded.plugin)
 
                 // Register plugin skills
                 for skill in loaded.skills {

--- a/Packages/OsaurusCore/Models/FileImport/FileImportDescriptor.swift
+++ b/Packages/OsaurusCore/Models/FileImport/FileImportDescriptor.swift
@@ -1,0 +1,99 @@
+//
+//  FileImportDescriptor.swift
+//  osaurus
+//
+//  Describes a file importer and the file formats it can normalize into
+//  chat-ready attachments.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+public enum FileImportSource: String, Codable, Sendable, CaseIterable {
+    case core
+    case nativePlugin = "native_plugin"
+    case sandboxPlugin = "sandbox_plugin"
+}
+
+public enum FileImportOutputMode: String, Codable, Sendable, CaseIterable {
+    case normalizedText = "normalized_text"
+    case artifactSummary = "artifact_summary"
+}
+
+public struct FileImportDescriptor: Codable, Sendable, Equatable {
+    public let id: String
+    public let extensions: [String]
+    public let utTypes: [String]
+    public let mimeTypes: [String]
+    public let maxBytes: Int
+    public let source: FileImportSource
+    public let outputMode: FileImportOutputMode
+    public let toolId: String?
+    public let outputSchemaVersion: Int
+
+    public init(
+        id: String,
+        extensions: [String],
+        utTypes: [String] = [],
+        mimeTypes: [String] = [],
+        maxBytes: Int,
+        source: FileImportSource,
+        outputMode: FileImportOutputMode,
+        toolId: String? = nil,
+        outputSchemaVersion: Int = 1
+    ) {
+        self.id = id
+        self.extensions = extensions.map { $0.lowercased() }
+        self.utTypes = utTypes
+        self.mimeTypes = mimeTypes
+        self.maxBytes = maxBytes
+        self.source = source
+        self.outputMode = outputMode
+        self.toolId = toolId
+        self.outputSchemaVersion = outputSchemaVersion
+    }
+
+    public func matches(url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        if !ext.isEmpty, normalizedExtensions.contains(ext) {
+            return true
+        }
+
+        guard !supportedUTTypes.isEmpty else { return false }
+
+        if let contentType = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType,
+            supportedUTTypes.contains(where: { contentType == $0 || contentType.conforms(to: $0) })
+        {
+            return true
+        }
+
+        if let inferredType = UTType(filenameExtension: ext),
+            supportedUTTypes.contains(where: { inferredType == $0 || inferredType.conforms(to: $0) })
+        {
+            return true
+        }
+
+        return false
+    }
+
+    public var supportedUTTypes: [UTType] {
+        var results: [UTType] = []
+        var seen = Set<String>()
+
+        for identifier in utTypes {
+            guard let type = UTType(identifier), seen.insert(type.identifier).inserted else { continue }
+            results.append(type)
+        }
+
+        for ext in extensions {
+            guard let type = UTType(filenameExtension: ext), seen.insert(type.identifier).inserted else { continue }
+            results.append(type)
+        }
+
+        return results
+    }
+
+    private var normalizedExtensions: Set<String> {
+        Set(extensions.map { $0.lowercased() })
+    }
+}

--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -179,6 +179,23 @@ public struct PluginManifest: Decodable, Sendable {
         public let config: ConfigSpec?
         public let web: WebSpec?
         public let artifact_handler: Bool?
+        public let file_importers: [FileImporterSpec]?
+
+        public init(
+            tools: [ToolSpec]? = nil,
+            routes: [RouteSpec]? = nil,
+            config: ConfigSpec? = nil,
+            web: WebSpec? = nil,
+            artifact_handler: Bool? = nil,
+            file_importers: [FileImporterSpec]? = nil
+        ) {
+            self.tools = tools
+            self.routes = routes
+            self.config = config
+            self.web = web
+            self.artifact_handler = artifact_handler
+            self.file_importers = file_importers
+        }
     }
 
     public struct ToolSpec: Decodable, Sendable {
@@ -187,6 +204,37 @@ public struct PluginManifest: Decodable, Sendable {
         public let parameters: JSONValue?
         public let requirements: [String]?
         public let permission_policy: String?
+    }
+
+    public struct FileImporterSpec: Decodable, Sendable {
+        public let id: String
+        public let tool_id: String
+        public let extensions: [String]
+        public let ut_types: [String]
+        public let mime_types: [String]
+        public let max_bytes: Int
+        public let output_mode: FileImportOutputMode
+        public let output_schema_version: Int
+
+        public init(
+            id: String,
+            tool_id: String,
+            extensions: [String],
+            ut_types: [String] = [],
+            mime_types: [String] = [],
+            max_bytes: Int,
+            output_mode: FileImportOutputMode = .normalizedText,
+            output_schema_version: Int = 1
+        ) {
+            self.id = id
+            self.tool_id = tool_id
+            self.extensions = extensions
+            self.ut_types = ut_types
+            self.mime_types = mime_types
+            self.max_bytes = max_bytes
+            self.output_mode = output_mode
+            self.output_schema_version = output_schema_version
+        }
     }
 
     /// Specification for a secret that a plugin requires (e.g., API key)

--- a/Packages/OsaurusCore/Services/FileImport/FileImportRegistry.swift
+++ b/Packages/OsaurusCore/Services/FileImport/FileImportRegistry.swift
@@ -1,0 +1,128 @@
+//
+//  FileImportRegistry.swift
+//  osaurus
+//
+//  Central registry for built-in and plugin-provided file importers.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+protocol FileImporter: Sendable {
+    var descriptor: FileImportDescriptor { get }
+    func importFile(at url: URL) async throws -> [Attachment]
+}
+
+final class FileImportRegistry: @unchecked Sendable {
+    static let shared = FileImportRegistry()
+
+    private struct Entry: Sendable {
+        let importer: any FileImporter
+        let ownerPluginId: String?
+        let registrationOrder: Int
+    }
+
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+    private var nextRegistrationOrder = 0
+
+    init() {}
+
+    func register(_ importer: any FileImporter, ownerPluginId: String? = nil) {
+        lock.withLock {
+            entries.removeAll { $0.importer.descriptor.id == importer.descriptor.id }
+            entries.append(
+                Entry(
+                    importer: importer,
+                    ownerPluginId: ownerPluginId,
+                    registrationOrder: nextRegistrationOrder
+                )
+            )
+            nextRegistrationOrder += 1
+        }
+    }
+
+    func unregisterImporter(id: String) {
+        lock.withLock {
+            entries.removeAll { $0.importer.descriptor.id == id }
+        }
+    }
+
+    func unregisterPluginImporters(pluginId: String) {
+        lock.withLock {
+            entries.removeAll { $0.ownerPluginId == pluginId }
+        }
+    }
+
+    func importer(for url: URL) -> (any FileImporter)? {
+        lock.withLock {
+            resolveLocked(for: url)?.importer
+        }
+    }
+
+    func descriptor(for url: URL) -> FileImportDescriptor? {
+        lock.withLock {
+            resolveLocked(for: url)?.importer.descriptor
+        }
+    }
+
+    func descriptors() -> [FileImportDescriptor] {
+        lock.withLock {
+            entries
+                .sorted { lhs, rhs in
+                    let lhsPriority = sourcePriority(lhs.importer.descriptor.source)
+                    let rhsPriority = sourcePriority(rhs.importer.descriptor.source)
+                    if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+                    return lhs.registrationOrder < rhs.registrationOrder
+                }
+                .map(\.importer.descriptor)
+        }
+    }
+
+    func supportedDocumentTypes() -> [UTType] {
+        var seen = Set<String>()
+        var results: [UTType] = []
+
+        for descriptor in descriptors() {
+            for type in descriptor.supportedUTTypes where seen.insert(type.identifier).inserted {
+                results.append(type)
+            }
+        }
+
+        return results
+    }
+
+    func canImport(url: URL) -> Bool {
+        descriptor(for: url) != nil
+    }
+
+    func reset() {
+        lock.withLock {
+            entries.removeAll()
+            nextRegistrationOrder = 0
+        }
+    }
+
+    private func resolveLocked(for url: URL) -> Entry? {
+        entries
+            .filter { $0.importer.descriptor.matches(url: url) }
+            .sorted { lhs, rhs in
+                let lhsPriority = sourcePriority(lhs.importer.descriptor.source)
+                let rhsPriority = sourcePriority(rhs.importer.descriptor.source)
+                if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+                return lhs.registrationOrder < rhs.registrationOrder
+            }
+            .first
+    }
+
+    private func sourcePriority(_ source: FileImportSource) -> Int {
+        switch source {
+        case .core:
+            return 0
+        case .nativePlugin:
+            return 1
+        case .sandboxPlugin:
+            return 2
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/FileImport/FileImportService.swift
+++ b/Packages/OsaurusCore/Services/FileImport/FileImportService.swift
@@ -1,0 +1,550 @@
+//
+//  FileImportService.swift
+//  osaurus
+//
+//  Registry-backed file import service with explicit built-in registration.
+//
+
+import AppKit
+import Foundation
+import os
+import PDFKit
+import UniformTypeIdentifiers
+
+public enum FileImportError: LocalizedError, Equatable {
+    case unsupportedFormat(String)
+    case readFailed(String)
+    case fileTooLarge(maxBytes: Int)
+    case emptyContent
+    case invalidFilePath
+    case pluginImportFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat(let ext):
+            return "Unsupported file format: .\(ext)"
+        case .readFailed(let reason):
+            return "Failed to read file: \(reason)"
+        case .fileTooLarge(let maxBytes):
+            return "Document exceeds the \(ByteCountFormatter.string(fromByteCount: Int64(maxBytes), countStyle: .file)) attachment limit"
+        case .emptyContent:
+            return "Document appears to be empty"
+        case .invalidFilePath:
+            return "Only regular files can be attached"
+        case .pluginImportFailed(let reason):
+            return "Plugin import failed: \(reason)"
+        }
+    }
+}
+
+enum FileImportService {
+    static let maxParsedTextLength = 500_000
+    static let maxPDFImagePages = 20
+    static let defaultMaxInputBytes = 25 * 1024 * 1024
+
+    private static let builtInRegistration = OSAllocatedUnfairLock(initialState: false)
+
+    static func parse(url: URL) async throws -> Attachment {
+        let attachments = try await parseAll(url: url)
+        guard let first = attachments.first else {
+            throw FileImportError.emptyContent
+        }
+        return first
+    }
+
+    static func parseAll(url: URL) async throws -> [Attachment] {
+        ensureBuiltInImportersRegistered()
+
+        guard url.isFileURL else {
+            throw FileImportError.invalidFilePath
+        }
+
+        let ext = url.pathExtension.lowercased()
+        let fileSize = try fileSize(for: url)
+
+        guard let importer = FileImportRegistry.shared.importer(for: url) else {
+            throw FileImportError.unsupportedFormat(ext)
+        }
+
+        try validate(url: url, descriptor: importer.descriptor, fileSize: fileSize)
+        let attachments = try await importer.importFile(at: url)
+        let normalized = normalizeAttachments(
+            attachments,
+            fallbackFilename: url.lastPathComponent,
+            fallbackFileSize: fileSize
+        )
+
+        guard !normalized.isEmpty else {
+            throw FileImportError.emptyContent
+        }
+
+        return normalized
+    }
+
+    static func canImport(url: URL) -> Bool {
+        ensureBuiltInImportersRegistered()
+        return FileImportRegistry.shared.canImport(url: url)
+    }
+
+    static var supportedDocumentTypes: [UTType] {
+        ensureBuiltInImportersRegistered()
+        return FileImportRegistry.shared.supportedDocumentTypes()
+    }
+
+    static func registerPluginImporters(from plugin: ExternalPlugin) {
+        ensureBuiltInImportersRegistered()
+        FileImportRegistry.shared.unregisterPluginImporters(pluginId: plugin.id)
+
+        for spec in plugin.manifest.capabilities.file_importers ?? [] {
+            let descriptor = FileImportDescriptor(
+                id: "\(plugin.id).\(spec.id)",
+                extensions: spec.extensions,
+                utTypes: spec.ut_types,
+                mimeTypes: spec.mime_types,
+                maxBytes: spec.max_bytes,
+                source: .nativePlugin,
+                outputMode: spec.output_mode,
+                toolId: spec.tool_id,
+                outputSchemaVersion: spec.output_schema_version
+            )
+            FileImportRegistry.shared.register(
+                PluginBackedFileImporter(
+                    descriptor: descriptor,
+                    plugin: plugin,
+                    toolId: spec.tool_id
+                ),
+                ownerPluginId: plugin.id
+            )
+        }
+    }
+
+    static func unregisterPluginImporters(pluginId: String) {
+        FileImportRegistry.shared.unregisterPluginImporters(pluginId: pluginId)
+    }
+
+    static func registerBuiltInImporters(on registry: FileImportRegistry) {
+        builtInImporters().forEach { registry.register($0) }
+    }
+
+    private static func ensureBuiltInImportersRegistered() {
+        builtInRegistration.withLock { builtInsRegistered in
+            guard !builtInsRegistered else { return }
+            registerBuiltInImporters(on: FileImportRegistry.shared)
+            builtInsRegistered = true
+        }
+    }
+
+    private static func builtInImporters() -> [any FileImporter] {
+        [
+            BuiltInFileImporter(
+                descriptor: FileImportDescriptor(
+                    id: "core.plain-text",
+                    extensions: Array(plainTextExtensions).sorted(),
+                    utTypes: [
+                        UTType.plainText.identifier,
+                        UTType.utf8PlainText.identifier,
+                        UTType.commaSeparatedText.identifier,
+                        UTType.json.identifier,
+                        UTType.xml.identifier,
+                        UTType.yaml.identifier,
+                        UTType("public.python-script")?.identifier ?? "public.python-script",
+                        UTType("public.swift-source")?.identifier ?? "public.swift-source",
+                        UTType("com.netscape.javascript-source")?.identifier ?? "com.netscape.javascript-source",
+                        UTType("public.shell-script")?.identifier ?? "public.shell-script",
+                    ],
+                    mimeTypes: [
+                        "text/plain",
+                        "text/csv",
+                        "text/tab-separated-values",
+                        "application/json",
+                        "application/xml",
+                        "application/x-yaml",
+                        "application/toml",
+                    ],
+                    maxBytes: defaultMaxInputBytes,
+                    source: .core,
+                    outputMode: .normalizedText
+                ),
+                handler: parsePlainTextFamily
+            ),
+            BuiltInFileImporter(
+                descriptor: FileImportDescriptor(
+                    id: "core.rich-document",
+                    extensions: ["doc", "docx", "html", "htm", "rtf", "rtfd"],
+                    utTypes: [
+                        UTType.rtf.identifier,
+                        UTType.rtfd.identifier,
+                        UTType.html.identifier,
+                        UTType("org.openxmlformats.wordprocessingml.document")?.identifier
+                            ?? "org.openxmlformats.wordprocessingml.document",
+                        UTType("com.microsoft.word.doc")?.identifier ?? "com.microsoft.word.doc",
+                    ],
+                    mimeTypes: [
+                        "application/msword",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                        "application/rtf",
+                        "text/html",
+                    ],
+                    maxBytes: defaultMaxInputBytes,
+                    source: .core,
+                    outputMode: .normalizedText
+                ),
+                handler: parseRichDocumentFamily
+            ),
+            BuiltInFileImporter(
+                descriptor: FileImportDescriptor(
+                    id: "core.pdf",
+                    extensions: ["pdf"],
+                    utTypes: [UTType.pdf.identifier],
+                    mimeTypes: ["application/pdf"],
+                    maxBytes: 50 * 1024 * 1024,
+                    source: .core,
+                    outputMode: .normalizedText
+                ),
+                handler: parsePDFWithFallback
+            ),
+        ]
+    }
+
+    private static let plainTextExtensions: Set<String> = [
+        "txt", "md", "markdown", "csv", "tsv",
+        "json", "xml", "yaml", "yml", "toml",
+        "log", "ini", "cfg", "conf", "env",
+        "swift", "py", "js", "ts", "tsx", "jsx",
+        "rs", "go", "java", "kt", "c", "cpp", "h", "hpp",
+        "rb", "php", "sh", "bash", "zsh", "fish",
+        "css", "scss", "less", "sql",
+        "r", "m", "mm", "lua", "pl", "ex", "exs",
+        "zig", "nim", "dart", "scala", "groovy",
+        "tf", "hcl", "dockerfile",
+        "gitignore", "editorconfig", "prettierrc",
+    ]
+
+    private static func fileSize(for url: URL) throws -> Int {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        return values.fileSize ?? 0
+    }
+
+    private static func validate(url: URL, descriptor: FileImportDescriptor, fileSize: Int) throws {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+        guard values.isRegularFile != false else {
+            throw FileImportError.invalidFilePath
+        }
+        if fileSize > descriptor.maxBytes {
+            throw FileImportError.fileTooLarge(maxBytes: descriptor.maxBytes)
+        }
+    }
+
+    private static func normalizeAttachments(
+        _ attachments: [Attachment],
+        fallbackFilename: String,
+        fallbackFileSize: Int
+    ) -> [Attachment] {
+        attachments.compactMap { attachment in
+            switch attachment.kind {
+            case .image(let data):
+                guard !data.isEmpty else { return nil }
+                return .image(data)
+            case .document(let filename, let content, let fileSize):
+                let hasMeaningfulContent = !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                guard hasMeaningfulContent else { return nil }
+                return .document(
+                    filename: filename.isEmpty ? fallbackFilename : filename,
+                    content: truncate(content),
+                    fileSize: fileSize > 0 ? fileSize : fallbackFileSize
+                )
+            }
+        }
+    }
+
+    private static func truncate(_ content: String) -> String {
+        guard content.count > maxParsedTextLength else { return content }
+        return String(content.prefix(maxParsedTextLength))
+            + "\n\n[Document truncated — exceeded \(maxParsedTextLength) character limit]"
+    }
+
+    private static func parsePlainTextFamily(url: URL) throws -> [Attachment] {
+        let filename = url.lastPathComponent
+        let fileSize = try fileSize(for: url)
+        let content = try parsePlainText(url: url)
+        return [.document(filename: filename, content: content, fileSize: fileSize)]
+    }
+
+    private static func parsePlainText(url: URL) throws -> String {
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            if let data = try? Data(contentsOf: url),
+                let str = String(data: data, encoding: .isoLatin1)
+            {
+                return str
+            }
+            throw FileImportError.readFailed(error.localizedDescription)
+        }
+    }
+
+    private static func parseRichDocumentFamily(url: URL) throws -> [Attachment] {
+        let filename = url.lastPathComponent
+        let fileSize = try fileSize(for: url)
+        let ext = url.pathExtension.lowercased()
+
+        let type: NSAttributedString.DocumentType?
+        switch ext {
+        case "doc":
+            type = .docFormat
+        case "rtf", "rtfd":
+            type = .rtf
+        case "html", "htm":
+            type = .html
+        default:
+            type = nil
+        }
+
+        let content = try parseRichDocument(url: url, type: type)
+        return [.document(filename: filename, content: content, fileSize: fileSize)]
+    }
+
+    private static func parseRichDocument(url: URL, type: NSAttributedString.DocumentType?) throws -> String {
+        do {
+            var options: [NSAttributedString.DocumentReadingOptionKey: Any] = [:]
+            if let type {
+                options[.documentType] = type
+            }
+            let attributed = try NSAttributedString(
+                url: url,
+                options: options,
+                documentAttributes: nil
+            )
+            return attributed.string
+        } catch {
+            throw FileImportError.readFailed(error.localizedDescription)
+        }
+    }
+
+    private static func parsePDFWithFallback(url: URL) throws -> [Attachment] {
+        let filename = url.lastPathComponent
+        let fileSize = try fileSize(for: url)
+
+        guard let document = PDFDocument(url: url) else {
+            throw FileImportError.readFailed("Could not open PDF")
+        }
+
+        let text = extractPDFText(from: document)
+        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return [.document(filename: filename, content: text, fileSize: fileSize)]
+        }
+
+        let images = renderPDFPagesAsImages(document: document, maxPages: maxPDFImagePages)
+        guard !images.isEmpty else {
+            throw FileImportError.emptyContent
+        }
+        return images.map { .image($0) }
+    }
+
+    private static func extractPDFText(from document: PDFDocument) -> String {
+        var pages: [String] = []
+        for i in 0 ..< document.pageCount {
+            guard let page = document.page(at: i), let text = page.string else { continue }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                pages.append(text)
+            }
+        }
+        return pages.joined(separator: "\n\n")
+    }
+
+    private static let maxPixelsPerPage = 4_000 * 4_000
+
+    private static func renderPDFPagesAsImages(document: PDFDocument, maxPages: Int) -> [Data] {
+        let pageCount = min(document.pageCount, maxPages)
+        var images: [Data] = []
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+
+        for i in 0 ..< pageCount {
+            guard let page = document.page(at: i) else { continue }
+
+            let bounds = page.bounds(for: .mediaBox)
+            let scale: CGFloat = 2.0
+            let intWidth = Int(bounds.width * scale)
+            let intHeight = Int(bounds.height * scale)
+
+            guard intWidth > 0, intHeight > 0, intWidth <= maxPixelsPerPage / intHeight else { continue }
+
+            guard
+                let context = CGContext(
+                    data: nil,
+                    width: intWidth,
+                    height: intHeight,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                )
+            else {
+                continue
+            }
+
+            context.setFillColor(CGColor.white)
+            context.fill(CGRect(x: 0, y: 0, width: intWidth, height: intHeight))
+            context.scaleBy(x: scale, y: scale)
+            page.draw(with: .mediaBox, to: context)
+
+            guard let cgImage = context.makeImage() else { continue }
+            let image = NSImage(cgImage: cgImage, size: NSSize(width: bounds.width, height: bounds.height))
+            if let pngData = image.pngData() {
+                images.append(pngData)
+            }
+        }
+
+        return images
+    }
+
+    private static func decodePluginImportResponse(
+        _ rawResponse: String,
+        fallbackFilename: String,
+        fallbackFileSize: Int
+    ) throws -> [Attachment] {
+        if let data = rawResponse.data(using: .utf8),
+            let response = try? JSONDecoder().decode(PluginFileImportResponse.self, from: data)
+        {
+            return response.attachments.map {
+                .document(
+                    filename: $0.filename ?? fallbackFilename,
+                    content: $0.content,
+                    fileSize: $0.file_size ?? fallbackFileSize
+                )
+            }
+        }
+
+        let trimmed = rawResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw FileImportError.pluginImportFailed("Plugin returned an empty response")
+        }
+        return [.document(filename: fallbackFilename, content: trimmed, fileSize: fallbackFileSize)]
+    }
+
+    private static func preferredMimeType(for url: URL, descriptor: FileImportDescriptor) -> String? {
+        if let contentType = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType,
+            let mimeType = contentType.preferredMIMEType
+        {
+            return mimeType
+        }
+
+        if let inferred = UTType(filenameExtension: url.pathExtension.lowercased()),
+            let mimeType = inferred.preferredMIMEType
+        {
+            return mimeType
+        }
+
+        return descriptor.mimeTypes.first
+    }
+
+    private struct BuiltInFileImporter: FileImporter {
+        let descriptor: FileImportDescriptor
+        private let handler: @Sendable (URL) throws -> [Attachment]
+
+        init(
+            descriptor: FileImportDescriptor,
+            handler: @escaping @Sendable (URL) throws -> [Attachment]
+        ) {
+            self.descriptor = descriptor
+            self.handler = handler
+        }
+
+        func importFile(at url: URL) async throws -> [Attachment] {
+            try handler(url)
+        }
+    }
+
+    private struct PluginBackedFileImporter: FileImporter {
+        let descriptor: FileImportDescriptor
+        let plugin: ExternalPlugin
+        let toolId: String
+
+        func importFile(at url: URL) async throws -> [Attachment] {
+            let fileSize = (try? FileImportService.fileSize(for: url)) ?? 0
+            let request = PluginFileImportRequest(
+                path: url.path,
+                filename: url.lastPathComponent,
+                file_extension: url.pathExtension.lowercased(),
+                mime_type: FileImportService.preferredMimeType(for: url, descriptor: descriptor),
+                max_bytes: descriptor.maxBytes,
+                max_chars: FileImportService.maxParsedTextLength,
+                output_mode: descriptor.outputMode.rawValue,
+                output_schema_version: descriptor.outputSchemaVersion
+            )
+            let payload = try String(decoding: JSONEncoder().encode(request), as: UTF8.self)
+            let response = try await plugin.invoke(
+                type: "tool",
+                id: toolId,
+                payload: payload,
+                agentId: WorkExecutionContext.currentAgentId
+            )
+            return try FileImportService.decodePluginImportResponse(
+                response,
+                fallbackFilename: url.lastPathComponent,
+                fallbackFileSize: fileSize
+            )
+        }
+    }
+
+    private struct PluginFileImportRequest: Encodable {
+        let path: String
+        let filename: String
+        let file_extension: String
+        let mime_type: String?
+        let max_bytes: Int
+        let max_chars: Int
+        let output_mode: String
+        let output_schema_version: Int
+    }
+
+    private struct PluginFileImportResponse: Decodable {
+        let attachments: [PluginImportedDocument]
+
+        private enum CodingKeys: String, CodingKey {
+            case attachments
+            case documents
+            case content
+            case filename
+            case file_size
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            if let attachments = try container.decodeIfPresent([PluginImportedDocument].self, forKey: .attachments) {
+                self.attachments = attachments
+                return
+            }
+
+            if let attachments = try container.decodeIfPresent([PluginImportedDocument].self, forKey: .documents) {
+                self.attachments = attachments
+                return
+            }
+
+            if let content = try container.decodeIfPresent(String.self, forKey: .content) {
+                self.attachments = [
+                    PluginImportedDocument(
+                        filename: try container.decodeIfPresent(String.self, forKey: .filename),
+                        content: content,
+                        file_size: try container.decodeIfPresent(Int.self, forKey: .file_size)
+                    )
+                ]
+                return
+            }
+
+            throw DecodingError.dataCorruptedError(
+                forKey: .attachments,
+                in: container,
+                debugDescription: "Expected attachments, documents, or content in importer response"
+            )
+        }
+    }
+
+    private struct PluginImportedDocument: Decodable {
+        let filename: String?
+        let content: String
+        let file_size: Int?
+    }
+}

--- a/Packages/OsaurusCore/Services/FileImport/FileImportService.swift
+++ b/Packages/OsaurusCore/Services/FileImport/FileImportService.swift
@@ -26,7 +26,8 @@ public enum FileImportError: LocalizedError, Equatable {
         case .readFailed(let reason):
             return "Failed to read file: \(reason)"
         case .fileTooLarge(let maxBytes):
-            return "Document exceeds the \(ByteCountFormatter.string(fromByteCount: Int64(maxBytes), countStyle: .file)) attachment limit"
+            return
+                "Document exceeds the \(ByteCountFormatter.string(fromByteCount: Int64(maxBytes), countStyle: .file)) attachment limit"
         case .emptyContent:
             return "Document appears to be empty"
         case .invalidFilePath:

--- a/Packages/OsaurusCore/Tests/FileImport/FileImportTests.swift
+++ b/Packages/OsaurusCore/Tests/FileImport/FileImportTests.swift
@@ -51,7 +51,10 @@ struct FileImportRegistryTests {
     }
 
     @Test func documentParserParsesTextAttachment() async throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -68,7 +71,7 @@ struct FileImportRegistryTests {
 private struct TestImporter: FileImporter {
     let descriptor: FileImportDescriptor
 
-    func importFile(at url: URL) async throws -> [Attachment] {
-        [.document(filename: url.lastPathComponent, content: "ok", fileSize: 2)]
+    func importFile(at url: URL) async throws -> [OsaurusCore.Attachment] {
+        [OsaurusCore.Attachment.document(filename: url.lastPathComponent, content: "ok", fileSize: 2)]
     }
 }

--- a/Packages/OsaurusCore/Tests/FileImport/FileImportTests.swift
+++ b/Packages/OsaurusCore/Tests/FileImport/FileImportTests.swift
@@ -1,0 +1,74 @@
+//
+//  FileImportTests.swift
+//  osaurusTests
+//
+//  Tests for the registry-backed file import layer.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct FileImportRegistryTests {
+
+    @Test func registryPrefersCoreImporterOverPluginImporter() async throws {
+        let registry = FileImportRegistry()
+        let pluginImporter = TestImporter(
+            descriptor: FileImportDescriptor(
+                id: "plugin.txt",
+                extensions: ["txt"],
+                maxBytes: 1_024,
+                source: .nativePlugin,
+                outputMode: .normalizedText
+            )
+        )
+        let coreImporter = TestImporter(
+            descriptor: FileImportDescriptor(
+                id: "core.txt",
+                extensions: ["txt"],
+                maxBytes: 1_024,
+                source: .core,
+                outputMode: .normalizedText
+            )
+        )
+
+        registry.register(pluginImporter, ownerPluginId: "com.test.plugin")
+        registry.register(coreImporter)
+
+        let url = URL(fileURLWithPath: "/tmp/example.txt")
+        #expect(registry.importer(for: url)?.descriptor.id == "core.txt")
+    }
+
+    @Test func registerBuiltInImportersIncludesCoreFormats() {
+        let registry = FileImportRegistry()
+        FileImportService.registerBuiltInImporters(on: registry)
+
+        let extensions = Set(registry.descriptors().flatMap(\.extensions))
+        #expect(extensions.contains("txt"))
+        #expect(extensions.contains("pdf"))
+        #expect(extensions.contains("docx"))
+    }
+
+    @Test func documentParserParsesTextAttachment() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let url = tempDir.appendingPathComponent("sample.txt")
+        try "alpha\nbeta\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let attachment = try await DocumentParser.parse(url: url)
+        #expect(attachment.isDocument)
+        #expect(attachment.filename == "sample.txt")
+        #expect(attachment.documentContent?.contains("beta") == true)
+    }
+}
+
+private struct TestImporter: FileImporter {
+    let descriptor: FileImportDescriptor
+
+    func importFile(at url: URL) async throws -> [Attachment] {
+        [.document(filename: url.lastPathComponent, content: "ok", fileSize: 2)]
+    }
+}

--- a/Packages/OsaurusCore/Tests/Plugin/PluginTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginTests.swift
@@ -478,6 +478,7 @@ struct PluginManifestDecodingTests {
         #expect(manifest.capabilities.routes == nil)
         #expect(manifest.capabilities.config == nil)
         #expect(manifest.capabilities.web == nil)
+        #expect(manifest.capabilities.file_importers == nil)
     }
 
     @Test func manifestWithRoutes() throws {
@@ -618,6 +619,45 @@ struct PluginManifestDecodingTests {
     @Test func routeAuthDefaultsToOwner() throws {
         let route = PluginManifest.RouteSpec(id: "test", path: "/test", methods: ["GET"])
         #expect(route.auth == .owner)
+    }
+
+    @Test func manifestWithFileImporters() throws {
+        let json = """
+            {
+                "plugin_id": "com.test.importers",
+                "capabilities": {
+                    "tools": [
+                        {
+                            "id": "import_xlsx",
+                            "description": "Import spreadsheet",
+                            "parameters": {
+                                "type": "object"
+                            }
+                        }
+                    ],
+                    "file_importers": [
+                        {
+                            "id": "xlsx",
+                            "tool_id": "import_xlsx",
+                            "extensions": ["xlsx", "xls"],
+                            "ut_types": ["org.openxmlformats.spreadsheetml.sheet"],
+                            "mime_types": ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+                            "max_bytes": 10485760,
+                            "output_mode": "normalized_text",
+                            "output_schema_version": 2
+                        }
+                    ]
+                }
+            }
+            """
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: Data(json.utf8))
+        let importer = try #require(manifest.capabilities.file_importers?.first)
+        #expect(importer.id == "xlsx")
+        #expect(importer.tool_id == "import_xlsx")
+        #expect(importer.extensions == ["xlsx", "xls"])
+        #expect(importer.max_bytes == 10_485_760)
+        #expect(importer.output_mode == .normalizedText)
+        #expect(importer.output_schema_version == 2)
     }
 }
 

--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -2,89 +2,31 @@
 //  DocumentParser.swift
 //  osaurus
 //
-//  Parses document files into plain text for context injection.
-//  Uses macOS built-in frameworks (PDFKit, NSAttributedString) — no external dependencies.
+//  Compatibility facade over the registry-backed file import service.
 //
 
-import AppKit
 import Foundation
-import PDFKit
 import UniformTypeIdentifiers
 
 enum DocumentParser {
+    typealias ParseError = FileImportError
 
-    static let maxParsedTextLength = 500_000  // ~500KB of text
-
-    enum ParseError: LocalizedError {
-        case unsupportedFormat(String)
-        case readFailed(String)
-        case fileTooLarge
-        case emptyContent
-
-        var errorDescription: String? {
-            switch self {
-            case .unsupportedFormat(let ext): return "Unsupported file format: .\(ext)"
-            case .readFailed(let reason): return "Failed to read file: \(reason)"
-            case .fileTooLarge: return "Document is too large to attach"
-            case .emptyContent: return "Document appears to be empty"
-            }
-        }
-    }
+    static let maxParsedTextLength = FileImportService.maxParsedTextLength
 
     // MARK: - Public API
 
-    static func parse(url: URL) throws -> Attachment {
-        let results = try parseAll(url: url)
-        guard let first = results.first else {
-            throw ParseError.emptyContent
-        }
-        return first
+    static func parse(url: URL) async throws -> Attachment {
+        try await FileImportService.parse(url: url)
     }
 
     /// Parse a file into one or more attachments.
     /// PDFs with no extractable text are rendered as page images (one per page).
-    static func parseAll(url: URL) throws -> [Attachment] {
-        let fileSize = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
-        let ext = url.pathExtension.lowercased()
-        let filename = url.lastPathComponent
-
-        // PDF may fall back to image rendering if text extraction yields nothing
-        if ext == "pdf" {
-            return try parsePDFWithFallback(url: url, filename: filename, fileSize: fileSize)
-        }
-
-        let content: String
-        switch ext {
-        case _ where isPlainText(ext: ext):
-            content = try parsePlainText(url: url)
-        case "docx":
-            content = try parseRichDocument(url: url)
-        case "doc":
-            content = try parseRichDocument(url: url, type: .docFormat)
-        case "rtf", "rtfd":
-            content = try parseRichDocument(url: url, type: .rtf)
-        case "html", "htm":
-            content = try parseRichDocument(url: url, type: .html)
-        default:
-            throw ParseError.unsupportedFormat(ext)
-        }
-
-        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw ParseError.emptyContent
-        }
-
-        let trimmed =
-            content.count > maxParsedTextLength
-            ? String(content.prefix(maxParsedTextLength))
-                + "\n\n[Document truncated — exceeded \(maxParsedTextLength) character limit]"
-            : content
-
-        return [.document(filename: filename, content: trimmed, fileSize: fileSize)]
+    static func parseAll(url: URL) async throws -> [Attachment] {
+        try await FileImportService.parseAll(url: url)
     }
 
     static func canParse(url: URL) -> Bool {
-        let ext = url.pathExtension.lowercased()
-        return isPlainText(ext: ext) || richDocumentExtensions.contains(ext)
+        FileImportService.canImport(url: url)
     }
 
     static func isImageFile(url: URL) -> Bool {
@@ -93,163 +35,6 @@ enum DocumentParser {
     }
 
     static var supportedDocumentTypes: [UTType] {
-        [
-            .plainText, .utf8PlainText,
-            .pdf,
-            .rtf, .rtfd,
-            .html,
-            UTType("org.openxmlformats.wordprocessingml.document") ?? .data,  // .docx
-            UTType("com.microsoft.word.doc") ?? .data,  // .doc
-            .commaSeparatedText,
-            .json, .xml, .yaml,
-            UTType("public.python-script") ?? .data,
-            UTType("public.swift-source") ?? .data,
-            UTType("com.netscape.javascript-source") ?? .data,
-            UTType("public.shell-script") ?? .data,
-        ].compactMap { $0 }
-    }
-
-    // MARK: - Plain Text
-
-    private static let plainTextExtensions: Set<String> = [
-        "txt", "md", "markdown", "csv", "tsv",
-        "json", "xml", "yaml", "yml", "toml",
-        "log", "ini", "cfg", "conf", "env",
-        "swift", "py", "js", "ts", "tsx", "jsx",
-        "rs", "go", "java", "kt", "c", "cpp", "h", "hpp",
-        "rb", "php", "sh", "bash", "zsh", "fish",
-        "css", "scss", "less", "sql",
-        "r", "m", "mm", "lua", "pl", "ex", "exs",
-        "zig", "nim", "dart", "scala", "groovy",
-        "tf", "hcl", "dockerfile",
-        "gitignore", "editorconfig", "prettierrc",
-    ]
-
-    private static let richDocumentExtensions: Set<String> = [
-        "pdf", "docx", "doc", "rtf", "rtfd", "html", "htm",
-    ]
-
-    private static func isPlainText(ext: String) -> Bool {
-        plainTextExtensions.contains(ext)
-    }
-
-    private static func parsePlainText(url: URL) throws -> String {
-        do {
-            return try String(contentsOf: url, encoding: .utf8)
-        } catch {
-            // Retry with latin1 for binary-ish text files
-            if let data = try? Data(contentsOf: url),
-                let str = String(data: data, encoding: .isoLatin1)
-            {
-                return str
-            }
-            throw ParseError.readFailed(error.localizedDescription)
-        }
-    }
-
-    // MARK: - PDF
-
-    /// Maximum number of PDF pages to render as images when text extraction fails
-    private static let maxPDFImagePages = 20
-
-    private static func parsePDFWithFallback(url: URL, filename: String, fileSize: Int) throws -> [Attachment] {
-        guard let document = PDFDocument(url: url) else {
-            throw ParseError.readFailed("Could not open PDF")
-        }
-
-        // Try text extraction first
-        let text = extractPDFText(from: document)
-        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let trimmed =
-                text.count > maxParsedTextLength
-                ? String(text.prefix(maxParsedTextLength))
-                    + "\n\n[Document truncated — exceeded \(maxParsedTextLength) character limit]"
-                : text
-            return [.document(filename: filename, content: trimmed, fileSize: fileSize)]
-        }
-
-        // Text extraction yielded nothing — render pages as images
-        let images = renderPDFPagesAsImages(document: document, maxPages: maxPDFImagePages)
-        guard !images.isEmpty else {
-            throw ParseError.emptyContent
-        }
-
-        return images.map { .image($0) }
-    }
-
-    private static func extractPDFText(from document: PDFDocument) -> String {
-        var pages: [String] = []
-        for i in 0 ..< document.pageCount {
-            if let page = document.page(at: i), let text = page.string,
-                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            {
-                pages.append(text)
-            }
-        }
-        return pages.joined(separator: "\n\n")
-    }
-
-    private static let maxPixelsPerPage = 4000 * 4000  // ~16MP cap per page
-
-    private static func renderPDFPagesAsImages(document: PDFDocument, maxPages: Int) -> [Data] {
-        let pageCount = min(document.pageCount, maxPages)
-        var images: [Data] = []
-        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
-
-        for i in 0 ..< pageCount {
-            guard let page = document.page(at: i) else { continue }
-            let bounds = page.bounds(for: .mediaBox)
-            // Render at 2x for readability
-            let scale: CGFloat = 2.0
-            let intWidth = Int(bounds.width * scale)
-            let intHeight = Int(bounds.height * scale)
-
-            guard intWidth > 0, intHeight > 0, intWidth <= maxPixelsPerPage / intHeight else { continue }
-
-            guard
-                let context = CGContext(
-                    data: nil,
-                    width: intWidth,
-                    height: intHeight,
-                    bitsPerComponent: 8,
-                    bytesPerRow: 0,
-                    space: colorSpace,
-                    bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
-                )
-            else { continue }
-
-            // White background
-            context.setFillColor(CGColor.white)
-            context.fill(CGRect(x: 0, y: 0, width: intWidth, height: intHeight))
-
-            context.scaleBy(x: scale, y: scale)
-            page.draw(with: .mediaBox, to: context)
-
-            guard let cgImage = context.makeImage() else { continue }
-            let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: bounds.width, height: bounds.height))
-            if let pngData = nsImage.pngData() {
-                images.append(pngData)
-            }
-        }
-        return images
-    }
-
-    // MARK: - Rich Documents (DOCX, RTF, HTML)
-
-    private static func parseRichDocument(url: URL, type: NSAttributedString.DocumentType? = nil) throws -> String {
-        do {
-            var options: [NSAttributedString.DocumentReadingOptionKey: Any] = [:]
-            if let type = type {
-                options[.documentType] = type
-            }
-            let attributed = try NSAttributedString(
-                url: url,
-                options: options,
-                documentAttributes: nil
-            )
-            return attributed.string
-        } catch {
-            throw ParseError.readFailed(error.localizedDescription)
-        }
+        FileImportService.supportedDocumentTypes
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1790,7 +1790,7 @@ extension FloatingInputCard {
                 let animation = theme.springAnimation()
                 Task.detached(priority: .userInitiated) {
                     do {
-                        let attachments = try DocumentParser.parseAll(url: url)
+                        let attachments = try await DocumentParser.parseAll(url: url)
                         await MainActor.run {
                             withAnimation(animation) {
                                 self.pendingAttachments.append(contentsOf: attachments)
@@ -2021,7 +2021,7 @@ extension FloatingInputCard {
         let animation = theme.springAnimation()
         Task.detached(priority: .userInitiated) {
             do {
-                let attachments = try DocumentParser.parseAll(url: url)
+                let attachments = try await DocumentParser.parseAll(url: url)
                 await MainActor.run {
                     withAnimation(animation) {
                         self.pendingAttachments.append(contentsOf: attachments)


### PR DESCRIPTION
## Summary
- add a registry-backed host file import layer with explicit importer descriptors and registration
- replace monolithic `DocumentParser` logic with a compatibility facade over `FileImportService`
- allow native plugins to declare `capabilities.file_importers` so later format packs can plug into the existing attachment flow
- add focused tests for importer registration and plugin manifest decoding

## Why This Matters
### Business reason
This is the base layer for broader file-format coverage without turning `OsaurusCore` into a dependency-heavy monolith. It creates the extension point needed for office, technical, mining, and scientific formats to arrive through plugins instead of expensive core rewrites.

### Programming reason
Importer registration is now explicit and testable. The host owns file selection, limits, and normalization, while plugins can extend format coverage without changing the attachment contract or prompt path that already works today.

## Scope
Included:
- `FileImportDescriptor`
- `FileImportRegistry`
- `FileImportService`
- async `DocumentParser` bridge
- native plugin manifest support for `capabilities.file_importers`
- focused importer and manifest tests

Deliberately excluded:
- safe-expansion formats like `jsonl`, `ndjson`, `svg`, and `plist`
- office/data/mining/scientific plugin packs
- docs already covered by `#841`

## Validation
Validated on rewritten branch head `fa94b8ae`.

Results:
- branch-local formatting passed
- 10 targeted tests passed across `FileImportRegistryTests` and `PluginManifestDecodingTests`
- workspace build succeeded
- launch smoke check passed
- worktree remained clean after validation

Exact commands and evidence are in the validation comments on the PR.
