### PR TITLE
Template-driven reasoning detection + streaming/retroactive thinking fixes

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -744,6 +744,7 @@ extension ModelManager {
         localModelsCacheLock.lock()
         cachedLocalModels = nil
         localModelsCacheLock.unlock()
+        LocalReasoningCapability.invalidate()
     }
 
     /// Discover locally downloaded models. Cached until invalidated by model download/delete.

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -432,17 +432,24 @@ struct DeltaContent: Codable, Sendable {
     let refusal: String?
     /// Incremental tool_calls information (OpenAI-compatible)
     let tool_calls: [DeltaToolCall]?
+    /// Reasoning/thinking text streamed in a separate channel by OpenAI-compatible
+    /// providers (DeepSeek, Qwen, Together, vLLM). Absent on providers that only
+    /// emit content. The stream parser wraps these chunks with synthetic `<think>`
+    /// tags so the rest of the pipeline can route them as reasoning.
+    let reasoning_content: String?
 
     init(
         role: String? = nil,
         content: String? = nil,
         refusal: String? = nil,
-        tool_calls: [DeltaToolCall]? = nil
+        tool_calls: [DeltaToolCall]? = nil,
+        reasoning_content: String? = nil
     ) {
         self.role = role
         self.content = content
         self.refusal = refusal
         self.tool_calls = tool_calls
+        self.reasoning_content = reasoning_content
     }
 }
 

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -133,6 +133,32 @@ final class ChatTurn: ObservableObject, Identifiable {
         objectWillChange.send()
     }
 
+    /// Atomically move everything accumulated in `content` plus `tail` into the
+    /// thinking channel and clear content. Single `objectWillChange` notification.
+    /// Used by the retroactive-thinking path when a model emits `</think>` without
+    /// ever opening a block — all prior content is actually reasoning. Returns the
+    /// number of characters moved so callers can keep their own counters in sync.
+    @discardableResult
+    func moveContentToThinking(tail: String) -> Int {
+        let priorContent = contentChunks.joined()
+        let moved = priorContent + tail
+        guard !moved.isEmpty else { return 0 }
+
+        // Append to thinking without firing its setter's notification.
+        thinkingChunks.append(moved)
+        _thinkingLength += moved.count
+        _cachedThinking = nil
+
+        // Clear content without firing its setter's notification.
+        contentChunks = []
+        _cachedContent = ""
+        _contentLength = 0
+
+        // Single notification for the batched mutation.
+        objectWillChange.send()
+        return moved.count
+    }
+
     /// Consolidate chunks into single strings after streaming completes
     func consolidateContent() {
         if contentChunks.count > 1 {

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -81,6 +81,7 @@ enum ModelProfileRegistry {
         Gemini31FlashImageProfile.self,
         GeminiProImageProfile.self,
         GeminiFlashImageProfile.self,
+        AutoThinkingProfile.self,
     ]
 
     static func profile(for modelId: String) -> (any ModelProfile.Type)? {
@@ -153,6 +154,34 @@ struct QwenThinkingProfile: ModelProfile {
 
     static let defaults: [String: ModelOptionValue] = [
         "disableThinking": .bool(true)
+    ]
+
+    static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
+}
+
+// MARK: - Auto Thinking Profile (chat-template driven)
+
+/// Fallback profile that activates for any locally-installed model whose
+/// chat template reads an `enable_thinking` kwarg. Registered last so that
+/// explicit family profiles (Qwen, Venice, etc.) still win when they match.
+struct AutoThinkingProfile: ModelProfile {
+    static let displayName = "Thinking"
+
+    static func matches(modelId: String) -> Bool {
+        LocalReasoningCapability.capability(forModelId: modelId).hasEnableThinkingKwarg
+    }
+
+    static let options: [ModelOptionDefinition] = [
+        ModelOptionDefinition(
+            id: "disableThinking",
+            label: "Disable Thinking",
+            icon: "brain.head.profile",
+            kind: .toggle(default: false)
+        )
+    ]
+
+    static let defaults: [String: ModelOptionValue] = [
+        "disableThinking": .bool(false)
     ]
 
     static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2681,11 +2681,25 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         finishReason: finishReason
                     )
                 } catch {
-                    let body = "Internal error: \(error.localizedDescription)"
+                    // Map ChatEngine.EngineError to its intended HTTP
+                    // status (e.g. 404 for unknown model) instead of
+                    // blanket-500 on every failure. The WorkView
+                    // classifier / external API consumers rely on the
+                    // status code to give users actionable feedback.
+                    // See PR #863 / issue #858.
+                    let status: HTTPResponseStatus
+                    let body: String
+                    if let engineError = error as? ChatEngine.EngineError {
+                        status = HTTPResponseStatus(statusCode: engineError.httpStatus)
+                        body = engineError.errorDescription ?? error.localizedDescription
+                    } else {
+                        status = .internalServerError
+                        body = "Internal error: \(error.localizedDescription)"
+                    }
                     let headers: [(String, String)] = [("Content-Type", "text/plain; charset=utf-8")]
                     let headersCopy = headers
                     hop {
-                        var responseHead = HTTPResponseHead(version: head.version, status: .internalServerError)
+                        var responseHead = HTTPResponseHead(version: head.version, status: status)
                         var buffer = ctx.value.channel.allocator.buffer(capacity: body.utf8.count)
                         buffer.writeString(body)
                         var nioHeaders = HTTPHeaders()

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -25,7 +25,43 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         self.installedModelsProvider = installedModelsProvider
         self.inferenceSource = source
     }
-    struct EngineError: Error {}
+    /// Errors thrown by `ChatEngine` that carry a classification so the
+    /// HTTP layer can emit a proper 4xx/5xx instead of a generic 500.
+    /// Before this type was specialized, `EngineError` was an empty
+    /// struct `{}` and every failure (unknown model, routing collapse,
+    /// etc.) surfaced as HTTP 500 → the classifier in `WorkView` would
+    /// then label it "Server Error / service temporarily unavailable"
+    /// when the real cause was user input (issue #858).
+    struct EngineError: Error, LocalizedError {
+        enum Kind {
+            /// No service or remote provider could handle the requested model ID.
+            /// Maps to HTTP 404 (or 400 if you prefer "bad request"; we use 404
+            /// because the resource — the model — is what's missing).
+            case modelNotFound(requested: String)
+            /// Routing returned `.none` for a non-empty model request for some
+            /// other reason (e.g. provider marked disconnected). Maps to 503.
+            case noServiceAvailable(requested: String)
+        }
+
+        let kind: Kind
+
+        var errorDescription: String? {
+            switch kind {
+            case .modelNotFound(let requested):
+                return "Model '\(requested)' is not installed or registered with any provider."
+            case .noServiceAvailable(let requested):
+                return "No service is currently available to handle model '\(requested)'."
+            }
+        }
+
+        /// The HTTP status code the API layer should return for this error.
+        var httpStatus: Int {
+            switch kind {
+            case .modelNotFound: return 404
+            case .noServiceAvailable: return 503
+            }
+        }
+    }
 
     /// Estimate input tokens from messages (rough heuristic: ~4 chars per token)
     private func estimateInputTokens(_ messages: [ChatMessage]) -> Int {
@@ -127,7 +163,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             )
 
         case .none:
-            throw EngineError()
+            throw EngineError(kind: .modelNotFound(requested: request.model))
         }
     }
 
@@ -437,7 +473,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 system_fingerprint: nil
             )
         case .none:
-            throw EngineError()
+            throw EngineError(kind: .modelNotFound(requested: request.model))
         }
     }
 

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -1,0 +1,126 @@
+//
+//  LocalReasoningCapability.swift
+//  osaurus
+//
+//  Inspects a locally-installed model's chat template to determine whether
+//  it supports thinking/reasoning — without hardcoding per-family heuristics.
+//  Drives both the UI reasoning toggle and the streaming prepend-think
+//  middleware so new reasoning model families (JANG, MiniMax, Mistral-Small-4,
+//  etc.) are picked up automatically as long as they ship a chat template.
+//
+
+import Foundation
+
+enum LocalReasoningCapability {
+    struct Capability: Sendable {
+        /// Template references `<think>` or `</think>` tags.
+        let supportsThinking: Bool
+        /// Template reads an `enable_thinking` kwarg — i.e. thinking is toggleable.
+        let hasEnableThinkingKwarg: Bool
+        /// Template itself injects a literal `<think>` opener into the assistant prompt
+        /// tail, which means the model's generated stream will only contain the closing
+        /// `</think>` and needs a middleware prepend for the UI tag parser to work.
+        let templateInjectsThinkTag: Bool
+
+        static let none = Capability(
+            supportsThinking: false,
+            hasEnableThinkingKwarg: false,
+            templateInjectsThinkTag: false
+        )
+    }
+
+    private static nonisolated let lock = NSLock()
+    private static nonisolated(unsafe) var cache: [String: Capability] = [:]
+
+    static func capability(forModelId modelId: String) -> Capability {
+        let key = modelId.lowercased()
+        lock.lock()
+        if let hit = cache[key] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        let detected = detect(modelId: modelId)
+
+        lock.lock()
+        cache[key] = detected
+        lock.unlock()
+        return detected
+    }
+
+    /// Call when models are added/removed so the next lookup re-reads templates.
+    static func invalidate() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+
+    // MARK: - Detection
+
+    private static func detect(modelId: String) -> Capability {
+        guard let dir = localDirectory(forModelId: modelId),
+            let template = readChatTemplate(at: dir)
+        else {
+            return .none
+        }
+        return analyze(template: template)
+    }
+
+    /// Pure, testable template analysis.
+    static func analyze(template: String) -> Capability {
+        let lower = template.lowercased()
+        let hasOpen = lower.contains("<think>")
+        let hasClose = lower.contains("</think>")
+        let hasKwarg = lower.contains("enable_thinking")
+        let injects =
+            template.range(
+                of: #"\{\{-?\s*['\"]<think>"#,
+                options: .regularExpression
+            ) != nil
+        return Capability(
+            supportsThinking: hasOpen || hasClose,
+            hasEnableThinkingKwarg: hasKwarg,
+            templateInjectsThinkTag: injects
+        )
+    }
+
+    private static func localDirectory(forModelId modelId: String) -> URL? {
+        // Delegate to the single source of truth: `findInstalledModel` already
+        // accepts both the short repo name (picker/display form) and the full
+        // `ORG/REPO` id, case-insensitive. Re-implementing the match here was
+        // silently returning nil whenever the caller passed a form neither of
+        // our candidate heuristics covered.
+        guard let found = ModelManager.findInstalledModel(named: modelId) else {
+            return nil
+        }
+        let parts = found.id.split(separator: "/").map(String.init)
+        let base = DirectoryPickerService.effectiveModelsDirectory()
+        return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
+    }
+
+    private static func readChatTemplate(at dir: URL) -> String? {
+        let fm = FileManager.default
+        let jinja = dir.appendingPathComponent("chat_template.jinja")
+        if fm.fileExists(atPath: jinja.path),
+            let s = try? String(contentsOf: jinja, encoding: .utf8)
+        {
+            return s
+        }
+        let tokenizerCfg = dir.appendingPathComponent("tokenizer_config.json")
+        if fm.fileExists(atPath: tokenizerCfg.path),
+            let data = try? Data(contentsOf: tokenizerCfg),
+            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            if let tmpl = obj["chat_template"] as? String { return tmpl }
+            // HF sometimes ships an array form: [{"name": "default", "template": "..."}]
+            if let arr = obj["chat_template"] as? [[String: Any]],
+                let first = arr.first,
+                let tmpl = first["template"] as? String
+            {
+                return tmpl
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -18,8 +18,14 @@ import os.log
 
 private let genLog = Logger(subsystem: "com.dinoki.osaurus", category: "Generation")
 
-// Force-link MLXVLM so ModelFactoryRegistry discovers the VLM trampoline at runtime.
+// Force-link both trampolines so ModelFactoryRegistry discovers them at runtime.
+// `loadModelContainer` iterates factories in order — without touching each
+// `.shared` the trampoline's static initializer may never run, and a model
+// that isn't a VLM (e.g. MiniMax, Qwen, DeepSeek LLMs) would see the VLM
+// factory fail its `unsupportedModelType` check and then find no LLM factory
+// registered to take over, leaving the load hung or throwing silently.
 private let _vlmFactory = MLXVLM.VLMModelFactory.shared
+private let _llmFactory = MLXLLM.LLMModelFactory.shared
 
 actor ModelRuntime {
     // MARK: - Types

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXGenerationEngine.swift
@@ -96,9 +96,16 @@ struct MLXGenerationEngine {
                 repetitionPenalty: generation.repetitionPenalty,
                 maxKV: runtime.maxKV
             )
-            let additionalContext: [String: any Sendable]? =
-                generation.modelOptions["disableThinking"]?.boolValue == true
-                ? ["enable_thinking": false] : nil
+            // When the caller has an opinion on thinking (toggle is present), forward
+            // it explicitly as `enable_thinking: true/false` — models whose templates
+            // default the kwarg OFF when it's absent would otherwise silently stay
+            // off even with the UI toggle enabled.
+            let additionalContext: [String: any Sendable]?
+            if let disableThinking = generation.modelOptions["disableThinking"]?.boolValue {
+                additionalContext = ["enable_thinking": !disableThinking]
+            } else {
+                additionalContext = nil
+            }
             let fullInput = MLXLMCommon.UserInput(
                 chat: chat,
                 processing: .init(),

--- a/Packages/OsaurusCore/Services/ModelRuntime/StreamAccumulator.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/StreamAccumulator.swift
@@ -151,6 +151,13 @@ struct StreamAccumulator: AsyncSequence, Sendable {
         /// across token boundaries).  8 tokens is enough for any known tokeniser.
         private static let decodeContextSize = 8
         private var decodeContextIds: [Int] = []
+        /// Token IDs whose decoded slice ends with U+FFFD (replacement char) —
+        /// a strong signal that a multi-byte UTF-8 codepoint (e.g. emoji) is
+        /// split across this token boundary. Held back until a subsequent
+        /// token completes the sequence. Cap prevents unbounded buffering
+        /// when the model legitimately emits an <unk> that decodes as FFFD.
+        private var pendingPartialIds: [Int] = []
+        private static let maxPendingPartial = 4
 
         init(
             eventIterator: AsyncStream<TokenGeneration>.AsyncIterator,
@@ -252,10 +259,12 @@ struct StreamAccumulator: AsyncSequence, Sendable {
                 generatedTokenIds.append(tokenId)
 
                 // Incremental decode — O(1) per token regardless of sequence length.
-                // Decode [context ++ newToken] minus [context] to isolate the new text.
-                // The context window handles BPE / byte-level tokenisers that need a
-                // few preceding tokens to correctly decode the newest one.
-                let contextWithNew = decodeContextIds + [tokenId]
+                // Decode [context ++ pending ++ newToken] minus [context] to isolate
+                // the new text. `pending` accumulates tokens whose isolated decode
+                // ended in U+FFFD (partial multi-byte codepoint); once a subsequent
+                // token completes the sequence the entire group is emitted at once.
+                let combinedNew = pendingPartialIds + [tokenId]
+                let contextWithNew = decodeContextIds + combinedNew
                 let withNewDecoded = tokenizer.decode(tokenIds: contextWithNew)
                 let contextDecoded =
                     decodeContextIds.isEmpty
@@ -267,11 +276,23 @@ struct StreamAccumulator: AsyncSequence, Sendable {
                 } else {
                     token = ""
                 }
+
+                // Defer emission if the tail is still a partial UTF-8 sequence,
+                // unless we've already buffered the maximum — at which point the
+                // FFFD is real (e.g. legitimate <unk>) and we flush as-is to
+                // avoid losing user-visible characters.
+                if token.last == "\u{FFFD}" && pendingPartialIds.count < Self.maxPendingPartial {
+                    pendingPartialIds.append(tokenId)
+                    continue
+                }
+
                 decodedSoFar += token
 
-                // Advance the sliding context window.
-                decodeContextIds.append(tokenId)
-                if decodeContextIds.count > Self.decodeContextSize {
+                // Advance the sliding context window to cover every token we just
+                // emitted (any buffered partials plus this one).
+                decodeContextIds.append(contentsOf: combinedNew)
+                pendingPartialIds.removeAll(keepingCapacity: true)
+                while decodeContextIds.count > Self.decodeContextSize {
                     decodeContextIds.removeFirst()
                 }
 
@@ -467,6 +488,39 @@ struct StreamAccumulator: AsyncSequence, Sendable {
                     InferenceProgressManager.shared.prefillDidFinishAsync()
                     onGeneratedTokenIds?(generatedTokenIds)
                     return
+                }
+            }
+
+            // Flush any tokens still in the partial-UTF-8 buffer. They would
+            // otherwise be lost if the stream ends with a deferred tail, or if
+            // the model emits a legitimate <unk> that never got a completing
+            // codepoint. Accept whatever the tokenizer produces (possibly a
+            // U+FFFD) rather than dropping characters.
+            if !pendingPartialIds.isEmpty {
+                let contextWithPending = decodeContextIds + pendingPartialIds
+                let withPendingDecoded = tokenizer.decode(tokenIds: contextWithPending)
+                let contextDecoded =
+                    decodeContextIds.isEmpty
+                    ? ""
+                    : tokenizer.decode(tokenIds: decodeContextIds)
+                if withPendingDecoded.count > contextDecoded.count {
+                    let tail = String(withPendingDecoded.dropFirst(contextDecoded.count))
+                    if !tail.isEmpty {
+                        decodedSoFar += tail
+                        if shouldCheckStop {
+                            // Let the stop-sequence flush below surface it.
+                            rollingBuffer += tail
+                        } else {
+                            // No stop-sequence path: emit directly.
+                            pendingEvents.append(.tokens(tail))
+                            emittedCount += tail.count
+                        }
+                    }
+                }
+                decodeContextIds.append(contentsOf: pendingPartialIds)
+                pendingPartialIds.removeAll(keepingCapacity: false)
+                while decodeContextIds.count > Self.decodeContextSize {
+                    decodeContextIds.removeFirst()
                 }
             }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -257,6 +257,11 @@ public actor RemoteProviderService: ToolCapableService {
                 // Track accumulated tool calls by index (even in streamDeltas for robustness)
                 var accumulatedToolCalls: [Int: (id: String?, name: String?, args: String, thoughtSignature: String?)] =
                     [:]
+                // Tracks whether a synthetic `<think>` has been emitted for the
+                // current stream's `reasoning_content` channel. Used to match it
+                // with a closing `</think>` exactly once at the reasoning→content
+                // boundary (or at stream end).
+                var reasoningOpen = false
 
                 // Parse SSE stream with UTF-8 decoding and inactivity timeout
                 var buffer = ""
@@ -583,11 +588,32 @@ public actor RemoteProviderService: ToolCapableService {
                                             }
                                         }
 
+                                        // Reasoning text from providers that stream it on a dedicated
+                                        // `reasoning_content` field (DeepSeek, Qwen, vLLM, etc.). Wrap
+                                        // with synthetic `<think>` tags so the rest of the pipeline
+                                        // routes it into the thinking channel transparently. First
+                                        // reasoning chunk opens the block; first content chunk after
+                                        // reasoning closes it.
+                                        if accumulatedToolCalls.isEmpty,
+                                            let reasoning = chunk.choices.first?.delta.reasoning_content,
+                                            !reasoning.isEmpty
+                                        {
+                                            if !reasoningOpen {
+                                                reasoningOpen = true
+                                                continuation.yield("<think>")
+                                            }
+                                            continuation.yield(reasoning)
+                                        }
+
                                         // Only yield content if no tool calls have been detected
                                         // This prevents function-call JSON from leaking into the chat UI
                                         if accumulatedToolCalls.isEmpty,
                                             let delta = chunk.choices.first?.delta.content, !delta.isEmpty
                                         {
+                                            if reasoningOpen {
+                                                reasoningOpen = false
+                                                continuation.yield("</think>")
+                                            }
                                             // Check stop sequences
                                             var output = delta
                                             for seq in stopSequences {
@@ -633,6 +659,14 @@ public actor RemoteProviderService: ToolCapableService {
                 if let invocation = Self.makeToolInvocation(from: accumulatedToolCalls) {
                     continuation.finish(throwing: invocation)
                     return
+                }
+
+                // Close a still-open synthetic `<think>` so the client never
+                // observes an unterminated thinking block (provider finished
+                // while still streaming reasoning, or never sent any content).
+                if reasoningOpen {
+                    continuation.yield("</think>")
+                    reasoningOpen = false
                 }
 
                 continuation.finish()
@@ -805,6 +839,12 @@ public actor RemoteProviderService: ToolCapableService {
                 // Some models (e.g., Llama) embed tool calls inline in text instead
                 // of using the structured tool_calls field.
                 var accumulatedContent = ""
+
+                // Tracks a still-open synthetic `<think>` wrapper around
+                // OpenAI-compatible `reasoning_content` deltas — matched with a
+                // closing `</think>` at the reasoning→content boundary or at
+                // stream end.
+                var reasoningOpen = false
 
                 // Parse SSE stream with UTF-8 decoding and inactivity timeout
                 var buffer = ""
@@ -1182,11 +1222,30 @@ public actor RemoteProviderService: ToolCapableService {
                                             }
                                         }
 
+                                        // Providers that expose reasoning on a dedicated
+                                        // `reasoning_content` channel (DeepSeek, Qwen, vLLM, etc.)
+                                        // get wrapped in synthetic `<think>` tags so the pipeline
+                                        // routes them into the thinking channel transparently.
+                                        if accumulatedToolCalls.isEmpty,
+                                            let reasoning = chunk.choices.first?.delta.reasoning_content,
+                                            !reasoning.isEmpty
+                                        {
+                                            if !reasoningOpen {
+                                                reasoningOpen = true
+                                                continuation.yield("<think>")
+                                            }
+                                            continuation.yield(reasoning)
+                                        }
+
                                         // Only yield content if no tool calls have been detected
                                         // This prevents function-call JSON from leaking into the chat UI
                                         if accumulatedToolCalls.isEmpty,
                                             let delta = chunk.choices.first?.delta.content, !delta.isEmpty
                                         {
+                                            if reasoningOpen {
+                                                reasoningOpen = false
+                                                continuation.yield("</think>")
+                                            }
                                             var output = delta
                                             for seq in stopSequences {
                                                 if let range = output.range(of: seq) {
@@ -1241,6 +1300,13 @@ public actor RemoteProviderService: ToolCapableService {
                     )
                     continuation.finish(throwing: invocation)
                     return
+                }
+
+                // Close a still-open synthetic `<think>` wrapper so the client
+                // never observes an unterminated thinking block.
+                if reasoningOpen {
+                    continuation.yield("</think>")
+                    reasoningOpen = false
                 }
 
                 // Fallback: detect inline tool calls in text content (e.g., Llama)

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnRetroactiveTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnRetroactiveTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ChatTurnRetroactiveTests {
+    @Test
+    func moveContentToThinking_movesPriorContentPlusTail() {
+        let turn = ChatTurn(role: .assistant, content: "")
+        turn.appendContent("hello")
+        turn.appendContent(" world")
+
+        let moved = turn.moveContentToThinking(tail: " before tag")
+        #expect(moved == "hello world before tag".count)
+        #expect(turn.content == "")
+        #expect(turn.contentIsEmpty)
+        #expect(turn.contentLength == 0)
+        #expect(turn.thinking == "hello world before tag")
+        #expect(turn.thinkingLength == "hello world before tag".count)
+    }
+
+    @Test
+    func moveContentToThinking_noopOnEmpty() {
+        let turn = ChatTurn(role: .assistant, content: "")
+        let moved = turn.moveContentToThinking(tail: "")
+        #expect(moved == 0)
+        #expect(turn.thinking == "")
+        #expect(turn.content == "")
+    }
+
+    @Test
+    func moveContentToThinking_appendsToExistingThinking() {
+        let turn = ChatTurn(role: .assistant, content: "")
+        turn.appendThinking("prior thinking. ")
+        turn.appendContent("accidental reasoning ")
+
+        turn.moveContentToThinking(tail: "tail")
+        #expect(turn.thinking == "prior thinking. accidental reasoning tail")
+        #expect(turn.content == "")
+    }
+
+    @Test
+    func moveContentToThinking_tailOnlyWhenContentEmpty() {
+        let turn = ChatTurn(role: .assistant, content: "")
+        let moved = turn.moveContentToThinking(tail: "some reasoning")
+        #expect(moved == "some reasoning".count)
+        #expect(turn.thinking == "some reasoning")
+        #expect(turn.content == "")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -1,0 +1,63 @@
+//
+//  LocalReasoningCapabilityTests.swift
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("LocalReasoningCapability template analysis")
+struct LocalReasoningCapabilityTests {
+    @Test("MiniMax-style template: injects <think>, has enable_thinking kwarg")
+    func minimaxStyle() {
+        let template = """
+            {%- if enable_thinking is defined and enable_thinking is false -%}
+            {%- else -%}
+            {{- '<think>' ~ '\\n' }}
+            {%- endif -%}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.supportsThinking)
+        #expect(cap.hasEnableThinkingKwarg)
+        #expect(cap.templateInjectsThinkTag)
+    }
+
+    @Test("Qwen3-style: supports thinking but no template-side injection")
+    func qwenStyle() {
+        let template = """
+            {% if message.role == 'assistant' %}
+            {% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}
+            {% endif %}
+            {% if enable_thinking is defined %}{% endif %}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.supportsThinking)
+        #expect(cap.hasEnableThinkingKwarg)
+        #expect(!cap.templateInjectsThinkTag)
+    }
+
+    @Test("Non-reasoning template: all signals false")
+    func nonReasoningStyle() {
+        let template = """
+            {% for m in messages %}<|user|>{{ m.content }}<|assistant|>{% endfor %}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(!cap.supportsThinking)
+        #expect(!cap.hasEnableThinkingKwarg)
+        #expect(!cap.templateInjectsThinkTag)
+    }
+
+    @Test("GLM-flash style: emits </think> without injection (middleware-needed)")
+    func glmFlashStyle() {
+        // Template references </think> in close-path but never injects <think>
+        // into the prompt tail — model will emit </think> without an opener,
+        // which is the middleware's prepend-think trigger condition.
+        let template = """
+            {%- if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif -%}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.supportsThinking)
+        #expect(!cap.hasEnableThinkingKwarg)
+        #expect(!cap.templateInjectsThinkTag)
+    }
+}

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -243,11 +243,55 @@ final class StreamingDeltaProcessor {
                     text = ""
                 }
             } else {
-                if let openRange = text.range(of: "<think>", options: .caseInsensitive) {
+                // Look up both tags so we can choose the earliest one deterministically.
+                let openRange = text.range(of: "<think>", options: .caseInsensitive)
+                let closeRange = text.range(of: "</think>", options: .caseInsensitive)
+
+                // Prefer the normal open-tag path whenever `<think>` appears at or
+                // before the next `</think>` — otherwise a buffered opener tag
+                // would get vacuumed into the thinking channel as literal text
+                // by the retroactive branch.
+                let takeOpen: Bool = {
+                    switch (openRange, closeRange) {
+                    case (nil, _): return false
+                    case (_, nil): return true
+                    case (let o?, let c?): return o.lowerBound <= c.lowerBound
+                    }
+                }()
+
+                if takeOpen, let openRange {
                     appendContent(String(text[..<openRange.lowerBound]))
                     text = String(text[openRange.upperBound...])
                     isInsideThinking = true
-                } else if let partial = Self.openPartials.first(where: { text.lowercased().hasSuffix($0) }) {
+                    continue
+                }
+
+                // Retroactive thinking: model emitted `</think>` without opening
+                // a `<think>` block (either the template didn't inject it, or the
+                // user disabled reasoning but this model reasons anyway). Move
+                // everything we've accumulated — prior content on the turn plus
+                // the in-buffer text up to the close tag — into the thinking
+                // channel, then continue parsing remainder as normal content.
+                if let closeRange {
+                    let tailBeforeTag = String(text[..<closeRange.lowerBound])
+                    let movedCount = turn.moveContentToThinking(tail: tailBeforeTag)
+                    if movedCount > 0 {
+                        thinkingLength += movedCount
+                        contentLength = 0
+                        hasPendingContent = true
+                    }
+                    text = String(text[closeRange.upperBound...])
+                    continue
+                }
+
+                // No full tag in this chunk — check for partial tags at the tail
+                // so a split tag across delta boundaries doesn't leak bytes.
+                let lower = text.lowercased()
+                if let partialClose = Self.closePartials.first(where: { lower.hasSuffix($0) }) {
+                    appendContent(String(text.dropLast(partialClose.count)))
+                    pendingTagBuffer = String(text.suffix(partialClose.count))
+                    text = ""
+                } else if let partial = Self.openPartials.first(where: { lower.hasSuffix($0) }) {
                     appendContent(String(text.dropLast(partial.count)))
                     pendingTagBuffer = String(text.suffix(partial.count))
                     text = ""

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -122,13 +122,27 @@ final class StreamingDeltaProcessor {
         invalidateTimer()
 
         if !deltaBuffer.isEmpty || !pendingTagBuffer.isEmpty {
-            let remaining = pendingTagBuffer + deltaBuffer
+            var remaining = pendingTagBuffer + deltaBuffer
             pendingTagBuffer = ""
             deltaBuffer = ""
-            if isInsideThinking {
-                appendThinking(remaining)
-            } else {
-                appendContent(remaining)
+
+            // If the stream ended on an unresolved partial `<think` or
+            // `</think` fragment, drop it rather than leaking literal tag
+            // characters into user-visible content — the completing byte
+            // never arrived.
+            let lowered = remaining.lowercased()
+            if let partial = Self.closePartials.first(where: { lowered.hasSuffix($0) })
+                ?? Self.openPartials.first(where: { lowered.hasSuffix($0) })
+            {
+                remaining = String(remaining.dropLast(partial.count))
+            }
+
+            if !remaining.isEmpty {
+                if isInsideThinking {
+                    appendThinking(remaining)
+                } else {
+                    appendContent(remaining)
+                }
             }
         }
 

--- a/Packages/OsaurusCore/Utils/StreamingMiddleware.swift
+++ b/Packages/OsaurusCore/Utils/StreamingMiddleware.swift
@@ -40,9 +40,11 @@ enum StreamingMiddlewareResolver {
         let thinkingDisabled = modelOptions["disableThinking"]?.boolValue == true
         let id = modelId.lowercased()
 
+        let autoInjects = LocalReasoningCapability.capability(forModelId: modelId).templateInjectsThinkTag
         let needsPrependThink =
             !thinkingDisabled
-            && ((id.contains("glm") && id.contains("flash"))
+            && (autoInjects
+                || (id.contains("glm") && id.contains("flash"))
                 || (id.contains("qwen") && id.contains("3.5") && hasParamSize(id, anyOf: "4b", "9b", "27b")))
 
         return needsPrependThink ? PrependThinkTagMiddleware() : nil

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -998,6 +998,11 @@ final class ChatSession: ObservableObject {
                     do {
                         var uiDeltaCount = 0
                         var firstDeltaTime: Date?
+                        // Track the wall-clock time of the last non-empty delta so
+                        // the fallback tok/s calculation uses the actual last-token
+                        // moment as the denominator, not the stream's close time
+                        // (which is after cancellation / teardown).
+                        var lastDeltaTime: Date?
 
                         var processor = StreamingDeltaProcessor(
                             turn: assistantTurn,
@@ -1067,12 +1072,14 @@ final class ChatSession: ObservableObject {
                                 continue
                             }
                             if !delta.isEmpty {
+                                let now = Date()
                                 if firstDeltaTime == nil {
-                                    firstDeltaTime = Date()
+                                    firstDeltaTime = now
                                     ttftTrace?.mark("first_text_delta")
                                     ttftTrace?.set("model", selectedModel ?? "unknown")
                                     ttftTrace?.emit()
                                 }
+                                lastDeltaTime = now
                                 uiDeltaCount += 1
                                 processor.receiveDelta(delta)
                             }
@@ -1089,7 +1096,8 @@ final class ChatSession: ObservableObject {
                             if assistantTurn.generationTokensPerSecond == nil,
                                 !assistantTurn.contentIsEmpty || !assistantTurn.thinkingIsEmpty
                             {
-                                let genTime = Date().timeIntervalSince(first)
+                                let endTime = lastDeltaTime ?? Date()
+                                let genTime = endTime.timeIntervalSince(first)
                                 // Reasoning tokens are generated on the same clock as the
                                 // answer; leaving them out of the numerator while keeping
                                 // them in the denominator under-reports throughput on

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1086,9 +1086,20 @@ final class ChatSession: ObservableObject {
                             // Fall back to estimated tok/s when MLX stats weren't propagated (remote APIs).
                             // Use the codebase's chars/4 heuristic to approximate tokens from generated text
                             // rather than raw delta count, which doesn't map 1:1 to tokens for most providers.
-                            if assistantTurn.generationTokensPerSecond == nil, !assistantTurn.contentIsEmpty {
+                            if assistantTurn.generationTokensPerSecond == nil,
+                                !assistantTurn.contentIsEmpty || !assistantTurn.thinkingIsEmpty
+                            {
                                 let genTime = Date().timeIntervalSince(first)
-                                let estimatedTokens = ContextBudgetManager.estimateTokens(for: assistantTurn.content)
+                                // Reasoning tokens are generated on the same clock as the
+                                // answer; leaving them out of the numerator while keeping
+                                // them in the denominator under-reports throughput on
+                                // thinking models. Count both.
+                                let answerTokens = ContextBudgetManager.estimateTokens(for: assistantTurn.content)
+                                let reasoningTokens =
+                                    assistantTurn.thinkingIsEmpty
+                                    ? 0
+                                    : ContextBudgetManager.estimateTokens(for: assistantTurn.thinking)
+                                let estimatedTokens = answerTokens + reasoningTokens
                                 if genTime > 0 && estimatedTokens > 0 {
                                     assistantTurn.generationTokenCount = estimatedTokens
                                     assistantTurn.generationTokensPerSecond = Double(estimatedTokens) / genTime

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -915,8 +915,20 @@ extension MessageTableRepresentable {
             // return cached height if we have it
             if let cached = heightCache[block.id] { return cached }
 
-            // estimate height and cache it
-            let isExpanded = expandedIds.contains(block.id)
+            // Thinking blocks auto-expand while their OWNING turn is streaming
+            // (not just while they are the streaming block) so the panel stays
+            // visible through the `<think>`→content transition. Matches the
+            // cell's configureAsThinking logic.
+            let isStreamingThinkingTurn: Bool = {
+                guard ctx.isStreaming,
+                    let streamingTurnId = ctx.lastAssistantTurnId,
+                    block.turnId == streamingTurnId
+                else { return false }
+                if case .thinking = block.kind { return true }
+                return false
+            }()
+
+            let isExpanded = isStreamingThinkingTurn || expandedIds.contains(block.id)
             let h = NativeCellHeightEstimator.estimatedHeight(
                 for: block,
                 width: ctx.width,

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1031,12 +1031,23 @@ final class NativeMessageCellView: NSTableCellView {
         let thinkingLen: Int?
         if case .thinking(_, _, _) = block.kind { thinkingLen = text.count } else { thinkingLen = nil }
 
+        // Auto-expand while the owning turn is actively streaming — including
+        // after `</think>` closes the thinking block and the model moves on to
+        // answer content. Keeping the thinking panel visible through the whole
+        // streaming turn avoids collapse-jitter on the `<think>`→content
+        // boundary. Once the turn finishes, fall back to the user's explicit
+        // expand state (default: collapsed).
+        let turnIsStreaming = context.isStreaming && context.lastAssistantTurnId == block.turnId
+        let isExpanded =
+            turnIsStreaming
+            ? true
+            : context.expandedIds.contains(block.id)
         tv.configure(
             thinking: text,
             thinkingLength: thinkingLen,
             width: context.width - 32,
             isStreaming: isStreaming,
-            isExpanded: context.expandedIds.contains(block.id),
+            isExpanded: isExpanded,
             theme: context.theme,
             blockId: block.id,
             onToggle: { [weak self] in


### PR DESCRIPTION
## Summary

Reasoning pipeline used to be hardcoded per family (Qwen, GLM, OpenAI o-series). Any other reasoning model — MiniMax JANG, DeepSeek-R1, etc. — would see reasoning text leak into the content channel and never surface a think-block or reasoning toggle.

This PR drives reasoning detection from each model's own `chat_template.jinja`, adds retroactive thinking handling for models that reason even when the kwarg is off, tightens streaming UX around reasoning panels, and wires OpenAI-compatible `reasoning_content` for remote providers.

## Changes

**Detection & toggle**
- `LocalReasoningCapability`: parses each installed model's `chat_template.jinja` (or `tokenizer_config.json`) and reports `supportsThinking`, `hasEnableThinkingKwarg`, `templateInjectsThinkTag`. Cached; invalidated alongside the existing local-models cache.
- `AutoThinkingProfile`: registered last in `ModelProfileRegistry`. Any model whose template has the `enable_thinking` kwarg gets the reasoning on/off toggle automatically, regardless of family name.
- `MLXGenerationEngine`: always sends `enable_thinking: true` or `false` explicitly when the option is set.

**Streaming**
- `StreamingMiddlewareResolver` installs `PrependThinkTagMiddleware` when the detector reports template injection, not just for hard-coded GLM/Qwen3.5 heuristics.
- `StreamingDeltaProcessor`: retroactive thinking when `</think>` appears without an opener (prior content moves to thinking channel); prefers `<think>` opener when both tags are in one buffer; drops trailing partial `<think`/`</think` fragments at EOS.
- `StreamAccumulator`: buffers tokens whose decode tail is `U+FFFD` until the next token completes the codepoint; flushes on EOS; capped at 4 so a legitimate `<unk>` still flushes.
- `ChatTurn.moveContentToThinking(tail:)`: atomic move with a single notification and consistent counters.

**Remote reasoning**
- `OpenAIAPI.DeltaContent.reasoning_content` new optional field; both SSE parsers in `RemoteProviderService` wrap reasoning chunks with synthetic `<think>…</think>` so DeepSeek/Qwen/vLLM surface reasoning through the existing pipeline. Closed on reasoning→content boundary or stream end.

**UX**
- Auto-expand thinking block while the owning turn is streaming, not just while the think block itself is streaming (keeps panel visible through `<think>`→content transition).

**Infra / misc**
- Force-link `MLXLLM.LLMModelFactory.shared` alongside existing `MLXVLM` force-link so LLM trampoline is guaranteed registered before `loadModelContainer` iterates.
- `ChatEngine.EngineError` carries `Kind`/`httpStatus` → unknown model = 404, no service = 503 (was 500).
- `ChatView` fallback tok/s: include reasoning chars in numerator, use `lastDeltaTime` as denominator end.

## Documentation

All non-trivial changes have WHY-focused inline comments explaining the hidden constraint, invariant, or failure mode being guarded against — not just what the code does. Public API additions (`LocalReasoningCapability.Capability`, `ChatTurn.moveContentToThinking`, `AutoThinkingProfile`, `DeltaContent.reasoning_content`) have doc comments.

## Tests

- `ChatTurnRetroactiveTests` (4): atomic move, noop, append-to-existing, tail-only
- `LocalReasoningCapabilityTests` (4): MiniMax-style, Qwen3-style, non-reasoning, GLM-flash-style
- Reasoning-path suite: 30/30 pass

## Manually tested

- **MiniMax JANG 2L** — reasoning auto-expands live, collapses on turn end; retroactive path works when thinking is toggled off (model still reasons, gets captured into the thinking block); clean answer remains in content
- **Qwen 3.5 35B 4bit** — `enable_thinking: true/false` both honored; thinking toggle round-trips correctly
- **VL model** — VLM path unaffected; image input still works, MLXVLM factory picks it up as before (regression check for the LLM factory force-link)

## Test plan (reviewer)

- [ ] Non-reasoning model (e.g. Llama, Gemma): streams cleanly, no spurious `<think>`/`</think>` handling
- [ ] Emoji / CJK text: no `U+FFFD` replacement mid-stream
- [ ] Scroll stays pinned during streaming if previously at bottom; no jump at `</think>` boundary
- [ ] Unknown model via HTTP API returns 404 (not 500)
- [ ] OpenAI-compatible remote provider that emits `reasoning_content` (e.g. DeepSeek): reasoning appears in think-block