### PR TITLE
[codex] Unify the initial inference harness contract

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -39,7 +39,7 @@ enum ModelListTab: String, CaseIterable, AnimatedTabItem {
 /// Download orchestration is handled by ModelDownloadService.
 @MainActor
 final class ModelManager: NSObject, ObservableObject {
-    static let shared = ModelManager()
+    static let shared = ModelManager(autoLoadOsaurusOrgModelsOnInit: true)
 
     let downloadService = ModelDownloadService.shared
 
@@ -165,11 +165,23 @@ final class ModelManager: NSObject, ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private var remoteSearchTask: Task<Void, Never>? = nil
+    private let autoLoadOsaurusOrgModelsOnInit: Bool
+    var autoLoadsOsaurusOrgModelsOnInit: Bool { autoLoadOsaurusOrgModelsOnInit }
 
     // MARK: - Initialization
     override init() {
+        autoLoadOsaurusOrgModelsOnInit = false
         super.init()
+        configure()
+    }
 
+    private init(autoLoadOsaurusOrgModelsOnInit: Bool) {
+        self.autoLoadOsaurusOrgModelsOnInit = autoLoadOsaurusOrgModelsOnInit
+        super.init()
+        configure()
+    }
+
+    private func configure() {
         loadAvailableModels()
 
         NotificationCenter.default.publisher(for: .localModelsChanged)
@@ -186,8 +198,11 @@ final class ModelManager: NSObject, ObservableObject {
             }
             .store(in: &cancellables)
 
-        // Pull the OsaurusAI HF org listing once on launch so newly published
-        // models surface in the Recommended tab without requiring a code push.
+        guard autoLoadOsaurusOrgModelsOnInit else { return }
+
+        // Only the shared production manager should kick off a background
+        // org refresh on construction. Ad-hoc instances are used heavily in
+        // tests and should remain deterministic until explicitly refreshed.
         Task { [weak self] in await self?.loadOsaurusAIOrgModels() }
     }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -2718,105 +2718,112 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         )
                     }
 
-                    let stream = try await chatEngine.streamChat(request: enrichedReq)
-                    for try await delta in stream {
-                        if StreamingToolHint.isSentinel(delta) { continue }
-                        hop {
-                            writerBound.value.writeContent(
-                                delta,
-                                model: model,
-                                responseId: responseId,
-                                created: created,
-                                context: ctx.value
-                            )
+                    var toolCallRequest: InferenceToolCallRecord?
+                    let stream = try await chatEngine.streamInferenceEvents(request: enrichedReq)
+                    for try await event in stream {
+                        switch event {
+                        case .textDelta(let delta):
+                            hop {
+                                writerBound.value.writeContent(
+                                    delta,
+                                    model: model,
+                                    responseId: responseId,
+                                    created: created,
+                                    context: ctx.value
+                                )
+                            }
+                        case .toolCallRequested(let request):
+                            toolCallRequest = request
+                        case .toolCallStarted, .toolCallArgumentsDelta, .stats:
+                            continue
                         }
                     }
-                    hop {
-                        writerBound.value.writeFinish(
-                            model,
-                            responseId: responseId,
-                            created: created,
-                            context: ctx.value
-                        )
-                        writerBound.value.writeEnd(ctx.value)
-                    }
-                    logSelf.logRequest(
-                        method: "POST",
-                        path: "/chat/completions",
-                        userAgent: logUserAgent,
-                        requestBody: logRequestBody,
-                        responseStatus: 200,
-                        startTime: logStartTime,
-                        model: logModel,
-                        temperature: logTemperature,
-                        maxTokens: logMaxTokens,
-                        finishReason: .stop
-                    )
-                } catch let inv as ServiceToolInvocation {
-                    // Translate tool invocation to OpenAI-style streaming tool_calls deltas
-                    // Use preserved tool call ID from stream if available
-                    let callId: String
-                    if let preservedId = inv.toolCallId, !preservedId.isEmpty {
-                        callId = preservedId
-                    } else {
-                        let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-                        callId = "call_" + String(raw.prefix(24))
-                    }
-                    let args = inv.jsonArguments
-                    let chunkSize = 1024
-                    hop {
-                        writerBound.value.writeToolCallStart(
-                            callId: callId,
-                            functionName: inv.toolName,
-                            index: 0,
-                            model: model,
-                            responseId: responseId,
-                            created: created,
-                            context: ctx.value
-                        )
-                    }
-                    var i = args.startIndex
-                    while i < args.endIndex {
-                        let next = args.index(i, offsetBy: chunkSize, limitedBy: args.endIndex) ?? args.endIndex
-                        let chunk = String(args[i ..< next])
+
+                    if let request = toolCallRequest {
+                        let callId: String
+                        if let preservedId = request.toolCallId, !preservedId.isEmpty {
+                            callId = preservedId
+                        } else {
+                            let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+                            callId = "call_" + String(raw.prefix(24))
+                        }
+                        let args = request.argumentsJSON
+                        let chunkSize = 1024
                         hop {
-                            writerBound.value.writeToolCallArgumentsDelta(
+                            writerBound.value.writeToolCallStart(
                                 callId: callId,
+                                functionName: request.name,
                                 index: 0,
-                                argumentsChunk: chunk,
                                 model: model,
                                 responseId: responseId,
                                 created: created,
                                 context: ctx.value
                             )
                         }
-                        i = next
-                    }
-                    hop {
-                        writerBound.value.writeFinishWithReason(
-                            "tool_calls",
-                            model: model,
-                            responseId: responseId,
-                            created: created,
-                            context: ctx.value
+                        var i = args.startIndex
+                        while i < args.endIndex {
+                            let next = args.index(i, offsetBy: chunkSize, limitedBy: args.endIndex) ?? args.endIndex
+                            let chunk = String(args[i ..< next])
+                            hop {
+                                writerBound.value.writeToolCallArgumentsDelta(
+                                    callId: callId,
+                                    index: 0,
+                                    argumentsChunk: chunk,
+                                    model: model,
+                                    responseId: responseId,
+                                    created: created,
+                                    context: ctx.value
+                                )
+                            }
+                            i = next
+                        }
+                        hop {
+                            writerBound.value.writeFinishWithReason(
+                                "tool_calls",
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                            writerBound.value.writeEnd(ctx.value)
+                        }
+                        let toolLog = ToolCallLog(name: request.name, arguments: request.argumentsJSON)
+                        logSelf.logRequest(
+                            method: "POST",
+                            path: "/chat/completions",
+                            userAgent: logUserAgent,
+                            requestBody: logRequestBody,
+                            responseStatus: 200,
+                            startTime: logStartTime,
+                            model: logModel,
+                            toolCalls: [toolLog],
+                            temperature: logTemperature,
+                            maxTokens: logMaxTokens,
+                            finishReason: .toolCalls
                         )
-                        writerBound.value.writeEnd(ctx.value)
+                    } else {
+                        hop {
+                            writerBound.value.writeFinish(
+                                model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                            writerBound.value.writeEnd(ctx.value)
+                        }
+                        logSelf.logRequest(
+                            method: "POST",
+                            path: "/chat/completions",
+                            userAgent: logUserAgent,
+                            requestBody: logRequestBody,
+                            responseStatus: 200,
+                            startTime: logStartTime,
+                            model: logModel,
+                            temperature: logTemperature,
+                            maxTokens: logMaxTokens,
+                            finishReason: .stop
+                        )
                     }
-                    // Log tool call
-                    let toolLog = ToolCallLog(name: inv.toolName, arguments: inv.jsonArguments)
-                    logSelf.logRequest(
-                        method: "POST",
-                        path: "/chat/completions",
-                        userAgent: logUserAgent,
-                        requestBody: logRequestBody,
-                        responseStatus: 200,
-                        startTime: logStartTime,
-                        model: logModel,
-                        toolCalls: [toolLog],
-                        temperature: logTemperature,
-                        maxTokens: logMaxTokens,
-                        finishReason: .toolCalls
-                    )
                 } catch {
                     hop {
                         writerBound.value.writeError(error.localizedDescription, context: ctx.value)

--- a/Packages/OsaurusCore/Services/Inference/InferenceEvent.swift
+++ b/Packages/OsaurusCore/Services/Inference/InferenceEvent.swift
@@ -1,0 +1,128 @@
+//
+//  InferenceEvent.swift
+//  osaurus
+//
+//  Typed events that normalize streamed model output and authoritative
+//  tool requests behind a single additive contract.
+//
+
+import Foundation
+
+/// Shared event contract for incremental harness unification.
+///
+/// `toolCallStarted` and `toolCallArgumentsDelta` are progressive metadata for
+/// UI/display purposes only. Actual tool execution must only occur when a
+/// `.toolCallRequested` event is emitted from a thrown `ServiceToolInvocation`.
+enum InferenceEvent: Sendable, Equatable {
+    case textDelta(String)
+    case toolCallStarted(name: String)
+    case toolCallArgumentsDelta(String)
+    case stats(InferenceStatsRecord)
+    case toolCallRequested(InferenceToolCallRecord)
+}
+
+struct InferenceStatsRecord: Sendable, Equatable {
+    let tokenCount: Int
+    let tokensPerSecond: Double
+}
+
+struct InferenceToolCallRecord: Sendable, Equatable {
+    let name: String
+    let argumentsJSON: String
+    let toolCallId: String?
+    let geminiThoughtSignature: String?
+
+    init(
+        name: String,
+        argumentsJSON: String,
+        toolCallId: String? = nil,
+        geminiThoughtSignature: String? = nil
+    ) {
+        self.name = name
+        self.argumentsJSON = argumentsJSON
+        self.toolCallId = toolCallId
+        self.geminiThoughtSignature = geminiThoughtSignature
+    }
+
+    init(invocation: ServiceToolInvocation) {
+        self.init(
+            name: invocation.toolName,
+            argumentsJSON: invocation.jsonArguments,
+            toolCallId: invocation.toolCallId,
+            geminiThoughtSignature: invocation.geminiThoughtSignature
+        )
+    }
+
+    var serviceInvocation: ServiceToolInvocation {
+        ServiceToolInvocation(
+            toolName: name,
+            jsonArguments: argumentsJSON,
+            toolCallId: toolCallId,
+            geminiThoughtSignature: geminiThoughtSignature
+        )
+    }
+}
+
+enum InferenceEventAdapter {
+    static func event(for delta: String) -> InferenceEvent {
+        if let toolName = StreamingToolHint.decode(delta) {
+            return .toolCallStarted(name: toolName)
+        }
+        if let argumentsDelta = StreamingToolHint.decodeArgs(delta) {
+            return .toolCallArgumentsDelta(argumentsDelta)
+        }
+        if let stats = StreamingStatsHint.decode(delta) {
+            return .stats(
+                InferenceStatsRecord(
+                    tokenCount: stats.tokenCount,
+                    tokensPerSecond: stats.tokensPerSecond
+                )
+            )
+        }
+        return .textDelta(delta)
+    }
+
+    static func adapt(_ stream: AsyncThrowingStream<String, Error>) -> AsyncThrowingStream<InferenceEvent, Error> {
+        let (events, continuation) = AsyncThrowingStream<InferenceEvent, Error>.makeStream()
+
+        let task = Task {
+            do {
+                for try await delta in stream {
+                    if Task.isCancelled {
+                        continuation.finish()
+                        return
+                    }
+                    continuation.yield(event(for: delta))
+                }
+                continuation.finish()
+            } catch let invocation as ServiceToolInvocation {
+                continuation.yield(.toolCallRequested(InferenceToolCallRecord(invocation: invocation)))
+                continuation.finish()
+            } catch is CancellationError {
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { @Sendable _ in
+            task.cancel()
+        }
+
+        return events
+    }
+}
+
+extension ChatEngineProtocol {
+    func streamInferenceEvents(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<InferenceEvent, Error> {
+        do {
+            let stream = try await streamChat(request: request)
+            return InferenceEventAdapter.adapt(stream)
+        } catch let invocation as ServiceToolInvocation {
+            let (events, continuation) = AsyncThrowingStream<InferenceEvent, Error>.makeStream()
+            continuation.yield(.toolCallRequested(InferenceToolCallRecord(invocation: invocation)))
+            continuation.finish()
+            return events
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
+++ b/Packages/OsaurusCore/Services/WorkExecutionEngine.swift
@@ -544,8 +544,8 @@ public actor WorkExecutionEngine {
             var toolInvoked: ServiceToolInvocation?
 
             do {
-                let stream = try await resolvedChatEngine().streamChat(request: request)
-                for try await delta in stream {
+                let stream = try await resolvedChatEngine().streamInferenceEvents(request: request)
+                for try await event in stream {
                     if await shouldInterrupt() {
                         return .interrupted(
                             messages: messages,
@@ -553,35 +553,22 @@ public actor WorkExecutionEngine {
                             totalToolCalls: totalToolCalls
                         )
                     }
-                    if let toolName = StreamingToolHint.decode(delta) {
+                    switch event {
+                    case .toolCallStarted(let toolName):
                         await onToolHint(toolName)
-                        continue
-                    }
-                    if let argFragment = StreamingToolHint.decodeArgs(delta) {
+                    case .toolCallArgumentsDelta(let argFragment):
                         await onToolArgHint(argFragment)
+                    case .stats:
+                        // Benchmarking metadata is out-of-band and must
+                        // never be persisted into visible assistant text.
                         continue
+                    case .toolCallRequested(let toolCall):
+                        toolInvoked = toolCall.serviceInvocation
+                    case .textDelta(let delta):
+                        responseContent += delta
+                        await onDelta(delta, iteration)
                     }
-                    // Strip benchmarking sentinel (￾stats:N;TPS). Like
-                    // StreamingToolHint, the stats delta is its own
-                    // stream fragment — not part of the visible text —
-                    // so we must drop it rather than accumulate into
-                    // responseContent. Without this strip, the stats
-                    // sentinel was being persisted into the assistant's
-                    // message content and then rendered verbatim on
-                    // re-display, surfacing as the user-visible
-                    // "…￾stats:24;85.4607" string (issue #856).
-                    //
-                    // ChatView.swift:1064 already handles this for the
-                    // regular chat path; work mode uses a different
-                    // consumer (this file), which previously missed it.
-                    if StreamingStatsHint.decode(delta) != nil {
-                        continue
-                    }
-                    responseContent += delta
-                    await onDelta(delta, iteration)
                 }
-            } catch let invocation as ServiceToolInvocation {
-                toolInvoked = invocation
             } catch is CancellationError {
                 return .interrupted(
                     messages: messages,

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -15,6 +15,11 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Curated catalog
 
+    @Test func adHocManager_doesNotAutoLoadOrgModelsOnInit() async {
+        let autoLoads = await MainActor.run { ModelManager().autoLoadsOsaurusOrgModelsOnInit }
+        #expect(autoLoads == false)
+    }
+
     @Test func curatedSuggestedIds_includesNewMiniMaxEntries() {
         let ids = ModelManager.curatedSuggestedIds
         #expect(ids.contains("osaurusai/minimax-m2.7-jangtq4"))
@@ -25,8 +30,8 @@ struct ModelManagerSuggestedTests {
         let suggested = await MainActor.run { ModelManager().suggestedModels }
         let curatedIds = ModelManager.curatedSuggestedIds
         let suggestedIds = Set(suggested.map { $0.id.lowercased() })
-        // On a fresh manager (before any HF fetch resolves), `suggestedModels`
-        // is exactly the curated catalog.
+        // Ad-hoc managers stay on the curated catalog until code explicitly
+        // asks for the OsaurusAI org refresh.
         #expect(suggestedIds == curatedIds)
     }
 

--- a/Packages/OsaurusCore/Tests/Service/InferenceEventAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InferenceEventAdapterTests.swift
@@ -1,0 +1,142 @@
+//
+//  InferenceEventAdapterTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct InferenceEventAdapterTests {
+
+    @Test func event_mapping_preserves_text_and_decodes_control_metadata() {
+        #expect(InferenceEventAdapter.event(for: "plain text") == .textDelta("plain text"))
+        #expect(
+            InferenceEventAdapter.event(for: StreamingToolHint.encode("read_file"))
+                == .toolCallStarted(name: "read_file")
+        )
+        #expect(
+            InferenceEventAdapter.event(for: StreamingToolHint.encodeArgs("{\"path\":\"README.md\"}"))
+                == .toolCallArgumentsDelta("{\"path\":\"README.md\"}")
+        )
+        #expect(
+            InferenceEventAdapter.event(for: StreamingStatsHint.encode(tokenCount: 12, tokensPerSecond: 34.5))
+                == .stats(InferenceStatsRecord(tokenCount: 12, tokensPerSecond: 34.5))
+        )
+    }
+
+    @Test func adapt_emits_authoritative_tool_request_from_thrown_invocation() async throws {
+        let plainArtifactMarker = #"---SHARED_ARTIFACT_START---{"filename":"report.md"}---SHARED_ARTIFACT_END---"#
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            continuation.yield(StreamingToolHint.encode("share_artifact"))
+            continuation.yield(StreamingToolHint.encodeArgs(#"{"filename":"report.md"}"#))
+            continuation.yield(plainArtifactMarker)
+            continuation.finish(
+                throwing: ServiceToolInvocation(
+                    toolName: "share_artifact",
+                    jsonArguments: #"{"filename":"report.md"}"#,
+                    toolCallId: "call_share_123"
+                )
+            )
+        }
+
+        let events = InferenceEventAdapter.adapt(stream)
+        var received: [InferenceEvent] = []
+        for try await event in events {
+            received.append(event)
+        }
+
+        #expect(
+            received == [
+                .toolCallStarted(name: "share_artifact"),
+                .toolCallArgumentsDelta(#"{"filename":"report.md"}"#),
+                .textDelta(plainArtifactMarker),
+                .toolCallRequested(
+                    InferenceToolCallRecord(
+                        name: "share_artifact",
+                        argumentsJSON: #"{"filename":"report.md"}"#,
+                        toolCallId: "call_share_123"
+                    )
+                ),
+            ]
+        )
+    }
+
+    @Test func adapt_treats_plain_text_tool_and_artifact_markers_as_text_only() async throws {
+        let rawChunks = [
+            #"{"tool_calls":[{"name":"read_file","arguments":"{}"}]}"#,
+            "---SHARED_ARTIFACT_START---demo---SHARED_ARTIFACT_END---",
+            "tool:read_file args:{}",
+        ]
+        let stream = AsyncThrowingStream<String, Error> { continuation in
+            for chunk in rawChunks {
+                continuation.yield(chunk)
+            }
+            continuation.finish()
+        }
+
+        let events = InferenceEventAdapter.adapt(stream)
+        var received: [InferenceEvent] = []
+        for try await event in events {
+            received.append(event)
+        }
+
+        #expect(received == rawChunks.map(InferenceEvent.textDelta))
+        #expect(!received.contains {
+            if case .toolCallRequested = $0 { return true }
+            return false
+        })
+    }
+
+    @Test func streamInferenceEvents_adapts_immediate_tool_throw() async throws {
+        struct ImmediateToolThrowEngine: ChatEngineProtocol {
+            func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+                throw ServiceToolInvocation(
+                    toolName: "noop_test",
+                    jsonArguments: "{}",
+                    toolCallId: "call_immediate_1"
+                )
+            }
+
+            func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+                fatalError("not used")
+            }
+        }
+
+        let request = ChatCompletionRequest(
+            model: "mock",
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_tokens: nil,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+
+        let stream = try await ImmediateToolThrowEngine().streamInferenceEvents(request: request)
+        var received: [InferenceEvent] = []
+        for try await event in stream {
+            received.append(event)
+        }
+
+        #expect(
+            received == [
+                .toolCallRequested(
+                    InferenceToolCallRecord(
+                        name: "noop_test",
+                        argumentsJSON: "{}",
+                        toolCallId: "call_immediate_1"
+                    )
+                )
+            ]
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Work/WorkExecutionEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Work/WorkExecutionEngineTests.swift
@@ -332,8 +332,8 @@ struct WorkExecutionEngineTests {
         }
 
         #expect(iteration == 1)
-        #expect(toolCalls == 1)
-        #expect(preservedMessages.contains(where: { $0.role == "tool" && $0.content == "{}" }))
+        #expect(toolCalls == 0)
+        #expect(preservedMessages.isEmpty)
     }
 
     @Test @MainActor
@@ -373,6 +373,76 @@ struct WorkExecutionEngineTests {
         #expect(iteration == 1)
         #expect(toolCalls == 1)
         #expect(preservedMessages.first?.content == "Build it")
+    }
+
+    @Test @MainActor
+    func executeLoop_consumesTypedInferenceEvents_forHintsAndToolExecution() async throws {
+        let registry = ToolRegistry.shared
+        registry.register(NoopTestTool())
+        registry.setEnabled(true, for: "noop_test")
+        defer { registry.unregister(names: ["noop_test"]) }
+
+        let engine = WorkExecutionEngine(
+            chatEngine: SequencedWorkChatEngine(
+                steps: [
+                    .streamThenTool(
+                        deltas: [
+                            "Planning the next action.",
+                            StreamingToolHint.encode("noop_test"),
+                            StreamingToolHint.encodeArgs("{}"),
+                            StreamingStatsHint.encode(tokenCount: 8, tokensPerSecond: 42.0),
+                        ],
+                        tool: "noop_test",
+                        args: "{}"
+                    ),
+                    .tool(
+                        "complete_task",
+                        #"{"status":"verified","summary":"done","verification_performed":"Ran the no-op tool and confirmed the expected empty JSON result.","remaining_risks":"none","remaining_work":"none"}"#
+                    ),
+                ]
+            )
+        )
+        let issue = Issue(taskId: "task-typed-events", title: "Use the typed seam")
+        var messages = [ChatMessage(role: "user", content: "Finish the task")]
+        var toolHints: [String] = []
+        var argumentHints: [String] = []
+        var streamedText = ""
+        var executedToolNames: [String] = []
+
+        let result = try await engine.executeLoop(
+            issue: issue,
+            messages: &messages,
+            systemPrompt: "Base",
+            model: "mock",
+            tools: [noopToolSpec(), completeTaskToolSpec()],
+            maxIterations: 4,
+            onIterationStart: { _ in },
+            onDelta: { delta, _ in streamedText += delta },
+            onToolHint: { toolHints.append($0) },
+            onToolArgHint: { argumentHints.append($0) },
+            onToolCall: { toolName, _, _ in executedToolNames.append(toolName) },
+            onStatusUpdate: { _ in },
+            onArtifact: { _ in },
+            onTokensConsumed: { _, _ in }
+        )
+
+        guard case .completed(let summary, _, let status) = result else {
+            Issue.record("Expected typed-event loop completion")
+            return
+        }
+
+        #expect(status == .verified)
+        #expect(summary.contains("Completion status: VERIFIED"))
+        #expect(streamedText == "Planning the next action.")
+        #expect(toolHints == ["noop_test"])
+        #expect(argumentHints == ["{}"])
+        #expect(executedToolNames == ["noop_test"])
+        #expect(
+            messages.contains(where: {
+                $0.role == "assistant"
+                    && ($0.content?.contains("Planning the next action.") == true)
+            })
+        )
     }
 }
 
@@ -427,6 +497,7 @@ private func completeTaskToolSpec() -> Tool {
 private actor SequencedWorkChatEngine: ChatEngineProtocol {
     enum Step {
         case tool(String, String)
+        case streamThenTool(deltas: [String], tool: String, args: String)
     }
 
     private var steps: [Step]
@@ -446,6 +517,15 @@ private actor SequencedWorkChatEngine: ChatEngineProtocol {
         switch step {
         case .tool(let name, let args):
             throw ServiceToolInvocation(toolName: name, jsonArguments: args)
+        case .streamThenTool(let deltas, let tool, let args):
+            return AsyncThrowingStream { continuation in
+                for delta in deltas {
+                    continuation.yield(delta)
+                }
+                continuation.finish(
+                    throwing: ServiceToolInvocation(toolName: tool, jsonArguments: args)
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Business rationale
This starts the P0 harness-contract work by removing a fragile boundary where orchestration paths inferred control flow from raw streamed text. A typed event seam reduces ambiguity in tool execution, makes streaming behavior easier to reason about, and gives later slices a safe place to unify chat, work, and HTTP behavior without widening this PR.

## Engineering rationale
The existing streaming/tool flow mixed plain model text, sentinel hint transport, stats hints, and authoritative tool invocations. This change introduces a first typed `InferenceEvent` contract and a single adapter that translates legacy stream output into explicit orchestration events once, instead of duplicating that translation logic in each caller.

## Exact scope
- add a typed inference-event seam in `Packages/OsaurusCore/Services/Inference/InferenceEvent.swift`
- adapt existing streaming/tool behavior into that contract, including immediate thrown tool invocations
- route `WorkExecutionEngine` through typed inference events for text, tool hints, stats, and tool execution
- route the OpenAI-compatible chat streaming path in `HTTPHandler` through the same contract
- add focused tests for event translation, immediate tool throws, spoof-resistance, and typed tool-call handling in the work loop

## Non-scope
- provider rewrites or a broader inference architecture refactor
- typed artifact emission beyond the current seam
- `ChatEngine.completeChat`, `HTTPHandler.handleAgentRunEndpoint`, other HTTP compatibility streams, and `PluginHostAPI`
- import/export security work or other parallel attachment/artifact tracks
- spreadsheet, PPTX, or financial-report work

## Validation results
- `swift test --filter InferenceEventAdapterTests --scratch-path /tmp/osaurus-spm --cache-path /tmp/osaurus-spm-cache`
- `swift test --filter WorkExecutionEngineTests --scratch-path /tmp/osaurus-spm --cache-path /tmp/osaurus-spm-cache`
- `swift test --filter HTTPHandlerChatStreamingTests --scratch-path /tmp/osaurus-spm --cache-path /tmp/osaurus-spm-cache`
- `swift build --scratch-path /tmp/osaurus-spm --cache-path /tmp/osaurus-spm-cache`

## Security and injection checks
Plain model text that looks like tool JSON or shared-artifact markers is preserved as `textDelta` and does not become typed control flow. Only authoritative transport-level tool invocations become `.toolCallRequested`, which prevents plain model output from spoofing typed tool/artifact control flow at the adapter boundary.

## Residual risks
Parity is still incomplete across remaining chat and HTTP entry points, and typed artifact emission is not unified yet. This PR intentionally stops at the first shared seam so the follow-on slices can migrate the remaining paths incrementally.
