### PR TITLE
fix(provider): send max_tokens to non-OpenAI-reasoning endpoints

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1935,24 +1935,27 @@ private struct OpenResponsesSSEEvent: Decodable {
 // MARK: - Request/Response Models for Remote Provider
 
 /// Reasoning configuration for OpenAI reasoning models (o-series, gpt-5+).
-private struct ReasoningConfig: Encodable {
+struct ReasoningConfig: Encodable {
     let effort: String
 }
 
 /// Venice-specific parameters injected into the request body for Venice AI providers.
 /// See https://docs.venice.ai/api-reference/api-spec
-private struct VeniceParameters: Encodable {
+struct VeniceParameters: Encodable {
     var enable_web_search: String?
     var disable_thinking: Bool?
     var include_venice_system_prompt: Bool?
 }
 
 /// Chat request structure for remote providers (matches OpenAI format)
-private struct RemoteChatRequest: Encodable {
+struct RemoteChatRequest: Encodable {
     let model: String
     let messages: [ChatMessage]
     let temperature: Float?
-    let max_completion_tokens: Int?  // OpenAI's newer parameter name
+    /// Canonical token-cap field. Named after OpenAI's newer parameter; the
+    /// on-the-wire key is chosen in `encode(to:)` based on the model — see
+    /// the block below for the Mistral / OpenAI-compat rationale.
+    let max_completion_tokens: Int?
     let stream: Bool
     let top_p: Float?
     let frequency_penalty: Float?
@@ -1965,12 +1968,52 @@ private struct RemoteChatRequest: Encodable {
     let modelOptions: [String: ModelOptionValue]
     let veniceParameters: VeniceParameters?
 
-    private enum CodingKeys: String, CodingKey {
-        case model, messages, temperature, max_completion_tokens, stream
+    enum CodingKeys: String, CodingKey {
+        case model, messages, temperature, max_completion_tokens, max_tokens, stream
         case top_p, frequency_penalty, presence_penalty, stop, tools, tool_choice
         case reasoning_effort
         case reasoning
         case veniceParameters = "venice_parameters"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model, forKey: .model)
+        try container.encode(messages, forKey: .messages)
+        try container.encodeIfPresent(temperature, forKey: .temperature)
+
+        // OpenAI-compatible endpoints disagree on the token-cap key:
+        //   - OpenAI's o1/o3/o4/gpt-5 reasoning models REQUIRE
+        //     `max_completion_tokens` and reject `max_tokens`.
+        //   - Mistral, OpenRouter, DeepSeek, Groq, Azure, and most other
+        //     "OpenAI-compatible" schemas are strict and reject
+        //     `max_completion_tokens` with a 422 (issue #556).
+        //   - OpenAI's own non-reasoning models accept BOTH names.
+        // Emit the widely-accepted `max_tokens` by default and only switch
+        // to `max_completion_tokens` for reasoning-model IDs, which are
+        // identified by prefix and don't collide with third-party
+        // provider naming.
+        if OpenAIReasoningProfile.matches(modelId: model) {
+            try container.encodeIfPresent(
+                max_completion_tokens,
+                forKey: .max_completion_tokens
+            )
+        } else {
+            try container.encodeIfPresent(max_completion_tokens, forKey: .max_tokens)
+        }
+
+        try container.encode(stream, forKey: .stream)
+        try container.encodeIfPresent(top_p, forKey: .top_p)
+        try container.encodeIfPresent(frequency_penalty, forKey: .frequency_penalty)
+        try container.encodeIfPresent(presence_penalty, forKey: .presence_penalty)
+        try container.encodeIfPresent(stop, forKey: .stop)
+        try container.encodeIfPresent(tools, forKey: .tools)
+        try container.encodeIfPresent(tool_choice, forKey: .tool_choice)
+        try container.encodeIfPresent(reasoning_effort, forKey: .reasoning_effort)
+        try container.encodeIfPresent(reasoning, forKey: .reasoning)
+        try container.encodeIfPresent(veniceParameters, forKey: .veniceParameters)
+        // `modelOptions` is intentionally not in `CodingKeys` — it stays
+        // in-process for model-specific feature flags.
     }
 
     /// Convert to Anthropic Messages API request format

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -1,0 +1,94 @@
+//
+//  RemoteChatRequestEncodingTests.swift
+//  osaurusTests
+//
+//  Pins the on-the-wire key-name choice between `max_tokens` and
+//  `max_completion_tokens` for the openaiLegacy outbound path. Issue
+//  #556 reported a 422 from Mistral ("Extra inputs are not permitted,
+//  `max_completion_tokens`") because OpenAI-compatible third-party
+//  providers reject OpenAI's newer parameter name. The encoder now
+//  emits the widely-accepted `max_tokens` by default and only switches
+//  to `max_completion_tokens` for the OpenAI reasoning-model families
+//  (o-series, gpt-5+) that require it.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("RemoteChatRequest encoding")
+struct RemoteChatRequestEncodingTests {
+
+    @Test func encode_nonReasoningModel_usesMaxTokens() throws {
+        let request = Self.makeRequest(model: "mistral-large-latest", maxTokens: 1024)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["max_tokens"] as? Int == 1024)
+        #expect(payload["max_completion_tokens"] == nil)
+    }
+
+    @Test func encode_openAINonReasoningModel_usesMaxTokens() throws {
+        let request = Self.makeRequest(model: "gpt-4o-mini", maxTokens: 512)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["max_tokens"] as? Int == 512)
+        #expect(payload["max_completion_tokens"] == nil)
+    }
+
+    @Test func encode_openAIReasoningModel_usesMaxCompletionTokens() throws {
+        let request = Self.makeRequest(model: "o1-mini", maxTokens: 2048)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["max_completion_tokens"] as? Int == 2048)
+        #expect(payload["max_tokens"] == nil)
+    }
+
+    @Test func encode_gpt5ReasoningModel_usesMaxCompletionTokens() throws {
+        let request = Self.makeRequest(model: "gpt-5-nano", maxTokens: 4096)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["max_completion_tokens"] as? Int == 4096)
+        #expect(payload["max_tokens"] == nil)
+    }
+
+    @Test func encode_nilMaxTokens_omitsBothKeys() throws {
+        let request = Self.makeRequest(model: "mistral-small-latest", maxTokens: nil)
+        let payload = try Self.encodeAsDictionary(request)
+
+        #expect(payload["max_tokens"] == nil)
+        #expect(payload["max_completion_tokens"] == nil)
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeRequest(model: String, maxTokens: Int?) -> RemoteChatRequest {
+        RemoteChatRequest(
+            model: model,
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: 0.7,
+            max_completion_tokens: maxTokens,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            tools: nil,
+            tool_choice: nil,
+            reasoning_effort: nil,
+            reasoning: nil,
+            modelOptions: [:],
+            veniceParameters: nil
+        )
+    }
+
+    private static func encodeAsDictionary(_ request: RemoteChatRequest) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(request)
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DecodeAsDictionaryError.notAnObject
+        }
+        return obj
+    }
+
+    private enum DecodeAsDictionaryError: Error { case notAnObject }
+}


### PR DESCRIPTION
## Business rationale

Osaurus users on 0.17.4 who point a remote provider at Mistral (or other strict OpenAI-compatible endpoints such as Azure AI Foundry's Mistral passthrough) can't complete a chat turn. The first request returns HTTP 422 with `{\"type\":\"extra_forbidden\",\"loc\":[\"body\",\"max_completion_tokens\"],\"msg\":\"Extra inputs are not permitted\"}` and the session never gets further. Issue #556 has been open since the 0.12.8 era and a user has just re-confirmed it still happens on the current release. The fix unblocks Mistral end-to-end; a handful of other providers that validate their schemas strictly (DeepSeek, Groq, OpenRouter when routed to Mistral, Azure AI Foundry) benefit from the same change.

## Coding rationale

`RemoteChatRequest.CodingKeys` emitted `max_completion_tokens` unconditionally for every openaiLegacy outbound body. That's OpenAI's newer parameter name, introduced alongside the `o1` family. Three things are simultaneously true:

- OpenAI's **reasoning models** (`o1*`, `o3*`, `o4*`, `gpt-5*`) **require** `max_completion_tokens` and **reject** `max_tokens`.
- OpenAI's **non-reasoning models** accept **both** names.
- Most third-party OpenAI-compatible schemas (Mistral, DeepSeek, Groq, most of OpenRouter) only accept **`max_tokens`** and 422 on `max_completion_tokens`.

So the widely-accepted default is `max_tokens` — the only case where we absolutely cannot use it is an OpenAI reasoning model. The project already has `OpenAIReasoningProfile.matches(modelId:)` (`Models/Configuration/ModelOptions.swift:108`) that identifies those by prefix, and `buildChatRequest` already uses it to gate `temperature` / `top_p`. This PR reuses the same helper to pick the token-cap key at encode time.

I chose a custom `Encodable.encode(to:)` over introducing a second stored property because the canonical in-process field stays `max_completion_tokens` (every converter — Anthropic, Gemini, OpenResponses — reads from it), and the choice is purely a wire-format concern. Adding a `max_tokens` entry to `CodingKeys` and selecting at encode time keeps every existing caller unchanged.

I also had to lift `RemoteChatRequest`, `ReasoningConfig`, and `VeniceParameters` from fileprivate to internal so the new test file can construct requests without spinning up a full provider harness. They stay internal to the module.

## What changed and why

- `Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift` — removed `private` on `RemoteChatRequest`, `ReasoningConfig`, `VeniceParameters`; added `max_tokens` to `CodingKeys`; replaced synthesized `Encodable` with an explicit `encode(to:)` that switches on `OpenAIReasoningProfile.matches(modelId:)` and emits exactly one of the two key names per request. Every other call-site invariant is preserved — nil stays nil, the Anthropic / Gemini / OpenResponses converters continue to read the same canonical field.
- `Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift` — 5 contract tests pinning the key-selection:
  - Mistral-family model (`mistral-large-latest`) → `max_tokens` present, `max_completion_tokens` absent.
  - OpenAI non-reasoning model (`gpt-4o-mini`) → `max_tokens`.
  - OpenAI reasoning model (`o1-mini`) → `max_completion_tokens`, `max_tokens` absent.
  - GPT-5 family (`gpt-5-nano`) → `max_completion_tokens`, `max_tokens` absent.
  - Nil token cap → neither key present.

## Validation

- `swift test --filter 'RemoteChatRequestEncoding'` — 5 of 5 passing.
- `swift test` (full `OsaurusCore` package) — 888 of 888 passing.
- `xcrun swift-format lint --strict` on every touched file — clean.
- `swiftlint` on every touched file — no new violations introduced (pre-existing warnings in unrelated parts of `RemoteProviderService.swift` untouched).
- Manual: encoded a sample request via `JSONEncoder` for `mistral-large-latest` and confirmed the JSON body contains `\"max_tokens\":1024` and no `max_completion_tokens` key. Confirmed the same request body for `o1-mini` contains `\"max_completion_tokens\":1024` and no `max_tokens`.

## Non-scope

- No change to temperature / top_p / stop gating — the reasoning-model guardrails added earlier stay exactly as they were.
- No change to Anthropic / Gemini / OpenResponses conversion paths. They continue to read the canonical `max_completion_tokens` field and map it to each API's native name (`max_tokens`, `maxOutputTokens`, `max_output_tokens`).
- No new provider-selection UI. The fix is a pure wire-format correction; it doesn't need a user-facing toggle.

## Residual risks

- The heuristic is model-name-based, not provider-host-based. If someone configures a custom OpenAI-compatible provider and names a non-reasoning model with an `o1*` / `gpt-5*` prefix, the encoder will pick `max_completion_tokens`. In practice this only collides when the upstream actually forwards to OpenAI (OpenRouter's OpenAI route, Azure OpenAI), where OpenAI expects `max_completion_tokens` anyway — so the collision is benign.
- The reverse is also true: a Mistral reasoning variant (e.g., Magistral family) would get `max_tokens` because its name doesn't match the OpenAI prefix set. That's the correct behaviour — Mistral's schema accepts `max_tokens` regardless of model.

Closes #556