### PR TITLE
removed unused theme properties & improved code block customization/readability

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
+++ b/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
@@ -565,6 +565,9 @@ public struct CustomTheme: Codable, Equatable, Sendable {
     public var messages: ThemeMessages
     public var borders: ThemeBorders
 
+    /// Syntax highlighting theme name (Highlightr). nil = auto (dark/light).
+    public var codeHighlightTheme: String?
+
     /// Whether this is a built-in theme (cannot be deleted)
     public var isBuiltIn: Bool
     public var isDark: Bool
@@ -579,6 +582,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         shadows: ThemeShadows = ThemeShadows(),
         messages: ThemeMessages = ThemeMessages(),
         borders: ThemeBorders = ThemeBorders(),
+        codeHighlightTheme: String? = nil,
         isBuiltIn: Bool = false,
         isDark: Bool = true
     ) {
@@ -591,6 +595,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         self.shadows = shadows
         self.messages = messages
         self.borders = borders
+        self.codeHighlightTheme = codeHighlightTheme
         self.isBuiltIn = isBuiltIn
         self.isDark = isDark
     }
@@ -607,6 +612,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         shadows = try container.decode(ThemeShadows.self, forKey: .shadows)
         messages = try container.decodeIfPresent(ThemeMessages.self, forKey: .messages) ?? ThemeMessages()
         borders = try container.decodeIfPresent(ThemeBorders.self, forKey: .borders) ?? ThemeBorders()
+        codeHighlightTheme = try container.decodeIfPresent(String.self, forKey: .codeHighlightTheme)
         isBuiltIn = try container.decode(Bool.self, forKey: .isBuiltIn)
         isDark = try container.decode(Bool.self, forKey: .isDark)
     }

--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -107,6 +107,9 @@ protocol ThemeProtocol {
     var captionSize: Double { get }
     var codeSize: Double { get }
 
+    // Code syntax highlighting theme (Highlightr name). nil = auto.
+    var codeHighlightTheme: String? { get }
+
     // Custom theme reference (for editing)
     var customThemeConfig: CustomTheme? { get }
 
@@ -149,6 +152,7 @@ extension ThemeProtocol {
     var captionSize: Double { 12 }
     var codeSize: Double { 13 }
 
+    var codeHighlightTheme: String? { nil }
     var customThemeConfig: CustomTheme? { nil }
 
     // Message bubble defaults
@@ -489,6 +493,9 @@ struct CustomizableTheme: ThemeProtocol {
     var bodySize: Double { config.typography.bodySize }
     var captionSize: Double { config.typography.captionSize }
     var codeSize: Double { config.typography.codeSize }
+
+    // Code syntax highlighting
+    var codeHighlightTheme: String? { config.codeHighlightTheme }
 
     // Custom theme reference
     var customThemeConfig: CustomTheme? { config }

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -708,12 +708,15 @@ final class NativeCodeBlockView: NSView {
         lastWidth = width
         lastThemeId = themeId
 
+        ensureHighlightrTheme(for: theme)
+        let bgColor = highlightrThemeBackgroundNSColor()
+
         langLabel.stringValue = language?.lowercased() ?? "code"
         langLabel.font = NSFont.monospacedSystemFont(ofSize: CGFloat(theme.captionSize) - 1, weight: .medium)
         langLabel.textColor = NSColor(theme.tertiaryText)
 
-        headerView.layer?.backgroundColor = NSColor(theme.codeBlockBackground).withAlphaComponent(0.6).cgColor
-        layer?.backgroundColor = NSColor(theme.codeBlockBackground).cgColor
+        headerView.layer?.backgroundColor = bgColor.withAlphaComponent(0.6).cgColor
+        layer?.backgroundColor = bgColor.cgColor
 
         let cv = ensureCodeView(theme: theme)
         if widthChanged {

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -695,7 +695,8 @@ final class NativeCodeBlockView: NSView {
     // MARK: Configure
 
     func configure(code: String, language: String?, width: CGFloat, theme: any ThemeProtocol) {
-        let themeId = "\(theme.monoFontName)|\(theme.codeSize)"
+        let resolvedHL = theme.codeHighlightTheme ?? (theme.isDark ? "auto-dark" : "auto-light")
+        let themeId = "\(theme.monoFontName)|\(theme.codeSize)|\(resolvedHL)"
         let codeChanged = code != lastCode || language != lastLang
         let widthChanged = abs(width - lastWidth) > 0.5
         let themeChanged = themeId != lastThemeId

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -819,11 +819,12 @@ final class NativeMessageCellView: NSTableCellView {
         case let .header(role, name, _):
             configureAsHeader(block: block, role: role, name: name, context: context, sameKind: sameKind)
 
-        case let .paragraph(_, text, isStreaming, _):
+        case let .paragraph(_, text, isStreaming, role):
             configureAsParagraph(
                 block: block,
                 text: text,
                 isStreaming: isStreaming,
+                role: role,
                 context: context,
                 sameKind: sameKind
             )
@@ -958,6 +959,7 @@ final class NativeMessageCellView: NSTableCellView {
         block: ContentBlock,
         text: String,
         isStreaming: Bool,
+        role: MessageRole,
         context: CellRenderingContext,
         sameKind: Bool
     ) {
@@ -986,6 +988,18 @@ final class NativeMessageCellView: NSTableCellView {
             cacheKey: block.id,
             isStreaming: isStreaming
         )
+
+        // Apply assistant bubble background when a custom color is set
+        if role == .assistant, let bubbleColor = context.theme.assistantBubbleColor {
+            self.wantsLayer = true
+            self.layer?.backgroundColor = NSColor(bubbleColor)
+                .withAlphaComponent(context.theme.assistantBubbleOpacity).cgColor
+            self.layer?.cornerRadius = 12
+        } else {
+            self.layer?.backgroundColor = nil
+            self.layer?.cornerRadius = 0
+        }
+
         // always report height: configure() can return early when text is unchanged (e.g. tool row
         // expand/collapse) and otherwise the table keeps a stale row height → clipped / squeezed text.
         let h = mv.measuredHeight(for: context.width - 32) + 8
@@ -1566,6 +1580,8 @@ final class NativeMessageCellView: NSTableCellView {
     // MARK: - Helpers
 
     private func removeAllContentViews() {
+        self.layer?.backgroundColor = nil
+        self.layer?.cornerRadius = 0
         spacerView?.removeFromSuperview(); spacerView = nil
         nativeHeaderView?.removeFromSuperview(); nativeHeaderView = nil
         nativeMarkdownView?.removeFromSuperview(); nativeMarkdownView = nil

--- a/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
+++ b/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
@@ -16,12 +16,38 @@ import SwiftUI
 // MARK: - Shared Highlightr Instance
 
 // Highlightr wraps highlight.js via JavaScriptCore — initialisation is expensive,
-// so we keep a single instance for the process lifetime.
+// so we keep a single instance for the process lifetime. The theme is switched
+// lazily when the resolved highlight theme name changes.
 nonisolated(unsafe) private let sharedHighlightr: Highlightr? = {
     guard let h = Highlightr() else { return nil }
-    h.setTheme(to: "pop")
+    h.setTheme(to: "atom-one-dark")
     return h
 }()
+
+/// Track which Highlightr theme is currently loaded so we only call setTheme when it changes.
+nonisolated(unsafe) private var currentHighlightrTheme: String = "atom-one-dark"
+
+private let defaultDarkHighlightTheme = "atom-one-dark"
+private let defaultLightHighlightTheme = "atom-one-light"
+
+/// Returns the available Highlightr theme names (cached after first call).
+nonisolated(unsafe) private var cachedAvailableThemes: [String]?
+func availableHighlightrThemes() -> [String] {
+    if let cached = cachedAvailableThemes { return cached }
+    let themes = (sharedHighlightr?.availableThemes() ?? []).sorted()
+    cachedAvailableThemes = themes
+    return themes
+}
+
+/// Resolves which Highlightr theme to use and switches if needed.
+/// Call this before highlighting — it's a no-op when the theme hasn't changed.
+func ensureHighlightrTheme(for theme: any ThemeProtocol) {
+    let resolved = theme.codeHighlightTheme
+        ?? (theme.isDark ? defaultDarkHighlightTheme : defaultLightHighlightTheme)
+    guard resolved != currentHighlightrTheme else { return }
+    sharedHighlightr?.setTheme(to: resolved)
+    currentHighlightrTheme = resolved
+}
 
 // MARK: - CodeBlockView
 
@@ -132,7 +158,8 @@ struct CodeContentView: NSViewRepresentable {
 
     func updateNSView(_ textView: CodeNSTextView, context: Context) {
         let coord = context.coordinator
-        let themeId = "\(theme.monoFontName)|\(theme.bodySize)"
+        let resolvedHL = theme.codeHighlightTheme ?? (theme.isDark ? "auto-dark" : "auto-light")
+        let themeId = "\(theme.monoFontName)|\(theme.bodySize)|\(resolvedHL)"
 
         let codeChanged = coord.lastCode != code
         let langChanged = coord.lastLanguage != language
@@ -220,6 +247,9 @@ struct CodeContentView: NSViewRepresentable {
         let gutterDigits = "\(lines.count)".count
         let gutterWidth = CGFloat(gutterDigits + 2) * fontSize * 0.62
         let indent: CGFloat = 12 + gutterWidth
+
+        // Ensure the Highlightr theme matches the current app theme before highlighting.
+        ensureHighlightrTheme(for: theme)
 
         // use Highlightr for syntax highlighting; fall back to plain text if it returns nil.
         let result: NSMutableAttributedString

--- a/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
+++ b/Packages/OsaurusCore/Views/Common/CodeBlockView.swift
@@ -49,6 +49,20 @@ func ensureHighlightrTheme(for theme: any ThemeProtocol) {
     currentHighlightrTheme = resolved
 }
 
+/// Returns the background color from the current Highlightr theme as a SwiftUI Color.
+/// Falls back to a sensible default if unavailable.
+func highlightrThemeBackgroundColor() -> Color {
+    if let bg = sharedHighlightr?.theme.themeBackgroundColor {
+        return Color(bg)
+    }
+    return Color(white: 0.1)
+}
+
+/// Returns the background color from the current Highlightr theme as an NSColor.
+func highlightrThemeBackgroundNSColor() -> NSColor {
+    sharedHighlightr?.theme.themeBackgroundColor ?? NSColor(white: 0.1, alpha: 1)
+}
+
 // MARK: - CodeBlockView
 
 struct CodeBlockView: View {
@@ -61,8 +75,11 @@ struct CodeBlockView: View {
     @State private var isHovered = false
 
     var body: some View {
+        let _ = ensureHighlightrTheme(for: theme)
+        let bgColor = highlightrThemeBackgroundColor()
+
         VStack(alignment: .leading, spacing: 0) {
-            headerBar
+            headerBar(bgColor: bgColor)
             CodeContentView(
                 code: code,
                 language: language,
@@ -74,14 +91,14 @@ struct CodeBlockView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(theme.codeBlockBackground)
+                .fill(bgColor)
         )
         .onHover { isHovered = $0 }
     }
 
     // MARK: - Header Bar
 
-    private var headerBar: some View {
+    private func headerBar(bgColor: Color) -> some View {
         HStack {
             Text(language?.lowercased() ?? "code")
                 .font(theme.monoFont(size: CGFloat(theme.captionSize) - 1, weight: .medium))
@@ -257,6 +274,9 @@ struct CodeContentView: NSViewRepresentable {
         if let highlighted = highlightedCode {
             result = NSMutableAttributedString(attributedString: highlighted)
             let fullRange = NSRange(location: 0, length: result.length)
+            // Strip background colors injected by the Highlightr CSS theme —
+            // the app's own codeBlockBackground is used instead.
+            result.removeAttribute(.backgroundColor, range: fullRange)
             result.enumerateAttribute(.font, in: fullRange, options: []) { value, range, _ in
                 let isBold = (value as? NSFont)?.fontDescriptor.symbolicTraits.contains(.bold) ?? false
                 result.addAttribute(

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -57,6 +57,7 @@ struct ThemeEditorView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     appearanceSection
+                    codeSection
                     colorsSection
                     messagesSection
                     textAndFontsSection
@@ -165,7 +166,21 @@ struct ThemeEditorView: View {
         }
     }
 
-    // MARK: - Section 2: Colors
+    // MARK: - Section 2: Code
+
+    private var codeSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            editorSection("Code") {
+                codeHighlightThemePicker
+                colorRow("Code Block BG", hex: $editingTheme.colors.codeBlockBackground)
+                colorRow("Text Selection", hex: $editingTheme.colors.selectionColor)
+                colorRow("Cursor", hex: $editingTheme.colors.cursorColor)
+                colorRow("Shadow", hex: $editingTheme.colors.shadowColor)
+            }
+        }
+    }
+
+    // MARK: - Section 3: Colors
 
     private var colorsSection: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -181,7 +196,7 @@ struct ThemeEditorView: View {
                 colorRow("Tertiary BG", hex: $editingTheme.colors.tertiaryBackground)
             }
 
-            editorSection("Advanced Colors", itemCount: 11) {
+            editorSection("Advanced Colors", itemCount: 7) {
                 colorRowOptional("Placeholder", hex: $editingTheme.colors.placeholderText)
 
                 Text("Status", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
@@ -200,14 +215,6 @@ struct ThemeEditorView: View {
                 colorRow("Card Border", hex: $editingTheme.colors.cardBorder)
                 colorRow("Input BG", hex: $editingTheme.colors.inputBackground)
                 colorRow("Input Border", hex: $editingTheme.colors.inputBorder)
-
-                Text("Code & Selection", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                ).textCase(.uppercase)
-                colorRow("Code Block BG", hex: $editingTheme.colors.codeBlockBackground)
-                colorRow("Text Selection", hex: $editingTheme.colors.selectionColor)
-                colorRow("Cursor", hex: $editingTheme.colors.cursorColor)
-                colorRow("Shadow", hex: $editingTheme.colors.shadowColor)
             }
         }
     }
@@ -581,6 +588,26 @@ struct ThemeEditorView: View {
         }
     }
 
+    private var codeHighlightThemePicker: some View {
+        HStack(spacing: 8) {
+            Text("Syntax Theme", bundle: .module)
+                .font(.system(size: 13))
+                .foregroundColor(currentTheme.primaryText)
+            Spacer()
+            Picker("", selection: Binding<String>(
+                get: { editingTheme.codeHighlightTheme ?? "auto" },
+                set: { editingTheme.codeHighlightTheme = $0 == "auto" ? nil : $0 }
+            )) {
+                Text("Auto", bundle: .module).tag("auto")
+                Divider()
+                ForEach(availableHighlightrThemes(), id: \.self) { name in
+                    Text(name).tag(name)
+                }
+            }
+            .frame(width: 180)
+        }
+    }
+
     private func colorRow(_ label: String, hex: Binding<String>) -> some View {
         HStack(spacing: 8) {
             Text(label)
@@ -934,42 +961,7 @@ struct ThemeChatPreview: View {
                     .font(bodyFont)
                     .foregroundColor(c(theme.colors.primaryText))
 
-                VStack(alignment: .leading, spacing: 0) {
-                    // Header bar
-                    HStack {
-                        Text("swift", bundle: .module)
-                            .font(monoFont(size: captionSize - 1, weight: .medium))
-                            .foregroundColor(c(theme.colors.tertiaryText))
-                        Spacer()
-                        Image(systemName: "doc.on.doc")
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(c(theme.colors.tertiaryText).opacity(0.45))
-                    }
-                    .padding(.horizontal, 12)
-                    .frame(height: 28)
-                    .background(c(theme.colors.codeBlockBackground).opacity(0.6))
-
-                    // Code area
-                    HStack(alignment: .top, spacing: 0) {
-                        Text("1", bundle: .module)
-                            .font(monoFont(size: CGFloat(theme.typography.codeSize), weight: .regular))
-                            .foregroundColor(c(theme.colors.tertiaryText).opacity(0.4))
-                            .frame(width: 24, alignment: .trailing)
-                            .padding(.trailing, 8)
-                        Text("print(\"Hello, World!\")", bundle: .module)
-                            .font(codeFont)
-                            .foregroundColor(c(theme.colors.primaryText))
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: 8).fill(
-                        c(theme.colors.codeBlockBackground)
-                    )
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                previewCodeBlock
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -983,6 +975,49 @@ struct ThemeChatPreview: View {
             )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Code Block Preview
+
+    private var previewCodeBlock: some View {
+        let themeProtocol = CustomizableTheme(config: theme)
+        let sampleCode = "print(\"Hello, World!\")"
+
+        return VStack(alignment: .leading, spacing: 0) {
+            // Header bar
+            HStack {
+                Text("swift", bundle: .module)
+                    .font(monoFont(size: captionSize - 1, weight: .medium))
+                    .foregroundColor(c(theme.colors.tertiaryText))
+                Spacer()
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(c(theme.colors.tertiaryText).opacity(0.45))
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 28)
+            .background(c(theme.colors.codeBlockBackground).opacity(0.6))
+
+            // Syntax-highlighted code via CodeContentView
+            GeometryReader { geo in
+                CodeContentView(
+                    code: sampleCode,
+                    language: "swift",
+                    baseWidth: geo.size.width - 24,
+                    theme: themeProtocol
+                )
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+            .frame(height: 36)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8).fill(
+                c(theme.colors.codeBlockBackground)
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     // MARK: - Background

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -1058,8 +1058,8 @@ struct ThemeChatPreview: View {
     // MARK: - Input
 
     private var previewInput: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Model selector row inside card
+        VStack(spacing: 8) {
+            // Selector row — outside the card
             HStack(spacing: 8) {
                 selectorChip {
                     Circle().fill(c(theme.colors.successColor)).frame(width: 5, height: 5)
@@ -1073,60 +1073,109 @@ struct ThemeChatPreview: View {
                     .font(primaryFont(size: captionSize - 1, weight: .medium))
                     .foregroundColor(c(theme.colors.tertiaryText).opacity(0.6))
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 6)
 
-            // Text input placeholder
-            Text("Message or attach files...", bundle: .module)
-                .font(bodyFont)
-                .foregroundColor(c(theme.colors.placeholderText ?? theme.colors.tertiaryText))
-                .padding(.horizontal, 14)
-                .padding(.bottom, 8)
+            // Input card
+            VStack(alignment: .leading, spacing: 0) {
+                // Text input placeholder
+                Text("Message or attach files...", bundle: .module)
+                    .font(bodyFont)
+                    .foregroundColor(c(theme.colors.placeholderText ?? theme.colors.tertiaryText))
+                    .padding(.horizontal, 14)
+                    .padding(.top, 12)
+                    .padding(.bottom, 8)
 
-            // Button bar
-            HStack(spacing: 8) {
-                Image(systemName: "paperclip").font(.system(size: 12, weight: .medium))
-                    .foregroundColor(c(theme.colors.tertiaryText))
-                Text("/", bundle: .module).font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(c(theme.colors.tertiaryText))
+                // Button bar
+                HStack(spacing: 6) {
+                    previewActionButton(icon: "paperclip")
+                    previewSlashButton
 
-                Spacer()
+                    Spacer()
 
-                HStack(spacing: 3) {
-                    Text("⏎", bundle: .module).font(primaryFont(size: captionSize - 2, weight: .medium))
-                    Text("to send", bundle: .module).font(primaryFont(size: captionSize - 1))
-                }
-                .foregroundColor(c(theme.colors.tertiaryText).opacity(0.5))
+                    HStack(spacing: 3) {
+                        Text("⏎", bundle: .module).font(primaryFont(size: captionSize - 2, weight: .medium))
+                        Text("to send", bundle: .module).font(primaryFont(size: captionSize - 1))
+                    }
+                    .foregroundColor(c(theme.colors.tertiaryText).opacity(0.5))
 
-                Circle()
-                    .fill(
-                        LinearGradient(
-                            colors: [c(theme.colors.accentColor), c(theme.colors.accentColor).opacity(0.85)],
-                            startPoint: .top,
-                            endPoint: .bottom
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [c(theme.colors.accentColor), c(theme.colors.accentColor).opacity(0.85)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
                         )
-                    )
-                    .frame(width: 26, height: 26)
-                    .overlay(
-                        Image(systemName: "arrow.up").font(.system(size: 11, weight: .bold)).foregroundColor(.white)
-                    )
+                        .frame(width: 26, height: 26)
+                        .overlay(
+                            Image(systemName: "arrow.up").font(.system(size: 11, weight: .bold)).foregroundColor(.white)
+                        )
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 10)
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(c(theme.colors.primaryBackground).opacity(0.9))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                .white.opacity(theme.isDark ? 0.2 : 0.3),
+                                c(theme.colors.primaryBorder).opacity(0.12),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 0.5
+                    )
+            )
         }
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(c(theme.colors.primaryBackground).opacity(0.9))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private func previewActionButton(icon: String) -> some View {
+        ZStack {
+            Circle()
+                .fill(c(theme.colors.tertiaryBackground).opacity(0.8))
+            Image(systemName: icon)
+                .font(.system(size: CGFloat(theme.typography.bodySize), weight: .medium))
+                .foregroundColor(c(theme.colors.secondaryText))
+        }
+        .frame(width: 32, height: 32)
         .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
+            Circle()
                 .strokeBorder(
                     LinearGradient(
                         colors: [
-                            .white.opacity(theme.isDark ? 0.2 : 0.3),
-                            c(theme.colors.primaryBorder).opacity(0.12),
+                            .white.opacity(0.15),
+                            c(theme.colors.primaryBorder).opacity(0.1),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.5
+                )
+        )
+    }
+
+    private var previewSlashButton: some View {
+        ZStack {
+            Circle()
+                .fill(c(theme.colors.tertiaryBackground).opacity(0.8))
+            Text("/")
+                .font(.system(size: 16, weight: .medium, design: .monospaced))
+                .foregroundColor(c(theme.colors.secondaryText))
+        }
+        .frame(width: 32, height: 32)
+        .overlay(
+            Circle()
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            .white.opacity(0.15),
+                            c(theme.colors.primaryBorder).opacity(0.1),
                         ],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -982,6 +982,8 @@ struct ThemeChatPreview: View {
     private var previewCodeBlock: some View {
         let themeProtocol = CustomizableTheme(config: theme)
         let sampleCode = "print(\"Hello, World!\")"
+        let _ = ensureHighlightrTheme(for: themeProtocol)
+        let bgColor = highlightrThemeBackgroundColor()
 
         return VStack(alignment: .leading, spacing: 0) {
             // Header bar
@@ -996,7 +998,7 @@ struct ThemeChatPreview: View {
             }
             .padding(.horizontal, 12)
             .frame(height: 28)
-            .background(c(theme.colors.codeBlockBackground).opacity(0.6))
+            .background(bgColor.opacity(0.6))
 
             // Syntax-highlighted code via CodeContentView
             GeometryReader { geo in
@@ -1013,9 +1015,7 @@ struct ThemeChatPreview: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 8).fill(
-                c(theme.colors.codeBlockBackground)
-            )
+            RoundedRectangle(cornerRadius: 8).fill(bgColor)
         )
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -857,24 +857,21 @@ struct ThemeChatPreview: View {
 
             VStack(spacing: 0) {
                 previewHeader
-                    .padding(.horizontal, 16)
-                    .padding(.top, 14)
-                    .padding(.bottom, 6)
 
                 ScrollView {
                     VStack(spacing: 0) {
                         previewUserMessage("Hey there! Can you help me with something?")
                         previewAssistantMessage()
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
+                    .padding(.horizontal, 4)
+                    .padding(.top, 4)
                 }
 
                 Spacer()
 
                 previewInput
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 16)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 12)
             }
         }
         .background(c(theme.colors.primaryBackground))
@@ -892,56 +889,99 @@ struct ThemeChatPreview: View {
         return c(theme.colors.accentColor)
     }
 
+    private var assistantBubbleColor: Color? {
+        guard let hex = theme.messages.assistantBubbleColor else { return nil }
+        return c(hex)
+    }
+
+    private func messageHeader(_ name: String, color: Color) -> some View {
+        Text(name)
+            .font(primaryFont(size: captionSize + 1, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     private func previewUserMessage(_ content: String) -> some View {
-        let radius: CGFloat = 10
+        let radius: CGFloat = 8
         let opacity = theme.messages.userBubbleOpacity
 
-        return Text(content)
-            .font(bodyFont)
-            .foregroundColor(c(theme.colors.primaryText))
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 10)
-            .background(
-                RoundedRectangle(cornerRadius: radius, style: .continuous)
-                    .fill(userBubbleColor.opacity(opacity))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity, alignment: .trailing)
+        return VStack(alignment: .trailing, spacing: 0) {
+            Text(content)
+                .font(bodyFont)
+                .foregroundColor(c(theme.colors.primaryText))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: radius, style: .continuous)
+                        .fill(userBubbleColor.opacity(opacity))
+                )
+                .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+                .padding(.horizontal, 10)
+        }
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
     private func previewAssistantMessage() -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Assistant", bundle: .module)
-                .font(primaryFont(size: captionSize + 1, weight: .semibold))
-                .foregroundColor(c(theme.colors.secondaryText))
+        VStack(alignment: .leading, spacing: 0) {
+            messageHeader("Assistant", color: c(theme.colors.secondaryText))
 
-            Text("Sure! Here's an example:", bundle: .module)
-                .font(bodyFont)
-                .foregroundColor(c(theme.colors.primaryText))
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text("swift", bundle: .module)
-                    .font(monoFont(size: captionSize, weight: .medium))
-                    .foregroundColor(c(theme.colors.tertiaryText))
-                    .padding(.horizontal, 10).padding(.top, 8)
-
-                Text("print(\"Hello, World!\")", bundle: .module)
-                    .font(codeFont)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Sure! Here's an example:", bundle: .module)
+                    .font(bodyFont)
                     .foregroundColor(c(theme.colors.primaryText))
-                    .padding(.horizontal, 10).padding(.bottom, 10)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: CGFloat(theme.borders.inputCornerRadius)).fill(
-                    c(theme.colors.codeBlockBackground)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    // Header bar
+                    HStack {
+                        Text("swift", bundle: .module)
+                            .font(monoFont(size: captionSize - 1, weight: .medium))
+                            .foregroundColor(c(theme.colors.tertiaryText))
+                        Spacer()
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(c(theme.colors.tertiaryText).opacity(0.45))
+                    }
+                    .padding(.horizontal, 12)
+                    .frame(height: 28)
+                    .background(c(theme.colors.codeBlockBackground).opacity(0.6))
+
+                    // Code area
+                    HStack(alignment: .top, spacing: 0) {
+                        Text("1", bundle: .module)
+                            .font(monoFont(size: CGFloat(theme.typography.codeSize), weight: .regular))
+                            .foregroundColor(c(theme.colors.tertiaryText).opacity(0.4))
+                            .frame(width: 24, alignment: .trailing)
+                            .padding(.trailing, 8)
+                        Text("print(\"Hello, World!\")", bundle: .module)
+                            .font(codeFont)
+                            .foregroundColor(c(theme.colors.primaryText))
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8).fill(
+                        c(theme.colors.codeBlockBackground)
+                    )
                 )
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                Group {
+                    if let bubbleColor = assistantBubbleColor {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(bubbleColor.opacity(theme.messages.assistantBubbleOpacity))
+                    }
+                }
             )
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -1012,153 +1052,99 @@ struct ThemeChatPreview: View {
     // MARK: - Header
 
     private var previewHeader: some View {
-        HStack(spacing: 10) {
-            headerButton("sidebar.left")
-
-            // Chat / Work mode toggle
-            HStack(spacing: 0) {
-                modeSegment("bubble.left.and.bubble.right", "Chat", isActive: true)
-                modeSegment("bolt.fill", "Work", isActive: false)
-            }
-            .padding(3)
-            .background(Capsule().fill(c(theme.colors.secondaryBackground).opacity(0.6)))
-
-            // Model badge
-            HStack(spacing: 5) {
-                Circle().fill(c(theme.colors.successColor)).frame(width: 6, height: 6)
-                Text("gpt-4", bundle: .module)
-                    .font(primaryFont(size: captionSize - 1, weight: .medium))
-                    .foregroundColor(c(theme.colors.secondaryText))
-            }
-
-            Spacer()
-
-            headerButton("plus")
-            headerButton("pin")
-        }
-    }
-
-    private func headerButton(_ icon: String) -> some View {
-        Image(systemName: icon)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundColor(c(theme.colors.secondaryText))
-            .frame(width: 28, height: 28)
-            .background(Circle().fill(c(theme.colors.secondaryBackground).opacity(0.6)))
-    }
-
-    private func modeSegment(_ icon: String, _ label: String, isActive: Bool) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon).font(.system(size: 10, weight: .medium))
-            Text(label).font(primaryFont(size: captionSize - 1, weight: .medium))
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
-        .background(isActive ? Capsule().fill(c(theme.colors.accentColor).opacity(0.15)) : nil)
-        .foregroundColor(isActive ? c(theme.colors.accentColor) : c(theme.colors.tertiaryText))
+        Color.clear.frame(height: 20)
     }
 
     // MARK: - Input
 
     private var previewInput: some View {
-        VStack(spacing: 8) {
-            // Selector row
-            HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 0) {
+            // Model selector row inside card
+            HStack(spacing: 8) {
                 selectorChip {
-                    Circle().fill(c(theme.colors.successColor)).frame(width: 6, height: 6)
-                    Text("gpt-4", bundle: .module).font(primaryFont(size: captionSize - 1, weight: .medium))
-                    Image(systemName: "chevron.up.chevron.down").font(.system(size: 8, weight: .semibold))
-                }
-
-                selectorChip {
-                    Image(systemName: "sparkles").font(.system(size: 9, weight: .medium))
-                    Text("3 tools", bundle: .module).font(primaryFont(size: captionSize - 1, weight: .medium))
+                    Circle().fill(c(theme.colors.successColor)).frame(width: 5, height: 5)
+                    Text("claude-4-sonnet", bundle: .module).font(primaryFont(size: captionSize - 1, weight: .medium))
+                    Image(systemName: "chevron.up.chevron.down").font(.system(size: 7, weight: .semibold))
                 }
 
                 Spacer()
 
+                Text("~2k / 200k", bundle: .module)
+                    .font(primaryFont(size: captionSize - 1, weight: .medium))
+                    .foregroundColor(c(theme.colors.tertiaryText).opacity(0.6))
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+
+            // Text input placeholder
+            Text("Message or attach files...", bundle: .module)
+                .font(bodyFont)
+                .foregroundColor(c(theme.colors.placeholderText ?? theme.colors.tertiaryText))
+                .padding(.horizontal, 14)
+                .padding(.bottom, 8)
+
+            // Button bar
+            HStack(spacing: 8) {
+                Image(systemName: "paperclip").font(.system(size: 12, weight: .medium))
+                    .foregroundColor(c(theme.colors.tertiaryText))
+                Text("/", bundle: .module).font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(c(theme.colors.tertiaryText))
+
+                Spacer()
+
                 HStack(spacing: 3) {
-                    Text("⏎").font(primaryFont(size: captionSize - 2, weight: .medium))
+                    Text("⏎", bundle: .module).font(primaryFont(size: captionSize - 2, weight: .medium))
                     Text("to send", bundle: .module).font(primaryFont(size: captionSize - 1))
                 }
-                .foregroundColor(c(theme.colors.tertiaryText).opacity(0.6))
-            }
+                .foregroundColor(c(theme.colors.tertiaryText).opacity(0.5))
 
-            // Input card
-            VStack(alignment: .leading, spacing: 0) {
-                Text("Message or paste image...", bundle: .module)
-                    .font(bodyFont)
-                    .foregroundColor(c(theme.colors.placeholderText ?? theme.colors.tertiaryText))
-                    .padding(.horizontal, 14)
-                    .padding(.top, 12)
-                    .padding(.bottom, 8)
-
-                HStack(spacing: 8) {
-                    Image(systemName: "photo.badge.plus").font(.system(size: 13, weight: .medium))
-                        .foregroundColor(c(theme.colors.tertiaryText))
-                    Image(systemName: "mic.fill").font(.system(size: 13, weight: .medium))
-                        .foregroundColor(c(theme.colors.tertiaryText))
-
-                    Spacer()
-
-                    Circle()
-                        .fill(
-                            LinearGradient(
-                                colors: [c(theme.colors.accentColor), c(theme.colors.accentColor).opacity(0.85)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .frame(width: 30, height: 30)
-                        .overlay(
-                            Image(systemName: "arrow.up").font(.system(size: 13, weight: .bold)).foregroundColor(.white)
-                        )
-                        .shadow(
-                            color: c(theme.colors.accentColor).opacity(theme.shadows.shadowOpacity * 0.5),
-                            radius: 4,
-                            x: 0,
-                            y: 2
-                        )
-                }
-                .padding(.horizontal, 14)
-                .padding(.bottom, 10)
-            }
-            .background(
-                RoundedRectangle(cornerRadius: CGFloat(theme.messages.bubbleCornerRadius), style: .continuous)
-                    .fill(c(theme.colors.inputBackground))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: CGFloat(theme.messages.bubbleCornerRadius), style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: CGFloat(theme.messages.bubbleCornerRadius), style: .continuous)
-                    .stroke(
+                Circle()
+                    .fill(
                         LinearGradient(
-                            colors: [
-                                c(theme.colors.primaryBorder),
-                                c(theme.colors.primaryBorder).opacity(0.35),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: CGFloat(theme.messages.borderWidth)
+                            colors: [c(theme.colors.accentColor), c(theme.colors.accentColor).opacity(0.85)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
                     )
-            )
-            .shadow(
-                color: c(theme.colors.shadowColor).opacity(theme.shadows.shadowOpacity),
-                radius: CGFloat(theme.shadows.cardShadowRadius),
-                x: 0,
-                y: CGFloat(theme.shadows.cardShadowY)
-            )
+                    .frame(width: 26, height: 26)
+                    .overlay(
+                        Image(systemName: "arrow.up").font(.system(size: 11, weight: .bold)).foregroundColor(.white)
+                    )
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 10)
         }
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(c(theme.colors.primaryBackground).opacity(0.9))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            .white.opacity(theme.isDark ? 0.2 : 0.3),
+                            c(theme.colors.primaryBorder).opacity(0.12),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.5
+                )
+        )
     }
 
     private func selectorChip<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        HStack(spacing: 5) { content() }
+        HStack(spacing: 4) { content() }
             .foregroundColor(c(theme.colors.secondaryText))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
             .background(
                 Capsule()
-                    .fill(c(theme.colors.secondaryBackground).opacity(0.8))
-                    .overlay(Capsule().stroke(c(theme.colors.primaryBorder).opacity(0.4), lineWidth: 0.5))
+                    .fill(c(theme.colors.secondaryBackground).opacity(0.6))
+                    .overlay(Capsule().stroke(c(theme.colors.primaryBorder).opacity(0.3), lineWidth: 0.5))
             )
     }
 }

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -139,7 +139,6 @@ struct ThemeEditorView: View {
         VStack(alignment: .leading, spacing: 16) {
             editorSection("Appearance") {
                 colorRow("Accent Color", hex: $editingTheme.colors.accentColor)
-                colorRow("Accent Light", hex: $editingTheme.colors.accentColorLight)
 
                 HStack {
                     Text("Mode", bundle: .module)
@@ -182,15 +181,8 @@ struct ThemeEditorView: View {
                 colorRow("Tertiary BG", hex: $editingTheme.colors.tertiaryBackground)
             }
 
-            editorSection("Advanced Colors", itemCount: 18) {
+            editorSection("Advanced Colors", itemCount: 11) {
                 colorRowOptional("Placeholder", hex: $editingTheme.colors.placeholderText)
-
-                Text("Sidebar", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                )
-                .textCase(.uppercase)
-                colorRow("Sidebar BG", hex: $editingTheme.colors.sidebarBackground)
-                colorRow("Sidebar Selected", hex: $editingTheme.colors.sidebarSelectedBackground)
 
                 Text("Status", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
                     currentTheme.tertiaryText
@@ -199,7 +191,6 @@ struct ThemeEditorView: View {
                 colorRow("Success", hex: $editingTheme.colors.successColor)
                 colorRow("Warning", hex: $editingTheme.colors.warningColor)
                 colorRow("Error", hex: $editingTheme.colors.errorColor)
-                colorRow("Info", hex: $editingTheme.colors.infoColor)
 
                 Text("Components", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
                     currentTheme.tertiaryText
@@ -207,15 +198,12 @@ struct ThemeEditorView: View {
                 .textCase(.uppercase)
                 colorRow("Card BG", hex: $editingTheme.colors.cardBackground)
                 colorRow("Card Border", hex: $editingTheme.colors.cardBorder)
-                colorRow("Button BG", hex: $editingTheme.colors.buttonBackground)
-                colorRow("Button Border", hex: $editingTheme.colors.buttonBorder)
                 colorRow("Input BG", hex: $editingTheme.colors.inputBackground)
                 colorRow("Input Border", hex: $editingTheme.colors.inputBorder)
 
                 Text("Code & Selection", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
                     currentTheme.tertiaryText
                 ).textCase(.uppercase)
-                colorRow("Glass Tint", hex: $editingTheme.colors.glassTintOverlay)
                 colorRow("Code Block BG", hex: $editingTheme.colors.codeBlockBackground)
                 colorRow("Text Selection", hex: $editingTheme.colors.selectionColor)
                 colorRow("Cursor", hex: $editingTheme.colors.cursorColor)
@@ -242,13 +230,6 @@ struct ThemeEditorView: View {
                 ).textCase(.uppercase)
                 colorRowOptional("Bubble Color", hex: $editingTheme.messages.assistantBubbleColor)
                 sliderRow("Opacity", value: $editingTheme.messages.assistantBubbleOpacity, range: 0 ... 1)
-
-                Divider().opacity(0.3)
-
-                Text("Bubble Style", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                ).textCase(.uppercase)
-                sliderRow("Corner Radius", value: $editingTheme.messages.bubbleCornerRadius, range: 0 ... 40)
             }
         }
     }
@@ -282,8 +263,6 @@ struct ThemeEditorView: View {
                 )
                 .textCase(.uppercase)
                 colorRow("Border Color", hex: $editingTheme.colors.primaryBorder)
-                colorRow("Secondary Border", hex: $editingTheme.colors.secondaryBorder)
-                colorRow("Focus Border", hex: $editingTheme.colors.focusBorder)
                 sliderRow("Border Width", value: $editingTheme.borders.defaultWidth, range: 0 ... 4)
                 sliderRow("Border Opacity", value: $editingTheme.borders.borderOpacity, range: 0 ... 1)
 
@@ -292,18 +271,7 @@ struct ThemeEditorView: View {
                 Text("Corner Radius", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
                     currentTheme.tertiaryText
                 ).textCase(.uppercase)
-                sliderRow("Card Radius", value: $editingTheme.borders.cardCornerRadius, range: 0 ... 30)
                 sliderRow("Input Radius", value: $editingTheme.borders.inputCornerRadius, range: 0 ... 20)
-
-                Divider().opacity(0.3)
-
-                Text("Shadows", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                )
-                .textCase(.uppercase)
-                sliderRow("Shadow Opacity", value: $editingTheme.shadows.shadowOpacity, range: 0 ... 1)
-                sliderRow("Card Shadow", value: $editingTheme.shadows.cardShadowRadius, range: 0 ... 30)
-                sliderRow("Hover Shadow", value: $editingTheme.shadows.cardShadowRadiusHover, range: 0 ... 40)
             }
         }
     }
@@ -346,7 +314,6 @@ struct ThemeEditorView: View {
                 }
 
                 sliderRow("Quick", value: $editingTheme.animationConfig.durationQuick, range: 0.05 ... 0.5)
-                sliderRow("Medium", value: $editingTheme.animationConfig.durationMedium, range: 0.1 ... 0.8)
                 sliderRow("Slow", value: $editingTheme.animationConfig.durationSlow, range: 0.2 ... 1.0)
                 sliderRow("Response", value: $editingTheme.animationConfig.springResponse, range: 0.1 ... 1.0)
                 sliderRow("Damping", value: $editingTheme.animationConfig.springDamping, range: 0.3 ... 1.0)
@@ -504,29 +471,6 @@ struct ThemeEditorView: View {
                     }
                 }
 
-                Divider().opacity(0.3)
-
-                Text("Overlay", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                )
-                .textCase(.uppercase)
-                colorRowOptional("Color", hex: $editingTheme.background.overlayColor)
-                sliderRow(
-                    "Opacity",
-                    value: Binding(
-                        get: { editingTheme.background.overlayOpacity ?? 0 },
-                        set: { editingTheme.background.overlayOpacity = $0 }
-                    ),
-                    range: 0 ... 1
-                )
-
-                Divider().opacity(0.3)
-
-                Text("Shadow Position", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
-                    currentTheme.tertiaryText
-                ).textCase(.uppercase)
-                sliderRow("Card Y Offset", value: $editingTheme.shadows.cardShadowY, range: 0 ... 20)
-                sliderRow("Hover Y Offset", value: $editingTheme.shadows.cardShadowYHover, range: 0 ... 20)
             }
         }
     }


### PR DESCRIPTION
  - Removed nused properties from the theme editor that had no effect on the UI                                                                
  - Replaced hardcoded Highlightr theme with a theme-aware system that auto-selects syntax theme with user override via new "Syntax Theme" picker        
  - Code block backgrounds now derive from the active Highlightr theme instead of the semi-transparent codeBlockBackground which fixes the transparent/mismatched background issue                                                               
  - Updated the live preview in theme edtiro to match the current chat UI

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
