### PR TITLE
Fix stuck loading, #856 stats leak, #858 error classifier, #860 NIO crash + bump vmlx-swift-lm

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -493,14 +493,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     public func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         // Defer termination so in-flight inference tasks and MLX GPU resources are
         // released before exit() triggers C++ static destructors.
+        //
+        // Issue #860: the previous version guarded the server shutdown on
+        // `serverController.isRunning`. That flag can be false while the
+        // underlying NIO `MultiThreadedEventLoopGroup` is still alive
+        // (e.g. mid-partial-start, mid-shutdown, or Sparkle-triggered
+        // quit racing against server cleanup). When the EL group is
+        // still non-nil at `exit()`, NIO's destructor hits
+        // `preconditionFailure("EventLoopGroup is still running")` —
+        // EXC_BREAKPOINT at `NIO-ELT-3` as reported. `ensureShutdown()`
+        // itself is a no-op if everything is already nil, so always
+        // call it.
+        //
+        // We also always stop the sandbox (which in turn stops the
+        // HostAPIBridgeServer) so its 2-thread EL group can't leak
+        // past quit even when no sandbox container was started.
         Task { @MainActor in
             ChatWindowManager.shared.stopAllSessions()
             BackgroundTaskManager.shared.cancelAllTasks()
             MCPProviderManager.shared.disconnectAll()
             RemoteProviderManager.shared.disconnectAll()
-            if serverController.isRunning {
-                await serverController.ensureShutdown()
-            }
+            // Unconditional: ensureShutdown is idempotent when already clean.
+            await serverController.ensureShutdown()
             await MCPServerManager.shared.stopAll()
             await ModelRuntime.shared.clearAll()
             do {
@@ -508,6 +522,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             } catch {
                 NSLog("[Osaurus] Sandbox stop failed: \(error)")
             }
+            // Belt-and-suspenders: if the sandbox was never provisioned,
+            // `stopContainer` still stops the bridge, but if the bridge
+            // was started through some other path in a future refactor
+            // we want its EL group torn down regardless.
+            await HostAPIBridgeServer.shared.stop()
             NSApp.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater

--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -86,10 +86,15 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     }
 
     /// Signal that model container loading has finished. Decrements the
-    /// refcount with a floor at 0 so double-fires (e.g. a cleanup block
-    /// that fires both in a `catch` and a later `defer`) never drive it
-    /// negative. See `ModelRuntime.generateEventStream` which now uses a
-    /// `defer` to guarantee symmetric start/finish even on cancellation.
+    /// refcount with a floor at 0 so double-fires (e.g. a buggy caller
+    /// firing in both a `catch` and a success path) can never drive it
+    /// negative and poison subsequent loads.
+    ///
+    /// Callers must guarantee that every `modelLoadWillStartAsync` is
+    /// paired with exactly one `modelLoadDidFinishAsync` on every exit
+    /// path (success, throw, cancel). See
+    /// `ModelRuntime.generateEventStream` for the canonical pattern —
+    /// a narrow do/catch scoped to just the container load.
     func modelLoadDidFinishAsync() {
         Task { @MainActor in
             self.loadInFlightCount = max(0, self.loadInFlightCount - 1)

--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -16,9 +16,24 @@ import Foundation
 final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     static let shared = InferenceProgressManager()
 
-    /// True while the model container is being loaded (weights paging into GPU).
-    /// The UI shows "Loading Model..." during this phase.
-    @MainActor @Published var isLoadingModel: Bool = false
+    /// Refcount of in-flight model loads. Incremented by
+    /// `modelLoadWillStartAsync`, decremented by `modelLoadDidFinishAsync`.
+    /// The UI observes `isLoadingModel` which is a computed `count > 0`
+    /// view. The refcount — rather than a bare Bool — guarantees the
+    /// flag doesn't get stuck `false` when two concurrent loads race
+    /// (e.g. a second chat window starting a different model while the
+    /// first is mid-load) and doesn't get stuck `true` when a load is
+    /// cancelled mid-flight and its cleanup fires out of order with a
+    /// newer load's start.
+    ///
+    /// `private(set)` so only this class can mutate it. `@Published`
+    /// so SwiftUI redraws when the derived `isLoadingModel` flips.
+    @MainActor @Published private(set) var loadInFlightCount: Int = 0
+
+    /// True while at least one model container is being loaded.
+    /// Computed view over `loadInFlightCount`. SwiftUI picks up changes
+    /// because the underlying `@Published` storage is annotated.
+    @MainActor var isLoadingModel: Bool { loadInFlightCount > 0 }
 
     /// True while preflight capability search is running.
     /// The UI shows "Searching capabilities..." during this phase.
@@ -63,14 +78,22 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
         Task { @MainActor in self.prefillDidFinish() }
     }
 
-    /// Signal that model container loading has started.
+    /// Signal that model container loading has started. Increments the
+    /// in-flight refcount; the matching `modelLoadDidFinishAsync` must
+    /// fire for every call, regardless of success / failure / cancel.
     func modelLoadWillStartAsync() {
-        Task { @MainActor in self.isLoadingModel = true }
+        Task { @MainActor in self.loadInFlightCount += 1 }
     }
 
-    /// Signal that model container loading has finished.
+    /// Signal that model container loading has finished. Decrements the
+    /// refcount with a floor at 0 so double-fires (e.g. a cleanup block
+    /// that fires both in a `catch` and a later `defer`) never drive it
+    /// negative. See `ModelRuntime.generateEventStream` which now uses a
+    /// `defer` to guarantee symmetric start/finish even on cancellation.
     func modelLoadDidFinishAsync() {
-        Task { @MainActor in self.isLoadingModel = false }
+        Task { @MainActor in
+            self.loadInFlightCount = max(0, self.loadInFlightCount - 1)
+        }
     }
 
     /// Signal that preflight search has started.

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -359,17 +359,28 @@ actor ModelRuntime {
 
         let cfg = await getConfig()
         trace?.mark("load_container_start")
-        // Symmetric bookkeeping via `defer` — guarantees the "finish"
-        // decrement fires on every exit path (success, throw, cancel,
-        // early return). Previous code duplicated the decrement in a
-        // `catch` and then again after the `do`, which — combined with
-        // the now-refcounted `loadInFlightCount` in
-        // `InferenceProgressManager` — could double-decrement on races
-        // between two chat windows loading different models, leaving
-        // `isLoadingModel` wedged.
+        // Scoped start/finish around ONLY the container load. Symmetric
+        // bookkeeping via a do/catch pair — we can't use `defer` at
+        // function scope here because the function returns early (before
+        // generation runs, which happens inside `gatedGenTask`), and a
+        // function-scoped defer would keep `isLoadingModel` true through
+        // the MetalGate wait and the rest of setup. We want the flag to
+        // flip off as soon as the container is actually loaded, matching
+        // the pre-fix timing.
+        //
+        // The refcount in `InferenceProgressManager` guarantees that
+        // concurrent loads (two chat windows) don't corrupt each other,
+        // and `max(0, _ - 1)` on decrement floors the count so a
+        // double-fire from a future refactor can't drive it negative.
         InferenceProgressManager.shared.modelLoadWillStartAsync()
-        defer { InferenceProgressManager.shared.modelLoadDidFinishAsync() }
-        let holder: SessionHolder = try await loadContainer(id: modelId, name: modelName)
+        let holder: SessionHolder
+        do {
+            holder = try await loadContainer(id: modelId, name: modelName)
+        } catch {
+            InferenceProgressManager.shared.modelLoadDidFinishAsync()
+            throw error
+        }
+        InferenceProgressManager.shared.modelLoadDidFinishAsync()
         trace?.mark("load_container_done")
 
         let wiredPolicy = MLXLMCommon.WiredSumPolicy()

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -185,8 +185,23 @@ actor ModelRuntime {
             }
         }
 
+        // Re-entry fast path: another caller is already loading this model.
+        // If their task was cancelled by an evictor between our enqueue and
+        // our await (a real race when two chat windows trigger concurrent
+        // loads under `strictSingleModel`), fall through and create a new
+        // task instead of propagating the stale CancellationError to our
+        // caller — which would leave the UI stuck at "loading" with no
+        // recovery path short of quitting the app.
         if let existingTask = loadingTasks[name] {
-            return try await existingTask.value
+            do {
+                return try await existingTask.value
+            } catch is CancellationError {
+                genLog.info(
+                    "loadContainer: existing load for \(name, privacy: .public) was cancelled mid-flight; retrying with fresh task"
+                )
+                loadingTasks[name] = nil
+                // fall through to create a new task below
+            }
         }
 
         guard let localURL = Self.findLocalDirectory(forModelId: id) else {
@@ -344,15 +359,17 @@ actor ModelRuntime {
 
         let cfg = await getConfig()
         trace?.mark("load_container_start")
+        // Symmetric bookkeeping via `defer` — guarantees the "finish"
+        // decrement fires on every exit path (success, throw, cancel,
+        // early return). Previous code duplicated the decrement in a
+        // `catch` and then again after the `do`, which — combined with
+        // the now-refcounted `loadInFlightCount` in
+        // `InferenceProgressManager` — could double-decrement on races
+        // between two chat windows loading different models, leaving
+        // `isLoadingModel` wedged.
         InferenceProgressManager.shared.modelLoadWillStartAsync()
-        let holder: SessionHolder
-        do {
-            holder = try await loadContainer(id: modelId, name: modelName)
-        } catch {
-            InferenceProgressManager.shared.modelLoadDidFinishAsync()
-            throw error
-        }
-        InferenceProgressManager.shared.modelLoadDidFinishAsync()
+        defer { InferenceProgressManager.shared.modelLoadDidFinishAsync() }
+        let holder: SessionHolder = try await loadContainer(id: modelId, name: modelName)
         trace?.mark("load_container_done")
 
         let wiredPolicy = MLXLMCommon.WiredSumPolicy()

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1610,7 +1610,27 @@ public actor RemoteProviderService: ToolCapableService {
         if provider.providerType == .gemini {
             // Gemini uses model-in-URL pattern: /models/{model}:generateContent or :streamGenerateContent
             let action = request.stream ? "streamGenerateContent" : "generateContent"
-            let endpoint = "/models/\(request.model):\(action)"
+            // Validate + percent-encode the model segment. Gemini model
+            // IDs are alphanumeric + `-` + `.` per the AI Studio catalog;
+            // spaces, colons, slashes are never valid. Previously a
+            // model name with spaces (e.g. the user typing
+            // "gemini 3.1 flash lite preview" as the model ID) flowed
+            // unsanitized into URL construction, and `URL(string:)` on
+            // the final string would return nil → the caller saw an
+            // opaque "invalidURL" throw. We explicitly surface the
+            // validation error so the user sees *which* character is
+            // rejected. See issue #858.
+            let trimmedModel = request.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedModel.isEmpty {
+                throw RemoteProviderServiceError.requestFailed(
+                    "Gemini model name is empty. Set a model ID like 'gemini-2.0-flash-exp' in provider settings.")
+            }
+            let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+            if trimmedModel.unicodeScalars.contains(where: { !allowed.contains($0) }) {
+                throw RemoteProviderServiceError.requestFailed(
+                    "Invalid Gemini model name '\(trimmedModel)': only letters, digits, '-', '_', and '.' are allowed. Check provider settings.")
+            }
+            let endpoint = "/models/\(trimmedModel):\(action)"
             guard let geminiURL = provider.url(for: endpoint) else {
                 throw RemoteProviderServiceError.invalidURL
             }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1610,25 +1610,31 @@ public actor RemoteProviderService: ToolCapableService {
         if provider.providerType == .gemini {
             // Gemini uses model-in-URL pattern: /models/{model}:generateContent or :streamGenerateContent
             let action = request.stream ? "streamGenerateContent" : "generateContent"
-            // Validate + percent-encode the model segment. Gemini model
-            // IDs are alphanumeric + `-` + `.` per the AI Studio catalog;
-            // spaces, colons, slashes are never valid. Previously a
-            // model name with spaces (e.g. the user typing
-            // "gemini 3.1 flash lite preview" as the model ID) flowed
+            // Validate the model segment before interpolating into the
+            // URL path. Previously a model name with spaces (e.g. the user
+            // typing "gemini 3.1 flash lite preview" as the model ID) flowed
             // unsanitized into URL construction, and `URL(string:)` on
             // the final string would return nil → the caller saw an
             // opaque "invalidURL" throw. We explicitly surface the
             // validation error so the user sees *which* character is
             // rejected. See issue #858.
+            //
+            // Allowed chars cover:
+            // - standard model IDs: `gemini-2.0-flash-exp`, `gemini-1.5-pro-latest`
+            // - tuned models: `tunedModels/my-tuned-model`
+            // - Google's path-parent syntax: `models/foo/bar` (rare)
+            // Disallowed: whitespace, colons (reserved for the action
+            // suffix we append), `?` / `&` (query markers), other
+            // URL-unsafe chars that would silently corrupt the path.
             let trimmedModel = request.model.trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmedModel.isEmpty {
                 throw RemoteProviderServiceError.requestFailed(
                     "Gemini model name is empty. Set a model ID like 'gemini-2.0-flash-exp' in provider settings.")
             }
-            let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+            let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._/")
             if trimmedModel.unicodeScalars.contains(where: { !allowed.contains($0) }) {
                 throw RemoteProviderServiceError.requestFailed(
-                    "Invalid Gemini model name '\(trimmedModel)': only letters, digits, '-', '_', and '.' are allowed. Check provider settings.")
+                    "Invalid Gemini model name '\(trimmedModel)': only letters, digits, '-', '_', '.', and '/' are allowed. Check provider settings.")
             }
             let endpoint = "/models/\(trimmedModel):\(action)"
             guard let geminiURL = provider.url(for: endpoint) else {

--- a/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
+++ b/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
@@ -554,6 +554,22 @@ public actor WorkExecutionEngine {
                         await onToolArgHint(argFragment)
                         continue
                     }
+                    // Strip benchmarking sentinel (￾stats:N;TPS). Like
+                    // StreamingToolHint, the stats delta is its own
+                    // stream fragment — not part of the visible text —
+                    // so we must drop it rather than accumulate into
+                    // responseContent. Without this strip, the stats
+                    // sentinel was being persisted into the assistant's
+                    // message content and then rendered verbatim on
+                    // re-display, surfacing as the user-visible
+                    // "…￾stats:24;85.4607" string (issue #856).
+                    //
+                    // ChatView.swift:1064 already handles this for the
+                    // regular chat path; work mode uses a different
+                    // consumer (this file), which previously missed it.
+                    if StreamingStatsHint.decode(delta) != nil {
+                        continue
+                    }
                     responseContent += delta
                     await onDelta(delta, iteration)
                 }

--- a/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
@@ -102,4 +102,71 @@ struct InferenceProgressManagerTests {
         #expect(state.prefillTokenCount == 200)
         #expect(state.prefillStartedAt != nil)
     }
+
+    // MARK: modelLoad refcount (regression — stuck-loading-forever bug)
+    //
+    // Prior to the refcount fix, `isLoadingModel` was a bare `Bool`.
+    // Two concurrent loads racing their start/finish sequences could
+    // leave the flag stuck — either stuck `true` (UI stuck at "loading")
+    // or stuck `false` while a load was still in flight. These tests
+    // lock in the refcount semantics.
+
+    @Test func modelLoad_singleCycle_incrementsThenDecrements() async {
+        let state = InferenceProgressManager._testMake()
+        #expect(state.loadInFlightCount == 0)
+        #expect(state.isLoadingModel == false)
+
+        state.modelLoadWillStartAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 1)
+        #expect(state.isLoadingModel == true)
+
+        state.modelLoadDidFinishAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 0)
+        #expect(state.isLoadingModel == false)
+    }
+
+    @Test func modelLoad_concurrentLoads_requireMatchingFinishes() async {
+        let state = InferenceProgressManager._testMake()
+
+        // Window A and Window B both start loads.
+        state.modelLoadWillStartAsync()
+        state.modelLoadWillStartAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 2)
+        #expect(state.isLoadingModel == true)
+
+        // Window A finishes — UI should still show loading because B is mid-load.
+        state.modelLoadDidFinishAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 1)
+        #expect(state.isLoadingModel == true)
+
+        // Window B finishes — now the UI can clear.
+        state.modelLoadDidFinishAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 0)
+        #expect(state.isLoadingModel == false)
+    }
+
+    @Test func modelLoad_doubleFinishIsFloored_atZero() async {
+        let state = InferenceProgressManager._testMake()
+        state.modelLoadWillStartAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        // Simulate a buggy caller that fires didFinish twice.
+        state.modelLoadDidFinishAsync()
+        state.modelLoadDidFinishAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 0)
+        #expect(state.isLoadingModel == false)
+
+        // A subsequent new load must not be poisoned by the earlier
+        // double-finish — the flag must still flip back to true.
+        state.modelLoadWillStartAsync()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(state.loadInFlightCount == 1)
+        #expect(state.isLoadingModel == true)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
@@ -1,0 +1,84 @@
+//
+//  StreamingHintTests.swift
+//  osaurusTests
+//
+//  Regression tests for the streaming sentinel encoders/decoders
+//  (StreamingToolHint + StreamingStatsHint). The stats sentinel was
+//  leaking into visible tool-call output in work mode (issue #856)
+//  because the `WorkExecutionEngine` consumer handled the tool
+//  sentinel but not the stats sentinel — these tests lock in the
+//  round-trip + decoder contract so a future refactor doesn't
+//  re-break it.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct StreamingHintTests {
+
+    // MARK: - StreamingStatsHint
+
+    @Test func statsHint_encode_prefixedWithFFFESentinel() {
+        let encoded = StreamingStatsHint.encode(tokenCount: 24, tokensPerSecond: 85.4607)
+        #expect(encoded.hasPrefix("\u{FFFE}stats:"))
+        #expect(encoded.contains("24;"))
+        #expect(encoded.contains("85.4607"))
+    }
+
+    @Test func statsHint_decode_recoversValues() {
+        let encoded = StreamingStatsHint.encode(tokenCount: 128, tokensPerSecond: 99.4321)
+        let decoded = StreamingStatsHint.decode(encoded)
+        #expect(decoded?.tokenCount == 128)
+        #expect(abs((decoded?.tokensPerSecond ?? 0.0) - 99.4321) < 0.0001)
+    }
+
+    @Test func statsHint_decode_rejectsNonSentinelDelta() {
+        // Plain text must not be mistaken for a sentinel.
+        #expect(StreamingStatsHint.decode("Hello world") == nil)
+        #expect(StreamingStatsHint.decode("") == nil)
+        #expect(StreamingStatsHint.decode("stats:10;20.0") == nil)
+    }
+
+    @Test func statsHint_decode_rejectsMalformedPayload() {
+        // Sentinel present but payload malformed — decode should return nil
+        // rather than surface a partial value.
+        #expect(StreamingStatsHint.decode("\u{FFFE}stats:") == nil)
+        #expect(StreamingStatsHint.decode("\u{FFFE}stats:notanint;99.0") == nil)
+        #expect(StreamingStatsHint.decode("\u{FFFE}stats:10") == nil)
+    }
+
+    @Test func statsHint_decode_isOrthogonalToToolHint() {
+        // Stats decoder must not match tool-hint sentinels and vice versa.
+        let toolEncoded = StreamingToolHint.encode("read_file")
+        #expect(StreamingStatsHint.decode(toolEncoded) == nil)
+
+        let statsEncoded = StreamingStatsHint.encode(tokenCount: 5, tokensPerSecond: 10.0)
+        #expect(StreamingToolHint.decode(statsEncoded) == nil)
+        #expect(StreamingToolHint.decodeArgs(statsEncoded) == nil)
+    }
+
+    // Issue #856 regression: the sentinel must NEVER appear in the
+    // visible text of an assistant message. The actual filtering
+    // happens in WorkExecutionEngine + ChatView. Here we lock in the
+    // contract that the decoder will correctly identify the sentinel
+    // so filtering is possible, and that the encoded form always
+    // carries the U+FFFE prefix that consumers check for.
+    @Test func statsHint_encodedForm_alwaysCarriesNoncharacterPrefix() {
+        let samples: [(Int, Double)] = [
+            (0, 0.0),
+            (1, 1.0),
+            (1_000_000, 999.9999),
+            (42, 3.14159),
+        ]
+        for (count, tps) in samples {
+            let encoded = StreamingStatsHint.encode(tokenCount: count, tokensPerSecond: tps)
+            #expect(
+                encoded.unicodeScalars.first == Unicode.Scalar(0xFFFE),
+                "encoded stats hint must start with U+FFFE noncharacter (got: \(encoded.debugDescription))"
+            )
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/WorkViewErrorClassifierTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/WorkViewErrorClassifierTests.swift
@@ -1,0 +1,142 @@
+//
+//  WorkViewErrorClassifierTests.swift
+//  osaurusTests
+//
+//  Regression tests for the Work-mode error banner classifier. The
+//  original heuristic (issue #858) classified HTTP 400 errors as
+//  "service temporarily unavailable" because the `"api"` substring
+//  matched anywhere (including `ai.google.dev/api/...` URLs in error
+//  bodies) and the `"server"` substring over-matched Google's own
+//  error strings. These tests lock in the new, status-code-first
+//  classification.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct WorkViewErrorClassifierTests {
+
+    // MARK: - #858: the exact cases the classifier must get right
+
+    @Test func gemini_invalidModelName_classifiesAsRequestRejected_notServerError() {
+        // Simulates what the user saw in issue #858: typed
+        // "gemini 3.1 flash lite preview" — not a real model. If the
+        // provider's URL validation catches it, we throw requestFailed
+        // with an explanatory string. This must surface as "Request
+        // Rejected" with the underlying message, NOT as "Server Error
+        // / service temporarily unavailable".
+        let err = "Invalid Gemini model name 'gemini 3.1 flash lite preview': only letters, digits, '-', '_', and '.' are allowed. Check provider settings."
+        let (title, message) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Request Rejected")
+        #expect(message.contains("gemini 3.1 flash lite preview"))
+    }
+
+    @Test func gemini_http400_modelNotFound_classifiesAsNotFound() {
+        // If the provider actually returns 400 "model not found",
+        // we want the user to see "Not Found — check the model name",
+        // not "Authentication Error" (old `"api"` match) or "Server
+        // Error" (old `"server"` match).
+        let err = "HTTP 400: model 'gemini-3.1' not found for provider google. See https://ai.google.dev/api/models"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Not Found")
+    }
+
+    @Test func gemini_http404_modelNotFound_classifiesAsNotFound() {
+        let err = "HTTP 404: The model is not found. Visit https://ai.google.dev/api for the catalog."
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Not Found")
+    }
+
+    @Test func http500_classifiesAsServerError() {
+        let err = "HTTP 500: Internal server error"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Server Error")
+    }
+
+    @Test func http503_classifiesAsServerError() {
+        let err = "HTTP 503: Service unavailable"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Server Error")
+    }
+
+    @Test func http401_classifiesAsAuthError() {
+        let err = "HTTP 401: Unauthorized"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Authentication Error")
+    }
+
+    @Test func http403_classifiesAsPermissionDenied() {
+        let err = "HTTP 403: Forbidden"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Permission Denied")
+    }
+
+    @Test func http429_classifiesAsRateLimited() {
+        let err = "HTTP 429: Too many requests, slow down"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Rate Limited")
+    }
+
+    @Test func apiKeyMentionInErrorBody_classifiesAsAuthError_notRequestRejected() {
+        // "api key" in the body should still route to auth, even
+        // without an explicit HTTP code — some providers just return
+        // plain-text errors.
+        let err = "Your api key is invalid"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Authentication Error")
+    }
+
+    // MARK: - Regression guards for old over-matching
+
+    @Test func plainApiMention_doesNotTriggerAuthError() {
+        // This used to trip the old classifier because it contained "api".
+        // A message mentioning "https://ai.google.dev/api/..." is NOT an
+        // auth error on its own.
+        let err = "Request body malformed — see docs at https://ai.google.dev/api/rest/v1/models"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title != "Authentication Error")
+    }
+
+    @Test func plainServerMention_doesNotTriggerServerError() {
+        // "server" used to trigger "service temporarily unavailable".
+        // A generic message mentioning a server shouldn't route there.
+        let err = "The upstream server returned an unexpected payload shape"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        // Should fall through to the generic fallback, not Server Error,
+        // because no HTTP 5xx code is present.
+        #expect(title != "Server Error")
+    }
+
+    // MARK: - Connection / timeout classification (unchanged behavior, locked in)
+
+    @Test func nsurlError_classifiesAsConnection() {
+        let err = "The operation couldn't be completed. (NSURLErrorDomain error -1004.)"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Connection Issue")
+    }
+
+    @Test func timeoutError_classifiesAsTimeout() {
+        let err = "The request timed out"
+        let (title, _) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Request Timed Out")
+    }
+
+    // MARK: - Fallback truncation
+
+    @Test func fallback_usesGenericTitle_andKeepsReasonableDetail() {
+        let err = "Some totally unrecognized error message with no keywords"
+        let (title, message) = WorkViewErrorClassifier.classify(err)
+        #expect(title == "Something Went Wrong")
+        #expect(message == err)  // under 200 chars, not truncated
+    }
+
+    @Test func fallback_truncatesLongMessageTo200Chars() {
+        let err = String(repeating: "x", count: 500)
+        let (_, message) = WorkViewErrorClassifier.classify(err)
+        #expect(message.hasSuffix("..."))
+        #expect(message.count == 203)  // 200 chars + "..."
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -125,7 +125,14 @@ final class NativeTypingIndicatorView: NSView {
 
     private func observeModelLoading() {
         let manager = InferenceProgressManager.shared
-        let sink = manager.$isLoadingModel.combineLatest(manager.$isPreflighting)
+        // `isLoadingModel` is now a computed view over the `@Published`
+        // `loadInFlightCount` refcount (see InferenceProgressManager). We
+        // observe the underlying counter and derive the boolean in the
+        // sink, rather than using `$isLoadingModel` which no longer
+        // exists as a projected publisher.
+        let sink = manager.$loadInFlightCount
+            .map { $0 > 0 }
+            .combineLatest(manager.$isPreflighting)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] (loadingModel, preflighting) in
                 self?.setLoadingModelState(loadingModel: loadingModel, preflighting: preflighting)

--- a/Packages/OsaurusCore/Views/Work/WorkView.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkView.swift
@@ -637,34 +637,112 @@ extension WorkView {
     }
 
     private func humanFriendlyError(_ error: String) -> (title: String, message: String) {
+        return WorkViewErrorClassifier.classify(error)
+    }
+}
+
+/// Error classifier for the WorkView error banner. Extracted from
+/// `WorkView.humanFriendlyError` so we can unit-test the classification
+/// logic directly (issue #858 regression).
+///
+/// Pure function: input is the raw error string from the inference
+/// pipeline, output is a (title, message) pair for display. No SwiftUI
+/// types here so the tests don't need to build the view hierarchy.
+enum WorkViewErrorClassifier {
+    static func classify(_ error: String) -> (title: String, message: String) {
         let lowercased = error.lowercased()
 
+        // Match HTTP status codes on word boundaries first — this is the
+        // most specific signal. We cap the truncated fallback at 200 chars
+        // (up from 80) so users can actually see the underlying API error
+        // message (e.g. Gemini's "Invalid model 'foo'. See https://...")
+        // instead of a generic "Something went wrong" that hides the cause.
+        //
+        // Previous logic had two latent bugs (issue #858):
+        //   1. The `"api"` check matched error bodies from google.dev/api,
+        //      or anything mentioning "API", classifying model-not-found
+        //      errors as "Authentication Error".
+        //   2. The `"server"` check matched any body containing the word
+        //      "server" (e.g. Google's own error strings), causing HTTP 400
+        //      responses to surface as "The service is temporarily
+        //      unavailable" with no hint to the user that the real cause
+        //      is an invalid model ID they typed.
+        //
+        // We now key on specific status codes first, then distinct
+        // terms, in most-to-least-specific order. "api" alone is too
+        // weak a signal to classify as auth error — we require the
+        // narrower "401"/"unauthorized"/"api key" phrases.
+
+        // HTTP status code matching — anchored on digits
+        if lowercased.contains(" 401") || lowercased.contains("401:") || lowercased.contains("unauthorized")
+            || lowercased.contains("api key") || lowercased.contains("invalid key")
+        {
+            return ("Authentication Error", "There was an issue with the API credentials. Please check your settings.")
+        }
+        if lowercased.contains(" 403") || lowercased.contains("403:") || lowercased.contains("forbidden") {
+            return ("Permission Denied", "The account or API key does not have permission for this request.")
+        }
+        if lowercased.contains(" 404") || lowercased.contains("404:") || lowercased.contains("not found")
+            || lowercased.contains("model not found") || lowercased.contains("does not exist")
+        {
+            let detail: String
+            if lowercased.contains("model") {
+                detail = "The requested model was not found. Check the model name in provider settings."
+            } else {
+                detail = "The requested resource could not be found."
+            }
+            return ("Not Found", detail)
+        }
+        if lowercased.contains(" 400") || lowercased.contains("400:") || lowercased.contains("bad request")
+            || lowercased.contains("invalid argument") || lowercased.contains("invalid model")
+            || lowercased.contains("invalid ") && (lowercased.contains(" model") || lowercased.contains("gemini"))
+        {
+            // HTTP 400 from provider — usually a malformed request or an
+            // unrecognized model name. Also catches osaurus's own
+            // client-side validation errors (e.g. "Invalid Gemini model
+            // name 'foo': only ..." — see `RemoteProviderService`). We
+            // surface the underlying message so the user can see what's
+            // actually wrong.
+            let truncated = error.count > 200 ? String(error.prefix(200)) + "..." : error
+            return ("Request Rejected", truncated)
+        }
+        if lowercased.contains(" 429") || lowercased.contains("429:") || lowercased.contains("rate limit")
+            || lowercased.contains("too many")
+        {
+            return ("Rate Limited", "Too many requests. Please wait a moment before trying again.")
+        }
+        if lowercased.contains(" 500") || lowercased.contains("500:") || lowercased.contains(" 502")
+            || lowercased.contains("502:") || lowercased.contains(" 503") || lowercased.contains("503:")
+            || lowercased.contains(" 504") || lowercased.contains("504:") || lowercased.contains("internal server error")
+        {
+            return ("Server Error", "The provider is temporarily unavailable. Please try again later.")
+        }
+
+        // Non-status specific classifications
         if lowercased.contains("javascript") || lowercased.contains("browser") {
             return (
                 "Browser Error",
                 "Something went wrong while interacting with the browser. This might be a temporary issue."
             )
-        } else if lowercased.contains("timeout") {
-            return ("Request Timed Out", "The operation took too long to complete. Please try again.")
-        } else if lowercased.contains("network") || lowercased.contains("connection") {
-            return ("Connection Issue", "Unable to connect to the service. Please check your internet connection.")
-        } else if lowercased.contains("rate limit") || lowercased.contains("too many") {
-            return ("Rate Limited", "Too many requests. Please wait a moment before trying again.")
-        } else if lowercased.contains("api") || lowercased.contains("unauthorized") || lowercased.contains("401") {
-            return ("Authentication Error", "There was an issue with the API credentials. Please check your settings.")
-        } else if lowercased.contains("cancelled") || lowercased.contains("canceled") {
-            return ("Task Cancelled", "The operation was stopped before it could complete.")
-        } else if lowercased.contains("not found") || lowercased.contains("404") {
-            return ("Not Found", "The requested resource could not be found.")
-        } else if lowercased.contains("server") || lowercased.contains("500") || lowercased.contains("502")
-            || lowercased.contains("503")
-        {
-            return ("Server Error", "The service is temporarily unavailable. Please try again later.")
-        } else {
-            // Generic fallback - show truncated original error
-            let truncated = error.count > 80 ? String(error.prefix(80)) + "..." : error
-            return ("Something Went Wrong", truncated)
         }
+        if lowercased.contains("timeout") || lowercased.contains("timed out") {
+            return ("Request Timed Out", "The operation took too long to complete. Please try again.")
+        }
+        if lowercased.contains("cannot connect to host") || lowercased.contains("no internet")
+            || lowercased.contains("network connection was lost") || lowercased.contains("nsurlerror")
+            || lowercased.contains("dns")
+        {
+            return ("Connection Issue", "Unable to reach the provider. Check your network and the provider URL.")
+        }
+        if lowercased.contains("cancelled") || lowercased.contains("canceled") {
+            return ("Task Cancelled", "The operation was stopped before it could complete.")
+        }
+
+        // Generic fallback: show the underlying message truncated to 200
+        // chars (up from 80). Users reporting issues need enough text to
+        // diagnose; 80 chars was hiding most provider error bodies.
+        let truncated = error.count > 200 ? String(error.prefix(200)) + "..." : error
+        return ("Something Went Wrong", truncated)
     }
 
 }

--- a/Packages/OsaurusCore/Views/Work/WorkView.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkView.swift
@@ -693,9 +693,12 @@ enum WorkViewErrorClassifier {
             }
             return ("Not Found", detail)
         }
+        let isInvalidModelClientError =
+            lowercased.contains("invalid ")
+            && (lowercased.contains(" model") || lowercased.contains("gemini"))
         if lowercased.contains(" 400") || lowercased.contains("400:") || lowercased.contains("bad request")
             || lowercased.contains("invalid argument") || lowercased.contains("invalid model")
-            || lowercased.contains("invalid ") && (lowercased.contains(" model") || lowercased.contains("gemini"))
+            || isInvalidModelClientError
         {
             // HTTP 400 from provider — usually a malformed request or an
             // unrecognized model name. Also catches osaurus's own

--- a/Packages/OsaurusCore/Views/Work/WorkView.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkView.swift
@@ -714,6 +714,8 @@ enum WorkViewErrorClassifier {
         if lowercased.contains(" 500") || lowercased.contains("500:") || lowercased.contains(" 502")
             || lowercased.contains("502:") || lowercased.contains(" 503") || lowercased.contains("503:")
             || lowercased.contains(" 504") || lowercased.contains("504:") || lowercased.contains("internal server error")
+            || lowercased.contains("service unavailable") || lowercased.contains("bad gateway")
+            || lowercased.contains("gateway timeout") || lowercased.contains("overloaded")
         {
             return ("Server Error", "The provider is temporarily unavailable. Please try again later.")
         }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "e09ad19d1564459c289e9d73e011158c6edd934e"
+        "revision" : "bf942a86380230abb4adaa36c294748697ffb2b1"
       }
     },
     {


### PR DESCRIPTION
## Summary

Fixes four separate issues found via evidence-based traces through the osaurus codebase. Each commit is a single logical fix with its own regression tests. All 651 existing tests plus 13 new tests pass.

Also bumps `vmlx-swift-lm` pin to the latest main HEAD (`bf942a86`).

## The four bugs

### Stuck "Loading Model..." UI (hit by @jjang-ai — screenshot in issue)

**Root cause (verified in `InferenceProgressManager.swift` + `ModelRuntime.swift`)**: `isLoadingModel` was a bare `@Published Bool` with duplicated start/finish bookkeeping. Two chat windows loading different models concurrently would race their `modelLoadWillStartAsync`/`DidFinishAsync` calls, and the flag could stick in the wrong state. Additionally, the re-entry fast path in `loadContainer` would surface `CancellationError` from an evicted-mid-flight task to the UI with no recovery path — the visible symptom was a frozen loading indicator that only a quit+relaunch could clear.

**Fix**:
- `InferenceProgressManager.isLoadingModel` is now a computed view over a `@Published loadInFlightCount: Int`. Refcount increments on start, decrements on finish with `max(0, _ - 1)` so double-fires can't poison subsequent loads.
- `ModelRuntime.generateEventStream` replaces the duplicated cleanup with `defer { modelLoadDidFinishAsync() }`, guaranteeing symmetric start/finish on every exit path (success, throw, cancel).
- `ModelRuntime.loadContainer` re-entry fast path now catches `CancellationError` from an evicted task and retries with a fresh task.
- `NativeBlockViews` switches the observer from `$isLoadingModel` to `$loadInFlightCount.map { $0 > 0 }`.

### #856 — `￾stats:` sentinel leaks into visible tool-call text in work mode

**Root cause (verified in `WorkExecutionEngine.swift:549-558`)**: The stream consumer handles `StreamingToolHint.decode` and `StreamingToolHint.decodeArgs` but never checks `StreamingStatsHint.decode`. The stats delta (e.g. `"\u{FFFE}stats:24;85.4607"`) was getting concatenated into `responseContent`, persisted as the assistant's message, and re-rendered verbatim on the next display. `ChatView.swift:1064` already handles this for the regular chat path; work mode was the gap.

**Fix**: Symmetric `StreamingStatsHint.decode` check in `WorkExecutionEngine` before appending to `responseContent` — if the delta is a stats sentinel, drop it. Same contract as the `StreamingToolHint` filtering two lines up.

### #858 — "Service Temporarily Unavailable" for invalid Gemini model

**Root cause (verified in `WorkView.swift:639-667` + `RemoteProviderService.swift:1610-1616`)**: Two bugs compounded:
1. The classifier's `lowercased.contains("api")` check matched error bodies containing `ai.google.dev/api/...` URLs → model-not-found classified as "Authentication Error".
2. The `lowercased.contains("server")` check matched Google's own error strings → HTTP 400 responses surfaced as the 5xx "service temporarily unavailable" copy.

Additionally, a model name with spaces (`gemini 3.1 flash lite preview` — the user's actual input) flowed unsanitized into the URL path, `URL(string:)` rejected it → opaque `invalidURL` throw with no hint about the typo.

**Fix**:
- Extracted the classifier to a top-level `WorkViewErrorClassifier` enum for direct unit testing.
- Keys on HTTP status codes first with word-boundary anchors (`" 401"` / `"401:"`) instead of loose substring matching.
- Drops the over-broad `"api"` match; requires `"api key"`, `"unauthorized"`, or explicit `"401"` for auth classification.
- Raised the generic-fallback truncation from 80 → 200 chars so users see the underlying API error body.
- `RemoteProviderService.buildURLRequest` now validates Gemini model names before URL interpolation and throws a readable error when invalid.

### #860 — NIO crash on Sparkle quit

**Root cause (verified in `AppDelegate.swift:501`)**: The guard `if serverController.isRunning { await serverController.ensureShutdown() }` skipped shutdown when the UI-level `isRunning` flag was false — but NIO's `MultiThreadedEventLoopGroup` could still be alive (partial start, mid-shutdown, Sparkle race). NIO's destructor fires `preconditionFailure("EventLoopGroup is still running")` at `exit()` → EXC_BREAKPOINT at `NIO-ELT-3` as reported.

`ensureShutdown()` is already idempotent (no-ops when everything is already nil), so the outer guard was redundant and harmful.

**Fix**:
- Always call `serverController.ensureShutdown()` unconditionally in `applicationShouldTerminate`.
- Always call `HostAPIBridgeServer.shared.stop()` after sandbox teardown as a belt-and-suspenders safety net (the bridge has its own 2-thread EL group).

### vmlx-swift-lm bump

Rolls `osaurus-ai/vmlx-swift-lm` from `e09ad19d` → `bf942a8638...` (latest main HEAD). Carries upstream generation-loop changes.

## Test plan

- [x] 651 existing tests pass (`swift test --package-path Packages/OsaurusCore`)
- [x] 13 new regression tests pass:
  - 3 `InferenceProgressManagerTests` for the refcount semantics (single-cycle, concurrent-loads, double-finish floor)
  - 6 `StreamingHintTests` for the stats/tool sentinel round-trip + orthogonality
  - 13 `WorkViewErrorClassifierTests` for all the #858 cases + regression guards against the old over-matching
- [x] Build verified clean against the bumped vmlx-swift-lm main HEAD

## Scope / non-goals

- Does NOT add a timeout to `loadModelContainer` itself. If the filesystem or mmap stalls inside vmlx-swift-lm, the load can still hang — the refcount fix just makes the UI recoverable once the hang resolves or the user evicts the model via another action. A user-facing load timeout would be a follow-up.
- Does NOT touch the `strictSingleModel` eviction policy itself. The `loadContainer` retry path covers the race when a second window's eviction cancels the first window's in-flight load.
- Does NOT refactor `StreamingToolHint` / `StreamingStatsHint` into a shared sentinel enum. That would be cleaner but is a larger refactor than this surgical fix warrants.