### PR TITLE
[codex] Stabilize agent loop control tools

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -168,7 +168,8 @@ struct AutoThinkingProfile: ModelProfile {
     static let displayName = "Thinking"
 
     static func matches(modelId: String) -> Bool {
-        LocalReasoningCapability.capability(forModelId: modelId).hasEnableThinkingKwarg
+        let capability = LocalReasoningCapability.capability(forModelId: modelId)
+        return capability.hasEnableThinkingKwarg && capability.supportsThinking
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -568,6 +568,7 @@ public struct SystemPromptComposer: Sendable {
         }
 
         if isManual {
+            add(ToolRegistry.shared.specs(forTools: Array(ToolRegistry.agentLoopControlToolNames)))
             if executionMode.usesSandboxTools {
                 add(filtered(ToolRegistry.shared.sandboxBuiltInSpecs(mode: executionMode)))
             }

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -86,11 +86,15 @@ struct ChatViewSandboxTests {
     @Test
     func alwaysLoadedSpecs_includesCapabilityTools() {
         let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: .none)
+        let names = Set(specs.map { $0.function.name })
 
-        #expect(specs.contains(where: { $0.function.name == "capabilities_search" }))
-        #expect(specs.contains(where: { $0.function.name == "capabilities_load" }))
-        #expect(specs.contains(where: { $0.function.name == "methods_save" }))
-        #expect(specs.contains(where: { $0.function.name == "methods_report" }))
+        #expect(names.contains("capabilities_search"))
+        #expect(names.contains("capabilities_load"))
+        #expect(names.contains("methods_save"))
+        #expect(names.contains("methods_report"))
+        for loopTool in ToolRegistry.agentLoopControlToolNames {
+            #expect(names.contains(loopTool), "missing loop control tool: \(loopTool)")
+        }
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -56,6 +56,17 @@ struct SystemPromptComposerToolResolutionTests {
         body()
     }
 
+    private var loopControlNames: Set<String> {
+        ToolRegistry.agentLoopControlToolNames
+    }
+
+    private func expectLoopControlsPresent(_ tools: [Tool]) {
+        let names = Set(tools.map { $0.function.name })
+        for name in loopControlNames {
+            #expect(names.contains(name), "missing loop control tool: \(name)")
+        }
+    }
+
     // MARK: - Auto mode
 
     @Test
@@ -69,6 +80,7 @@ struct SystemPromptComposerToolResolutionTests {
             )
             // Built-ins like capabilities_search must be present in auto mode.
             #expect(tools.contains { $0.function.name == "capabilities_search" })
+            expectLoopControlsPresent(tools)
         }
     }
 
@@ -81,9 +93,11 @@ struct SystemPromptComposerToolResolutionTests {
                 agentId: agentId,
                 executionMode: .none
             )
-            // Manual mode is strict: nothing besides the user's selection.
-            #expect(tools.count == 1)
-            #expect(tools.first?.function.name == "render_chart")
+            // Manual mode is strict except for agent-loop controls, which
+            // are the chat runtime contract rather than optional capability
+            // tools.
+            let names = Set(tools.map { $0.function.name })
+            #expect(names == loopControlNames.union(["render_chart"]))
             // Capability discovery tools must be absent.
             #expect(tools.contains { $0.function.name == "capabilities_search" } == false)
             // Memory/graph/charts built-ins must NOT leak in.
@@ -100,6 +114,7 @@ struct SystemPromptComposerToolResolutionTests {
                     executionMode: .sandbox
                 )
                 #expect(tools.contains { $0.function.name == "render_chart" })
+                expectLoopControlsPresent(tools)
                 // Sandbox built-ins are additive when sandbox is active.
                 #expect(tools.contains { $0.function.name == "sandbox_exec" })
                 // Non-sandbox built-ins are still excluded.
@@ -122,7 +137,9 @@ struct SystemPromptComposerToolResolutionTests {
                 // registry's snapshot rather than a name prefix.
                 let names = Set(tools.map { $0.function.name })
                 let allowed = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+                    .union(loopControlNames)
                 #expect(names.isSubset(of: allowed) || names.isEmpty)
+                expectLoopControlsPresent(tools)
                 // Built-ins like capabilities_search MUST NOT be there.
                 #expect(names.contains("capabilities_search") == false)
             }

--- a/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
@@ -134,6 +134,18 @@ struct AgentLoopToolsTests {
         #expect(CompleteTool.validate(summary: "Wrote app.py and ran swift test, 12 passed.") == nil)
     }
 
+    @Test
+    @MainActor
+    func complete_interceptRejectsInvalidSummary() {
+        #expect(ChatSession.validatedCompleteSummary(from: #"{"summary": "done"}"#) == nil)
+        #expect(
+            ChatSession.validatedCompleteSummary(
+                from: #"{"summary": "Updated the loop tool schema and verified with targeted tests."}"#
+            )
+                == "Updated the loop tool schema and verified with targeted tests."
+        )
+    }
+
     // MARK: - clarify
 
     @Test
@@ -148,5 +160,15 @@ struct AgentLoopToolsTests {
     func clarify_rejectsEmptyQuestion() async throws {
         let result = try await ClarifyTool().execute(argumentsJSON: #"{"question": ""}"#)
         #expect(result.contains("non-empty"))
+    }
+
+    @Test
+    @MainActor
+    func clarify_interceptRejectsEmptyQuestion() {
+        #expect(ChatSession.validatedClarifyQuestion(from: #"{"question": ""}"#) == nil)
+        #expect(
+            ChatSession.validatedClarifyQuestion(from: #"{"question": "Use Postgres or SQLite?"}"#)
+                == "Use Postgres or SQLite?"
+        )
     }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -17,13 +17,10 @@ final class ToolRegistry: ObservableObject {
     /// Names of tools registered via registerBuiltInTools (always loaded).
     private(set) var builtInToolNames: Set<String> = []
 
-    /// Tool names that are reserved for agent-loop intercepts and must NOT
-    /// appear in the schema sent to the model. They stay registered so the
-    /// chat engine can dispatch them internally if it ever needs to surface
-    /// them (e.g. mid-loop nudge), but the model never sees them by default.
-    /// Hiding them keeps the schema small and prevents the model from
-    /// pattern-matching the names into "I should plan" behaviour.
-    static let agentInterceptToolNames: Set<String> = ["todo", "complete", "clarify"]
+    /// Agent-loop control tools. These are real model-visible tools, but the
+    /// chat engine intercepts their results to update inline state, pause, or
+    /// end the loop.
+    static let agentLoopControlToolNames: Set<String> = ["todo", "complete", "clarify"]
 
     /// Tool names that require the sandbox container to be running
     private var sandboxToolNames: Set<String> = []
@@ -175,11 +172,8 @@ final class ToolRegistry: ObservableObject {
     }
 
     /// Get specs for specific tools by name (ignores enabled state).
-    /// Agent-intercept tools are filtered out — they never appear in the
-    /// schema sent to the model.
     func specs(forTools toolNames: [String]) -> [Tool] {
         return toolNames.compactMap { name in
-            guard !Self.agentInterceptToolNames.contains(name) else { return nil }
             return toolsByName[name]?.asOpenAITool()
         }
     }
@@ -726,7 +720,6 @@ final class ToolRegistry: ObservableObject {
                 builtInNames.contains(tool.name) || runtimeNames.contains(tool.name)
             }
             .filter { !excluded.contains($0.name) }
-            .filter { !Self.agentInterceptToolNames.contains($0.name) }
             .filter { !excludeCapabilityTools || !Self.capabilityToolNames.contains($0.name) }
             .sorted { $0.name < $1.name }
             .map { $0.asOpenAITool() }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -223,6 +223,13 @@ final class ChatSession: ObservableObject {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func validatedCompleteSummary(from json: String) -> String? {
+        guard let summary = parseCompleteSummary(from: json),
+            CompleteTool.validate(summary: summary) == nil
+        else { return nil }
+        return summary
+    }
+
     /// Pull `question` out of a `clarify(...)` tool call's JSON body.
     static func parseClarifyQuestion(from json: String) -> String? {
         guard let data = json.data(using: .utf8),
@@ -231,6 +238,10 @@ final class ChatSession: ObservableObject {
         else { return nil }
         let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func validatedClarifyQuestion(from json: String) -> String? {
+        parseClarifyQuestion(from: json)
     }
 
     /// Apply initial model selection after agentId is set (for cached picker items)
@@ -1398,22 +1409,25 @@ final class ChatSession: ObservableObject {
                             if !isRunActive(runId) { break outer }
 
                             // Agent-loop intercepts: `complete` and `clarify`
-                            // end the iteration loop. `todo` already wrote
-                            // into AgentTodoStore via TaskLocal; the session
-                            // observer mirrors it into the inline UI block.
-                            // Break out of the outer iteration loop so we
-                            // don't keep prompting the model for more.
+                            // end the iteration loop only after their control
+                            // payloads validate. Invalid calls fall through as
+                            // normal tool results so the model can recover on
+                            // the next iteration.
                             if inv.toolName == "complete" {
-                                self.lastCompletionSummary =
-                                    Self.parseCompleteSummary(from: inv.jsonArguments) ?? resultText
-                                self.lastClarifyQuestion = nil
-                                break outer
+                                if let summary = Self.validatedCompleteSummary(from: inv.jsonArguments) {
+                                    self.lastCompletionSummary = summary
+                                    self.lastClarifyQuestion = nil
+                                    break outer
+                                }
+                                self.lastCompletionSummary = nil
                             }
                             if inv.toolName == "clarify" {
-                                self.lastClarifyQuestion =
-                                    Self.parseClarifyQuestion(from: inv.jsonArguments)
-                                self.lastCompletionSummary = nil
-                                break outer
+                                if let question = Self.validatedClarifyQuestion(from: inv.jsonArguments) {
+                                    self.lastClarifyQuestion = question
+                                    self.lastCompletionSummary = nil
+                                    break outer
+                                }
+                                self.lastClarifyQuestion = nil
                             }
 
                             // Hot-load tools injected by capabilities_load or sandbox_plugin_register.

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -22,7 +22,7 @@ There is no separate "Agent" or "Work" tab — the same chat window handles a on
                                      loop ends
 ```
 
-The chat engine intercepts three special tools so the loop has structure without a separate planner: `todo`, `complete`, and `clarify`. Every other tool (file, sandbox, plugin, MCP, …) just runs and returns its output to the model on the next turn.
+The chat engine exposes and intercepts three control tools so the loop has structure without a separate planner: `todo`, `complete`, and `clarify`. They are model-visible whenever tools are enabled, including manual tool-selection mode, because they are the chat runtime contract rather than optional capabilities. Every other tool (file, sandbox, plugin, MCP, …) just runs and returns its output to the model on the next turn.
 
 ---
 

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -1,0 +1,81 @@
+# Development Plan
+
+This plan treats PR #893 as the architectural baseline: Osaurus is a single Chat / Agent Loop product, not a split Chat Mode plus Work Mode product.
+
+The development path starts by making the Agent Loop contract reliable, then moves the remaining planned work onto that chat-native foundation.
+
+---
+
+## 1. Stabilize the Agent Loop Contract
+
+**Goal:** Make every chat capable of reliable autonomous work when tools are enabled.
+
+The loop controls are `todo(markdown)`, `clarify(question)`, and `complete(summary)`. They are real model-visible tools in both auto and manual tool modes. They are omitted only when tools are explicitly disabled.
+
+Implementation requirements:
+
+- `todo` writes or replaces the visible session checklist and then lets the model continue.
+- `complete` ends the loop only after summary validation passes.
+- invalid `complete` calls return a tool error/result and do not end the loop.
+- `clarify` pauses visible chat only after a non-empty question is supplied.
+- invalid `clarify` calls return a tool error/result and do not pause.
+
+Business rationale: this makes the new single Chat / Agent architecture reliable enough to replace Work Mode without teaching local models a second execution protocol.
+
+---
+
+## 2. Harden Chat Artifacts
+
+**Goal:** Preserve user trust as Work artifacts move into chat.
+
+Artifacts must be safe by default:
+
+- sanitize filenames;
+- reject path traversal and sibling-prefix attacks;
+- keep host-folder sources inside the selected folder;
+- keep sandbox sources inside the expected sandbox workspace or agent directory;
+- persist surfaced artifacts under the chat artifact directory.
+
+Business rationale: once chat becomes the execution surface, generated files and copied files must obey the same trust boundary every time.
+
+---
+
+## 3. Build the Import/Export Capability Registry
+
+**Goal:** Make file import/export extensible instead of hard-coded.
+
+Document and artifact support should be registry-backed. The registry should describe supported extensions, trust level, active-content risk, prompt-ingestion behavior, icon metadata, and scaffold-only capabilities.
+
+Business rationale: Osaurus can add formats and exporters without scattering file-extension logic through parser and UI code.
+
+---
+
+## 4. Adopt Typed Inference Events
+
+**Goal:** Replace fragile sentinel-string handling with typed streaming events.
+
+Typed events should represent text deltas, single tool requests, batched tool requests, metadata/stats, and completion. Tool execution remains authoritative only on tool-request events; display-only argument deltas are not execution triggers.
+
+Business rationale: this improves API compatibility, local model tool calling, and streaming correctness.
+
+---
+
+## 5. Merge MLX Runtime Tuning
+
+**Goal:** Improve local model reliability without regressing lower-memory Macs.
+
+Runtime tuning should be RAM-aware, deterministic under test, conservative on low-memory systems, and compatible with JANG tool-call format resolution.
+
+Business rationale: the harness compounds only if local inference remains fast and stable across common Apple Silicon machines.
+
+---
+
+## 6. Add Durable State Only Where It Is Justified
+
+**Goal:** Cover real product gaps without rebuilding Work Mode.
+
+Persist state only when it is needed after restart, required by an API caller, needed for audit/undo/security, or impossible to reconstruct from the chat transcript.
+
+Likely candidates are persistent todo history, artifact index metadata, file-operation review history, and machine-readable background task events.
+
+Business rationale: this keeps the product simpler while preserving the specific durability users and integrations actually need.


### PR DESCRIPTION
## Business rationale

PR #893 moves Osaurus away from a separate Work Mode and into a single Chat / Agent Loop product surface. That direction only works if the loop controls are reliable for the model. This PR makes `todo`, `clarify`, and `complete` first-class model-visible control tools so local models have a concrete schema for planning, pausing, and finishing work instead of relying on hidden prompt conventions.

## Design rationale

This follows the new design principle: Chat is the product surface, tools are the capability surface, and the Agent Loop is the behavior. Loop controls are not optional plugin capabilities; they are the runtime contract of chat-native autonomous execution. For that reason they are visible in both auto and manual tool-selection modes whenever tools are enabled.

## Technical explanation

- Stops filtering `todo`, `complete`, and `clarify` out of tool schemas.
- Adds loop controls to manual tool mode while preserving strict exclusion of unrelated always-loaded tools.
- Keeps the existing chat-engine intercept behavior, but validates `complete(summary)` and `clarify(question)` before ending or pausing the loop.
- Lets invalid loop-control calls fall through as normal tool results so the model can recover on the next iteration.
- Tightens automatic thinking-profile matching so Gemma templates that mention `enable_thinking` without compatible `<think>` stream support do not expose a misleading reasoning toggle.
- Adds `docs/DEVELOPMENT_PLAN.md` to make the PR #893-aligned development sequence explicit.

## Compatibility notes

Manual tool mode still excludes discovery, memory, and other unrelated built-ins unless selected. The intentional compatibility change is that Agent Loop controls are always available when tools are enabled, because they define chat task control rather than external capability access.

## Tests run

- `swift test --package-path Packages/OsaurusCore --scratch-path /tmp/osauruscore-pr893-pr1-build --filter 'ModelProfileRegistryTests|AgentLoopToolsTests|SystemPromptComposerToolResolutionTests|ChatViewSandboxTests'`
  - 35 tests in 4 suites passed.
- `swift test --package-path Packages/OsaurusCore --scratch-path /tmp/osauruscore-pr893-pr1-build`
  - 743 tests in 109 suites passed.
  - `SandboxIntegrationTests` skipped by the existing `OSAURUS_RUN_SANDBOX_INTEGRATION_TESTS=1` environment gate.
- `git diff --check`
- conflict-marker scan with `rg`.

## Risk

The main risk is increased schema surface for manual-mode agents. The mitigation is small: only three one-field control tools are added, while unrelated always-loaded tools remain excluded. The benefit is that local models get an explicit, test-backed way to drive the new Agent Loop architecture.
