### PR TITLE
ci: add practical PR validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,50 @@ jobs:
           -skip-testing OsaurusCoreTests/KVCacheStoreTests
           -skip-testing OsaurusCoreTests/MLXGenerationEngineTests
 
+  build-app:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      WORKSPACE: osaurus.xcworkspace
+      SPM_CACHE: .spm-cache
+      DERIVED_DATA: build/DerivedData-ci
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
+      - name: Cache SPM packages
+        uses: actions/cache@v4
+        with:
+          path: .spm-cache
+          key: spm-${{ runner.os }}-${{ hashFiles('osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
+      - name: Resolve dependencies
+        run: >-
+          xcodebuild -resolvePackageDependencies
+          -workspace $WORKSPACE
+          -scheme osaurus
+          -clonedSourcePackagesDirPath $SPM_CACHE
+
+      - name: Build osaurus app
+        run: >-
+          xcodebuild build
+          -workspace $WORKSPACE
+          -scheme osaurus
+          -configuration Debug
+          -disableAutomaticPackageResolution
+          -clonedSourcePackagesDirPath $SPM_CACHE
+          -derivedDataPath $DERIVED_DATA
+          CODE_SIGNING_ALLOWED=NO
+          CODE_SIGNING_REQUIRED=NO
+
   test-cli:
     runs-on: macos-latest
     timeout-minutes: 45

--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ lefthook install
 
 This installs a `pre-push` hook that runs `swift-format` over the `Packages/` directory before each push.
 
+For PR-ready branches, run the practical validation lane before pushing updates:
+
+```bash
+scripts/validate_pr_branch.sh \
+  --test-filter 'AttachedDocumentToolsTests|ChatViewSandboxTests' \
+  --launch-check
+```
+
+The helper expects a clean working tree and will fail if the branch already has
+uncommitted changes or if the build/test steps leave tracked drift behind.
+
+Use the workspace build path, not `xcodebuild -project`, so package resolution stays aligned with `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ scripts/validate_pr_branch.sh \
 
 The helper expects a clean working tree and will fail if the branch already has
 uncommitted changes or if the build/test steps leave tracked drift behind.
+It lints only the Swift files touched by the PR branch relative to the default
+base branch, so unrelated formatting debt already present on `main` does not
+block a clean feature branch.
 
 Use the workspace build path, not `xcodebuild -project`, so package resolution stays aligned with `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`.
 

--- a/scripts/validate_pr_branch.sh
+++ b/scripts/validate_pr_branch.sh
@@ -166,8 +166,11 @@ fi
 
 require_command git
 require_command swift
-require_command swift-format
 require_command xcodebuild
+
+if (( skip_lint == 0 )); then
+  require_command swift-format
+fi
 
 if (( launch_check == 1 )); then
   require_command open

--- a/scripts/validate_pr_branch.sh
+++ b/scripts/validate_pr_branch.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validate_pr_branch.sh [options]
+
+Run the practical validation lane for an Osaurus PR branch:
+  - git whitespace check
+  - swift-format lint
+  - focused Swift package tests
+  - workspace app build
+  - optional app launch smoke check
+
+Options:
+  --repo-root PATH          Validate a different worktree or checkout
+  --test-filter FILTER      Swift test filter; repeatable, combined with |
+  --scratch-path PATH       SwiftPM scratch path
+  --derived-data-path PATH  Xcode DerivedData path
+  --scheme NAME             Xcode scheme to build (default: osaurus)
+  --skip-lint               Skip swift-format lint
+  --skip-tests              Skip Swift package tests
+  --skip-build              Skip workspace app build
+  --launch-check            Launch the built app and verify the process starts
+  --clean                   Remove the derived-data and scratch paths first
+  --help                    Show this help
+
+Examples:
+  scripts/validate_pr_branch.sh \
+    --test-filter 'AttachedDocumentToolsTests|ChatViewSandboxTests' \
+    --launch-check
+
+  scripts/validate_pr_branch.sh \
+    --repo-root ../other-worktree \
+    --test-filter 'FileImportRegistryTests|PluginManifestDecodingTests'
+EOF
+}
+
+log_step() {
+  printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+require_clean_worktree() {
+  local status
+  status="$(git status --short --untracked-files=all)"
+  if [[ -n "$status" ]]; then
+    echo "Working tree must be clean before validation:" >&2
+    echo "$status" >&2
+    exit 1
+  fi
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+scheme="osaurus"
+scratch_path=""
+derived_data_path=""
+skip_lint=0
+skip_tests=0
+skip_build=0
+launch_check=0
+clean_paths=0
+declare -a test_filters=()
+
+while (($# > 0)); do
+  case "$1" in
+    --repo-root)
+      repo_root="$2"
+      shift 2
+      ;;
+    --test-filter)
+      test_filters+=("$2")
+      shift 2
+      ;;
+    --scratch-path)
+      scratch_path="$2"
+      shift 2
+      ;;
+    --derived-data-path)
+      derived_data_path="$2"
+      shift 2
+      ;;
+    --scheme)
+      scheme="$2"
+      shift 2
+      ;;
+    --skip-lint)
+      skip_lint=1
+      shift
+      ;;
+    --skip-tests)
+      skip_tests=1
+      shift
+      ;;
+    --skip-build)
+      skip_build=1
+      shift
+      ;;
+    --launch-check)
+      launch_check=1
+      shift
+      ;;
+    --clean)
+      clean_paths=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$repo_root" && pwd)"
+workspace_path="$repo_root/osaurus.xcworkspace"
+package_path="$repo_root/Packages/OsaurusCore"
+scratch_path="${scratch_path:-/tmp/osaurus-pr-validation-$(basename "$repo_root")-tests}"
+derived_data_path="${derived_data_path:-$repo_root/build/DerivedData-pr-validation}"
+app_path="$derived_data_path/Build/Products/Debug/osaurus.app"
+app_binary="$app_path/Contents/MacOS/osaurus"
+
+if (( skip_tests == 0 )) && ((${#test_filters[@]} == 0)); then
+  echo "At least one --test-filter is required unless --skip-tests is used." >&2
+  exit 2
+fi
+
+require_command git
+require_command swift
+require_command swift-format
+require_command xcodebuild
+
+if (( launch_check == 1 )); then
+  require_command open
+  require_command pgrep
+fi
+
+if [[ ! -d "$workspace_path" ]]; then
+  echo "Workspace not found: $workspace_path" >&2
+  exit 1
+fi
+
+if [[ ! -f "$package_path/Package.swift" ]]; then
+  echo "Swift package not found: $package_path" >&2
+  exit 1
+fi
+
+if (( clean_paths == 1 )); then
+  log_step "Cleaning prior build state"
+  rm -rf "$scratch_path" "$derived_data_path"
+fi
+
+cd "$repo_root"
+
+log_step "Checking worktree cleanliness"
+require_clean_worktree
+
+log_step "Checking git diff formatting"
+git diff --check
+
+if (( skip_lint == 0 )); then
+  log_step "Running swift-format lint"
+  swift-format lint --strict --recursive Packages App
+fi
+
+if (( skip_tests == 0 )); then
+  test_filter_regex="${test_filters[0]}"
+  if ((${#test_filters[@]} > 1)); then
+    for filter in "${test_filters[@]:1}"; do
+      test_filter_regex="${test_filter_regex}|${filter}"
+    done
+  fi
+
+  log_step "Running focused Swift package tests"
+  swift test \
+    --package-path "$package_path" \
+    --scratch-path "$scratch_path" \
+    --filter "$test_filter_regex"
+fi
+
+if (( skip_build == 0 )); then
+  log_step "Building app from workspace"
+  xcodebuild \
+    -workspace "$workspace_path" \
+    -scheme "$scheme" \
+    -configuration Debug \
+    -destination 'platform=macOS,arch=arm64' \
+    -derivedDataPath "$derived_data_path" \
+    CODE_SIGNING_ALLOWED=NO \
+    CODE_SIGNING_REQUIRED=NO \
+    build
+fi
+
+if (( launch_check == 1 )); then
+  log_step "Launching built app for smoke check"
+  if [[ ! -d "$app_path" ]]; then
+    echo "Built app not found at $app_path" >&2
+    exit 1
+  fi
+
+  existing_pids="$(pgrep -f "$app_binary" || true)"
+  if [[ -n "$existing_pids" ]]; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] || continue
+      kill "$pid" || true
+    done <<<"$existing_pids"
+    sleep 2
+  fi
+
+  /usr/bin/open -n "$app_path"
+  sleep 5
+  launched_pid="$(pgrep -f "$app_binary" | head -n 1 || true)"
+  if [[ -z "$launched_pid" ]]; then
+    echo "Launch check failed for $app_binary" >&2
+    exit 1
+  fi
+  echo "Launch check passed with PID $launched_pid"
+  kill "$launched_pid" || true
+fi
+
+log_step "Re-checking worktree cleanliness"
+require_clean_worktree
+
+log_step "Validation complete"

--- a/scripts/validate_pr_branch.sh
+++ b/scripts/validate_pr_branch.sh
@@ -40,6 +40,35 @@ log_step() {
   printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
 }
 
+resolve_base_ref() {
+  local candidate
+  for candidate in upstream/main origin/main upstream/master origin/master; do
+    if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+collect_swift_lint_targets() {
+  local base_ref merge_base path
+
+  if ! base_ref="$(resolve_base_ref)"; then
+    return 1
+  fi
+
+  merge_base="$(git merge-base HEAD "$base_ref")"
+  git diff --name-only --diff-filter=ACMR "$merge_base"...HEAD -- . \
+    | while IFS= read -r path; do
+      case "$path" in
+        *.swift|Package.swift)
+          printf '%s\n' "$path"
+          ;;
+      esac
+    done
+}
+
 require_clean_worktree() {
   local status
   status="$(git status --short --untracked-files=all)"
@@ -170,7 +199,22 @@ git diff --check
 
 if (( skip_lint == 0 )); then
   log_step "Running swift-format lint"
-  swift-format lint --strict --recursive Packages App
+  lint_targets=()
+  while IFS= read -r lint_target; do
+    [[ -n "$lint_target" ]] || continue
+    lint_targets+=("$lint_target")
+  done < <(collect_swift_lint_targets || true)
+
+  if ((${#lint_targets[@]} > 0)); then
+    swift-format lint --strict "${lint_targets[@]}"
+  else
+    if resolve_base_ref >/dev/null 2>&1; then
+      echo "No PR-local Swift files changed; skipping swift-format lint."
+    else
+      echo "Could not resolve a base ref for diff-aware linting; falling back to full tree."
+      swift-format lint --strict --recursive Packages App
+    fi
+  fi
 fi
 
 if (( skip_tests == 0 )); then

--- a/scripts/validate_pr_branch.sh
+++ b/scripts/validate_pr_branch.sh
@@ -62,7 +62,7 @@ collect_swift_lint_targets() {
   git diff --name-only --diff-filter=ACMR "$merge_base"...HEAD -- . \
     | while IFS= read -r path; do
       case "$path" in
-        *.swift|Package.swift)
+        *.swift)
           printf '%s\n' "$path"
           ;;
       esac

--- a/scripts/validate_pr_branch.sh
+++ b/scripts/validate_pr_branch.sh
@@ -86,6 +86,25 @@ require_command() {
   fi
 }
 
+require_swift_format() {
+  if command -v swift-format >/dev/null 2>&1; then
+    return 0
+  fi
+  if xcrun --find swift-format >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "Missing required command: swift-format" >&2
+  exit 1
+}
+
+run_swift_format() {
+  if command -v swift-format >/dev/null 2>&1; then
+    swift-format "$@"
+    return
+  fi
+  xcrun swift-format "$@"
+}
+
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 scheme="osaurus"
 scratch_path=""
@@ -169,7 +188,7 @@ require_command swift
 require_command xcodebuild
 
 if (( skip_lint == 0 )); then
-  require_command swift-format
+  require_swift_format
 fi
 
 if (( launch_check == 1 )); then
@@ -209,13 +228,13 @@ if (( skip_lint == 0 )); then
   done < <(collect_swift_lint_targets || true)
 
   if ((${#lint_targets[@]} > 0)); then
-    swift-format lint --strict "${lint_targets[@]}"
+    run_swift_format lint --strict "${lint_targets[@]}"
   else
     if resolve_base_ref >/dev/null 2>&1; then
       echo "No PR-local Swift files changed; skipping swift-format lint."
     else
       echo "Could not resolve a base ref for diff-aware linting; falling back to full tree."
-      swift-format lint --strict --recursive Packages App
+      run_swift_format lint --strict --recursive Packages App
     fi
   fi
 fi


### PR DESCRIPTION
## Summary
- add a repo-owned `scripts/validate_pr_branch.sh` helper for practical PR validation
- make the validation lane check clean worktree state, whitespace, branch-local formatting, focused tests, workspace build, optional launch, and post-run cleanliness
- document the local validation lane in the README

## Why This Matters
### Business reason
PR credibility drops fast when branches only work in theory. This adds a repeatable practical gate so contributors can prove a branch compiles, launches, and stays clean before asking for review.

### Programming reason
The validator checks the branch under review, not a different checkout and not the whole repo. The latest update also scopes formatting checks to PR-local Swift files, which prevents unrelated lint debt already on `main` from creating false negatives.

## Scope
Included:
- `scripts/validate_pr_branch.sh`
- README guidance for the validation lane
- diff-aware Swift formatting checks relative to the base branch
- Bash 3 compatible implementation for macOS default shells

## Validation
Validated on branch head `30082fc4`.

Results:
- script syntax check passed
- `git diff --check` passed
- the validator was used successfully against rebuilt `#832`, `#840`, `#846`, and `#848`
- those runs proved branch-local formatting, focused tests, workspace builds, launch smoke checks, and post-run cleanliness on real PR branches

Exact evidence is in the validation comment on the PR.
