### PR TITLE
fix thinking block collapse

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -513,19 +513,6 @@ extension MessageTableRepresentable {
             let newLookup = Dictionary(blocks.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
             let newStreamingBlockId = Self.detectStreamingBlockId(in: blocks, isStreaming: isStreaming)
 
-            // Seed expanded state for newly-inserted thinking blocks in the
-            // actively streaming turn so the panel opens by default without
-            // hard-coding `isExpanded = true` anywhere downstream. Once the
-            // id lives in `expandedIds`, the user's collapse tap removes it
-            // and stays removed — fixing the bug where the thinking panel
-            // refused to collapse while streaming.
-            seedExpandedIdsForNewThinkingBlocks(
-                newLookup: newLookup,
-                oldLookup: blockLookup,
-                isStreaming: isStreaming,
-                streamingTurnId: lastAssistantTurnId
-            )
-
             // Detect streaming-ended transition before any state mutations.
             let streamingJustEnded = streamingBlockId != nil && newStreamingBlockId == nil
             let previousStreamingBlockId = streamingBlockId
@@ -928,10 +915,8 @@ extension MessageTableRepresentable {
             // return cached height if we have it
             if let cached = heightCache[block.id] { return cached }
 
-            // new thinking blocks are seeded into
-            // `expandedIds` on insertion (see `seedExpandedIdsForNewThinkingBlocks`)
-            // so the auto expand no longer needs to be forced here and the
-            // user's collapse tap is honored even mid stream
+            // `expandedIds` is the sole source of truth and the thinking blocks
+            // start collapsed by default and open only when the user taps
             let isExpanded = expandedIds.contains(block.id)
             let h = NativeCellHeightEstimator.estimatedHeight(
                 for: block,
@@ -967,28 +952,6 @@ extension MessageTableRepresentable {
         }
 
         // MARK: - Helpers
-
-        /// Auto-expand newly inserted thinking blocks by recording their id in
-        /// `expandedIds` (and the session store). A block counts as "new" if
-        /// its id isn't in `oldLookup`. We only seed during the owning turn's
-        /// streaming phase so restored session thinking blocks stay collapsed
-        private func seedExpandedIdsForNewThinkingBlocks(
-            newLookup: [String: ContentBlock],
-            oldLookup: [String: ContentBlock],
-            isStreaming: Bool,
-            streamingTurnId: UUID?
-        ) {
-            guard isStreaming, let streamingTurnId else { return }
-            for (id, block) in newLookup {
-                guard case .thinking = block.kind,
-                    block.turnId == streamingTurnId,
-                    oldLookup[id] == nil,
-                    !expandedIds.contains(id)
-                else { continue }
-                expandedIds.insert(id)
-                sessionExpandedStore?.expand(id)
-            }
-        }
 
         private static func detectStreamingBlockId(in blocks: [ContentBlock], isStreaming: Bool) -> String? {
             guard isStreaming else { return nil }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1032,11 +1032,6 @@ final class NativeMessageCellView: NSTableCellView {
         let thinkingLen: Int?
         if case .thinking(_, _, _) = block.kind { thinkingLen = text.count } else { thinkingLen = nil }
 
-        // `expandedIds` is the single source of truth. New thinking blocks in
-        // a streaming turn are seeded into the set by the coordinator on
-        // insertion (see `seedExpandedIdsForNewThinkingBlocks`) so the panel
-        // starts expanded without this code path needing to force it. which
-        // means the user's collapse tap is honored even mid stream
         let isExpanded = context.expandedIds.contains(block.id)
         tv.configure(
             thinking: text,


### PR DESCRIPTION
## Summary

collapses the thinking block when streaming

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
