### PR TITLE
fix(ci): bump vmlx-swift-lm pin to 5b84387

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   # Bump to invalidate every cache entry without source surgery (e.g., after a
   # known-bad cache or an Xcode toolchain upgrade we want to flush manually).
-  CACHE_SALT: v1
+  CACHE_SALT: v2-vmlx-5b84387
   # Pin Xcode so cache keys are stable across runner image bumps. When you
   # need to upgrade, change here AND in setup-xcode below.
   XCODE_VERSION: "26.3"

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "105ff8bf6a1665aa4e19e64586e63fd8d370d244"
+        "revision" : "5b84387a1f4a05a8cf3801e6a525fcbe41c82142"
       }
     },
     {


### PR DESCRIPTION
## Summary

Bumps vmlx-swift-lm pin from `105ff8b` → `5b84387`, picking up six upstream commits. Three address crashes reproducible on models osaurus users run (Qwen 3.6 27B detokenizer shrinkage, Gemma-4 / Nemotron chat-template parser gaps, Qwen 3.5-VL cache-hit prefill shape). No public vmlx API drift — drop-in.

## Key upstream commits

- **`3e0ec66`** — `fix(tokenizer): guard NaiveStreamingDetokenizer against decode shrinkage`
  Root cause of tpae's reproducible `EXC_BREAKPOINT` on Qwen 3.6 27B via osaurus 0.17.3. `newSegment.suffix(newSegment.count - segment.count)` trapped when tokenizer stateful reassembly produced a shorter string than the previous segment. Fix yields nil instead of crashing.

- **`021e64a`** — `harden: defensive guards across the generate() and prefill paths`
  Three nil-guards and a `max(0, …)` offset clamp; all strict supersets of prior behavior.

- **`7b95bca`** + **`5b84387`** — auto-fallback + swift-transformers 1.3.0 bump
  swift-transformers 1.3.0 transitively pulls huggingface/swift-jinja 2.3.5, which contains the three fixes we previously needed a fork for (Gemma-4 lexer `{{%` ambiguity, Nemotron dict-iter, SelectExpression). Both osaurus and vmlx now resolve the SAME swift-jinja identity — no SPM conflict. `ChatTemplateFallbacks` stays as safety net.

- **`8bc98e5`** — `fix(batch-engine): 2D tensor shape for cache-hit prefill + Kimi routing`
  Fixes Qwen 3.5-VL / Qwen 3.6-27B cache-hit prefill crash on 1D tensor. Adds Kimi-K2 routing to `ToolCallFormat` and `ReasoningParser` (orthogonal, additive).

## Cohesion audit (5 target families)

| Model | `model_type` | Reasoning parser | Tool parser | Template path | `enable_thinking` | Structured `tool_calls` |
|---|---|---|---|---|---|---|
| Gemma-4 26B-A4B | `gemma4` | harmony `<\|channel>` | `.gemma4` | Native | honored | `message.tool_calls[i]` |
| Qwen 3.6 27B | `qwen3_5_moe` | think_xml | `.xmlFunction` | Native | honored | `message.tool_calls[i]` |
| MiniMax M2 | `minimax_m2` | think_xml | `.minimaxM2` | Native | honored | `message.tool_calls[i]` |
| Nemotron-Cascade-2 | `nemotron_h` | think_xml | `.xmlFunction` | Native | honored | `message.tool_calls[i]` |
| Qwen 3.5-VL | `qwen3_5` | think_xml | `.xmlFunction` | Native | honored | `message.tool_calls[i]` |

## What this PR does NOT change

- No osaurus source files (`ModelRuntime.swift`, `MLXBatchAdapter.swift`, `LocalReasoningCapability.swift`, `MLXService.swift`)
- No `Chat.Message` / `GenerateParameters` / `Generation` / `UserInput` signatures
- No JANG / JANGTQ loader behavior
- No duplicate rendering paths (`HuggingFaceIntegrationMacros` uses try-native-then-fallback)
- No osaurus-side zombie code

## Test plan

- [x] `swift package resolve`: clean, vmlx@5b84387, swift-transformers 1.3.0
- [x] `swift test --parallel` against OsaurusCore: 883/883 pass across 120 suites
- [x] Release build + launch of `/Applications/Osaurus.app` on prior pin (`8bc98e5`); `5b84387` is dep-bump-only delta
- [ ] Manual repro of tpae's Qwen 3.6 27B crash on this pin (expected: no crash — `3e0ec66` fix)
- [ ] Manual test: Gemma-4 26B-A4B multi-turn with tools (expected: native template renders, `<\|channel>` reasoning envelopes stream correctly)
- [ ] Manual test: Qwen 3.5-VL with images (expected: cache-hit prefill works; 2D tensor fix)