### PR TITLE
fix(models): refuse model download when disk lacks space to finish

### DIFF
--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -165,6 +165,29 @@ final class ModelDownloadService: ObservableObject {
                     }
                 }
 
+                // Preflight disk-space check. Runs on the filesystem that hosts
+                // `model.localDirectory` — which may be an external drive when
+                // the user has pointed `DirectoryPickerService` at one — so we
+                // can't assume boot-volume capacity. If the query itself fails
+                // we proceed with the download; a stale estimate is worse than
+                // none, and the ordinary write-path error handling still fires.
+                let bytesToDownload = totalBytes - completedFileBytes
+                if bytesToDownload > 0,
+                    let freeBytes = Self.freeBytesOnVolume(containing: model.localDirectory),
+                    let refusal = Self.storageRefusalMessage(
+                        neededBytes: bytesToDownload,
+                        freeBytes: freeBytes
+                    )
+                {
+                    await MainActor.run {
+                        if self.downloadTokens[model.id] == token {
+                            self.downloadStates[model.id] = .failed(error: refusal)
+                            self.clearDownloadTracking(for: model.id)
+                        }
+                    }
+                    return
+                }
+
                 await MainActor.run {
                     guard self.downloadTokens[model.id] == token else { return }
                     let fraction = totalBytes > 0 ? Double(completedFileBytes) / Double(totalBytes) : 0
@@ -355,6 +378,54 @@ final class ModelDownloadService: ObservableObject {
     static func resolveURL(repoId: String, path: String) -> URL? {
         let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
         return URL(string: "https://huggingface.co/\(repoId)/resolve/main/\(encoded)")
+    }
+
+    // MARK: - Disk-space preflight
+
+    /// Safety margin on top of the raw byte count, to cover Hugging Face LFS
+    /// pointers that can under-report file size and the OS's need for a small
+    /// amount of headroom during the atomic rename at the tail of each file.
+    static let storageSafetyMarginBytes: Int64 = 256 * 1024 * 1024  // 256 MB
+
+    /// Returns a user-visible refusal message if the download should be
+    /// blocked, or `nil` if `freeBytes` is sufficient for `neededBytes`
+    /// plus the safety margin.
+    ///
+    /// Extracted so the comparison can be unit-tested without mocking the
+    /// filesystem.
+    static func storageRefusalMessage(
+        neededBytes: Int64,
+        freeBytes: Int64
+    ) -> String? {
+        // No new bytes to write (e.g. every file is already on disk from a
+        // prior successful download) — never block on volume capacity.
+        guard neededBytes > 0 else { return nil }
+        guard neededBytes + storageSafetyMarginBytes > freeBytes else { return nil }
+        let needed = ByteCountFormatter.string(fromByteCount: neededBytes, countStyle: .file)
+        let free = ByteCountFormatter.string(fromByteCount: freeBytes, countStyle: .file)
+        return
+            "Not enough disk space to finish this download: need \(needed) free, only \(free) available."
+    }
+
+    /// Returns the free-for-important-usage byte count on the volume that
+    /// hosts `url`. Falls back to the older `.systemFreeSize` query if the
+    /// modern `.volumeAvailableCapacityForImportantUsageKey` is unavailable.
+    /// Returns `nil` if both queries fail — callers should treat `nil` as
+    /// "unknown, proceed" rather than "zero, block".
+    static func freeBytesOnVolume(containing url: URL) -> Int64? {
+        let probe = url
+        let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
+        if let values = try? probe.resourceValues(forKeys: keys),
+            let capacity = values.volumeAvailableCapacityForImportantUsage
+        {
+            return capacity
+        }
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: probe.path),
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
+        {
+            return free
+        }
+        return nil
     }
 
     private func updateDownloadProgress(

--- a/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
@@ -1,0 +1,110 @@
+//
+//  ModelDownloadServiceStorageTests.swift
+//  osaurusTests
+//
+//  Covers the disk-space preflight helpers introduced for #580, where a
+//  failed parallel download leaves orphaned partial files on disk and
+//  the UI ends up permanently out of sync with the CLI. The primary
+//  defense is refusing to start a download that cannot possibly finish;
+//  these tests pin the refusal-threshold arithmetic so the safety margin
+//  never silently collapses to zero or inverts.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct ModelDownloadServiceStorageTests {
+
+    // MARK: - storageRefusalMessage
+
+    @Test func refusesWhenNeededExceedsFree() {
+        // 10 GB requested, 1 GB free → refuse.
+        let message = ModelDownloadService.storageRefusalMessage(
+            neededBytes: 10 * 1024 * 1024 * 1024,
+            freeBytes: 1 * 1024 * 1024 * 1024
+        )
+        #expect(message != nil)
+        #expect(message?.contains("Not enough disk space") == true)
+    }
+
+    @Test func allowsWhenFreeComfortablyExceedsNeeded() {
+        // 1 GB requested, 10 GB free → proceed.
+        let message = ModelDownloadService.storageRefusalMessage(
+            neededBytes: 1 * 1024 * 1024 * 1024,
+            freeBytes: 10 * 1024 * 1024 * 1024
+        )
+        #expect(message == nil)
+    }
+
+    @Test func enforcesSafetyMargin() {
+        // When the tail of the write needs a little headroom (LFS size
+        // under-reports, OS rename scratch), refusing exactly-at-the-line
+        // avoids "ran out of space in the last megabyte" failures.
+        let needed: Int64 = 1 * 1024 * 1024 * 1024  // 1 GB
+        let margin = ModelDownloadService.storageSafetyMarginBytes
+
+        // Free = needed + (margin - 1): should REFUSE (margin not satisfied).
+        let refusedAtEdge = ModelDownloadService.storageRefusalMessage(
+            neededBytes: needed,
+            freeBytes: needed + margin - 1
+        )
+        #expect(refusedAtEdge != nil)
+
+        // Free = needed + margin: should REFUSE (strict >, not >=).
+        let refusedAtMargin = ModelDownloadService.storageRefusalMessage(
+            neededBytes: needed,
+            freeBytes: needed + margin
+        )
+        #expect(refusedAtMargin == nil)
+
+        // Free = needed + margin + 1: should PROCEED.
+        let proceed = ModelDownloadService.storageRefusalMessage(
+            neededBytes: needed,
+            freeBytes: needed + margin + 1
+        )
+        #expect(proceed == nil)
+    }
+
+    @Test func zeroNeededBytesAlwaysProceeds() {
+        // Resume of a fully-complete download: nothing left to write, so
+        // even a near-full volume should pass the preflight.
+        let message = ModelDownloadService.storageRefusalMessage(
+            neededBytes: 0,
+            freeBytes: 0
+        )
+        #expect(message == nil)
+    }
+
+    @Test func refusalMessageIsUserFacingAndHumanSized() {
+        // Reporters of #580 had no actionable detail in the failure — the
+        // refusal surface must name the numbers. This test locks in that
+        // the formatter is invoked (byte counts rendered as e.g. "1 GB",
+        // not raw digits) so an accidental drop of ByteCountFormatter
+        // surfaces immediately.
+        let message = ModelDownloadService.storageRefusalMessage(
+            neededBytes: 5_000_000_000,
+            freeBytes: 500_000_000
+        )
+        guard let message else { Issue.record("expected refusal"); return }
+        #expect(message.contains(" GB") || message.contains(" MB"))
+        #expect(!message.contains("5000000000"))
+    }
+
+    // MARK: - freeBytesOnVolume
+
+    @Test func freeBytesOnCurrentVolumeIsPositive() {
+        // The test harness always runs on a mounted volume with at least
+        // some free space; this sanity-checks that the query returns
+        // something at all, so a future regression in the `resourceValues`
+        // key usage (e.g. passing a wrong key) would be caught.
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let bytes = ModelDownloadService.freeBytesOnVolume(containing: tmp)
+        #expect(bytes != nil)
+        if let bytes {
+            #expect(bytes > 0)
+        }
+    }
+}


### PR DESCRIPTION
## Business rationale

Issue #580 describes a cascade: two simultaneous model downloads fail with an out-of-space error, the UI then shows no models (while the CLI still lists them), and the inconsistency persists across manual delete-and-redownload. Users who hit this path once land in a "the app is broken" state with no actionable diagnostic.

The primary trigger is the failed download itself — nothing today stops a download from starting when the target volume cannot possibly hold the result. Catching this at the preflight turns a silent-data-corruption-adjacent failure into a clear, actionable error before any bytes hit disk, which is the cheapest place to fix the class of bug.

The issue is labeled `good first issue`, suggesting a scoped contributor fix is expected; this PR is that scope.

## Coding rationale

### Root cause (for the preflight portion)

`ModelDownloadService.download(_:)` resolves the Hugging Face file list, sums its byte count into `totalBytes`, and starts writing immediately. There is no disk-space check. When the volume fills mid-download, URLSession's atomic-move fails and the service sets `.failed`, but by then partial files are on disk and tracked state can drift from what the UI shows.

### Approach

Refuse to start the download if the target volume can't hold what's left to fetch:

1. **Compute remaining bytes** as `totalBytes - completedFileBytes` — i.e. the actual new bytes we'd write, accounting for files already fully present on disk from an earlier partial attempt.
2. **Query the correct volume.** The models directory can be redirected to an external drive via `DirectoryPickerService`, so capacity is queried on `model.localDirectory` rather than assuming the boot volume. Preferred key is `URLResourceKey.volumeAvailableCapacityForImportantUsageKey` (Int64, excludes system reserve), with a fallback to `FileManager.attributesOfFileSystem(forPath:)` + `.systemFreeSize` when the key isn't available.
3. **Fail open on query failure.** If both queries fail, the preflight returns `nil` and the download proceeds — a stale or missing estimate is worse than none; the ordinary write-path error handling still catches the failure.
4. **Safety margin.** `256 MB` is subtracted from the free-space estimate before the comparison, because Hugging Face LFS pointers can slightly under-report file size and the OS needs some headroom for the atomic-rename at the tail of each file. Refusing at the edge avoids "ran out of space on the last megabyte" failures.

The comparison itself is extracted into a pure `storageRefusalMessage(neededBytes:freeBytes:)` helper so the threshold arithmetic can be unit-tested without filesystem mocking.

### Known limits (deliberate, noted for reviewers)

- **Partial-file cleanup is NOT part of this PR.** When a download fails mid-flight for any other reason (network drop, user cancel that races the writer), orphaned partial files stay on disk. A follow-up PR should add cleanup in `DirectDownloader`'s error path; that's a separate concern with its own testing surface.
- **CLI/UI source-of-truth alignment is NOT part of this PR.** Issue #580 also reports that the CLI sees models the UI does not. The CLI queries the running server's `/models` endpoint (`Packages/OsaurusCLI/.../List.swift`), while the UI scans the models directory via `ModelManager.discoverLocalModels()`. Reconciling the two warrants its own design — they can legitimately diverge briefly during downloads — and is out of scope here.

## What changed and why

- `Packages/OsaurusCore/Services/ModelDownloadService.swift`
  - Added preflight block immediately after `totalBytes` is computed and `filesToDownload` is determined, before the first byte is written. Refuses with `.failed(error: …)` and `clearDownloadTracking(for:)` when the helper returns a message.
  - Added three new static helpers: `storageSafetyMarginBytes` (256 MB constant), `storageRefusalMessage(neededBytes:freeBytes:)` (pure comparison), and `freeBytesOnVolume(containing:)` (the URL-resource-value query with fallback).
- `Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift` (new)
  - Six tests covering the refusal-threshold arithmetic: refuses when needed exceeds free, allows when free comfortably exceeds needed, enforces the safety margin exactly at the boundary, zero needed always proceeds, refusal message is user-facing (ByteCountFormatter-formatted, not raw digits), and a sanity check that `freeBytesOnVolume` returns a positive value on `NSTemporaryDirectory()`.

## Validation

\`\`\`
swift build --package-path Packages/OsaurusCore
# Build complete!

swift test --package-path Packages/OsaurusCore --filter ModelDownloadServiceStorageTests
# Test run with 6 tests in 1 suite passed
\`\`\`

Closes #580.