### PR TITLE
prevent app freeze during HTTP agent runs

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -271,14 +271,16 @@ public struct SystemPromptComposer: Sendable {
 
     /// Compose agent context (base prompt + memory) and inject into an existing message array.
     /// Returns `(cacheHint, staticPrefix)` for the caller to set on the request.
-    @MainActor
     @discardableResult
     static func injectAgentContext(
         agentId: UUID,
         query: String = "",
         into messages: inout [ChatMessage]
     ) async -> (cacheHint: String, staticPrefix: String) {
-        var composer = forChat(agentId: agentId, executionMode: .none)
+        // only forChat needs @MainActor. so hop there briefly and return the value type composer.
+        // appendMemory (memory search + embeddings) then runs on the cooperative thread pool to
+        // keep the mac app responsive during HTTP API requests
+        var composer = await MainActor.run { forChat(agentId: agentId, executionMode: .none) }
         await composer.appendMemory(agentId: agentId.uuidString, query: query.isEmpty ? nil : query)
         let manifest = composer.manifest()
         let rendered = composer.render()


### PR DESCRIPTION
## Summary

`injectAgentContext` was marked `MainActor` which was causing every `/agents/{id}/run` HTTP request to pin the main thread for the entire  duration of the memory search (vector embeddings via MemorySearchService). This froze the app and stalled the HTTP response until the searches completed.

So this fix removes `MainActor` from the function and replaces the one call that actually needs the main thread (forChat) with a targeted `await MainActor.run { }` hop. Memory search now runs on the cooperative thread pool to ensure that the app is responsive. The chat flow (composeChatContext) is unaffected

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
