### PR TITLE
fix: tighten prompt hygiene for local chat

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -183,6 +183,8 @@ public struct SystemPromptComposer: Sendable {
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
         let isManual = toolMode == .manual
 
+        // Work mode keeps the full tool set available. On-demand narrowing is chat-only so
+        // autonomous task execution never silently loses a required tool.
         if preferOnDemandTools && !isManual, case .none = executionMode {
             return resolveOnDemandLocalChatTools(query: query, preflight: preflight)
         }
@@ -239,6 +241,8 @@ public struct SystemPromptComposer: Sendable {
 
     private static func queryLikelyNeedsCapabilityDiscovery(_ query: String) -> Bool {
         let normalized = query.lowercased()
+        // This is intentionally a loose first-pass heuristic. Prefer a few false positives in
+        // local auto chat over hiding capability tools when the user is asking what Osaurus can do.
         let keywords = [
             "tool", "tools", "skill", "skills", "plugin", "plugins", "method", "methods", "capability",
             "capabilities", "workflow", "workflows",

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -83,6 +83,7 @@ public struct SystemPromptComposer: Sendable {
             composer: composer,
             agentId: agentId,
             executionMode: executionMode,
+            preferOnDemandTools: model.map(SystemPromptTemplates.isLocalModel) ?? false,
             query: query,
             toolsDisabled: toolsDisabled,
             model: model,
@@ -98,6 +99,7 @@ public struct SystemPromptComposer: Sendable {
         composer: SystemPromptComposer,
         agentId: UUID,
         executionMode: WorkExecutionMode,
+        preferOnDemandTools: Bool = false,
         query: String,
         toolsDisabled: Bool,
         model: String? = nil,
@@ -137,13 +139,18 @@ public struct SystemPromptComposer: Sendable {
             agentId: agentId,
             executionMode: executionMode,
             toolsDisabled: effectiveToolsOff,
-            preflight: preflight
+            preflight: preflight,
+            query: query,
+            preferOnDemandTools: preferOnDemandTools
         )
         trace?.mark("resolve_tools_done")
 
         let manifest = comp.manifest()
         let toolNames = tools.map { $0.function.name }
         debugLog("[Context] \(manifest.debugDescription)")
+        debugLog(
+            "[Context] resolvedTools count=\(toolNames.count) preferOnDemand=\(preferOnDemandTools) names=\(toolNames)"
+        )
 
         let rendered = comp.render()
         trace?.set("systemPromptChars", rendered.count)
@@ -167,12 +174,18 @@ public struct SystemPromptComposer: Sendable {
         agentId: UUID,
         executionMode: WorkExecutionMode,
         toolsDisabled: Bool = false,
-        preflight: PreflightResult = .empty
+        preflight: PreflightResult = .empty,
+        query: String = "",
+        preferOnDemandTools: Bool = false
     ) -> [Tool] {
         guard !toolsDisabled else { return [] }
 
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
         let isManual = toolMode == .manual
+
+        if preferOnDemandTools && !isManual, case .none = executionMode {
+            return resolveOnDemandLocalChatTools(query: query, preflight: preflight)
+        }
 
         var tools = ToolRegistry.shared.alwaysLoadedSpecs(
             mode: executionMode,
@@ -195,6 +208,42 @@ public struct SystemPromptComposer: Sendable {
         }
 
         return tools
+    }
+
+    @MainActor
+    private static func resolveOnDemandLocalChatTools(
+        query: String,
+        preflight: PreflightResult
+    ) -> [Tool] {
+        var tools: [Tool] = []
+        var seen: Set<String> = []
+
+        let needsCapabilityTools =
+            queryLikelyNeedsCapabilityDiscovery(query)
+            || preflight.items.contains(where: { $0.type == .skill })
+
+        if needsCapabilityTools {
+            for spec in ToolRegistry.shared.specs(forTools: ["capabilities_search", "capabilities_load"])
+            where seen.insert(spec.function.name).inserted {
+                tools.append(spec)
+            }
+        }
+
+        for spec in preflight.toolSpecs
+        where seen.insert(spec.function.name).inserted {
+            tools.append(spec)
+        }
+
+        return tools
+    }
+
+    private static func queryLikelyNeedsCapabilityDiscovery(_ query: String) -> Bool {
+        let normalized = query.lowercased()
+        let keywords = [
+            "tool", "tools", "skill", "skills", "plugin", "plugins", "method", "methods", "capability",
+            "capabilities", "workflow", "workflows",
+        ]
+        return keywords.contains { normalized.contains($0) }
     }
 
     /// Compose the full work system prompt: base + workMode + sandbox.
@@ -249,6 +298,7 @@ public struct SystemPromptComposer: Sendable {
             composer: composer,
             agentId: agentId,
             executionMode: executionMode,
+            preferOnDemandTools: false,
             query: query,
             toolsDisabled: toolsDisabled
         )

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -241,13 +241,30 @@ public struct SystemPromptComposer: Sendable {
 
     private static func queryLikelyNeedsCapabilityDiscovery(_ query: String) -> Bool {
         let normalized = query.lowercased()
-        // This is intentionally a loose first-pass heuristic. Prefer a few false positives in
-        // local auto chat over hiding capability tools when the user is asking what Osaurus can do.
+        // Keep this heuristic intentionally lightweight, but prefer word-boundary matches plus a
+        // handful of explicit "what can you do" phrasings so benign queries like "best method
+        // for making pasta" stay out of the capability path.
+        let tokens = Set(
+            normalized.split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+        )
         let keywords = [
-            "tool", "tools", "skill", "skills", "plugin", "plugins", "method", "methods", "capability",
+            "tool", "tools", "skill", "skills", "plugin", "plugins", "capability",
             "capabilities", "workflow", "workflows",
         ]
-        return keywords.contains { normalized.contains($0) }
+        if keywords.contains(where: tokens.contains) {
+            return true
+        }
+
+        let capabilityPhrases = [
+            "what can you do",
+            "what can you help me with",
+            "what are you able to do",
+            "what are your capabilities",
+            "which tools do you have",
+            "which skills do you have",
+        ]
+        return capabilityPhrases.contains(where: normalized.contains)
     }
 
     /// Compose the full work system prompt: base + workMode + sandbox.

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -390,8 +390,8 @@ public enum SystemPromptTemplates {
         if trimmed.isEmpty || trimmed == "default" || trimmed == "foundation" {
             return true
         }
-        if trimmed.contains("/") {
-            return false
+        if ModelInfo.load(modelId: modelId ?? "") != nil {
+            return true
         }
         return ModelManager.findInstalledModel(named: trimmed) != nil
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -393,6 +393,23 @@ public enum SystemPromptTemplates {
         if ModelInfo.load(modelId: modelId ?? "") != nil {
             return true
         }
-        return ModelManager.findInstalledModel(named: trimmed) != nil
+        if ModelManager.findInstalledModel(named: trimmed) != nil {
+            return true
+        }
+        if let repoComponent = trimmed.split(separator: "/").last.map(String.init),
+            repoComponent != trimmed,
+            ModelManager.findInstalledModel(named: repoComponent) != nil
+        {
+            return true
+        }
+
+        // Local MLX picker items keep full org/repo ids, but remote providers also use
+        // slash-style prefixes. Only fall back to "local" when the repo id still looks
+        // like an MLX/local model identifier.
+        guard trimmed.contains("/") else { return false }
+        return trimmed.contains("mlx")
+            || ModelMetadataParser.parameterCount(from: trimmed) != nil
+            || ModelMetadataParser.quantization(from: trimmed) != nil
+            || ModelMetadataParser.quantizationOllama(from: trimmed) != nil
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -258,6 +258,16 @@ struct ChatViewSandboxTests {
 
         #expect(sanitized == "Reasonable beginning.")
     }
+
+    @Test
+    func sanitizedCorruptedAssistantOutput_preservesEmojiBeforeChannelMarker() {
+        let corrupted =
+            "Hello 🎉 world.\n<channel>|<channel>thought\n<channel>|<channel>thought"
+
+        let sanitized = ChatSession.sanitizedCorruptedAssistantOutput(corrupted)
+
+        #expect(sanitized == "Hello 🎉 world.")
+    }
 }
 
 @MainActor

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -94,6 +94,48 @@ struct ChatViewSandboxTests {
     }
 
     @Test
+    func resolveTools_localAutoChatUsesOnDemandSet() {
+        let specs = SystemPromptComposer.resolveTools(
+            agentId: Agent.defaultId,
+            executionMode: .none,
+            preflight: .empty,
+            query: "What is the capital of France?",
+            preferOnDemandTools: true
+        )
+
+        #expect(specs.isEmpty)
+    }
+
+    @Test
+    func resolveTools_localAutoChatAddsCapabilityAndPreflightToolsWhenNeeded() {
+        let memoryTool = ToolRegistry.shared.specs(forTools: ["search_working_memory"]).first
+        #expect(memoryTool != nil)
+
+        let preflight = PreflightResult(
+            toolSpecs: memoryTool.map { [$0] } ?? [],
+            contextSnippet: "## Available Skills\n- skill/Sandbox Plugin Creator: Create tools on demand",
+            items: [
+                .init(type: .skill, name: "Sandbox Plugin Creator", description: "Create sandbox plugins")
+            ]
+        )
+
+        let specs = SystemPromptComposer.resolveTools(
+            agentId: Agent.defaultId,
+            executionMode: .none,
+            preflight: preflight,
+            query: "What tools do you have for working with files?",
+            preferOnDemandTools: true
+        )
+
+        let names = Set(specs.map(\.function.name))
+        #expect(names.contains("capabilities_search"))
+        #expect(names.contains("capabilities_load"))
+        #expect(names.contains("search_working_memory"))
+        #expect(names.contains("methods_save") == false)
+        #expect(names.contains("methods_report") == false)
+    }
+
+    @Test
     func prepareChatExecutionMode_usesSessionAgentInsteadOfActiveAgent() async {
         let manager = AgentManager.shared
         let registrar = SandboxToolRegistrar.shared
@@ -168,6 +210,53 @@ struct ChatViewSandboxTests {
             #expect(sandboxToolTokens > inactiveToolTokens)
             #expect(sandboxToolTokens == ToolRegistry.shared.totalEstimatedTokens(for: sandboxTools))
         }
+    }
+
+    @Test
+    func isLocalModel_treatsSlashStyleLocalPickerIdsAsLocal() {
+        let modelId = "TheCluster/Gemma-4-31B-Heretic-MLX-mxfp4"
+
+        #expect(SystemPromptTemplates.isLocalModel(modelId))
+    }
+
+    @Test
+    func isLikelyCorruptedAssistantOutput_detectsRepeatedNGramLoops() {
+        let corrupted =
+            "Based on the chat logs, Carola is interesting. "
+            + String(repeating: "eded", count: 80)
+
+        #expect(ChatSession.isLikelyCorruptedAssistantOutput(corrupted))
+    }
+
+    @Test
+    func isLikelyCorruptedAssistantOutput_allowsNormalAssistantText() {
+        let normal =
+            "Based on the provided notes, the person appears guarded, inconsistent, and highly reactive under stress, but the text does not support stronger claims without more context."
+
+        #expect(!ChatSession.isLikelyCorruptedAssistantOutput(normal))
+    }
+
+    @Test
+    func sanitizedCorruptedAssistantOutput_trimsRepeatedWordTail() {
+        let corrupted =
+            "**Location Inference**\n\nThe street markings suggest Spain. "
+            + String(repeating: "own ", count: 40)
+
+        let sanitized = ChatSession.sanitizedCorruptedAssistantOutput(corrupted)
+
+        #expect(sanitized.contains("The street markings suggest Spain."))
+        #expect(!sanitized.contains("own own own own own"))
+        #expect(sanitized.count < corrupted.count)
+    }
+
+    @Test
+    func sanitizedCorruptedAssistantOutput_trimsLeakedChannelMarkers() {
+        let corrupted =
+            "Reasonable beginning.\n<channel>|<channel>thought\n<channel>|<channel>thought"
+
+        let sanitized = ChatSession.sanitizedCorruptedAssistantOutput(corrupted)
+
+        #expect(sanitized == "Reasonable beginning.")
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -136,6 +136,34 @@ struct ChatViewSandboxTests {
     }
 
     @Test
+    func resolveTools_localAutoChatIgnoresBenignMethodQueries() {
+        let specs = SystemPromptComposer.resolveTools(
+            agentId: Agent.defaultId,
+            executionMode: .none,
+            preflight: .empty,
+            query: "What's the best method for making pasta?",
+            preferOnDemandTools: true
+        )
+
+        #expect(specs.isEmpty)
+    }
+
+    @Test
+    func resolveTools_localAutoChatAddsCapabilityToolsForBroadCapabilityQuestion() {
+        let specs = SystemPromptComposer.resolveTools(
+            agentId: Agent.defaultId,
+            executionMode: .none,
+            preflight: .empty,
+            query: "What can you help me with?",
+            preferOnDemandTools: true
+        )
+
+        let names = Set(specs.map(\.function.name))
+        #expect(names.contains("capabilities_search"))
+        #expect(names.contains("capabilities_load"))
+    }
+
+    @Test
     func prepareChatExecutionMode_usesSessionAgentInsteadOfActiveAgent() async {
         let manager = AgentManager.shared
         let registrar = SandboxToolRegistrar.shared
@@ -217,6 +245,13 @@ struct ChatViewSandboxTests {
         let modelId = "TheCluster/Gemma-4-31B-Heretic-MLX-mxfp4"
 
         #expect(SystemPromptTemplates.isLocalModel(modelId))
+    }
+
+    @Test
+    func isLocalModel_keepsRemoteProviderPrefixesRemote() {
+        let modelId = "openai/gpt-4.1"
+
+        #expect(SystemPromptTemplates.isLocalModel(modelId) == false)
     }
 
     @Test

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -347,6 +347,98 @@ final class ChatSession: ObservableObject {
         return parts.joined(separator: "\n\n")
     }
 
+    static func isLikelyCorruptedAssistantOutput(_ content: String) -> Bool {
+        let normalized = content.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalized.count >= 256 else { return false }
+
+        let characters = Array(normalized)
+        for gramLength in 1 ... 8 {
+            let requiredRepeats = gramLength == 1 ? 32 : 16
+            let minimumSpan = gramLength * requiredRepeats
+            guard characters.count >= minimumSpan else { continue }
+
+            var start = 0
+            while start + minimumSpan <= characters.count {
+                let pattern = Array(characters[start ..< (start + gramLength)])
+                var repeats = 1
+                var cursor = start + gramLength
+
+                while cursor + gramLength <= characters.count,
+                    Array(characters[cursor ..< (cursor + gramLength)]) == pattern
+                {
+                    repeats += 1
+                    if repeats >= requiredRepeats {
+                        return true
+                    }
+                    cursor += gramLength
+                }
+
+                start += 1
+            }
+        }
+
+        return false
+    }
+
+    static func containsLeakedChannelThoughtMarkers(_ content: String) -> Bool {
+        let normalized = content.lowercased()
+        return normalized.contains("<channel>|<channel>thought")
+            || normalized.contains("<channel><|channel|>thought")
+            || normalized.contains("<channel><channel>thought")
+    }
+
+    static func sanitizedCorruptedAssistantOutput(_ content: String) -> String {
+        var sanitized = content
+
+        let lowercased = sanitized.lowercased()
+        let markerCandidates = [
+            "<channel>|<channel>thought",
+            "<channel><|channel|>thought",
+            "<channel><channel>thought",
+        ]
+
+        for marker in markerCandidates {
+            if let range = lowercased.range(of: marker) {
+                let distance = lowercased.distance(from: lowercased.startIndex, to: range.lowerBound)
+                let cutoff = sanitized.index(sanitized.startIndex, offsetBy: distance)
+                sanitized = String(sanitized[..<cutoff])
+                break
+            }
+        }
+
+        let words = sanitized.split(whereSeparator: \.isWhitespace)
+        if let lastWordRaw = words.last {
+            let lastWord = lastWordRaw
+                .trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+                .lowercased()
+            if !lastWord.isEmpty {
+                var repeatedTailCount = 0
+                for word in words.reversed() {
+                    let normalizedWord = word
+                        .trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+                        .lowercased()
+                    if normalizedWord == lastWord {
+                        repeatedTailCount += 1
+                    } else {
+                        break
+                    }
+                }
+
+                if repeatedTailCount >= 16 {
+                    let escapedWord = NSRegularExpression.escapedPattern(for: lastWord)
+                    let pattern = "(?i)(?:\\b\(escapedWord)\\b(?:\\s+\\b\(escapedWord)\\b){15,})\\s*$"
+                    sanitized = sanitized.replacingOccurrences(
+                        of: pattern,
+                        with: "",
+                        options: .regularExpression
+                    )
+                }
+            }
+        }
+
+        return sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Format token count for display (e.g., "1.2K", "15K")
     static func formatTokenCount(_ tokens: Int) -> String {
         if tokens < 1000 {
@@ -886,7 +978,23 @@ final class ChatSession: ObservableObject {
                             return nil
                         }
 
-                        let content: String? = t.contentIsEmpty ? nil : t.content
+                        let assistantContent = t.content
+                        if Self.isLikelyCorruptedAssistantOutput(assistantContent) {
+                            debugLog(
+                                "[ChatSession] skipping corrupted assistant turn id=\(t.id.uuidString) len=\(assistantContent.count)"
+                            )
+                            if t.toolCalls == nil || t.toolCalls!.isEmpty {
+                                return nil
+                            }
+                            return ChatMessage(
+                                role: "assistant",
+                                content: nil,
+                                tool_calls: t.toolCalls,
+                                tool_call_id: nil
+                            )
+                        }
+
+                        let content: String? = t.contentIsEmpty ? nil : assistantContent
 
                         return ChatMessage(
                             role: "assistant",
@@ -998,6 +1106,7 @@ final class ChatSession: ObservableObject {
                     do {
                         var uiDeltaCount = 0
                         var firstDeltaTime: Date?
+                        var abortedForCorruption = false
 
                         var processor = StreamingDeltaProcessor(
                             turn: assistantTurn,
@@ -1075,11 +1184,27 @@ final class ChatSession: ObservableObject {
                                 }
                                 uiDeltaCount += 1
                                 processor.receiveDelta(delta)
+                                if assistantTurn.contentLength >= 256, uiDeltaCount % 8 == 0 {
+                                    let currentContent = assistantTurn.content
+                                    if Self.containsLeakedChannelThoughtMarkers(currentContent)
+                                        || Self.isLikelyCorruptedAssistantOutput(currentContent)
+                                    {
+                                        abortedForCorruption = true
+                                        debugLog(
+                                            "[ChatSession] aborting stream due to detected corrupted output id=\(assistantTurn.id.uuidString) len=\(currentContent.count)"
+                                        )
+                                        break
+                                    }
+                                }
                             }
                         }
 
                         // Flush any remaining buffered content (including partial tags)
                         processor.finalize()
+                        let sanitizedContent = Self.sanitizedCorruptedAssistantOutput(assistantTurn.content)
+                        if sanitizedContent != assistantTurn.content {
+                            assistantTurn.content = sanitizedContent
+                        }
 
                         if let first = firstDeltaTime {
                             assistantTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
@@ -1100,6 +1225,10 @@ final class ChatSession: ObservableObject {
                         print(
                             "[Osaurus][UI] Stream consumption completed: \(uiDeltaCount) deltas in \(String(format: "%.2f", totalTime))s, final contentLen=\(assistantTurn.contentLength)"
                         )
+
+                        if abortedForCorruption {
+                            break
+                        }
 
                         break  // finished normally
                     } catch let inv as ServiceToolInvocation {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -351,29 +351,28 @@ final class ChatSession: ObservableObject {
         let normalized = content.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard normalized.count >= 256 else { return false }
 
-        let characters = Array(normalized)
+        // Corruption appears as repeated trailing loops during streaming, so we only inspect a
+        // bounded suffix instead of rescanning the entire accumulated output every few deltas.
+        let scanWindow = String(normalized.suffix(512))
+        let characters = Array(scanWindow)
         for gramLength in 1 ... 8 {
             let requiredRepeats = gramLength == 1 ? 32 : 16
             let minimumSpan = gramLength * requiredRepeats
             guard characters.count >= minimumSpan else { continue }
 
-            var start = 0
-            while start + minimumSpan <= characters.count {
-                let pattern = Array(characters[start ..< (start + gramLength)])
-                var repeats = 1
-                var cursor = start + gramLength
+            let loopStart = characters.count - minimumSpan
+            let pattern = Array(characters[loopStart ..< (loopStart + gramLength)])
+            var cursor = loopStart + gramLength
+            var repeats = 1
 
-                while cursor + gramLength <= characters.count,
-                    Array(characters[cursor ..< (cursor + gramLength)]) == pattern
-                {
-                    repeats += 1
-                    if repeats >= requiredRepeats {
-                        return true
-                    }
-                    cursor += gramLength
+            while cursor + gramLength <= characters.count,
+                Array(characters[cursor ..< (cursor + gramLength)]) == pattern
+            {
+                repeats += 1
+                if repeats >= requiredRepeats {
+                    return true
                 }
-
-                start += 1
+                cursor += gramLength
             }
         }
 
@@ -390,7 +389,6 @@ final class ChatSession: ObservableObject {
     static func sanitizedCorruptedAssistantOutput(_ content: String) -> String {
         var sanitized = content
 
-        let lowercased = sanitized.lowercased()
         let markerCandidates = [
             "<channel>|<channel>thought",
             "<channel><|channel|>thought",
@@ -398,24 +396,19 @@ final class ChatSession: ObservableObject {
         ]
 
         for marker in markerCandidates {
-            if let range = lowercased.range(of: marker) {
-                let distance = lowercased.distance(from: lowercased.startIndex, to: range.lowerBound)
-                let cutoff = sanitized.index(sanitized.startIndex, offsetBy: distance)
-                sanitized = String(sanitized[..<cutoff])
+            if let range = sanitized.range(of: marker, options: [.caseInsensitive]) {
+                sanitized = String(sanitized[..<range.lowerBound])
                 break
             }
         }
 
         let words = sanitized.split(whereSeparator: \.isWhitespace)
         if let lastWordRaw = words.last {
-            let lastWord = lastWordRaw
-                .trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-                .lowercased()
+            let lastWord = lastWordRaw.trimmingCharacters(in: CharacterSet.alphanumerics.inverted).lowercased()
             if !lastWord.isEmpty {
                 var repeatedTailCount = 0
                 for word in words.reversed() {
-                    let normalizedWord = word
-                        .trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+                    let normalizedWord = word.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
                         .lowercased()
                     if normalizedWord == lastWord {
                         repeatedTailCount += 1
@@ -424,9 +417,12 @@ final class ChatSession: ObservableObject {
                     }
                 }
 
-                if repeatedTailCount >= 16 {
+                let minimumRepeatedTailCount = 16
+                if repeatedTailCount >= minimumRepeatedTailCount {
                     let escapedWord = NSRegularExpression.escapedPattern(for: lastWord)
-                    let pattern = "(?i)(?:\\b\(escapedWord)\\b(?:\\s+\\b\(escapedWord)\\b){15,})\\s*$"
+                    let repeatedWordSuffix = minimumRepeatedTailCount - 1
+                    let pattern =
+                        "(?i)(?:\\b\(escapedWord)\\b(?:\\s+\\b\(escapedWord)\\b){\(repeatedWordSuffix),})\\s*$"
                     sanitized = sanitized.replacingOccurrences(
                         of: pattern,
                         with: "",
@@ -1201,9 +1197,13 @@ final class ChatSession: ObservableObject {
 
                         // Flush any remaining buffered content (including partial tags)
                         processor.finalize()
-                        let sanitizedContent = Self.sanitizedCorruptedAssistantOutput(assistantTurn.content)
-                        if sanitizedContent != assistantTurn.content {
-                            assistantTurn.content = sanitizedContent
+                        if abortedForCorruption {
+                            assistantTurn.content = ""
+                        } else {
+                            let sanitizedContent = Self.sanitizedCorruptedAssistantOutput(assistantTurn.content)
+                            if sanitizedContent != assistantTurn.content {
+                                assistantTurn.content = sanitizedContent
+                            }
                         }
 
                         if let first = firstDeltaTime {


### PR DESCRIPTION
## Summary
- tighten local-chat tool selection so local auto mode only loads on-demand capability tools when the query actually needs them
- treat slash-style installed local model ids as local models for compact prompt selection
- detect and strip obviously corrupted assistant output so repeated loops and leaked channel markers do not poison later turns

## Why
This packages the prompt-hygiene slice from the local inference recovery work as a separate change from the MLX runtime and attached-document work. The main user-visible effect is cleaner prompt assembly for local chat and safer handling of malformed streamed output.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter ChatViewSandboxTests`
