### PR TITLE
fixed thinking block misroute

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -582,6 +582,8 @@ actor ModelRuntime {
             modelName: modelName
         )
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
+        let modelSupportsThinking =
+            LocalReasoningCapability.capability(forModelId: modelName).supportsThinking
         let producerTask = Task {
             // Collect every tool invocation parsed from this completion. Local
             // models can emit multiple `<tool_call>` blocks per response;
@@ -600,7 +602,11 @@ actor ModelRuntime {
                         if !s.isEmpty { continuation.yield(s) }
                     case .reasoning(let s):
                         if !s.isEmpty {
-                            continuation.yield(StreamingReasoningHint.encode(s))
+                            if modelSupportsThinking {
+                                continuation.yield(StreamingReasoningHint.encode(s))
+                            } else {
+                                continuation.yield(s)
+                            }
                         }
                     case .toolInvocation(let name, let argsJSON):
                         continuation.yield(StreamingToolHint.encode(name))


### PR DESCRIPTION
## Summary

fixed a bug where non thinking local MLX models rendered their entire response inside the thinking block

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
