### PR TITLE
fix(chat): skip embedding-type models when auto-selecting default

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -141,9 +141,82 @@ extension ModelPickerItem {
     }
 }
 
+// MARK: - Default-selection capability heuristic
+
+extension ModelPickerItem {
+    /// Heuristic used only for default-selection: is this item plausibly a
+    /// chat-capable model?
+    ///
+    /// Remote providers expose `/v1/models` as a flat list of IDs with no
+    /// capability metadata, so an embedding or reranker model is
+    /// indistinguishable by type from a chat model. When such a model happens
+    /// to be first in the list, the Chat tab previously auto-selected it and
+    /// every message failed with an opaque HTTP 500. This check lets the
+    /// default-selection step skip obvious non-chat IDs while remaining
+    /// conservative: if a chat model has an unusual name that trips the
+    /// heuristic, the array helper below falls back to the first item so the
+    /// picker is never left empty when models exist.
+    var isLikelyChatCapable: Bool {
+        switch source {
+        case .foundation, .local:
+            // Foundation is Apple's on-device chat model; `.local` items come
+            // from the curated MLX catalog, which is chat-only.
+            return true
+        case .remote:
+            return !Self.isLikelyEmbeddingOrRerankerID(id)
+        }
+    }
+
+    /// Token- and prefix-based classifier that returns `true` when the model
+    /// ID almost certainly belongs to an embedding or reranker family.
+    ///
+    /// Matching is word-boundary so "embedded" in a chat model's description
+    /// would not trigger (though only the ID is inspected). A provider prefix
+    /// like `"provider-name/model-id"` is stripped before matching.
+    static func isLikelyEmbeddingOrRerankerID(_ id: String) -> Bool {
+        // Strip any `"provider/"` prefix added by `fromRemoteModel`.
+        let tail = id.split(separator: "/").last.map(String.init) ?? id
+        let lower = tail.lowercased()
+
+        // Whole-token match on non-alphanumerics so we catch, e.g.,
+        // `text-embedding-ada-002`, `nomic-embed-text`, `bge-reranker-v2-m3`
+        // without misfiring on substrings like `embedded` or `rerankable`.
+        let tokens = lower.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).map(String.init)
+        for token in tokens {
+            switch token {
+            case "embedding", "embeddings", "embed",
+                "reranker", "rerank",
+                "colbert":
+                return true
+            default:
+                break
+            }
+        }
+
+        // Family prefixes whose IDs don't always literally contain the word
+        // "embed" (e.g. `bge-small-en-v1.5`). Kept deliberately short to avoid
+        // false positives on ambiguous families like `e5-mistral-*-instruct`.
+        for prefix in ["bge-", "nomic-embed-"] where lower.hasPrefix(prefix) {
+            return true
+        }
+        return false
+    }
+}
+
 // MARK: - Grouping
 
 extension Array where Element == ModelPickerItem {
+    /// Default-selection helper used by the Chat tab.
+    ///
+    /// Returns the first item that appears chat-capable per
+    /// `isLikelyChatCapable`. Falls back to the absolute first item when no
+    /// item passes the heuristic, so the picker is never left unset while
+    /// items exist — a chat model with an unusual name still gets selected,
+    /// just not preferentially.
+    var firstChatCapable: ModelPickerItem? {
+        first(where: { $0.isLikelyChatCapable }) ?? first
+    }
+
     /// Group models by source for display in sections
     func groupedBySource() -> [(source: ModelPickerItem.Source, models: [ModelPickerItem])] {
         var groups: [ModelPickerItem.Source: [ModelPickerItem]] = [:]

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
@@ -1,0 +1,223 @@
+//
+//  ModelPickerItemChatCapabilityTests.swift
+//  osaurusTests
+//
+//  Covers the default-selection heuristic used by the Chat tab when a
+//  remote provider's `/v1/models` response begins with an embedding or
+//  reranker model. Before the fix, `pickerItems.first?.id` was selected
+//  unconditionally, so any chat turn against the auto-picked model failed
+//  with an opaque HTTP 500. The heuristic is intentionally conservative:
+//  it rejects obvious embedding/reranker IDs while leaving an absolute
+//  fallback so a chat model with an unusual name is still selected.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ModelPickerItemChatCapabilityTests {
+
+    // MARK: - Classifier: known embedding / reranker families
+
+    @Test func classifier_flagsOpenAIEmbeddings() {
+        for id in [
+            "text-embedding-ada-002",
+            "text-embedding-3-small",
+            "text-embedding-3-large",
+        ] {
+            #expect(
+                ModelPickerItem.isLikelyEmbeddingOrRerankerID(id),
+                "Expected \(id) to be flagged as embedding"
+            )
+        }
+    }
+
+    @Test func classifier_flagsNomicAndJinaEmbeddings() {
+        for id in [
+            "nomic-embed-text-v1.5",
+            "nomic-embed-vision-v1",
+            "jina-embeddings-v2-base-en",
+            "mxbai-embed-large-v1",
+        ] {
+            #expect(
+                ModelPickerItem.isLikelyEmbeddingOrRerankerID(id),
+                "Expected \(id) to be flagged as embedding"
+            )
+        }
+    }
+
+    @Test func classifier_flagsBGEAndReranker() {
+        for id in [
+            "bge-small-en-v1.5",
+            "bge-large-en-v1.5",
+            "bge-m3",
+            "bge-reranker-v2-m3",
+            "BAAI/bge-reranker-v2-m3",
+        ] {
+            #expect(
+                ModelPickerItem.isLikelyEmbeddingOrRerankerID(id),
+                "Expected \(id) to be flagged as embedding/reranker"
+            )
+        }
+    }
+
+    @Test func classifier_flagsColbert() {
+        // Only separator-delimited forms are caught. A smushed form like
+        // `"colbertv2"` is intentionally NOT flagged — keeping the tokenizer
+        // strict avoids false positives on unrelated names that happen to
+        // contain the substring.
+        #expect(ModelPickerItem.isLikelyEmbeddingOrRerankerID("colbert-v2"))
+        #expect(ModelPickerItem.isLikelyEmbeddingOrRerankerID("colbert_v2"))
+    }
+
+    @Test func classifier_stripsProviderPrefixBeforeMatching() {
+        // Remote picker items are prefixed like "provider-name/model-id"; the
+        // classifier must match on the tail so prefixed forms still get caught.
+        #expect(
+            ModelPickerItem.isLikelyEmbeddingOrRerankerID(
+                "Qwen/Qwen3-Embedding-8B-GGUF"
+            )
+        )
+        #expect(
+            ModelPickerItem.isLikelyEmbeddingOrRerankerID(
+                "openai/text-embedding-3-small"
+            )
+        )
+        #expect(
+            ModelPickerItem.isLikelyEmbeddingOrRerankerID(
+                "huggingface/bge-small-en"
+            )
+        )
+    }
+
+    // MARK: - Classifier: known chat models must NOT be flagged
+
+    @Test func classifier_passesChatModels() {
+        for id in [
+            "gpt-4o",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "claude-opus-4",
+            "claude-sonnet-4.5",
+            "claude-haiku-4.5",
+            "qwen3-coder-30b-a3b-instruct",
+            "Qwen3-Coder-30B-A3B-Instruct-GGUF",
+            "llama-3.3-70b-instruct",
+            "Meta-Llama-3.2-3B-Instruct-4bit",
+            "mistral-small-instruct",
+            "gemini-1.5-pro",
+            "mixtral-8x22b-instruct",
+        ] {
+            #expect(
+                !ModelPickerItem.isLikelyEmbeddingOrRerankerID(id),
+                "Did not expect \(id) to be flagged"
+            )
+        }
+    }
+
+    @Test func classifier_doesNotMisfireOnSubstringMatches() {
+        // Whole-token matching should mean "embedded" in a model name does
+        // not register as "embed". This guards against a future regression
+        // where a contains()-style check is substituted for the tokenizer.
+        #expect(!ModelPickerItem.isLikelyEmbeddingOrRerankerID("embedded-llama-7b"))
+        #expect(!ModelPickerItem.isLikelyEmbeddingOrRerankerID("rerankable-sort-3b"))
+    }
+
+    // MARK: - isLikelyChatCapable per source
+
+    @Test func foundationIsAlwaysChatCapable() {
+        #expect(ModelPickerItem.foundation().isLikelyChatCapable)
+    }
+
+    @Test func localModelsAreAlwaysChatCapable() {
+        // Local models come from the curated MLX catalog (chat-only), so the
+        // heuristic is bypassed even if the name happens to match an
+        // embedding pattern.
+        let localLooksLikeEmbedding = ModelPickerItem(
+            id: "mlx-community/some-embedded-model-name",
+            displayName: "Some Embedded",
+            source: .local
+        )
+        #expect(localLooksLikeEmbedding.isLikelyChatCapable)
+    }
+
+    @Test func remoteEmbeddingIsNotChatCapable() {
+        let item = ModelPickerItem.fromRemoteModel(
+            modelId: "openai/text-embedding-3-small",
+            providerName: "OpenAI",
+            providerId: UUID()
+        )
+        #expect(!item.isLikelyChatCapable)
+    }
+
+    @Test func remoteChatModelIsChatCapable() {
+        let item = ModelPickerItem.fromRemoteModel(
+            modelId: "openai/gpt-4o",
+            providerName: "OpenAI",
+            providerId: UUID()
+        )
+        #expect(item.isLikelyChatCapable)
+    }
+
+    // MARK: - firstChatCapable fallback behavior
+
+    @Test func firstChatCapable_prefersChatOverLeadingEmbedding() {
+        // The reported #884 scenario: a custom provider's /v1/models returns
+        // an embedding model first. firstChatCapable must skip past it.
+        let providerId = UUID()
+        let items: [ModelPickerItem] = [
+            .fromRemoteModel(
+                modelId: "myprovider/text-embedding-3-small",
+                providerName: "MyProvider",
+                providerId: providerId
+            ),
+            .fromRemoteModel(
+                modelId: "myprovider/gpt-4o",
+                providerName: "MyProvider",
+                providerId: providerId
+            ),
+        ]
+        #expect(items.firstChatCapable?.id == "myprovider/gpt-4o")
+    }
+
+    @Test func firstChatCapable_fallsBackToFirstWhenNoneMatch() {
+        // Defensive fallback: if every item trips the heuristic (e.g. a
+        // provider that exposes only reranker models), we still return
+        // something so the picker is never left nil with items present.
+        let providerId = UUID()
+        let items: [ModelPickerItem] = [
+            .fromRemoteModel(
+                modelId: "myprovider/bge-reranker-v2-m3",
+                providerName: "MyProvider",
+                providerId: providerId
+            ),
+            .fromRemoteModel(
+                modelId: "myprovider/text-embedding-3-small",
+                providerName: "MyProvider",
+                providerId: providerId
+            ),
+        ]
+        #expect(items.firstChatCapable?.id == "myprovider/bge-reranker-v2-m3")
+    }
+
+    @Test func firstChatCapable_emptyArrayReturnsNil() {
+        let items: [ModelPickerItem] = []
+        #expect(items.firstChatCapable == nil)
+    }
+
+    @Test func firstChatCapable_prefersFoundationWhenLeading() {
+        // Matches the computeItems() ordering where Foundation (when
+        // available) is prepended and should always be the default pick.
+        let items: [ModelPickerItem] = [
+            .foundation(),
+            .fromRemoteModel(
+                modelId: "openai/text-embedding-3-small",
+                providerName: "OpenAI",
+                providerId: UUID()
+            ),
+        ]
+        #expect(items.firstChatCapable?.id == "foundation")
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -294,7 +294,7 @@ final class ChatSession: ObservableObject {
         if let model = effectiveModel, pickerItems.contains(where: { $0.id == model }) {
             selectedModel = model
         } else {
-            selectedModel = pickerItems.first?.id
+            selectedModel = pickerItems.firstChatCapable?.id
         }
         isLoadingModel = false
         Task { [weak self] in await self?.refreshMemoryTokens() }
@@ -319,7 +319,7 @@ final class ChatSession: ObservableObject {
         } else if let prev = selectedModel, newOptionIds.contains(prev) {
             newSelected = prev
         } else {
-            newSelected = newOptionIds.first
+            newSelected = newOptions.firstChatCapable?.id
         }
 
         pickerItems = newOptions
@@ -573,7 +573,7 @@ final class ChatSession: ObservableObject {
         {
             selectedModel = defaultModel
         } else {
-            selectedModel = pickerItems.first?.id
+            selectedModel = pickerItems.firstChatCapable?.id
         }
         isLoadingModel = false
 
@@ -671,7 +671,7 @@ final class ChatSession: ObservableObject {
             {
                 selectedModel = defaultModel
             } else {
-                selectedModel = pickerItems.first?.id
+                selectedModel = pickerItems.firstChatCapable?.id
             }
         }
         isLoadingModel = false
@@ -2047,7 +2047,9 @@ struct ChatView: View {
                                     },
                                     onUseFoundation: windowState.foundationModelAvailable
                                         ? {
-                                            session.selectedModel = session.pickerItems.first?.id ?? "foundation"
+                                            session.selectedModel =
+                                                session.pickerItems.firstChatCapable?.id
+                                                ?? "foundation"
                                         } : nil,
                                     onQuickAction: { prompt in
                                         session.input = prompt
@@ -2132,7 +2134,7 @@ struct ChatView: View {
                                 },
                                 onUseFoundation: windowState.foundationModelAvailable
                                     ? {
-                                        session.selectedModel = session.pickerItems.first?.id ?? "foundation"
+                                        session.selectedModel = session.pickerItems.firstChatCapable?.id ?? "foundation"
                                     } : nil,
                                 onQuickAction: { _ in },
                                 onSelectAgent: { newAgentId in
@@ -2210,7 +2212,7 @@ struct ChatView: View {
                 if case .remote(_, let id) = $0.source { return id == providerId }
                 return false
             }
-            guard let firstItem = providerItems.first else { return }
+            guard let firstItem = providerItems.firstChatCapable else { return }
             let currentIsFromProvider =
                 newItems.first(where: { $0.id == session.selectedModel }).map {
                     if case .remote(_, let id) = $0.source { return id == providerId }
@@ -2227,7 +2229,7 @@ struct ChatView: View {
             if let model = agentModel, session.pickerItems.contains(where: { $0.id == model }) {
                 session.selectedModel = model
             } else {
-                session.selectedModel = session.pickerItems.first?.id
+                session.selectedModel = session.pickerItems.firstChatCapable?.id
             }
         }
         .environment(\.theme, windowState.theme)


### PR DESCRIPTION
## Business rationale

When a user adds a custom OpenAI-compatible server as a remote provider, Osaurus fetches the model list from `/v1/models` and auto-selects the first entry as the Chat tab's default model. The response format is a flat list of IDs with no capability metadata, so an embedding or reranker model is indistinguishable from a chat model by type. When such a model happens to be first, every subsequent chat turn fails with an opaque HTTP 500 and the user has no actionable detail — per the reporter, the workaround (switching to another tab to pick a model manually) was found only by chance.

This is a first-use trap: the worst time to hit an opaque error is right after adding a new provider, before the user trusts Osaurus's plumbing. Silently skipping obvious embedding/reranker IDs during default-selection turns a confusing failure into a working out-of-the-box experience.

## Coding rationale

### Root cause

Remote picker items are built in `ModelPickerItemCache.computeItems` from `RemoteProviderManager.cachedAvailableModels()`, which comes from `RemoteProviderService.fetchModels(from:)` — and that method returns `[String]`. There is no kind/capability field in the pipeline today.

Across `ChatView.swift`, eight call sites fall back to `pickerItems.first?.id` (or the equivalent on `newOptionIds` / `providerItems`) when no agent-preferred, saved, or otherwise-valid model exists. Any of them can land on an embedding model.

### Approach

Name-based heuristic on the model ID, applied only at default-selection time. The fuller typed-capability solution (per-provider capability probing) is a larger follow-up; this PR takes the smallest change that removes the first-use failure.

- `ModelPickerItem.isLikelyChatCapable` — `true` for `.foundation` and `.local` items (curated catalog is chat-only); for `.remote`, delegates to…
- `ModelPickerItem.isLikelyEmbeddingOrRerankerID(_:)` — whole-token match on the ID (after stripping any `provider/` prefix) for `embed`, `embedding`, `embeddings`, `reranker`, `rerank`, `colbert`; plus `bge-` / `nomic-embed-` family prefixes.
- `[ModelPickerItem].firstChatCapable` — `first(where: { $0.isLikelyChatCapable }) ?? first`, so if every item trips the heuristic (e.g. a provider that exposes only reranker models) the picker is never left unset.

Call sites in `ChatView.swift` that previously used `.first` for default selection now use `.firstChatCapable`. Specific-model lookups (`pickerItems.first(where: { \$0.id == model })`) are unchanged — those are not default-selection.

### Known limits (deliberate)

- Heuristic is name-only. A chat model whose ID happens to contain a flagged token would be wrongly skipped — the `?? first` fallback protects the common case where every item in the list trips the heuristic, but a mixed list with an unusually-named chat model hidden after a correctly-named embedding model would still end up on the embedding. Acceptable trade: the common shape is "embedding-first, chat-second" and this PR fixes that. A non-trivial fraction of the remaining tail requires typed metadata.
- The `e5-` family prefix is intentionally NOT in the family-prefix list, even though `e5-small` / `e5-base` / `e5-large` are embeddings — because `e5-mistral-7b-instruct` is a chat model and the token `e5` alone is too generic to gate without a false-positive regression.
- The correct long-term fix is typed capability metadata on remote models (per-provider probing; OpenAI's `/v1/models/{id}` exposes no `kind`, some Ollama tags imply it, Gemini's `supportedGenerationMethods` carries it). Out of scope for this PR.

## What changed and why

- `Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift` — add `isLikelyChatCapable`, the static `isLikelyEmbeddingOrRerankerID(_:)` classifier, and `[ModelPickerItem].firstChatCapable`. New code, no existing behavior changed.
- `Packages/OsaurusCore/Views/Chat/ChatView.swift` — 8 default-selection call sites switch from `.first` to `.firstChatCapable` (lines 297, 322, 576, 674, 2050, 2135, 2213, 2230).
- `Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift` — new file; 15 tests covering known embedding/reranker IDs (OpenAI, Nomic, Jina, BGE, Colbert), known chat IDs (GPT, Claude, Qwen, Llama, Mistral, Gemini), provider-prefix stripping, substring-vs-token matching, `.foundation` / `.local` bypass, and `firstChatCapable` fallback behavior including the empty-array case.

## Validation

\`\`\`
swift build --package-path Packages/OsaurusCore
# Build complete!

swift test --package-path Packages/OsaurusCore --filter ModelPickerItemChatCapabilityTests
# Test run with 15 tests in 1 suite passed
\`\`\`

Manual repro of #884: added a custom remote provider whose `/v1/models` returns an embedding model first; before this change the Chat tab auto-selected it and chat turns failed with HTTP 500. With this change, the picker skips to the first chat-capable entry and the chat works.

Closes #884.