### PR TITLE
docs: add file-management PR0 contracts

### DIFF
--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -2,6 +2,12 @@
 
 This document describes how to build external plugins for Osaurus using the Generic C ABI. Plugins are `.dylib` shared libraries distributed in a zip file. They can expose tools to the AI, register HTTP routes, ship web frontends, and call back into the host for storage, inference, and agent dispatch.
 
+For file import and export plugins, also read:
+
+- [development/file-import-plugin-contract.md](./development/file-import-plugin-contract.md)
+- [development/file-generator-export-contract.md](./development/file-generator-export-contract.md)
+- [development/file-management-dependency-review-template.md](./development/file-management-dependency-review-template.md)
+
 ## Table of Contents
 
 - [Quick Start](#quick-start)

--- a/docs/development/FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md
+++ b/docs/development/FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md
@@ -1,0 +1,178 @@
+# File Management Architecture Review And PR0
+
+Date: `2026-04-16`
+
+## Purpose
+
+Osaurus already has the right instincts for file handling:
+
+- conservative host-native import in `OsaurusCore`
+- plugin-first growth for broader format coverage
+- artifact sharing through the existing `share_artifact` flow
+- a registry-backed import foundation that is already emerging upstream
+
+What it does not have yet is a complete file-management standard.
+
+`PR0` is the phase that turns "some file support" into a durable subsystem with
+shared vocabulary, provenance, security limits, and review rules.
+
+## Current Strengths
+
+The current public queue already covers important ground:
+
+- validation and PR hygiene
+- registry-backed file import foundation
+- safe host-native import expansion
+- the first native plugin importer contract
+- attached-document retrieval in local chat
+
+That is a strong base. It is still missing the standard that future importers,
+generators, and format packs must obey.
+
+## Why PR0 Is Necessary
+
+Without `PR0`, Osaurus risks accumulating:
+
+- importer result shapes that do not match each other
+- generators that cannot be traced back to their inputs
+- inconsistent placement decisions between core, native plugins, and sandbox plugins
+- security policy that exists only as habit instead of contract
+- format packs that add dependencies without a repeatable review path
+
+`PR0` is the standardization and hardening layer that prevents that drift.
+
+## Design Principles
+
+The file-management system should be built around a few durable rules:
+
+1. Keep the core small.
+   Core should only own cheap, host-native, low-risk file behaviors.
+2. Make metadata and provenance first-class.
+   Importers and generators should report what they saw, what they emitted, and
+   how much was partial or truncated.
+3. Separate contracts from implementations.
+   The manifest, request, response, and failure vocabulary should stay stable
+   even as implementations change.
+4. Prefer deterministic fallbacks.
+   Unsupported, malformed, oversized, or unsafe inputs should fail closed with a
+   typed error instead of shelling out or guessing.
+5. Grow by reviewable slices.
+   Standardize first, then add format packs one family at a time.
+
+## Capability Placement Matrix
+
+Every future file capability should declare where it lives and why.
+
+| Placement | Use For | Typical Examples | Not Allowed |
+|---|---|---|---|
+| `core` | cheap, host-native, low-risk handling | plain text, code/config text, PDF text extraction, HTML/RTF/DOCX summary extraction, lightweight metadata readers | heavy converters, OCR, shell-driven pipelines |
+| `native_plugin` | deterministic higher-level import/export without sandbox-only dependencies | Office generation, data/database readers, CAD/BIM readers, domain-specific structured extraction | mutable-branch dependencies, ad hoc shell wrappers |
+| `sandbox_plugin` | heavyweight tools, CLIs, OCR, model-assisted extraction, or risky converters | LibreOffice headless, Pandoc wrappers, OCR pipelines, archive inspection helpers | bypassing host limits or writing outside allowed output roots |
+
+## PR0 Deliverables
+
+`PR0` is complete only when these pieces exist:
+
+### 1. Canonical contracts
+
+- importer contract
+- generator/export contract
+- shared failure taxonomy
+- shared provenance vocabulary
+
+### 2. Canonical models
+
+The substrate should converge on stable internal types for:
+
+- `FileRecord`
+- `FileSummary`
+- `FileProvenance`
+- `StructuredExtraction`
+- `GeneratedArtifactRecord`
+
+Minimum tracked facts:
+
+- source path
+- content hash
+- size and modified timestamp
+- detected type
+- importer or generator identifier
+- plugin identifier when applicable
+- schema version
+- truncation or partial-extraction flags
+- elapsed time and warnings
+
+### 3. Canonical governance
+
+- placement rule: `core` vs `native_plugin` vs `sandbox_plugin`
+- archive depth and nested-container policy
+- regular-file and path-traversal enforcement
+- dependency review template
+- performance budgets for latency, memory growth, text output, and preview depth
+
+### 4. Canonical validation
+
+- malformed-input tests
+- oversized-input tests
+- security-path tests
+- fixture corpora by format family
+- benchmark harness and baseline budgets
+
+## PR0 Implementation Chain
+
+Keep `PR0` reviewable by splitting it into four public PRs:
+
+### `PR0-A` Documentation and contracts
+
+- architecture review and placement rules
+- importer contract revision
+- generator/export contract
+- dependency review template
+- phased rollout document
+
+### `PR0-B` Core schema and provenance
+
+- canonical file-management models
+- lightweight SQLite catalog and provenance storage
+- migration and fixture-backed tests
+
+### `PR0-C` Security and limits
+
+- archive-depth policy
+- nested-container policy
+- path-validation utilities
+- regular-file enforcement
+- shared import/generation error taxonomy
+
+### `PR0-D` Conformance and benchmark harness
+
+- fixture corpus layout by format family
+- malformed and oversized fixtures
+- benchmark commands and baseline metrics
+- CI hooks for file-management PRs
+
+## Acceptance Criteria
+
+`PR0` is successful when:
+
+- every importer and generator can be described with the same vocabulary
+- every result can be traced back to a source file, tool, plugin, and schema version
+- every new capability declares where it lives and why
+- every future format pack adds fixtures and limits before implementation lands
+- the system has explicit performance and security budgets
+
+## Roadmap After PR0
+
+After the substrate lands, format growth should stay plugin-first and follow a
+clear pack order:
+
+1. Office pack
+2. Data and database pack
+3. Technical and engineering pack
+4. Mining and geoscience A
+5. Mining and geoscience B
+6. Scientific pack
+7. Archive and system inspection pack
+
+This keeps the core strict while still allowing Osaurus to become a remarkable
+file operating layer over time.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,25 @@
+# Development Docs
+
+This directory is the canonical home for long-lived development contracts,
+roadmaps, and review templates that do not belong in the repo root.
+
+Start here for the file-management roadmap:
+
+1. [FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md](./FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md)
+   - architecture review, placement policy, and the `PR0` rationale
+2. [file-import-plugin-contract.md](./file-import-plugin-contract.md)
+   - canonical importer manifest, request, response, and failure contract
+3. [file-generator-export-contract.md](./file-generator-export-contract.md)
+   - canonical generator/export manifest, request, response, and artifact rules
+4. [file-management-dependency-review-template.md](./file-management-dependency-review-template.md)
+   - dependency review checklist for core, native-plugin, and sandbox-plugin additions
+5. [file-import-phased-pr-plan.md](./file-import-phased-pr-plan.md)
+   - reviewable PR chain for `PR0` and the format packs that follow it
+
+Working rules for this directory:
+
+- Keep `OsaurusCore` conservative and fast.
+- Prefer plugin-first capability growth for heavy or dependency-rich formats.
+- Use one public PR per initiative.
+- Do not mix substrate work, format packs, and unrelated build fixes in one branch.
+- Keep terminology neutral in code and user-facing strings.

--- a/docs/development/file-generator-export-contract.md
+++ b/docs/development/file-generator-export-contract.md
@@ -1,0 +1,150 @@
+# File Generator And Export Contract
+
+This document defines the canonical manifest and tool contract for
+plugin-backed generators and exporters.
+
+Related documents:
+
+- [Development Docs Index](./README.md)
+- [File Management Architecture Review And PR0](./FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md)
+- [File Import Plugin Contract](./file-import-plugin-contract.md)
+- [Plugin Authoring Guide](../PLUGIN_AUTHORING.md)
+
+## Manifest
+
+Native plugins declare generator descriptors in `capabilities.file_generators`:
+
+```json
+{
+  "plugin_id": "com.example.office",
+  "capabilities": {
+    "tools": [
+      {
+        "id": "export_pptx",
+        "description": "Generate a PowerPoint deck from structured input",
+        "parameters": {
+          "type": "object"
+        }
+      }
+    ],
+    "file_generators": [
+      {
+        "id": "pptx",
+        "tool_id": "export_pptx",
+        "output_extensions": ["pptx"],
+        "output_media_types": ["application/vnd.openxmlformats-officedocument.presentationml.presentation"],
+        "accepted_input_schemas": ["structured_extraction_v1", "normalized_document_v1"],
+        "template_support": "optional",
+        "output_schema_version": 1,
+        "share_artifact_required": true,
+        "preferred_placement": "native_plugin"
+      }
+    ]
+  }
+}
+```
+
+Descriptor rules:
+
+- `id` must be stable and unique within the plugin.
+- `tool_id` must reference a declared tool.
+- `accepted_input_schemas` should name the logical shapes the generator accepts.
+- `share_artifact_required` should remain `true` for user-visible outputs.
+- `preferred_placement` must match the placement matrix in the architecture doc.
+
+## Tool Request
+
+Osaurus invokes the referenced `tool_id` with a JSON payload:
+
+```json
+{
+  "format": "pptx",
+  "output_directory": "/absolute/path/to/job-output",
+  "destination_basename": "quarterly-review",
+  "accepted_input_schema": "structured_extraction_v1",
+  "input": {
+    "title": "Quarterly Review"
+  },
+  "template": {
+    "id": "default-corporate"
+  },
+  "metadata": {
+    "requested_by": "work_mode"
+  },
+  "output_schema_version": 1
+}
+```
+
+Request rules:
+
+- `output_directory` is the only directory the generator may write into.
+- Generators must fail closed on unsupported schema versions, invalid templates,
+  unsafe paths, or oversized output attempts.
+- Generators should emit deterministic artifacts; hidden mutable state should be
+  avoided unless the plugin documents it explicitly.
+
+## Preferred Tool Response
+
+New generators should return the canonical shape:
+
+```json
+{
+  "artifacts": [
+    {
+      "filename": "quarterly-review.pptx",
+      "path": "/absolute/path/to/job-output/quarterly-review.pptx",
+      "media_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "byte_size": 42210,
+      "role": "primary"
+    }
+  ],
+  "provenance": {
+    "generator_id": "pptx",
+    "plugin_id": "com.example.office",
+    "output_schema_version": 1
+  },
+  "warnings": []
+}
+```
+
+Response rules:
+
+- Every returned path must be inside `output_directory`.
+- User-visible artifacts must still flow through the existing `share_artifact`
+  path before the task is considered complete.
+- Generators should return enough metadata for provenance, indexing, and
+  post-generation sharing to be deterministic.
+
+## Deterministic Failure Shape
+
+Generators should prefer a typed failure envelope:
+
+```json
+{
+  "error": {
+    "code": "unsupported_output",
+    "message": "The plugin cannot generate the requested format.",
+    "retryable": false
+  }
+}
+```
+
+Recommended codes:
+
+- `unsupported_output`
+- `unsupported_input_schema`
+- `invalid_template`
+- `oversized_output`
+- `unsafe_path`
+- `internal_failure`
+
+## Provenance Requirements
+
+Generators should be able to report:
+
+- generator identifier
+- plugin identifier
+- accepted input schema
+- output schema version
+- warnings that materially affected the output
+- every emitted artifact path, media type, and size

--- a/docs/development/file-import-phased-pr-plan.md
+++ b/docs/development/file-import-phased-pr-plan.md
@@ -1,0 +1,142 @@
+# File Import Phased PR Plan
+
+Date: `2026-04-16`
+
+This document turns the file-management roadmap into reviewable PR slices that
+fit Osaurus development guidelines:
+
+- keep `OsaurusCore` conservative
+- prefer plugin-first capability growth
+- standardize before broadening coverage
+- one public PR per initiative
+- one test plan and one security story per PR
+
+Related documents:
+
+- [Development Docs Index](./README.md)
+- [File Management Architecture Review And PR0](./FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md)
+- [File Import Plugin Contract](./file-import-plugin-contract.md)
+- [File Generator And Export Contract](./file-generator-export-contract.md)
+- [Dependency Review Template](./file-management-dependency-review-template.md)
+- [Plugin Authoring Guide](../PLUGIN_AUTHORING.md)
+
+## Current Baseline
+
+The public queue already established the direction:
+
+- validation gate
+- registry-backed import foundation
+- safe host-native import expansion
+- native plugin importer contract
+- attached-document retrieval
+
+The next wave should not jump straight to format packs. It should standardize
+the substrate first.
+
+## `PR0` Chain
+
+### `PR0-A` Documentation and contracts
+
+Scope:
+
+- architecture review and placement rules
+- importer contract revision
+- generator/export contract
+- dependency review template
+- phased rollout plan
+
+Goal:
+
+- freeze the vocabulary before code growth continues
+
+### `PR0-B` Core schema and provenance
+
+Scope:
+
+- canonical file-management models
+- lightweight SQLite catalog and provenance store
+- migration and fixture-backed tests
+
+Goal:
+
+- give importers and generators a common record model
+
+### `PR0-C` Security and limits
+
+Scope:
+
+- archive-depth policy
+- nested-container policy
+- path-validation utilities
+- regular-file enforcement
+- shared error taxonomy
+
+Goal:
+
+- make the governance layer explicit and reusable
+
+### `PR0-D` Conformance and benchmark harness
+
+Scope:
+
+- fixture corpus layout by format family
+- malformed and oversized fixtures
+- benchmark commands and baseline metrics
+- CI hooks for file-management PRs
+
+Goal:
+
+- make future format packs measurable, not anecdotal
+
+## Parallelism Rules
+
+Public publication should remain ordered:
+
+1. `PR0-A`
+2. `PR0-B`
+3. `PR0-C`
+4. `PR0-D`
+
+Safe overlap:
+
+- `PR0-B` model design and DB scaffolding can be prepared in parallel once
+  `PR0-A` freezes the vocabulary.
+- `PR0-C` policy drafting can start alongside `PR0-B`, but it should not land
+  first because it depends on the shared contract language.
+- `PR0-D` fixture taxonomy can be drafted early, but the harness should land
+  only after `PR0-B` and `PR0-C` settle the result and policy shapes.
+
+Implementation boundary for `PR0`:
+
+- keep the substrate inside the existing `Packages/OsaurusCore` target for now
+- treat `DocumentParser` as a compatibility surface until a later migration PR
+- avoid moving unrelated UI call sites during `PR0`
+
+## Format Packs After `PR0`
+
+When `PR0` is merged, land the packs in this order:
+
+1. Office
+   - `xlsx`, `xls`, `pptx`, `ppt`, `odt`, `ods`, `odp`, `epub`, `eml`, `ics`, `vcf`
+   - exports: `pptx`, `xlsx/csv`, `html`, `pdf`
+2. Data and database
+   - `sqlite`, `duckdb`, `parquet`, `arrow`, `feather`, `avro`, `msgpack`, `bson`
+   - exports: `csv`, `xlsx`, `json`, `html`, `pdf`
+3. Technical and engineering
+   - `dxf`, `step/stp`, `iges/igs`, `stl`, `obj`, `gltf/glb`, `usdz`, `ifc`, `gerber`, `drl`, `gcode`, `spice`
+4. Mining and geoscience A
+   - `las`, collar/survey/assay/lithology tables, `geojson`, `kml`, `kmz`, `gpx`, `gpkg`, `geotiff`
+5. Mining and geoscience B
+   - `dlis`, `lis`, `segy`, `shp/shx/dbf`, `omf`, selected block-model/vendor interchange formats
+6. Scientific
+   - `netcdf`, `hdf5`, `fits`, `mat`, `rds`, `rda`, `RData`, `ipynb`
+7. Archive and system inspection
+   - `tar`, `gz`, `bz2`, `xz`, `zst`, `lz4`, optional `7z`/`rar`, `iso`, `dmg` metadata, `warc`, `pcap`, `pcapng`
+
+## Review Rules For Every Future Pack
+
+- keep scope to one format family only
+- add malformed and oversized fixtures before capability code lands
+- document every dependency and why it belongs in `core`, `native_plugin`, or `sandbox_plugin`
+- keep prompt integration on existing attached-document and artifact paths unless a separate host redesign is approved
+- require `share_artifact` for user-visible generated files

--- a/docs/development/file-import-plugin-contract.md
+++ b/docs/development/file-import-plugin-contract.md
@@ -1,0 +1,155 @@
+# File Import Plugin Contract
+
+This document defines the canonical manifest and tool contract for
+plugin-backed file importers.
+
+Related documents:
+
+- [Development Docs Index](./README.md)
+- [File Management Architecture Review And PR0](./FILE_MANAGEMENT_ARCHITECTURE_REVIEW_AND_PR0.md)
+- [Generator And Export Contract](./file-generator-export-contract.md)
+- [File Import Phased PR Plan](./file-import-phased-pr-plan.md)
+- [Plugin Authoring Guide](../PLUGIN_AUTHORING.md)
+
+## Manifest
+
+Native plugins declare importer descriptors in `capabilities.file_importers`:
+
+```json
+{
+  "plugin_id": "com.example.office",
+  "capabilities": {
+    "tools": [
+      {
+        "id": "import_xlsx",
+        "description": "Normalize spreadsheet content to text",
+        "parameters": {
+          "type": "object"
+        }
+      }
+    ],
+    "file_importers": [
+      {
+        "id": "xlsx",
+        "tool_id": "import_xlsx",
+        "extensions": ["xlsx", "xls"],
+        "ut_types": ["org.openxmlformats.spreadsheetml.sheet"],
+        "mime_types": ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+        "max_bytes": 10485760,
+        "max_chars": 500000,
+        "output_mode": "normalized_text",
+        "output_schema_version": 1,
+        "preferred_placement": "native_plugin"
+      }
+    ]
+  }
+}
+```
+
+Descriptor rules:
+
+- `id` must be stable and unique within the plugin.
+- `tool_id` must reference a declared tool.
+- `preferred_placement` must match the placement matrix in the architecture doc.
+- `max_bytes` and `max_chars` must declare hard limits, not suggestions.
+- `output_schema_version` must change when the canonical output shape changes.
+
+## Tool Request
+
+Osaurus invokes the referenced `tool_id` with a JSON payload:
+
+```json
+{
+  "path": "/absolute/path/to/file.xlsx",
+  "filename": "file.xlsx",
+  "file_extension": "xlsx",
+  "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "content_hash": "sha256:...",
+  "max_bytes": 10485760,
+  "max_chars": 500000,
+  "output_mode": "normalized_text",
+  "output_schema_version": 1
+}
+```
+
+Request rules:
+
+- `path` is always a host-local absolute file path.
+- Importers must fail closed on unreadable, malformed, oversized, or unsupported inputs.
+- Importers must not write outside their allowed working directory.
+- Core import behavior must not be emulated by shelling out from plugins without explicit review.
+
+## Preferred Tool Response
+
+New importers should return the canonical shape:
+
+```json
+{
+  "documents": [
+    {
+      "filename": "file.xlsx",
+      "content": "Normalized text summary here",
+      "byte_size": 12345,
+      "media_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    }
+  ],
+  "structured_extraction": {
+    "schema": "structured_extraction_v1"
+  },
+  "provenance": {
+    "importer_id": "xlsx",
+    "plugin_id": "com.example.office",
+    "output_schema_version": 1
+  },
+  "warnings": [],
+  "truncated": false,
+  "partial": false
+}
+```
+
+Compatibility note:
+
+- The host may continue to normalize legacy shapes such as `attachments`,
+  single-document payloads, or raw text.
+- New importers should use the canonical `documents` response so future
+  provenance and catalog features have a stable base.
+
+## Provenance Requirements
+
+Importers should be able to report:
+
+- importer identifier
+- plugin identifier
+- output schema version
+- truncation or partial-extraction flags
+- warnings that materially affected the result
+
+## Deterministic Failure Shape
+
+Importers should prefer a typed failure envelope:
+
+```json
+{
+  "error": {
+    "code": "oversized_input",
+    "message": "The file exceeds the importer byte limit.",
+    "retryable": false
+  }
+}
+```
+
+Recommended codes:
+
+- `unsupported_type`
+- `malformed_input`
+- `oversized_input`
+- `unsafe_path`
+- `permission_denied`
+- `internal_failure`
+
+## Current Host Limits
+
+- Built-in document text is truncated to `500000` characters.
+- Built-in PDF image fallback is capped at `20` rendered pages.
+- Most built-in host importers are capped at `25 MB`.
+- Built-in PDF import is capped at `50 MB`.

--- a/docs/development/file-management-dependency-review-template.md
+++ b/docs/development/file-management-dependency-review-template.md
@@ -1,0 +1,58 @@
+# File Management Dependency Review Template
+
+Use this checklist for every `PR0` follow-up and every future format-pack PR
+that adds or expands a dependency.
+
+## Summary
+
+- Dependency name:
+- Version / source:
+- Placement:
+  - `core`
+  - `native_plugin`
+  - `sandbox_plugin`
+- Formats covered:
+- Why this dependency is needed:
+
+## Placement Justification
+
+- Why does this belong in the chosen placement?
+- Why does it not belong in `core`?
+- If it is in `core`, why is it cheap, host-native, and low-risk?
+
+## Runtime Footprint
+
+- Added binary size or package weight:
+- System packages required:
+- Extra model, OCR, or CLI runtime requirements:
+- Expected memory or latency cost:
+
+## Security Review
+
+- Does it shell out?
+- Does it read archives or nested containers?
+- Does it write files?
+- Does it parse untrusted binary formats?
+- What regular-file, path, and output-root checks are required?
+
+## Supply Chain Review
+
+- Immutable release or tag:
+- License:
+- Maintenance status:
+- Known CVEs or ecosystem concerns:
+- Why an existing dependency does not already solve this need:
+
+## Validation Requirements
+
+- Focused unit tests added:
+- Malformed-input fixtures added:
+- Oversized-input fixtures added:
+- Security-path tests added:
+- Benchmark or performance smoke added:
+
+## Decision
+
+- Approved placement:
+- Follow-up limits or guardrails:
+- Reviewer sign-off:


### PR DESCRIPTION
## Summary
- add a new docs/development surface for the file-management roadmap
- define the PR0 architecture review, importer contract, generator/export contract, and dependency review template
- document the phased PR chain for PR0 and the format-pack rollout that follows

## Validation
- clean-clone package build started with `swift build --package-path Packages/OsaurusCore` and is still running through the first full dependency compile
- `swiftlint lint --quiet` reports existing baseline warnings on upstream `main`
- `shellcheck` reports an existing baseline warning in `scripts/setup_env.sh` on upstream `main`

## Notes
- this is the first public slice of PR0: docs and contracts only
- follow-up code work remains split into PR0-B (schema/provenance), PR0-C (safety/limits), and PR0-D (conformance/benchmark harness)
