### PR TITLE
Improve work prompt tool guidance foundation

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/HarnessReliabilityFlags.swift
+++ b/Packages/OsaurusCore/Services/Chat/HarnessReliabilityFlags.swift
@@ -1,0 +1,62 @@
+//
+//  HarnessReliabilityFlags.swift
+//  osaurus
+//
+//  Internal rollout switches for staged harness improvements.
+//
+
+import Foundation
+
+enum HarnessReliabilityFlag: String {
+    case toolPromptFoundation = "HarnessReliability.ToolPromptFoundationEnabled"
+
+    var environmentVariable: String {
+        switch self {
+        case .toolPromptFoundation:
+            return "OSAURUS_HARNESS_TOOL_PROMPT_FOUNDATION"
+        }
+    }
+}
+
+@MainActor
+enum HarnessReliabilityFlags {
+    private static var overrides: [HarnessReliabilityFlag: Bool] = [:]
+
+    static func isEnabled(_ flag: HarnessReliabilityFlag) -> Bool {
+        if let override = overrides[flag] {
+            return override
+        }
+        if let envValue = ProcessInfo.processInfo.environment[flag.environmentVariable] {
+            return parseBool(envValue) ?? false
+        }
+        return UserDefaults.standard.object(forKey: flag.rawValue) as? Bool ?? false
+    }
+
+    static func withOverride<T>(
+        _ enabled: Bool,
+        for flag: HarnessReliabilityFlag,
+        perform: () throws -> T
+    ) rethrows -> T {
+        let previous = overrides[flag]
+        overrides[flag] = enabled
+        defer {
+            if let previous {
+                overrides[flag] = previous
+            } else {
+                overrides.removeValue(forKey: flag)
+            }
+        }
+        return try perform()
+    }
+
+    private static func parseBool(_ raw: String) -> Bool? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -216,6 +216,7 @@ public struct SystemPromptComposer: Sendable {
     }
 
     /// Compose a work prompt from a pre-resolved base string (e.g. base+memory from WorkEngine).
+    @MainActor
     public static func composeWorkPrompt(
         base: String,
         executionMode: WorkExecutionMode,
@@ -348,6 +349,7 @@ public struct SystemPromptComposer: Sendable {
         return composer.withWorkSections(executionMode: executionMode, compact: compact, secretNames: secretNames)
     }
 
+    @MainActor
     static func forWork(
         base: String,
         executionMode: WorkExecutionMode,
@@ -359,6 +361,7 @@ public struct SystemPromptComposer: Sendable {
         return composer.withWorkSections(executionMode: executionMode, compact: compact, secretNames: secretNames)
     }
 
+    @MainActor
     private func withWorkSections(
         executionMode: WorkExecutionMode,
         compact: Bool,
@@ -379,6 +382,15 @@ public struct SystemPromptComposer: Sendable {
                     id: "sandbox",
                     label: "Sandbox",
                     content: SystemPromptTemplates.sandbox(mode: .work, compact: compact, secretNames: secretNames)
+                )
+            )
+        }
+        if HarnessReliabilityFlags.isEnabled(.toolPromptFoundation) {
+            result.append(
+                .static(
+                    id: "toolGuide",
+                    label: "Tool Guide",
+                    content: ToolRegistry.shared.workPromptGuide(mode: executionMode, compact: compact)
                 )
             )
         }

--- a/Packages/OsaurusCore/Tests/Work/WorkExecutionEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Work/WorkExecutionEngineTests.swift
@@ -56,7 +56,7 @@ struct WorkExecutionEngineTests {
         #expect((decoded["stderr"] as? String)?.contains(WorkExecutionEngine.truncationOmissionMarker) == true)
     }
 
-    @Test func buildAgentSystemPrompt_sandboxIncludesWorkflowGuidance() async {
+    @Test @MainActor func buildAgentSystemPrompt_sandboxIncludesWorkflowGuidance() async {
         let (prompt, _) = SystemPromptComposer.composeWorkPrompt(
             base: "Base prompt",
             executionMode: .sandbox

--- a/Packages/OsaurusCore/Tests/Work/WorkPromptToolGuideTests.swift
+++ b/Packages/OsaurusCore/Tests/Work/WorkPromptToolGuideTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct WorkPromptToolGuideTests {
+    @Test
+    func toolGuideIsDisabledByDefault() {
+        let context = WorkFolderContext(
+            rootPath: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString),
+            projectType: .swift,
+            tree: "./\nPackage.swift\nSources/\n",
+            manifest: "Package.swift",
+            gitStatus: "## main\n M Sources/App.swift",
+            isGitRepo: true
+        )
+
+        let (prompt, _) = SystemPromptComposer.composeWorkPrompt(
+            base: "Base prompt",
+            executionMode: .hostFolder(context)
+        )
+
+        #expect(!prompt.contains("## Tool Guide"))
+    }
+
+    @Test
+    func hostFolderPromptIncludesBudgetedToolGuide() throws {
+        let context = WorkFolderContext(
+            rootPath: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString),
+            projectType: .swift,
+            tree: "./\nPackage.swift\nSources/\n",
+            manifest: "Package.swift",
+            gitStatus: "## main\n M Sources/App.swift",
+            isGitRepo: true
+        )
+
+        let prompt = HarnessReliabilityFlags.withOverride(true, for: .toolPromptFoundation) {
+            let (prompt, _) = SystemPromptComposer.composeWorkPrompt(
+                base: "Base prompt",
+                executionMode: .hostFolder(context)
+            )
+            return prompt
+        }
+
+        #expect(prompt.contains("## Tool Guide"))
+        #expect(prompt.contains("`file_read`"))
+        #expect(prompt.contains("`file_edit`"))
+        #expect(prompt.contains("`shell_run`"))
+        #expect(prompt.contains("`complete_task`"))
+        #expect(prompt.contains("`share_artifact`"))
+    }
+
+    @Test
+    func compactToolGuideStaysWithinBudget() {
+        let context = WorkFolderContext(
+            rootPath: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString),
+            projectType: .swift,
+            tree: "./\nPackage.swift\nSources/\n",
+            manifest: "Package.swift",
+            gitStatus: "## main\n M Sources/App.swift",
+            isGitRepo: true
+        )
+
+        let guide = HarnessReliabilityFlags.withOverride(true, for: .toolPromptFoundation) {
+            ToolRegistry.shared.workPromptGuide(mode: .hostFolder(context), compact: true)
+        }
+
+        #expect(guide.contains("## Tool Guide"))
+        #expect(guide.count <= ToolMetadataCatalog.promptGuideBudget(compact: true))
+    }
+}
+
+struct ToolPromptCardTests {
+    @Test
+    func sanitizesPromptInjectedMarkup() {
+        let metadata = ToolMetadata(
+            purpose: "Read the file",
+            whenToUse: "checking the implementation",
+            avoidWhen: "editing unread files",
+            example: "```json\n{\"path\":\"App.swift\"}\n```",
+            promptPriority: 50
+        )
+
+        let card = ToolPromptCard(
+            name: "file_read\n## injected",
+            description: "Read a file\n## injected",
+            metadata: metadata
+        )
+        let rendered = card.render(compact: false)
+
+        #expect(!rendered.contains("```"))
+        #expect(!rendered.contains("\n## injected"))
+        #expect(rendered.contains("`file_read ## injected`"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Work/WorkPromptToolGuideTests.swift
+++ b/Packages/OsaurusCore/Tests/Work/WorkPromptToolGuideTests.swift
@@ -53,6 +53,23 @@ struct WorkPromptToolGuideTests {
     }
 
     @Test
+    func sandboxPromptIncludesBudgetedToolGuide() {
+        let prompt = HarnessReliabilityFlags.withOverride(true, for: .toolPromptFoundation) {
+            let (prompt, _) = SystemPromptComposer.composeWorkPrompt(
+                base: "Base prompt",
+                executionMode: .sandbox
+            )
+            return prompt
+        }
+
+        #expect(prompt.contains("## Tool Guide"))
+        #expect(prompt.contains("`sandbox_read_file`"))
+        #expect(prompt.contains("`sandbox_edit_file`"))
+        #expect(prompt.contains("`sandbox_exec`"))
+        #expect(prompt.contains("`complete_task`"))
+    }
+
+    @Test
     func compactToolGuideStaysWithinBudget() {
         let context = WorkFolderContext(
             rootPath: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString),
@@ -93,5 +110,26 @@ struct ToolPromptCardTests {
         #expect(!rendered.contains("```"))
         #expect(!rendered.contains("\n## injected"))
         #expect(rendered.contains("`file_read ## injected`"))
+    }
+
+    @Test
+    func preservesMoreExampleRoomInNonCompactMode() {
+        let longExample =
+            #"{"path":"Sources/App.swift","replacement":"let result = input.filter { value in value.isLetter || value.isNumber || value == "-" || value == "_" }","notes":"keep enough structured context so longer examples survive non-compact rendering"}"#
+        let metadata = ToolMetadata(
+            purpose: "Read the file",
+            example: longExample,
+            promptPriority: 50
+        )
+
+        let card = ToolPromptCard(
+            name: "file_read",
+            description: "Read a file",
+            metadata: metadata
+        )
+
+        let rendered = card.render(compact: false)
+        #expect(rendered.contains("replacement"))
+        #expect(rendered.contains("structured context"))
     }
 }

--- a/Packages/OsaurusCore/Tools/OsaurusTool.swift
+++ b/Packages/OsaurusCore/Tools/OsaurusTool.swift
@@ -14,12 +14,18 @@ protocol OsaurusTool: Sendable {
     var description: String { get }
     /// JSON schema for function parameters (OpenAI-compatible minimal subset)
     var parameters: JSONValue? { get }
+    /// Internal metadata for budgeted prompt guidance and future scheduling.
+    var promptMetadata: ToolMetadata? { get }
 
     /// Execute the tool with arguments provided as a JSON string
     func execute(argumentsJSON: String) async throws -> String
 }
 
 extension OsaurusTool {
+    var promptMetadata: ToolMetadata? {
+        ToolMetadataCatalog.metadata(for: name)
+    }
+
     /// Build OpenAI-compatible Tool specification
     func asOpenAITool() -> Tool {
         Tool(

--- a/Packages/OsaurusCore/Tools/ToolPromptSupport.swift
+++ b/Packages/OsaurusCore/Tools/ToolPromptSupport.swift
@@ -53,6 +53,10 @@ struct ToolMetadata: Sendable, Equatable {
 }
 
 struct ToolPromptCard: Sendable, Equatable {
+    private static let summaryMaxLength = 160
+    private static let detailMaxLength = 160
+    private static let nonCompactExampleMaxLength = 320
+
     let name: String
     let summary: String
     let whenToUse: String?
@@ -63,10 +67,13 @@ struct ToolPromptCard: Sendable, Equatable {
     init(name: String, description: String, metadata: ToolMetadata) {
         self.name = Self.sanitize(name, maxLength: 80)
         let fallbackSummary = description.isEmpty ? metadata.purpose : description
-        self.summary = Self.sanitize(metadata.purpose.isEmpty ? fallbackSummary : metadata.purpose, maxLength: 160)
-        self.whenToUse = Self.optionalSanitize(metadata.whenToUse, maxLength: 160)
-        self.avoidWhen = Self.optionalSanitize(metadata.avoidWhen, maxLength: 160)
-        self.example = Self.optionalSanitize(metadata.example, maxLength: 160)
+        self.summary = Self.sanitize(
+            metadata.purpose.isEmpty ? fallbackSummary : metadata.purpose,
+            maxLength: Self.summaryMaxLength
+        )
+        self.whenToUse = Self.optionalSanitize(metadata.whenToUse, maxLength: Self.detailMaxLength)
+        self.avoidWhen = Self.optionalSanitize(metadata.avoidWhen, maxLength: Self.detailMaxLength)
+        self.example = Self.optionalSanitize(metadata.example, maxLength: Self.nonCompactExampleMaxLength)
         self.promptPriority = metadata.promptPriority
     }
 
@@ -372,14 +379,16 @@ enum ToolMetadataCatalog {
         toolDescriptions: [String: String],
         executionMode: WorkExecutionMode
     ) -> [ToolPromptCard] {
-        let orderedNames = orderedPromptToolNames(for: executionMode)
+        let candidateNames = candidatePromptToolNames(for: executionMode)
         var seen = Set<String>()
 
-        return orderedNames.compactMap { name in
+        return candidateNames.compactMap { name in
             guard seen.insert(name).inserted, let metadata = metadata(for: name) else { return nil }
             let description = toolDescriptions[name] ?? metadata.purpose
             return ToolPromptCard(name: name, description: description, metadata: metadata)
         }
+        // Candidate enumeration decides inclusion and de-duplication. Final card order is
+        // always driven by prompt priority so the rendered guide stays predictable.
         .sorted {
             if $0.promptPriority != $1.promptPriority {
                 return $0.promptPriority > $1.promptPriority
@@ -388,7 +397,7 @@ enum ToolMetadataCatalog {
         }
     }
 
-    private static func orderedPromptToolNames(for executionMode: WorkExecutionMode) -> [String] {
+    private static func candidatePromptToolNames(for executionMode: WorkExecutionMode) -> [String] {
         let core = [
             "complete_task",
             "share_artifact",

--- a/Packages/OsaurusCore/Tools/ToolPromptSupport.swift
+++ b/Packages/OsaurusCore/Tools/ToolPromptSupport.swift
@@ -1,0 +1,434 @@
+//
+//  ToolPromptSupport.swift
+//  osaurus
+//
+//  Internal metadata and rendering helpers for concise tool guidance inside
+//  work-mode system prompts.
+//
+
+import Foundation
+
+struct ToolMetadata: Sendable, Equatable {
+    enum ConcurrencyClass: String, Sendable {
+        case readOnly
+        case workspaceWrite
+        case shell
+        case coordination
+        case completion
+        case externalSideEffect
+        case unknown
+    }
+
+    let purpose: String
+    let whenToUse: String?
+    let avoidWhen: String?
+    let preconditions: [String]
+    let sideEffects: [String]
+    let refusalGuidance: String?
+    let example: String?
+    let concurrencyClass: ConcurrencyClass
+    let promptPriority: Int
+
+    init(
+        purpose: String,
+        whenToUse: String? = nil,
+        avoidWhen: String? = nil,
+        preconditions: [String] = [],
+        sideEffects: [String] = [],
+        refusalGuidance: String? = nil,
+        example: String? = nil,
+        concurrencyClass: ConcurrencyClass = .unknown,
+        promptPriority: Int
+    ) {
+        self.purpose = purpose
+        self.whenToUse = whenToUse
+        self.avoidWhen = avoidWhen
+        self.preconditions = preconditions
+        self.sideEffects = sideEffects
+        self.refusalGuidance = refusalGuidance
+        self.example = example
+        self.concurrencyClass = concurrencyClass
+        self.promptPriority = promptPriority
+    }
+}
+
+struct ToolPromptCard: Sendable, Equatable {
+    let name: String
+    let summary: String
+    let whenToUse: String?
+    let avoidWhen: String?
+    let example: String?
+    let promptPriority: Int
+
+    init(name: String, description: String, metadata: ToolMetadata) {
+        self.name = Self.sanitize(name, maxLength: 80)
+        let fallbackSummary = description.isEmpty ? metadata.purpose : description
+        self.summary = Self.sanitize(metadata.purpose.isEmpty ? fallbackSummary : metadata.purpose, maxLength: 160)
+        self.whenToUse = Self.optionalSanitize(metadata.whenToUse, maxLength: 160)
+        self.avoidWhen = Self.optionalSanitize(metadata.avoidWhen, maxLength: 160)
+        self.example = Self.optionalSanitize(metadata.example, maxLength: 160)
+        self.promptPriority = metadata.promptPriority
+    }
+
+    func render(compact: Bool) -> String {
+        var parts = ["- `\(name)`: \(summary)."]
+        if let whenToUse, !whenToUse.isEmpty {
+            parts.append("Use when \(whenToUse).")
+        }
+        if let avoidWhen, !avoidWhen.isEmpty {
+            parts.append("Avoid \(avoidWhen).")
+        }
+        if !compact, let example, !example.isEmpty {
+            parts.append("Example: \(example)")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    static func sanitize(_ text: String, maxLength: Int) -> String {
+        let collapsed =
+            text
+            .replacingOccurrences(of: "`", with: "'")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard collapsed.count > maxLength else { return collapsed }
+        let endIndex = collapsed.index(collapsed.startIndex, offsetBy: maxLength)
+        return String(collapsed[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+
+    private static func optionalSanitize(_ text: String?, maxLength: Int) -> String? {
+        guard let text else { return nil }
+        let sanitized = sanitize(text, maxLength: maxLength)
+        return sanitized.isEmpty ? nil : sanitized
+    }
+}
+
+enum ToolMetadataCatalog {
+    static func metadata(for name: String) -> ToolMetadata? {
+        switch name {
+        case "complete_task":
+            return ToolMetadata(
+                purpose:
+                    "Finish the task with verified, partial, or blocked status plus concrete verification evidence",
+                whenToUse: "the requested work is done and you have real evidence",
+                avoidWhen: "using it for progress updates or before sharing user-visible outputs",
+                preconditions: ["Share every user-visible file first"],
+                sideEffects: ["Ends the current task loop"],
+                refusalGuidance: "If evidence is weak, keep working and gather proof before completion",
+                example:
+                    #"{"status":"verified","summary":"Fixed the bug","verification_performed":"Ran unit tests","remaining_risks":"none","remaining_work":"none"}"#,
+                concurrencyClass: .completion,
+                promptPriority: 100
+            )
+        case "share_artifact":
+            return ToolMetadata(
+                purpose: "Expose a file, directory, or inline content to the user",
+                whenToUse: "you created output the user needs to see",
+                avoidWhen: "assuming written files are automatically visible",
+                sideEffects: ["Publishes an artifact to the user-facing thread"],
+                example: #"{"path":"reports/final.md","description":"Final report"}"#,
+                concurrencyClass: .externalSideEffect,
+                promptPriority: 95
+            )
+        case "save_notes":
+            return ToolMetadata(
+                purpose: "Persist findings, decisions, and file locations across long tasks and compaction",
+                whenToUse: "you discover information that must survive resume or context loss",
+                avoidWhen: "using it as a replacement for the final completion summary",
+                sideEffects: ["Appends persistent task notes"],
+                concurrencyClass: .coordination,
+                promptPriority: 82
+            )
+        case "read_notes":
+            return ToolMetadata(
+                purpose: "Reload notes saved earlier in the current task",
+                whenToUse: "resuming work or recovering after context loss",
+                avoidWhen: "calling it repeatedly when no saved notes exist",
+                concurrencyClass: .readOnly,
+                promptPriority: 78
+            )
+        case "request_clarification":
+            return ToolMetadata(
+                purpose:
+                    "Ask the user for a missing decision that cannot be derived safely from the repo or current task state",
+                whenToUse: "the task is blocked on a high-impact ambiguity",
+                avoidWhen: "asking questions you can answer by exploring the codebase",
+                concurrencyClass: .coordination,
+                promptPriority: 68
+            )
+        case "create_issue":
+            return ToolMetadata(
+                purpose: "Record adjacent follow-up work without derailing the current task",
+                whenToUse: "you uncover real follow-up work that should be tracked separately",
+                avoidWhen: "using it for work you can complete inside the current task",
+                sideEffects: ["Creates a tracked follow-up issue"],
+                concurrencyClass: .coordination,
+                promptPriority: 62
+            )
+        case "file_tree":
+            return ToolMetadata(
+                purpose: "Get a quick tree view of the workspace or a subdirectory",
+                whenToUse: "starting in an unfamiliar folder",
+                avoidWhen: "you already know the exact file to inspect",
+                concurrencyClass: .readOnly,
+                promptPriority: 48
+            )
+        case "file_search":
+            return ToolMetadata(
+                purpose: "Search across the workspace for symbols, strings, or file matches before opening files",
+                whenToUse: "locating the right file or code region",
+                avoidWhen: "treating matches as enough without reading the file",
+                concurrencyClass: .readOnly,
+                promptPriority: 96
+            )
+        case "file_read":
+            return ToolMetadata(
+                purpose: "Read exact file contents or line ranges before making changes",
+                whenToUse: "validating search hits or understanding current implementation",
+                avoidWhen: "editing files you have not read first",
+                concurrencyClass: .readOnly,
+                promptPriority: 98
+            )
+        case "file_edit":
+            return ToolMetadata(
+                purpose: "Make targeted edits to an existing file while preserving untouched content",
+                whenToUse: "the change is localized and you know the current file contents",
+                avoidWhen: "rewriting an entire file for a narrow change",
+                sideEffects: ["Mutates an existing file"],
+                concurrencyClass: .workspaceWrite,
+                promptPriority: 97
+            )
+        case "file_write":
+            return ToolMetadata(
+                purpose: "Create a new file or intentionally replace a whole file",
+                whenToUse: "adding a new artifact or doing a deliberate full rewrite",
+                avoidWhen: "small in-place edits that `file_edit` can handle safely",
+                sideEffects: ["Creates or replaces file content"],
+                concurrencyClass: .workspaceWrite,
+                promptPriority: 84
+            )
+        case "shell_run":
+            return ToolMetadata(
+                purpose: "Run build, test, lint, or diagnostic shell commands inside the workspace",
+                whenToUse: "verification, debugging, or repo-native workflows",
+                avoidWhen: "reading or editing files when dedicated tools exist",
+                sideEffects: ["Runs workspace commands and may create build artifacts"],
+                concurrencyClass: .shell,
+                promptPriority: 88
+            )
+        case "git_status":
+            return ToolMetadata(
+                purpose: "Inspect the current branch and working tree state",
+                whenToUse: "checking repo state before summarizing or committing",
+                avoidWhen: "using it when you need the actual patch details",
+                concurrencyClass: .readOnly,
+                promptPriority: 42
+            )
+        case "git_diff":
+            return ToolMetadata(
+                purpose: "Inspect code changes before verification or summary",
+                whenToUse: "reviewing what changed",
+                avoidWhen: "calling it before any edits exist",
+                concurrencyClass: .readOnly,
+                promptPriority: 56
+            )
+        case "git_commit":
+            return ToolMetadata(
+                purpose: "Create a commit after changes are verified and the workflow calls for a commit",
+                whenToUse: "the user explicitly wants a commit or the task requires one",
+                avoidWhen: "committing speculative or unverified work",
+                sideEffects: ["Creates a git commit"],
+                concurrencyClass: .externalSideEffect,
+                promptPriority: 38
+            )
+        case "sandbox_search_files":
+            return ToolMetadata(
+                purpose: "Search the sandbox workspace for text matches before opening files",
+                whenToUse: "locating files or symbols in the sandbox",
+                avoidWhen: "treating a search hit as enough without reading it",
+                concurrencyClass: .readOnly,
+                promptPriority: 92
+            )
+        case "sandbox_read_file":
+            return ToolMetadata(
+                purpose: "Read sandbox files before you edit or execute against them",
+                whenToUse: "checking exact file contents or tailing logs",
+                avoidWhen: "editing a file you have not inspected",
+                concurrencyClass: .readOnly,
+                promptPriority: 94
+            )
+        case "sandbox_edit_file":
+            return ToolMetadata(
+                purpose: "Apply targeted edits to an existing sandbox file",
+                whenToUse: "the change is local and you already read the file",
+                avoidWhen: "rewriting large files for a small patch",
+                sideEffects: ["Mutates sandbox file content"],
+                concurrencyClass: .workspaceWrite,
+                promptPriority: 91
+            )
+        case "sandbox_write_file":
+            return ToolMetadata(
+                purpose: "Create or replace a sandbox file in one shot",
+                whenToUse: "new files or deliberate full rewrites",
+                avoidWhen: "small edits better handled by sandbox_edit_file",
+                sideEffects: ["Writes sandbox file content"],
+                concurrencyClass: .workspaceWrite,
+                promptPriority: 70
+            )
+        case "sandbox_exec":
+            return ToolMetadata(
+                purpose: "Run a shell command inside the sandbox for build, test, install, or diagnostics",
+                whenToUse: "verification or environment-level commands",
+                avoidWhen: "using shell commands for file reading or editing when dedicated tools exist",
+                sideEffects: ["Runs sandbox commands and may change the environment"],
+                concurrencyClass: .shell,
+                promptPriority: 86
+            )
+        case "sandbox_run_script":
+            return ToolMetadata(
+                purpose: "Run a multi-line script inside the sandbox for batch edits or setup",
+                whenToUse: "coordinated multi-step logic is cleaner than many one-line commands",
+                avoidWhen: "a single dedicated tool call would do the job",
+                sideEffects: ["Runs scripted sandbox operations"],
+                concurrencyClass: .shell,
+                promptPriority: 74
+            )
+        case "sandbox_list_directory":
+            return ToolMetadata(
+                purpose: "List sandbox directories to understand structure",
+                whenToUse: "you need a quick directory overview",
+                avoidWhen: "you already know the exact file path",
+                concurrencyClass: .readOnly,
+                promptPriority: 44
+            )
+        case "sandbox_find_files":
+            return ToolMetadata(
+                purpose: "Locate sandbox files by name pattern",
+                whenToUse: "you know a filename shape but not its location",
+                avoidWhen: "full-text search is the real need",
+                concurrencyClass: .readOnly,
+                promptPriority: 46
+            )
+        default:
+            return nil
+        }
+    }
+
+    static func workPromptGuide(
+        toolDescriptions: [String: String],
+        executionMode: WorkExecutionMode,
+        compact: Bool
+    ) -> String {
+        let budget = promptGuideBudget(compact: compact)
+        let intro =
+            if compact {
+                "Choose the narrowest tool for the current step. Read before editing. Share outputs before `complete_task`."
+            } else {
+                "Choose the narrowest tool for the current step. Prefer search/read/edit tools over shell when possible. Share every user-visible output before `complete_task`."
+            }
+
+        var lines = ["## Tool Guide", intro]
+        var used = lines.joined(separator: "\n").count
+
+        let cards = promptCards(toolDescriptions: toolDescriptions, executionMode: executionMode)
+        var omitted: [String] = []
+
+        for card in cards {
+            let rendered = card.render(compact: compact)
+            let candidateLength = used + rendered.count + 1
+            if !lines.isEmpty && candidateLength > budget {
+                omitted.append(card.name)
+                continue
+            }
+            lines.append(rendered)
+            used = candidateLength
+        }
+
+        if !omitted.isEmpty {
+            let maxOmitted = compact ? 4 : 6
+            let renderedNames = omitted.prefix(maxOmitted).map { "`\($0)`" }.joined(separator: ", ")
+            let overflowLine =
+                if compact {
+                    "Also available when needed: \(renderedNames)."
+                } else {
+                    "Other specialized tools remain available when needed: \(renderedNames)."
+                }
+            if used + overflowLine.count + 1 <= budget {
+                lines.append(overflowLine)
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    static func promptGuideBudget(compact: Bool) -> Int {
+        compact ? 1100 : 2400
+    }
+
+    private static func promptCards(
+        toolDescriptions: [String: String],
+        executionMode: WorkExecutionMode
+    ) -> [ToolPromptCard] {
+        let orderedNames = orderedPromptToolNames(for: executionMode)
+        var seen = Set<String>()
+
+        return orderedNames.compactMap { name in
+            guard seen.insert(name).inserted, let metadata = metadata(for: name) else { return nil }
+            let description = toolDescriptions[name] ?? metadata.purpose
+            return ToolPromptCard(name: name, description: description, metadata: metadata)
+        }
+        .sorted {
+            if $0.promptPriority != $1.promptPriority {
+                return $0.promptPriority > $1.promptPriority
+            }
+            return $0.name < $1.name
+        }
+    }
+
+    private static func orderedPromptToolNames(for executionMode: WorkExecutionMode) -> [String] {
+        let core = [
+            "complete_task",
+            "share_artifact",
+            "save_notes",
+            "read_notes",
+            "request_clarification",
+            "create_issue",
+        ]
+
+        switch executionMode {
+        case .none:
+            return core
+        case .sandbox:
+            return core + [
+                "sandbox_search_files",
+                "sandbox_read_file",
+                "sandbox_edit_file",
+                "sandbox_write_file",
+                "sandbox_exec",
+                "sandbox_run_script",
+                "sandbox_list_directory",
+                "sandbox_find_files",
+            ]
+        case .hostFolder(let context):
+            var names =
+                core
+                + [
+                    "file_search",
+                    "file_read",
+                    "file_edit",
+                    "file_write",
+                    "file_tree",
+                ]
+            if context.projectType != .unknown {
+                names.append("shell_run")
+            }
+            if context.isGitRepo {
+                names += ["git_status", "git_diff", "git_commit"]
+            }
+            return names
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -123,6 +123,23 @@ final class ToolRegistry: ObservableObject {
         tool.asOpenAITool().function.name.count + (tool.description.count / 4)
     }
 
+    private func alwaysLoadedTools(
+        mode: WorkExecutionMode,
+        excludeCapabilityTools: Bool = false
+    ) -> [OsaurusTool] {
+        let builtInNames = Set(builtInToolNames)
+        let runtimeNames = runtimeManagedToolNames
+        let excluded = excludedToolNames(for: mode)
+
+        return toolsByName.values
+            .filter { tool in
+                builtInNames.contains(tool.name) || runtimeNames.contains(tool.name)
+            }
+            .filter { !excluded.contains($0.name) }
+            .filter { !excludeCapabilityTools || !Self.capabilityToolNames.contains($0.name) }
+            .sorted { $0.name < $1.name }
+    }
+
     /// Get specs for specific tools by name (ignores enabled state)
     func specs(forTools toolNames: [String]) -> [Tool] {
         return toolNames.compactMap { name in
@@ -591,17 +608,18 @@ final class ToolRegistry: ObservableObject {
     /// dynamic discovery tools are stripped so the model only sees
     /// the user's explicitly chosen tools.
     func alwaysLoadedSpecs(mode: WorkExecutionMode, excludeCapabilityTools: Bool = false) -> [Tool] {
-        let builtInNames = Set(builtInToolNames)
-        let runtimeNames = runtimeManagedToolNames
-        let excluded = excludedToolNames(for: mode)
-
-        return toolsByName.values
-            .filter { tool in
-                builtInNames.contains(tool.name) || runtimeNames.contains(tool.name)
-            }
-            .filter { !excluded.contains($0.name) }
-            .filter { !excludeCapabilityTools || !Self.capabilityToolNames.contains($0.name) }
-            .sorted { $0.name < $1.name }
+        alwaysLoadedTools(mode: mode, excludeCapabilityTools: excludeCapabilityTools)
             .map { $0.asOpenAITool() }
+    }
+
+    func workPromptGuide(mode: WorkExecutionMode, compact: Bool) -> String {
+        let activeDescriptions = Dictionary(
+            uniqueKeysWithValues: alwaysLoadedTools(mode: mode).map { ($0.name, $0.description) }
+        )
+        return ToolMetadataCatalog.workPromptGuide(
+            toolDescriptions: activeDescriptions,
+            executionMode: mode,
+            compact: compact
+        )
     }
 }


### PR DESCRIPTION
## Problem
The harness currently exposes tools through their raw function schemas and generic descriptions. That leaves the model to infer when a tool should be used, when it should be avoided, and which tools are terminal versus preparatory. In practice this increases malformed tool use, avoidable retries, and wasted inference on work-mode tasks.

## Technical reason
Reliable tool use needs a second layer beyond JSON schema: concise operational guidance that fits inside the system prompt budget. This change adds internal metadata for high-value work tools and renders that metadata into budgeted tool cards. The cards are intentionally short, sanitized, and ordered by prompt priority so the prompt adds decision support without turning into an unbounded glossary. The behavior is gated behind a dedicated rollout flag so it can be enabled deliberately and expanded phase by phase.

## Why this matters in real use
When the model can distinguish between discovery tools, mutation tools, coordination tools, and completion tools, it spends less time thrashing between the wrong actions. That translates into fewer failed first attempts, faster completion on file-heavy work, and clearer end-user outcomes because completion and artifact-sharing expectations are stated up front.

## Implementation summary
- Added `ToolMetadata` and `ToolPromptCard` support for concise, priority-ordered tool guidance.
- Added a metadata catalog for the core work tools and sandbox tools used in work mode.
- Extended `OsaurusTool` with internal prompt metadata and taught `ToolRegistry` to render a budgeted work-mode tool guide from the active tool set.
- Appended the tool guide to the structured work prompt in `SystemPromptComposer`.
- Added `HarnessReliabilityFlags.toolPromptFoundation` so the new prompt section is disabled by default and can be enabled explicitly.
- Added tests for disabled-by-default behavior, enabled rendering, prompt budget limits, and sanitization against prompt-shaped markup.

## Failure modes and safeguards
- Prompt bloat: the tool guide is budget-capped and ordered by prompt priority.
- Prompt injection through tool copy: rendered cards collapse whitespace, strip backticks, and truncate long text.
- Premature rollout: the new section is behind `OSAURUS_HARNESS_TOOL_PROMPT_FOUNDATION` / `HarnessReliability.ToolPromptFoundationEnabled` and remains off by default.
- Regression in existing work prompts: existing workflow guidance tests were retained and updated for the new actor boundary.

## Build and test evidence
- `swift-format lint --strict --recursive Packages App`
- `swiftlint lint` completed with the repository's existing warning baseline and no new serious violations.
- `xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild test -workspace osaurus.xcworkspace -scheme OsaurusCoreTests -destination 'platform=macOS' -derivedDataPath build/DerivedData -resultBundlePath build/results/phase1-osauruscore-full-postflag.xcresult -skip-testing:OsaurusCoreTests/KVCacheStoreTests -skip-testing:OsaurusCoreTests/MLXGenerationEngineTests`
- `xcodebuild test -workspace osaurus.xcworkspace -scheme OsaurusCLITests -destination 'platform=macOS' -derivedDataPath build/DerivedData -resultBundlePath build/results/phase1-osauruscli.xcresult`
- Focused regression runs also passed for `WorkPromptToolGuideTests` and `WorkExecutionEngineTests`.
- Local launch smoke check: opened the built macOS app bundle successfully and confirmed the `osaurus` process started.

## Security evidence
- Added negative coverage proving prompt-card rendering sanitizes prompt-shaped markup and fenced code snippets before insertion into the system prompt.
- The new metadata is internal-only and does not widen tool permissions or execution surface area.
- Rollout is fail-closed: disabled by default unless the flag is explicitly enabled.

## Rollout and fallback
- Flag: `HarnessReliability.ToolPromptFoundationEnabled`
- Environment override for local testing: `OSAURUS_HARNESS_TOOL_PROMPT_FOUNDATION=1`
- Default state: off
- Fallback: disable the flag to return to the prior work prompt shape without reverting code.

## Out of scope
- No change to tool execution policy or permission handling.
- No new analytics or runtime telemetry.
- No parallel execution, denial normalization, or compaction recovery changes yet.
