### PR TITLE
Fix pairing approval Enter shortcut ignoring persistent choice

### DIFF
--- a/Packages/OsaurusCore/Services/PairingPromptService.swift
+++ b/Packages/OsaurusCore/Services/PairingPromptService.swift
@@ -11,6 +11,12 @@ import SwiftUI
 
 @MainActor
 enum PairingPromptService {
+    enum ShortcutAction: Equatable {
+        case allow(isPermanent: Bool)
+        case deny
+        case none
+    }
+
     private static var pairingWindow: NSPanel?
     private static var localKeyMonitor: Any?
     private static var globalKeyMonitor: Any?
@@ -37,10 +43,12 @@ enum PairingPromptService {
                 continuation.resume(returning: (approved: false, isPermanent: false))
             }
 
+            let approvalState = PairingApprovalState()
             let themeManager = ThemeManager.shared
             let approvalView = PairingApprovalView(
                 agentName: agentName,
                 connectorAddress: connectorAddress,
+                state: approvalState,
                 onAllow: onAllow,
                 onDeny: onDeny
             )
@@ -97,14 +105,16 @@ enum PairingPromptService {
             }
 
             let handleKeyEvent: (NSEvent) -> Bool = { event in
-                if event.keyCode == 36 {  // Enter — approve as temporary (checkbox state drives permanent)
-                    onAllow(false)
+                switch shortcutAction(for: event.keyCode, isPermanent: approvalState.isPermanent) {
+                case .allow(let isPermanent):
+                    onAllow(isPermanent)
                     return true
-                } else if event.keyCode == 53 {  // Escape
+                case .deny:
                     onDeny()
                     return true
+                case .none:
+                    return false
                 }
-                return false
             }
 
             localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
@@ -144,5 +154,13 @@ enum PairingPromptService {
         }
         pairingWindow?.orderOut(nil)
         pairingWindow = nil
+    }
+
+    nonisolated static func shortcutAction(for keyCode: UInt16, isPermanent: Bool) -> ShortcutAction {
+        switch keyCode {
+        case 36: return .allow(isPermanent: isPermanent)
+        case 53: return .deny
+        default: return .none
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/PairingPromptServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/PairingPromptServiceTests.swift
@@ -1,0 +1,26 @@
+//
+//  PairingPromptServiceTests.swift
+//  OsaurusCoreTests
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+struct PairingPromptServiceTests {
+    @Test func enterShortcutPreservesPermanentChoice() {
+        let temporary = PairingPromptService.shortcutAction(for: 36, isPermanent: false)
+        #expect(temporary == .allow(isPermanent: false))
+
+        let permanent = PairingPromptService.shortcutAction(for: 36, isPermanent: true)
+        #expect(permanent == .allow(isPermanent: true))
+    }
+
+    @Test func escapeShortcutDenies() {
+        #expect(PairingPromptService.shortcutAction(for: 53, isPermanent: true) == .deny)
+    }
+
+    @Test func unrelatedShortcutDoesNothing() {
+        #expect(PairingPromptService.shortcutAction(for: 0, isPermanent: true) == .none)
+    }
+}

--- a/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
+++ b/Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift
@@ -8,9 +8,14 @@
 import AppKit
 import SwiftUI
 
+final class PairingApprovalState: ObservableObject {
+    @Published var isPermanent = false
+}
+
 struct PairingApprovalView: View {
     let agentName: String
     let connectorAddress: OsaurusID
+    @ObservedObject var state: PairingApprovalState
     /// Called with `isPermanent` when the user approves.
     let onAllow: (Bool) -> Void
     let onDeny: () -> Void
@@ -19,7 +24,6 @@ struct PairingApprovalView: View {
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     @State private var appeared = false
-    @State private var isPermanent = false
 
     private var cardGradient: LinearGradient {
         LinearGradient(
@@ -47,7 +51,7 @@ struct PairingApprovalView: View {
                     .opacity(appeared ? 1 : 0)
                     .offset(y: appeared ? 0 : 4)
 
-                Toggle(isOn: $isPermanent) {
+                Toggle(isOn: $state.isPermanent) {
                     Text("Remember this device", bundle: .module)
                         .font(.system(size: 13))
                         .foregroundColor(theme.primaryText)
@@ -173,7 +177,7 @@ struct PairingApprovalView: View {
                 icon: "checkmark",
                 isPrimary: true,
                 color: theme.successColor,
-                action: { onAllow(isPermanent) }
+                action: { onAllow(state.isPermanent) }
             )
         }
     }


### PR DESCRIPTION
## Summary

Fix the pairing approval keyboard shortcut so Return/Enter preserves the current **"Remember this device"** selection instead of always approving as temporary.

## Root cause

`PairingPromptService` handled the Enter shortcut with `onAllow(false)`, while the button path in `PairingApprovalView` already used the checkbox state.

That made the keyboard path behaviorally different from the mouse path for the same approval action.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

### Implementation

- Introduce a small `shortcutAction(for:isPermanent:)` helper in `PairingPromptService` so the shortcut mapping is explicit and testable.
- Share a `PairingApprovalState` object between the sheet view and the keyboard handler.
- Use the shared `isPermanent` value when Return triggers approval.
- Mark the pure shortcut helper as `nonisolated` so the focused tests compile cleanly under the package's actor isolation rules.
- Add focused tests covering Enter temporary, Enter persistent, Escape deny, and unrelated key behavior.

## Why this scope

This PR intentionally stays narrow:
- `Packages/OsaurusCore/Services/PairingPromptService.swift`
- `Packages/OsaurusCore/Views/Pairing/PairingApprovalView.swift`
- `Packages/OsaurusCore/Tests/Service/PairingPromptServiceTests.swift`

No pairing/auth/networking semantics are changed beyond making the keyboard approval path match the existing button behavior.

## Validation

- Source-level validation on latest upstream `main` (`c2eaf1c6`) confirmed the bug and the fix path.
- `swift test --package-path Packages/OsaurusCore --filter PairingPromptServiceTests`

## Issue

Closes #875
