### PR TITLE
performance improvements

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -412,7 +412,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
 
         panel.isOpaque = true
         panel.backgroundColor = .windowBackgroundColor
-        panel.hasShadow = false
+        panel.hasShadow = true
         panel.animationBehavior = .none
         panel.becomesKeyOnlyIfNeeded = false
         panel.hidesOnDeactivate = false

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -39,6 +39,10 @@ enum ContentBlockKind: Equatable {
     case typingIndicator
     case groupSpacer
     case chart(spec: ChartSpec)
+    /// Footer row appended to every completed assistant turn.
+    /// Replaces the hover-revealed copy/regenerate buttons that used to live in the header,
+    /// so moving the mouse over the assistant transcript no longer triggers per-row reconfigures.
+    case assistantActions(turnId: UUID)
 
     /// Custom Equatable optimized for performance during streaming.
     /// Uses text length comparison as a cheap proxy for content change detection.
@@ -89,6 +93,9 @@ enum ContentBlockKind: Equatable {
         case let (.chart(lSpec), .chart(rSpec)):
             return lSpec == rSpec
 
+        case let (.assistantActions(lId), .assistantActions(rId)):
+            return lId == rId
+
         default:
             return false
         }
@@ -109,7 +116,7 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         case let .header(role, _, _): return role
         case let .paragraph(_, _, _, role): return role
         case .toolCallGroup, .thinking, .sharedArtifact, .pendingToolCall, .preflightCapabilities,
-            .generationStats, .typingIndicator, .groupSpacer, .chart:
+            .generationStats, .typingIndicator, .groupSpacer, .chart, .assistantActions:
             return .assistant
         case .userMessage: return .user
         }
@@ -251,6 +258,15 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
     static func groupSpacer(afterTurnId: UUID, associatedWithTurnId: UUID? = nil) -> ContentBlock {
         let turnId = associatedWithTurnId ?? afterTurnId
         return ContentBlock(id: "spacer-\(afterTurnId.uuidString)", turnId: turnId, kind: .groupSpacer, position: .only)
+    }
+
+    static func assistantActions(turnId: UUID, position: BlockPosition) -> ContentBlock {
+        ContentBlock(
+            id: "actions-\(turnId.uuidString)",
+            turnId: turnId,
+            kind: .assistantActions(turnId: turnId),
+            position: position
+        )
     }
 
     static func chart(turnId: UUID, spec: ChartSpec, position: BlockPosition) -> ContentBlock {
@@ -452,6 +468,14 @@ extension ContentBlock {
                         position: .middle
                     )
                 )
+            }
+
+            // copy/regenerate bar pinned to the bottom of every completed assistant turn.
+            // only emitted once the turn is not streaming and has something worth acting on
+            if !isStreaming && turn.role == .assistant,
+                !turn.contentIsEmpty || !(turn.toolCalls ?? []).isEmpty
+            {
+                turnBlocks.append(.assistantActions(turnId: turn.id, position: .last))
             }
 
             blocks.append(contentsOf: assignPositions(to: turnBlocks))

--- a/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
+++ b/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
@@ -39,7 +39,10 @@ final class ChatPerfTrace: @unchecked Sendable {
 
     /// Reset state and start a new trace window. Safe to call while a
     /// previous trace is still open — it emits the previous report first.
+    /// Debug-only: compiles away to a no-op in release builds so the lock,
+    /// timestamping, and file I/O have zero runtime cost in shipped binaries.
     func begin(_ label: String) {
+        #if DEBUG
         lock.lock()
         let hadPrevious = startedAt != nil
         lock.unlock()
@@ -52,11 +55,13 @@ final class ChatPerfTrace: @unchecked Sendable {
         self.durations.removeAll(keepingCapacity: true)
         self.peaks.removeAll(keepingCapacity: true)
         lock.unlock()
+        #endif
     }
 
     /// Flush the accumulated counters/durations to disk and clear state.
-    /// A no-op if `begin()` was never called.
+    /// A no-op if `begin()` was never called. Debug-only.
     func end() {
+        #if DEBUG
         lock.lock()
         guard let start = startedAt else { lock.unlock(); return }
         let label = self.label
@@ -78,13 +83,16 @@ final class ChatPerfTrace: @unchecked Sendable {
             durations: durations,
             peaks: peaks
         )
+        #endif
     }
 
     // MARK: - Instrumentation API
 
     /// Increment a named counter (or add `n`). Zero-alloc on the hot path
-    /// once the key exists in the dictionary.
+    /// once the key exists in the dictionary. Debug-only — release builds
+    /// get an empty body that -O optimizes to a no-op call.
     func count(_ key: String, _ n: Int = 1) {
+        #if DEBUG
         lock.lock()
         // Only record when a trace is active; avoids polluting counters
         // between streams.
@@ -92,12 +100,15 @@ final class ChatPerfTrace: @unchecked Sendable {
             counters[key, default: 0] += n
         }
         lock.unlock()
+        #endif
     }
 
     /// Time a block. Accumulates into `durations[key]` and tracks the
-    /// peak single-call duration in `peaks[key]`.
+    /// peak single-call duration in `peaks[key]`. Debug-only — release
+    /// builds skip the timestamping and just run the block.
     @discardableResult
     func time<T>(_ key: String, _ block: () -> T) -> T {
+        #if DEBUG
         let t0 = CFAbsoluteTimeGetCurrent()
         let result = block()
         let dt = CFAbsoluteTimeGetCurrent() - t0
@@ -109,6 +120,9 @@ final class ChatPerfTrace: @unchecked Sendable {
         }
         lock.unlock()
         return result
+        #else
+        return block()
+        #endif
     }
 
     // MARK: - Emit

--- a/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
+++ b/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
@@ -1,0 +1,173 @@
+//
+//  ChatPerfTrace.swift
+//  osaurus
+//
+//  Counter + timing trace for the chat streaming UI. Mirrors TTFTTrace's
+//  file-backed format but is designed for a long-running session: begin()
+//  at stream start, end() at stream end, and every hot-path site calls
+//  `count(_:)` or `time(_:_:)` to accumulate totals.
+//
+//  Report lands in /tmp/osaurus_chat_perf.log as an append-only block per
+//  stream, so multiple streams can be compared without clearing the file.
+//
+//  Usage:
+//    ChatPerfTrace.shared.begin("stream-...")
+//    ChatPerfTrace.shared.count("applyBlocks.path2")
+//    ChatPerfTrace.shared.time("applyBlocks") { ... }
+//    ChatPerfTrace.shared.end()   // flushes + writes report
+//
+
+import Foundation
+
+final class ChatPerfTrace: @unchecked Sendable {
+
+    static let shared = ChatPerfTrace()
+
+    private let lock = NSLock()
+
+    private var label: String = ""
+    private var startedAt: CFAbsoluteTime?
+    private var counters: [String: Int] = [:]
+    /// Accumulated durations in seconds.
+    private var durations: [String: Double] = [:]
+    /// Peak single-call durations in seconds (useful for spotting stalls).
+    private var peaks: [String: Double] = [:]
+
+    private static let path = "/tmp/osaurus_chat_perf.log"
+
+    // MARK: - Lifecycle
+
+    /// Reset state and start a new trace window. Safe to call while a
+    /// previous trace is still open — it emits the previous report first.
+    func begin(_ label: String) {
+        lock.lock()
+        let hadPrevious = startedAt != nil
+        lock.unlock()
+        if hadPrevious { end() }
+
+        lock.lock()
+        self.label = label
+        self.startedAt = CFAbsoluteTimeGetCurrent()
+        self.counters.removeAll(keepingCapacity: true)
+        self.durations.removeAll(keepingCapacity: true)
+        self.peaks.removeAll(keepingCapacity: true)
+        lock.unlock()
+    }
+
+    /// Flush the accumulated counters/durations to disk and clear state.
+    /// A no-op if `begin()` was never called.
+    func end() {
+        lock.lock()
+        guard let start = startedAt else { lock.unlock(); return }
+        let label = self.label
+        let totalSec = CFAbsoluteTimeGetCurrent() - start
+        let counters = self.counters
+        let durations = self.durations
+        let peaks = self.peaks
+        self.startedAt = nil
+        self.label = ""
+        self.counters.removeAll(keepingCapacity: true)
+        self.durations.removeAll(keepingCapacity: true)
+        self.peaks.removeAll(keepingCapacity: true)
+        lock.unlock()
+
+        emit(
+            label: label,
+            totalSec: totalSec,
+            counters: counters,
+            durations: durations,
+            peaks: peaks
+        )
+    }
+
+    // MARK: - Instrumentation API
+
+    /// Increment a named counter (or add `n`). Zero-alloc on the hot path
+    /// once the key exists in the dictionary.
+    func count(_ key: String, _ n: Int = 1) {
+        lock.lock()
+        // Only record when a trace is active; avoids polluting counters
+        // between streams.
+        if startedAt != nil {
+            counters[key, default: 0] += n
+        }
+        lock.unlock()
+    }
+
+    /// Time a block. Accumulates into `durations[key]` and tracks the
+    /// peak single-call duration in `peaks[key]`.
+    @discardableResult
+    func time<T>(_ key: String, _ block: () -> T) -> T {
+        let t0 = CFAbsoluteTimeGetCurrent()
+        let result = block()
+        let dt = CFAbsoluteTimeGetCurrent() - t0
+        lock.lock()
+        if startedAt != nil {
+            durations[key, default: 0] += dt
+            if dt > (peaks[key] ?? 0) { peaks[key] = dt }
+            counters[key + ".n", default: 0] += 1
+        }
+        lock.unlock()
+        return result
+    }
+
+    // MARK: - Emit
+
+    private func emit(
+        label: String,
+        totalSec: Double,
+        counters: [String: Int],
+        durations: [String: Double],
+        peaks: [String: Double]
+    ) {
+        guard !counters.isEmpty || !durations.isEmpty else { return }
+
+        var lines: [String] = []
+        let dateStr = ISO8601DateFormatter().string(from: Date())
+        lines.append("═══ ChatPerf \(dateStr) [\(label)] ═══")
+        lines.append(String(format: "  duration                        %8.2f s", totalSec))
+
+        // Counters, sorted alphabetically so reports diff cleanly.
+        if !counters.isEmpty {
+            lines.append("  ── counters ──")
+            for key in counters.keys.sorted() {
+                let n = counters[key] ?? 0
+                let rate = totalSec > 0 ? Double(n) / totalSec : 0
+                let padded = key.padding(toLength: 36, withPad: " ", startingAt: 0)
+                lines.append(String(format: "  %@ %8d  (%.1f/s)", padded, n, rate))
+            }
+        }
+
+        // Durations (total + peak ms).
+        if !durations.isEmpty {
+            lines.append("  ── timings ──")
+            for key in durations.keys.sorted() {
+                let total = (durations[key] ?? 0) * 1000
+                let peak = (peaks[key] ?? 0) * 1000
+                let n = counters[key + ".n"] ?? 0
+                let mean = n > 0 ? total / Double(n) : 0
+                let padded = key.padding(toLength: 36, withPad: " ", startingAt: 0)
+                lines.append(
+                    String(
+                        format: "  %@ total=%7.1f ms  peak=%6.2f ms  mean=%6.2f ms",
+                        padded, total, peak, mean
+                    )
+                )
+            }
+        }
+        lines.append("")
+
+        let block = lines.joined(separator: "\n") + "\n"
+        guard let data = block.data(using: .utf8) else { return }
+
+        if FileManager.default.fileExists(atPath: Self.path) {
+            if let fh = FileHandle(forWritingAtPath: Self.path) {
+                fh.seekToEndOfFile()
+                fh.write(data)
+                fh.closeFile()
+            }
+        } else {
+            try? data.write(to: URL(fileURLWithPath: Self.path))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -66,6 +66,8 @@ final class StreamingDeltaProcessor {
     /// inline (O(1) integer comparisons), and flushes if thresholds are met.
     func receiveDelta(_ delta: String) {
         guard !delta.isEmpty else { return }
+        ChatPerfTrace.shared.count("stream.delta")
+        ChatPerfTrace.shared.count("stream.deltaBytes", delta.utf8.count)
         deltaBuffer += delta
 
         let now = Date()
@@ -172,6 +174,7 @@ final class StreamingDeltaProcessor {
     private func syncToTurn() {
         guard hasPendingContent else { return }
         syncCount += 1
+        ChatPerfTrace.shared.count("stream.syncToTurn")
         turn.notifyContentChanged()
         hasPendingContent = false
         lastSyncTime = Date()
@@ -180,12 +183,15 @@ final class StreamingDeltaProcessor {
 
     private func syncIfNeeded(now: Date) {
         let totalChars = contentLength + thinkingLength
+        // First-tier bumped 100 → 150ms: at a typical remote-provider rate (~125 B/s),
+        // the perceptual difference is invisible but it halves WindowServer load driven
+        // by streaming height updates + scroll-to-bottom re-damages per sync.
         let syncIntervalMs: Double =
             switch totalChars {
-            case 0 ..< 2_000: 100
-            case 2_000 ..< 5_000: 150
-            case 5_000 ..< 10_000: 200
-            default: 250
+            case 0 ..< 2_000: 150
+            case 2_000 ..< 5_000: 200
+            case 5_000 ..< 10_000: 250
+            default: 300
             }
 
         let timeSinceSync = now.timeIntervalSince(lastSyncTime) * 1000

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -11,10 +11,32 @@ import LocalAuthentication
 @preconcurrency import MLXLMCommon
 import SwiftUI
 
+/// Holds the derived, streaming-mutated `[ContentBlock]` list for the chat
+/// thread. Kept as a separate `ObservableObject` so that per-token visibleBlocks
+/// updates don't fire `ChatSession.objectWillChange` — that would force
+/// `ChatView`'s entire body (and every sibling, notably `FloatingInputCard`
+/// with its expensive glass/gradient chrome) to re-evaluate several times per
+/// second during streaming. Only the message-thread subtree observes this
+/// store, so streaming re-renders stay localized to the table.
+@MainActor
+final class VisibleBlocksStore: ObservableObject {
+    @Published var blocks: [ContentBlock] = []
+    @Published var groupHeaderMap: [UUID: UUID] = [:]
+}
+
 @MainActor
 final class ChatSession: ObservableObject {
     @Published var turns: [ChatTurn] = []
-    @Published var isStreaming: Bool = false
+    @Published var isStreaming: Bool = false {
+        didSet {
+            guard isStreaming != oldValue else { return }
+            if isStreaming {
+                ChatPerfTrace.shared.begin("stream-\(Int(Date().timeIntervalSince1970))")
+            } else {
+                ChatPerfTrace.shared.end()
+            }
+        }
+    }
     @Published var lastStreamError: String?
 
     /// Single-slot FIFO queue for in-chat prompt overlays (secrets,
@@ -322,13 +344,20 @@ final class ChatSession: ObservableObject {
         return pickerItems.first { $0.id == model }
     }
 
-    /// Flattened content blocks for NSTableView rendering.
-    /// Stored and updated explicitly (not recomputed on every body pass).
-    /// Call `rebuildVisibleBlocks()` after any turn mutation to refresh.
-    @Published private(set) var visibleBlocks: [ContentBlock] = []
+    /// Backing store for the streaming-mutated `visibleBlocks` / group-header map.
+    /// Deliberately NOT `@Published` — mutations go through the store's own
+    /// `objectWillChange`, not the session's, so ChatView's body + every sibling
+    /// view stay static during streaming. The message thread subtree observes
+    /// this store directly.
+    let visibleBlocksStore = VisibleBlocksStore()
 
-    /// Precomputed group header map. Updated alongside `visibleBlocks`.
-    @Published private(set) var visibleBlocksGroupHeaderMap: [UUID: UUID] = [:]
+    /// Flattened content blocks for NSTableView rendering.
+    /// Read-through to `visibleBlocksStore.blocks` so existing call sites
+    /// (helpers, checks that don't need to drive re-renders) keep working.
+    var visibleBlocks: [ContentBlock] { visibleBlocksStore.blocks }
+
+    /// Precomputed group header map. Read-through to the store.
+    var visibleBlocksGroupHeaderMap: [UUID: UUID] { visibleBlocksStore.groupHeaderMap }
 
     /// Whether the message thread has content (includes USE_MOCK_CHAT_DATA stress data).
     var hasVisibleThreadMessages: Bool {
@@ -349,6 +378,13 @@ final class ChatSession: ObservableObject {
     /// Rebuild `visibleBlocks` and `visibleBlocksGroupHeaderMap` from current turns.
     /// Cheap to call repeatedly — BlockMemoizer fast-paths when nothing changed.
     func rebuildVisibleBlocks() {
+        ChatPerfTrace.shared.count("rebuildVisibleBlocks")
+        ChatPerfTrace.shared.time("rebuildVisibleBlocks.total") {
+            rebuildVisibleBlocksImpl()
+        }
+    }
+
+    private func rebuildVisibleBlocksImpl() {
         let agent = AgentManager.shared.agent(for: agentId ?? Agent.defaultId)
         let displayName = agent?.isBuiltIn == true ? "Assistant" : (agent?.name ?? "Assistant")
         let streamingTurnId = isStreaming ? turns.last?.id : nil
@@ -363,8 +399,8 @@ final class ChatSession: ObservableObject {
             )
             let newHeaderMap = blockMemoizer.groupHeaderMap
             withAnimation(.none) {
-                visibleBlocks = newBlocks
-                visibleBlocksGroupHeaderMap = newHeaderMap
+                visibleBlocksStore.blocks = newBlocks
+                visibleBlocksStore.groupHeaderMap = newHeaderMap
             }
             return
         }
@@ -380,8 +416,8 @@ final class ChatSession: ObservableObject {
         // use withAnimation(.none) to suppress the warning about publishing during view updates
         // this wraps the changes in a proper SwiftUI transaction
         withAnimation(.none) {
-            visibleBlocks = newBlocks
-            visibleBlocksGroupHeaderMap = newHeaderMap
+            visibleBlocksStore.blocks = newBlocks
+            visibleBlocksStore.groupHeaderMap = newHeaderMap
         }
     }
 
@@ -526,8 +562,8 @@ final class ChatSession: ObservableObject {
         // Clear caches
         blockMemoizer.clear()
         cachedContext = nil
-        visibleBlocks = []
-        visibleBlocksGroupHeaderMap = [:]
+        visibleBlocksStore.blocks = []
+        visibleBlocksStore.groupHeaderMap = [:]
 
         // Apply model from agent or global config (don't auto-persist, it's already saved)
         isLoadingModel = true
@@ -1886,6 +1922,7 @@ struct ChatView: View {
     }
 
     var body: some View {
+        let _ = ChatPerfTrace.shared.count("body.ChatView")
         chatModeContent
             .themedAlertScope(.chat(windowState.windowId))
             .overlay(ThemedAlertHost(scope: .chat(windowState.windowId)))
@@ -2332,21 +2369,37 @@ struct ChatView: View {
 
     /// Isolated message thread view to prevent cascading re-renders
     private func messageThread(_ width: CGFloat) -> some View {
-        // read stored @Published values — no blockMemoizer call on every body pass
-        let blocks = session.visibleBlocks
-        let groupHeaderMap = session.visibleBlocksGroupHeaderMap
+        ChatPerfTrace.shared.count("body.messageThread")
+        // do not read `session.visibleBlocks` here as that would
+        // subscribe this enclosing body to per-sync changes (via ChatSession's
+        // objectWillChange, if visibleBlocks were @Published) and/or delay the
+        // reactivity needed by the table. `IsolatedThreadView` observes the
+        // store directly, so only *its* body re-runs on per-token updates
         let displayName = windowState.cachedAgentDisplayName
         let lastAssistantTurnId = session.lastAssistantTurnIdForThread
 
         return ZStack {
             VStack(spacing: 8) {
                 agentInlineBlocks
-                threadCore(
-                    blocks: blocks,
-                    groupHeaderMap: groupHeaderMap,
+                IsolatedThreadView(
+                    store: session.visibleBlocksStore,
                     width: width,
-                    displayName: displayName,
-                    lastAssistantTurnId: lastAssistantTurnId
+                    agentName: displayName,
+                    isStreaming: session.isStreaming,
+                    lastAssistantTurnId: lastAssistantTurnId,
+                    expandedBlocksStore: session.expandedBlocksStore,
+                    scrollToBottomTrigger: scrollToBottomTrigger,
+                    onScrolledToBottom: { isPinnedToBottom = true },
+                    onScrolledAwayFromBottom: { isPinnedToBottom = false },
+                    onCopy: copyTurnContent,
+                    onRegenerate: regenerateTurn,
+                    onEdit: beginEditingTurn,
+                    onDelete: deleteTurn,
+                    editingTurnId: editingTurnId,
+                    editText: $editText,
+                    onConfirmEdit: confirmEditAndRegenerate,
+                    onCancelEdit: cancelEditing,
+                    onUserImagePreview: openUserAttachmentPreview(attachmentId:)
                 )
             }
 
@@ -2377,6 +2430,13 @@ struct ChatView: View {
                     .imageFullScreenSheetPresentation()
             }
         }
+        // re-pin to bottom when any in-chat prompt overlay opens. previously
+        // wired on the MessageThreadView itself. hoisted here after the store
+        // isolation so only ChatView's @State pin toggles, not the thread's
+        // per-sync data path
+        .onReceive(NotificationCenter.default.publisher(for: .chatOverlayActivated)) { _ in
+            isPinnedToBottom = true
+        }
     }
 
     /// Inline agent-loop blocks rendered above the message thread. Each
@@ -2403,38 +2463,62 @@ struct ChatView: View {
         }
     }
 
-    private func threadCore(
-        blocks: [ContentBlock],
-        groupHeaderMap: [UUID: UUID],
-        width: CGFloat,
-        displayName: String,
-        lastAssistantTurnId: UUID?
-    ) -> some View {
+}
+
+/// Isolates the streaming-driven `visibleBlocks` observation from `ChatView`'s
+/// body. This view is the only place `VisibleBlocksStore.objectWillChange`
+/// propagates into SwiftUI; ChatView and its other children (FloatingInputCard,
+/// toolbar, sidebar) stay outside the subscription and do not re-evaluate on
+/// every streaming sync.
+private struct IsolatedThreadView: View {
+    @ObservedObject var store: VisibleBlocksStore
+    let width: CGFloat
+    let agentName: String
+    let isStreaming: Bool
+    let lastAssistantTurnId: UUID?
+    let expandedBlocksStore: ExpandedBlocksStore
+    let scrollToBottomTrigger: Int
+    let onScrolledToBottom: () -> Void
+    let onScrolledAwayFromBottom: () -> Void
+    let onCopy: (UUID) -> Void
+    let onRegenerate: ((UUID) -> Void)?
+    let onEdit: ((UUID) -> Void)?
+    let onDelete: ((UUID) -> Void)?
+    let editingTurnId: UUID?
+    let editText: Binding<String>?
+    let onConfirmEdit: (() -> Void)?
+    let onCancelEdit: (() -> Void)?
+    let onUserImagePreview: ((String) -> Void)?
+
+    var body: some View {
+        let _ = ChatPerfTrace.shared.count("body.IsolatedThreadView")
         MessageThreadView(
-            blocks: blocks,
-            groupHeaderMap: groupHeaderMap,
+            blocks: store.blocks,
+            groupHeaderMap: store.groupHeaderMap,
             width: width,
-            agentName: displayName,
-            isStreaming: session.isStreaming,
+            agentName: agentName,
+            isStreaming: isStreaming,
             lastAssistantTurnId: lastAssistantTurnId,
-            expandedBlocksStore: session.expandedBlocksStore,
+            expandedBlocksStore: expandedBlocksStore,
             scrollToBottomTrigger: scrollToBottomTrigger,
-            onScrolledToBottom: { isPinnedToBottom = true },
-            onScrolledAwayFromBottom: { isPinnedToBottom = false },
-            onCopy: copyTurnContent,
-            onRegenerate: regenerateTurn,
-            onEdit: beginEditingTurn,
-            onDelete: deleteTurn,
+            onScrolledToBottom: onScrolledToBottom,
+            onScrolledAwayFromBottom: onScrolledAwayFromBottom,
+            onCopy: onCopy,
+            onRegenerate: onRegenerate,
+            onEdit: onEdit,
+            onDelete: onDelete,
             editingTurnId: editingTurnId,
-            editText: $editText,
-            onConfirmEdit: confirmEditAndRegenerate,
-            onCancelEdit: cancelEditing,
-            onUserImagePreview: openUserAttachmentPreview(attachmentId:)
+            editText: editText,
+            onConfirmEdit: onConfirmEdit,
+            onCancelEdit: onCancelEdit,
+            onUserImagePreview: onUserImagePreview
         )
-        .onReceive(NotificationCenter.default.publisher(for: .chatOverlayActivated)) { _ in
-            isPinnedToBottom = true
-        }
     }
+}
+
+// Reopen ChatView's declaration for the remaining methods (threadCore was
+// inlined into `messageThread` via `IsolatedThreadView` above)
+extension ChatView {
 
     private func openUserAttachmentPreview(attachmentId: String) {
         if let img = ChatImageCache.shared.cachedImage(for: attachmentId) {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -330,6 +330,7 @@ struct FloatingInputCard: View {
     }
 
     var body: some View {
+        let _ = ChatPerfTrace.shared.count("body.FloatingInputCard")
         mainContent
             .onAppear {
                 let isReappear = !localText.isEmpty || voiceInputState != .idle

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -544,19 +544,6 @@ extension MessageTableRepresentable {
             let newLookup = Dictionary(blocks.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
             let newStreamingBlockId = Self.detectStreamingBlockId(in: blocks, isStreaming: isStreaming)
 
-            // Seed expanded state for newly-inserted thinking blocks in the
-            // actively streaming turn so the panel opens by default without
-            // hard-coding `isExpanded = true` anywhere downstream. Once the
-            // id lives in `expandedIds`, the user's collapse tap removes it
-            // and stays removed — fixing the bug where the thinking panel
-            // refused to collapse while streaming.
-            seedExpandedIdsForNewThinkingBlocks(
-                newLookup: newLookup,
-                oldLookup: blockLookup,
-                isStreaming: isStreaming,
-                streamingTurnId: lastAssistantTurnId
-            )
-
             // Detect streaming-ended transition before any state mutations.
             let streamingJustEnded = streamingBlockId != nil && newStreamingBlockId == nil
             let previousStreamingBlockId = streamingBlockId
@@ -1003,10 +990,8 @@ extension MessageTableRepresentable {
             // return cached height if we have it
             if let cached = heightCache[block.id] { return cached }
 
-            // new thinking blocks are seeded into
-            // `expandedIds` on insertion (see `seedExpandedIdsForNewThinkingBlocks`)
-            // so the auto expand no longer needs to be forced here and the
-            // user's collapse tap is honored even mid stream
+            // `expandedIds` is the sole source of truth and the thinking blocks
+            // start collapsed by default and open only when the user taps
             let isExpanded = expandedIds.contains(block.id)
             let h = NativeCellHeightEstimator.estimatedHeight(
                 for: block,

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -126,6 +126,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        ChatPerfTrace.shared.count("table.updateNSView")
         let coordinator = context.coordinator
         coordinator.scrollAnchor.onScrolledToBottom = onScrolledToBottom
         coordinator.scrollAnchor.onScrolledAwayFromBottom = onScrolledAwayFromBottom
@@ -329,6 +330,10 @@ extension MessageTableRepresentable {
 
         /// Caches measured row heights to avoid calling fittingSize on every scroll.
         private var heightCache: [String: CGFloat] = [:]
+        /// Last height we actually told AppKit about per block, so a scheduled
+        /// streaming height update can skip when the row's measured height
+        /// hasn't changed since the previous `noteHeightOfRows` call for it.
+        private var lastNotedHeight: [String: CGFloat] = [:]
 
         // MARK: Streaming Height Debounce
 
@@ -465,6 +470,12 @@ extension MessageTableRepresentable {
         /// Re-measure specific rows without animation.
         private func noteRowHeightsChanged(_ rows: IndexSet) {
             guard let tableView else { return }
+            ChatPerfTrace.shared.count("noteHeightOfRows")
+            ChatPerfTrace.shared.count("noteHeightOfRows.rows", rows.count)
+            for row in rows where row < blockIds.count {
+                let bid = blockIds[row]
+                if let h = heightCache[bid] { lastNotedHeight[bid] = h }
+            }
             NSAnimationContext.beginGrouping()
             NSAnimationContext.current.duration = 0
             tableView.noteHeightOfRows(withIndexesChanged: rows)
@@ -479,6 +490,26 @@ extension MessageTableRepresentable {
         ///   2. In-place update (reconfigure changed cells directly)
         ///   3. Full snapshot (diffable data source apply + scroll anchoring)
         func applyBlocks(
+            _ blocks: [ContentBlock],
+            groupHeaderMap: [UUID: UUID],
+            context: CellRenderingContext,
+            isStreaming: Bool,
+            lastAssistantTurnId: UUID?,
+            autoScrollEnabled: Bool
+        ) {
+            ChatPerfTrace.shared.time("applyBlocks") {
+                applyBlocksImpl(
+                    blocks,
+                    groupHeaderMap: groupHeaderMap,
+                    context: context,
+                    isStreaming: isStreaming,
+                    lastAssistantTurnId: lastAssistantTurnId,
+                    autoScrollEnabled: autoScrollEnabled
+                )
+            }
+        }
+
+        private func applyBlocksImpl(
             _ blocks: [ContentBlock],
             groupHeaderMap: [UUID: UUID],
             context: CellRenderingContext,
@@ -546,6 +577,7 @@ extension MessageTableRepresentable {
 
             // --- Path 1: No-change early return ---
             if !widthChanged, newIds == blockIds, !hasContentChanges(newLookup: newLookup) {
+                ChatPerfTrace.shared.count("applyBlocks.path1.noChange")
                 let contextAffectsCells =
                     previousStreaming != context.isStreaming
                     || previousLastAssistantTurnId != context.lastAssistantTurnId
@@ -563,6 +595,7 @@ extension MessageTableRepresentable {
             // stableChangedIds is empty so cells would keep stale layout width until
             // some later content update — visible as a gap on the first resize.
             if widthChanged, newIds == blockIds, !hasContentChanges(newLookup: newLookup) {
+                ChatPerfTrace.shared.count("applyBlocks.path1b.widthOnly")
                 blockLookup = newLookup
                 streamingBlockId = newStreamingBlockId
                 reconfigureAllCellsFromLookup(newLookup)
@@ -571,6 +604,7 @@ extension MessageTableRepresentable {
 
             // --- Path 2: In-place update (IDs unchanged, content changed) ---
             if !widthChanged, newIds == blockIds {
+                ChatPerfTrace.shared.count("applyBlocks.path2.inPlace")
                 reconfigureChangedCells(newLookup: newLookup, streamId: newStreamingBlockId)
                 blockLookup = newLookup
                 streamingBlockId = newStreamingBlockId
@@ -578,6 +612,7 @@ extension MessageTableRepresentable {
             }
 
             // --- Path 3: Full snapshot ---
+            ChatPerfTrace.shared.count("applyBlocks.path3.fullSnapshot")
             applyFullSnapshot(
                 newIds: newIds,
                 newLookup: newLookup,
@@ -603,6 +638,7 @@ extension MessageTableRepresentable {
         private func reconfigureChangedCells(newLookup: [String: ContentBlock], streamId: String?) {
             guard let tableView else { return }
             var nonStreamingRows = IndexSet()
+            var reconfigured = 0
 
             for (index, id) in blockIds.enumerated() {
                 guard newLookup[id] != blockLookup[id],
@@ -613,6 +649,7 @@ extension MessageTableRepresentable {
                 // invalidate height cache for changed block
                 heightCache.removeValue(forKey: id)
                 configureCell(cell, with: block)
+                reconfigured += 1
 
                 if id == streamId {
                     scheduleStreamingHeightUpdate(row: index)
@@ -621,10 +658,12 @@ extension MessageTableRepresentable {
                 }
             }
 
+            ChatPerfTrace.shared.count("reconfigureChangedCells.rows", reconfigured)
             if !nonStreamingRows.isEmpty {
                 noteRowHeightsChanged(nonStreamingRows)
                 if scrollAnchor.isPinnedToBottom {
-                    scrollAnchor.scrollToBottom()
+                    ChatPerfTrace.shared.count("scrollToBottom.path2")
+                    scrollAnchor.scrollToBottomCoalesced()
                 }
             }
         }
@@ -768,11 +807,13 @@ extension MessageTableRepresentable {
         }
 
         private func configureCell(_ cell: NativeMessageCellView, with block: ContentBlock) {
-            let groupId = groupHeaderMap[block.turnId] ?? block.turnId
-            var context = ctx
-            context.expandedIds = expandedIds
-            context.isTurnHovered = hoveredGroupId == groupId
-            cell.configure(block: block, context: context)
+            ChatPerfTrace.shared.time("configureCell") {
+                let groupId = groupHeaderMap[block.turnId] ?? block.turnId
+                var context = ctx
+                context.expandedIds = expandedIds
+                context.isTurnHovered = hoveredGroupId == groupId
+                cell.configure(block: block, context: context)
+            }
         }
 
         // MARK: - Context-Driven Reconfiguration
@@ -807,9 +848,11 @@ extension MessageTableRepresentable {
                 affectedRows.insert(index)
             }
             guard !affectedRows.isEmpty else { return }
+            ChatPerfTrace.shared.count("reconfigureAllCells.rows", affectedRows.count)
             noteRowHeightsChanged(affectedRows)
             if scrollAnchor.isPinnedToBottom {
-                scrollAnchor.scrollToBottom()
+                ChatPerfTrace.shared.count("scrollToBottom.allCells")
+                scrollAnchor.scrollToBottomCoalesced()
             }
         }
 
@@ -819,13 +862,28 @@ extension MessageTableRepresentable {
             streamingHeightWorkItem?.cancel()
             let work = DispatchWorkItem { [weak self] in
                 guard let self, let tv = self.tableView, row < tv.numberOfRows else { return }
-                // Force the hosting view to flush its SwiftUI layout cycle so the
-                // new intrinsic content size (driven by streamingContentHeight) is
-                // committed before we ask the table to re-measure the row.
+                ChatPerfTrace.shared.count("streamingHeightUpdate.fire")
+
+                // skip when the measured height didn't actually change since the
+                // last noteHeightOfRows for this row. Happens constantly when
+                // tokens land within the current last line — height is identical
+                // yet we'd otherwise cascade-repaint every row below it and
+                // damage the full clip view via scrollToBottom
+                if row < self.blockIds.count {
+                    let bid = self.blockIds[row]
+                    if let h = self.heightCache[bid], let noted = self.lastNotedHeight[bid],
+                       abs(h - noted) < 0.5
+                    {
+                        ChatPerfTrace.shared.count("streamingHeightUpdate.skipped")
+                        return
+                    }
+                }
+
                 self.noteRowHeightsChanged(IndexSet(integer: row))
 
                 if self.scrollAnchor.isPinnedToBottom {
-                    self.scrollAnchor.scrollToBottom()
+                    ChatPerfTrace.shared.count("scrollToBottom.streaming")
+                    self.scrollAnchor.scrollToBottomCoalesced()
                 }
             }
             streamingHeightWorkItem = work
@@ -872,6 +930,7 @@ extension MessageTableRepresentable {
         // MARK: - Hover Tracking
 
         private func handleMouseMoved(with event: NSEvent) {
+            ChatPerfTrace.shared.count("hover.mouseMoved")
             guard let tableView else { return setHoveredGroup(nil) }
             let point = tableView.convert(event.locationInWindow, from: nil)
             let row = tableView.row(at: point)
@@ -881,16 +940,28 @@ extension MessageTableRepresentable {
             else {
                 return setHoveredGroup(nil)
             }
+            // Assistant turns expose their actions via a pinned footer row
+            // (see ContentBlockKind.assistantActions)
+            // hovering them must not
+            // trigger per-row reconfigures.
+            // Clearing hover also tears down any
+            // lingering user-turn hover if the cursor just moved off one
+            if block.role == .assistant {
+                return setHoveredGroup(nil)
+            }
             setHoveredGroup(groupHeaderMap[block.turnId] ?? block.turnId)
         }
 
         private func setHoveredGroup(_ newGroupId: UUID?) {
             guard hoveredGroupId != newGroupId else { return }
+            ChatPerfTrace.shared.count("hover.groupChanged")
             let oldGroupId = hoveredGroupId
             hoveredGroupId = newGroupId
 
             guard let tableView else { return }
             let range = tableView.rows(in: tableView.visibleRect)
+            var reconfiguredRows = 0
+            var fastPathRows = 0
             for row in range.location ..< (range.location + range.length) {
                 guard row < blockIds.count,
                     let block = blockLookup[blockIds[row]]
@@ -908,10 +979,14 @@ extension MessageTableRepresentable {
                 // for header rows, use the fast hover path
                 if case .header = block.kind {
                     cell.setTurnHovered(groupId == newGroupId)
+                    fastPathRows += 1
                 } else {
                     configureCell(cell, with: block)
+                    reconfiguredRows += 1
                 }
             }
+            ChatPerfTrace.shared.count("hover.fastPathRows", fastPathRows)
+            ChatPerfTrace.shared.count("hover.reconfigureRows", reconfiguredRows)
         }
 
         // MARK: - NSTableViewDelegate

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -43,8 +43,6 @@ final class NativeTypingIndicatorView: NSView {
     override init(frame: NSRect) {
         super.init(frame: frame)
         buildViews()
-        startAnimation()
-        observeMemory()
         observeModelLoading()
     }
 
@@ -53,6 +51,20 @@ final class NativeTypingIndicatorView: NSView {
     deinit {
         bounceTimer?.invalidate()
         memoryPollTimer?.invalidate()
+    }
+
+    /// Stop animations + memory polling when the cell scrolls offscreen or gets reused —
+    /// otherwise every live typing indicator instance keeps firing CABasicAnimation ticks
+    /// into WindowServer regardless of visibility.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            startAnimation()
+            observeMemory()
+        } else {
+            bounceTimer?.invalidate(); bounceTimer = nil
+            memoryPollTimer?.invalidate(); memoryPollTimer = nil
+        }
     }
 
     func configure(theme: any ThemeProtocol) {
@@ -270,6 +282,18 @@ final class NativePendingToolCallView: NSView {
 
     deinit {
         pulseTimer?.invalidate()
+    }
+
+    /// Stop the pulse when the cell leaves the window so recycled/offscreen
+    /// instances don't keep driving CATransaction ticks.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            startPulse()
+        } else {
+            pulseTimer?.invalidate()
+            pulseTimer = nil
+        }
     }
 
     // MARK: Configure

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -114,6 +114,7 @@ final class NativeMarkdownView: NSView {
         cacheKey: String?,
         isStreaming: Bool
     ) {
+        ChatPerfTrace.shared.count("markdown.configure.called")
         let themeFingerprint = makeThemeFingerprint(theme)
         let textChanged = text != lastText
         let widthChanged = abs(width - lastWidth) > 0.5
@@ -123,7 +124,11 @@ final class NativeMarkdownView: NSView {
         // must re-run layout when streaming ends even if text matches the last delta — otherwise
         // configure() returns early, measuredHeight/onHeightChanged never fire, height cache is
         // empty, and the table falls back to NativeCellHeightEstimator (too small).
-        guard textChanged || widthChanged || themeChanged || streamingChanged else { return }
+        guard textChanged || widthChanged || themeChanged || streamingChanged else {
+            ChatPerfTrace.shared.count("markdown.configure.noOp")
+            return
+        }
+        ChatPerfTrace.shared.count("markdown.configure.applied")
 
         lastWidth = width
         lastThemeFingerprint = themeFingerprint
@@ -175,7 +180,8 @@ final class NativeMarkdownView: NSView {
         if textChanged || widthChanged || themeChanged {
             coordinator.cacheKey = cacheKey
             let stv = SelectableTextView(blocks: blocks, baseWidth: width, theme: theme)
-            if !widthChanged && !lastBlocks.isEmpty {
+            let incrementalPath = !widthChanged && !lastBlocks.isEmpty
+            if incrementalPath {
                 stv.updateTextStorageIncrementally(
                     textView: tv,
                     oldBlocks: lastBlocks,
@@ -186,7 +192,11 @@ final class NativeMarkdownView: NSView {
                 tv.textStorage?.setAttributedString(stv.buildAttributedString(coordinator: coordinator))
             }
             lastBlocks = blocks
-            tv.needsDisplay = true
+            // incremental path sets a bounded tail rect internally. only the
+            // full rebuild path needs to mark the whole view dirty
+            if !incrementalPath {
+                tv.needsDisplay = true
+            }
         }
 
         // nested NativeMarkdownView (text segment inside mixed content) must update heightConstraint
@@ -332,7 +342,8 @@ final class NativeMarkdownView: NSView {
         if textChanged || widthChanged {
             coordinator.cacheKey = cacheKey
             let stv = SelectableTextView(blocks: blocks, baseWidth: width, theme: theme)
-            if !widthChanged && !lastBlocks.isEmpty {
+            let incrementalPath = !widthChanged && !lastBlocks.isEmpty
+            if incrementalPath {
                 stv.updateTextStorageIncrementally(
                     textView: tv,
                     oldBlocks: lastBlocks,
@@ -343,7 +354,9 @@ final class NativeMarkdownView: NSView {
                 tv.textStorage?.setAttributedString(stv.buildAttributedString(coordinator: coordinator))
             }
             lastBlocks = blocks
-            tv.needsDisplay = true
+            if !incrementalPath {
+                tv.needsDisplay = true
+            }
         }
 
         // must update heightConstraint — init leaves 100pt; otherwise user bubbles stay artificially tall

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -150,25 +150,23 @@ final class NativeHeaderView: NSView {
             v.removeFromSuperview()
         }
 
+        // Assistant actions (copy, regenerate) are rendered in a dedicated footer row
+        // under every completed assistant turn, so the header only carries actions for
+        // user messages now. This lets the table coordinator skip hover reconfigures
+        // for assistant rows entirely.
+        guard role == .user else { return }
+
         addBtn(icon: "doc.on.doc", help: L("Copy"), theme: theme, tint: nil) { [weak self] in
             guard let self else { return }
             self.onCopy?(self.turnId)
         }
-
-        if role == .assistant {
-            addBtn(icon: "arrow.counterclockwise", help: L("Regenerate"), theme: theme, tint: nil) { [weak self] in
-                guard let self else { return }
-                self.onRegenerate?(self.turnId)
-            }
-        } else {
-            addBtn(icon: "pencil", help: L("Edit"), theme: theme, tint: nil) { [weak self] in
-                guard let self else { return }
-                self.onEdit?(self.turnId)
-            }
-            addBtn(icon: "trash", help: L("Delete"), theme: theme, tint: nil) { [weak self] in
-                guard let self else { return }
-                self.onDelete?(self.turnId)
-            }
+        addBtn(icon: "pencil", help: L("Edit"), theme: theme, tint: nil) { [weak self] in
+            guard let self else { return }
+            self.onEdit?(self.turnId)
+        }
+        addBtn(icon: "trash", help: L("Delete"), theme: theme, tint: nil) { [weak self] in
+            guard let self else { return }
+            self.onDelete?(self.turnId)
         }
 
         if isEditing, let onCancelEdit {
@@ -209,9 +207,9 @@ final class NativeHeaderView: NSView {
 
 /// `NSButton`’s cell/layer often disagree with `bounds`, producing non-circular backgrounds; draw the
 /// chrome on a plain `NSView` and keep a borderless `NSButton` for hit-testing and keyboard focus.
-private final class HeaderCircleActionControl: NSView {
+final class HeaderCircleActionControl: NSView {
     private let button: NSButton
-    private let block: () -> Void
+    private var block: () -> Void
     private var fillBase: NSColor = .clear
     private var fillHover: NSColor = .clear
     private var tracking: NSTrackingArea?
@@ -288,6 +286,92 @@ private final class HeaderCircleActionControl: NSView {
     }
 
     @objc private func fire() { block() }
+
+    func setAction(_ newAction: @escaping () -> Void) {
+        block = newAction
+    }
+}
+
+// MARK: - Native Assistant Actions View
+
+/// Copy + Regenerate pinned under every completed assistant turn.
+/// Always visible (no hover), so the table coordinator can skip hover
+/// reconfigures for assistant rows entirely.
+final class NativeAssistantActionsView: NSView {
+
+    private let copyButton: HeaderCircleActionControl
+    private let regenerateButton: HeaderCircleActionControl
+
+    private var turnId: UUID = UUID()
+    private var onCopy: ((UUID) -> Void)?
+    private var onRegenerate: ((UUID) -> Void)?
+
+    override init(frame: NSRect) {
+        let copyControl = HeaderCircleActionControl(action: {})
+        let regenControl = HeaderCircleActionControl(action: {})
+        self.copyButton = copyControl
+        self.regenerateButton = regenControl
+        super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        regenerateButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(copyButton)
+        addSubview(regenerateButton)
+
+        copyButton.setAction { [weak self] in
+            guard let self else { return }
+            self.onCopy?(self.turnId)
+        }
+        regenerateButton.setAction { [weak self] in
+            guard let self else { return }
+            self.onRegenerate?(self.turnId)
+        }
+
+        let size: CGFloat = 28
+        NSLayoutConstraint.activate([
+            copyButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            copyButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            copyButton.widthAnchor.constraint(equalToConstant: size),
+            copyButton.heightAnchor.constraint(equalToConstant: size),
+
+            regenerateButton.leadingAnchor.constraint(equalTo: copyButton.trailingAnchor, constant: 4),
+            regenerateButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            regenerateButton.widthAnchor.constraint(equalToConstant: size),
+            regenerateButton.heightAnchor.constraint(equalToConstant: size),
+            regenerateButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(
+        turnId: UUID,
+        theme: any ThemeProtocol,
+        onCopy: ((UUID) -> Void)?,
+        onRegenerate: ((UUID) -> Void)?
+    ) {
+        self.turnId = turnId
+        self.onCopy = onCopy
+        self.onRegenerate = onRegenerate
+
+        let pointSize = CGFloat(theme.captionSize) - 1
+        let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .medium)
+        copyButton.setSymbol(
+            NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: L("Copy"))?
+                .withSymbolConfiguration(cfg),
+            toolTip: L("Copy"),
+            theme: theme,
+            iconTint: nil
+        )
+        regenerateButton.setSymbol(
+            NSImage(systemSymbolName: "arrow.counterclockwise", accessibilityDescription: L("Regenerate"))?
+                .withSymbolConfiguration(cfg),
+            toolTip: L("Regenerate"),
+            theme: theme,
+            iconTint: nil
+        )
+    }
 }
 
 // MARK: - Padded inline edit buttons
@@ -722,11 +806,16 @@ final class NativeMessageCellView: NSTableCellView {
     private var nativeChartView: NativeChartView?
     private var nativePreflightView: NativePreflightCapabilitiesView?
     private var nativeStatsView: NativeStatsView?
+    private var nativeAssistantActionsView: NativeAssistantActionsView?
 
     private var userBubbleCornerRadius: CGFloat = 0
     private var userBubbleWidthConstraint: NSLayoutConstraint?
     /// Height occupied by attachments above the bubble (docs + images + gaps), set during rebuild.
     private var userAttachmentsHeight: CGFloat = 0
+    /// Last CGColor assigned to `layer.backgroundColor` for the assistant bubble, so
+    /// per-token reconfigures can skip the CoreAnimation mutation when nothing changed.
+    private var lastBubbleBackgroundCGColor: CGColor?
+    private var lastBubbleCornerRadius: CGFloat = 0
 
     // MARK: State
 
@@ -881,6 +970,9 @@ final class NativeMessageCellView: NSTableCellView {
                 sameKind: sameKind
             )
 
+        case let .assistantActions(turnId):
+            configureAsAssistantActions(turnId: turnId, context: context, sameKind: sameKind)
+
         default:
             // last resort: no hosted fallback — render a compact unsupported-block placeholder
             configureAsUnsupported(sameKind: sameKind)
@@ -989,16 +1081,27 @@ final class NativeMessageCellView: NSTableCellView {
             isStreaming: isStreaming
         )
 
-        // Apply assistant bubble background when a custom color is set
+        // Apply assistant bubble background only when the target value actually changes —
+        // configure() runs on every streaming token, so unconditional CGColor assignment
+        // would churn the layer and force per-token compositor work.
+        let targetBg: CGColor?
+        let targetRadius: CGFloat
         if role == .assistant, let bubbleColor = context.theme.assistantBubbleColor {
-            self.wantsLayer = true
-            self.layer?.backgroundColor =
-                NSColor(bubbleColor)
+            targetBg = NSColor(bubbleColor)
                 .withAlphaComponent(context.theme.assistantBubbleOpacity).cgColor
-            self.layer?.cornerRadius = 12
+            targetRadius = 12
         } else {
-            self.layer?.backgroundColor = nil
-            self.layer?.cornerRadius = 0
+            targetBg = nil
+            targetRadius = 0
+        }
+        if targetBg != nil { self.wantsLayer = true }
+        if !cgColorsEqual(lastBubbleBackgroundCGColor, targetBg) {
+            self.layer?.backgroundColor = targetBg
+            lastBubbleBackgroundCGColor = targetBg
+        }
+        if lastBubbleCornerRadius != targetRadius {
+            self.layer?.cornerRadius = targetRadius
+            lastBubbleCornerRadius = targetRadius
         }
 
         // always report height: configure() can return early when text is unchanged (e.g. tool row
@@ -1462,6 +1565,35 @@ final class NativeMessageCellView: NSTableCellView {
         )
     }
 
+    // MARK: - AssistantActions
+
+    private func configureAsAssistantActions(
+        turnId: UUID,
+        context: CellRenderingContext,
+        sameKind: Bool
+    ) {
+        if !sameKind || nativeAssistantActionsView == nil {
+            removeAllContentViews()
+            let av = NativeAssistantActionsView()
+            av.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(av)
+            NSLayoutConstraint.activate([
+                av.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                av.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+                av.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+                av.heightAnchor.constraint(equalToConstant: 28),
+                av.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -8),
+            ])
+            nativeAssistantActionsView = av
+        }
+        nativeAssistantActionsView?.configure(
+            turnId: turnId,
+            theme: context.theme,
+            onCopy: context.onCopy,
+            onRegenerate: context.onRegenerate
+        )
+    }
+
     // MARK: - SharedArtifact
 
     private func configureAsArtifact(
@@ -1589,6 +1721,8 @@ final class NativeMessageCellView: NSTableCellView {
     private func removeAllContentViews() {
         self.layer?.backgroundColor = nil
         self.layer?.cornerRadius = 0
+        lastBubbleBackgroundCGColor = nil
+        lastBubbleCornerRadius = 0
         spacerView?.removeFromSuperview(); spacerView = nil
         nativeHeaderView?.removeFromSuperview(); nativeHeaderView = nil
         nativeMarkdownView?.removeFromSuperview(); nativeMarkdownView = nil
@@ -1599,6 +1733,7 @@ final class NativeMessageCellView: NSTableCellView {
         nativeArtifactView?.removeFromSuperview(); nativeArtifactView = nil
         nativePreflightView?.removeFromSuperview(); nativePreflightView = nil
         nativeStatsView?.removeFromSuperview(); nativeStatsView = nil
+        nativeAssistantActionsView?.removeFromSuperview(); nativeAssistantActionsView = nil
         userMessageContainer?.removeFromSuperview(); userMessageContainer = nil
         userTextView = nil
         userInlineEditView = nil
@@ -1771,12 +1906,22 @@ private final class UserDocumentChipView: NSView {
     }
 }
 
+/// Tri-state equality: two nils match, one nil differs, otherwise defer to CGColor.==.
+private func cgColorsEqual(_ lhs: CGColor?, _ rhs: CGColor?) -> Bool {
+    switch (lhs, rhs) {
+    case (nil, nil): return true
+    case let (l?, r?): return l == r
+    default: return false
+    }
+}
+
 // MARK: - ContentBlockKindTag
 
 /// Lightweight discriminator used to detect kind changes without comparing full associated values.
 enum ContentBlockKindTag: Equatable {
     case header, paragraph, toolCallGroup, thinking, userMessage, pendingToolCall
-    case generationStats, typingIndicator, groupSpacer, sharedArtifact, preflightCapabilities, chart, other
+    case generationStats, typingIndicator, groupSpacer, sharedArtifact, preflightCapabilities, chart
+    case assistantActions, other
 }
 
 extension ContentBlockKind {
@@ -1794,6 +1939,7 @@ extension ContentBlockKind {
         case .sharedArtifact: return .sharedArtifact
         case .preflightCapabilities: return .preflightCapabilities
         case .chart: return .chart
+        case .assistantActions: return .assistantActions
         }
     }
 }
@@ -1820,6 +1966,10 @@ enum NativeCellHeightEstimator {
 
         case .generationStats:
             return 24
+
+        case .assistantActions:
+            // 4 top gap + 28 button + 8 bottom gap
+            return 40
 
         case .typingIndicator:
             // 4 top + ~22 content + 6 bottom (tight to header / thinking row above)

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1135,11 +1135,6 @@ final class NativeMessageCellView: NSTableCellView {
         let thinkingLen: Int?
         if case .thinking(_, _, _) = block.kind { thinkingLen = text.count } else { thinkingLen = nil }
 
-        // `expandedIds` is the single source of truth. New thinking blocks in
-        // a streaming turn are seeded into the set by the coordinator on
-        // insertion (see `seedExpandedIdsForNewThinkingBlocks`) so the panel
-        // starts expanded without this code path needing to force it. which
-        // means the user's collapse tap is honored even mid stream
         let isExpanded = context.expandedIds.contains(block.id)
         tv.configure(
             thinking: text,

--- a/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeThinkingView.swift
@@ -62,6 +62,13 @@ final class NativeThinkingView: NSView {
     override func layout() {
         super.layout()
         updateBorderStrokePath()
+        // unshaped shadows force an offscreen rasterization every time the layer
+        // contents change — during streaming that's every token. supply a cheap
+        // rounded-rect path so CoreAnimation composites the shadow directly
+        if let layer {
+            let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius).cgPath
+            layer.shadowPath = path
+        }
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -134,16 +141,8 @@ final class NativeThinkingView: NSView {
         updateChevron(expanded: isExpanded, animated: isExpanded != self.isExpanded)
         self.isExpanded = isExpanded
 
-        // matches ThinkingBlockView: fill + strokeBorder + light shadow (stroke via CAShapeLayer in layout)
-        layer?.cornerRadius = cornerRadius
-        layer?.masksToBounds = false
-        layer?.backgroundColor = thinkingTint.withAlphaComponent(0.05).cgColor
-        layer?.borderWidth = 0
-        layer?.borderColor = nil
-        layer?.shadowColor = thinkingTint.withAlphaComponent(0.04).cgColor
-        layer?.shadowOffset = CGSize(width: 0, height: 1)
-        layer?.shadowRadius = 2
-        layer?.shadowOpacity = 1
+        // layer chrome (fill + shadow) is set once in buildViews(). mutating CGColor
+        // per configure() would churn the layer on every streaming token
 
         contentContainer.isHidden = !isExpanded
         separatorView.isHidden = !isExpanded
@@ -185,6 +184,18 @@ final class NativeThinkingView: NSView {
     private func buildViews() {
         wantsLayer = true
         translatesAutoresizingMaskIntoConstraints = false
+
+        // fill + shadow never change once the view exists, so bake them in here instead of
+        // reapplying inside configure() (which runs per streaming token)
+        layer?.cornerRadius = cornerRadius
+        layer?.masksToBounds = false
+        layer?.backgroundColor = thinkingTint.withAlphaComponent(0.05).cgColor
+        layer?.borderWidth = 0
+        layer?.borderColor = nil
+        layer?.shadowColor = thinkingTint.withAlphaComponent(0.04).cgColor
+        layer?.shadowOffset = CGSize(width: 0, height: 1)
+        layer?.shadowRadius = 2
+        layer?.shadowOpacity = 1
 
         // header button in back - transparent overlay covering the header row for click handling
         headerButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Packages/OsaurusCore/Views/Chat/ScrollAnchorManager.swift
+++ b/Packages/OsaurusCore/Views/Chat/ScrollAnchorManager.swift
@@ -46,6 +46,11 @@ final class ScrollAnchorManager {
     /// Saved scroll anchor (row + pixel offset).
     private var savedAnchor: Anchor?
 
+    /// One shot flag for coalesced `scrollToBottomCoalesced()`. multiple calls in
+    /// the same runloop tick collapse to a single bounds mutation which avoids
+    /// redundant clip view composites during streaming
+    private var coalescedScrollPending: Bool = false
+
     private struct Anchor {
         let row: Int
         let offsetFromRowTop: CGFloat
@@ -121,6 +126,14 @@ final class ScrollAnchorManager {
         let clipView = scrollView.contentView
         let maxY = max(0, documentView.frame.height - clipView.bounds.height)
 
+        // if already within 1pt of the target — skip. streaming height updates fire
+        // this repeatedly even when the row grew by less than a pixel, and each
+        // call would otherwise re-damage the full clip view via
+        // `reflectScrolledClipView`
+        if !animated, abs(clipView.bounds.origin.y - maxY) <= 1.0 {
+            return
+        }
+
         if animated {
             NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.2
@@ -130,6 +143,20 @@ final class ScrollAnchorManager {
             scrollView.reflectScrolledClipView(clipView)
         } else {
             setScrollOriginY(maxY)
+        }
+    }
+
+    /// Coalesced variant: multiple calls within the same runloop tick collapse
+    /// to a single trailing-edge `scrollToBottom()`. Use from per-token paths
+    /// (streaming height update + path 2 reconfigures can fire back-to-back
+    /// within a few ms of each other).
+    func scrollToBottomCoalesced() {
+        guard !coalescedScrollPending else { return }
+        coalescedScrollPending = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.coalescedScrollPending = false
+            self.scrollToBottom()
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -141,7 +141,9 @@ struct SelectableTextView: NSViewRepresentable {
         }
 
         if blocksChanged || widthChanged || themeChanged {
-            if !widthChanged && !themeChanged && !context.coordinator.lastBlocks.isEmpty {
+            let incrementalPath =
+                !widthChanged && !themeChanged && !context.coordinator.lastBlocks.isEmpty
+            if incrementalPath {
                 updateTextStorageIncrementally(
                     textView: textView,
                     oldBlocks: context.coordinator.lastBlocks,
@@ -160,7 +162,11 @@ struct SelectableTextView: NSViewRepresentable {
             context.coordinator.lastBlocks = blocks
             context.coordinator.lastWidth = baseWidth
             context.coordinator.lastThemeFingerprint = themeFingerprint
-            textView.needsDisplay = true
+            // incremental path already invalidated a bounded tail rect. full
+            // re-assign path needs an unbounded repaint
+            if !incrementalPath {
+                textView.needsDisplay = true
+            }
         }
     }
 
@@ -202,13 +208,18 @@ struct SelectableTextView: NSViewRepresentable {
 
     // MARK: - Incremental Updates
 
+    /// Apply an incremental text-storage update and bound the dirty rect to
+    /// the changed tail so WindowServer composites only the affected region.
+    /// Returns the character offset where the change begins, so callers can
+    /// skip the unbounded `needsDisplay = true` fallback.
+    @discardableResult
     func updateTextStorageIncrementally(
         textView: SelectableNSTextView,
         oldBlocks: [SelectableTextBlock],
         newBlocks: [SelectableTextBlock],
         coordinator: Coordinator
-    ) {
-        guard let storage = textView.textStorage else { return }
+    ) -> Int {
+        guard let storage = textView.textStorage else { return 0 }
 
         // Find first differing block
         var diffIndex = 0
@@ -230,6 +241,8 @@ struct SelectableTextView: NSViewRepresentable {
             diffIndex = 0
             prefixLength = 0
         }
+
+        let damageStart = prefixLength
 
         // Delete everything after the common prefix
         let deleteRange = NSRange(location: prefixLength, length: storage.length - prefixLength)
@@ -270,6 +283,8 @@ struct SelectableTextView: NSViewRepresentable {
         }
 
         coordinator.blockLengths = newLengths
+
+        return damageStart
     }
 
     // MARK: - Package-Internal Convenience Builder

--- a/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedOrb.swift
@@ -42,8 +42,6 @@ struct AnimatedOrb: View {
 
     // MARK: - State
 
-    @State private var floatOffset: CGFloat = 0
-    @State private var glowPulse: CGFloat = 1.0
     @State private var isHovered = false
     @State private var isAppActive = true
 
@@ -69,8 +67,14 @@ struct AnimatedOrb: View {
                 .frame(width: orbSize, height: orbSize)
                 .scaleEffect(contentScale)
         }
-        .shadow(color: color.opacity(shadowOpacity), radius: shadowRadius)
-        .offset(y: showFloat ? floatOffset : 0)
+        // Dropped two per-vsync compositor costs:
+        //   1. `.shadow(color:radius:)` — SwiftUI's shadow modifier has no
+        //      `shadowPath` hook, so every re-composite rasterizes it offscreen.
+        //      The outer-glow radial gradient already provides the halo.
+        //   2. `.offset(y: floatOffset)` with a `repeatForever` animation —
+        //      kept the entire orb subtree (shader + shadow) in CoreAnimation's
+        //      active list every frame, composited at full display refresh rate
+        //      regardless of the TimelineView's 6Hz shader tick.
         .contentShape(Circle().scale(1.3))
         .onHover { hovering in
             guard isInteractive else { return }
@@ -78,33 +82,19 @@ struct AnimatedOrb: View {
                 isHovered = hovering
             }
         }
-        .onAppear(perform: startAnimations)
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.willResignActiveNotification)
         ) { _ in
             isAppActive = false
-            withAnimation(.easeOut(duration: 0.4)) {
-                floatOffset = 0
-                glowPulse = 1.0
-            }
         }
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
         ) { _ in
             isAppActive = true
-            startAnimations()
         }
     }
 
     // MARK: - Computed Properties
-
-    private var shadowOpacity: Double {
-        isInteractive && isHovered ? 0.4 : 0.3
-    }
-
-    private var shadowRadius: CGFloat {
-        isInteractive && isHovered ? 10 : 8
-    }
 
     private var glowScale: CGFloat {
         isInteractive && isHovered ? 1.5 : 1.4
@@ -118,26 +108,21 @@ struct AnimatedOrb: View {
 
     @ViewBuilder
     private func outerGlow(size: CGFloat) -> some View {
-        let opacity = (isInteractive && isHovered ? 0.22 : 0.15) * glowPulse
+        let opacity = isInteractive && isHovered ? 0.22 : 0.15
         Circle()
-            .fill(color.opacity(opacity))
+            .fill(
+                RadialGradient(
+                    gradient: Gradient(colors: [
+                        color.opacity(opacity),
+                        color.opacity(opacity * 0.6),
+                        color.opacity(0),
+                    ]),
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: (size * glowScale) / 2
+                )
+            )
             .frame(width: size * glowScale, height: size * glowScale)
-            .blur(radius: isInteractive && isHovered ? 14 : 12)
-    }
-
-    // MARK: - Animations
-
-    private func startAnimations() {
-        if showFloat {
-            withAnimation(.easeInOut(duration: 2.3 + Double(seedHash) * 0.4).repeatForever(autoreverses: true)) {
-                floatOffset = -3
-            }
-        }
-        if showGlow {
-            withAnimation(.easeInOut(duration: 3.5 + Double(seedHash) * 0.8).repeatForever(autoreverses: true)) {
-                glowPulse = 1.2
-            }
-        }
     }
 }
 
@@ -160,7 +145,8 @@ private struct OrbShaderContent: View {
                 // the display link when paused — .periodic fires at the given interval regardless
                 // of app state, still submitting CA draw calls that keep the compositor busy.
                 // paused: !isAppActive ensures zero CA updates when the app is not in the foreground.
-                TimelineView(.animation(minimumInterval: 1.0 / 15.0, paused: !isAppActive)) { timeline in
+                //
+                TimelineView(.animation(minimumInterval: 1.0 / 6.0, paused: !isAppActive)) { timeline in
                     let elapsed = Float(timeline.date.timeIntervalSince(startTime))
                     // when paused, timeline.date stops advancing, but on resume it jumps to wall-clock
                     // time; use frozenTime to preserve the shader's animation phase across pause/resume.


### PR DESCRIPTION
## Summary

  - moved Copy/Regenerate button stack off header hover onto a pinned footer row under completed assistant turns.
  - isolated streaming from SwiftUI with a new VisibleBlocksStore + IsolatedThreadView so ChatView / FloatingInputCard no longer re-render per token
  - guarded cell background/corner reassignment, baked thinking cell shadow once with shadowPath and offscreen typing/pending timers now pause
  - dropped unbounded setNeedsDisplay on incremental text updates and let NSLayoutManager invalidate the actual edited range in SelectableTextView
  - new ChatPerfTrace writes counters + timings per stream to /tmp/osaurus_chat_perf.log in debug builds to test performance in the future
  - fixed thinking block collapse glitch during streaming
  - added shadow to window (addresses #910)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
