### PR TITLE
optimize TTFT for local models

### DIFF
--- a/App/osaurus.xcodeproj/project.pbxproj
+++ b/App/osaurus.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = osaurus/osaurus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -499,7 +499,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = osaurus/osaurus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/App/osaurus.xcodeproj/project.pbxproj
+++ b/App/osaurus.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = osaurus/osaurus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -499,7 +499,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = osaurus/osaurus.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -16,6 +16,10 @@ import Foundation
 final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     static let shared = InferenceProgressManager()
 
+    /// True while the model container is being loaded (weights paging into GPU).
+    /// The UI shows "Loading Model..." during this phase.
+    @MainActor @Published var isLoadingModel: Bool = false
+
     /// Non-nil while a prefill is in progress.  Set to the prompt token count
     /// just before `prepareAndGenerate` is called; cleared as soon as the first
     /// generated token arrives (or on error / cancellation).
@@ -53,5 +57,15 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     /// Fire-and-forget variant for call sites that are not on MainActor.
     func prefillDidFinishAsync() {
         Task { @MainActor in self.prefillDidFinish() }
+    }
+
+    /// Signal that model container loading has started.
+    func modelLoadWillStartAsync() {
+        Task { @MainActor in self.isLoadingModel = true }
+    }
+
+    /// Signal that model container loading has finished.
+    func modelLoadDidFinishAsync() {
+        Task { @MainActor in self.isLoadingModel = false }
     }
 }

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -359,6 +359,8 @@ struct ChatCompletionRequest: Codable, Sendable {
     var modelOptions: [String: ModelOptionValue]? = nil
     /// Static system prompt content for prefix cache building (not serialized to JSON).
     var staticPrefix: String? = nil
+    /// Optional TTFT trace for diagnostic timing (not serialized to JSON).
+    var ttftTrace: TTFTTrace? = nil
 
     /// Resolved max tokens, preferring max_tokens then max_completion_tokens.
     var resolvedMaxTokens: Int? { max_tokens ?? max_completion_tokens }

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -37,6 +37,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
     func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
         debugLog("[ChatEngine] streamChat: start model=\(request.model)")
+        let trace = request.ttftTrace
+        trace?.mark("chatengine_start")
         let messages = request.messages
         debugLog("[ChatEngine] streamChat: messages count=\(messages.count), fetching remote services")
         let temperature = request.temperature
@@ -55,7 +57,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             modelOptions: request.modelOptions ?? [:],
             sessionId: request.session_id,
             cacheHint: request.cache_hint,
-            staticPrefix: request.staticPrefix
+            staticPrefix: request.staticPrefix,
+            ttftTrace: trace
         )
 
         // Candidate services and installed models (injected for testability)
@@ -63,7 +66,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
         // Fetch current remote services from MainActor at request time so routing always
         // reflects the latest connected Bonjour/remote agents without requiring a new engine.
+        trace?.mark("fetch_remote_services")
         let remoteServices = await MainActor.run { RemoteProviderManager.shared.connectedServices() }
+        trace?.mark("route_resolve")
         debugLog("[ChatEngine] streamChat: remoteServices=\(remoteServices.count), routing model=\(request.model)")
 
         let route = ModelServiceRouter.resolve(
@@ -81,6 +86,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             if let tools = request.tools, !tools.isEmpty, let toolSvc = service as? ToolCapableService {
                 let stopSequences = request.stop ?? []
                 debugLog("[ChatEngine] streamChat: calling streamWithTools tools=\(tools.count)")
+                trace?.mark("chatengine_streamWithTools_start")
                 innerStream = try await toolSvc.streamWithTools(
                     messages: messages,
                     parameters: params,
@@ -89,15 +95,18 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     toolChoice: request.tool_choice,
                     requestedModel: request.model
                 )
+                trace?.mark("chatengine_streamWithTools_done")
                 debugLog("[ChatEngine] streamChat: streamWithTools returned")
             } else {
                 debugLog("[ChatEngine] streamChat: calling streamDeltas")
+                trace?.mark("chatengine_streamDeltas_start")
                 innerStream = try await service.streamDeltas(
                     messages: messages,
                     parameters: params,
                     requestedModel: request.model,
                     stopSequences: request.stop ?? []
                 )
+                trace?.mark("chatengine_streamDeltas_done")
                 debugLog("[ChatEngine] streamChat: streamDeltas returned")
             }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -85,6 +85,7 @@ public struct SystemPromptComposer: Sendable {
             executionMode: executionMode,
             query: query,
             toolsDisabled: toolsDisabled,
+            model: model,
             trace: trace
         )
         trace?.mark("compose_context_done")
@@ -99,6 +100,7 @@ public struct SystemPromptComposer: Sendable {
         executionMode: WorkExecutionMode,
         query: String,
         toolsDisabled: Bool,
+        model: String? = nil,
         trace: TTFTTrace? = nil
     ) async -> ComposedContext {
         var comp = composer
@@ -108,8 +110,9 @@ public struct SystemPromptComposer: Sendable {
         trace?.mark("memory_done")
 
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
+        let isLocalModel = MLXService.shared.handles(requestedModel: model)
         let preflight: PreflightResult
-        if !toolsDisabled && toolMode == .auto && !query.isEmpty {
+        if !toolsDisabled && toolMode == .auto && !query.isEmpty && !isLocalModel {
             let mode = ChatConfigurationStore.load().preflightSearchMode ?? .balanced
             trace?.mark("preflight_search_start")
             preflight = await PreflightCapabilitySearch.search(query: query, mode: mode)

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -74,16 +74,21 @@ public struct SystemPromptComposer: Sendable {
         executionMode: WorkExecutionMode,
         model: String? = nil,
         query: String = "",
-        toolsDisabled: Bool = false
+        toolsDisabled: Bool = false,
+        trace: TTFTTrace? = nil
     ) async -> ComposedContext {
+        trace?.mark("compose_context_start")
         let composer = forChat(agentId: agentId, executionMode: executionMode, model: model)
-        return await finalizeContext(
+        let result = await finalizeContext(
             composer: composer,
             agentId: agentId,
             executionMode: executionMode,
             query: query,
-            toolsDisabled: toolsDisabled
+            toolsDisabled: toolsDisabled,
+            trace: trace
         )
+        trace?.mark("compose_context_done")
+        return result
     }
 
     /// Shared pipeline: append memory + preflight + skills + resolve tools + build ComposedContext.
@@ -93,16 +98,22 @@ public struct SystemPromptComposer: Sendable {
         agentId: UUID,
         executionMode: WorkExecutionMode,
         query: String,
-        toolsDisabled: Bool
+        toolsDisabled: Bool,
+        trace: TTFTTrace? = nil
     ) async -> ComposedContext {
         var comp = composer
+
+        trace?.mark("memory_start")
         await comp.appendMemory(agentId: agentId.uuidString)
+        trace?.mark("memory_done")
 
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
         let preflight: PreflightResult
         if !toolsDisabled && toolMode == .auto && !query.isEmpty {
             let mode = ChatConfigurationStore.load().preflightSearchMode ?? .balanced
+            trace?.mark("preflight_search_start")
             preflight = await PreflightCapabilitySearch.search(query: query, mode: mode)
+            trace?.mark("preflight_search_done")
         } else {
             preflight = .empty
         }
@@ -114,18 +125,26 @@ public struct SystemPromptComposer: Sendable {
             comp.append(.dynamic(id: "skills", label: "Skills", content: section))
         }
 
+        trace?.mark("resolve_tools_start")
         let tools = resolveTools(
             agentId: agentId,
             executionMode: executionMode,
             toolsDisabled: toolsDisabled,
             preflight: preflight
         )
+        trace?.mark("resolve_tools_done")
+
         let manifest = comp.manifest()
         let toolNames = tools.map { $0.function.name }
         debugLog("[Context] \(manifest.debugDescription)")
 
+        let rendered = comp.render()
+        trace?.set("systemPromptChars", rendered.count)
+        trace?.set("toolCount", tools.count)
+        trace?.set("preflightItems", preflight.items.count)
+
         return ComposedContext(
-            prompt: comp.render(),
+            prompt: rendered,
             manifest: manifest,
             tools: tools,
             toolTokens: ToolRegistry.shared.totalEstimatedTokens(for: tools),

--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -104,7 +104,8 @@ enum CapabilitySearch {
     static func canCreatePlugins() async -> Bool {
         await MainActor.run {
             let agentId = AgentManager.shared.activeAgent.id
-            return AgentManager.shared.effectiveAutonomousExec(for: agentId)?.pluginCreate == true
+            guard let config = AgentManager.shared.effectiveAutonomousExec(for: agentId) else { return false }
+            return config.enabled && config.pluginCreate
         }
     }
 }
@@ -140,7 +141,7 @@ enum PreflightCapabilitySearch {
         )
 
         if selectedNames.isEmpty {
-            return await sandboxPluginCreatorFallback()
+            return .empty
         }
 
         let (toolSpecs, items) = await MainActor.run {

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -26,6 +26,8 @@ struct GenerationParameters: Sendable {
     /// dynamic sections like memory), producing a KV cache that exactly matches
     /// the reusable portion across requests.
     let staticPrefix: String?
+    /// Optional TTFT trace for diagnostic timing instrumentation.
+    let ttftTrace: TTFTTrace?
 
     init(
         temperature: Float?,
@@ -35,7 +37,8 @@ struct GenerationParameters: Sendable {
         modelOptions: [String: ModelOptionValue] = [:],
         sessionId: String? = nil,
         cacheHint: String? = nil,
-        staticPrefix: String? = nil
+        staticPrefix: String? = nil,
+        ttftTrace: TTFTTrace? = nil
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
@@ -45,6 +48,7 @@ struct GenerationParameters: Sendable {
         self.sessionId = sessionId
         self.cacheHint = cacheHint
         self.staticPrefix = staticPrefix
+        self.ttftTrace = ttftTrace
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -478,7 +478,15 @@ actor ModelRuntime {
         let effectiveStopSequences = stopSequences
         let cfg = await getConfig()
         trace?.mark("load_container_start")
-        let holder = try await loadContainer(id: modelId, name: modelName)
+        InferenceProgressManager.shared.modelLoadWillStartAsync()
+        let holder: SessionHolder
+        do {
+            holder = try await loadContainer(id: modelId, name: modelName)
+        } catch {
+            InferenceProgressManager.shared.modelLoadDidFinishAsync()
+            throw error
+        }
+        InferenceProgressManager.shared.modelLoadDidFinishAsync()
         trace?.mark("load_container_done")
 
         let wiredPolicy = MLXLMCommon.WiredSumPolicy()

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -454,11 +454,16 @@ actor ModelRuntime {
         modelId: String,
         modelName: String
     ) async throws -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
+        let trace = parameters.ttftTrace
+        trace?.mark("runtime_start")
+
+        trace?.mark("await_active_gen")
         _ = await activeGenerationTask?.value
         if Task.isCancelled { throw CancellationError() }
 
         // Cancel and await any background prefix-cache tasks for this model so
         // we never have two concurrent Metal/MLX operations on the same container.
+        trace?.mark("await_prefix_tasks")
         let modelPrefix = "\(modelName):"
         let stalePrefixTasks = prefixCacheTasks.filter { $0.key.hasPrefix(modelPrefix) }
         for (key, task) in stalePrefixTasks {
@@ -472,7 +477,9 @@ actor ModelRuntime {
 
         let effectiveStopSequences = stopSequences
         let cfg = await getConfig()
+        trace?.mark("load_container_start")
         let holder = try await loadContainer(id: modelId, name: modelName)
+        trace?.mark("load_container_done")
 
         let wiredPolicy = MLXLMCommon.WiredSumPolicy()
         let wiredTicket = wiredPolicy.ticket(
@@ -493,6 +500,7 @@ actor ModelRuntime {
         // nonisolated(unsafe) suppresses the Sendable check for [any KVCache] which
         // doesn't conform to Sendable but is safe here because access is serialized
         // through the ModelRuntime actor and ModelContainer.perform.
+        trace?.mark("kv_cache_lookup")
         nonisolated(unsafe) let existingCacheInfo: ([any KVCache]?, [Int]?) = {
             if let sid = sessionId {
                 let (sessionCache, tokens) = kvCacheStore.getCache(sessionId: sid, modelName: modelName)
@@ -503,6 +511,8 @@ actor ModelRuntime {
 
         nonisolated(unsafe) let existingCache = existingCacheInfo.0
         let cachedTokens = existingCacheInfo.1
+        trace?.set("cacheHit", existingCache != nil ? (cachedTokens != nil ? "session(\(cachedTokens!.count) tokens)" : "prefix") : "miss")
+        trace?.set("isVLM", holder.isVLM)
 
         let capturedMessages = chatMessages
         let buildChat: @Sendable () -> [MLXLMCommon.Chat.Message] = { capturedMessages }
@@ -525,7 +535,9 @@ actor ModelRuntime {
 
         // Acquire exclusive Metal access after all throwing setup is complete.
         // This ensures the gate is never left locked by a loadContainer failure.
+        trace?.mark("metal_gate_enter")
         await MetalGate.shared.enterGeneration()
+        trace?.mark("metal_gate_acquired")
         if Task.isCancelled {
             await MetalGate.shared.exitGeneration()
             throw CancellationError()
@@ -535,6 +547,7 @@ actor ModelRuntime {
         // The UI shows a spinner; once the first generated token arrives prefillDidFinish() clears it.
         InferenceProgressManager.shared.prefillWillStartAsync(tokenCount: 0)
 
+        trace?.mark("prepare_and_generate_start")
         do {
             let genResult = try await MLXGenerationEngine.prepareAndGenerate(
                 container: holder.container,
@@ -550,6 +563,9 @@ actor ModelRuntime {
                 genResult.stream, genResult.tokenizer, genResult.cache,
                 genResult.promptTokens, genResult.genTask, genResult.toolCallFormat
             )
+            trace?.mark("prepare_and_generate_done")
+            trace?.set("promptTokens", newTokens.count)
+            trace?.set("twoPhase", genResult.snapshotCache != nil)
             // For two-phase prefill, override snapshot with the stable-boundary snapshot.
             if let snapCache = genResult.snapshotCache, let snapTokens = genResult.snapshotTokens {
                 snapshotCacheOverride = (snapCache, snapTokens)

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
@@ -133,7 +133,9 @@ struct MLXGenerationEngine {
             }
         }
 
+        let trace = generation.ttftTrace
         let result: ResultBox = try await container.perform { (context: MLXLMCommon.ModelContext) in
+            trace?.mark("container_perform_entered")
             let chat = preprocessImages(in: buildChat())
             let toolsSpec = buildToolsSpec()
             let parameters = ModelRuntime.makeGenerateParameters(
@@ -158,6 +160,7 @@ struct MLXGenerationEngine {
                 additionalContext: additionalContext
             )
             let fullLMInput: LMInput
+            trace?.mark("tokenization_start")
             do {
                 fullLMInput = try await context.processor.prepare(input: fullInput)
             } catch {
@@ -170,6 +173,7 @@ struct MLXGenerationEngine {
                     userInfo: [NSLocalizedDescriptionKey: "Chat template error: \(detail)"]
                 )
             }
+            trace?.mark("tokenization_done")
 
             var contextWithEOS = context
             let existing = context.configuration.extraEOSTokens
@@ -189,6 +193,7 @@ struct MLXGenerationEngine {
             }
             var cache: [any KVCache]
             var effectiveInput = fullLMInput
+            trace?.mark("cache_reuse_start")
 
             if let existingCache = existingCache, let cachedTokens = cachedTokens, fullLMInput.image == nil,
                 fullLMInput.video == nil
@@ -330,7 +335,10 @@ struct MLXGenerationEngine {
                 "[MLXGenerationEngine] twoPhase=\(useTwoPhase) genPrefixLen=\(genPrefixLen) stableTokens=\(stableTokenCount) canTrim=\(canTrimPromptCache(cache)) hasExisting=\(existingCache != nil)"
             )
 
+            trace?.mark("cache_reuse_done")
+
             if useTwoPhase {
+                trace?.mark("twophase_prefill_start")
                 // ── Phase 1: prefill stableTokens ─────────────────────────────────────
                 // effectiveInput may already be sliced (cache reuse path); recompute against
                 // stableTokenCount to find what still needs processing.
@@ -498,6 +506,7 @@ struct MLXGenerationEngine {
                 genContinuation.onTermination = { @Sendable _ in genTask.cancel() }
 
                 engineLog.info("prepareAndGenerate: twoPhase stream created, returning")
+                trace?.mark("twophase_prefill_done")
 
                 let toolCallFormat = contextWithEOS.configuration.toolCallFormat ?? .json
                 return ResultBox(
@@ -513,6 +522,9 @@ struct MLXGenerationEngine {
             }
 
             // ── Single-phase (standard) path ──────────────────────────────────────────
+            trace?.mark("cache_reuse_done")
+            trace?.mark("singlephase_prefill_start")
+            trace?.set("effectiveTokens", effectiveInput.text.tokens.dim(0))
             engineLog.info(
                 "prepareAndGenerate: constructing TokenIterator effectiveTokens=\(effectiveInput.text.tokens.dim(0), privacy: .public)"
             )
@@ -524,6 +536,7 @@ struct MLXGenerationEngine {
                     parameters: parameters
                 )
             }
+            trace?.mark("singlephase_prefill_done")
             let postPrefillOffset = effectiveCacheOffset(cache)
             debugLog(
                 "[MLXGenerationEngine] post-prefill effectiveCacheOffset=\(postPrefillOffset) cacheCount=\(cache.count) cacheTypes=\(cache.prefix(4).map { type(of: $0) })"

--- a/Packages/OsaurusCore/Utils/TTFTTrace.swift
+++ b/Packages/OsaurusCore/Utils/TTFTTrace.swift
@@ -1,0 +1,98 @@
+//
+//  TTFTTrace.swift
+//  osaurus
+//
+//  Structured TTFT (Time-To-First-Token) phase tracing.
+//  Writes a human-readable timing breakdown to /tmp/osaurus_ttft_trace.log
+//  after each generation completes, so bottlenecks are immediately visible.
+//
+//  Usage:
+//    let trace = TTFTTrace()
+//    trace.mark("phaseName")
+//    // ... do work ...
+//    trace.mark("nextPhase")
+//    trace.set("promptTokens", 3200)
+//    trace.emit()   // writes the full breakdown to disk
+//
+
+import Foundation
+
+final class TTFTTrace: @unchecked Sendable {
+
+    private struct Mark {
+        let name: String
+        let time: CFAbsoluteTime
+    }
+
+    private let created: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
+    private var marks: [Mark] = []
+    private var metadata: [(String, String)] = []
+    private let lock = NSLock()
+
+    private static let path = "/tmp/osaurus_ttft_trace.log"
+
+    /// Record a named checkpoint. Call this at the boundary between phases.
+    func mark(_ name: String) {
+        let now = CFAbsoluteTimeGetCurrent()
+        lock.lock()
+        marks.append(Mark(name: name, time: now))
+        lock.unlock()
+    }
+
+    /// Attach a key-value metric (e.g. token counts, cache hit type).
+    func set(_ key: String, _ value: Any) {
+        lock.lock()
+        metadata.append((key, "\(value)"))
+        lock.unlock()
+    }
+
+    /// Write the full trace block to disk. Call once per generation.
+    func emit() {
+        lock.lock()
+        let snapshot = marks
+        let meta = metadata
+        lock.unlock()
+
+        guard !snapshot.isEmpty else { return }
+
+        var lines: [String] = []
+        let dateStr = ISO8601DateFormatter().string(from: Date())
+        lines.append("═══ TTFT Trace \(dateStr) ═══")
+
+        // Phase durations: time between consecutive marks
+        var prev = created
+        var totalMs: Double = 0
+        for m in snapshot {
+            let ms = (m.time - prev) * 1000
+            totalMs += ms
+            let padded = m.name.padding(toLength: 40, withPad: " ", startingAt: 0)
+            lines.append("  \(padded) \(String(format: "%8.1f", ms)) ms")
+            prev = m.time
+        }
+        let totalPad = "TOTAL".padding(toLength: 40, withPad: " ", startingAt: 0)
+        lines.append("  \(totalPad) \(String(format: "%8.1f", totalMs)) ms")
+
+        // Metadata
+        if !meta.isEmpty {
+            lines.append("  ── metrics ──")
+            for (k, v) in meta {
+                let kPad = k.padding(toLength: 40, withPad: " ", startingAt: 0)
+                lines.append("  \(kPad) \(v)")
+            }
+        }
+        lines.append("")
+
+        let block = lines.joined(separator: "\n") + "\n"
+        guard let data = block.data(using: .utf8) else { return }
+
+        if FileManager.default.fileExists(atPath: Self.path) {
+            if let fh = FileHandle(forWritingAtPath: Self.path) {
+                fh.seekToEndOfFile()
+                fh.write(data)
+                fh.closeFile()
+            }
+        } else {
+            try? data.write(to: URL(fileURLWithPath: Self.path))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -810,7 +810,7 @@ final class ChatSession: ObservableObject {
             // user-only while isStreaming is true and the table early-returns without assistant rows.
             rebuildVisibleBlocks()
             #if DEBUG
-            let ttftTrace = TTFTTrace()
+            let ttftTrace: TTFTTrace? = TTFTTrace()
             #else
             let ttftTrace: TTFTTrace? = nil
             #endif

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -809,13 +809,16 @@ final class ChatSession: ObservableObject {
             // Must refresh block memoizer before first delta — otherwise visibleBlocks stays
             // user-only while isStreaming is true and the table early-returns without assistant rows.
             rebuildVisibleBlocks()
+            let ttftTrace = TTFTTrace()
             do {
                 let engine = chatEngineFactory()
                 let chatCfg = ChatConfigurationStore.load()
 
                 // MARK: - Capability Setup
                 let effectiveAgentId = agentId ?? Agent.defaultId
+                ttftTrace.mark("prepare_exec_mode_start")
                 let executionMode = await prepareChatExecutionMode(agentId: effectiveAgentId)
+                ttftTrace.mark("prepare_exec_mode_done")
                 guard isRunActive(runId) else { return }
 
                 let context = await SystemPromptComposer.composeChatContext(
@@ -823,7 +826,8 @@ final class ChatSession: ObservableObject {
                     executionMode: executionMode,
                     model: selectedModel,
                     query: trimmed,
-                    toolsDisabled: chatCfg.disableTools
+                    toolsDisabled: chatCfg.disableTools,
+                    trace: ttftTrace
                 )
                 guard isRunActive(runId) else { return }
 
@@ -840,6 +844,16 @@ final class ChatSession: ObservableObject {
                 var toolSpecs = context.tools
                 let isManualTools = AgentManager.shared.effectiveToolSelectionMode(for: effectiveAgentId) == .manual
                 cachedContext = context
+
+                // Skip tool injection for local models when preflight found no relevant tools.
+                // Tool definitions are verbose in chat templates (~500 tokens each) and dominate
+                // the prompt token count, causing slow prefill on memory-constrained devices.
+                if context.preflightItems.isEmpty
+                    && !isManualTools
+                    && MLXService.shared.handles(requestedModel: selectedModel)
+                {
+                    toolSpecs = []
+                }
 
                 if !context.preflightItems.isEmpty {
                     assistantTurn.preflightCapabilities = context.preflightItems
@@ -913,9 +927,32 @@ final class ChatSession: ObservableObject {
                 var pendingBudgetNotice: String?
                 let effectiveTemp = AgentManager.shared.effectiveTemperature(for: effectiveAgentId)
 
+                ttftTrace.mark("pre_ttft_done")
+
                 outer: while attempts < maxAttempts {
                     attempts += 1
+                    ttftTrace.mark("build_messages_start")
                     var msgs = buildMessages()
+                    ttftTrace.mark("build_messages_done")
+                    ttftTrace.set("messageCount", msgs.count)
+                    ttftTrace.set("conversationTurns", turns.count)
+
+                    // Dump full prompt to debug log for TTFT analysis
+                    if attempts == 1 {
+                        var promptDump = "═══ FULL PROMPT DUMP ═══\n"
+                        for (i, m) in msgs.enumerated() {
+                            promptDump += "── [\(i)] role=\(m.role) chars=\(m.content?.count ?? 0) ──\n"
+                            promptDump += (m.content ?? "(nil)") + "\n"
+                        }
+                        if let tools = toolSpecs.isEmpty ? nil : toolSpecs {
+                            promptDump += "── TOOLS (\(tools.count)) ──\n"
+                            for t in tools {
+                                promptDump += "  - \(t.function.name): \(t.function.description)\n"
+                            }
+                        }
+                        promptDump += "═══ END PROMPT DUMP ═══"
+                        debugLog(promptDump)
+                    }
                     if let notice = pendingBudgetNotice {
                         msgs.append(ChatMessage(role: "user", content: notice))
                         pendingBudgetNotice = nil
@@ -943,6 +980,7 @@ final class ChatSession: ObservableObject {
                     req.cache_hint = context.cacheHint
                     req.staticPrefix = context.staticPrefix
                     req.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
+                    req.ttftTrace = ttftTrace
                     debugLog(
                         "send: attempt=\(attempts) model=\(req.model) tools=\(req.tools?.count ?? 0) sessionId=\(req.session_id ?? "nil")"
                     )
@@ -961,7 +999,9 @@ final class ChatSession: ObservableObject {
                             self?.rebuildVisibleBlocks()
                         }
 
+                        ttftTrace.mark("engine_streamChat_start")
                         let stream = try await engine.streamChat(request: req)
+                        ttftTrace.mark("engine_streamChat_returned")
                         debugLog("send: got stream, entering delta loop")
                         for try await delta in stream {
                             if !isRunActive(runId) {
@@ -1014,7 +1054,12 @@ final class ChatSession: ObservableObject {
                                 continue
                             }
                             if !delta.isEmpty {
-                                if firstDeltaTime == nil { firstDeltaTime = Date() }
+                                if firstDeltaTime == nil {
+                                    firstDeltaTime = Date()
+                                    ttftTrace.mark("first_text_delta")
+                                    ttftTrace.set("model", selectedModel ?? "unknown")
+                                    ttftTrace.emit()
+                                }
                                 uiDeltaCount += 1
                                 processor.receiveDelta(delta)
                             }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -809,16 +809,20 @@ final class ChatSession: ObservableObject {
             // Must refresh block memoizer before first delta — otherwise visibleBlocks stays
             // user-only while isStreaming is true and the table early-returns without assistant rows.
             rebuildVisibleBlocks()
+            #if DEBUG
             let ttftTrace = TTFTTrace()
+            #else
+            let ttftTrace: TTFTTrace? = nil
+            #endif
             do {
                 let engine = chatEngineFactory()
                 let chatCfg = ChatConfigurationStore.load()
 
                 // MARK: - Capability Setup
                 let effectiveAgentId = agentId ?? Agent.defaultId
-                ttftTrace.mark("prepare_exec_mode_start")
+                ttftTrace?.mark("prepare_exec_mode_start")
                 let executionMode = await prepareChatExecutionMode(agentId: effectiveAgentId)
-                ttftTrace.mark("prepare_exec_mode_done")
+                ttftTrace?.mark("prepare_exec_mode_done")
                 guard isRunActive(runId) else { return }
 
                 let context = await SystemPromptComposer.composeChatContext(
@@ -927,16 +931,17 @@ final class ChatSession: ObservableObject {
                 var pendingBudgetNotice: String?
                 let effectiveTemp = AgentManager.shared.effectiveTemperature(for: effectiveAgentId)
 
-                ttftTrace.mark("pre_ttft_done")
+                ttftTrace?.mark("pre_ttft_done")
 
                 outer: while attempts < maxAttempts {
                     attempts += 1
-                    ttftTrace.mark("build_messages_start")
+                    ttftTrace?.mark("build_messages_start")
                     var msgs = buildMessages()
-                    ttftTrace.mark("build_messages_done")
-                    ttftTrace.set("messageCount", msgs.count)
-                    ttftTrace.set("conversationTurns", turns.count)
+                    ttftTrace?.mark("build_messages_done")
+                    ttftTrace?.set("messageCount", msgs.count)
+                    ttftTrace?.set("conversationTurns", turns.count)
 
+                    #if DEBUG
                     // Dump full prompt to debug log for TTFT analysis
                     if attempts == 1 {
                         var promptDump = "═══ FULL PROMPT DUMP ═══\n"
@@ -953,6 +958,7 @@ final class ChatSession: ObservableObject {
                         promptDump += "═══ END PROMPT DUMP ═══"
                         debugLog(promptDump)
                     }
+                    #endif
                     if let notice = pendingBudgetNotice {
                         msgs.append(ChatMessage(role: "user", content: notice))
                         pendingBudgetNotice = nil
@@ -985,7 +991,6 @@ final class ChatSession: ObservableObject {
                         "send: attempt=\(attempts) model=\(req.model) tools=\(req.tools?.count ?? 0) sessionId=\(req.session_id ?? "nil")"
                     )
                     do {
-                        let streamStartTime = Date()
                         var uiDeltaCount = 0
                         var firstDeltaTime: Date?
 
@@ -999,9 +1004,12 @@ final class ChatSession: ObservableObject {
                             self?.rebuildVisibleBlocks()
                         }
 
-                        ttftTrace.mark("engine_streamChat_start")
+                        ttftTrace?.mark("engine_streamChat_start")
                         let stream = try await engine.streamChat(request: req)
-                        ttftTrace.mark("engine_streamChat_returned")
+                        ttftTrace?.mark("engine_streamChat_returned")
+                        // Start TTFT timer after model is loaded and stream is ready.
+                        // This excludes model loading time from the displayed TTFT.
+                        let streamStartTime = Date()
                         debugLog("send: got stream, entering delta loop")
                         for try await delta in stream {
                             if !isRunActive(runId) {
@@ -1056,9 +1064,9 @@ final class ChatSession: ObservableObject {
                             if !delta.isEmpty {
                                 if firstDeltaTime == nil {
                                     firstDeltaTime = Date()
-                                    ttftTrace.mark("first_text_delta")
-                                    ttftTrace.set("model", selectedModel ?? "unknown")
-                                    ttftTrace.emit()
+                                    ttftTrace?.mark("first_text_delta")
+                                    ttftTrace?.set("model", selectedModel ?? "unknown")
+                                    ttftTrace?.emit()
                                 }
                                 uiDeltaCount += 1
                                 processor.receiveDelta(delta)

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -10,6 +10,7 @@
 //
 
 import AppKit
+import Combine
 import QuartzCore
 
 // MARK: - NativeTypingIndicatorView
@@ -23,6 +24,7 @@ final class NativeTypingIndicatorView: NSView {
     private let memoryIcon = NSImageView()
     private let memoryLabel = NSTextField(labelWithString: "")
     private var memoryStack: NSStackView?
+    private let loadingLabel = NSTextField(labelWithString: "")
 
     // MARK: Animation
 
@@ -34,6 +36,7 @@ final class NativeTypingIndicatorView: NSView {
     // MARK: State
 
     private var theme: (any ThemeProtocol)?
+    private var isShowingLoadingLabel = false
 
     // MARK: Init
 
@@ -42,6 +45,7 @@ final class NativeTypingIndicatorView: NSView {
         buildViews()
         startAnimation()
         observeMemory()
+        observeModelLoading()
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -90,6 +94,18 @@ final class NativeTypingIndicatorView: NSView {
             dotStack.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
+        // "Loading Model..." label (hidden by default, shown during model load)
+        loadingLabel.stringValue = "Loading Model..."
+        loadingLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        loadingLabel.textColor = .secondaryLabelColor
+        loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+        loadingLabel.isHidden = true
+        addSubview(loadingLabel)
+        NSLayoutConstraint.activate([
+            loadingLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            loadingLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
         // height is controlled by the parent cell — no fixed height constraint here
     }
 
@@ -107,8 +123,24 @@ final class NativeTypingIndicatorView: NSView {
         updateMemoryLabel(monitor: monitor)
     }
 
+    private func observeModelLoading() {
+        let manager = InferenceProgressManager.shared
+        let sink = manager.$isLoadingModel.receive(on: DispatchQueue.main).sink { [weak self] loading in
+            self?.setLoadingModelState(loading)
+        }
+        cancellables.append(sink)
+    }
+
+    private func setLoadingModelState(_ loading: Bool) {
+        guard loading != isShowingLoadingLabel else { return }
+        isShowingLoadingLabel = loading
+        loadingLabel.isHidden = !loading
+        dotStack.isHidden = loading
+        memoryStack?.isHidden = loading
+    }
+
     private func updateMemoryLabel(monitor: SystemMonitorService) {
-        guard monitor.totalMemoryGB > 0 else {
+        guard monitor.totalMemoryGB > 0, !isShowingLoadingLabel else {
             memoryStack?.isHidden = true
             return
         }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1885,7 +1885,7 @@ enum NativeCellHeightEstimator {
             return h + 12 + 24
 
         case let .chart(spec):
-            var h: CGFloat = NativeChartView.cardPadding + NativeChartView.chartHeight + 12 // top pad + chart + cell insets
+            var h: CGFloat = NativeChartView.cardPadding + NativeChartView.chartHeight + 12
             h += (spec.title ?? "").isEmpty ? 0 : (20 + 4)   // title + gap
             h += (spec.note  ?? "").isEmpty
                 ? NativeChartView.cardPadding                  // bottom padding only


### PR DESCRIPTION
## Summary

Fixes the root causes of slow Time-To-First-Token (TTFT) on local MLX models, particularly on memory constrained devices. 

## Changes

  - Fixed sandbox plugin creator guard by requirinh `canCreatePlugins()` to have both ```config.enabled && config.pluginCreate```  instead of just `pluginCreate`. This prevented the 4.2k characters `Sandbox Plugin Creator skill` from being injected when the sandbox toggle is off.                                    
  - Removed preflight no-match fallback so that when preflight search finds no relevant tools, it returns .empty instead of injecting the full `Sandbox Plugin Creator skill` into every unrelated prompt
  - Skip tool injection for local models in the system prompt entirely. When preflight finds no relevant tools and the model is a local MLX model, all 9 tool specs (~4300 tokens) are now dropped from the system prompt.
  - Preflight LLM call will now be skipped for local models since tools are stripped anyway                
  - Fixed TTFT math by moving `streamStartTime` to after `engine.streamChat()`. This was incorrectly measuring TTFT by including the model loading time as well.  Now the displayed TTFT reflects inference time only not model loading                              
  - Added "Loading Model..." indicator in the assistant message
  cell during `loadContainer` which signifies that the model is still initializing and not ready for inference just yet. It will transition to the three dot indicator once the model is ready and prefill begins (this is when it actually starts processing the prompt and this also the timestamp from which TTFT will be measured)    
  - Added TTFT trace instrumentation (debug-only) to write structured phase timings to `/tmp/osaurus_ttft_trace.log` with full prompt dump to `/tmp/osaurus_debug.log` gated behind `#if DEBUG`

NOTE: the local models can still use tool calls mid conversation via `capabilities_search → capabilities_load`

*Before*

16s TTFT for a simple prompt

<img width="1118" height="263" alt="image" src="https://github.com/user-attachments/assets/bac52098-8a8e-4830-9343-d1fdb4e1b5b1" />

*After*

<1s TTFT for the same prompt

<img width="782" height="205" alt="image" src="https://github.com/user-attachments/assets/3ffa91f5-ba10-4915-812c-ff315c617e37" />

<img width="775" height="244" alt="image" src="https://github.com/user-attachments/assets/322ed390-5a1e-463e-8dba-1a604efb7857" />

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
