### PR TITLE
[codex] Make ModelManager initialization deterministic

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -39,7 +39,7 @@ enum ModelListTab: String, CaseIterable, AnimatedTabItem {
 /// Download orchestration is handled by ModelDownloadService.
 @MainActor
 final class ModelManager: NSObject, ObservableObject {
-    static let shared = ModelManager()
+    static let shared = ModelManager(autoLoadOsaurusOrgModelsOnInit: true)
 
     let downloadService = ModelDownloadService.shared
 
@@ -165,11 +165,23 @@ final class ModelManager: NSObject, ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private var remoteSearchTask: Task<Void, Never>? = nil
+    private let autoLoadOsaurusOrgModelsOnInit: Bool
+    var autoLoadsOsaurusOrgModelsOnInit: Bool { autoLoadOsaurusOrgModelsOnInit }
 
     // MARK: - Initialization
     override init() {
+        autoLoadOsaurusOrgModelsOnInit = false
         super.init()
+        configure()
+    }
 
+    private init(autoLoadOsaurusOrgModelsOnInit: Bool) {
+        self.autoLoadOsaurusOrgModelsOnInit = autoLoadOsaurusOrgModelsOnInit
+        super.init()
+        configure()
+    }
+
+    private func configure() {
         loadAvailableModels()
 
         NotificationCenter.default.publisher(for: .localModelsChanged)
@@ -186,8 +198,11 @@ final class ModelManager: NSObject, ObservableObject {
             }
             .store(in: &cancellables)
 
-        // Pull the OsaurusAI HF org listing once on launch so newly published
-        // models surface in the Recommended tab without requiring a code push.
+        guard autoLoadOsaurusOrgModelsOnInit else { return }
+
+        // Only the shared production manager should kick off a background
+        // org refresh on construction. Ad-hoc instances are used heavily in
+        // tests and should remain deterministic until explicitly refreshed.
         Task { [weak self] in await self?.loadOsaurusAIOrgModels() }
     }
 

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -15,6 +15,11 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Curated catalog
 
+    @Test func adHocManager_doesNotAutoLoadOrgModelsOnInit() async {
+        let autoLoads = await MainActor.run { ModelManager().autoLoadsOsaurusOrgModelsOnInit }
+        #expect(autoLoads == false)
+    }
+
     @Test func curatedSuggestedIds_includesNewMiniMaxEntries() {
         let ids = ModelManager.curatedSuggestedIds
         #expect(ids.contains("osaurusai/minimax-m2.7-jangtq4"))
@@ -25,8 +30,8 @@ struct ModelManagerSuggestedTests {
         let suggested = await MainActor.run { ModelManager().suggestedModels }
         let curatedIds = ModelManager.curatedSuggestedIds
         let suggestedIds = Set(suggested.map { $0.id.lowercased() })
-        // On a fresh manager (before any HF fetch resolves), `suggestedModels`
-        // is exactly the curated catalog.
+        // Ad-hoc managers stay on the curated catalog until code explicitly
+        // asks for the OsaurusAI org refresh.
         #expect(suggestedIds == curatedIds)
     }
 


### PR DESCRIPTION
## What changed
- make plain `ModelManager()` instances deterministic by removing the automatic OsaurusAI org refresh from the default initializer
- keep the production behavior on `ModelManager.shared` by letting only the shared singleton auto-load the OsaurusAI org on construction
- add a regression test that locks the ad-hoc initializer contract and keep the suggested-model assertions tied to explicit refresh behavior

## Root cause
`ModelManager.init()` was kicking off `loadOsaurusAIOrgModels()` in a background task. Tests instantiate fresh ad-hoc managers and then assert synchronous `suggestedModels` state, so the background network fetch could race those assertions and overwrite test-injected data. That is why `ModelManagerSuggestedTests.applyOsaurusOrgFetch_addsNewEntriesAfterCurated()` failed in CI even though the harness PR did not touch `ModelManager`.

## Why this fix
The underlying issue is constructor side effects, not the harness contract work. Moving the auto-refresh behavior behind the shared production singleton preserves app behavior while making ad-hoc/test instances deterministic until code explicitly asks for the OsaurusAI org refresh.

## Scope
- `Packages/OsaurusCore/Managers/Model/ModelManager.swift`
- `Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift`

## Non-scope
- harness contract work
- model catalog behavior changes beyond initialization determinism
- any broader network or test infrastructure refactor

## Validation
- `swift test --filter ModelManagerSuggestedTests --scratch-path /tmp/osaurus-pr887-spm --cache-path /tmp/osaurus-pr887-spm-cache` in a clean merge-result worktree
- `xcodebuild test -workspace osaurus.xcworkspace -scheme OsaurusCoreTests -disableAutomaticPackageResolution -clonedSourcePackagesDirPath /tmp/osaurus-pr887-spm -resultBundlePath /tmp/modelmanager-ci.xcresult -skipPackagePluginValidation -skipMacroValidation -enableCodeCoverage NO -test-timeouts-enabled YES -default-test-execution-time-allowance 60 -maximum-test-execution-time-allowance 120 COMPILER_INDEX_STORE_ENABLE=NO SWIFT_COMPILATION_MODE=incremental -only-testing:OsaurusCoreTests/ModelManagerSuggestedTests -destination 'platform=macOS'`

## Risk
Low. The only behavioral change is that ad-hoc `ModelManager()` instances no longer mutate themselves via a background network task at construction time. `ModelManager.shared` still performs the production auto-refresh.
