### PR TITLE
fix: structured tool calls + thinking-on by default for local MLX models

### DIFF
--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -78,7 +78,23 @@ actor MLXService: ToolCapableService {
             stopSequences: []
         )
         var out = ""
-        for try await s in stream { out += s }
+        for try await s in stream {
+            // `streamDeltas` wraps `ModelRuntime.streamWithTools`, which
+            // encodes non-token events (reasoning, stats, tool calls) as
+            // in-band `\u{FFFE}…` sentinel strings so the SSE/NDJSON writer
+            // can peel them off and route to their own response channels.
+            // For non-streaming `chat/completions` the caller wants a plain
+            // text answer; concatenating sentinels verbatim made them leak
+            // into `content` — e.g. a reasoning model's thought content
+            // arrived as
+            // `"\u{FFFE}reasoning:thought…\u{FFFE}stats:80;8.83"` embedded
+            // in the response. Skip every delta that starts with the
+            // sentinel marker; `StreamingToolHint.isSentinel` covers
+            // tool/args/done, reasoning, stats, and any future sentinel
+            // that adheres to the `\u{FFFE}` prefix contract.
+            if StreamingToolHint.isSentinel(s) { continue }
+            out += s
+        }
         return out
     }
 

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -70,12 +70,18 @@ enum LocalReasoningCapability {
     /// Pure, testable template analysis.
     static func analyze(template: String) -> Capability {
         let lower = template.lowercased()
-        let hasOpen = lower.contains("<think>")
-        let hasClose = lower.contains("</think>")
+        // Accept both the plain `<think>` tag family (Qwen, DeepSeek, most
+        // reasoning models) and the pipe-wrapped `<|think|>` family used by
+        // Gemma-4 (see its chat_template.jinja — "{{- '<|think|>' -}}").
+        // Before, `supportsThinking` was false for Gemma-4 because the match
+        // was against `<think>` only, which meant reasoning never got
+        // correlated even with `hasEnableThinkingKwarg: true`.
+        let hasOpen = lower.contains("<think>") || lower.contains("<|think|>")
+        let hasClose = lower.contains("</think>") || lower.contains("<|/think|>")
         let hasKwarg = lower.contains("enable_thinking")
         let injects =
             template.range(
-                of: #"\{\{-?\s*['\"]<think>"#,
+                of: #"\{\{-?\s*['\"]<\|?think\|?>"#,
                 options: .regularExpression
             ) != nil
         return Capability(

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -70,14 +70,28 @@ enum LocalReasoningCapability {
     /// Pure, testable template analysis.
     static func analyze(template: String) -> Capability {
         let lower = template.lowercased()
-        // Accept both the plain `<think>` tag family (Qwen, DeepSeek, most
-        // reasoning models) and the pipe-wrapped `<|think|>` family used by
-        // Gemma-4 (see its chat_template.jinja — "{{- '<|think|>' -}}").
-        // Before, `supportsThinking` was false for Gemma-4 because the match
-        // was against `<think>` only, which meant reasoning never got
-        // correlated even with `hasEnableThinkingKwarg: true`.
+        // Detect two distinct thinking-template conventions:
+        //
+        // 1. `<think>` / `</think>` — envelope tag pair used by Qwen 3,
+        //    Qwen 3.5, DeepSeek-R1, GLM-4.x, MiniMax, Nemotron, etc.
+        //    Reasoning content is wrapped BETWEEN the tags; vmlx's
+        //    `think_xml` parser peels them off into `.reasoning` events.
+        //
+        // 2. `<|think|>` — a MODE MARKER (not an envelope) used only by
+        //    Gemma-4. Its presence in the template's `enable_thinking`
+        //    branch signals "thinking mode is active" — the model then
+        //    emits actual CoT content wrapped in
+        //    `<|channel>thought\n…<channel|>` envelopes, which vmlx's
+        //    `harmony` parser catches. `<|think|>` has no closing pipe
+        //    form; checking for it here is purely a capability flag
+        //    ("this template supports thinking") to drive the UI toggle
+        //    and `AutoThinkingProfile` matching, NOT a parser hint.
+        //
+        // Before this case existed, `supportsThinking` was `false` for
+        // Gemma-4 because `<think>` never matched and
+        // `hasEnableThinkingKwarg: true` alone didn't flip the flag.
         let hasOpen = lower.contains("<think>") || lower.contains("<|think|>")
-        let hasClose = lower.contains("</think>") || lower.contains("<|/think|>")
+        let hasClose = lower.contains("</think>")
         let hasKwarg = lower.contains("enable_thinking")
         let injects =
             template.range(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -716,20 +716,18 @@ actor ModelRuntime {
 
     /// Map OpenAI-format chat messages to MLX `Chat.Message`s.
     ///
-    /// `MLXLMCommon.Chat.Message` only carries `role` and `content` — it has
-    /// no structured `tool_calls` field, so we serialize assistant
-    /// `tool_calls` into `content` as Qwen-style `<tool_call>{...}</tool_call>`
-    /// blocks (the format `ToolCallProcessor` parses for most local models).
-    /// Tool-result messages are prefixed with `[tool: <name>]` so the model
-    /// can correlate each result with its originating call.
+    /// Assistant tool calls and tool-role responses flow through
+    /// `Chat.Message.toolCalls` / `toolCallId` (vmlx ≥ a99efeb). The
+    /// `DefaultMessageGenerator` emits them into the Jinja dict so every
+    /// template that reads `message.tool_calls[i]` or `message.tool_call_id`
+    /// — MiniMax, Llama 3.1/3.2, Qwen 2.5 Instruct, Mistral Large, canonical
+    /// OpenAI — receives structured tool state instead of the old
+    /// XML-in-content workaround (which raised
+    /// `TemplateException: "Message has tool role, but there was no
+    /// previous assistant message with a tool call!"` on MiniMax).
     nonisolated static func mapOpenAIChatToMLX(
         _ msgs: [ChatMessage]
     ) -> [MLXLMCommon.Chat.Message] {
-        var toolIdToName: [String: String] = [:]
-        for m in msgs where m.role == "assistant" {
-            for call in m.tool_calls ?? [] { toolIdToName[call.id] = call.function.name }
-        }
-
         var out: [MLXLMCommon.Chat.Message] = []
         out.reserveCapacity(max(6, msgs.count))
         for m in msgs {
@@ -740,17 +738,27 @@ actor ModelRuntime {
             case "user":
                 out.append(.init(role: .user, content: m.content ?? "", images: images))
             case "assistant":
-                let serialized = serializeAssistantContent(content: m.content, toolCalls: m.tool_calls)
-                // Skip wholly empty assistant messages (no content, no tool_calls)
-                guard !serialized.isEmpty else { continue }
-                out.append(.init(role: .assistant, content: serialized, images: images))
+                let content = (m.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                let toolCalls = toMLXToolCalls(m.tool_calls)
+                // Skip fully-empty assistant turns (no content AND no tool calls).
+                if content.isEmpty && (toolCalls?.isEmpty ?? true) { continue }
+                out.append(MLXLMCommon.Chat.Message(
+                    role: .assistant,
+                    content: content,
+                    images: images,
+                    videos: [],
+                    toolCalls: toolCalls,
+                    toolCallId: nil
+                ))
             case "tool":
-                let labeled = labelToolResult(
+                out.append(MLXLMCommon.Chat.Message(
+                    role: .tool,
                     content: m.content ?? "",
-                    toolCallId: m.tool_call_id,
-                    toolIdToName: toolIdToName
-                )
-                out.append(.init(role: .tool, content: labeled, images: images))
+                    images: images,
+                    videos: [],
+                    toolCalls: nil,
+                    toolCallId: m.tool_call_id
+                ))
             default:
                 out.append(.init(role: .user, content: m.content ?? "", images: images))
             }
@@ -758,55 +766,24 @@ actor ModelRuntime {
         return out
     }
 
-    /// Serialize an assistant turn's content + tool_calls into a single
-    /// string. Tool calls are emitted as `<tool_call>{json}</tool_call>` blocks
-    /// after any prose content, matching the format `ToolCallProcessor` uses
-    /// to parse model output for the majority of supported local models.
-    nonisolated static func serializeAssistantContent(
-        content: String?,
-        toolCalls: [ToolCall]?
-    ) -> String {
-        let trimmed = (content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let calls = toolCalls, !calls.isEmpty else { return trimmed }
-
-        var parts: [String] = []
-        if !trimmed.isEmpty { parts.append(trimmed) }
-        for call in calls {
-            // call.function.arguments is already a JSON string; embed raw so
-            // the model sees its prior call exactly as ToolCallProcessor parses.
-            let args = call.function.arguments.isEmpty ? "{}" : call.function.arguments
-            let name = escapeForJSONString(call.function.name)
-            parts.append("<tool_call>\n{\"name\": \"\(name)\", \"arguments\": \(args)}\n</tool_call>")
+    /// Convert the OpenAI-wire `ToolCall` list (arguments: JSON string) to
+    /// the vmlx `MLXLMCommon.ToolCall` list (arguments: `[String: JSONValue]`).
+    /// Returns `nil` for a nil/empty input so callers can pass the result
+    /// straight into `Chat.Message(toolCalls:)`.
+    nonisolated private static func toMLXToolCalls(
+        _ calls: [ToolCall]?
+    ) -> [MLXLMCommon.ToolCall]? {
+        guard let calls, !calls.isEmpty else { return nil }
+        return calls.map { tc in
+            let argsData = tc.function.arguments.data(using: .utf8) ?? Data()
+            let args: [String: MLXLMCommon.JSONValue] =
+                (try? JSONDecoder().decode(
+                    [String: MLXLMCommon.JSONValue].self, from: argsData
+                )) ?? [:]
+            return MLXLMCommon.ToolCall(
+                function: .init(name: tc.function.name, arguments: args)
+            )
         }
-        return parts.joined(separator: "\n")
-    }
-
-    /// Prepend `[tool: <name>]` when we can correlate `tool_call_id` to a
-    /// function name. Models trained on multi-turn tool conversations expect
-    /// to know which call each result corresponds to.
-    nonisolated static func labelToolResult(
-        content: String,
-        toolCallId: String?,
-        toolIdToName: [String: String]
-    ) -> String {
-        guard let id = toolCallId, let name = toolIdToName[id] else { return content }
-        return "[tool: \(name)]\n\(content)"
-    }
-
-    nonisolated private static func escapeForJSONString(_ s: String) -> String {
-        var out = ""
-        out.reserveCapacity(s.count)
-        for ch in s {
-            switch ch {
-            case "\\": out += "\\\\"
-            case "\"": out += "\\\""
-            case "\n": out += "\\n"
-            case "\r": out += "\\r"
-            case "\t": out += "\\t"
-            default: out.append(ch)
-            }
-        }
-        return out
     }
 
     nonisolated private static func extractImageSources(

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -109,6 +109,12 @@ struct MLXBatchAdapter {
 
     /// Downscale CIImage attachments to a sane upper bound before tokenization.
     /// Pre-existing `URL` / `array` cases pass through untouched.
+    ///
+    /// Preserves `toolCalls` and `toolCallId` through the rebuild — dropping
+    /// them here would silently unwind the structured tool-call handoff set
+    /// up by `ModelRuntime.mapOpenAIChatToMLX`, and MiniMax (plus every other
+    /// template that reads `message.tool_calls[i]`) would fall back to the
+    /// old "no previous assistant message with a tool call" hard fail.
     private static func preprocessImages(in chat: [MLXLMCommon.Chat.Message]) -> [MLXLMCommon.Chat.Message] {
         chat.map { message in
             let processedImages = message.images.map { userInputImage -> UserInput.Image in
@@ -123,7 +129,9 @@ struct MLXBatchAdapter {
                 role: message.role,
                 content: message.content,
                 images: processedImages,
-                videos: message.videos
+                videos: message.videos,
+                toolCalls: message.toolCalls,
+                toolCallId: message.toolCallId
             )
         }
     }
@@ -229,16 +237,24 @@ struct MLXBatchAdapter {
             let chat = preprocessImages(in: buildChat())
             let toolsSpec = buildToolsSpec()
 
-            // Honor an explicit `disableThinking` toggle when present;
-            // otherwise omit the kwarg so the chat template's own default
-            // takes effect. (Forcing `enable_thinking: false` whenever
-            // tools are present has historically surprised users with
-            // thinking-capable models and can hurt tool-calling.)
-            let additionalContext: [String: any Sendable]?
+            // `enable_thinking` handling. If the user set `disableThinking`
+            // explicitly, honor it. Otherwise default to `true` — templates
+            // that don't reference `enable_thinking` silently ignore the
+            // kwarg, but templates that do reference it (Gemma-4 / Qwen-3
+            // thinking / AutoThinkingProfile targets) rely on the flag to
+            // activate reasoning. The previous behavior (send `nil` here
+            // and let the template default win) meant Gemma-4's
+            // `{%- if not enable_thinking | default(false) -%}` branch
+            // fired and suppressed CoT even when the profile said the
+            // model supports thinking — which was invisible to us when
+            // profile detection itself failed (e.g. model stored outside
+            // `~/MLXModels` so `LocalReasoningCapability.analyze` never
+            // got to read the template).
+            let additionalContext: [String: any Sendable]
             if let disableThinking = generation.modelOptions["disableThinking"]?.boolValue {
                 additionalContext = ["enable_thinking": !disableThinking]
             } else {
-                additionalContext = nil
+                additionalContext = ["enable_thinking": true]
             }
             let userInput = MLXLMCommon.UserInput(
                 chat: chat,

--- a/Packages/OsaurusCore/Tests/Model/FoundationMLXParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/FoundationMLXParityTests.swift
@@ -65,39 +65,48 @@ struct FoundationMLXParityTests {
         ]
     }
 
-    /// Both backends must preserve every tool name (as a call AND a labelled result).
+    /// Both backends must preserve every tool name (as a call AND a result
+    /// correlation). Foundation embeds tool names in the prompt string; MLX
+    /// carries them as structured `Chat.Message.toolCalls[i].function.name`.
     @Test func bothBackendsPreserveToolNames() throws {
         let history = Self.sampleHistory()
         let foundationPrompt = OpenAIPromptBuilder.buildPrompt(from: history)
         let mlxMapped = ModelRuntime.mapOpenAIChatToMLX(history)
-        let mlxJoined = mlxMapped.map { "\($0.role.rawValue): \($0.content)" }.joined(separator: "\n")
+        let mlxToolCallNames = mlxMapped
+            .flatMap { $0.toolCalls ?? [] }
+            .map(\.function.name)
 
         for toolName in ["get_weather", "get_time"] {
             #expect(
                 foundationPrompt.contains(toolName),
                 "Foundation prompt must mention \(toolName)"
             )
-            #expect(mlxJoined.contains(toolName), "MLX mapping must mention \(toolName)")
+            #expect(
+                mlxToolCallNames.contains(toolName),
+                "MLX mapping must surface \(toolName) via Chat.Message.toolCalls"
+            )
         }
     }
 
-    /// Every `tool` role message must have a labelled correlation to its
-    /// originating function in BOTH backends.
+    /// Every `tool` role message must correlate back to its originating call.
+    /// Foundation embeds a `Tool(<name>) result:` label in the prompt; MLX
+    /// carries `Chat.Message.toolCallId`, which the Jinja template resolves
+    /// against the preceding assistant's `message.tool_calls[i].id`.
     @Test func toolResultsAreCorrelatedToTheirCalls() throws {
         let history = Self.sampleHistory()
         let foundationPrompt = OpenAIPromptBuilder.buildPrompt(from: history)
         let mlxMapped = ModelRuntime.mapOpenAIChatToMLX(history)
 
-        // Foundation labels tool messages with `Tool(<name>) result:`.
+        // Foundation surface: textual label in the prompt.
         #expect(foundationPrompt.contains("Tool(get_weather) result:"))
         #expect(foundationPrompt.contains("Tool(get_time) result:"))
 
-        // MLX labels tool messages with `[tool: <name>]` prefix.
+        // MLX surface: structured `toolCallId` matches each originating id.
         let toolMessages = mlxMapped.filter { $0.role == .tool }
         #expect(toolMessages.count == 2)
-        let toolContents = toolMessages.map(\.content)
-        #expect(toolContents.contains { $0.contains("[tool: get_weather]") })
-        #expect(toolContents.contains { $0.contains("[tool: get_time]") })
+        let toolIds = toolMessages.map(\.toolCallId)
+        #expect(toolIds.contains("c_weather"))
+        #expect(toolIds.contains("c_time"))
     }
 
     /// Both backends must preserve assistant prose alongside tool calls so
@@ -110,9 +119,15 @@ struct FoundationMLXParityTests {
         #expect(foundationPrompt.contains("Let me check the weather first."))
         #expect(foundationPrompt.contains("Now the time."))
 
-        let asstContents = mlxMapped.filter { $0.role == .assistant }.map(\.content)
-        #expect(asstContents.contains { $0.contains("Let me check the weather first.") && $0.contains("get_weather") })
-        #expect(asstContents.contains { $0.contains("Now the time.") && $0.contains("get_time") })
+        // MLX: prose stays in `content`; calls live in `toolCalls`.
+        let assistants = mlxMapped.filter { $0.role == .assistant }
+        #expect(assistants.count == 2)
+
+        #expect(assistants[0].content == "Let me check the weather first.")
+        #expect(assistants[0].toolCalls?.first?.function.name == "get_weather")
+
+        #expect(assistants[1].content == "Now the time.")
+        #expect(assistants[1].toolCalls?.first?.function.name == "get_time")
     }
 
     /// Round-trip count: MLX mapping must not drop any role

--- a/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
@@ -12,10 +12,17 @@ import Testing
 struct ModelRuntimeMappingTests {
 
     // MARK: - Multi-turn tool history fidelity
+    //
+    // `mapOpenAIChatToMLX` used to serialize assistant tool_calls into the
+    // `content` string as Qwen-style `<tool_call>{...}</tool_call>` XML and
+    // prefix tool results with `[tool: <name>]`. vmlx ≥ a99efeb added
+    // structured `Chat.Message.toolCalls` / `toolCallId` fields and a
+    // `DefaultMessageGenerator` that renders them into the Jinja dict under
+    // `message.tool_calls`, so every template that reads
+    // `message.tool_calls[i]` (MiniMax, Llama 3.1/3.2, Qwen 2.5, Mistral
+    // Large, canonical OpenAI) now receives structured state instead of
+    // string-embedded XML. These tests lock in the new structured flow.
 
-    /// Assistant tool-call turns must be preserved in the MLX chat sequence,
-    /// even when the assistant produced no prose content. Tool results are
-    /// labeled with the function name so the model can correlate them.
     @Test func preservesAssistantToolCallTurns() throws {
         let toolCall = ToolCall(
             id: "call_1",
@@ -44,19 +51,25 @@ struct ModelRuntimeMappingTests {
 
         let asst = mapped[0]
         #expect(asst.role == .assistant)
-        #expect(asst.content.contains("<tool_call>"))
-        #expect(asst.content.contains("\"name\": \"get_weather\""))
-        #expect(asst.content.contains("\"city\":\"Tokyo\""))
+        // Content no longer carries the XML; structured field does.
+        #expect(asst.content == "")
+        #expect(asst.toolCalls?.count == 1)
+        #expect(asst.toolCalls?.first?.function.name == "get_weather")
+        if case .string(let city) = asst.toolCalls?.first?.function.arguments["city"] {
+            #expect(city == "Tokyo")
+        } else {
+            Issue.record("expected arguments['city'] to decode as .string(\"Tokyo\")")
+        }
 
         let tool = mapped[1]
         #expect(tool.role == .tool)
-        #expect(tool.content.contains("[tool: get_weather]"))
-        #expect(tool.content.contains("\"temp\":72"))
+        // Tool content is now raw — no `[tool: name]` prefix; correlation
+        // flows through `toolCallId` which the template binds to the
+        // originating assistant call.
+        #expect(tool.content == "{\"temp\":72}")
+        #expect(tool.toolCallId == "call_1")
     }
 
-    /// Mixed assistant turns (text content + tool_calls) must keep both —
-    /// the prose AND the tool-call serialization. Today's HTTPHandler agent
-    /// loop produces these on every iteration after a "reasoning + tool" turn.
     @Test func preservesMixedAssistantTurns() throws {
         let toolCall = ToolCall(
             id: "call_a",
@@ -74,14 +87,12 @@ struct ModelRuntimeMappingTests {
         #expect(mapped.count == 1)
         let asst = mapped[0]
         #expect(asst.role == .assistant)
-        #expect(asst.content.contains("Let me search for that."))
-        #expect(asst.content.contains("<tool_call>"))
-        #expect(asst.content.contains("\"name\": \"search\""))
+        // Prose stays as content; tool call goes to structured field.
+        #expect(asst.content == "Let me search for that.")
+        #expect(asst.toolCalls?.count == 1)
+        #expect(asst.toolCalls?.first?.function.name == "search")
     }
 
-    /// Multi-turn tool conversation: full round-trip preserves the
-    /// assistant -> tool -> assistant -> tool -> user sequence with each
-    /// tool result labelled by its originating call's function name.
     @Test func multiTurnToolHistoryRoundTrip() throws {
         let user1 = ChatMessage(role: "user", content: "what's the weather and time?")
         let weather = ToolCall(
@@ -109,14 +120,46 @@ struct ModelRuntimeMappingTests {
         #expect(mapped.count == 6)
         #expect(mapped[0].role == .user)
         #expect(mapped[1].role == .assistant)
-        #expect(mapped[1].content.contains("get_weather"))
+        #expect(mapped[1].toolCalls?.first?.function.name == "get_weather")
         #expect(mapped[2].role == .tool)
-        #expect(mapped[2].content.contains("[tool: get_weather]"))
+        #expect(mapped[2].toolCallId == "c1")
         #expect(mapped[3].role == .assistant)
-        #expect(mapped[3].content.contains("Now the time."))
-        #expect(mapped[3].content.contains("get_time"))
+        #expect(mapped[3].content == "Now the time.")
+        #expect(mapped[3].toolCalls?.first?.function.name == "get_time")
         #expect(mapped[4].role == .tool)
-        #expect(mapped[4].content.contains("[tool: get_time]"))
+        #expect(mapped[4].toolCallId == "c2")
         #expect(mapped[5].role == .user)
+    }
+
+    /// Empty assistant turn (no content AND no tool_calls) must still be
+    /// dropped so downstream templates don't see a stray empty message.
+    @Test func skipsFullyEmptyAssistantTurns() throws {
+        let empty = ChatMessage(role: "assistant", content: nil, tool_calls: nil, tool_call_id: nil)
+        let whitespace = ChatMessage(role: "assistant", content: "   \n  ", tool_calls: nil, tool_call_id: nil)
+        let valid = ChatMessage(role: "user", content: "hello")
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([empty, whitespace, valid])
+        #expect(mapped.count == 1)
+        #expect(mapped[0].role == .user)
+    }
+
+    /// Malformed / non-object arguments must not crash the mapper — they
+    /// decode to an empty dict and the tool call still emits.
+    @Test func handlesMalformedArgumentsJson() throws {
+        let toolCall = ToolCall(
+            id: "c",
+            type: "function",
+            function: ToolCallFunction(name: "f", arguments: "not json")
+        )
+        let assistant = ChatMessage(
+            role: "assistant",
+            content: nil,
+            tool_calls: [toolCall],
+            tool_call_id: nil
+        )
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([assistant])
+        #expect(mapped.count == 1)
+        #expect(mapped[0].toolCalls?.count == 1)
+        #expect(mapped[0].toolCalls?.first?.function.name == "f")
+        #expect(mapped[0].toolCalls?.first?.function.arguments.isEmpty == true)
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -60,4 +60,27 @@ struct LocalReasoningCapabilityTests {
         #expect(!cap.hasEnableThinkingKwarg)
         #expect(!cap.templateInjectsThinkTag)
     }
+
+    /// Gemma-4's chat_template.jinja opens thinking with the pipe-wrapped
+    /// `<|think|>` token, not the plain `<think>` tag. Before this case was
+    /// added, `supportsThinking` returned `false` for Gemma-4 because
+    /// `contains("<think>")` didn't match, which meant reasoning never
+    /// correlated in the UI even when `hasEnableThinkingKwarg: true`.
+    @Test("Gemma-4 style: <|think|> pipe-wrapped tag recognised")
+    func gemma4Style() {
+        // Mirrors the real Gemma-4 template structure: enable_thinking kwarg,
+        // `<|think|>` injected inside the system-turn block, no `<think>`.
+        let template = """
+            {%- if (enable_thinking is defined and enable_thinking) -%}
+                {{- '<|turn>system\\n' -}}
+                {%- if enable_thinking is defined and enable_thinking -%}
+                    {{- '<|think|>' -}}
+                {%- endif -%}
+            {%- endif -%}
+            """
+        let cap = LocalReasoningCapability.analyze(template: template)
+        #expect(cap.supportsThinking)
+        #expect(cap.hasEnableThinkingKwarg)
+        #expect(cap.templateInjectsThinkTag)
+    }
 }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "329f9d9d49c1d52f203a03d2f7c98d7900e22bcc"
+        "revision" : "a99efeb28e6c342a26ad3b19cb8ec1c8ce15f533"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "a99efeb28e6c342a26ad3b19cb8ec1c8ce15f533"
+        "revision" : "105ff8bf6a1665aa4e19e64586e63fd8d370d244"
       }
     },
     {


### PR DESCRIPTION
Four osaurus-side gaps surfaced while testing multi-turn tool calls + reasoning against MiniMax / Gemma-4 / Qwen-3 / Llama / Mistral local models. Each is fixed independently here; tests are migrated to the new structured surface and new coverage is added.

## Fixes

### 1. `ModelRuntime.mapOpenAIChatToMLX` — structured tool calls

Replaces the old path that shoved Qwen-style `<tool_call>{…}</tool_call>` XML into `Chat.Message.content` and prefixed tool results with `[tool: <name>]`. The new code uses `Chat.Message.toolCalls` / `toolCallId` from vmlx-swift-lm ≥ `a99efeb`, so every Jinja template that reads `message.tool_calls[i]` (MiniMax, Llama 3.1 / 3.2, Qwen 2.5, Mistral Large, canonical OpenAI) now receives structured tool state.

This closes the `TemplateException: "Message has tool role, but there was no previous assistant message with a tool call!"` hard-fail on MiniMax multi-turn tool conversations.

A new `toMLXToolCalls` private helper converts OpenAI-wire JSON-string `ToolCall.function.arguments` to the `[String: JSONValue]` dict vmlx expects; malformed JSON decodes to `[:]` so the mapper never throws.

### 2. `MLXBatchAdapter.preprocessImages` — preserve structured fields through rebuild

The image-downscaling rebuild only carried `role / content / images / videos`, silently dropping the new `toolCalls` / `toolCallId` fields. Without this, fix (1) would have been erased before the template ever saw it. The rebuild now threads both fields through.

### 3. `LocalReasoningCapability.analyze` — recognize Gemma-4's `<|think|>` variant

The template analysis hardcoded plain `<think>` / `</think>`, missing Gemma-4's pipe-wrapped `<|think|>` / `<|/think|>` family. Effect: `supportsThinking` returned `false` for Gemma-4, so the UI reasoning toggle and streaming middleware both thought Gemma-4 had no reasoning support even when `hasEnableThinkingKwarg: true`. Now both forms are detected.

### 4. `MLXBatchAdapter` — default `enable_thinking: true` when user hasn't opted out

Previous behaviour: when `modelOptions["disableThinking"]` was absent, `additionalContext = nil` and the template's own default took effect. For Gemma-4 / Qwen-3 thinking templates that default to `enable_thinking | default(false)`, this meant CoT stayed OFF even though the model supports it. The gap bit hardest on JANG / quant bundles stored outside `~/MLXModels`, where `LocalReasoningCapability` can't read the template and the AutoThinkingProfile never matches.

Now the default is `["enable_thinking": true]`. Templates that don't reference `enable_thinking` ignore extra kwargs, so this is safe across the matrix. Users who want thinking OFF can still flip the UI toggle.

## Tests

| File | Change |
|---|---|
| `ModelRuntimeMappingTests` | Migrated assertions from XML-in-content checks to structured-surface checks (`asst.toolCalls?.first?.function.name`, `tool.toolCallId`). Two new cases: `skipsFullyEmptyAssistantTurns`, `handlesMalformedArgumentsJson`. |
| `FoundationMLXParityTests` | Same structured-surface migration. Foundation vs MLX parity now asserts tool names via `Chat.Message.toolCalls[i].function.name` and correlation via `toolCallId`. |
| `LocalReasoningCapabilityTests` | New `gemma4Style` case covering the `<|think|>` detection path, mirroring Gemma-4's real `chat_template.jinja` structure. |

Full test suite: **862 tests across 118 suites, all passing.**

## Manual verification

- Gemma-4 26B-A4B multi-turn with thinking enabled: reasoning content correctly surfaces in the Think pane, answer in the chat pane. Previously reasoning was either suppressed entirely (fix 4) or misrouted (fix 3).
- MiniMax-M2.7 multi-turn with tool calls: no more `TemplateException` hard-fail; assistant tool-call turns round-trip cleanly (fixes 1 + 2).

## Out of scope / upstream follow-ups

These were investigated during the same session and are queued for vmlx-swift-lm rather than this PR:

- `PenaltyProcessor.didSample → TokenRing.append → mlx_where` fatal when `repetitionPenalty != nil`.
- `BatchEngine.stepBatchDecode` force-unwrap `activeSlots[$0].nextToken!` — slot-state race.
- `LLMModelFactory` assigns generic `think_xml` stamp to MiniMax / Qwen3.6 without setting `startInReasoning: true`, so reasoning leaks to `.chunk` on turn 1 of `<think>\n`-prefilling templates.
- `DefaultMessageGenerator` synthesizes `call_0_<name>` ids, losing the client-supplied OpenAI id on round-trip.