### PR TITLE
fixed thinking block glitch

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -513,6 +513,19 @@ extension MessageTableRepresentable {
             let newLookup = Dictionary(blocks.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
             let newStreamingBlockId = Self.detectStreamingBlockId(in: blocks, isStreaming: isStreaming)
 
+            // Seed expanded state for newly-inserted thinking blocks in the
+            // actively streaming turn so the panel opens by default without
+            // hard-coding `isExpanded = true` anywhere downstream. Once the
+            // id lives in `expandedIds`, the user's collapse tap removes it
+            // and stays removed — fixing the bug where the thinking panel
+            // refused to collapse while streaming.
+            seedExpandedIdsForNewThinkingBlocks(
+                newLookup: newLookup,
+                oldLookup: blockLookup,
+                isStreaming: isStreaming,
+                streamingTurnId: lastAssistantTurnId
+            )
+
             // Detect streaming-ended transition before any state mutations.
             let streamingJustEnded = streamingBlockId != nil && newStreamingBlockId == nil
             let previousStreamingBlockId = streamingBlockId
@@ -915,20 +928,11 @@ extension MessageTableRepresentable {
             // return cached height if we have it
             if let cached = heightCache[block.id] { return cached }
 
-            // Thinking blocks auto-expand while their OWNING turn is streaming
-            // (not just while they are the streaming block) so the panel stays
-            // visible through the `<think>`→content transition. Matches the
-            // cell's configureAsThinking logic.
-            let isStreamingThinkingTurn: Bool = {
-                guard ctx.isStreaming,
-                    let streamingTurnId = ctx.lastAssistantTurnId,
-                    block.turnId == streamingTurnId
-                else { return false }
-                if case .thinking = block.kind { return true }
-                return false
-            }()
-
-            let isExpanded = isStreamingThinkingTurn || expandedIds.contains(block.id)
+            // new thinking blocks are seeded into
+            // `expandedIds` on insertion (see `seedExpandedIdsForNewThinkingBlocks`)
+            // so the auto expand no longer needs to be forced here and the
+            // user's collapse tap is honored even mid stream
+            let isExpanded = expandedIds.contains(block.id)
             let h = NativeCellHeightEstimator.estimatedHeight(
                 for: block,
                 width: ctx.width,
@@ -963,6 +967,28 @@ extension MessageTableRepresentable {
         }
 
         // MARK: - Helpers
+
+        /// Auto-expand newly inserted thinking blocks by recording their id in
+        /// `expandedIds` (and the session store). A block counts as "new" if
+        /// its id isn't in `oldLookup`. We only seed during the owning turn's
+        /// streaming phase so restored session thinking blocks stay collapsed
+        private func seedExpandedIdsForNewThinkingBlocks(
+            newLookup: [String: ContentBlock],
+            oldLookup: [String: ContentBlock],
+            isStreaming: Bool,
+            streamingTurnId: UUID?
+        ) {
+            guard isStreaming, let streamingTurnId else { return }
+            for (id, block) in newLookup {
+                guard case .thinking = block.kind,
+                    block.turnId == streamingTurnId,
+                    oldLookup[id] == nil,
+                    !expandedIds.contains(id)
+                else { continue }
+                expandedIds.insert(id)
+                sessionExpandedStore?.expand(id)
+            }
+        }
 
         private static func detectStreamingBlockId(in blocks: [ContentBlock], isStreaming: Bool) -> String? {
             guard isStreaming else { return nil }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1032,17 +1032,12 @@ final class NativeMessageCellView: NSTableCellView {
         let thinkingLen: Int?
         if case .thinking(_, _, _) = block.kind { thinkingLen = text.count } else { thinkingLen = nil }
 
-        // Auto-expand while the owning turn is actively streaming — including
-        // after `</think>` closes the thinking block and the model moves on to
-        // answer content. Keeping the thinking panel visible through the whole
-        // streaming turn avoids collapse-jitter on the `<think>`→content
-        // boundary. Once the turn finishes, fall back to the user's explicit
-        // expand state (default: collapsed).
-        let turnIsStreaming = context.isStreaming && context.lastAssistantTurnId == block.turnId
-        let isExpanded =
-            turnIsStreaming
-            ? true
-            : context.expandedIds.contains(block.id)
+        // `expandedIds` is the single source of truth. New thinking blocks in
+        // a streaming turn are seeded into the set by the coordinator on
+        // insertion (see `seedExpandedIdsForNewThinkingBlocks`) so the panel
+        // starts expanded without this code path needing to force it. which
+        // means the user's collapse tap is honored even mid stream
+        let isExpanded = context.expandedIds.contains(block.id)
         tv.configure(
             thinking: text,
             thinkingLength: thinkingLen,


### PR DESCRIPTION
## Summary

Fixed the thinking block refusing to collapse during streaming by creating a single source of truth. New blocks are seeded into it on insertion instead of being force expanded every layout pass so the user's toggle is no longer stomped mid stream

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
