### PR TITLE
[codex] Harden chat shared artifacts

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
+++ b/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
@@ -160,7 +160,7 @@ extension SharedArtifact {
     /// Raw parsed content extracted from the marker-delimited region.
     struct ParsedMarkers {
         var metadata: [String: Any]
-        let filename: String
+        var filename: String
         let contentLines: [String]
         let startRange: Range<String.Index>
         let endRange: Range<String.Index>
@@ -218,9 +218,22 @@ extension SharedArtifact {
         let hasContent = parsed.metadata["has_content"] as? Bool ?? false
         let path = parsed.metadata["path"] as? String
 
+        guard let sanitizedFilename = sanitizeArtifactFilename(parsed.filename) else {
+            NSLog("[SharedArtifact] Refused invalid artifact filename '%@'", parsed.filename)
+            return nil
+        }
+        if sanitizedFilename != parsed.filename {
+            NSLog("[SharedArtifact] Sanitized artifact filename '%@' -> '%@'", parsed.filename, sanitizedFilename)
+        }
+        parsed.filename = sanitizedFilename
+        parsed.metadata["filename"] = sanitizedFilename
+
         let contextDir = OsaurusPaths.contextArtifactsDir(contextId: contextId)
         OsaurusPaths.ensureExistsSilent(contextDir)
-        let destPath = contextDir.appendingPathComponent(parsed.filename)
+        guard let destPath = resolveDestinationPath(filename: parsed.filename, contextDir: contextDir) else {
+            NSLog("[SharedArtifact] Refused destination path for filename '%@'", parsed.filename)
+            return nil
+        }
 
         let artifact: SharedArtifact
         let contentLines: [String]
@@ -389,30 +402,83 @@ extension SharedArtifact {
                 relativePath = String(relativePath.dropFirst(containerHome.count + 1))
             } else if relativePath.hasPrefix("/workspace/") {
                 let stripped = String(relativePath.dropFirst("/workspace/".count))
-                let candidate = OsaurusPaths.containerWorkspace().appendingPathComponent(stripped)
-                if fm.fileExists(atPath: candidate.path) { return candidate }
+                return resolveContainedPath(stripped, within: OsaurusPaths.containerWorkspace())
             }
             if relativePath.hasPrefix("./") {
                 relativePath = String(relativePath.dropFirst(2))
             }
+            guard !relativePath.hasPrefix("/") else { return nil }
 
-            let primary = agentDir.appendingPathComponent(relativePath)
-            if fm.fileExists(atPath: primary.path) { return primary }
+            if let primary = resolveContainedPath(relativePath, within: agentDir),
+                fm.fileExists(atPath: primary.path)
+            {
+                return primary
+            }
 
             // Basename fallback in common output subdirectories
-            let basename = (path as NSString).lastPathComponent
+            guard let basename = extractPathComponent(path) else { return nil }
             for sub in ["output", "out", "build", "dist"] {
-                let attempt = agentDir.appendingPathComponent(sub).appendingPathComponent(basename)
-                if fm.fileExists(atPath: attempt.path) { return attempt }
+                if let attempt = resolveContainedPath("\(sub)/\(basename)", within: agentDir),
+                    fm.fileExists(atPath: attempt.path)
+                {
+                    return attempt
+                }
             }
             return nil
 
         case .hostFolder(let ctx):
-            return ctx.rootPath.appendingPathComponent(path)
+            let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedPath.hasPrefix("/") else { return nil }
+            return resolveContainedPath(trimmedPath, within: ctx.rootPath)
 
         case .none:
             return nil
         }
+    }
+
+    private static func resolveDestinationPath(filename: String, contextDir: URL) -> URL? {
+        let contextRoot = canonicalizedURL(contextDir)
+        let destination = contextRoot.appendingPathComponent(filename).standardizedFileURL
+        guard isContained(destination, in: contextRoot) else { return nil }
+        return destination
+    }
+
+    private static func resolveContainedPath(_ rawPath: String, within root: URL) -> URL? {
+        let trimmedPath = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty else { return nil }
+
+        let rootURL = canonicalizedURL(root)
+        let candidate =
+            trimmedPath.hasPrefix("/")
+            ? URL(fileURLWithPath: trimmedPath)
+            : rootURL.appendingPathComponent(trimmedPath)
+        let resolved = canonicalizedURL(candidate)
+
+        guard isContained(resolved, in: rootURL) else { return nil }
+        return resolved
+    }
+
+    private static func sanitizeArtifactFilename(_ rawFilename: String) -> String? {
+        extractPathComponent(rawFilename)
+    }
+
+    private static func extractPathComponent(_ rawPath: String) -> String? {
+        let normalized = rawPath.replacingOccurrences(of: "\\", with: "/")
+        let basename = (normalized as NSString).lastPathComponent
+        let sanitized = basename.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+        let cleaned = String(String.UnicodeScalarView(sanitized)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty, cleaned != ".", cleaned != ".." else { return nil }
+        return cleaned
+    }
+
+    private static func canonicalizedURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    private static func isContained(_ candidate: URL, in root: URL) -> Bool {
+        let candidatePath = candidate.path
+        let rootPath = root.path
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
     }
 
     private static func rebuildToolResult(

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -168,7 +168,8 @@ struct AutoThinkingProfile: ModelProfile {
     static let displayName = "Thinking"
 
     static func matches(modelId: String) -> Bool {
-        LocalReasoningCapability.capability(forModelId: modelId).hasEnableThinkingKwarg
+        let capability = LocalReasoningCapability.capability(forModelId: modelId)
+        return capability.hasEnableThinkingKwarg && capability.supportsThinking
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -568,6 +568,7 @@ public struct SystemPromptComposer: Sendable {
         }
 
         if isManual {
+            add(ToolRegistry.shared.specs(forTools: Array(ToolRegistry.agentLoopControlToolNames)))
             if executionMode.usesSandboxTools {
                 add(filtered(ToolRegistry.shared.sandboxBuiltInSpecs(mode: executionMode)))
             }

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -86,11 +86,15 @@ struct ChatViewSandboxTests {
     @Test
     func alwaysLoadedSpecs_includesCapabilityTools() {
         let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: .none)
+        let names = Set(specs.map { $0.function.name })
 
-        #expect(specs.contains(where: { $0.function.name == "capabilities_search" }))
-        #expect(specs.contains(where: { $0.function.name == "capabilities_load" }))
-        #expect(specs.contains(where: { $0.function.name == "methods_save" }))
-        #expect(specs.contains(where: { $0.function.name == "methods_report" }))
+        #expect(names.contains("capabilities_search"))
+        #expect(names.contains("capabilities_load"))
+        #expect(names.contains("methods_save"))
+        #expect(names.contains("methods_report"))
+        for loopTool in ToolRegistry.agentLoopControlToolNames {
+            #expect(names.contains(loopTool), "missing loop control tool: \(loopTool)")
+        }
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/SharedArtifactSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SharedArtifactSecurityTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Shared artifact trust boundary hardening", .serialized)
+struct SharedArtifactSecurityTests {
+
+    @Test func processToolResult_sanitizesDestinationFilename() throws {
+        let contextId = "artifact-dest-\(UUID().uuidString)"
+        defer { cleanupArtifacts(contextId: contextId) }
+
+        let toolResult = try makeToolResult(
+            metadata: [
+                "filename": "../exports/../../quarterly.md",
+                "mime_type": "text/plain",
+                "has_content": true,
+            ],
+            contentLines: ["safe payload"]
+        )
+
+        let processed = try #require(
+            SharedArtifact.processToolResult(
+                toolResult,
+                contextId: contextId,
+                contextType: .chat,
+                executionMode: .none
+            )
+        )
+
+        let contextDir = OsaurusPaths.contextArtifactsDir(contextId: contextId).resolvingSymlinksInPath()
+        let artifactURL = URL(fileURLWithPath: processed.artifact.hostPath).resolvingSymlinksInPath()
+
+        #expect(processed.artifact.filename == "quarterly.md")
+        #expect(artifactURL.deletingLastPathComponent().path == contextDir.path)
+        #expect(FileManager.default.fileExists(atPath: artifactURL.path))
+
+        let enrichedArtifact = try #require(SharedArtifact.fromEnrichedToolResult(processed.enrichedToolResult))
+        #expect(enrichedArtifact.filename == "quarterly.md")
+    }
+
+    @Test func processToolResult_rejectsInvalidDestinationFilename() throws {
+        let contextId = "artifact-invalid-\(UUID().uuidString)"
+        defer { cleanupArtifacts(contextId: contextId) }
+
+        let toolResult = try makeToolResult(
+            metadata: [
+                "filename": "../..",
+                "mime_type": "text/plain",
+                "has_content": true,
+            ],
+            contentLines: ["unsafe payload"]
+        )
+
+        let processed = SharedArtifact.processToolResult(
+            toolResult,
+            contextId: contextId,
+            contextType: .chat,
+            executionMode: .none
+        )
+
+        #expect(processed == nil)
+    }
+
+    @Test func processToolResult_rejectsHostFolderPathTraversal() throws {
+        try withTemporaryWorkspace { root in
+            let contextId = "artifact-host-\(UUID().uuidString)"
+            defer { cleanupArtifacts(contextId: contextId) }
+
+            let fm = FileManager.default
+            let workspaceRoot = root.appendingPathComponent("workspace", isDirectory: true)
+            let outsideFile = root.appendingPathComponent("outside.txt")
+            try fm.createDirectory(at: workspaceRoot, withIntermediateDirectories: true)
+            try Data("outside".utf8).write(to: outsideFile)
+
+            let context = FolderContext(
+                rootPath: workspaceRoot,
+                projectType: .unknown,
+                tree: "",
+                manifest: nil,
+                gitStatus: nil,
+                isGitRepo: false
+            )
+            let toolResult = try makeToolResult(
+                metadata: [
+                    "filename": "artifact.txt",
+                    "mime_type": "text/plain",
+                    "path": "../outside.txt",
+                    "has_content": false,
+                ]
+            )
+
+            let processed = SharedArtifact.processToolResult(
+                toolResult,
+                contextId: contextId,
+                contextType: .chat,
+                executionMode: .hostFolder(context)
+            )
+
+            #expect(processed == nil)
+        }
+    }
+
+    @Test func processToolResult_rejectsAbsoluteHostFolderSourcePath() throws {
+        try withTemporaryWorkspace { root in
+            let contextId = "artifact-host-absolute-\(UUID().uuidString)"
+            defer { cleanupArtifacts(contextId: contextId) }
+
+            let fm = FileManager.default
+            let workspaceRoot = root.appendingPathComponent("workspace", isDirectory: true)
+            let sourceFile = workspaceRoot.appendingPathComponent("safe.txt")
+            try fm.createDirectory(at: workspaceRoot, withIntermediateDirectories: true)
+            try Data("safe".utf8).write(to: sourceFile)
+
+            let context = FolderContext(
+                rootPath: workspaceRoot,
+                projectType: .unknown,
+                tree: "",
+                manifest: nil,
+                gitStatus: nil,
+                isGitRepo: false
+            )
+            let toolResult = try makeToolResult(
+                metadata: [
+                    "filename": "artifact.txt",
+                    "mime_type": "text/plain",
+                    "path": sourceFile.path,
+                    "has_content": false,
+                ]
+            )
+
+            let processed = SharedArtifact.processToolResult(
+                toolResult,
+                contextId: contextId,
+                contextType: .chat,
+                executionMode: .hostFolder(context)
+            )
+
+            #expect(processed == nil)
+        }
+    }
+
+    @Test func processToolResult_rejectsSandboxPathTraversal() throws {
+        let agentName = "artifact-security-agent-\(UUID().uuidString)"
+        let contextId = "artifact-sandbox-\(UUID().uuidString)"
+        defer { cleanupArtifacts(contextId: contextId) }
+
+        let toolResult = try makeToolResult(
+            metadata: [
+                "filename": "artifact.txt",
+                "mime_type": "text/plain",
+                "path": "/workspace/agents/\(agentName)/../../../outside.txt",
+                "has_content": false,
+            ]
+        )
+
+        let processed = SharedArtifact.processToolResult(
+            toolResult,
+            contextId: contextId,
+            contextType: .chat,
+            executionMode: .sandbox,
+            sandboxAgentName: agentName
+        )
+
+        #expect(processed == nil)
+    }
+
+    private func withTemporaryWorkspace(_ body: (URL) throws -> Void) throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("osaurus-artifact-security-\(UUID().uuidString)", isDirectory: true)
+
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+
+        defer {
+            try? fm.removeItem(at: root)
+        }
+
+        try body(root)
+    }
+
+    private func cleanupArtifacts(contextId: String) {
+        try? FileManager.default.removeItem(at: OsaurusPaths.contextArtifactsDir(contextId: contextId))
+    }
+
+    private func makeToolResult(
+        metadata: [String: Any],
+        contentLines: [String] = []
+    ) throws -> String {
+        let metadataData = try JSONSerialization.data(withJSONObject: metadata)
+        let metadataLine = String(data: metadataData, encoding: .utf8) ?? "{}"
+        let contentBlock = contentLines.isEmpty ? "" : "\n" + contentLines.joined(separator: "\n")
+        return SharedArtifact.startMarker + metadataLine + contentBlock + SharedArtifact.endMarker
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -56,6 +56,17 @@ struct SystemPromptComposerToolResolutionTests {
         body()
     }
 
+    private var loopControlNames: Set<String> {
+        ToolRegistry.agentLoopControlToolNames
+    }
+
+    private func expectLoopControlsPresent(_ tools: [Tool]) {
+        let names = Set(tools.map { $0.function.name })
+        for name in loopControlNames {
+            #expect(names.contains(name), "missing loop control tool: \(name)")
+        }
+    }
+
     // MARK: - Auto mode
 
     @Test
@@ -69,6 +80,7 @@ struct SystemPromptComposerToolResolutionTests {
             )
             // Built-ins like capabilities_search must be present in auto mode.
             #expect(tools.contains { $0.function.name == "capabilities_search" })
+            expectLoopControlsPresent(tools)
         }
     }
 
@@ -81,9 +93,11 @@ struct SystemPromptComposerToolResolutionTests {
                 agentId: agentId,
                 executionMode: .none
             )
-            // Manual mode is strict: nothing besides the user's selection.
-            #expect(tools.count == 1)
-            #expect(tools.first?.function.name == "render_chart")
+            // Manual mode is strict except for agent-loop controls, which
+            // are the chat runtime contract rather than optional capability
+            // tools.
+            let names = Set(tools.map { $0.function.name })
+            #expect(names == loopControlNames.union(["render_chart"]))
             // Capability discovery tools must be absent.
             #expect(tools.contains { $0.function.name == "capabilities_search" } == false)
             // Memory/graph/charts built-ins must NOT leak in.
@@ -100,6 +114,7 @@ struct SystemPromptComposerToolResolutionTests {
                     executionMode: .sandbox
                 )
                 #expect(tools.contains { $0.function.name == "render_chart" })
+                expectLoopControlsPresent(tools)
                 // Sandbox built-ins are additive when sandbox is active.
                 #expect(tools.contains { $0.function.name == "sandbox_exec" })
                 // Non-sandbox built-ins are still excluded.
@@ -122,7 +137,9 @@ struct SystemPromptComposerToolResolutionTests {
                 // registry's snapshot rather than a name prefix.
                 let names = Set(tools.map { $0.function.name })
                 let allowed = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+                    .union(loopControlNames)
                 #expect(names.isSubset(of: allowed) || names.isEmpty)
+                expectLoopControlsPresent(tools)
                 // Built-ins like capabilities_search MUST NOT be there.
                 #expect(names.contains("capabilities_search") == false)
             }

--- a/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
@@ -134,6 +134,18 @@ struct AgentLoopToolsTests {
         #expect(CompleteTool.validate(summary: "Wrote app.py and ran swift test, 12 passed.") == nil)
     }
 
+    @Test
+    @MainActor
+    func complete_interceptRejectsInvalidSummary() {
+        #expect(ChatSession.validatedCompleteSummary(from: #"{"summary": "done"}"#) == nil)
+        #expect(
+            ChatSession.validatedCompleteSummary(
+                from: #"{"summary": "Updated the loop tool schema and verified with targeted tests."}"#
+            )
+                == "Updated the loop tool schema and verified with targeted tests."
+        )
+    }
+
     // MARK: - clarify
 
     @Test
@@ -148,5 +160,15 @@ struct AgentLoopToolsTests {
     func clarify_rejectsEmptyQuestion() async throws {
         let result = try await ClarifyTool().execute(argumentsJSON: #"{"question": ""}"#)
         #expect(result.contains("non-empty"))
+    }
+
+    @Test
+    @MainActor
+    func clarify_interceptRejectsEmptyQuestion() {
+        #expect(ChatSession.validatedClarifyQuestion(from: #"{"question": ""}"#) == nil)
+        #expect(
+            ChatSession.validatedClarifyQuestion(from: #"{"question": "Use Postgres or SQLite?"}"#)
+                == "Use Postgres or SQLite?"
+        )
     }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -17,13 +17,10 @@ final class ToolRegistry: ObservableObject {
     /// Names of tools registered via registerBuiltInTools (always loaded).
     private(set) var builtInToolNames: Set<String> = []
 
-    /// Tool names that are reserved for agent-loop intercepts and must NOT
-    /// appear in the schema sent to the model. They stay registered so the
-    /// chat engine can dispatch them internally if it ever needs to surface
-    /// them (e.g. mid-loop nudge), but the model never sees them by default.
-    /// Hiding them keeps the schema small and prevents the model from
-    /// pattern-matching the names into "I should plan" behaviour.
-    static let agentInterceptToolNames: Set<String> = ["todo", "complete", "clarify"]
+    /// Agent-loop control tools. These are real model-visible tools, but the
+    /// chat engine intercepts their results to update inline state, pause, or
+    /// end the loop.
+    static let agentLoopControlToolNames: Set<String> = ["todo", "complete", "clarify"]
 
     /// Tool names that require the sandbox container to be running
     private var sandboxToolNames: Set<String> = []
@@ -175,11 +172,8 @@ final class ToolRegistry: ObservableObject {
     }
 
     /// Get specs for specific tools by name (ignores enabled state).
-    /// Agent-intercept tools are filtered out — they never appear in the
-    /// schema sent to the model.
     func specs(forTools toolNames: [String]) -> [Tool] {
         return toolNames.compactMap { name in
-            guard !Self.agentInterceptToolNames.contains(name) else { return nil }
             return toolsByName[name]?.asOpenAITool()
         }
     }
@@ -726,7 +720,6 @@ final class ToolRegistry: ObservableObject {
                 builtInNames.contains(tool.name) || runtimeNames.contains(tool.name)
             }
             .filter { !excluded.contains($0.name) }
-            .filter { !Self.agentInterceptToolNames.contains($0.name) }
             .filter { !excludeCapabilityTools || !Self.capabilityToolNames.contains($0.name) }
             .sorted { $0.name < $1.name }
             .map { $0.asOpenAITool() }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -223,6 +223,13 @@ final class ChatSession: ObservableObject {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func validatedCompleteSummary(from json: String) -> String? {
+        guard let summary = parseCompleteSummary(from: json),
+            CompleteTool.validate(summary: summary) == nil
+        else { return nil }
+        return summary
+    }
+
     /// Pull `question` out of a `clarify(...)` tool call's JSON body.
     static func parseClarifyQuestion(from json: String) -> String? {
         guard let data = json.data(using: .utf8),
@@ -231,6 +238,10 @@ final class ChatSession: ObservableObject {
         else { return nil }
         let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func validatedClarifyQuestion(from json: String) -> String? {
+        parseClarifyQuestion(from: json)
     }
 
     /// Apply initial model selection after agentId is set (for cached picker items)
@@ -1398,22 +1409,25 @@ final class ChatSession: ObservableObject {
                             if !isRunActive(runId) { break outer }
 
                             // Agent-loop intercepts: `complete` and `clarify`
-                            // end the iteration loop. `todo` already wrote
-                            // into AgentTodoStore via TaskLocal; the session
-                            // observer mirrors it into the inline UI block.
-                            // Break out of the outer iteration loop so we
-                            // don't keep prompting the model for more.
+                            // end the iteration loop only after their control
+                            // payloads validate. Invalid calls fall through as
+                            // normal tool results so the model can recover on
+                            // the next iteration.
                             if inv.toolName == "complete" {
-                                self.lastCompletionSummary =
-                                    Self.parseCompleteSummary(from: inv.jsonArguments) ?? resultText
-                                self.lastClarifyQuestion = nil
-                                break outer
+                                if let summary = Self.validatedCompleteSummary(from: inv.jsonArguments) {
+                                    self.lastCompletionSummary = summary
+                                    self.lastClarifyQuestion = nil
+                                    break outer
+                                }
+                                self.lastCompletionSummary = nil
                             }
                             if inv.toolName == "clarify" {
-                                self.lastClarifyQuestion =
-                                    Self.parseClarifyQuestion(from: inv.jsonArguments)
-                                self.lastCompletionSummary = nil
-                                break outer
+                                if let question = Self.validatedClarifyQuestion(from: inv.jsonArguments) {
+                                    self.lastClarifyQuestion = question
+                                    self.lastCompletionSummary = nil
+                                    break outer
+                                }
+                                self.lastClarifyQuestion = nil
                             }
 
                             // Hot-load tools injected by capabilities_load or sandbox_plugin_register.

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -22,7 +22,7 @@ There is no separate "Agent" or "Work" tab — the same chat window handles a on
                                      loop ends
 ```
 
-The chat engine intercepts three special tools so the loop has structure without a separate planner: `todo`, `complete`, and `clarify`. Every other tool (file, sandbox, plugin, MCP, …) just runs and returns its output to the model on the next turn.
+The chat engine exposes and intercepts three control tools so the loop has structure without a separate planner: `todo`, `complete`, and `clarify`. They are model-visible whenever tools are enabled, including manual tool-selection mode, because they are the chat runtime contract rather than optional capabilities. Every other tool (file, sandbox, plugin, MCP, …) just runs and returns its output to the model on the next turn.
 
 ---
 

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -1,0 +1,81 @@
+# Development Plan
+
+This plan treats PR #893 as the architectural baseline: Osaurus is a single Chat / Agent Loop product, not a split Chat Mode plus Work Mode product.
+
+The development path starts by making the Agent Loop contract reliable, then moves the remaining planned work onto that chat-native foundation.
+
+---
+
+## 1. Stabilize the Agent Loop Contract
+
+**Goal:** Make every chat capable of reliable autonomous work when tools are enabled.
+
+The loop controls are `todo(markdown)`, `clarify(question)`, and `complete(summary)`. They are real model-visible tools in both auto and manual tool modes. They are omitted only when tools are explicitly disabled.
+
+Implementation requirements:
+
+- `todo` writes or replaces the visible session checklist and then lets the model continue.
+- `complete` ends the loop only after summary validation passes.
+- invalid `complete` calls return a tool error/result and do not end the loop.
+- `clarify` pauses visible chat only after a non-empty question is supplied.
+- invalid `clarify` calls return a tool error/result and do not pause.
+
+Business rationale: this makes the new single Chat / Agent architecture reliable enough to replace Work Mode without teaching local models a second execution protocol.
+
+---
+
+## 2. Harden Chat Artifacts
+
+**Goal:** Preserve user trust as Work artifacts move into chat.
+
+Artifacts must be safe by default:
+
+- sanitize filenames;
+- reject path traversal and sibling-prefix attacks;
+- keep host-folder sources inside the selected folder;
+- keep sandbox sources inside the expected sandbox workspace or agent directory;
+- persist surfaced artifacts under the chat artifact directory.
+
+Business rationale: once chat becomes the execution surface, generated files and copied files must obey the same trust boundary every time.
+
+---
+
+## 3. Build the Import/Export Capability Registry
+
+**Goal:** Make file import/export extensible instead of hard-coded.
+
+Document and artifact support should be registry-backed. The registry should describe supported extensions, trust level, active-content risk, prompt-ingestion behavior, icon metadata, and scaffold-only capabilities.
+
+Business rationale: Osaurus can add formats and exporters without scattering file-extension logic through parser and UI code.
+
+---
+
+## 4. Adopt Typed Inference Events
+
+**Goal:** Replace fragile sentinel-string handling with typed streaming events.
+
+Typed events should represent text deltas, single tool requests, batched tool requests, metadata/stats, and completion. Tool execution remains authoritative only on tool-request events; display-only argument deltas are not execution triggers.
+
+Business rationale: this improves API compatibility, local model tool calling, and streaming correctness.
+
+---
+
+## 5. Merge MLX Runtime Tuning
+
+**Goal:** Improve local model reliability without regressing lower-memory Macs.
+
+Runtime tuning should be RAM-aware, deterministic under test, conservative on low-memory systems, and compatible with JANG tool-call format resolution.
+
+Business rationale: the harness compounds only if local inference remains fast and stable across common Apple Silicon machines.
+
+---
+
+## 6. Add Durable State Only Where It Is Justified
+
+**Goal:** Cover real product gaps without rebuilding Work Mode.
+
+Persist state only when it is needed after restart, required by an API caller, needed for audit/undo/security, or impossible to reconstruct from the chat transcript.
+
+Likely candidates are persistent todo history, artifact index metadata, file-operation review history, and machine-readable background task events.
+
+Business rationale: this keeps the product simpler while preserving the specific durability users and integrations actually need.

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -261,7 +261,7 @@ Agents can check for and store secrets (API keys, tokens) using `sandbox_secret_
 | Path | When | How |
 |------|------|-----|
 | **Direct** | Agent already has the value (e.g., received via Host API or Telegram bot) | Pass `value` parameter to `sandbox_secret_set` |
-| **Prompt** | Agent needs the user to provide the value (Chat or Work UI) | Omit `value` — a secure overlay appears with `SecureField` input |
+| **Prompt** | Agent needs the user to provide the value in chat | Omit `value` — a secure overlay appears with `SecureField` input |
 
 The prompt path keeps secret values out of the conversation history and LLM context entirely. The execution loop pauses via `withCheckedContinuation` until the user submits or cancels.
 
@@ -269,7 +269,7 @@ The prompt path keeps secret values out of the conversation history and LLM cont
 
 1. Agent calls `sandbox_secret_set` without `value`
 2. Tool returns a `secret_prompt` marker (JSON with key, description, instructions)
-3. The execution loop (Chat or Work) intercepts the marker and shows `SecretPromptOverlay`
+3. The chat execution loop intercepts the marker and shows `SecretPromptOverlay`
 4. User enters the secret value in a `SecureField` and submits (or cancels via button/ESC)
 5. The value is stored in Keychain and the tool result is rewritten to `{"stored": true, "key": "..."}` (or cancelled)
 6. Execution resumes with the sanitized result — the LLM never sees the secret

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -24,6 +24,19 @@ What to include in your report:
 
 We will acknowledge receipt within 72 hours, assess the impact, and work on a fix. We may request additional information for reproduction.
 
+## Current Security Focus
+
+The chat-native agent loop introduced by the Work Mode migration makes folder access, sandbox execution, shared artifacts, and plugin dispatch the primary trust boundaries.
+
+When changing those areas:
+
+- keep host-folder paths relative to the selected working folder
+- keep sandbox paths constrained to the sandbox workspace and artifact staging areas
+- keep shared artifacts under the per-session artifact root before exposing them to plugins or HTTP clients
+- treat plugin-dispatched tasks as headless chat sessions, not privileged Work Mode jobs
+
+The active hardening plan is tracked in [DEVELOPMENT_PLAN.md](DEVELOPMENT_PLAN.md), especially the artifact-security and agent-loop stabilization work.
+
 ## Disclosure
 
 Once a fix is available, we will credit reporters who wish to be acknowledged and include mitigation instructions in the release notes when applicable.


### PR DESCRIPTION
## Business rationale

Work Mode artifacts are moving into chat, which makes chat artifacts a primary trust boundary. This PR hardens that boundary so model-produced artifact metadata cannot write outside the chat artifact directory or copy files from outside the user-approved execution root. The direct adoption benefit is confidence: users can let chat-driven tools create and export artifacts without accepting path traversal risk.

## Design rationale

This follows the PR #893 direction: Chat is the product surface, tools are the capability surface, and the Agent Loop is the behavior. Artifact handling therefore belongs in chat, not in a revived Work Mode subsystem. The implementation keeps artifact processing local to `SharedArtifact` and treats sandbox paths, host-folder paths, and destination filenames as explicit contracts.

This branch is stacked after PR #896 because PR2 depends on the Agent Loop stabilization baseline for a clean full-suite run.

## Technical explanation

- Sanitizes artifact destination filenames by extracting a safe basename and stripping control characters.
- Rejects invalid destination filenames such as empty names, `.`, and `..` instead of silently falling back to a generic file.
- Resolves artifact destination paths under the per-context artifact directory and rejects paths outside that root.
- Resolves sandbox artifact sources through contained-path checks for `/workspace` and agent-relative paths.
- Resolves host-folder artifact sources through contained-path checks and rejects absolute host-folder source paths.
- Adds `SharedArtifactSecurityTests` covering destination traversal, invalid filenames, host-folder traversal, absolute host paths, and sandbox traversal.
- Updates security and sandbox docs to describe the chat artifact trust boundary.

## Compatibility notes

- Artifact filenames containing path components are reduced to the basename, preserving expected user-facing names while removing traversal semantics.
- Invalid filenames are rejected and no artifact is produced.
- Host-folder artifact source paths are now required to be relative to the selected host folder. Absolute host paths are intentionally rejected even if they point inside the selected folder.
- No Work Mode behavior is restored.

## Tests run

- `swift test --package-path Packages/OsaurusCore --scratch-path /tmp/osauruscore-pr893-pr2-build --filter 'SharedArtifactSecurityTests|SandboxManagerCleanupTests'`
  - Passed: 9 tests in 2 suites.
- `swift test --package-path Packages/OsaurusCore --scratch-path /tmp/osauruscore-pr893-pr2-build`
  - Passed: 748 tests in 110 suites.
  - Existing sandbox integration tests skipped unless `OSAURUS_RUN_SANDBOX_INTEGRATION_TESTS=1` is set.
- `git diff --check HEAD~2..HEAD`
  - Passed.
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" . -g '!Packages/OsaurusCore/.build/**' -g '!build/**' -g '!*.xcuserstate'`
  - Passed: no conflict markers found.

## Risk

The main behavior change is stricter artifact rejection. A tool that previously emitted an absolute host path as an artifact source will now need to emit the relative path from the selected host folder. That is intentional: it keeps the host-folder contract explicit and prevents a chat artifact from becoming a general host file copy primitive.
