### PR TITLE
fix(server): route API Reference self-tests through loopback

### DIFF
--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -744,6 +744,19 @@ private struct APIReferenceTabContent: View {
         "http://\(server.localNetworkAddress):\(server.port)"
     }
 
+    /// URL used for the in-panel "Test endpoint" calls. Always points at the
+    /// loopback address, even when the server is exposed to the LAN, because
+    /// the request is issued from the osaurus UI process on the same machine
+    /// and the server's auth gate trusts loopback without a Bearer token
+    /// (see `HTTPHandler`'s `isLoopback` check). Using `localNetworkAddress`
+    /// here sent self-test requests through the authenticated path, where
+    /// the UI has no access key to attach, and the panel failed with
+    /// `{"error":{"message":"Invalid access key: Unrecognized token format"}}`
+    /// once exposure was enabled (issue #596).
+    private var testURL: String {
+        "http://127.0.0.1:\(server.port)"
+    }
+
     private var filteredGroups: [(category: APIEndpoint.EndpointCategory, endpoints: [APIEndpoint])] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return APIEndpoint.groupedEndpoints }
@@ -999,7 +1012,7 @@ private struct APIReferenceTabContent: View {
         Task {
             let startTime = Date()
             do {
-                let url = URL(string: "\(serverURL)\(endpoint.path)")!
+                let url = URL(string: "\(testURL)\(endpoint.path)")!
                 let data: Data
                 let response: URLResponse
 
@@ -1037,7 +1050,7 @@ private struct APIReferenceTabContent: View {
         Task {
             let startTime = Date()
             do {
-                let url = URL(string: "\(serverURL)\(endpoint.path)")!
+                let url = URL(string: "\(testURL)\(endpoint.path)")!
                 var request = URLRequest(url: url)
                 request.httpMethod = "POST"
 


### PR DESCRIPTION
## Business rationale

When a user exposes the Osaurus server to the LAN and then opens Server → API Reference to test an endpoint (#596 reporter specifically tried `GET /models`), every test call fails with:

```json
{"error":{"message":"Invalid access key: Unrecognized token format","type":"authentication_error"}}
```

The page that ships as "test your server without leaving the app" is broken in the exact scenario where it matters most — verifying that network exposure works at all. First-use impression on a feature that's meant to be the first thing users try.

## Coding rationale

### Root cause

`APIReferenceTabContent.serverURL` is built from `server.localNetworkAddress`:

```swift
private var serverURL: String {
    "http://\(server.localNetworkAddress):\(server.port)"
}
```

and both `runEndpointTest(_:)` and `runAudioTranscriptionTest(_:)` use that same URL to `URLSession.shared.data(...)` the request. When exposure is on, `localNetworkAddress` is the machine's LAN IP (e.g. `192.168.x.x`), which is a non-loopback address.

`HTTPHandler`'s auth gate trusts loopback-only:

```swift
let isLoopback = trustLoopback && (context.channel.remoteAddress?.isLoopback ?? false)
if !publicPaths.contains(path) && !isPluginRoute && !isLoopback {
    let authHeader = head.headers.first(name: "Authorization") ?? ""
    // … validate Bearer token or 401 …
}
```

The panel sends no `Authorization` header at all (see `runEndpointTest` — only `Content-Type` is set on POST). An empty token splits to `[""]`, `APIKeyValidator.validate` matches `parts.count != 3`, and returns `.invalid(reason: "Unrecognized token format")` — exactly what the reporter pastes. `/models` is not in `publicPaths: {"/", "/health", "/pair"}`, so it's gated.

### Approach

The self-test surface is semantically loopback: it's issued from the same process (the osaurus UI) as the server, on the same machine. Routing self-tests through `127.0.0.1:<port>` keeps them inside the `isLoopback` trust boundary regardless of exposure configuration, and requires no key-wrangling in the UI layer.

Two changes:

1. Add a `private var testURL: String` that returns `"http://127.0.0.1:\(server.port)"`.
2. Point the two self-test call sites (`runEndpointTest` line 1015, `runAudioTranscriptionTest` line 1053) at `testURL` instead of `serverURL`.

`serverURL` is unchanged — it's still shown in the UI for the user to copy, and still embedded in the endpoint-reference documentation rendering. Display is the LAN address; execution is loopback.

### Known limits / considerations

- Does NOT alter the server's auth gate, the key validator, or any external-network path. Users hitting `/models` from another machine still need a valid Bearer key — that's the intended behavior.
- If a future change removes the loopback trust (`isLoopback` check), the self-tests would start failing again. That's flagged in the comment on `testURL` so the dependency is visible.
- The audio transcription test (`runAudioTranscriptionTest`) also benefits from this fix for free; it had the same bug even though the issue reporter only hit `/models`.

## What changed and why

- `Packages/OsaurusCore/Views/Settings/ServerView.swift`
  - Added `private var testURL: String` pointing at `http://127.0.0.1:\(server.port)`, documented inline with a `#596` reference so the reason this diverges from `serverURL` is visible to future readers.
  - Changed both `let url = URL(string: "\(serverURL)\(endpoint.path)")!` sites (endpoint test + audio transcription test) to use `testURL`.

## Validation

\`\`\`
swift build --package-path Packages/OsaurusCore
# Build complete!
\`\`\`

Manual repro of #596 (requires a Mac to run the UI):

1. Enable "Expose to network" in Server settings.
2. Create at least one access key (so `apiKeyValidator.hasKeys == true`; otherwise the gate returns "No access keys configured").
3. Open Server → API Reference → GET /models → Test.
4. Before: 401 with `"Invalid access key: Unrecognized token format"`.
5. After: 200 with the model list (or the server's real response for that endpoint).

Closes #596.