### PR TITLE
feat: allow bonjour agents to pair automatically and use relay

### DIFF
--- a/Packages/OsaurusCore/Identity/APIKeyManager.swift
+++ b/Packages/OsaurusCore/Identity/APIKeyManager.swift
@@ -136,6 +136,18 @@ public final class APIKeyManager: @unchecked Sendable {
         }
     }
 
+    /// Revoke an access key and remove it from the key list entirely.
+    /// Use this for temporary keys that should leave no trace after deletion.
+    public func delete(id: UUID) {
+        queue.sync(flags: .barrier) {
+            guard let index = keys.firstIndex(where: { $0.id == id }) else { return }
+            let key = keys[index]
+            RevocationStore.shared.revokeKey(address: key.iss, nonce: key.nonce)
+            keys.remove(at: index)
+            Self.saveToKeychain(keys)
+        }
+    }
+
     // MARK: - List
 
     public func listKeys() -> [AccessKeyInfo] {

--- a/Packages/OsaurusCore/Identity/CryptoHelpers.swift
+++ b/Packages/OsaurusCore/Identity/CryptoHelpers.swift
@@ -164,6 +164,10 @@ func signAccessPayload(_ payload: Data, privateKey: Data) throws -> Data {
     try signWithPrefix(payload, privateKey: privateKey, prefix: "Osaurus Signed Access")
 }
 
+func signPairingPayload(_ payload: Data, privateKey: Data) throws -> Data {
+    try signWithPrefix(payload, privateKey: privateKey, prefix: "Osaurus Signed Pairing")
+}
+
 /// EIP-191 personal_sign compatible signing.
 /// Produces `\x19Ethereum Signed Message:\n<len><message>` hash + secp256k1 recoverable signature.
 func signEIP191Message(_ message: String, privateKey: Data) throws -> Data {

--- a/Packages/OsaurusCore/Identity/PairingKey.swift
+++ b/Packages/OsaurusCore/Identity/PairingKey.swift
@@ -1,0 +1,33 @@
+//
+//  PairingKey.swift
+//  osaurus
+//
+//  Deterministic pairing key derivation for per-device connector identities.
+//  Derived from the Master Key via HMAC-SHA512 with domain "osaurus-pair-v1".
+//  Never stored — re-derived on demand.
+//
+
+import CryptoKit
+import Foundation
+
+public struct PairingKey: Sendable {
+    private static let domain = Data("osaurus-pair-v1".utf8)
+
+    static func derive(masterKey: Data) -> Data {
+        let hmac = HMAC<SHA512>.authenticationCode(
+            for: domain,
+            using: SymmetricKey(data: masterKey)
+        )
+        return Data(hmac.prefix(32))
+    }
+
+    public static func deriveAddress(masterKey: Data) throws -> OsaurusID {
+        let childKey = derive(masterKey: masterKey)
+        return try deriveOsaurusId(from: childKey)
+    }
+
+    static func sign(payload: Data, masterKey: Data) throws -> Data {
+        let childKey = derive(masterKey: masterKey)
+        return try signPairingPayload(payload, privateKey: childKey)
+    }
+}

--- a/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
+++ b/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
@@ -1,0 +1,40 @@
+//
+//  TemporaryPairedKeyStore.swift
+//  osaurus
+//
+//  Tracks API keys generated for temporary (non-permanent) Bonjour pairings.
+//  On app termination, all tracked keys are revoked and removed from APIKeyManager
+//  so they cannot be reused in future sessions.
+//
+
+import AppKit
+import Foundation
+
+public final class TemporaryPairedKeyStore: @unchecked Sendable {
+    public static let shared = TemporaryPairedKeyStore()
+
+    private let queue = DispatchQueue(label: "com.osaurus.temporary-paired-keys")
+    private var keyIds: [UUID] = []
+
+    private init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillTerminate),
+            name: NSApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    public func register(keyId: UUID) {
+        queue.sync(flags: .barrier) {
+            keyIds.append(keyId)
+        }
+    }
+
+    @objc private func applicationWillTerminate() {
+        let ids = queue.sync { keyIds }
+        for id in ids {
+            APIKeyManager.shared.delete(id: id)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
+++ b/Packages/OsaurusCore/Identity/TemporaryPairedKeyStore.swift
@@ -31,6 +31,10 @@ public final class TemporaryPairedKeyStore: @unchecked Sendable {
         }
     }
 
+    public func isTemporary(id: UUID) -> Bool {
+        queue.sync { keyIds.contains(id) }
+    }
+
     @objc private func applicationWillTerminate() {
         let ids = queue.sync { keyIds }
         for id in ids {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -47,6 +47,8 @@ final class ChatWindowState: ObservableObject {
     @Published private(set) var discoveredAgents: [DiscoveredAgent] = []
     @Published var selectedDiscoveredAgent: DiscoveredAgent?
     @Published var selectedDiscoveredAgentProviderId: UUID?
+    @Published private(set) var pairedRelayAgents: [PairedRelayAgent] = []
+    @Published var selectedRelayAgent: PairedRelayAgent?
 
     // MARK: - Theme State
 
@@ -98,6 +100,7 @@ final class ChatWindowState: ObservableObject {
 
         setupNotificationObservers()
         observeBonjourBrowser()
+        refreshPairedRelayAgents()
     }
 
     /// Wrap an existing `ExecutionContext`, reusing its sessions without duplication.
@@ -129,6 +132,7 @@ final class ChatWindowState: ObservableObject {
 
         setupNotificationObservers()
         observeBonjourBrowser()
+        refreshPairedRelayAgents()
     }
 
     deinit {
@@ -141,6 +145,7 @@ final class ChatWindowState: ObservableObject {
         removeEphemeralProviderIfNeeded()
         selectedDiscoveredAgent = nil
         selectedDiscoveredAgentProviderId = nil
+        selectedRelayAgent = nil
         workSession?.cancelExecution()
         session.stop()
         workSession = nil
@@ -161,6 +166,7 @@ final class ChatWindowState: ObservableObject {
         removeEphemeralProviderIfNeeded()
         selectedDiscoveredAgent = nil
         selectedDiscoveredAgentProviderId = nil
+        selectedRelayAgent = nil
         session.reset(for: newAgentId)
         refreshTheme()
         refreshSessions()
@@ -312,7 +318,28 @@ final class ChatWindowState: ObservableObject {
                     self?.selectedDiscoveredAgent = nil
                     self?.selectedDiscoveredAgentProviderId = nil
                 }
+                self?.refreshPairedRelayAgents(discoveredAgents: agents)
             }
+    }
+
+    func refreshPairedRelayAgents(discoveredAgents: [DiscoveredAgent]? = nil) {
+        let knownAgents = discoveredAgents ?? self.discoveredAgents
+        let discoveredIds = Set(knownAgents.map(\.id))
+        let manager = RemoteProviderManager.shared
+        pairedRelayAgents = manager.configuration.providers.compactMap { provider in
+            guard provider.providerType == .osaurus,
+                  !manager.isEphemeral(id: provider.id),
+                  let agentId = provider.remoteAgentId,
+                  let relayAddress = provider.remoteAgentAddress,
+                  !discoveredIds.contains(agentId)
+            else { return nil }
+            return PairedRelayAgent(
+                id: agentId,
+                name: provider.name,
+                remoteAgentAddress: relayAddress,
+                providerId: provider.id
+            )
+        }
     }
 
     private func removeEphemeralProviderIfNeeded() {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -410,5 +410,26 @@ final class ChatWindowState: ObservableObject {
                 }
             }
         )
+        // Clear selected paired/relay agent pill when its provider is removed from settings
+        notificationObservers.append(
+            NotificationCenter.default.addObserver(
+                forName: .remoteProviderStatusChanged,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    guard let self,
+                          let providerId = self.selectedDiscoveredAgentProviderId
+                    else { return }
+                    let providerExists = RemoteProviderManager.shared.configuration.providers
+                        .contains(where: { $0.id == providerId })
+                    guard !providerExists else { return }
+                    self.selectedDiscoveredAgent = nil
+                    self.selectedRelayAgent = nil
+                    self.selectedDiscoveredAgentProviderId = nil
+                    self.refreshPairedRelayAgents()
+                }
+            }
+        )
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
+++ b/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
@@ -221,11 +221,14 @@ final class SSEResponseWriter: ResponseWriter {
 
     @inline(__always)
     private func writeSSEChunk(_ chunk: ChatCompletionChunk, context: ChannelHandlerContext) {
-        let encoder = IkigaJSONEncoder()  // Create encoder per write for thread safety
         var buffer = context.channel.allocator.buffer(capacity: 256)
         buffer.writeString("data: ")
         do {
-            try encoder.encodeAndWrite(chunk, into: &buffer)
+            // Use standard JSONEncoder for cross-machine compatibility — IkigaJSON is optimized
+            // for intra-process NIO usage but its nil-value strategy can produce output that
+            // Apple's JSONDecoder rejects when consuming the SSE stream on a remote client.
+            let jsonData = try JSONEncoder().encode(chunk)
+            buffer.writeBytes(jsonData)
             buffer.writeString("\n\n")
             context.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
             context.flush()

--- a/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
+++ b/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
@@ -221,14 +221,11 @@ final class SSEResponseWriter: ResponseWriter {
 
     @inline(__always)
     private func writeSSEChunk(_ chunk: ChatCompletionChunk, context: ChannelHandlerContext) {
+        let encoder = IkigaJSONEncoder()  // Create encoder per write for thread safety
         var buffer = context.channel.allocator.buffer(capacity: 256)
         buffer.writeString("data: ")
         do {
-            // Use standard JSONEncoder for cross-machine compatibility — IkigaJSON is optimized
-            // for intra-process NIO usage but its nil-value strategy can produce output that
-            // Apple's JSONDecoder rejects when consuming the SSE stream on a remote client.
-            let jsonData = try JSONEncoder().encode(chunk)
-            buffer.writeBytes(jsonData)
+            try encoder.encodeAndWrite(chunk, into: &buffer)
             buffer.writeString("\n\n")
             context.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buffer))), promise: nil)
             context.flush()

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -89,10 +89,14 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     /// The UUID of the agent on the remote Osaurus server. Only used when providerType == .osaurus.
     public var remoteAgentId: UUID?
 
+    /// The crypto address (e.g. "0x...") of the remote agent, used to build relay tunnel URLs.
+    /// Only used when providerType == .osaurus.
+    public var remoteAgentAddress: String?
+
     private enum CodingKeys: String, CodingKey {
         case id, name, host, providerProtocol, port, basePath
         case customHeaders, authType, providerType, enabled, autoConnect, timeout
-        case secretHeaderKeys, remoteAgentId
+        case secretHeaderKeys, remoteAgentId, remoteAgentAddress
     }
 
     public init(
@@ -109,7 +113,8 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         autoConnect: Bool = true,
         timeout: TimeInterval = 60,
         secretHeaderKeys: [String] = [],
-        remoteAgentId: UUID? = nil
+        remoteAgentId: UUID? = nil,
+        remoteAgentAddress: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -125,6 +130,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         self.timeout = timeout
         self.secretHeaderKeys = secretHeaderKeys
         self.remoteAgentId = remoteAgentId
+        self.remoteAgentAddress = remoteAgentAddress
     }
 
     /// Custom decoder – uses `decodeIfPresent` for backward compatibility with older config files.
@@ -146,6 +152,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         timeout = try container.decodeIfPresent(TimeInterval.self, forKey: .timeout) ?? 60
         secretHeaderKeys = try container.decodeIfPresent([String].self, forKey: .secretHeaderKeys) ?? []
         remoteAgentId = try container.decodeIfPresent(UUID.self, forKey: .remoteAgentId)
+        remoteAgentAddress = try container.decodeIfPresent(String.self, forKey: .remoteAgentAddress)
     }
 
     /// Get the effective port (uses protocol default if not specified)

--- a/Packages/OsaurusCore/Networking/BonjourBrowser.swift
+++ b/Packages/OsaurusCore/Networking/BonjourBrowser.swift
@@ -11,7 +11,7 @@ import Foundation
 // MARK: - DiscoveredAgent
 
 /// A remote Osaurus agent discovered via Bonjour on the local network.
-public struct DiscoveredAgent: Identifiable, Equatable {
+public struct DiscoveredAgent: Identifiable, Equatable, Sendable {
     public let id: UUID
     public let name: String
     public let agentDescription: String

--- a/Packages/OsaurusCore/Networking/BonjourBrowser.swift
+++ b/Packages/OsaurusCore/Networking/BonjourBrowser.swift
@@ -8,6 +8,21 @@
 
 import Foundation
 
+// MARK: - PairedRelayAgent
+
+/// A remote Osaurus agent that is persistently paired and reachable via the relay tunnel,
+/// but is not currently discoverable on the local network via Bonjour.
+public struct PairedRelayAgent: Identifiable, Equatable, Sendable {
+    /// The UUID of the agent on the remote Osaurus server.
+    public let id: UUID
+    /// Display name of the remote agent.
+    public let name: String
+    /// The crypto address (e.g. "0x...") used to construct the relay tunnel URL.
+    public let remoteAgentAddress: String
+    /// The local provider ID used to connect to this agent.
+    public let providerId: UUID
+}
+
 // MARK: - DiscoveredAgent
 
 /// A remote Osaurus agent discovered via Bonjour on the local network.

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1509,6 +1509,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private struct PairResponse: Codable {
         let agentAddress: String
         let apiKey: String
+        let isPermanent: Bool
     }
 
     /// POST /pair — unauthenticated endpoint for cryptographic Bonjour pairing.
@@ -1547,6 +1548,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logStartTime = startTime
         let logUserAgent = userAgent
         let logRequestBody = requestBodyString
+        // Strip port from Host header (e.g. "device.local:1337" → "device.local")
+        let pairingHost = (head.headers.first(name: "Host") ?? "unknown")
+            .components(separatedBy: ":").first ?? "unknown"
 
         Task(priority: .userInitiated) {
             // 1. Verify the connector's signature over the nonce.
@@ -1586,12 +1590,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
 
             // 3. Show the approval popup on the advertiser's device.
-            let approved = await PairingPromptService.requestApproval(
+            let approval = await PairingPromptService.requestApproval(
                 connectorAddress: req.connectorAddress,
                 agentName: agent.name
             )
 
-            guard approved else {
+            guard approval.approved else {
                 hop {
                     var headers = [("Content-Type", "application/json; charset=utf-8")]
                     headers.append(contentsOf: cors)
@@ -1602,13 +1606,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
+            let isPermanent = approval.isPermanent
+
             // 4. Generate a master-scoped osk-v1 API key (agentIndex: nil) so its
             //    aud == masterAddress, which always passes the server validator's
             //    audience check regardless of which agent the connector targets.
             //    This triggers biometric auth to access the Master Key.
-            let shortAddr = String(req.connectorAddress.prefix(10))
-            let label = "Paired – \(shortAddr)"
-            guard let (fullKey, _) = try? APIKeyManager.shared.generate(
+            let label = "Paired – \(pairingHost)"
+            guard let (fullKey, keyInfo) = try? APIKeyManager.shared.generate(
                 label: label,
                 expiration: .never,
                 agentIndex: nil
@@ -1623,8 +1628,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
-            // 5. Return the agent's address and the generated API key.
-            let response = PairResponse(agentAddress: agentAddress, apiKey: fullKey)
+            // Temporary keys are revoked and removed from the key list on app exit.
+            if !isPermanent {
+                TemporaryPairedKeyStore.shared.register(keyId: keyInfo.id)
+            }
+
+            // 5. Return the agent's address, the generated API key, and the permanence flag.
+            let response = PairResponse(agentAddress: agentAddress, apiKey: fullKey, isPermanent: isPermanent)
             let json = (try? JSONEncoder().encode(response)).map { String(decoding: $0, as: UTF8.self) } ?? #"{"error":"Encoding failed"}"#
 
             hop {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -138,7 +138,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // Access key authentication gate (all data snapshotted at server start, zero locks)
             // Plugin routes handle their own auth per-route, so skip the global gate.
             // Loopback connections (CLI / local tools) are trusted without a token.
-            let publicPaths: Set<String> = ["/", "/health"]
+            let publicPaths: Set<String> = ["/", "/health", "/pair"]
             let isPluginRoute = path.hasPrefix("/plugins/")
             let isLoopback = trustLoopback && (context.channel.remoteAddress?.isLoopback ?? false)
             if !publicPaths.contains(path) && !isPluginRoute && !isLoopback {
@@ -297,6 +297,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 handleOpenResponses(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .POST, path == "/memory/ingest" {
                 handleMemoryIngest(head: head, context: context, startTime: startTime, userAgent: userAgent)
+            } else if head.method == .POST, path == "/pair" {
+                handlePairEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .GET, path == "/agents" {
                 handleListAgents(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .GET, path.hasPrefix("/agents/") {
@@ -1493,6 +1495,143 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     private struct AgentListResponse: Codable {
         let agents: [AgentListItem]
+    }
+
+    // MARK: - Pair Endpoint
+
+    private struct PairRequest: Codable {
+        let connectorAddress: String
+        let agentId: String
+        let nonce: String
+        let signature: String
+    }
+
+    private struct PairResponse: Codable {
+        let agentAddress: String
+        let apiKey: String
+    }
+
+    /// POST /pair — unauthenticated endpoint for cryptographic Bonjour pairing.
+    private func handlePairEndpoint(
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext,
+        startTime: Date,
+        userAgent: String?
+    ) {
+        let data: Data
+        let requestBodyString: String?
+        if let body = stateRef.value.requestBodyBuffer {
+            var bodyCopy = body
+            let bytes = bodyCopy.readBytes(length: bodyCopy.readableBytes) ?? []
+            data = Data(bytes)
+            requestBodyString = String(decoding: data, as: UTF8.self)
+        } else {
+            data = Data()
+            requestBodyString = nil
+        }
+
+        guard let req = try? JSONDecoder().decode(PairRequest.self, from: data) else {
+            var headers = [("Content-Type", "application/json; charset=utf-8")]
+            headers.append(contentsOf: stateRef.value.corsHeaders)
+            let body = #"{"error":"Invalid pairing request"}"#
+            sendResponse(context: context, version: head.version, status: .badRequest, headers: headers, body: body)
+            logRequest(method: "POST", path: "/pair", userAgent: userAgent, requestBody: requestBodyString, responseBody: body, responseStatus: 400, startTime: startTime)
+            return
+        }
+
+        let cors = stateRef.value.corsHeaders
+        let loop = context.eventLoop
+        let ctx = NIOLoopBound(context, eventLoop: loop)
+        let hop = makeHop(channel: context.channel, loop: loop)
+        let logSelf = self
+        let logStartTime = startTime
+        let logUserAgent = userAgent
+        let logRequestBody = requestBodyString
+
+        Task(priority: .userInitiated) {
+            // 1. Verify the connector's signature over the nonce.
+            let hexSig = req.signature.hasPrefix("0x") ? String(req.signature.dropFirst(2)) : req.signature
+            guard let sigBytes = Data(hexEncoded: hexSig),
+                let recovered = try? recoverAddress(
+                    payload: Data(req.nonce.utf8),
+                    signature: sigBytes,
+                    domainPrefix: "Osaurus Signed Pairing"
+                ),
+                recovered == req.connectorAddress
+            else {
+                hop {
+                    var headers = [("Content-Type", "application/json; charset=utf-8")]
+                    headers.append(contentsOf: cors)
+                    let body = #"{"error":"Signature verification failed"}"#
+                    self.sendResponse(context: ctx.value, version: head.version, status: .unauthorized, headers: headers, body: body)
+                    logSelf.logRequest(method: "POST", path: "/pair", userAgent: logUserAgent, requestBody: logRequestBody, responseBody: body, responseStatus: 401, startTime: logStartTime)
+                }
+                return
+            }
+
+            // 2. Resolve the target agent.
+            let agents = await MainActor.run { AgentManager.shared.agents }
+            guard let agentUUID = UUID(uuidString: req.agentId),
+                let agent = agents.first(where: { $0.id == agentUUID && $0.bonjourEnabled }),
+                let agentAddress = agent.agentAddress
+            else {
+                hop {
+                    var headers = [("Content-Type", "application/json; charset=utf-8")]
+                    headers.append(contentsOf: cors)
+                    let body = #"{"error":"Agent not found or not available for pairing"}"#
+                    self.sendResponse(context: ctx.value, version: head.version, status: .notFound, headers: headers, body: body)
+                    logSelf.logRequest(method: "POST", path: "/pair", userAgent: logUserAgent, requestBody: logRequestBody, responseBody: body, responseStatus: 404, startTime: logStartTime)
+                }
+                return
+            }
+
+            // 3. Show the approval popup on the advertiser's device.
+            let approved = await PairingPromptService.requestApproval(
+                connectorAddress: req.connectorAddress,
+                agentName: agent.name
+            )
+
+            guard approved else {
+                hop {
+                    var headers = [("Content-Type", "application/json; charset=utf-8")]
+                    headers.append(contentsOf: cors)
+                    let body = #"{"error":"Pairing denied"}"#
+                    self.sendResponse(context: ctx.value, version: head.version, status: .forbidden, headers: headers, body: body)
+                    logSelf.logRequest(method: "POST", path: "/pair", userAgent: logUserAgent, requestBody: logRequestBody, responseBody: body, responseStatus: 403, startTime: logStartTime)
+                }
+                return
+            }
+
+            // 4. Generate an osk-v1 API key scoped to the paired agent.
+            //    This triggers biometric auth to access the Master Key.
+            let shortAddr = String(req.connectorAddress.prefix(10))
+            let label = "Paired – \(shortAddr)"
+            guard let (fullKey, _) = try? APIKeyManager.shared.generate(
+                label: label,
+                expiration: .never,
+                agentIndex: agent.agentIndex
+            ) else {
+                hop {
+                    var headers = [("Content-Type", "application/json; charset=utf-8")]
+                    headers.append(contentsOf: cors)
+                    let body = #"{"error":"Failed to generate access key"}"#
+                    self.sendResponse(context: ctx.value, version: head.version, status: .internalServerError, headers: headers, body: body)
+                    logSelf.logRequest(method: "POST", path: "/pair", userAgent: logUserAgent, requestBody: logRequestBody, responseBody: body, responseStatus: 500, startTime: logStartTime)
+                }
+                return
+            }
+
+            // 5. Return the agent's address and the generated API key.
+            let response = PairResponse(agentAddress: agentAddress, apiKey: fullKey)
+            let json = (try? JSONEncoder().encode(response)).map { String(decoding: $0, as: UTF8.self) } ?? #"{"error":"Encoding failed"}"#
+
+            hop {
+                var headers = [("Content-Type", "application/json; charset=utf-8")]
+                headers.append(contentsOf: cors)
+                self.sendResponse(context: ctx.value, version: head.version, status: .ok, headers: headers, body: json)
+                logSelf.logRequest(method: "POST", path: "/pair", userAgent: logUserAgent, requestBody: logRequestBody, responseBody: json, responseStatus: 200, startTime: logStartTime)
+            }
+        }
     }
 
     private func handleListAgents(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1602,14 +1602,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
-            // 4. Generate an osk-v1 API key scoped to the paired agent.
+            // 4. Generate a master-scoped osk-v1 API key (agentIndex: nil) so its
+            //    aud == masterAddress, which always passes the server validator's
+            //    audience check regardless of which agent the connector targets.
             //    This triggers biometric auth to access the Master Key.
             let shortAddr = String(req.connectorAddress.prefix(10))
             let label = "Paired – \(shortAddr)"
             guard let (fullKey, _) = try? APIKeyManager.shared.generate(
                 label: label,
                 expiration: .never,
-                agentIndex: agent.agentIndex
+                agentIndex: nil
             ) else {
                 hop {
                     var headers = [("Content-Type", "application/json; charset=utf-8")]

--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -389,8 +389,6 @@ public final class RelayTunnelManager: ObservableObject {
             let headers = flattenHeaders(httpResponse?.allHeaderFields)
             let contentType = headers["content-type"] ?? ""
 
-            print("[RelayDebug][Server] Local response: id=\(frame.id) status=\(status) content-type=\(contentType)")
-
             if contentType.contains("text/event-stream") || contentType.contains("application/x-ndjson") {
                 await relayStreamingResponse(
                     id: frame.id,
@@ -451,47 +449,28 @@ public final class RelayTunnelManager: ObservableObject {
         bytes: URLSession.AsyncBytes,
         via webSocket: URLSessionWebSocketTask?
     ) async {
-        print("[RelayDebug][Server] relayStreamingResponse start: id=\(id) status=\(status) contentType=\(contentType)")
         sendFrame(RelayStreamStartFrame(id: id, status: status, headers: headers), via: webSocket)
 
         let isSSE = contentType.contains("text/event-stream")
-        var eventBuffer = ""
-        var lineCount = 0
-        var chunkCount = 0
 
         do {
             for try await line in bytes.lines {
-                lineCount += 1
-                print("[RelayDebug][Server] Line #\(lineCount): \(line.prefix(120).debugDescription)")
+                guard !line.isEmpty else { continue }
                 if isSSE {
-                    if line.isEmpty && !eventBuffer.isEmpty {
-                        chunkCount += 1
-                        let chunkData = eventBuffer + "\n"
-                        print("[RelayDebug][Server] Sending stream_chunk #\(chunkCount): \(chunkData.prefix(120).debugDescription)")
-                        sendFrame(
-                            RelayStreamChunkFrame(id: id, data: chunkData),
-                            via: webSocket
-                        )
-                        eventBuffer = ""
-                    } else if !line.isEmpty {
-                        eventBuffer += line + "\n"
-                    }
-                } else if !line.isEmpty {
-                    chunkCount += 1
+                    // URLSession.AsyncBytes.lines does not yield empty strings for consecutive
+                    // newlines, so blank-line SSE event boundaries are never observed here.
+                    // Each non-empty line from the NIO server is one complete SSE event
+                    // (e.g. "data: {...}"), so forward it immediately with the required \n\n
+                    // terminator so Machine A's SSE parser sees proper event boundaries.
+                    sendFrame(RelayStreamChunkFrame(id: id, data: line + "\n\n"), via: webSocket)
+                } else {
                     sendFrame(RelayStreamChunkFrame(id: id, data: line + "\n"), via: webSocket)
                 }
             }
         } catch {
-            print("[RelayDebug][Server] Stream read error after \(lineCount) lines: \(error)")
+            // Stream interrupted — close cleanly
         }
 
-        if !eventBuffer.isEmpty {
-            chunkCount += 1
-            print("[RelayDebug][Server] Flushing leftover buffer as chunk #\(chunkCount): \(eventBuffer.prefix(120).debugDescription)")
-            sendFrame(RelayStreamChunkFrame(id: id, data: eventBuffer), via: webSocket)
-        }
-
-        print("[RelayDebug][Server] relayStreamingResponse done: \(lineCount) lines, \(chunkCount) chunks sent")
         sendFrame(RelayStreamEndFrame(id: id), via: webSocket)
     }
 

--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -389,6 +389,8 @@ public final class RelayTunnelManager: ObservableObject {
             let headers = flattenHeaders(httpResponse?.allHeaderFields)
             let contentType = headers["content-type"] ?? ""
 
+            print("[RelayDebug][Server] Local response: id=\(frame.id) status=\(status) content-type=\(contentType)")
+
             if contentType.contains("text/event-stream") || contentType.contains("application/x-ndjson") {
                 await relayStreamingResponse(
                     id: frame.id,
@@ -449,17 +451,25 @@ public final class RelayTunnelManager: ObservableObject {
         bytes: URLSession.AsyncBytes,
         via webSocket: URLSessionWebSocketTask?
     ) async {
+        print("[RelayDebug][Server] relayStreamingResponse start: id=\(id) status=\(status) contentType=\(contentType)")
         sendFrame(RelayStreamStartFrame(id: id, status: status, headers: headers), via: webSocket)
 
         let isSSE = contentType.contains("text/event-stream")
         var eventBuffer = ""
+        var lineCount = 0
+        var chunkCount = 0
 
         do {
             for try await line in bytes.lines {
+                lineCount += 1
+                print("[RelayDebug][Server] Line #\(lineCount): \(line.prefix(120).debugDescription)")
                 if isSSE {
                     if line.isEmpty && !eventBuffer.isEmpty {
+                        chunkCount += 1
+                        let chunkData = eventBuffer + "\n"
+                        print("[RelayDebug][Server] Sending stream_chunk #\(chunkCount): \(chunkData.prefix(120).debugDescription)")
                         sendFrame(
-                            RelayStreamChunkFrame(id: id, data: eventBuffer + "\n"),
+                            RelayStreamChunkFrame(id: id, data: chunkData),
                             via: webSocket
                         )
                         eventBuffer = ""
@@ -467,17 +477,21 @@ public final class RelayTunnelManager: ObservableObject {
                         eventBuffer += line + "\n"
                     }
                 } else if !line.isEmpty {
+                    chunkCount += 1
                     sendFrame(RelayStreamChunkFrame(id: id, data: line + "\n"), via: webSocket)
                 }
             }
         } catch {
-            // Stream interrupted — flush what we have and close cleanly
+            print("[RelayDebug][Server] Stream read error after \(lineCount) lines: \(error)")
         }
 
         if !eventBuffer.isEmpty {
+            chunkCount += 1
+            print("[RelayDebug][Server] Flushing leftover buffer as chunk #\(chunkCount): \(eventBuffer.prefix(120).debugDescription)")
             sendFrame(RelayStreamChunkFrame(id: id, data: eventBuffer), via: webSocket)
         }
 
+        print("[RelayDebug][Server] relayStreamingResponse done: \(lineCount) lines, \(chunkCount) chunks sent")
         sendFrame(RelayStreamEndFrame(id: id), via: webSocket)
     }
 

--- a/Packages/OsaurusCore/Services/PairingPromptService.swift
+++ b/Packages/OsaurusCore/Services/PairingPromptService.swift
@@ -16,22 +16,25 @@ enum PairingPromptService {
     private static var globalKeyMonitor: Any?
     private static var closeObserver: NSObjectProtocol?
 
-    static func requestApproval(connectorAddress: OsaurusID, agentName: String) async -> Bool {
+    static func requestApproval(
+        connectorAddress: OsaurusID,
+        agentName: String
+    ) async -> (approved: Bool, isPermanent: Bool) {
         return await withCheckedContinuation { continuation in
             var hasResumed = false
 
-            let onAllow = {
+            let onAllow = { (isPermanent: Bool) in
                 guard !hasResumed else { return }
                 hasResumed = true
                 dismissWindow()
-                continuation.resume(returning: true)
+                continuation.resume(returning: (approved: true, isPermanent: isPermanent))
             }
 
             let onDeny = {
                 guard !hasResumed else { return }
                 hasResumed = true
                 dismissWindow()
-                continuation.resume(returning: false)
+                continuation.resume(returning: (approved: false, isPermanent: false))
             }
 
             let themeManager = ThemeManager.shared
@@ -94,8 +97,8 @@ enum PairingPromptService {
             }
 
             let handleKeyEvent: (NSEvent) -> Bool = { event in
-                if event.keyCode == 36 {  // Enter
-                    onAllow()
+                if event.keyCode == 36 {  // Enter — approve as temporary (checkbox state drives permanent)
+                    onAllow(false)
                     return true
                 } else if event.keyCode == 53 {  // Escape
                     onDeny()

--- a/Packages/OsaurusCore/Services/PairingPromptService.swift
+++ b/Packages/OsaurusCore/Services/PairingPromptService.swift
@@ -1,0 +1,145 @@
+//
+//  PairingPromptService.swift
+//  osaurus
+//
+//  Presents a pairing approval dialog when a remote device requests to pair.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+
+@MainActor
+enum PairingPromptService {
+    private static var pairingWindow: NSPanel?
+    private static var localKeyMonitor: Any?
+    private static var globalKeyMonitor: Any?
+    private static var closeObserver: NSObjectProtocol?
+
+    static func requestApproval(connectorAddress: OsaurusID, agentName: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            var hasResumed = false
+
+            let onAllow = {
+                guard !hasResumed else { return }
+                hasResumed = true
+                dismissWindow()
+                continuation.resume(returning: true)
+            }
+
+            let onDeny = {
+                guard !hasResumed else { return }
+                hasResumed = true
+                dismissWindow()
+                continuation.resume(returning: false)
+            }
+
+            let themeManager = ThemeManager.shared
+            let approvalView = PairingApprovalView(
+                agentName: agentName,
+                connectorAddress: connectorAddress,
+                onAllow: onAllow,
+                onDeny: onDeny
+            )
+            .environment(\.theme, themeManager.currentTheme)
+
+            let hostingController = NSHostingController(rootView: approvalView)
+
+            let panel = NSPanel(
+                contentRect: NSRect(x: 0, y: 0, width: 480, height: 300),
+                styleMask: [.fullSizeContentView],
+                backing: .buffered,
+                defer: false
+            )
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = true
+            panel.level = .modalPanel
+            panel.hidesOnDeactivate = false
+            panel.isMovableByWindowBackground = true
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            panel.animationBehavior = .alertPanel
+            panel.contentViewController = hostingController
+
+            hostingController.view.layoutSubtreeIfNeeded()
+
+            let fittingSize = hostingController.view.fittingSize
+            let windowSize = NSSize(
+                width: max(fittingSize.width, 480),
+                height: max(fittingSize.height, 300)
+            )
+
+            let mouse = NSEvent.mouseLocation
+            let targetScreen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+
+            if let screen = targetScreen {
+                let visibleFrame = screen.visibleFrame
+                let x = visibleFrame.origin.x + (visibleFrame.width - windowSize.width) / 2
+                let y = visibleFrame.origin.y + (visibleFrame.height - windowSize.height) / 2
+                panel.setFrame(NSRect(x: x, y: y, width: windowSize.width, height: windowSize.height), display: false)
+            } else {
+                panel.setContentSize(windowSize)
+                panel.center()
+            }
+
+            pairingWindow = panel
+
+            nonisolated(unsafe) let onDenyForClose = onDeny
+            closeObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.willCloseNotification,
+                object: panel,
+                queue: .main
+            ) { _ in
+                onDenyForClose()
+            }
+
+            let handleKeyEvent: (NSEvent) -> Bool = { event in
+                if event.keyCode == 36 {  // Enter
+                    onAllow()
+                    return true
+                } else if event.keyCode == 53 {  // Escape
+                    onDeny()
+                    return true
+                }
+                return false
+            }
+
+            localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                if handleKeyEvent(event) { return nil }
+                return event
+            }
+
+            globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+                guard pairingWindow?.isVisible == true else { return }
+                _ = handleKeyEvent(event)
+            }
+
+            NSApp.activate(ignoringOtherApps: true)
+            panel.makeKeyAndOrderFront(nil)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                panel.makeKey()
+                if let contentView = panel.contentView {
+                    panel.makeFirstResponder(contentView)
+                }
+            }
+        }
+    }
+
+    private static func dismissWindow() {
+        if let observer = closeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            closeObserver = nil
+        }
+        if let monitor = localKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            localKeyMonitor = nil
+        }
+        if let monitor = globalKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalKeyMonitor = nil
+        }
+        pairingWindow?.orderOut(nil)
+        pairingWindow = nil
+    }
+}

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -225,7 +225,6 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         let urlRequest = try buildURLRequest(for: request)
-        print("[RelayDebug][Client] streamDeltas URL: \(urlRequest.url?.absoluteString ?? "nil") method=\(urlRequest.httpMethod ?? "nil") providerType=\(self.provider.providerType)")
         let currentSession = self.session
         let providerType = self.provider.providerType
         let inactivityTimeout = self.streamInactivityTimeout
@@ -242,8 +241,6 @@ public actor RemoteProviderService: ToolCapableService {
                 }
 
                 let statusCode = httpResponse.statusCode
-                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? "nil"
-                print("[RelayDebug][Client] HTTP response: status=\(statusCode) content-type=\(contentType)")
 
                 if statusCode >= 400 {
                     var errorData = Data()
@@ -251,7 +248,6 @@ public actor RemoteProviderService: ToolCapableService {
                         errorData.append(byte)
                     }
                     let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                    print("[RelayDebug][Client] HTTP error body: \(errorMessage)")
                     continuation.finish(
                         throwing: RemoteProviderServiceError.requestFailed(
                             "HTTP \(statusCode): \(errorMessage)"
@@ -272,7 +268,6 @@ public actor RemoteProviderService: ToolCapableService {
                 // Parse SSE stream with UTF-8 decoding and inactivity timeout
                 var buffer = ""
                 var sseEventData = ""
-                var rawByteCount = 0
                 var utf8Buffer = Data()
                 let maxUtf8BufferSize = 1024
                 let byteRef = ByteIteratorRef(bytes.makeAsyncIterator())
@@ -292,9 +287,6 @@ public actor RemoteProviderService: ToolCapableService {
                         break
                     }
 
-                    rawByteCount += 1
-                    if rawByteCount == 1 { print("[RelayDebug][Client] First byte received") }
-
                     utf8Buffer.append(byte)
                     if let decoded = String(data: utf8Buffer, encoding: .utf8) {
                         buffer.append(decoded)
@@ -309,14 +301,11 @@ public actor RemoteProviderService: ToolCapableService {
                         let line = String(buffer[..<newlineIndex])
                         buffer = String(buffer[buffer.index(after: newlineIndex)...])
 
-                        print("[RelayDebug][Client] Line: \(line.prefix(120).debugDescription)")
-
                         // SSE event boundary: blank line dispatches accumulated data
                         if line.trimmingCharacters(in: .whitespaces).isEmpty {
                             guard !sseEventData.isEmpty else { continue }
                             let dataContent = sseEventData
                             sseEventData = ""
-                            print("[RelayDebug][Client] Dispatching SSE event (\(dataContent.count) chars): \(dataContent.prefix(120).debugDescription)")
 
                             // Check for stream end (OpenAI format)
                             if dataContent.trimmingCharacters(in: .whitespaces) == "[DONE]" {
@@ -673,8 +662,6 @@ public actor RemoteProviderService: ToolCapableService {
                     }
                 }
 
-                print("[RelayDebug][Client] Byte loop exited: totalBytes=\(rawByteCount) remainingBuffer=\(buffer.count) remainingSSEData=\(sseEventData.count)")
-
                 // Flush remaining buffer into SSE event accumulator
                 if !buffer.trimmingCharacters(in: .whitespaces).isEmpty {
                     Self.accumulateSSELine(buffer, into: &sseEventData)
@@ -697,10 +684,8 @@ public actor RemoteProviderService: ToolCapableService {
                 continuation.finish()
             } catch {
                 if Task.isCancelled {
-                    print("[RelayDebug][Client] Stream task cancelled")
                     continuation.finish()
                 } else {
-                    print("[RelayDebug][Client] Stream task error: \(error)")
                     continuation.finish(throwing: error)
                 }
             }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -637,7 +637,17 @@ public actor RemoteProviderService: ToolCapableService {
                                         }
                                     }
                                 } catch {
-                                    // Log parsing errors for debugging
+                                    // Check if this is a server-side error payload before discarding
+                                    if let errorResponse = try? JSONDecoder().decode(
+                                        OpenAIError.self, from: jsonData
+                                    ) {
+                                        continuation.finish(
+                                            throwing: RemoteProviderServiceError.streamingError(
+                                                errorResponse.error.message
+                                            )
+                                        )
+                                        return
+                                    }
                                     print(
                                         "[Osaurus] Warning: Failed to parse SSE chunk in streamDeltas: \(error.localizedDescription)"
                                     )
@@ -1275,7 +1285,17 @@ public actor RemoteProviderService: ToolCapableService {
                                         }
                                     }
                                 } catch {
-                                    // Log parsing errors for debugging instead of silently ignoring
+                                    // Check if this is a server-side error payload before discarding
+                                    if let errorResponse = try? JSONDecoder().decode(
+                                        OpenAIError.self, from: jsonData
+                                    ) {
+                                        continuation.finish(
+                                            throwing: RemoteProviderServiceError.streamingError(
+                                                errorResponse.error.message
+                                            )
+                                        )
+                                        return
+                                    }
                                     print(
                                         "[Osaurus] Warning: Failed to parse SSE chunk: \(error.localizedDescription)"
                                     )

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -639,17 +639,7 @@ public actor RemoteProviderService: ToolCapableService {
                                         }
                                     }
                                 } catch {
-                                    // Check if this is a server-side error payload before discarding
-                                    if let errorResponse = try? JSONDecoder().decode(
-                                        OpenAIError.self, from: jsonData
-                                    ) {
-                                        continuation.finish(
-                                            throwing: RemoteProviderServiceError.streamingError(
-                                                errorResponse.error.message
-                                            )
-                                        )
-                                        return
-                                    }
+                                    // Log parsing errors for debugging
                                     print(
                                         "[Osaurus] Warning: Failed to parse SSE chunk in streamDeltas: \(error.localizedDescription)"
                                     )
@@ -1287,17 +1277,7 @@ public actor RemoteProviderService: ToolCapableService {
                                         }
                                     }
                                 } catch {
-                                    // Check if this is a server-side error payload before discarding
-                                    if let errorResponse = try? JSONDecoder().decode(
-                                        OpenAIError.self, from: jsonData
-                                    ) {
-                                        continuation.finish(
-                                            throwing: RemoteProviderServiceError.streamingError(
-                                                errorResponse.error.message
-                                            )
-                                        )
-                                        return
-                                    }
+                                    // Log parsing errors for debugging instead of silently ignoring
                                     print(
                                         "[Osaurus] Warning: Failed to parse SSE chunk: \(error.localizedDescription)"
                                     )

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -225,6 +225,7 @@ public actor RemoteProviderService: ToolCapableService {
         }
 
         let urlRequest = try buildURLRequest(for: request)
+        print("[RelayDebug][Client] streamDeltas URL: \(urlRequest.url?.absoluteString ?? "nil") method=\(urlRequest.httpMethod ?? "nil") providerType=\(self.provider.providerType)")
         let currentSession = self.session
         let providerType = self.provider.providerType
         let inactivityTimeout = self.streamInactivityTimeout
@@ -240,15 +241,20 @@ public actor RemoteProviderService: ToolCapableService {
                     return
                 }
 
-                if httpResponse.statusCode >= 400 {
+                let statusCode = httpResponse.statusCode
+                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? "nil"
+                print("[RelayDebug][Client] HTTP response: status=\(statusCode) content-type=\(contentType)")
+
+                if statusCode >= 400 {
                     var errorData = Data()
                     for try await byte in bytes {
                         errorData.append(byte)
                     }
                     let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+                    print("[RelayDebug][Client] HTTP error body: \(errorMessage)")
                     continuation.finish(
                         throwing: RemoteProviderServiceError.requestFailed(
-                            "HTTP \(httpResponse.statusCode): \(errorMessage)"
+                            "HTTP \(statusCode): \(errorMessage)"
                         )
                     )
                     return
@@ -266,6 +272,7 @@ public actor RemoteProviderService: ToolCapableService {
                 // Parse SSE stream with UTF-8 decoding and inactivity timeout
                 var buffer = ""
                 var sseEventData = ""
+                var rawByteCount = 0
                 var utf8Buffer = Data()
                 let maxUtf8BufferSize = 1024
                 let byteRef = ByteIteratorRef(bytes.makeAsyncIterator())
@@ -285,6 +292,9 @@ public actor RemoteProviderService: ToolCapableService {
                         break
                     }
 
+                    rawByteCount += 1
+                    if rawByteCount == 1 { print("[RelayDebug][Client] First byte received") }
+
                     utf8Buffer.append(byte)
                     if let decoded = String(data: utf8Buffer, encoding: .utf8) {
                         buffer.append(decoded)
@@ -299,11 +309,14 @@ public actor RemoteProviderService: ToolCapableService {
                         let line = String(buffer[..<newlineIndex])
                         buffer = String(buffer[buffer.index(after: newlineIndex)...])
 
+                        print("[RelayDebug][Client] Line: \(line.prefix(120).debugDescription)")
+
                         // SSE event boundary: blank line dispatches accumulated data
                         if line.trimmingCharacters(in: .whitespaces).isEmpty {
                             guard !sseEventData.isEmpty else { continue }
                             let dataContent = sseEventData
                             sseEventData = ""
+                            print("[RelayDebug][Client] Dispatching SSE event (\(dataContent.count) chars): \(dataContent.prefix(120).debugDescription)")
 
                             // Check for stream end (OpenAI format)
                             if dataContent.trimmingCharacters(in: .whitespaces) == "[DONE]" {
@@ -660,6 +673,8 @@ public actor RemoteProviderService: ToolCapableService {
                     }
                 }
 
+                print("[RelayDebug][Client] Byte loop exited: totalBytes=\(rawByteCount) remainingBuffer=\(buffer.count) remainingSSEData=\(sseEventData.count)")
+
                 // Flush remaining buffer into SSE event accumulator
                 if !buffer.trimmingCharacters(in: .whitespaces).isEmpty {
                     Self.accumulateSSELine(buffer, into: &sseEventData)
@@ -682,8 +697,10 @@ public actor RemoteProviderService: ToolCapableService {
                 continuation.finish()
             } catch {
                 if Task.isCancelled {
+                    print("[RelayDebug][Client] Stream task cancelled")
                     continuation.finish()
                 } else {
+                    print("[RelayDebug][Client] Stream task error: \(error)")
                     continuation.finish(throwing: error)
                 }
             }

--- a/Packages/OsaurusCore/Views/Chat/ChatEmptyState.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatEmptyState.swift
@@ -23,6 +23,9 @@ struct ChatEmptyState: View {
     var discoveredAgents: [DiscoveredAgent] = []
     var onSelectDiscoveredAgent: ((DiscoveredAgent) -> Void)? = nil
     var activeDiscoveredAgent: DiscoveredAgent? = nil
+    var pairedRelayAgents: [PairedRelayAgent] = []
+    var onSelectRelayAgent: ((PairedRelayAgent) -> Void)? = nil
+    var activeRelayAgent: PairedRelayAgent? = nil
 
     @State private var hasAppeared = false
     @Environment(\.theme) private var theme
@@ -138,7 +141,10 @@ struct ChatEmptyState: View {
             onSelectAgent: onSelectAgent,
             discoveredAgents: discoveredAgents,
             onSelectDiscoveredAgent: onSelectDiscoveredAgent,
-            activeDiscoveredAgent: activeDiscoveredAgent
+            activeDiscoveredAgent: activeDiscoveredAgent,
+            pairedRelayAgents: pairedRelayAgents,
+            onSelectRelayAgent: onSelectRelayAgent,
+            activeRelayAgent: activeRelayAgent
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import Combine
+import LocalAuthentication
 import SwiftUI
 
 @MainActor
@@ -1657,13 +1658,23 @@ struct ChatView: View {
         .environment(\.theme, windowState.theme)
         .tint(theme.accentColor)
         .sheet(item: $pendingDiscoveredAgent) { agent in
-            BonjourTokenSheet(agentName: agent.name) { token in
-                connectToDiscoveredAgent(agent, token: token)
-                pendingDiscoveredAgent = nil
-            } onCancel: {
-                pendingDiscoveredAgent = nil
+            if agent.address != nil {
+                PairingSheet(agent: agent) { apiKey in
+                    connectToDiscoveredAgent(agent, token: apiKey)
+                    pendingDiscoveredAgent = nil
+                } onCancel: {
+                    pendingDiscoveredAgent = nil
+                }
+                .environment(\.theme, windowState.theme)
+            } else {
+                BonjourTokenSheet(agentName: agent.name) { token in
+                    connectToDiscoveredAgent(agent, token: token)
+                    pendingDiscoveredAgent = nil
+                } onCancel: {
+                    pendingDiscoveredAgent = nil
+                }
+                .environment(\.theme, windowState.theme)
             }
-            .environment(\.theme, windowState.theme)
         }
     }
 
@@ -1995,6 +2006,164 @@ private struct BonjourTokenSheet: View {
         }
         .padding(24)
         .frame(width: 380)
+    }
+}
+
+// MARK: - Pairing Sheet
+
+/// Sheet shown when the user selects a Bonjour-discovered agent that has a crypto address.
+/// Performs cryptographic pairing instead of prompting for a manual server token.
+private struct PairingSheet: View {
+    let agent: DiscoveredAgent
+    let onSuccess: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var isPairing = false
+    @State private var errorMessage: String? = nil
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Pair with \(agent.name)", bundle: .module)
+                    .font(theme.font(size: 16, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+
+                Text(
+                    "This will cryptographically verify both devices. The remote device will show an approval prompt.",
+                    bundle: .module
+                )
+                .font(theme.font(size: 13))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(theme.font(size: 12))
+                    .foregroundColor(theme.errorColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Button { onCancel() } label: { Text("Cancel", bundle: .module) }
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(isPairing)
+                Spacer()
+                if isPairing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.trailing, 4)
+                } else {
+                    Button {
+                        Task { await performPairing() }
+                    } label: {
+                        Text("Pair", bundle: .module)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding(24)
+        .frame(width: 380)
+    }
+
+    private func performPairing() async {
+        isPairing = true
+        errorMessage = nil
+        defer { isPairing = false }
+
+        do {
+            let apiKey = try await PairingClient.pair(with: agent)
+            onSuccess(apiKey)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Pairing Client
+
+private enum PairingClient {
+    struct PairRequestBody: Codable {
+        let connectorAddress: String
+        let agentId: String
+        let nonce: String
+        let signature: String
+    }
+
+    struct PairResponseBody: Codable {
+        let agentAddress: String
+        let apiKey: String
+    }
+
+    enum PairingError: LocalizedError {
+        case missingHost
+        case signFailed
+        case networkError(Int)
+        case decodingFailed
+        case denied
+
+        var errorDescription: String? {
+            switch self {
+            case .missingHost: return "Could not resolve the agent's network address."
+            case .signFailed: return "Failed to sign the pairing request."
+            case .networkError(let code): return "Pairing request failed (HTTP \(code))."
+            case .decodingFailed: return "Unexpected response from the remote device."
+            case .denied: return "Pairing was denied by the remote device."
+            }
+        }
+    }
+
+    static func pair(with agent: DiscoveredAgent) async throws -> String {
+        let context = LAContext()
+        context.touchIDAuthenticationAllowableReuseDuration = 300
+
+        var masterKey = try MasterKey.getPrivateKey(context: context)
+        defer {
+            masterKey.withUnsafeMutableBytes { ptr in
+                if let base = ptr.baseAddress { memset(base, 0, ptr.count) }
+            }
+        }
+
+        let connectorAddress = try PairingKey.deriveAddress(masterKey: masterKey)
+        let nonce = UUID().uuidString
+
+        let signature = try PairingKey.sign(payload: Data(nonce.utf8), masterKey: masterKey)
+        let hexSig = "0x" + signature.hexEncodedString
+
+        let rawHost = agent.host ?? ""
+        guard !rawHost.isEmpty else { throw PairingError.missingHost }
+        let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
+
+        let urlString = "http://\(host):\(agent.port)/pair"
+        guard let url = URL(string: urlString) else { throw PairingError.missingHost }
+
+        let body = PairRequestBody(
+            connectorAddress: connectorAddress,
+            agentId: agent.id.uuidString,
+            nonce: nonce,
+            signature: hexSig
+        )
+        let bodyData = try JSONEncoder().encode(body)
+
+        var request = URLRequest(url: url, timeoutInterval: 120)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = bodyData
+
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if statusCode == 403 { throw PairingError.denied }
+        guard statusCode == 200 else { throw PairingError.networkError(statusCode) }
+
+        guard let decoded = try? JSONDecoder().decode(PairResponseBody.self, from: responseData) else {
+            throw PairingError.decodingFailed
+        }
+
+        return decoded.apiKey
     }
 }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1510,7 +1510,10 @@ struct ChatView: View {
                                     onOpenOnboarding: nil,
                                     discoveredAgents: windowState.discoveredAgents,
                                     onSelectDiscoveredAgent: { agent in selectDiscoveredAgent(agent) },
-                                    activeDiscoveredAgent: windowState.selectedDiscoveredAgent
+                                    activeDiscoveredAgent: windowState.selectedDiscoveredAgent,
+                                    pairedRelayAgents: windowState.pairedRelayAgents,
+                                    onSelectRelayAgent: { relay in connectToRelayAgent(relay) },
+                                    activeRelayAgent: windowState.selectedRelayAgent
                                 )
                                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
                             } else {
@@ -1589,7 +1592,9 @@ struct ChatView: View {
                                     AppDelegate.shared?.showOnboardingWindow()
                                 },
                                 discoveredAgents: windowState.discoveredAgents,
-                                onSelectDiscoveredAgent: { agent in selectDiscoveredAgent(agent) }
+                                onSelectDiscoveredAgent: { agent in selectDiscoveredAgent(agent) },
+                                pairedRelayAgents: windowState.pairedRelayAgents,
+                                onSelectRelayAgent: { relay in connectToRelayAgent(relay) }
                             )
                         }
                     }
@@ -1714,8 +1719,10 @@ struct ChatView: View {
             providerId = existing.id
             var updated = existing
             updated.host = host
+            updated.providerProtocol = .http
             updated.port = agent.port
             updated.enabled = true
+            if let address = agent.address { updated.remoteAgentAddress = address }
             if !token.isEmpty {
                 updated.authType = .apiKey
                 manager.updateProvider(updated, apiKey: token)
@@ -1735,14 +1742,40 @@ struct ChatView: View {
                 providerType: .osaurus,
                 enabled: true,
                 autoConnect: true,
-                remoteAgentId: agent.id
+                remoteAgentId: agent.id,
+                remoteAgentAddress: agent.address
             )
             providerId = provider.id
             manager.addProvider(provider, apiKey: token.isEmpty ? nil : token, isEphemeral: isEphemeral)
         }
 
+        windowState.selectedRelayAgent = nil
         windowState.selectedDiscoveredAgent = agent
         windowState.selectedDiscoveredAgentProviderId = providerId
+        windowState.refreshPairedRelayAgents()
+        session.reset()
+        Task { await session.refreshPickerItems() }
+    }
+
+    private func connectToRelayAgent(_ relay: PairedRelayAgent) {
+        let relayHost = "\(relay.remoteAgentAddress).agent.osaurus.ai"
+        let manager = RemoteProviderManager.shared
+
+        guard let existing = manager.configuration.providers.first(where: { $0.id == relay.providerId }) else {
+            return
+        }
+
+        var updated = existing
+        updated.host = relayHost
+        updated.providerProtocol = .https
+        updated.port = nil
+        updated.enabled = true
+        manager.updateProvider(updated, apiKey: nil)
+        Task { try? await manager.connect(providerId: relay.providerId) }
+
+        windowState.selectedDiscoveredAgent = nil
+        windowState.selectedRelayAgent = relay
+        windowState.selectedDiscoveredAgentProviderId = relay.providerId
         session.reset()
         Task { await session.refreshPickerItems() }
     }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1323,14 +1323,19 @@ struct ChatView: View {
     /// Convenience accessor for the window ID
     private var windowId: UUID { windowState.windowId }
 
-    /// Picker items filtered to the active Bonjour provider, or all items when no Bonjour agent is selected.
+    /// Picker items filtered to the active Bonjour provider's models when a remote agent is selected,
+    /// or local/foundation models only when no remote agent is active.
     private var filteredPickerItems: [ModelPickerItem] {
-        guard let providerId = windowState.selectedDiscoveredAgentProviderId else {
-            return session.pickerItems
+        if let providerId = windowState.selectedDiscoveredAgentProviderId {
+            return session.pickerItems.filter {
+                if case .remote(_, let id) = $0.source { return id == providerId }
+                return false
+            }
         }
+        // No remote agent selected: hide all remote models so the picker stays local.
         return session.pickerItems.filter {
-            if case .remote(_, let id) = $0.source { return id == providerId }
-            return false
+            if case .remote = $0.source { return false }
+            return true
         }
     }
 
@@ -1504,7 +1509,7 @@ struct ChatView: View {
                                     },
                                     onOpenOnboarding: nil,
                                     discoveredAgents: windowState.discoveredAgents,
-                                    onSelectDiscoveredAgent: { agent in pendingDiscoveredAgent = agent },
+                                    onSelectDiscoveredAgent: { agent in selectDiscoveredAgent(agent) },
                                     activeDiscoveredAgent: windowState.selectedDiscoveredAgent
                                 )
                                 .transition(.opacity.combined(with: .scale(scale: 0.98)))
@@ -1584,7 +1589,7 @@ struct ChatView: View {
                                     AppDelegate.shared?.showOnboardingWindow()
                                 },
                                 discoveredAgents: windowState.discoveredAgents,
-                                onSelectDiscoveredAgent: { agent in pendingDiscoveredAgent = agent }
+                                onSelectDiscoveredAgent: { agent in selectDiscoveredAgent(agent) }
                             )
                         }
                     }
@@ -1675,6 +1680,23 @@ struct ChatView: View {
                 }
                 .environment(\.theme, windowState.theme)
             }
+        }
+    }
+
+    /// Called when the user picks a discovered agent from the menu.
+    /// If a persistent (non-ephemeral) paired provider already exists for this agent,
+    /// connect directly without showing the pairing sheet.
+    private func selectDiscoveredAgent(_ agent: DiscoveredAgent) {
+        let manager = RemoteProviderManager.shared
+        let hasPersistentProvider = manager.configuration.providers.contains(where: {
+            $0.providerType == .osaurus
+                && $0.remoteAgentId == agent.id
+                && !manager.isEphemeral(id: $0.id)
+        })
+        if hasPersistentProvider {
+            connectToDiscoveredAgent(agent, token: "", isEphemeral: false)
+        } else {
+            pendingDiscoveredAgent = agent
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1659,8 +1659,8 @@ struct ChatView: View {
         .tint(theme.accentColor)
         .sheet(item: $pendingDiscoveredAgent) { agent in
             if agent.address != nil {
-                PairingSheet(agent: agent) { apiKey in
-                    connectToDiscoveredAgent(agent, token: apiKey)
+                PairingSheet(agent: agent) { apiKey, isPermanent in
+                    connectToDiscoveredAgent(agent, token: apiKey, isEphemeral: !isPermanent)
                     pendingDiscoveredAgent = nil
                 } onCancel: {
                     pendingDiscoveredAgent = nil
@@ -1678,7 +1678,7 @@ struct ChatView: View {
         }
     }
 
-    private func connectToDiscoveredAgent(_ agent: DiscoveredAgent, token: String) {
+    private func connectToDiscoveredAgent(_ agent: DiscoveredAgent, token: String, isEphemeral: Bool = true) {
         // Strip trailing dot from mDNS hostnames (e.g. "device.local." -> "device.local")
         let rawHost = agent.host ?? "localhost"
         let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
@@ -1716,7 +1716,7 @@ struct ChatView: View {
                 remoteAgentId: agent.id
             )
             providerId = provider.id
-            manager.addProvider(provider, apiKey: token.isEmpty ? nil : token, isEphemeral: true)
+            manager.addProvider(provider, apiKey: token.isEmpty ? nil : token, isEphemeral: isEphemeral)
         }
 
         windowState.selectedDiscoveredAgent = agent
@@ -2015,7 +2015,7 @@ private struct BonjourTokenSheet: View {
 /// Performs cryptographic pairing instead of prompting for a manual server token.
 private struct PairingSheet: View {
     let agent: DiscoveredAgent
-    let onSuccess: (String) -> Void
+    let onSuccess: (String, Bool) -> Void  // (apiKey, isPermanent)
     let onCancel: () -> Void
 
     @State private var isPairing = false
@@ -2075,8 +2075,8 @@ private struct PairingSheet: View {
         defer { isPairing = false }
 
         do {
-            let apiKey = try await PairingClient.pair(with: agent)
-            onSuccess(apiKey)
+            let (apiKey, isPermanent) = try await PairingClient.pair(with: agent)
+            onSuccess(apiKey, isPermanent)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -2096,6 +2096,7 @@ private enum PairingClient {
     struct PairResponseBody: Codable {
         let agentAddress: String
         let apiKey: String
+        let isPermanent: Bool
     }
 
     enum PairingError: LocalizedError {
@@ -2116,7 +2117,7 @@ private enum PairingClient {
         }
     }
 
-    static func pair(with agent: DiscoveredAgent) async throws -> String {
+    static func pair(with agent: DiscoveredAgent) async throws -> (apiKey: String, isPermanent: Bool) {
         let context = LAContext()
         context.touchIDAuthenticationAllowableReuseDuration = 300
 
@@ -2163,7 +2164,7 @@ private enum PairingClient {
             throw PairingError.decodingFailed
         }
 
-        return decoded.apiKey
+        return (apiKey: decoded.apiKey, isPermanent: decoded.isPermanent)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
@@ -174,6 +174,9 @@ struct AgentPill: View {
     var discoveredAgents: [DiscoveredAgent] = []
     var onSelectDiscoveredAgent: ((DiscoveredAgent) -> Void)? = nil
     var activeDiscoveredAgent: DiscoveredAgent? = nil
+    var pairedRelayAgents: [PairedRelayAgent] = []
+    var onSelectRelayAgent: ((PairedRelayAgent) -> Void)? = nil
+    var activeRelayAgent: PairedRelayAgent? = nil
 
     @State private var isHovered = false
     @Environment(\.theme) private var theme
@@ -196,11 +199,16 @@ struct AgentPill: View {
     }
 
     private var displayName: String {
+        if let relay = activeRelayAgent { return relay.name }
         guard let discovered = activeDiscoveredAgent else { return activeAgent.name }
         if let host = discovered.host {
             return "\(discovered.name) (\(shortHost(host)))"
         }
         return discovered.name
+    }
+
+    private var isRemoteActive: Bool {
+        activeDiscoveredAgent != nil || activeRelayAgent != nil
     }
 
     var body: some View {
@@ -209,7 +217,7 @@ struct AgentPill: View {
                 Button(action: { onSelectAgent(agent.id) }) {
                     HStack {
                         Text(agent.name)
-                        if agent.id == activeAgentId && activeDiscoveredAgent == nil {
+                        if agent.id == activeAgentId && !isRemoteActive {
                             Spacer()
                             Image(systemName: "checkmark")
                                 .font(.system(size: 12, weight: .medium))
@@ -234,6 +242,22 @@ struct AgentPill: View {
                 }
             }
 
+            if !pairedRelayAgents.isEmpty && onSelectRelayAgent != nil {
+                Divider()
+                Section {
+                    ForEach(pairedRelayAgents) { relay in
+                        Button(action: { onSelectRelayAgent?(relay) }) {
+                            Label(
+                                relay.name,
+                                systemImage: activeRelayAgent?.id == relay.id ? "checkmark" : "antenna.radiowaves.left.and.right"
+                            )
+                        }
+                    }
+                } header: {
+                    Text("Paired", bundle: .module)
+                }
+            }
+
             Divider()
 
             Button(action: {
@@ -247,7 +271,7 @@ struct AgentPill: View {
             }
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: activeDiscoveredAgent != nil ? "network" : "person.fill")
+                Image(systemName: isRemoteActive ? "network" : "person.fill")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(isHovered ? theme.accentColor : theme.secondaryText)
 

--- a/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
+++ b/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
@@ -1,0 +1,215 @@
+//
+//  PairingApprovalView.swift
+//  osaurus
+//
+//  Approval dialog shown on the advertiser when a remote device requests pairing.
+//
+
+import AppKit
+import SwiftUI
+
+struct PairingApprovalView: View {
+    let agentName: String
+    let connectorAddress: OsaurusID
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+
+    @ObservedObject private var themeManager = ThemeManager.shared
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    @State private var appeared = false
+
+    private var cardGradient: LinearGradient {
+        LinearGradient(
+            colors: [theme.cardBackground, theme.cardBackground.opacity(0.95)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(cardGradient)
+
+            VStack(spacing: 0) {
+                header
+                    .padding(.top, 24)
+                    .padding(.horizontal, 24)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : -8)
+
+                addressBlock
+                    .padding(.top, 12)
+                    .padding(.horizontal, 24)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 4)
+
+                Rectangle()
+                    .fill(theme.primaryBorder.opacity(0.3))
+                    .frame(height: 1)
+                    .padding(.top, 16)
+                    .opacity(appeared ? 1 : 0)
+
+                actionButtons
+                    .padding(.top, 16)
+                    .padding(.bottom, 16)
+                    .padding(.horizontal, 24)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 8)
+            }
+        }
+        .frame(width: 380)
+        .fixedSize(horizontal: true, vertical: true)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [theme.glassEdgeLight, theme.glassEdgeLight.opacity(0.3)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+        )
+        .shadow(
+            color: theme.shadowColor.opacity(theme.shadowOpacity * 2),
+            radius: 24,
+            x: 0,
+            y: 12
+        )
+        .onAppear {
+            withAnimation(theme.springAnimation(responseMultiplier: 1.25).delay(0.05)) {
+                appeared = true
+            }
+        }
+        .environment(\.theme, themeManager.currentTheme)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Circle()
+                .fill(theme.accentColor.opacity(0.15))
+                .frame(width: 48, height: 48)
+                .overlay(
+                    Image(systemName: "link.badge.plus")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(theme.accentColor)
+                )
+
+            Text("Pairing Request", bundle: .module)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+                .multilineTextAlignment(.center)
+
+            Text("A device wants to pair with **\(agentName)**.\nAllow this device to connect?", bundle: .module)
+                .font(.system(size: 13))
+                .foregroundColor(theme.secondaryText)
+                .multilineTextAlignment(.center)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: - Address Block
+
+    private var addressBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label { Text("Device Address", bundle: .module) } icon: { Image(systemName: "person.badge.key.fill") }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+
+            Text(connectorAddress)
+                .font(theme.monoFont(size: 11.5))
+                .foregroundColor(theme.primaryText.opacity(0.9))
+                .textSelection(.enabled)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(theme.codeBlockBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(
+                        theme.primaryBorder.opacity(0.6),
+                        lineWidth: 1
+                    )
+                )
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        HStack(spacing: 12) {
+            PairingActionButton(
+                title: "Deny",
+                shortcutHint: "esc",
+                icon: "xmark",
+                isPrimary: false,
+                color: theme.errorColor,
+                action: onDeny
+            )
+            PairingActionButton(
+                title: "Allow",
+                shortcutHint: "return",
+                icon: "checkmark",
+                isPrimary: true,
+                color: theme.successColor,
+                action: onAllow
+            )
+        }
+    }
+}
+
+// MARK: - Pairing Action Button
+
+private struct PairingActionButton: View {
+    let title: String
+    let shortcutHint: String
+    let icon: String
+    let isPrimary: Bool
+    let color: Color
+    let action: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Label(title, systemImage: icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(isPrimary ? (theme.isDark ? theme.primaryBackground : .white) : theme.primaryText)
+                Text(shortcutHint)
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(isPrimary ? Color.white.opacity(0.7) : theme.secondaryText.opacity(0.7))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(isPrimary ? Color.white.opacity(0.15) : theme.tertiaryBackground.opacity(0.5))
+                    )
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+                isPrimary
+                    ? color.opacity(isHovering ? 0.9 : 1.0)
+                    : theme.tertiaryBackground.opacity(isHovering ? 0.8 : 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(
+                    isPrimary ? .clear : (isHovering ? theme.primaryBorder : theme.cardBorder),
+                    lineWidth: 1
+                )
+            )
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovering ? 1.02 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: isHovering)
+        .onHover { isHovering = $0 }
+    }
+}

--- a/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
+++ b/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
@@ -11,13 +11,15 @@ import SwiftUI
 struct PairingApprovalView: View {
     let agentName: String
     let connectorAddress: OsaurusID
-    let onAllow: () -> Void
+    /// Called with `isPermanent` when the user approves.
+    let onAllow: (Bool) -> Void
     let onDeny: () -> Void
 
     @ObservedObject private var themeManager = ThemeManager.shared
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     @State private var appeared = false
+    @State private var isPermanent = false
 
     private var cardGradient: LinearGradient {
         LinearGradient(
@@ -44,6 +46,16 @@ struct PairingApprovalView: View {
                     .padding(.horizontal, 24)
                     .opacity(appeared ? 1 : 0)
                     .offset(y: appeared ? 0 : 4)
+
+                Toggle(isOn: $isPermanent) {
+                    Text("Remember this device", bundle: .module)
+                        .font(.system(size: 13))
+                        .foregroundColor(theme.primaryText)
+                }
+                .toggleStyle(.checkbox)
+                .padding(.top, 12)
+                .padding(.horizontal, 24)
+                .opacity(appeared ? 1 : 0)
 
                 Rectangle()
                     .fill(theme.primaryBorder.opacity(0.3))
@@ -157,7 +169,7 @@ struct PairingApprovalView: View {
                 icon: "checkmark",
                 isPrimary: true,
                 color: theme.successColor,
-                action: onAllow
+                action: { onAllow(isPermanent) }
             )
         }
     }

--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -412,6 +412,10 @@ private struct AccessKeysSection: View {
                         keyBadge("Active", color: theme.successColor)
                     }
 
+                    if TemporaryPairedKeyStore.shared.isTemporary(id: key.id) {
+                        keyBadge("Temporary", color: theme.warningColor)
+                    }
+
                     if key.aud == key.iss {
                         keyBadge("All Agents", color: theme.accentColor)
                     }

--- a/Packages/OsaurusCore/Views/Work/WorkEmptyState.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkEmptyState.swift
@@ -17,6 +17,8 @@ struct WorkEmptyState: View {
     let onSelectAgent: (UUID) -> Void
     var discoveredAgents: [DiscoveredAgent] = []
     var onSelectDiscoveredAgent: ((DiscoveredAgent) -> Void)? = nil
+    var pairedRelayAgents: [PairedRelayAgent] = []
+    var onSelectRelayAgent: ((PairedRelayAgent) -> Void)? = nil
 
     @State private var hasAppeared = false
     @Environment(\.theme) private var theme
@@ -76,7 +78,9 @@ struct WorkEmptyState: View {
                     activeAgentId: activeAgentId,
                     onSelectAgent: onSelectAgent,
                     discoveredAgents: discoveredAgents,
-                    onSelectDiscoveredAgent: onSelectDiscoveredAgent
+                    onSelectDiscoveredAgent: onSelectDiscoveredAgent,
+                    pairedRelayAgents: pairedRelayAgents,
+                    onSelectRelayAgent: onSelectRelayAgent
                 )
                 .opacity(hasAppeared ? 1 : 0)
                 .offset(y: hasAppeared ? 0 : 12)


### PR DESCRIPTION
## Summary

This PR allows for pairing of agents on the local network using Bonjour. Paired agents that afterwards be reached using a relay server.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

Steps to verify locally (commands, screenshots, recordings). Include model used.

## Screenshots

If UI updated, add before/after.

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
