### PR TITLE
partition memory by source mode so tool-session facts don't leak into pure chat

### DIFF
--- a/Packages/OsaurusCore/Models/Memory/MemoryModels.swift
+++ b/Packages/OsaurusCore/Models/Memory/MemoryModels.swift
@@ -35,6 +35,7 @@ public struct ProfileEvent: Codable, Sendable, Identifiable {
     public var status: String
     public var incorporatedIn: Int?
     public var createdAt: String
+    public var sourceMode: MemorySourceMode?
 
     public init(
         id: Int = 0,
@@ -45,7 +46,8 @@ public struct ProfileEvent: Codable, Sendable, Identifiable {
         model: String? = nil,
         status: String = "active",
         incorporatedIn: Int? = nil,
-        createdAt: String = ""
+        createdAt: String = "",
+        sourceMode: MemorySourceMode? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -56,6 +58,7 @@ public struct ProfileEvent: Codable, Sendable, Identifiable {
         self.status = status
         self.incorporatedIn = incorporatedIn
         self.createdAt = createdAt
+        self.sourceMode = sourceMode
     }
 }
 
@@ -113,13 +116,14 @@ public struct MemoryEntry: Codable, Sendable, Identifiable {
     public var accessCount: Int
     public var validFrom: String
     public var validUntil: String?
+    public var sourceMode: MemorySourceMode?
 
     public var tags: [String]
 
     private enum CodingKeys: String, CodingKey {
         case id, agentId, type, content, confidence, model, sourceConversationId
         case tagsJSON, status, supersededBy, createdAt, lastAccessed, accessCount
-        case validFrom, validUntil
+        case validFrom, validUntil, sourceMode
     }
 
     private static func decodeTags(from json: String?) -> [String] {
@@ -144,7 +148,8 @@ public struct MemoryEntry: Codable, Sendable, Identifiable {
         lastAccessed: String = "",
         accessCount: Int = 0,
         validFrom: String = "",
-        validUntil: String? = nil
+        validUntil: String? = nil,
+        sourceMode: MemorySourceMode? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -161,6 +166,7 @@ public struct MemoryEntry: Codable, Sendable, Identifiable {
         self.accessCount = max(0, accessCount)
         self.validFrom = validFrom
         self.validUntil = validUntil
+        self.sourceMode = sourceMode
         self.tags = Self.decodeTags(from: tagsJSON)
     }
 
@@ -181,6 +187,7 @@ public struct MemoryEntry: Codable, Sendable, Identifiable {
         accessCount = try c.decode(Int.self, forKey: .accessCount)
         validFrom = try c.decode(String.self, forKey: .validFrom)
         validUntil = try c.decodeIfPresent(String.self, forKey: .validUntil)
+        sourceMode = try c.decodeIfPresent(MemorySourceMode.self, forKey: .sourceMode)
         tags = Self.decodeTags(from: tagsJSON)
     }
 }
@@ -197,6 +204,7 @@ public struct ConversationSummary: Codable, Sendable, Identifiable {
     public var conversationAt: String
     public var status: String
     public var createdAt: String
+    public var sourceMode: MemorySourceMode?
 
     public init(
         id: Int = 0,
@@ -207,7 +215,8 @@ public struct ConversationSummary: Codable, Sendable, Identifiable {
         model: String,
         conversationAt: String,
         status: String = "active",
-        createdAt: String = ""
+        createdAt: String = "",
+        sourceMode: MemorySourceMode? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -218,6 +227,7 @@ public struct ConversationSummary: Codable, Sendable, Identifiable {
         self.conversationAt = conversationAt
         self.status = status
         self.createdAt = createdAt
+        self.sourceMode = sourceMode
     }
 }
 
@@ -268,6 +278,7 @@ public struct PendingSignal: Codable, Sendable {
     public var assistantMessage: String?
     public var status: String
     public var createdAt: String
+    public var sourceMode: MemorySourceMode?
 
     public init(
         id: Int = 0,
@@ -277,7 +288,8 @@ public struct PendingSignal: Codable, Sendable {
         userMessage: String,
         assistantMessage: String? = nil,
         status: String = "pending",
-        createdAt: String = ""
+        createdAt: String = "",
+        sourceMode: MemorySourceMode? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -287,6 +299,7 @@ public struct PendingSignal: Codable, Sendable {
         self.assistantMessage = assistantMessage
         self.status = status
         self.createdAt = createdAt
+        self.sourceMode = sourceMode
     }
 }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1432,7 +1432,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         role: role,
                         content: content,
                         tokenCount: tokens,
-                        createdAt: turnDate
+                        createdAt: turnDate,
+                        sourceMode: .chat
                     )
                     await MemorySearchService.shared.indexConversationChunk(chunk)
                 }
@@ -1443,6 +1444,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         assistantMessage: turn.assistant,
                         agentId: req.agent_id,
                         conversationId: req.conversation_id,
+                        sourceMode: .chat,
                         sessionDate: turnDate
                     )
                 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -47,19 +47,25 @@ public struct SystemPromptComposer: Sendable {
         append(.static(id: "base", label: "Base Prompt", content: effective))
     }
 
-    public mutating func appendMemory(agentId: String, query: String? = nil) async {
+    public mutating func appendMemory(
+        agentId: String,
+        query: String? = nil,
+        toolsAvailable: Bool = true
+    ) async {
         let config = MemoryConfigurationStore.load()
         let context: String
         if let query, !query.isEmpty {
             context = await MemoryContextAssembler.assembleContext(
                 agentId: agentId,
                 config: config,
-                query: query
+                query: query,
+                toolsAvailable: toolsAvailable
             )
         } else {
             context = await MemoryContextAssembler.assembleContext(
                 agentId: agentId,
-                config: config
+                config: config,
+                toolsAvailable: toolsAvailable
             )
         }
         append(.dynamic(id: "memory", label: "Memory", content: context))
@@ -110,7 +116,10 @@ public struct SystemPromptComposer: Sendable {
 
         trace?.mark("memory_start")
         if !memoryOff {
-            await comp.appendMemory(agentId: agentId.uuidString)
+            await comp.appendMemory(
+                agentId: agentId.uuidString,
+                toolsAvailable: !effectiveToolsOff
+            )
         }
         trace?.mark("memory_done")
 
@@ -279,7 +288,12 @@ public struct SystemPromptComposer: Sendable {
         into messages: inout [ChatMessage]
     ) async -> (cacheHint: String, staticPrefix: String) {
         var composer = forChat(agentId: agentId, executionMode: .none)
-        await composer.appendMemory(agentId: agentId.uuidString, query: query.isEmpty ? nil : query)
+        let toolsOff = AgentManager.shared.effectiveToolsDisabled(for: agentId)
+        await composer.appendMemory(
+            agentId: agentId.uuidString,
+            query: query.isEmpty ? nil : query,
+            toolsAvailable: !toolsOff
+        )
         let manifest = composer.manifest()
         let rendered = composer.render()
         debugLog("[Context:inject] \(manifest.debugDescription)")

--- a/Packages/OsaurusCore/Services/Memory/MemoryContextAssembler.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryContextAssembler.swift
@@ -18,14 +18,34 @@ public actor MemoryContextAssembler {
         let timestamp: Date
     }
 
+    /// Cache is keyed by (agentId, toolsAvailable) so the two filter views don't
+    /// collide. Chat-only vs. full-view produce different context strings and
+    /// must not share a slot.
     private var cache: [String: CacheEntry] = [:]
     private static let cacheTTL: TimeInterval = 10
+
+    private static func cacheKey(agentId: String, toolsAvailable: Bool) -> String {
+        "\(agentId)|tools=\(toolsAvailable ? 1 : 0)"
+    }
 
     /// Assemble the full memory context string for injection before the system prompt.
     /// User edits and profile are never trimmed. Working memory, summaries, and key
     /// relationships are budget-trimmed. Results are cached for 10 seconds per agent.
-    public static func assembleContext(agentId: String, config: MemoryConfiguration) async -> String {
-        await shared.assembleContextCached(agentId: agentId, config: config)
+    ///
+    /// When `toolsAvailable` is false (pure chat), entries, summaries, and conversation
+    /// chunks recorded under tool-using modes are excluded so that agentic contributions
+    /// don't prime the model with phantom tool affordances. Pre-v4 rows (NULL source_mode)
+    /// are always included to preserve history after upgrade.
+    public static func assembleContext(
+        agentId: String,
+        config: MemoryConfiguration,
+        toolsAvailable: Bool = true
+    ) async -> String {
+        await shared.assembleContextCached(
+            agentId: agentId,
+            config: config,
+            toolsAvailable: toolsAvailable
+        )
     }
 
     /// Assemble context with query-aware retrieval. Includes a "Relevant Memories" section
@@ -33,19 +53,30 @@ public actor MemoryContextAssembler {
     public static func assembleContext(
         agentId: String,
         config: MemoryConfiguration,
-        query: String
+        query: String,
+        toolsAvailable: Bool = true
     ) async -> String {
-        await shared.assembleContextWithQuery(agentId: agentId, config: config, query: query)
+        await shared.assembleContextWithQuery(
+            agentId: agentId,
+            config: config,
+            query: query,
+            toolsAvailable: toolsAvailable
+        )
     }
 
     private func assembleContextWithQuery(
         agentId: String,
         config: MemoryConfiguration,
-        query: String
+        query: String,
+        toolsAvailable: Bool
     ) async -> String {
         guard config.enabled else { return "" }
 
-        let baseContext = buildContext(agentId: agentId, config: config)
+        let baseContext = buildContext(
+            agentId: agentId,
+            config: config,
+            toolsAvailable: toolsAvailable
+        )
 
         guard !query.isEmpty else { return baseContext }
 
@@ -53,7 +84,8 @@ public actor MemoryContextAssembler {
             agentId: agentId,
             query: query,
             config: config,
-            existingContext: baseContext
+            existingContext: baseContext,
+            toolsAvailable: toolsAvailable
         )
 
         if relevantSection.isEmpty {
@@ -63,15 +95,24 @@ public actor MemoryContextAssembler {
         return baseContext.isEmpty ? relevantSection : baseContext + "\n\n" + relevantSection
     }
 
-    private func assembleContextCached(agentId: String, config: MemoryConfiguration) -> String {
+    private func assembleContextCached(
+        agentId: String,
+        config: MemoryConfiguration,
+        toolsAvailable: Bool
+    ) -> String {
         guard config.enabled else { return "" }
 
-        if let cached = cache[agentId], Date().timeIntervalSince(cached.timestamp) < Self.cacheTTL {
+        let key = Self.cacheKey(agentId: agentId, toolsAvailable: toolsAvailable)
+        if let cached = cache[key], Date().timeIntervalSince(cached.timestamp) < Self.cacheTTL {
             return cached.context
         }
 
-        let context = buildContext(agentId: agentId, config: config)
-        cache[agentId] = CacheEntry(context: context, timestamp: Date())
+        let context = buildContext(
+            agentId: agentId,
+            config: config,
+            toolsAvailable: toolsAvailable
+        )
+        cache[key] = CacheEntry(context: context, timestamp: Date())
         return context
     }
 
@@ -84,9 +125,17 @@ public actor MemoryContextAssembler {
         }
     }
 
-    private func buildContext(agentId: String, config: MemoryConfiguration) -> String {
+    private func buildContext(
+        agentId: String,
+        config: MemoryConfiguration,
+        toolsAvailable: Bool
+    ) -> String {
         let db = MemoryDatabase.shared
         guard db.isOpen else { return "" }
+
+        // Pure-chat recall filters out tool-mode contributions to prevent
+        // phantom-tool priming. Tool-capable recall sees everything.
+        let chatOnly = !toolsAvailable
 
         var sections: [String] = []
 
@@ -119,7 +168,7 @@ public actor MemoryContextAssembler {
 
         // 3. Remembered Details (this agent's active entries)
         do {
-            let entries = try db.loadActiveEntries(agentId: agentId)
+            let entries = try db.loadActiveEntries(agentId: agentId, chatOnly: chatOnly)
             if !entries.isEmpty {
                 let block = buildBudgetSection(
                     header: "## Remembered Details",
@@ -139,7 +188,11 @@ public actor MemoryContextAssembler {
 
         // 4. Conversation Summaries (this agent, last N days)
         do {
-            let summaries = try db.loadSummaries(agentId: agentId, days: config.summaryRetentionDays)
+            let summaries = try db.loadSummaries(
+                agentId: agentId,
+                days: config.summaryRetentionDays,
+                chatOnly: chatOnly
+            )
             if !summaries.isEmpty {
                 sections.append(
                     buildBudgetSection(
@@ -244,9 +297,12 @@ public actor MemoryContextAssembler {
 
     /// Expand retrieved chunks by loading adjacent turns from the same conversation,
     /// providing conversational context that helps answer cross-turn questions.
+    /// The mode filter must match the one used to retrieve the seed chunks so
+    /// window expansion cannot resurface tool-mode turns.
     private static func expandChunkWindow(
         _ chunks: [ConversationChunk],
-        windowSize: Int
+        windowSize: Int,
+        chatOnly: Bool
     ) -> [ConversationChunk] {
         guard !chunks.isEmpty else { return [] }
 
@@ -267,7 +323,10 @@ public actor MemoryContextAssembler {
 
         var allChunks = chunks
         if !expandedKeys.isEmpty {
-            if let adjacent = try? MemoryDatabase.shared.loadChunksByKeys(expandedKeys) {
+            if let adjacent = try? MemoryDatabase.shared.loadChunksByKeys(
+                expandedKeys,
+                chatOnly: chatOnly
+            ) {
                 allChunks.append(contentsOf: adjacent)
             }
         }
@@ -286,20 +345,23 @@ public actor MemoryContextAssembler {
         agentId: String,
         query: String,
         config: MemoryConfiguration,
-        existingContext: String
+        existingContext: String,
+        toolsAvailable: Bool
     ) async -> String {
         let searchService = MemorySearchService.shared
 
         let topK = config.recallTopK
         let lambda = config.mmrLambda
         let fetchMultiplier = config.mmrFetchMultiplier
+        let chatOnly = !toolsAvailable
 
         async let entriesResult = searchService.searchMemoryEntries(
             query: query,
             agentId: agentId,
             topK: topK,
             lambda: lambda,
-            fetchMultiplier: fetchMultiplier
+            fetchMultiplier: fetchMultiplier,
+            chatOnly: chatOnly
         )
         async let chunksResult = searchService.searchConversations(
             query: query,
@@ -307,21 +369,23 @@ public actor MemoryContextAssembler {
             days: 3650,
             topK: topK,
             lambda: lambda,
-            fetchMultiplier: fetchMultiplier
+            fetchMultiplier: fetchMultiplier,
+            chatOnly: chatOnly
         )
         async let summariesResult = searchService.searchSummaries(
             query: query,
             agentId: agentId,
             topK: topK,
             lambda: lambda,
-            fetchMultiplier: fetchMultiplier
+            fetchMultiplier: fetchMultiplier,
+            chatOnly: chatOnly
         )
 
         let entries = await entriesResult
         let searchedChunks = await chunksResult
         let summaries = await summariesResult
 
-        let chunks = Self.expandChunkWindow(searchedChunks, windowSize: 2)
+        let chunks = Self.expandChunkWindow(searchedChunks, windowSize: 2, chatOnly: chatOnly)
 
         var sections: [String] = []
         var allDates: [String] = []

--- a/Packages/OsaurusCore/Services/Memory/MemorySearchService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemorySearchService.swift
@@ -160,7 +160,8 @@ public actor MemorySearchService {
         agentId: String? = nil,
         topK: Int = 10,
         lambda: Double? = nil,
-        fetchMultiplier: Double? = nil
+        fetchMultiplier: Double? = nil,
+        chatOnly: Bool = false
     ) async -> [MemoryEntry] {
         guard topK > 0 else { return [] }
         if let db = vectorDB {
@@ -178,7 +179,11 @@ public actor MemorySearchService {
                 )
 
                 let idStrings = results.map { $0.id.uuidString }
-                let entries = try MemoryDatabase.shared.loadEntriesByIds(idStrings, agentId: agentId)
+                let entries = try MemoryDatabase.shared.loadEntriesByIds(
+                    idStrings,
+                    agentId: agentId,
+                    chatOnly: chatOnly
+                )
                 let scored: [(item: MemoryEntry, score: Double, content: String)] = entries.compactMap { entry in
                     guard let match = scoreMap[entry.id] else { return nil }
                     return (item: entry, score: match.score, content: entry.content)
@@ -191,7 +196,11 @@ public actor MemorySearchService {
         }
 
         do {
-            return try MemoryDatabase.shared.searchMemoryEntries(query: query, agentId: agentId)
+            return try MemoryDatabase.shared.searchMemoryEntries(
+                query: query,
+                agentId: agentId,
+                chatOnly: chatOnly
+            )
         } catch {
             MemoryLogger.search.error("Text fallback search failed: \(error)")
             return []
@@ -244,7 +253,8 @@ public actor MemorySearchService {
         days: Int = 30,
         topK: Int = 10,
         lambda: Double? = nil,
-        fetchMultiplier: Double? = nil
+        fetchMultiplier: Double? = nil,
+        chatOnly: Bool = false
     ) async -> [ConversationChunk] {
         guard topK > 0 else { return [] }
         if let db = vectorDB {
@@ -266,7 +276,7 @@ public actor MemorySearchService {
                 }
 
                 if !keys.isEmpty {
-                    let chunks = try MemoryDatabase.shared.loadChunksByKeys(keys)
+                    let chunks = try MemoryDatabase.shared.loadChunksByKeys(keys, chatOnly: chatOnly)
                     let scored: [(item: ConversationChunk, score: Double, content: String)] = chunks.compactMap {
                         chunk in
                         let compositeKey = "\(chunk.conversationId):\(chunk.chunkIndex)"
@@ -286,7 +296,12 @@ public actor MemorySearchService {
         }
 
         do {
-            return try MemoryDatabase.shared.searchChunks(query: query, agentId: agentId, days: days)
+            return try MemoryDatabase.shared.searchChunks(
+                query: query,
+                agentId: agentId,
+                days: days,
+                chatOnly: chatOnly
+            )
         } catch {
             MemoryLogger.search.error("Text fallback chunk search failed: \(error)")
             return []
@@ -302,7 +317,8 @@ public actor MemorySearchService {
         days: Int = 30,
         topK: Int = 10,
         lambda: Double? = nil,
-        fetchMultiplier: Double? = nil
+        fetchMultiplier: Double? = nil,
+        chatOnly: Bool = false
     ) async -> [ConversationSummary] {
         guard topK > 0 else { return [] }
         if let db = vectorDB {
@@ -326,7 +342,8 @@ public actor MemorySearchService {
                 if !compositeKeys.isEmpty {
                     let summaries = try MemoryDatabase.shared.loadSummariesByCompositeKeys(
                         compositeKeys,
-                        filterAgentId: agentId
+                        filterAgentId: agentId,
+                        chatOnly: chatOnly
                     )
                     let scored: [(item: ConversationSummary, score: Double, content: String)] =
                         summaries.compactMap { summary in
@@ -345,7 +362,12 @@ public actor MemorySearchService {
         }
 
         do {
-            return try MemoryDatabase.shared.searchSummaries(query: query, agentId: agentId, days: days)
+            return try MemoryDatabase.shared.searchSummaries(
+                query: query,
+                agentId: agentId,
+                days: days,
+                chatOnly: chatOnly
+            )
         } catch {
             MemoryLogger.search.error("Text fallback summary search failed: \(error)")
             return []

--- a/Packages/OsaurusCore/Services/Memory/MemoryService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryService.swift
@@ -35,6 +35,7 @@ public actor MemoryService {
         assistantMessage: String?,
         agentId: String,
         conversationId: String,
+        sourceMode: MemorySourceMode = .chat,
         sessionDate: String? = nil
     ) async {
         do {
@@ -44,7 +45,8 @@ public actor MemoryService {
                     conversationId: conversationId,
                     signalType: "conversation",
                     userMessage: userMessage,
-                    assistantMessage: assistantMessage
+                    assistantMessage: assistantMessage,
+                    sourceMode: sourceMode
                 )
             )
         } catch {
@@ -85,7 +87,8 @@ public actor MemoryService {
                 from: parsed.entries,
                 agentId: agentId,
                 conversationId: conversationId,
-                model: coreModelId
+                model: coreModelId,
+                sourceMode: sourceMode
             )
 
             let verifyResult = await verifyAndInsertEntries(
@@ -99,7 +102,8 @@ public actor MemoryService {
                 parsed.profileFacts,
                 agentId: agentId,
                 conversationId: conversationId,
-                model: coreModelId
+                model: coreModelId,
+                sourceMode: sourceMode
             )
             insertGraphData(parsed.graph, model: coreModelId)
 
@@ -183,7 +187,11 @@ public actor MemoryService {
 
         do {
             let currentProfile = try db.loadUserProfile()
-            let allContributions = try db.loadActiveContributions()
+            // Compile the user profile from chat-origin contributions only.
+            // Tool/sandbox-origin facts ("User opened admin.py", "User ran
+            // sandbox_exec") stay out of the global profile so pure-chat
+            // prompts aren't primed with phantom tool affordances.
+            let allContributions = try db.loadActiveContributions(chatOnly: true)
             let edits = try db.loadUserEdits()
             let contributions = allContributions.filter { $0.incorporatedIn == nil }
             MemoryLogger.service.info(
@@ -394,13 +402,18 @@ public actor MemoryService {
             }
 
             let tokenCount = max(1, summaryText.count / MemoryConfiguration.charsPerToken)
+            // Inherit source_mode from the signals being summarized so the
+            // summary filters identically on recall. Falls back to .chat for
+            // pre-v4 signals with NULL mode.
+            let inheritedMode = signals.compactMap(\.sourceMode).first ?? .chat
             let summaryObj = ConversationSummary(
                 agentId: agentId,
                 conversationId: conversationId,
                 summary: summaryText,
                 tokenCount: tokenCount,
                 model: coreModelId,
-                conversationAt: conversationAt
+                conversationAt: conversationAt,
+                sourceMode: inheritedMode
             )
             do {
                 try db.insertSummaryAndMarkProcessed(summaryObj)
@@ -700,7 +713,8 @@ public actor MemoryService {
         from parsed: [ExtractionParseResult.EntryData],
         agentId: String,
         conversationId: String,
-        model: String
+        model: String,
+        sourceMode: MemorySourceMode
     ) -> [MemoryEntry] {
         let entries = parsed.compactMap { entry -> MemoryEntry? in
             guard let entryType = MemoryEntryType(rawValue: entry.type) else { return nil }
@@ -718,7 +732,8 @@ public actor MemoryService {
                 model: model,
                 sourceConversationId: conversationId,
                 tagsJSON: tagsJSON,
-                validFrom: entry.valid_from ?? ""
+                validFrom: entry.valid_from ?? "",
+                sourceMode: sourceMode
             )
         }
 
@@ -792,9 +807,13 @@ public actor MemoryService {
 
     /// Insert profile facts, skipping duplicates. Returns number of facts stored.
     @discardableResult
-    private func insertProfileFacts(_ facts: [String], agentId: String, conversationId: String? = nil, model: String)
-        -> Int
-    {
+    private func insertProfileFacts(
+        _ facts: [String],
+        agentId: String,
+        conversationId: String? = nil,
+        model: String,
+        sourceMode: MemorySourceMode
+    ) -> Int {
         guard !facts.isEmpty else { return 0 }
         let existingContributions: [ProfileEvent]
         do {
@@ -820,7 +839,8 @@ public actor MemoryService {
                         conversationId: conversationId,
                         eventType: "contribution",
                         content: fact,
-                        model: model
+                        model: model,
+                        sourceMode: sourceMode
                     )
                 )
                 stored += 1

--- a/Packages/OsaurusCore/Storage/MemoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/MemoryDatabase.swift
@@ -31,11 +31,11 @@ public enum MemoryDatabaseError: Error, LocalizedError {
 public final class MemoryDatabase: @unchecked Sendable {
     public static let shared = MemoryDatabase()
 
-    private static let schemaVersion = 3
+    private static let schemaVersion = 4
 
     private static let memoryEntryColumns = """
         id, agent_id, type, content, confidence, model, source_conversation_id, tags, status,
-        superseded_by, created_at, last_accessed, access_count, valid_from, valid_until
+        superseded_by, created_at, last_accessed, access_count, valid_from, valid_until, source_mode
         """
 
     private static let insertMemoryEventSQL =
@@ -157,6 +157,7 @@ public final class MemoryDatabase: @unchecked Sendable {
         if currentVersion < 1 { try migrateToV1() }
         if currentVersion < 2 { try migrateToV2() }
         if currentVersion < 3 { try migrateToV3() }
+        if currentVersion < 4 { try migrateToV4() }
     }
 
     private func getSchemaVersion() throws -> Int {
@@ -488,6 +489,45 @@ public final class MemoryDatabase: @unchecked Sendable {
         MemoryLogger.database.info("Migration to v3 completed")
     }
 
+    /// V4 migration: tag memory writes with their source execution mode so
+    /// reads can exclude tool-using contributions from pure-chat contexts.
+    /// Pre-v4 rows remain NULL (treated as chat-compatible).
+    /// The compiled user_profile is cleared to force regeneration under the new filter.
+    private func migrateToV4() throws {
+        MemoryLogger.database.info("Running migration to v4")
+
+        for table in [
+            "memory_entries",
+            "profile_events",
+            "conversation_summaries",
+            "conversation_chunks",
+            "pending_signals",
+        ] {
+            try executeRaw("ALTER TABLE \(table) ADD COLUMN source_mode TEXT")
+        }
+
+        try executeRaw(
+            "CREATE INDEX IF NOT EXISTS idx_entries_source_mode ON memory_entries(agent_id, status, source_mode)"
+        )
+        try executeRaw(
+            "CREATE INDEX IF NOT EXISTS idx_summaries_source_mode ON conversation_summaries(agent_id, status, source_mode)"
+        )
+        try executeRaw(
+            "CREATE INDEX IF NOT EXISTS idx_profile_events_source_mode ON profile_events(event_type, status, source_mode)"
+        )
+
+        // Force profile regeneration: existing profile was compiled from
+        // mixed-mode contributions. Clearing it lets the next regen apply the
+        // new chat-only filter.
+        try executeRaw("DELETE FROM user_profile")
+
+        try executeRaw(
+            "INSERT OR IGNORE INTO schema_version (version, description) VALUES (4, 'Tag memory writes with source_mode for tools-aware filtering')"
+        )
+        try setSchemaVersion(4)
+        MemoryLogger.database.info("Migration to v4 completed")
+    }
+
     // MARK: - Query Execution
 
     private func executeRaw(_ sql: String) throws {
@@ -667,8 +707,8 @@ public final class MemoryDatabase: @unchecked Sendable {
     public func insertProfileEvent(_ event: ProfileEvent) throws {
         _ = try executeUpdate(
             """
-            INSERT INTO profile_events (agent_id, conversation_id, event_type, content, model, status)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO profile_events (agent_id, conversation_id, event_type, content, model, status, source_mode)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             """
         ) { stmt in
             Self.bindText(stmt, index: 1, value: event.agentId)
@@ -677,13 +717,14 @@ public final class MemoryDatabase: @unchecked Sendable {
             Self.bindText(stmt, index: 4, value: event.content)
             Self.bindText(stmt, index: 5, value: event.model)
             Self.bindText(stmt, index: 6, value: event.status)
+            Self.bindText(stmt, index: 7, value: event.sourceMode?.rawValue)
         }
     }
 
     public func loadRecentProfileEvents(limit: Int = 20) throws -> [ProfileEvent] {
         var events: [ProfileEvent] = []
         try prepareAndExecute(
-            "SELECT id, agent_id, conversation_id, event_type, content, model, status, incorporated_in, created_at FROM profile_events ORDER BY created_at DESC LIMIT ?1",
+            "SELECT id, agent_id, conversation_id, event_type, content, model, status, incorporated_in, created_at, source_mode FROM profile_events ORDER BY created_at DESC LIMIT ?1",
             bind: { stmt in sqlite3_bind_int(stmt, 1, Int32(limit)) },
             process: { stmt in
                 while sqlite3_step(stmt) == SQLITE_ROW {
@@ -694,15 +735,30 @@ public final class MemoryDatabase: @unchecked Sendable {
         return events
     }
 
-    public func loadActiveContributions() throws -> [ProfileEvent] {
+    /// Load active profile contributions.
+    /// When `chatOnly` is true, excludes contributions recorded under tool-using modes.
+    /// Rows with NULL source_mode are pre-v4 and always included.
+    public func loadActiveContributions(chatOnly: Bool = false) throws -> [ProfileEvent] {
         var events: [ProfileEvent] = []
+        let sql: String
+        if chatOnly {
+            sql = """
+                SELECT id, agent_id, conversation_id, event_type, content, model, status, incorporated_in, created_at, source_mode
+                FROM profile_events
+                WHERE event_type = 'contribution' AND status = 'active'
+                  AND (source_mode IS NULL OR source_mode = 'chat')
+                ORDER BY created_at ASC
+                """
+        } else {
+            sql = """
+                SELECT id, agent_id, conversation_id, event_type, content, model, status, incorporated_in, created_at, source_mode
+                FROM profile_events
+                WHERE event_type = 'contribution' AND status = 'active'
+                ORDER BY created_at ASC
+                """
+        }
         try prepareAndExecute(
-            """
-            SELECT id, agent_id, conversation_id, event_type, content, model, status, incorporated_in, created_at
-            FROM profile_events
-            WHERE event_type = 'contribution' AND status = 'active'
-            ORDER BY created_at ASC
-            """,
+            sql,
             bind: { _ in },
             process: { stmt in
                 while sqlite3_step(stmt) == SQLITE_ROW {
@@ -723,7 +779,8 @@ public final class MemoryDatabase: @unchecked Sendable {
             model: sqlite3_column_text(stmt, 5).map { String(cString: $0) },
             status: String(cString: sqlite3_column_text(stmt, 6)),
             incorporatedIn: sqlite3_column_type(stmt, 7) != SQLITE_NULL ? Int(sqlite3_column_int(stmt, 7)) : nil,
-            createdAt: String(cString: sqlite3_column_text(stmt, 8))
+            createdAt: String(cString: sqlite3_column_text(stmt, 8)),
+            sourceMode: sqlite3_column_text(stmt, 9).flatMap { MemorySourceMode(rawValue: String(cString: $0)) }
         )
     }
 
@@ -778,8 +835,8 @@ public final class MemoryDatabase: @unchecked Sendable {
 
     private static let insertEntrySQL = """
         INSERT INTO memory_entries (id, agent_id, type, content, confidence, model,
-            source_conversation_id, tags, status, valid_from)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            source_conversation_id, tags, status, valid_from, source_mode)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         """
 
     private static let supersedeEntrySQL =
@@ -811,6 +868,7 @@ public final class MemoryDatabase: @unchecked Sendable {
             Self.bindText(stmt, index: 8, value: entry.tagsJSON)
             Self.bindText(stmt, index: 9, value: entry.status)
             Self.bindText(stmt, index: 10, value: validFrom)
+            Self.bindText(stmt, index: 11, value: entry.sourceMode?.rawValue)
         }
     }
 
@@ -826,11 +884,19 @@ public final class MemoryDatabase: @unchecked Sendable {
         }
     }
 
-    public func loadActiveEntries(agentId: String, limit: Int = 0) throws -> [MemoryEntry] {
+    /// Load active memory entries for an agent.
+    /// When `chatOnly` is true, excludes entries recorded under tool-using modes.
+    /// Rows with NULL source_mode are pre-v4 and always included.
+    public func loadActiveEntries(
+        agentId: String,
+        limit: Int = 0,
+        chatOnly: Bool = false
+    ) throws -> [MemoryEntry] {
         var entries: [MemoryEntry] = []
+        let modeFilter = chatOnly ? " AND (source_mode IS NULL OR source_mode = 'chat')" : ""
         var sql = """
             SELECT \(Self.memoryEntryColumns)
-            FROM memory_entries WHERE agent_id = ?1 AND status = 'active'
+            FROM memory_entries WHERE agent_id = ?1 AND status = 'active'\(modeFilter)
             ORDER BY last_accessed DESC
             """
         if limit > 0 { sql += " LIMIT ?2" }
@@ -868,7 +934,11 @@ public final class MemoryDatabase: @unchecked Sendable {
         return entries
     }
 
-    public func loadEntriesByIds(_ ids: [String], agentId: String? = nil) throws -> [MemoryEntry] {
+    public func loadEntriesByIds(
+        _ ids: [String],
+        agentId: String? = nil,
+        chatOnly: Bool = false
+    ) throws -> [MemoryEntry] {
         guard !ids.isEmpty else { return [] }
         let placeholders = ids.enumerated().map { "?\($0.offset + 1)" }.joined(separator: ",")
         var sql = """
@@ -876,6 +946,7 @@ public final class MemoryDatabase: @unchecked Sendable {
             FROM memory_entries WHERE status = 'active' AND id IN (\(placeholders))
             """
         if agentId != nil { sql += " AND agent_id = ?\(ids.count + 1)" }
+        if chatOnly { sql += " AND (source_mode IS NULL OR source_mode = 'chat')" }
         sql += " ORDER BY last_accessed DESC"
 
         var entries: [MemoryEntry] = []
@@ -1069,7 +1140,8 @@ public final class MemoryDatabase: @unchecked Sendable {
             lastAccessed: String(cString: sqlite3_column_text(stmt, 11)),
             accessCount: Int(sqlite3_column_int(stmt, 12)),
             validFrom: String(cString: sqlite3_column_text(stmt, 13)),
-            validUntil: sqlite3_column_text(stmt, 14).map { String(cString: $0) }
+            validUntil: sqlite3_column_text(stmt, 14).map { String(cString: $0) },
+            sourceMode: sqlite3_column_text(stmt, 15).flatMap { MemorySourceMode(rawValue: String(cString: $0)) }
         )
     }
 
@@ -1078,8 +1150,8 @@ public final class MemoryDatabase: @unchecked Sendable {
     public func insertSummary(_ summary: ConversationSummary) throws {
         _ = try executeUpdate(
             """
-            INSERT INTO conversation_summaries (agent_id, conversation_id, summary, token_count, model, conversation_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO conversation_summaries (agent_id, conversation_id, summary, token_count, model, conversation_at, source_mode)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             """
         ) { stmt in
             Self.bindText(stmt, index: 1, value: summary.agentId)
@@ -1088,6 +1160,7 @@ public final class MemoryDatabase: @unchecked Sendable {
             sqlite3_bind_int(stmt, 4, Int32(summary.tokenCount))
             Self.bindText(stmt, index: 5, value: summary.model)
             Self.bindText(stmt, index: 6, value: summary.conversationAt)
+            Self.bindText(stmt, index: 7, value: summary.sourceMode?.rawValue)
         }
     }
 
@@ -1096,8 +1169,8 @@ public final class MemoryDatabase: @unchecked Sendable {
         try inTransaction { _ in
             try self.transactionalStep(
                 """
-                INSERT INTO conversation_summaries (agent_id, conversation_id, summary, token_count, model, conversation_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                INSERT INTO conversation_summaries (agent_id, conversation_id, summary, token_count, model, conversation_at, source_mode)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                 """
             ) { stmt in
                 Self.bindText(stmt, index: 1, value: summary.agentId)
@@ -1106,6 +1179,7 @@ public final class MemoryDatabase: @unchecked Sendable {
                 sqlite3_bind_int(stmt, 4, Int32(summary.tokenCount))
                 Self.bindText(stmt, index: 5, value: summary.model)
                 Self.bindText(stmt, index: 6, value: summary.conversationAt)
+                Self.bindText(stmt, index: 7, value: summary.sourceMode?.rawValue)
             }
             try self.transactionalStep(
                 "UPDATE pending_signals SET status = 'processed' WHERE conversation_id = ?1 AND status = 'pending'"
@@ -1115,22 +1189,32 @@ public final class MemoryDatabase: @unchecked Sendable {
         }
     }
 
-    public func loadSummaries(agentId: String, days: Int = 0) throws -> [ConversationSummary] {
+    /// Load conversation summaries for an agent.
+    /// When `chatOnly` is true, excludes summaries recorded under tool-using modes.
+    /// Rows with NULL source_mode are pre-v4 and always included.
+    public func loadSummaries(
+        agentId: String,
+        days: Int = 0,
+        chatOnly: Bool = false
+    ) throws -> [ConversationSummary] {
         var summaries: [ConversationSummary] = []
+        let modeFilter = chatOnly ? " AND (source_mode IS NULL OR source_mode = 'chat')" : ""
         let sql: String
         if days > 0 {
             sql = """
-                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
                 FROM conversation_summaries
                 WHERE agent_id = ?1 AND status = 'active'
                   AND conversation_at >= datetime('now', '-' || ?2 || ' days')
+                  \(modeFilter)
                 ORDER BY conversation_at DESC
                 """
         } else {
             sql = """
-                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
                 FROM conversation_summaries
                 WHERE agent_id = ?1 AND status = 'active'
+                  \(modeFilter)
                 ORDER BY conversation_at DESC
                 """
         }
@@ -1154,14 +1238,14 @@ public final class MemoryDatabase: @unchecked Sendable {
         let sql: String
         if days != nil {
             sql = """
-                    SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+                    SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
                     FROM conversation_summaries WHERE status = 'active'
                     AND conversation_at >= datetime('now', '-' || ?1 || ' days')
                     ORDER BY conversation_at DESC
                 """
         } else {
             sql = """
-                    SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+                    SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
                     FROM conversation_summaries WHERE status = 'active'
                     ORDER BY conversation_at DESC
                 """
@@ -1184,7 +1268,7 @@ public final class MemoryDatabase: @unchecked Sendable {
         guard !ids.isEmpty else { return [] }
         let placeholders = ids.enumerated().map { "?\($0.offset + 1)" }.joined(separator: ",")
         var sql = """
-            SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+            SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
             FROM conversation_summaries WHERE status = 'active' AND id IN (\(placeholders))
             """
         if agentId != nil { sql += " AND agent_id = ?\(ids.count + 1)" }
@@ -1239,7 +1323,8 @@ public final class MemoryDatabase: @unchecked Sendable {
             model: String(cString: sqlite3_column_text(stmt, 5)),
             conversationAt: String(cString: sqlite3_column_text(stmt, 6)),
             status: String(cString: sqlite3_column_text(stmt, 7)),
-            createdAt: String(cString: sqlite3_column_text(stmt, 8))
+            createdAt: String(cString: sqlite3_column_text(stmt, 8)),
+            sourceMode: sqlite3_column_text(stmt, 9).flatMap { MemorySourceMode(rawValue: String(cString: $0)) }
         )
     }
 
@@ -1268,13 +1353,14 @@ public final class MemoryDatabase: @unchecked Sendable {
         role: String,
         content: String,
         tokenCount: Int,
-        createdAt: String? = nil
+        createdAt: String? = nil,
+        sourceMode: MemorySourceMode? = nil
     ) throws {
         let effectiveDate = (createdAt?.isEmpty == false) ? createdAt : nil
         _ = try executeUpdate(
             """
-            INSERT INTO conversation_chunks (conversation_id, chunk_index, role, content, token_count, created_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, COALESCE(?6, datetime('now')))
+            INSERT INTO conversation_chunks (conversation_id, chunk_index, role, content, token_count, created_at, source_mode)
+            VALUES (?1, ?2, ?3, ?4, ?5, COALESCE(?6, datetime('now')), ?7)
             """
         ) { stmt in
             Self.bindText(stmt, index: 1, value: conversationId)
@@ -1283,6 +1369,7 @@ public final class MemoryDatabase: @unchecked Sendable {
             Self.bindText(stmt, index: 4, value: content)
             sqlite3_bind_int(stmt, 5, Int32(tokenCount))
             Self.bindText(stmt, index: 6, value: effectiveDate)
+            Self.bindText(stmt, index: 7, value: sourceMode?.rawValue)
         }
     }
 
@@ -1324,17 +1411,21 @@ public final class MemoryDatabase: @unchecked Sendable {
         return chunks
     }
 
-    public func loadChunksByKeys(_ keys: [(conversationId: String, chunkIndex: Int)]) throws -> [ConversationChunk] {
+    public func loadChunksByKeys(
+        _ keys: [(conversationId: String, chunkIndex: Int)],
+        chatOnly: Bool = false
+    ) throws -> [ConversationChunk] {
         guard !keys.isEmpty else { return [] }
         let conditions = keys.enumerated().map { (i, _) in
             "(cc.conversation_id = ?\(i * 2 + 1) AND cc.chunk_index = ?\(i * 2 + 2))"
         }.joined(separator: " OR ")
+        let modeFilter = chatOnly ? " AND (cc.source_mode IS NULL OR cc.source_mode = 'chat')" : ""
         let sql = """
             SELECT cc.id, cc.conversation_id, cc.chunk_index, cc.role, cc.content, cc.token_count, cc.created_at,
                    c.agent_id, c.title
             FROM conversation_chunks cc
             JOIN conversations c ON c.id = cc.conversation_id
-            WHERE \(conditions)
+            WHERE (\(conditions))\(modeFilter)
             ORDER BY cc.created_at DESC
             """
         var chunks: [ConversationChunk] = []
@@ -1355,7 +1446,12 @@ public final class MemoryDatabase: @unchecked Sendable {
         return chunks
     }
 
-    public func searchChunks(query: String, agentId: String? = nil, days: Int = 30) throws -> [ConversationChunk] {
+    public func searchChunks(
+        query: String,
+        agentId: String? = nil,
+        days: Int = 30,
+        chatOnly: Bool = false
+    ) throws -> [ConversationChunk] {
         var chunks: [ConversationChunk] = []
         var sql = """
                 SELECT cc.id, cc.conversation_id, cc.chunk_index, cc.role, cc.content, cc.token_count, cc.created_at,
@@ -1366,6 +1462,7 @@ public final class MemoryDatabase: @unchecked Sendable {
                   AND cc.created_at >= datetime('now', '-' || ?2 || ' days')
             """
         if agentId != nil { sql += " AND c.agent_id = ?3" }
+        if chatOnly { sql += " AND (cc.source_mode IS NULL OR cc.source_mode = 'chat')" }
         sql += " ORDER BY cc.created_at DESC LIMIT 20"
 
         try prepareAndExecute(
@@ -1403,8 +1500,8 @@ public final class MemoryDatabase: @unchecked Sendable {
     public func insertPendingSignal(_ signal: PendingSignal) throws {
         _ = try executeUpdate(
             """
-            INSERT INTO pending_signals (agent_id, conversation_id, signal_type, user_message, assistant_message, status)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO pending_signals (agent_id, conversation_id, signal_type, user_message, assistant_message, status, source_mode)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             """
         ) { stmt in
             Self.bindText(stmt, index: 1, value: signal.agentId)
@@ -1413,28 +1510,32 @@ public final class MemoryDatabase: @unchecked Sendable {
             Self.bindText(stmt, index: 4, value: signal.userMessage)
             Self.bindText(stmt, index: 5, value: signal.assistantMessage)
             Self.bindText(stmt, index: 6, value: signal.status)
+            Self.bindText(stmt, index: 7, value: signal.sourceMode?.rawValue)
         }
+    }
+
+    private static func readPendingSignal(_ stmt: OpaquePointer) -> PendingSignal {
+        PendingSignal(
+            id: Int(sqlite3_column_int(stmt, 0)),
+            agentId: String(cString: sqlite3_column_text(stmt, 1)),
+            conversationId: String(cString: sqlite3_column_text(stmt, 2)),
+            signalType: String(cString: sqlite3_column_text(stmt, 3)),
+            userMessage: String(cString: sqlite3_column_text(stmt, 4)),
+            assistantMessage: sqlite3_column_text(stmt, 5).map { String(cString: $0) },
+            status: String(cString: sqlite3_column_text(stmt, 6)),
+            createdAt: String(cString: sqlite3_column_text(stmt, 7)),
+            sourceMode: sqlite3_column_text(stmt, 8).flatMap { MemorySourceMode(rawValue: String(cString: $0)) }
+        )
     }
 
     public func loadPendingSignals(agentId: String) throws -> [PendingSignal] {
         var signals: [PendingSignal] = []
         try prepareAndExecute(
-            "SELECT id, agent_id, conversation_id, signal_type, user_message, assistant_message, status, created_at FROM pending_signals WHERE agent_id = ?1 AND status = 'pending' ORDER BY created_at",
+            "SELECT id, agent_id, conversation_id, signal_type, user_message, assistant_message, status, created_at, source_mode FROM pending_signals WHERE agent_id = ?1 AND status = 'pending' ORDER BY created_at",
             bind: { stmt in Self.bindText(stmt, index: 1, value: agentId) },
             process: { stmt in
                 while sqlite3_step(stmt) == SQLITE_ROW {
-                    signals.append(
-                        PendingSignal(
-                            id: Int(sqlite3_column_int(stmt, 0)),
-                            agentId: String(cString: sqlite3_column_text(stmt, 1)),
-                            conversationId: String(cString: sqlite3_column_text(stmt, 2)),
-                            signalType: String(cString: sqlite3_column_text(stmt, 3)),
-                            userMessage: String(cString: sqlite3_column_text(stmt, 4)),
-                            assistantMessage: sqlite3_column_text(stmt, 5).map { String(cString: $0) },
-                            status: String(cString: sqlite3_column_text(stmt, 6)),
-                            createdAt: String(cString: sqlite3_column_text(stmt, 7))
-                        )
-                    )
+                    signals.append(Self.readPendingSignal(stmt))
                 }
             }
         )
@@ -1444,22 +1545,11 @@ public final class MemoryDatabase: @unchecked Sendable {
     public func loadPendingSignals(conversationId: String) throws -> [PendingSignal] {
         var signals: [PendingSignal] = []
         try prepareAndExecute(
-            "SELECT id, agent_id, conversation_id, signal_type, user_message, assistant_message, status, created_at FROM pending_signals WHERE conversation_id = ?1 AND status = 'pending' ORDER BY created_at",
+            "SELECT id, agent_id, conversation_id, signal_type, user_message, assistant_message, status, created_at, source_mode FROM pending_signals WHERE conversation_id = ?1 AND status = 'pending' ORDER BY created_at",
             bind: { stmt in Self.bindText(stmt, index: 1, value: conversationId) },
             process: { stmt in
                 while sqlite3_step(stmt) == SQLITE_ROW {
-                    signals.append(
-                        PendingSignal(
-                            id: Int(sqlite3_column_int(stmt, 0)),
-                            agentId: String(cString: sqlite3_column_text(stmt, 1)),
-                            conversationId: String(cString: sqlite3_column_text(stmt, 2)),
-                            signalType: String(cString: sqlite3_column_text(stmt, 3)),
-                            userMessage: String(cString: sqlite3_column_text(stmt, 4)),
-                            assistantMessage: sqlite3_column_text(stmt, 5).map { String(cString: $0) },
-                            status: String(cString: sqlite3_column_text(stmt, 6)),
-                            createdAt: String(cString: sqlite3_column_text(stmt, 7))
-                        )
-                    )
+                    signals.append(Self.readPendingSignal(stmt))
                 }
             }
         )
@@ -1611,7 +1701,11 @@ public final class MemoryDatabase: @unchecked Sendable {
 
     // MARK: - Text Search (BM25 fallback)
 
-    public func searchMemoryEntries(query: String, agentId: String? = nil) throws -> [MemoryEntry] {
+    public func searchMemoryEntries(
+        query: String,
+        agentId: String? = nil,
+        chatOnly: Bool = false
+    ) throws -> [MemoryEntry] {
         var entries: [MemoryEntry] = []
         var sql = """
                 SELECT \(Self.memoryEntryColumns)
@@ -1619,6 +1713,7 @@ public final class MemoryDatabase: @unchecked Sendable {
                 WHERE status = 'active' AND content LIKE '%' || ?1 || '%'
             """
         if agentId != nil { sql += " AND agent_id = ?2" }
+        if chatOnly { sql += " AND (source_mode IS NULL OR source_mode = 'chat')" }
         sql += " ORDER BY last_accessed DESC LIMIT 20"
 
         try prepareAndExecute(
@@ -1692,15 +1787,21 @@ public final class MemoryDatabase: @unchecked Sendable {
         return entries
     }
 
-    public func searchSummaries(query: String, agentId: String? = nil, days: Int = 30) throws -> [ConversationSummary] {
+    public func searchSummaries(
+        query: String,
+        agentId: String? = nil,
+        days: Int = 30,
+        chatOnly: Bool = false
+    ) throws -> [ConversationSummary] {
         var summaries: [ConversationSummary] = []
         var sql = """
-                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+                SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
                 FROM conversation_summaries
                 WHERE status = 'active' AND summary LIKE '%' || ?1 || '%'
                   AND conversation_at >= datetime('now', '-' || ?2 || ' days')
             """
         if agentId != nil { sql += " AND agent_id = ?3" }
+        if chatOnly { sql += " AND (source_mode IS NULL OR source_mode = 'chat')" }
         sql += " ORDER BY conversation_at DESC LIMIT 20"
 
         try prepareAndExecute(
@@ -1769,17 +1870,19 @@ public final class MemoryDatabase: @unchecked Sendable {
 
     public func loadSummariesByCompositeKeys(
         _ keys: [(agentId: String, conversationId: String, conversationAt: String)],
-        filterAgentId: String? = nil
+        filterAgentId: String? = nil,
+        chatOnly: Bool = false
     ) throws -> [ConversationSummary] {
         guard !keys.isEmpty else { return [] }
         let conditions = keys.enumerated().map { (i, _) in
             "(agent_id = ?\(i * 3 + 1) AND conversation_id = ?\(i * 3 + 2) AND conversation_at = ?\(i * 3 + 3))"
         }.joined(separator: " OR ")
         var sql = """
-            SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at
+            SELECT id, agent_id, conversation_id, summary, token_count, model, conversation_at, status, created_at, source_mode
             FROM conversation_summaries WHERE status = 'active' AND (\(conditions))
             """
         if filterAgentId != nil { sql += " AND agent_id = ?\(keys.count * 3 + 1)" }
+        if chatOnly { sql += " AND (source_mode IS NULL OR source_mode = 'chat')" }
         sql += " ORDER BY conversation_at DESC"
 
         var summaries: [ConversationSummary] = []

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -528,9 +528,11 @@ final class ChatSession: ObservableObject {
             }
             return
         }
+        let toolsOff = AgentManager.shared.effectiveToolsDisabled(for: effectiveAgentId)
         let context = await MemoryContextAssembler.assembleContext(
             agentId: effectiveAgentId.uuidString,
-            config: MemoryConfigurationStore.load()
+            config: MemoryConfigurationStore.load(),
+            toolsAvailable: !toolsOff
         )
         let newTokens = ContextBudgetManager.estimateTokens(for: context)
         guard newTokens != cachedContext?.manifest.memoryTokens ?? 0 else { return }
@@ -667,6 +669,10 @@ final class ChatSession: ObservableObject {
         let agentUUID = UUID(uuidString: context.memoryAgentId) ?? Agent.defaultId
         let memoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentUUID)
 
+        // Tag memory writes with the execution mode active for this agent so
+        // pure-chat recall can filter out tool-mode contributions.
+        let sourceMode: MemorySourceMode = estimatedChatExecutionMode(agentId: agentUUID).memorySourceMode
+
         if !memoryOff, context.hasContent, let sid = sessionId {
             let convId = sid.uuidString
             let aid = context.memoryAgentId
@@ -682,7 +688,8 @@ final class ChatSession: ObservableObject {
                     chunkIndex: userChunkIndex,
                     role: "user",
                     content: context.userContent,
-                    tokenCount: max(1, context.userContent.count / 4)
+                    tokenCount: max(1, context.userContent.count / 4),
+                    sourceMode: sourceMode
                 )
             } catch {
                 MemoryLogger.database.warning("Failed to insert user chunk: \(error)")
@@ -704,7 +711,8 @@ final class ChatSession: ObservableObject {
                         chunkIndex: chunkIdx,
                         role: "assistant",
                         content: assistantContent,
-                        tokenCount: max(1, assistantContent.count / 4)
+                        tokenCount: max(1, assistantContent.count / 4),
+                        sourceMode: sourceMode
                     )
                 } catch {
                     MemoryLogger.database.warning("Failed to insert assistant chunk: \(error)")
@@ -734,6 +742,7 @@ final class ChatSession: ObservableObject {
                     assistantMessage: assistantContent,
                     agentId: context.memoryAgentId,
                     conversationId: context.memoryConversationId,
+                    sourceMode: sourceMode,
                     sessionDate: today
                 )
             }

--- a/Packages/OsaurusCore/Views/Work/WorkSession.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkSession.swift
@@ -1471,12 +1471,14 @@ extension WorkSession: WorkEngineDelegate {
             !AgentManager.shared.effectiveMemoryDisabled(for: agentId)
         {
             let convId = issue.id
+            let sourceMode = estimatedExecutionModeForBudget().memorySourceMode
             Task.detached {
                 await MemoryService.shared.recordConversationTurn(
                     userMessage: userMessage,
                     assistantMessage: assistantContent,
                     agentId: agentStr,
-                    conversationId: convId
+                    conversationId: convId,
+                    sourceMode: sourceMode
                 )
             }
         }

--- a/Packages/OsaurusCore/Work/WorkExecutionMode.swift
+++ b/Packages/OsaurusCore/Work/WorkExecutionMode.swift
@@ -31,3 +31,29 @@ public enum WorkExecutionMode: Sendable {
         return false
     }
 }
+
+/// Origin mode for a memory write. Persisted alongside entries so reads can
+/// filter out tool-using contributions when the current request has no tools.
+/// NULL on pre-v4 rows is treated as chat-compatible (shown everywhere).
+public enum MemorySourceMode: String, Codable, Sendable {
+    case chat
+    case chatSandbox = "chat_sandbox"
+    case workHost = "work_host"
+    case workSandbox = "work_sandbox"
+
+    /// True when the turn was recorded in a mode that had agentic tools.
+    public var hasTools: Bool { self != .chat }
+}
+
+public extension WorkExecutionMode {
+    /// Derive the memory source mode from the execution mode.
+    /// Callers in pure-chat contexts without sandbox should pass `.chat` directly;
+    /// `.none` here maps to `.chat` as a safe default.
+    var memorySourceMode: MemorySourceMode {
+        switch self {
+        case .none:       return .chat
+        case .hostFolder: return .workHost
+        case .sandbox:    return .workSandbox
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #852 

- Fixed a regression where local MLX chats stopped emitting code and instead narrated phantom tool calls
- Added `MemorySourceMode` (chat / chatSandbox / workHost / workSandbox) and a WorkExecutionMode.memorySourceMode extension
- Migrated schema to v4 (added `source_mode` TEXT to memory_entries, profile_events, conversation_summaries,  
  conversation_chunks, pending_signals. Pre-v4 rows stay NULL and are always visible (backward compatible). Clears user_profile once so the next regen runs under the new filter
- the `sourceMode` is now threaded through all write paths like ```recordConversationTurn, insertPendingSignal,
  insertMemoryEntry, insertProfileEvent, insertSummary, insertChunk```. Summaries inherit the mode of their pending signals
- `toolsAvailable` is threaded through read paths like ```MemoryContextAssembler.assembleContext, MemorySearchService``` (vector + text fallbacks) and the underlying DB loaders. When `toolsAvailable == false`, tool-mode rows are excluded and NULL rows are included
- Profile regeneration compiles from chat origin contributions only so global user_profile is never bloated by tool-session facts
- Assembler cache is now keyed by (agentId, toolsAvailable) so the two views don't collide

This will not introduce any data loss. Writes going forward are correctly partitioned and profile re-stabilizes clean within a few turns.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
