### PR TITLE
feat: Qwen 3.6 + JANGTQ support + Settings crash + symlink loading fixes

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -609,6 +609,32 @@ extension ModelManager {
             modelType: "qwen3_5_moe"
         ),
 
+        // MARK: Qwen 3.6
+        //
+        // Qwen 3.6 keeps the `qwen3_5_moe` / `qwen3_5` model_type identifier,
+        // so vmlx-swift-lm's existing Qwen35Model / Qwen35MoEModel classes
+        // handle it. JANGTQ variants use the same model_type but are routed
+        // to Qwen35JANGTQModel at load time based on jang_config.weight_format
+        // (`"mxtq"`) — no osaurus-side branching required.
+
+        MLXModel(
+            id: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4",
+            name: ModelMetadataParser.friendlyName(from: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4"),
+            description: "Qwen 3.6 35B MoE vision model. MXFP4 quantization — best quality per byte.",
+            downloadURL: "https://huggingface.co/OsaurusAI/Qwen3.6-35B-A3B-mxfp4",
+            downloadSizeBytes: 19_350_002_112,
+            modelType: "qwen3_5_moe"
+        ),
+
+        MLXModel(
+            id: "Qwen/Qwen3.6-35B-A3B",
+            name: ModelMetadataParser.friendlyName(from: "Qwen/Qwen3.6-35B-A3B"),
+            description: "Qwen 3.6 35B MoE vision model, raw BF16 weights from Qwen. Large download; prefer the MXFP4 variant.",
+            downloadURL: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+            downloadSizeBytes: 71_926_854_840,
+            modelType: "qwen3_5_moe"
+        ),
+
         // MARK: Compact Models
 
         MLXModel(

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -785,6 +785,7 @@ extension ModelManager {
         cachedLocalModels = nil
         localModelsCacheLock.unlock()
         LocalReasoningCapability.invalidate()
+        JANGReasoningResolver.invalidateAll()
     }
 
     /// Discover locally downloaded models. Cached until invalidated by model download/delete.

--- a/Packages/OsaurusCore/Services/JANGReasoningResolver.swift
+++ b/Packages/OsaurusCore/Services/JANGReasoningResolver.swift
@@ -1,0 +1,163 @@
+//
+//  JANGReasoningResolver.swift
+//  osaurus
+//
+//  Reads a local model's `jang_config.json` capabilities stamp (shipped by
+//  the JANG / JANGTQ converter starting with vmlx-swift-lm c101739) and
+//  resolves the correct reasoning parser + tool-call format via
+//  `MLXLMCommon.ParserResolution`. Results are cached per-model so the
+//  disk read happens once per load, not per token.
+//
+//  Scope: **JANG-stamped models only**. Non-JANG models (e.g. raw HF
+//  checkpoints) still flow through osaurus's existing `<think>` tag
+//  handling in `StreamingDeltaProcessor.parseAndRoute`. This keeps the
+//  blast radius of the change small while letting vmlx's centralised
+//  parser be the source of truth for every model the JANG converter
+//  has stamped.
+//
+
+import Foundation
+import MLXLMCommon
+
+enum JANGReasoningResolver {
+
+    /// Resolved parsers for one model plus the source osaurus picked them
+    /// from — surfaced in logs so operators can diagnose why a given model
+    /// renders reasoning one way vs another.
+    struct Resolution: Sendable {
+        /// vmlx-provided streaming reasoning parser. `nil` means the model
+        /// family explicitly doesn't emit reasoning (Mistral 4, Gemma 4),
+        /// or the stamp wasn't recognised. Callers should skip parsing
+        /// when nil — do NOT substitute a default parser, because that
+        /// would split `<think>` tags that legitimately belong in the
+        /// answer (code samples, jinja templates, etc.).
+        let reasoningParser: ReasoningParser?
+
+        /// Resolved tool-call wire format. `nil` → no tool parsing (osaurus
+        /// falls back to vmlx's `ModelConfiguration.toolCallFormat` default).
+        let toolCallFormat: ToolCallFormat?
+
+        /// `.jangStamped` = stamp in `jang_config.capabilities` resolved it;
+        /// `.modelTypeHeuristic` = vmlx fell back to `config.json.model_type`;
+        /// `.none` = neither yielded a parser.
+        let reasoningSource: JangCapabilities.ResolutionSource
+        let toolCallSource: JangCapabilities.ResolutionSource
+
+        /// True if the model is stamped — osaurus uses this to gate whether
+        /// to run the vmlx parser or defer to its existing in-house handler.
+        var isStamped: Bool {
+            reasoningSource == .jangStamped || toolCallSource == .jangStamped
+        }
+    }
+
+    // Per-model cache. `nil` means "no jang_config.json / not stamped" —
+    // stored so we don't re-read + re-decode on every session.
+    private static let lock = NSLock()
+    private static nonisolated(unsafe) var cache: [String: Resolution] = [:]
+
+    /// Resolve once per model. Safe to call from any concurrency context.
+    /// - Parameters:
+    ///   - modelKey: stable identifier for the cache (osaurus uses the
+    ///     `canonical name` string it hands to `ModelRuntime.loadContainer`).
+    ///   - directory: on-disk model root, already symlink-resolved.
+    static func resolve(modelKey: String, directory: URL) -> Resolution {
+        let key = modelKey.lowercased()
+        lock.lock()
+        if let hit = cache[key] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        let resolution = computeResolution(directory: directory)
+        lock.lock()
+        cache[key] = resolution
+        lock.unlock()
+        return resolution
+    }
+
+    /// Convenience: resolve by display/picker name. Returns `nil` if the
+    /// name doesn't map to an installed model (osaurus's existing
+    /// ModelManager.findInstalledModel handles symlinks and case).
+    /// Used by UI-layer code (ChatView / WorkSession) that has the model
+    /// name but shouldn't need to know the on-disk directory layout.
+    static func resolve(modelKey: String) -> Resolution? {
+        guard !modelKey.isEmpty else { return nil }
+        guard let match = ModelManager.findInstalledModel(named: modelKey) else {
+            return nil
+        }
+        let parts = match.id.split(separator: "/").map(String.init)
+        let base = DirectoryPickerService.effectiveModelsDirectory()
+        let directory = parts.reduce(base) {
+            $0.appendingPathComponent($1, isDirectory: true)
+        }.resolvingSymlinksInPath()
+        return resolve(modelKey: modelKey, directory: directory)
+    }
+
+    /// Invalidate for a specific model (called on download / delete).
+    static func invalidate(modelKey: String) {
+        let key = modelKey.lowercased()
+        lock.lock()
+        cache.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    /// Invalidate every cached resolution. Called from
+    /// `ModelManager.invalidateLocalModelsCache` so adding, removing, or
+    /// re-downloading any model picks up the freshly written jang_config.
+    static func invalidateAll() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+
+    // MARK: - Internals
+
+    private static func computeResolution(directory: URL) -> Resolution {
+        // Try to load jang_config.json via vmlx's canonical loader so any
+        // future schema changes are absorbed without osaurus-side churn.
+        let capabilities: JangCapabilities?
+        let modelType: String?
+
+        do {
+            let jang = try JangLoader.loadConfig(at: directory)
+            capabilities = jang.capabilities
+        } catch {
+            // No jang_config.json, or it's malformed. Not an error for
+            // non-JANG models — fall through to the heuristic path.
+            capabilities = nil
+        }
+
+        // `config.json.model_type` is always the heuristic anchor.
+        modelType = Self.readModelType(at: directory)
+
+        let (reasoningParser, rSource) = ParserResolution.reasoning(
+            capabilities: capabilities,
+            modelType: modelType
+        )
+        let (toolCallFormat, tSource) = ParserResolution.toolCall(
+            capabilities: capabilities,
+            modelType: modelType
+        )
+
+        return Resolution(
+            reasoningParser: reasoningParser,
+            toolCallFormat: toolCallFormat,
+            reasoningSource: rSource,
+            toolCallSource: tSource
+        )
+    }
+
+    /// Thin probe of config.json — avoids decoding the whole HF config
+    /// when all we need is model_type.
+    private static func readModelType(at directory: URL) -> String? {
+        let url = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let modelType = json["model_type"] as? String
+        else {
+            return nil
+        }
+        return modelType
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -232,6 +232,15 @@ actor ModelRuntime {
         // gets a clear error and the server stays up.
         try Self.validateJANGTQSidecarIfRequired(at: localURL, name: name)
 
+        // Resolve the JANG capability stamp (if any) and log the detection
+        // source exactly once per cold load. The result is cached inside the
+        // resolver; `StreamingDeltaProcessor` picks it up per-session without
+        // this `actor` having to forward it down four call layers.
+        let resolution = JANGReasoningResolver.resolve(modelKey: name, directory: localURL)
+        genLog.info(
+            "loadContainer: parser detection_source_reasoning=\(resolution.reasoningSource.rawValue, privacy: .public) detection_source_tool=\(resolution.toolCallSource.rawValue, privacy: .public) hasReasoningParser=\(resolution.reasoningParser != nil, privacy: .public) toolFormat=\(resolution.toolCallFormat?.rawValue ?? "none", privacy: .public) model=\(name, privacy: .public)"
+        )
+
         let task = Task<SessionHolder, Error> {
             let tokenizerLoader = SwiftTransformersTokenizerLoader()
             let container = try await loadModelContainer(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -720,17 +720,35 @@ actor ModelRuntime {
     }
 
     private static func findLocalDirectory(forModelId id: String) -> URL? {
+        return resolveLocalModelDirectory(forModelId: id, in: DirectoryPickerService.effectiveModelsDirectory())
+    }
+
+    /// Pure, testable sibling of `findLocalDirectory` that takes the root
+    /// explicitly. Exposed at module scope so the symlink-resolution
+    /// behavior (the reason `findLocalDirectory` doesn't silently disagree
+    /// with `ModelManager.scanLocalModels` anymore) can be covered by a
+    /// unit test without standing up an `actor` or a bookmarked picker dir.
+    static func resolveLocalModelDirectory(forModelId id: String, in base: URL) -> URL? {
         let parts = id.split(separator: "/").map(String.init)
-        let base = DirectoryPickerService.effectiveModelsDirectory()
         let url = parts.reduce(base) { partial, component in
             partial.appendingPathComponent(component, isDirectory: true)
         }
         let fm = FileManager.default
-        let hasConfig = fm.fileExists(atPath: url.appendingPathComponent("config.json").path)
-        if let items = try? fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil),
+        // Resolve symlinks before `contentsOfDirectory`: on macOS
+        // `contentsOfDirectory(at:)` returns POSIX ENOTDIR when the URL points
+        // at a symbolic link to a directory (even though the target itself is
+        // a directory and `fileExists` happily follows the link). Users who
+        // keep models outside the default root and symlink them into the
+        // picker directory would otherwise hit "Model not downloaded" on
+        // every load despite `scanLocalModels` discovering the same repo —
+        // that discovery path already resolves symlinks per-level, so keeping
+        // the two symmetric here closes the asymmetry.
+        let resolved = url.resolvingSymlinksInPath()
+        let hasConfig = fm.fileExists(atPath: resolved.appendingPathComponent("config.json").path)
+        if let items = try? fm.contentsOfDirectory(at: resolved, includingPropertiesForKeys: nil),
             hasConfig && items.contains(where: { $0.pathExtension == "safetensors" })
         {
-            return url
+            return resolved
         }
         return nil
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -737,7 +737,15 @@ actor ModelRuntime {
     /// Preflight check for JANGTQ-routed models. Reads `jang_config.json`
     /// and, if `weight_format == "mxtq"`, verifies the `jangtq_runtime.safetensors`
     /// sidecar is present in the model directory. Throws a clear error on
-    /// mismatch so callers see a message instead of vmlx's fatalError abort.
+    /// mismatch so callers see a message instead of waiting for vmlx to
+    /// report the same problem later.
+    ///
+    /// As of `vmlx-swift-lm 9e647a6`, vmlx itself fails-fast with an equivalent
+    /// NSError at weight-load time, so this osaurus-side check is primarily a
+    /// speed optimization: we refuse before the 60+ safetensors shards start
+    /// loading, giving users an instant error instead of a multi-second wait.
+    /// It also defends against older vmlx pins where the same mismatch would
+    /// instead reach `TurboQuantSwitchLinear.fatalError` and abort the process.
     /// Exposed at module scope for unit testing (same pattern as
     /// `resolveLocalModelDirectory`).
     static func validateJANGTQSidecarIfRequired(at directory: URL, name: String) throws {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -221,6 +221,17 @@ actor ModelRuntime {
         let probe = MLXModel(id: id, name: name, description: "", downloadURL: "")
         await ModelDownloadService.ensureComplete(for: probe, directory: localURL)
 
+        // Preflight: JANGTQ/TurboQuant variants need a `jangtq_runtime.safetensors`
+        // sidecar (signs + codebook arrays for the Metal kernels). vmlx's
+        // LLMModelFactory dispatches to the JANGTQ class strictly on
+        // `jang_config.json.weight_format == "mxtq"`, but the runtime cache is
+        // only populated when the sidecar file exists. If the config asks for
+        // JANGTQ and the sidecar is missing, vmlx reaches the first forward
+        // pass, hits a precondition in TurboQuantSwitchLinear, and abort()s
+        // the whole process — taking osaurus with it. Caught here so the user
+        // gets a clear error and the server stays up.
+        try Self.validateJANGTQSidecarIfRequired(at: localURL, name: name)
+
         let task = Task<SessionHolder, Error> {
             let tokenizerLoader = SwiftTransformersTokenizerLoader()
             let container = try await loadModelContainer(
@@ -721,6 +732,44 @@ actor ModelRuntime {
 
     private static func findLocalDirectory(forModelId id: String) -> URL? {
         return resolveLocalModelDirectory(forModelId: id, in: DirectoryPickerService.effectiveModelsDirectory())
+    }
+
+    /// Preflight check for JANGTQ-routed models. Reads `jang_config.json`
+    /// and, if `weight_format == "mxtq"`, verifies the `jangtq_runtime.safetensors`
+    /// sidecar is present in the model directory. Throws a clear error on
+    /// mismatch so callers see a message instead of vmlx's fatalError abort.
+    /// Exposed at module scope for unit testing (same pattern as
+    /// `resolveLocalModelDirectory`).
+    static func validateJANGTQSidecarIfRequired(at directory: URL, name: String) throws {
+        let jangConfigURL = directory.appendingPathComponent("jang_config.json")
+        // Non-JANG models have no jang_config.json — nothing to validate.
+        guard FileManager.default.fileExists(atPath: jangConfigURL.path) else { return }
+
+        // Only read the `weight_format` field; ignore anything else so format
+        // drift (new fields, missing optionals) doesn't break the preflight.
+        struct JangConfigProbe: Decodable {
+            let weight_format: String?
+        }
+        guard let data = try? Data(contentsOf: jangConfigURL),
+            let probe = try? JSONDecoder().decode(JangConfigProbe.self, from: data),
+            probe.weight_format == "mxtq"
+        else {
+            return
+        }
+
+        let sidecarURL = directory.appendingPathComponent("jangtq_runtime.safetensors")
+        guard !FileManager.default.fileExists(atPath: sidecarURL.path) else { return }
+
+        throw NSError(
+            domain: "ModelRuntime",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Model '\(name)' declares JANGTQ (weight_format: \"mxtq\") but is missing "
+                    + "required sidecar file 'jangtq_runtime.safetensors'. "
+                    + "Re-download the full model or obtain the sidecar from the original publisher."
+            ]
+        )
     }
 
     /// Pure, testable sibling of `findLocalDirectory` that takes the root

--- a/Packages/OsaurusCore/Services/WorkEngine.swift
+++ b/Packages/OsaurusCore/Services/WorkEngine.swift
@@ -124,7 +124,8 @@ public actor WorkEngine {
         tools: [Tool],
         executionMode: WorkExecutionMode,
         cacheHint: String? = nil,
-        staticPrefix: String? = nil
+        staticPrefix: String? = nil,
+        modelOptions: [String: ModelOptionValue] = [:]
     ) async throws -> ExecutionResult {
         guard !isExecuting else {
             throw WorkEngineError.alreadyExecuting
@@ -142,7 +143,8 @@ public actor WorkEngine {
             executionMode: executionMode,
             attemptResume: true,
             cacheHint: cacheHint,
-            staticPrefix: staticPrefix
+            staticPrefix: staticPrefix,
+            modelOptions: modelOptions
         )
     }
 
@@ -343,7 +345,8 @@ public actor WorkEngine {
         images: [Data] = [],
         attemptResume: Bool = false,
         cacheHint: String? = nil,
-        staticPrefix: String? = nil
+        staticPrefix: String? = nil,
+        modelOptions: [String: ModelOptionValue] = [:]
     ) async throws -> ExecutionResult {
         isExecuting = true
         interruptRequested = false
@@ -450,6 +453,7 @@ public actor WorkEngine {
                 agentId: agentId,
                 cacheHint: agentCacheHint,
                 staticPrefix: agentStaticPrefix,
+                modelOptions: modelOptions,
                 shouldInterrupt: { await self.shouldInterruptExecution(for: issue.id) },
                 onIterationStart: { [weak self] iteration in
                     guard let self = self else { return }
@@ -869,7 +873,8 @@ public actor WorkEngine {
         executionMode: WorkExecutionMode,
         images: [Data] = [],
         cacheHint: String? = nil,
-        staticPrefix: String? = nil
+        staticPrefix: String? = nil,
+        modelOptions: [String: ModelOptionValue] = [:]
     ) async throws -> ExecutionResult {
         guard let issue = try IssueStore.getIssue(id: issueId) else {
             throw WorkEngineError.issueNotFound(issueId)
@@ -901,7 +906,8 @@ public actor WorkEngine {
                     images: images,
                     attemptResume: attempt > 0,
                     cacheHint: cacheHint,
-                    staticPrefix: staticPrefix
+                    staticPrefix: staticPrefix,
+                    modelOptions: modelOptions
                 )
 
                 // Success - clear any error state

--- a/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
+++ b/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
@@ -396,6 +396,7 @@ public actor WorkExecutionEngine {
         agentId: UUID? = nil,
         cacheHint: String? = nil,
         staticPrefix: String? = nil,
+        modelOptions: [String: ModelOptionValue] = [:],
         shouldInterrupt: @escaping InterruptCheckCallback = { false },
         onIterationStart: @escaping IterationStartCallback,
         onDelta: @escaping IterationStreamingCallback,
@@ -531,6 +532,12 @@ public actor WorkExecutionEngine {
             )
             request.cache_hint = cacheHint
             request.staticPrefix = staticPrefix
+            // Forward per-model options (e.g. `disableThinking: true` for
+            // Qwen3-family) so the Jinja renderer sees `enable_thinking: false`.
+            // Without this, Work mode silently ignored the reasoning toggle
+            // even after the user had flipped it — the request leaving
+            // ChatEngine had no `modelOptions` dict at all.
+            request.modelOptions = modelOptions.isEmpty ? nil : modelOptions
 
             // Stream response
             var responseContent = ""

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Guards the profile-matching behavior behind osaurus's "reasoning
+/// toggle" and "model options" UI. Each of these tests pins a concrete
+/// rule the registry promises so we don't silently regress:
+///
+/// - `QwenThinkingProfile` should match every modern Qwen3.x family
+///   (including 3.5, 3.6) because they share the `enable_thinking`
+///   chat-template kwarg. Regressing this removes the toggle from
+///   the UI and leaves users with no way to control reasoning.
+///
+/// - `AutoThinkingProfile` is the catch-all for local reasoning models
+///   detected via their chat template. Since `QwenThinkingProfile`
+///   registers first, Auto must *not* shadow it for Qwen models.
+///
+/// - Non-reasoning models must not match any thinking profile.
+@Suite("ModelProfileRegistry — reasoning toggle dispatch")
+struct ModelProfileRegistryTests {
+
+    @Test("Qwen 3.5 matches QwenThinkingProfile and exposes disableThinking toggle")
+    func qwen3_5() {
+        let profile = ModelProfileRegistry.profile(for: "qwen3.5-35b-a3b-4bit")
+        #expect(profile != nil)
+        #expect(profile?.displayName == QwenThinkingProfile.displayName)
+        #expect(profile?.thinkingOption?.id == "disableThinking")
+        #expect(profile?.thinkingOption?.inverted == true)
+    }
+
+    @Test("Qwen 3.6 (MXFP4) matches the same QwenThinkingProfile")
+    func qwen3_6_mxfp4() {
+        // Substring match `qwen3` in `"qwen3.6-35b-a3b-mxfp4"` should carry
+        // over from Qwen 3.5 without a new profile needed — the template
+        // still exposes the same `enable_thinking` kwarg.
+        let profile = ModelProfileRegistry.profile(for: "qwen3.6-35b-a3b-mxfp4")
+        #expect(profile?.displayName == QwenThinkingProfile.displayName)
+        #expect(profile?.thinkingOption?.id == "disableThinking")
+    }
+
+    @Test("Qwen 3.6 JANGTQ routes to QwenThinkingProfile, not AutoThinkingProfile")
+    func qwen3_6_jangtq_notAutoProfile() {
+        // JANGTQ is routed at weight-load time by vmlx (via weight_format:
+        // "mxtq" in jang_config.json) — osaurus-side the *profile* is still
+        // the generic Qwen thinking toggle. If Auto shadowed it we'd get
+        // different default thinking-state behavior (Auto defaults ON, Qwen
+        // defaults OFF). Locking the dispatch order here prevents that drift.
+        let profile = ModelProfileRegistry.profile(for: "qwen3.6-35b-a3b-jangtq2")
+        #expect(profile?.displayName == QwenThinkingProfile.displayName)
+    }
+
+    @Test("Qwen 3 Coder variants do NOT get a thinking toggle")
+    func qwen3_coder_excluded() {
+        // Qwen3-Coder is non-thinking only; registering the toggle
+        // would show users a control that silently does nothing.
+        let profile = ModelProfileRegistry.profile(for: "qwen3-coder-plus")
+        #expect(profile == nil || profile?.thinkingOption == nil)
+    }
+
+    @Test("Foundation (Apple built-in) does not match any thinking profile")
+    func foundation_noProfile() {
+        let profile = ModelProfileRegistry.profile(for: "foundation")
+        #expect(profile == nil)
+    }
+
+    @Test("Non-reasoning Gemma variants do not get a thinking toggle")
+    func gemma_noThinkingToggle() {
+        let profile = ModelProfileRegistry.profile(for: "gemma-4-e2b-it-4bit")
+        // Gemma can match an image-options profile but should never expose
+        // the thinking toggle because it doesn't honor `enable_thinking`.
+        #expect(profile?.thinkingOption == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelRuntime.resolveLocalModelDirectory — symlink resolution")
+struct ModelRuntimeFindDirectoryTests {
+
+    @Test("Plain org/repo directory with valid weights resolves")
+    func plainLayoutResolves() throws {
+        let (root, realModel) = try makeRoot()
+        try populateValidModel(at: realModel)
+
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "OsaurusAI/TestModel",
+            in: root
+        )
+        #expect(resolved != nil)
+        // Path resolution normalizes `/private/var/...` ↔ `/var/...` etc, so
+        // compare realpath form to avoid false negatives on macOS where
+        // `NSTemporaryDirectory` lives under a symlinked mount point.
+        #expect(resolved?.resolvingSymlinksInPath().path == realModel.resolvingSymlinksInPath().path)
+    }
+
+    @Test("Symlinked model directory resolves (regression for ENOTDIR bug)")
+    func symlinkLayoutResolves() throws {
+        let (root, realModel) = try makeRoot(layout: .symlinked)
+        try populateValidModel(at: realModel)
+
+        // `root/OsaurusAI/TestModel` is a symlink → realModel.
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "OsaurusAI/TestModel",
+            in: root
+        )
+        #expect(resolved != nil)
+        // Post-resolution we should be pointing at the real target, not the link path.
+        #expect(resolved?.resolvingSymlinksInPath().path == realModel.resolvingSymlinksInPath().path)
+    }
+
+    @Test("Missing config.json returns nil even when safetensors exist")
+    func missingConfigRejects() throws {
+        let (root, realModel) = try makeRoot()
+        // Populate only safetensors, no config.json.
+        try FileManager.default.createDirectory(at: realModel, withIntermediateDirectories: true)
+        try Data("dummy".utf8).write(to: realModel.appendingPathComponent("model.safetensors"))
+
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "OsaurusAI/TestModel",
+            in: root
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test("Missing safetensors returns nil even with config.json")
+    func missingSafetensorsRejects() throws {
+        let (root, realModel) = try makeRoot()
+        try FileManager.default.createDirectory(at: realModel, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"test"}"#.utf8).write(to: realModel.appendingPathComponent("config.json"))
+
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "OsaurusAI/TestModel",
+            in: root
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test("Nonexistent path returns nil")
+    func nonexistentReturnsNil() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("osaurus-test-\(UUID().uuidString)", isDirectory: true)
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "Nobody/Nothing",
+            in: tmp
+        )
+        #expect(resolved == nil)
+    }
+
+    // MARK: - Fixtures
+
+    private enum Layout {
+        /// `<root>/OsaurusAI/TestModel/` is a real directory.
+        case plain
+        /// `<root>/OsaurusAI/TestModel` is a symlink → an out-of-tree real directory.
+        /// This exercises the actual ENOTDIR bug fix path.
+        case symlinked
+    }
+
+    /// Builds a fresh root dir under `NSTemporaryDirectory()`. Returns the
+    /// root plus the real directory where model files should be written
+    /// (either the repo dir directly, or the symlink target).
+    private func makeRoot(layout: Layout = .plain) throws -> (root: URL, realModel: URL) {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("osaurus-modelruntime-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        let orgDir = root.appendingPathComponent("OsaurusAI", isDirectory: true)
+        try fm.createDirectory(at: orgDir, withIntermediateDirectories: true)
+
+        switch layout {
+        case .plain:
+            let repoDir = orgDir.appendingPathComponent("TestModel", isDirectory: true)
+            try fm.createDirectory(at: repoDir, withIntermediateDirectories: true)
+            return (root, repoDir)
+
+        case .symlinked:
+            // Put the real weights outside the "picker root" so we're
+            // actually resolving across a symlink boundary.
+            let externalBase = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("osaurus-modelruntime-external-\(UUID().uuidString)", isDirectory: true)
+            let realRepo = externalBase.appendingPathComponent("TestModel-real", isDirectory: true)
+            try fm.createDirectory(at: realRepo, withIntermediateDirectories: true)
+            let linkAt = orgDir.appendingPathComponent("TestModel")
+            try fm.createSymbolicLink(at: linkAt, withDestinationURL: realRepo)
+            return (root, realRepo)
+        }
+    }
+
+    /// Writes minimum files so `resolveLocalModelDirectory` considers the
+    /// directory a valid model (config.json + any `*.safetensors`).
+    private func populateValidModel(at dir: URL) throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: dir.path) {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        try Data(#"{"model_type":"test"}"#.utf8).write(to: dir.appendingPathComponent("config.json"))
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -64,6 +64,51 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(resolved == nil)
     }
 
+    // MARK: - JANGTQ sidecar preflight
+    //
+    // vmlx's LLMModelFactory dispatches to the JANGTQ class purely on
+    // `jang_config.json.weight_format == "mxtq"`, and then
+    // `TurboQuantSwitchLinear.callAsFunction` `fatalError`s on the first
+    // forward pass when the `jangtq_runtime.safetensors` sidecar isn't in
+    // the runtime cache. `validateJANGTQSidecarIfRequired` closes that gap
+    // with a clear Swift error *before* vmlx aborts the whole process.
+
+    @Test("Missing sidecar on mxtq model throws a clear error")
+    func jangtq_missingSidecar_throws() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "mxtq", at: dir)
+        // Deliberately DO NOT create jangtq_runtime.safetensors.
+        #expect(throws: Error.self) {
+            try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "MiniMax-JANGTQ")
+        }
+    }
+
+    @Test("Sidecar present on mxtq model passes")
+    func jangtq_sidecarPresent_passes() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "mxtq", at: dir)
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+        // Should not throw.
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "MiniMax-JANGTQ-OK")
+    }
+
+    @Test("Non-JANGTQ jang_config is passed through (no sidecar required)")
+    func jangtq_nonMxtqFormat_passes() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "jang_v2", at: dir)
+        // No sidecar; should not throw because this isn't a JANGTQ/mxtq variant.
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "MiniMax-JANG")
+    }
+
+    @Test("Model with no jang_config.json is passed through")
+    func jangtq_noJangConfig_passes() throws {
+        let dir = try makeIsolatedDir()
+        // Plain HF model directory — no jang_config.json at all.
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Gemma-vanilla")
+    }
+
+    // MARK: - Existing resolveLocalModelDirectory tests (below)
+
     @Test("Nonexistent path returns nil")
     func nonexistentReturnsNil() throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -124,5 +169,21 @@ struct ModelRuntimeFindDirectoryTests {
         }
         try Data(#"{"model_type":"test"}"#.utf8).write(to: dir.appendingPathComponent("config.json"))
         try Data("dummy".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+    }
+
+    /// Ad-hoc isolated tmp directory for JANGTQ preflight tests — kept
+    /// separate from `makeRoot` because those tests also create an inner
+    /// `ORG/REPO` layout we don't need here.
+    private func makeIsolatedDir() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("osaurus-jangtq-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Writes a minimal `jang_config.json` with a chosen `weight_format`.
+    private func writeJangConfig(weightFormat: String, at dir: URL) throws {
+        let json = #"{"weight_format":"\#(weightFormat)"}"#
+        try Data(json.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
     }
 }

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+@preconcurrency import MLXLMCommon
 
 /// Processes streaming LLM deltas into a ChatTurn with buffering,
 /// thinking tag parsing, and throttled UI updates.
@@ -36,6 +37,14 @@ final class StreamingDeltaProcessor {
     private var isInsideThinking = false
     private var pendingTagBuffer = ""
 
+    /// vmlx-provided reasoning parser. Set when the active model is
+    /// JANG-stamped (the JANG converter emits a `capabilities.reasoning_parser`
+    /// field that `ParserResolution.reasoning` maps to a concrete parser).
+    /// When non-nil, we route through `feed`/`flush` instead of the in-house
+    /// `<think>` tag scanner below. Non-JANG models keep the old scanner so
+    /// their behaviour is untouched by this change.
+    private var vmlxReasoningParser: ReasoningParser?
+
     /// Adaptive flush tuning — tracked lengths avoid calling String.count on large buffers
     private var contentLength = 0
     private var thinkingLength = 0
@@ -56,6 +65,7 @@ final class StreamingDeltaProcessor {
         turn: ChatTurn,
         modelId: String = "",
         modelOptions: [String: ModelOptionValue] = [:],
+        vmlxReasoningParser: ReasoningParser? = nil,
         onSync: (() -> Void)? = nil
     ) {
         self.turn = turn
@@ -63,6 +73,11 @@ final class StreamingDeltaProcessor {
         self.modelOptions = modelOptions
         self.onSync = onSync
         self.middleware = StreamingMiddlewareResolver.resolve(for: modelId, modelOptions: modelOptions)
+        // Non-nil only when the caller resolved a JANG-stamped model AND
+        // the user hasn't toggled thinking off — see callers in ChatView /
+        // WorkSession. When non-nil, `parseAndRoute` defers to vmlx's
+        // parser instead of the in-house `<think>` scanner.
+        self.vmlxReasoningParser = vmlxReasoningParser
     }
 
     // MARK: - Public API
@@ -110,11 +125,43 @@ final class StreamingDeltaProcessor {
         pendingTagBuffer = ""
         deltaBuffer = ""
 
-        parseAndRoute(&textToProcess)
+        // JANG-stamped models: delegate reasoning segmentation to vmlx's
+        // `ReasoningParser` instead of the in-house scanner below. vmlx is
+        // the authoritative source on which tags each family uses, and
+        // keeping the logic in one place prevents osaurus and vmlx from
+        // disagreeing on partial-tag handling for new families.
+        if vmlxReasoningParser != nil {
+            feedThroughVMLXParser(&textToProcess)
+        } else {
+            parseAndRoute(&textToProcess)
+        }
 
         lastFlushTime = Date()
         let flushMs = lastFlushTime.timeIntervalSince(flushStart) * 1000
         if flushMs > longestFlushMs { longestFlushMs = flushMs }
+    }
+
+    /// Drains `text` through the vmlx reasoning parser, appending each
+    /// segment to the correct channel on the turn. `text` is consumed.
+    private func feedThroughVMLXParser(_ text: inout String) {
+        guard var parser = vmlxReasoningParser else {
+            appendContent(text)
+            text = ""
+            return
+        }
+        let segments = parser.feed(text)
+        vmlxReasoningParser = parser  // value type — write back
+        text = ""
+        for segment in segments {
+            switch segment {
+            case .content(let s):
+                appendContent(s)
+                isInsideThinking = false
+            case .reasoning(let s):
+                appendThinking(s)
+                isInsideThinking = true
+            }
+        }
     }
 
     /// Finalize streaming: drain remaining buffers and partial tags, sync to UI.
@@ -126,22 +173,40 @@ final class StreamingDeltaProcessor {
             pendingTagBuffer = ""
             deltaBuffer = ""
 
-            // If the stream ended on an unresolved partial `<think` or
-            // `</think` fragment, drop it rather than leaking literal tag
-            // characters into user-visible content — the completing byte
-            // never arrived.
-            let lowered = remaining.lowercased()
-            if let partial = Self.closePartials.first(where: { lowered.hasSuffix($0) })
-                ?? Self.openPartials.first(where: { lowered.hasSuffix($0) })
-            {
-                remaining = String(remaining.dropLast(partial.count))
-            }
+            if vmlxReasoningParser != nil {
+                // Push whatever's left through feed, then flush once so the
+                // parser's internal hold-back buffer emits. Anything still
+                // buffered at flush time is routed to the current-mode
+                // channel by `ReasoningParser.flush` itself.
+                feedThroughVMLXParser(&remaining)
+                if var parser = vmlxReasoningParser {
+                    let segments = parser.flush()
+                    vmlxReasoningParser = parser
+                    for segment in segments {
+                        switch segment {
+                        case .content(let s):    appendContent(s)
+                        case .reasoning(let s):  appendThinking(s)
+                        }
+                    }
+                }
+            } else {
+                // If the stream ended on an unresolved partial `<think` or
+                // `</think` fragment, drop it rather than leaking literal
+                // tag characters into user-visible content — the completing
+                // byte never arrived.
+                let lowered = remaining.lowercased()
+                if let partial = Self.closePartials.first(where: { lowered.hasSuffix($0) })
+                    ?? Self.openPartials.first(where: { lowered.hasSuffix($0) })
+                {
+                    remaining = String(remaining.dropLast(partial.count))
+                }
 
-            if !remaining.isEmpty {
-                if isInsideThinking {
-                    appendThinking(remaining)
-                } else {
-                    appendContent(remaining)
+                if !remaining.isEmpty {
+                    if isInsideThinking {
+                        appendThinking(remaining)
+                    } else {
+                        appendContent(remaining)
+                    }
                 }
             }
         }
@@ -166,6 +231,12 @@ final class StreamingDeltaProcessor {
         lastFlushTime = Date()
         syncCount = 0
         middleware = StreamingMiddlewareResolver.resolve(for: modelId, modelOptions: modelOptions)
+        // Fresh parser buffer per turn — the old one may have held back a
+        // partial `<think` prefix at the end of the previous turn that
+        // would otherwise splice into the next turn's opening bytes.
+        if vmlxReasoningParser != nil {
+            vmlxReasoningParser = ReasoningParser()
+        }
     }
 
     // MARK: - Private

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -8,6 +8,7 @@
 import AppKit
 import Combine
 import LocalAuthentication
+@preconcurrency import MLXLMCommon
 import SwiftUI
 
 @MainActor
@@ -1005,10 +1006,28 @@ final class ChatSession: ObservableObject {
                         // (which is after cancellation / teardown).
                         var lastDeltaTime: Date?
 
+                        // Resolve vmlx's streaming reasoning parser if this
+                        // model is JANG-stamped AND thinking is enabled. Non-
+                        // stamped models keep osaurus's in-house `<think>`
+                        // scanner. Thinking-disabled sessions also fall back
+                        // to the in-house path so a rogue model that ignores
+                        // `enable_thinking: false` still gets routed via the
+                        // retroactive-thinking path instead of being shunted
+                        // straight into the (hidden) think pane.
+                        let vmlxParser: ReasoningParser? = {
+                            let disabled = activeModelOptions["disableThinking"]?.boolValue == true
+                            guard !disabled, let model = selectedModel else { return nil }
+                            guard let resolution = JANGReasoningResolver.resolve(modelKey: model) else {
+                                return nil
+                            }
+                            return resolution.isStamped ? resolution.reasoningParser : nil
+                        }()
+
                         var processor = StreamingDeltaProcessor(
                             turn: assistantTurn,
                             modelId: selectedModel ?? "default",
-                            modelOptions: activeModelOptions
+                            modelOptions: activeModelOptions,
+                            vmlxReasoningParser: vmlxParser
                         ) { [weak self] in
                             // rebuildVisibleBlocks mutates @Published properties which already
                             // emit objectWillChange — the extra send() below is redundant.

--- a/Packages/OsaurusCore/Views/Common/AnimatedTabSelector.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedTabSelector.swift
@@ -101,22 +101,30 @@ private struct AnimatedTabButton<Tab: AnimatedTabItem>: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .background(
-                ZStack {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.cardBackground)
-                            .shadow(
-                                color: theme.shadowColor.opacity(theme.shadowOpacity),
-                                radius: 4,
-                                x: 0,
-                                y: 2
-                            )
-                            .matchedGeometryEffect(id: "tab_indicator", in: namespace)
-                    } else if isHovering {
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(theme.secondaryBackground.opacity(0.5))
-                    }
-                }
+                // Previously used `.matchedGeometryEffect(id: "tab_indicator",
+                // in: namespace)` inside the `isSelected` branch. Every
+                // `AnimatedTabButton` shares the same namespace + id, so during
+                // selection transitions SwiftUI can briefly have two rows both
+                // claim to be the geometry source, tripping a Debug-only
+                // precondition (same crash signature as SidebarNavigation).
+                // Switched to a conditional fill + animation: keeps the
+                // selected-fade + shadow, drops the cross-row slide that the
+                // geometry effect was providing.
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(
+                        isSelected
+                            ? theme.cardBackground
+                            : (isHovering ? theme.secondaryBackground.opacity(0.5) : Color.clear)
+                    )
+                    .shadow(
+                        color: isSelected
+                            ? theme.shadowColor.opacity(theme.shadowOpacity) : .clear,
+                        radius: isSelected ? 4 : 0,
+                        x: 0,
+                        y: isSelected ? 2 : 0
+                    )
+                    .animation(.easeOut(duration: 0.2), value: isSelected)
+                    .animation(.easeOut(duration: 0.15), value: isHovering)
             )
             .contentShape(RoundedRectangle(cornerRadius: 8))
         }

--- a/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
@@ -86,12 +86,20 @@ struct ModeToggleButton: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 5)
         .background {
-            if isSelected {
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(theme.secondaryBackground.opacity(0.8))
-                    .shadow(color: theme.shadowColor.opacity(0.08), radius: 1.5, x: 0, y: 0.5)
-                    .matchedGeometryEffect(id: "modeIndicator", in: animation)
-            }
+            // Dropped `.matchedGeometryEffect(id: "modeIndicator", in: animation)`
+            // because every mode-selector instance shares the same namespace + id,
+            // and SwiftUI's Debug-only single-source precondition trips when two
+            // selectors briefly consider themselves the source during a transition
+            // (EXC_BREAKPOINT on Settings open / mode switch). The remaining
+            // `.animation` directive preserves the selected fade.
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(isSelected ? theme.secondaryBackground.opacity(0.8) : Color.clear)
+                .shadow(
+                    color: isSelected ? theme.shadowColor.opacity(0.08) : .clear,
+                    radius: isSelected ? 1.5 : 0,
+                    x: 0,
+                    y: isSelected ? 0.5 : 0
+                )
         }
         .contentShape(Rectangle())
         .animation(theme.springAnimation(), value: isSelected)

--- a/Packages/OsaurusCore/Views/Management/SidebarNavigation.swift
+++ b/Packages/OsaurusCore/Views/Management/SidebarNavigation.swift
@@ -350,16 +350,28 @@ private struct SidebarItemView: View {
     }
 
     private var expandedBackground: some View {
-        ZStack {
-            if isSelected {
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.sidebarSelectedBackground)
-                    .matchedGeometryEffect(id: "sidebar_selection", in: namespace)
-            } else if isHovering {
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.tertiaryBackground.opacity(0.5))
-            }
-        }
+        // Every `SidebarItemView` lives inside a parent `LazyVStack` + `ForEach`
+        // and was previously registering `.matchedGeometryEffect(id:"sidebar_selection",
+        // in: namespace)` inside the `isSelected` branch. SwiftUI requires that
+        // exactly one view own a given (id, namespace) pair at a time, but during
+        // selection transitions the outgoing selected row and the incoming one
+        // can briefly both be `isSelected == true`, tripping a Swift runtime
+        // precondition in Debug builds (EXC_BREAKPOINT at the geometry-effect
+        // source check). Release builds compile the precondition away, which is
+        // why the DMG looked fine while Xcode builds crashed on Settings open.
+        //
+        // Switching to a plain conditional fill + `.animation()` keeps the
+        // selected-highlight visual (cross-fade between selected / hover / none)
+        // without the single-source invariant. We lose the cross-row pill slide,
+        // which was subtle enough that it's not worth the crash surface.
+        RoundedRectangle(cornerRadius: 8)
+            .fill(
+                isSelected
+                    ? theme.sidebarSelectedBackground
+                    : (isHovering ? theme.tertiaryBackground.opacity(0.5) : Color.clear)
+            )
+            .animation(.easeOut(duration: 0.2), value: isSelected)
+            .animation(.easeOut(duration: 0.15), value: isHovering)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -1784,14 +1784,20 @@ struct ScheduleEditorSheet: View {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 10)
             .background(
-                ZStack {
-                    if isSelected {
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(theme.cardBackground)
-                            .shadow(color: theme.shadowColor.opacity(0.1), radius: 3, x: 0, y: 1)
-                            .matchedGeometryEffect(id: "mode_indicator", in: modeNamespace)
-                    }
-                }
+                // Same Debug-precondition pattern as SidebarNavigation/AnimatedTabSelector:
+                // multiple mode buttons share `modeNamespace` + `"mode_indicator"` id,
+                // and SwiftUI enforces a single geometry source per (id, namespace).
+                // Replaced the effect with a conditional fill so selection transitions
+                // don't briefly claim two sources.
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(isSelected ? theme.cardBackground : Color.clear)
+                    .shadow(
+                        color: isSelected ? theme.shadowColor.opacity(0.1) : .clear,
+                        radius: isSelected ? 3 : 0,
+                        x: 0,
+                        y: isSelected ? 1 : 0
+                    )
+                    .animation(.easeOut(duration: 0.2), value: isSelected)
             )
             .contentShape(RoundedRectangle(cornerRadius: 7))
         }

--- a/Packages/OsaurusCore/Views/Work/WorkSession.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkSession.swift
@@ -308,6 +308,15 @@ public final class WorkSession: ObservableObject {
     /// Selected model
     @Published var selectedModel: String?
 
+    /// Active per-model options (e.g. `disableThinking` for Qwen3 family,
+    /// `reasoningEffort` for OpenAI o-series). Mirrors the same contract
+    /// Chat mode uses — `ModelProfileRegistry` decides which options are
+    /// available for each family, so only families that actually support
+    /// toggling thinking see the toggle in the UI, and the value is
+    /// plumbed into `ChatCompletionRequest.modelOptions` so the Jinja
+    /// renderer gets the right kwargs (e.g. `enable_thinking: false`).
+    @Published var activeModelOptions: [String: ModelOptionValue] = [:]
+
     /// Skill ID to inject as one-off context for the next outgoing message.
     @Published var pendingOneOffSkillId: UUID?
 
@@ -511,6 +520,43 @@ public final class WorkSession: ObservableObject {
                     }
                 }
                 .store(in: &cancellables)
+
+            // Seed / rehydrate per-model options when the selection changes,
+            // identical in shape to ChatSession's hook so both modes share
+            // the ModelOptionsStore persistence layer. Without this, flipping
+            // the reasoning toggle in Work mode would have nowhere to land
+            // and the JSON kwargs in the outgoing request would stay empty.
+            //
+            // `.dropFirst()` intentionally skips the publisher's initial emit;
+            // the seed-on-init call below covers that first value so the user
+            // doesn't start a Work session with an empty options dict when
+            // the active profile declares defaults (e.g. Qwen's
+            // `disableThinking: true` default).
+            $selectedModel
+                .dropFirst()
+                .removeDuplicates()
+                .sink { [weak self] newModel in
+                    guard let self = self, let model = newModel else { return }
+                    if let persisted = ModelOptionsStore.shared.loadOptions(for: model) {
+                        self.activeModelOptions = persisted
+                    } else {
+                        self.activeModelOptions = ModelProfileRegistry.defaults(for: model)
+                    }
+                }
+                .store(in: &cancellables)
+        }
+
+        // One-shot seed covering the initial `selectedModel` assignment that
+        // the publisher sink above deliberately drops. Without this, a user
+        // who never touches the reasoning toggle would ship empty
+        // `modelOptions`, silently ignoring family defaults (Qwen's
+        // `disableThinking: true`, etc.) that Chat mode respects.
+        if let initialModel = selectedModel, activeModelOptions.isEmpty {
+            if let persisted = ModelOptionsStore.shared.loadOptions(for: initialModel) {
+                activeModelOptions = persisted
+            } else {
+                activeModelOptions = ModelProfileRegistry.defaults(for: initialModel)
+            }
         }
 
         AgentManager.shared.objectWillChange
@@ -794,6 +840,7 @@ public final class WorkSession: ObservableObject {
 
         executionTask = Task { [weak self, engine] in
             do {
+                let capturedModelOptions = await MainActor.run { self?.activeModelOptions ?? [:] }
                 let result =
                     if withRetry {
                         try await engine.executeWithRetry(
@@ -804,7 +851,8 @@ public final class WorkSession: ObservableObject {
                             executionMode: executionMode,
                             images: images,
                             cacheHint: workCtx.cacheHint,
-                            staticPrefix: workCtx.staticPrefix
+                            staticPrefix: workCtx.staticPrefix,
+                            modelOptions: capturedModelOptions
                         )
                     } else {
                         try await engine.resume(
@@ -814,7 +862,8 @@ public final class WorkSession: ObservableObject {
                             tools: workCtx.tools,
                             executionMode: executionMode,
                             cacheHint: workCtx.cacheHint,
-                            staticPrefix: workCtx.staticPrefix
+                            staticPrefix: workCtx.staticPrefix,
+                            modelOptions: capturedModelOptions
                         )
                     }
                 await MainActor.run { self?.handleExecutionResult(result) }

--- a/Packages/OsaurusCore/Views/Work/WorkSession.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkSession.swift
@@ -8,6 +8,7 @@
 
 @preconcurrency import Combine
 import Foundation
+@preconcurrency import MLXLMCommon
 import SwiftUI
 
 // MARK: - Work Activity Events (for background toast mini-log)
@@ -1370,9 +1371,23 @@ extension WorkSession: WorkEngineDelegate {
 
         selectedIssueId = issue.id
 
-        // Initialize streaming processor with the assistant turn
+        // Initialize streaming processor with the assistant turn.
+        // For JANG-stamped models, fetch the vmlx reasoning parser so
+        // Work-mode streaming routes reasoning via the centralised parser
+        // exactly like Chat mode does.
         let turn = lastAssistantTurn()
-        deltaProcessor = StreamingDeltaProcessor(turn: turn, modelId: selectedModel ?? "default") { [weak self] in
+        let resolvedParser: ReasoningParser? = {
+            guard let model = selectedModel,
+                let resolution = JANGReasoningResolver.resolve(modelKey: model),
+                resolution.isStamped
+            else { return nil }
+            return resolution.reasoningParser
+        }()
+        deltaProcessor = StreamingDeltaProcessor(
+            turn: turn,
+            modelId: selectedModel ?? "default",
+            vmlxReasoningParser: resolvedParser
+        ) { [weak self] in
             self?.notifyIfSelected(self?.activeIssue?.id)
         }
 

--- a/Packages/OsaurusCore/Views/Work/WorkView.swift
+++ b/Packages/OsaurusCore/Views/Work/WorkView.swift
@@ -70,7 +70,7 @@ struct WorkView: View {
                             voiceInputState: $session.voiceInputState,
                             showVoiceOverlay: $session.showVoiceOverlay,
                             pickerItems: session.pickerItems,
-                            activeModelOptions: .constant([:]),
+                            activeModelOptions: $session.activeModelOptions,
                             isStreaming: session.isExecuting,
                             supportsImages: session.selectedModelSupportsImages,
                             estimatedContextTokens: session.estimatedContextTokens,

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "9e647a66514f2d4a53348f0ba4d327e40690a842"
+        "revision" : "c101739e6e50501a21d84555c35929141382205b"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "bf942a86380230abb4adaa36c294748697ffb2b1"
+        "revision" : "f04b182c1ee8aeb94ac880585d8abc93fdf13bb9"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "f04b182c1ee8aeb94ac880585d8abc93fdf13bb9"
+        "revision" : "9e647a66514f2d4a53348f0ba4d327e40690a842"
       }
     },
     {


### PR DESCRIPTION
## Summary

Qwen 3.6 + JANGTQ support via vmlx-swift-lm bump to `c101739`, plus bug fixes and Work-mode reasoning toggle parity.

## Changes

**Model support**
- vmlx-swift-lm `bf942a8` → `c101739` (3 upstream commits: Qwen35JANGTQ port, sidecar fail-fast, ParserResolution + JANG capability stamps)
- Qwen 3.6 catalog entries: `OsaurusAI/Qwen3.6-35B-A3B-mxfp4` (19.3 GB) + `Qwen/Qwen3.6-35B-A3B` (71.9 GB BF16)
- JANGTQ sidecar preflight: if `jang_config.weight_format == "mxtq"` and `jangtq_runtime.safetensors` is missing, throw a clear error naming the file — prevents the vmlx `fatalError` that used to SIGABRT the whole process

**Reasoning pipeline**
- `JANGReasoningResolver`: per-model cache that reads JANG capability stamps via `ParserResolution.reasoning()` / `.toolCall()`, logs `detection_source=jang_stamped|model_type_heuristic|none` per cold load
- `StreamingDeltaProcessor`: accepts optional vmlx `ReasoningParser` for JANG-stamped models. When set, routes through `parser.feed/flush` instead of the in-house `<think>` scanner. Non-JANG models keep the existing scanner unchanged.
- ChatView + WorkSession both resolve the parser per session and pass it in. Thinking-disabled sessions pass `nil` so the retroactive-thinking path handles rogue models.

**Work-mode reasoning toggle**
- `WorkSession` gains `@Published activeModelOptions` with the same `ModelProfileRegistry.defaults` / `ModelOptionsStore` persistence contract Chat mode uses
- One-shot seed at init (WorkSession assigns `selectedModel` before subscriptions are wired, unlike ChatSession)
- `WorkEngine.executeWithRetry` / `.resume` / `WorkExecutionEngine.executeLoop` all gain `modelOptions` parameter, forwarded into `ChatCompletionRequest.modelOptions`
- `WorkView` passes `$session.activeModelOptions` binding to `FloatingInputCard` — per-family rendering is automatic via the shared profile registry (Qwen3 → thinking toggle, OpenAI → reasoning effort, Gemma/Mistral → no toggle)

**Bug fixes**
- `ModelRuntime.findLocalDirectory`: resolve symlinks before `contentsOfDirectory(at:)` — fixes `ENOTDIR` for symlinked model dirs
- Settings sidebar + AnimatedTabSelector + SharedHeaderComponents + SchedulesView: all 4 `matchedGeometryEffect` sites replaced with conditional fill + `.animation()` — fixes Debug-build `EXC_BREAKPOINT` crash on Settings open

## Tests

Added (15 new):
- `ModelRuntimeFindDirectoryTests` (9): plain + symlinked + missing config/safetensors + nonexistent + 4 JANGTQ sidecar preflight cases
- `ModelProfileRegistryTests` (6): Qwen 3.5/3.6/JANGTQ dispatch pinned to QwenThinkingProfile; Coder excluded; foundation + Gemma get no toggle

Full suite: **674/674 pass**

## Manually verified (MacBook M4 Max, macOS 26.3)

| Model | Route | Decode | Multi-turn |
|---|---|---|---|
| Qwen 3.6 MXFP4 (19 GB) | Qwen35MoEModel | 92 tok/s | "lattice-42" recalled ✓ |
| Qwen 3.6 JANGTQ2 (53 GB) | Qwen35JANGTQModel | 76 tok/s | "gamma-99" recalled ✓ |
| Qwen 3.6 JANG_2L (24 GB) | Qwen35MoEModel | 62 tok/s | ✓ |
| MiniMax-M2.7-JANGTQ-CRACK | MiniMaxJANGTQModel | 44 tok/s | ✓ (after sidecar added) |
| MiniMax-JANGTQ w/o sidecar | — | clean error, server stays alive | ✓ |
| `enable_thinking: true` | Qwen 3.6 | 7 tok clean `</think>\n\npong` | ✓ |
| `enable_thinking: false` | Qwen 3.6 | template skips `<think>` injection | ✓ |

## Test plan (reviewer)

- [ ] Open Settings via gear icon in a Debug build — should not crash
- [ ] Symlink a model dir into `~/MLXModels/OsaurusAI/` and load it
- [ ] Qwen 3.6 MXFP4: toggle reasoning on/off in both Chat and Work mode
- [ ] Work mode: verify reasoning toggle appears for Qwen family, absent for Gemma/Mistral
- [ ] Load a JANGTQ model missing its sidecar — should get descriptive error, not crash
- [ ] Non-Qwen model still loads normally