### PR TITLE
Preflight Search Optimization + Evals Framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONFIG := Release
 PROJECT := App/osaurus.xcodeproj
 DERIVED := build/DerivedData
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals evals-report
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals evals-verbose evals-report
 
 help:
 	@echo "Targets:"
@@ -23,6 +23,7 @@ help:
 	@echo "  bench-run           Run LOCOMO benchmark only (skip ingestion)"
 	@echo "  bench               Full ingest + run LOCOMO benchmark"
 	@echo "  evals               Run OsaurusEvals preflight suite (MODEL=, FILTER=, EVALS_SUITE=)"
+	@echo "  evals-verbose       Same as 'evals' plus per-case raw LLM response (debugging prompt iter)"
 	@echo "  evals-report        Same as 'evals' but also writes JSON to EVALS_OUT (build/evals.json)"
 	@echo "  test           Run OsaurusCore package tests via 'swift test'"
 	@echo "  ci-test        Reproduce the CI test-core job locally (xcodebuild + xcbeautify)"
@@ -146,6 +147,14 @@ evals:
 	@echo "Running OsaurusEvals against $(EVALS_SUITE)…"
 	swift run --package-path Packages/OsaurusEvals osaurus-evals run \
 		--suite $(EVALS_SUITE) \
+		$(if $(MODEL),--model $(MODEL),) \
+		$(if $(FILTER),--filter $(FILTER),)
+
+evals-verbose:
+	@echo "Running OsaurusEvals (verbose) against $(EVALS_SUITE)…"
+	swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+		--suite $(EVALS_SUITE) \
+		--verbose \
 		$(if $(MODEL),--model $(MODEL),) \
 		$(if $(FILTER),--filter $(FILTER),)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONFIG := Release
 PROJECT := App/osaurus.xcodeproj
 DERIVED := build/DerivedData
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals evals-report
 
 help:
 	@echo "Targets:"
@@ -22,6 +22,8 @@ help:
 	@echo "  bench-ingest-chunks Fast chunk-only backfill (no LLM, ~minutes)"
 	@echo "  bench-run           Run LOCOMO benchmark only (skip ingestion)"
 	@echo "  bench               Full ingest + run LOCOMO benchmark"
+	@echo "  evals               Run OsaurusEvals preflight suite (MODEL=, FILTER=, EVALS_SUITE=)"
+	@echo "  evals-report        Same as 'evals' but also writes JSON to EVALS_OUT (build/evals.json)"
 	@echo "  test           Run OsaurusCore package tests via 'swift test'"
 	@echo "  ci-test        Reproduce the CI test-core job locally (xcodebuild + xcbeautify)"
 	@echo "  clean          Remove DerivedData build output"
@@ -128,6 +130,33 @@ bench-run:
 		--batch-size $(BENCH_BATCH)
 
 bench: bench-ingest bench-run
+
+## ── OsaurusEvals (off-CI behaviour evals) ────────────────────────
+# Override on the command line, e.g.
+#   make evals MODEL=foundation
+#   make evals MODEL=openai/gpt-4o-mini FILTER=browser
+#   make evals-report EVALS_OUT=reports/today.json
+# Default model is `auto` (whatever ChatConfigurationStore is set to);
+# see Packages/OsaurusEvals/README.md for the full --model grammar.
+
+EVALS_SUITE ?= Packages/OsaurusEvals/Suites/Preflight
+EVALS_OUT ?= build/evals.json
+
+evals:
+	@echo "Running OsaurusEvals against $(EVALS_SUITE)…"
+	swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+		--suite $(EVALS_SUITE) \
+		$(if $(MODEL),--model $(MODEL),) \
+		$(if $(FILTER),--filter $(FILTER),)
+
+evals-report:
+	@mkdir -p $(dir $(EVALS_OUT))
+	swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+		--suite $(EVALS_SUITE) \
+		$(if $(MODEL),--model $(MODEL),) \
+		$(if $(FILTER),--filter $(FILTER),) \
+		--out $(EVALS_OUT)
+	@echo "Wrote $(EVALS_OUT)"
 
 ## ── Housekeeping ─────────────────────────────────────────────────
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -231,6 +231,31 @@ public struct SystemPromptComposer: Sendable {
                 .subtracting([BuiltinSandboxTools.initPendingToolName])
         }
 
+        // Plugin Companions: when preflight picked a tool from a plugin,
+        // surface the plugin's *other* enabled tools and bundled skill as
+        // a compact teaser. The model uses `capabilities_load` to pull
+        // them in on demand — so the schema stays small this turn but
+        // the model knows what's reachable. Gated on auto-mode (preflight
+        // only runs in auto) and on the presence of `capabilities_load`
+        // (the section instructs the model to call it). Rendering itself
+        // skips when `companions` is empty, so this just decides whether
+        // to even ask for a section.
+        if toolMode == .auto,
+            !effectiveToolsOff,
+            !preflight.companions.isEmpty,
+            tools.contains(where: { $0.function.name == "capabilities_load" }),
+            let companionsSection = PreflightCompanions.render(preflight.companions)
+        {
+            comp.append(
+                .dynamic(
+                    id: "pluginCompanions",
+                    label: "Plugin Companions",
+                    content: companionsSection
+                )
+            )
+            trace?.set("pluginCompanions", String(preflight.companions.count))
+        }
+
         // Agent-loop guidance: short cheat-sheet for the chat-layer-
         // intercepted tools (todo / complete / clarify / share_artifact).
         // Gated on at least one of those names appearing in the resolved

--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -35,6 +35,22 @@ public enum PreflightSearchMode: String, Codable, CaseIterable, Sendable {
         }
     }
 
+    /// Number of catalog candidates pre-ranked by embedding similarity
+    /// and shown to the LLM. Smaller than the full catalog by design —
+    /// Apple Foundation Models has a 4K-token context window and a
+    /// 77-tool catalog tokenises to ~4.3K, blowing the budget before
+    /// the LLM sees the request. The LLM still does the final pick;
+    /// this just narrows its candidate pool. `0` means "show every
+    /// dynamic tool" (legacy behaviour, useful if the embedder breaks).
+    var catalogTopK: Int {
+        switch self {
+        case .off: return 0
+        case .narrow: return 6
+        case .balanced: return 12
+        case .wide: return 24
+        }
+    }
+
     public var helpText: String {
         switch self {
         case .off: return L("Disable pre-flight search. Only explicit tool calls are used.")
@@ -88,6 +104,39 @@ struct PreflightResult: Sendable {
         self.items = items
         self.companions = companions
     }
+}
+
+/// Full diagnostic capture from one preflight invocation. Surfaced only
+/// to the eval path (via `PreflightCapabilitySearch.searchWithDiagnostic`)
+/// — the production chat / HTTP path uses the bare `search(...)` which
+/// drops this so the per-session preflight cache stays small.
+///
+/// The point: when a small model (Foundation, etc.) returns no picks,
+/// engineers need to see WHY — `NONE`, malformed picks, prose, an empty
+/// catalog (config issue), etc. Every short-circuit branch populates a
+/// diagnostic so "no picks" never reads as "no information".
+struct PreflightDiagnostic: Sendable {
+    /// The exact system prompt sent to the LLM. `nil` when preflight
+    /// short-circuited before rendering it (empty query / mode .off /
+    /// empty catalog).
+    let systemPrompt: String?
+    /// Raw text the LLM returned. `nil` when the LLM threw or was
+    /// never called (short-circuit branches above).
+    let rawResponse: String?
+    /// Picks the parser extracted, BEFORE the embedding guardrail
+    /// dropped any. Lets evals tell apart "model picked nothing" from
+    /// "model picked but guardrail rejected".
+    let llmPicks: [String]
+    /// Number of dynamic tools (MCP / plugin / sandbox-plugin) the LLM
+    /// would see in the catalog. Zero means the eval-CLI process has
+    /// no enabled plugin tools — usually a config-dir mismatch with
+    /// the host app, not a preflight bug.
+    let catalogSize: Int
+    /// String description of the error the LLM bridge threw, if any.
+    /// `nil` means the LLM call succeeded (or was never made). Captured
+    /// so verbose eval output can distinguish "model returned NONE"
+    /// from "model bridge threw timeout / circuit-breaker / network".
+    let llmError: String?
 }
 
 /// Per-session record of the initial preflight selection plus every tool the
@@ -238,24 +287,107 @@ enum PreflightCapabilitySearch {
         llm: LLMGenerator,
         embedder: Embedder?
     ) async -> PreflightResult {
+        let (result, _) = await searchWithDiagnostic(
+            query: query,
+            mode: mode,
+            llm: llm,
+            embedder: embedder
+        )
+        return result
+    }
+
+    /// Diagnostic-capturing entry point. Wires the production LLM +
+    /// embedder so callers (the eval CLI, future scoreboards) get the
+    /// exact same one-shot generation contract the chat path uses.
+    /// `agentId` is reserved for future per-agent gating, mirroring
+    /// `search(query:mode:agentId:)`.
+    static func searchWithDiagnostic(
+        query: String,
+        mode: PreflightSearchMode = .balanced,
+        agentId: UUID
+    ) async -> (PreflightResult, PreflightDiagnostic?) {
+        await searchWithDiagnostic(
+            query: query,
+            mode: mode,
+            llm: defaultLLM,
+            embedder: defaultEmbedder
+        )
+    }
+
+    /// Diagnostic-capturing variant with injectable seams. Returns the
+    /// same `PreflightResult` as `search(...)` plus a
+    /// `PreflightDiagnostic?` carrying the system prompt + raw LLM
+    /// response + pre-guardrail picks + catalog stats + LLM error.
+    /// The diagnostic is `nil` only for the truly nothing-to-say
+    /// short-circuits (empty query, mode .off); the empty-catalog
+    /// branch still emits one so verbose eval output can pinpoint a
+    /// config-dir mismatch instead of a model failure.
+    ///
+    /// Only the OsaurusEvals path uses the diagnostic. The chat / HTTP
+    /// path uses the bare `search(...)` so the diagnostic doesn't ride
+    /// along on the per-session `SessionToolState.initialPreflight`
+    /// cache and inflate it.
+    static func searchWithDiagnostic(
+        query: String,
+        mode: PreflightSearchMode,
+        llm: LLMGenerator,
+        embedder: Embedder?
+    ) async -> (PreflightResult, PreflightDiagnostic?) {
+        // Truly nothing-to-say short-circuits — no diagnostic at all.
         guard mode != .off,
             !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else { return .empty }
+        else { return (.empty, nil) }
 
         let (catalog, groups) = await MainActor.run { loadDynamicCatalog() }
-        guard !catalog.isEmpty else { return .empty }
+        // Empty-catalog short-circuit: still emit a diagnostic so verbose
+        // eval output tells the operator "the LLM was never called
+        // because there are no plugin tools enabled" instead of leaving
+        // them guessing.
+        guard !catalog.isEmpty else {
+            return (
+                .empty,
+                PreflightDiagnostic(
+                    systemPrompt: nil,
+                    rawResponse: nil,
+                    llmPicks: [],
+                    catalogSize: 0,
+                    llmError: nil
+                )
+            )
+        }
 
         InferenceProgressManager.shared.preflightWillStartAsync()
         defer { InferenceProgressManager.shared.preflightDidFinishAsync() }
 
-        let llmPicks = await selectTools(
+        // Pre-rank the catalog by embedding similarity and show the LLM
+        // only the top-K — small models (Apple Foundation, 4K window)
+        // can't take a 70+ tool dump otherwise. Full catalog still
+        // backs `validationCatalog` below so the parser accepts any
+        // valid tool name, and the post-pick embedding guardrail
+        // gates relevance regardless. `rankCatalog` falls back to the
+        // full catalog when the index is unavailable.
+        let displayCatalog = await rankCatalog(
             query: query,
             catalog: catalog,
+            topK: mode.catalogTopK
+        )
+
+        let (llmPicks, rawResponse, systemPrompt, llmError) = await selectTools(
+            query: query,
+            displayCatalog: displayCatalog,
+            validationCatalog: catalog,
             groups: groups,
             cap: mode.toolCap,
             llm: llm
         )
-        guard !llmPicks.isEmpty else { return .empty }
+        let diagnostic = PreflightDiagnostic(
+            systemPrompt: systemPrompt,
+            rawResponse: rawResponse,
+            llmPicks: llmPicks,
+            catalogSize: displayCatalog.count,
+            llmError: llmError
+        )
+        guard !llmPicks.isEmpty else { return (.empty, diagnostic) }
 
         let nameToDesc = Dictionary(uniqueKeysWithValues: catalog.map { ($0.name, $0.description) })
         let selectedNames = await applyEmbeddingGuardrail(
@@ -264,7 +396,7 @@ enum PreflightCapabilitySearch {
             nameToDesc: nameToDesc,
             embedder: embedder
         )
-        guard !selectedNames.isEmpty else { return .empty }
+        guard !selectedNames.isEmpty else { return (.empty, diagnostic) }
 
         let (toolSpecs, items, companions) = await MainActor.run {
             let specs = ToolRegistry.shared.specs(forTools: selectedNames)
@@ -286,7 +418,61 @@ enum PreflightCapabilitySearch {
         logger.info(
             "Pre-flight loaded \(toolSpecs.count) tools, \(companions.count) companion plugin(s)"
         )
-        return PreflightResult(toolSpecs: toolSpecs, items: items, companions: companions)
+        let result = PreflightResult(toolSpecs: toolSpecs, items: items, companions: companions)
+        return (result, diagnostic)
+    }
+
+    /// Pre-rank `catalog` by embedding similarity to the query and keep
+    /// the top `topK`. The LLM-visible catalog gets compressed from
+    /// "every dynamic tool" to "the K most semantically relevant",
+    /// which is the only way Apple Foundation Models (4K context) can
+    /// preflight against a real plugin install — a 77-tool dump
+    /// tokenises to ~4.3K and overflows the window before the LLM
+    /// sees the prompt.
+    ///
+    /// Implementation reuses `ToolSearchService` (already maintained
+    /// for the `capabilities_search` tool path) so we don't pay a
+    /// second embed cost per call. Threshold zero so the LLM is the
+    /// floor — embedding rank gates *order*, not *eligibility*.
+    /// Returns the full catalog when:
+    ///   - `topK` is zero or negative (legacy / disabled)
+    ///   - the catalog already fits (no point ranking N down to N)
+    ///   - the search returns nothing (index empty / embedder broken /
+    ///     query is gibberish) — the model still gets to see the full
+    ///     candidate pool rather than nothing
+    static func rankCatalog(
+        query: String,
+        catalog: [ToolRegistry.ToolEntry],
+        topK: Int
+    ) async -> [ToolRegistry.ToolEntry] {
+        guard topK > 0, catalog.count > topK else { return catalog }
+
+        let hits = await ToolSearchService.shared.search(
+            query: query,
+            topK: topK,
+            threshold: 0.0
+        )
+        guard !hits.isEmpty else { return catalog }
+
+        // Map ranked names back to the input catalog entries (preserves
+        // each entry's parameters / enabled state untouched). Keep
+        // search-score order so the LLM sees the strongest match first.
+        let byName = Dictionary(uniqueKeysWithValues: catalog.map { ($0.name, $0) })
+        var ranked: [ToolRegistry.ToolEntry] = []
+        ranked.reserveCapacity(min(topK, hits.count))
+        var seen: Set<String> = []
+        for hit in hits {
+            guard let entry = byName[hit.entry.name],
+                seen.insert(entry.name).inserted
+            else { continue }
+            ranked.append(entry)
+            if ranked.count >= topK { break }
+        }
+        // Last-resort safety net: if the index returned hits but none
+        // mapped back to the live catalog (stale index, MCP
+        // re-registration race, etc.), don't strand the LLM with an
+        // empty list — fall back to the full catalog.
+        return ranked.isEmpty ? catalog : ranked
     }
 
     /// Snapshot the dynamic-tool catalog and its `tool → group` map from the
@@ -327,45 +513,79 @@ enum PreflightCapabilitySearch {
         try await EmbeddingService.shared.embed(texts: texts)
     }
 
+    /// Returns picks + the raw LLM response + the exact system prompt sent
+    /// + a string description of any LLM error. The raw text, prompt, and
+    /// error feed `PreflightDiagnostic` for the eval path; the chat path
+    /// discards them. `rawResponse == nil` means the LLM call threw —
+    /// `error` then carries the reason.
+    ///
+    /// `displayCatalog` is what the LLM sees in the prompt (post-rerank,
+    /// usually 12 tools). `validationCatalog` is the full dynamic
+    /// registry — we parse picks against the full set so the model can
+    /// reference a tool by name even if rerank didn't surface it
+    /// (small models often know popular tool names from training and
+    /// fill in `browser_navigate` even when it wasn't in the top-K).
+    /// The post-pick embedding guardrail still gates relevance, so
+    /// false-positive picks from outside the displayed window get
+    /// dropped before reaching the agent.
     private static func selectTools(
         query: String,
-        catalog: [ToolRegistry.ToolEntry],
+        displayCatalog: [ToolRegistry.ToolEntry],
+        validationCatalog: [ToolRegistry.ToolEntry],
         groups: [String: String],
         cap: Int,
         llm: LLMGenerator
-    ) async -> [String] {
+    ) async -> (picks: [String], rawResponse: String?, systemPrompt: String, error: String?) {
+        // Prompt design — three deliberate shifts that landed when we
+        // started running the eval suite against Apple Foundation:
+        //   1. Lead with a one-sentence "what is the user trying to
+        //      do?" scaffold so small models leave pure pattern-match
+        //      mode before they pick.
+        //   2. Three positive examples covering distinct shapes
+        //      (lookup / browser / sandbox) + two NONE examples —
+        //      keeps the abstain signal without letting it dominate.
+        //   3. Dropped "Prefer NONE over guessing" — the examples
+        //      teach the abstain boundary better than a rule does.
         let systemPrompt = """
-            You are a tool selector. Pick the FEWEST tools needed to satisfy the user's request.
+            You are a tool selector for a chat agent.
 
-            Output format: one pick per line as
-                <tool_name> | <one short reason this tool matches the request>
-            If nothing in the catalog clearly matches, output exactly:
-                NONE
+            Step 1 — In one short sentence, name what the user is trying to do.
+            Step 2 — Pick the tool whose purpose serves that intent. Prefer fewer; up to \(cap).
+            Step 3 — Output one pick per line as: tool_name | one short reason
+                     The bare tool name on its own line is also accepted.
+                     Do not wrap the name in angle brackets, backticks, or quotes.
+                     If nothing in the catalog fits, output exactly: NONE
 
-            Hard rules:
-            - \(cap) is a HARD CEILING, not a target. Prefer fewer. Prefer NONE over guessing.
-            - Only pick a tool when its description (or params) clearly matches the request. Do not pad.
-            - If the message is small talk, a status check, a thank-you, or a continuation that needs no new external action, output NONE.
-            - Pick specific tools only — never the `[provider]` labels.
-            - Use exact tool names from the `tool:` lines below; nothing else.
+            Examples
+            --------
+            "what's the weather in Tokyo?"      -> get_weather | current weather for a city
+            "check my orders on amazon"         -> browser_navigate | open the orders page in a browser
+            "convert this csv to json"          -> sandbox_exec | run a script to convert formats
+            "thanks, that's perfect"            -> NONE
+            "write me a haiku about cats"       -> NONE
 
-            Example input: "what's the weather in Tokyo?"
-            Example output:
-            get_weather | fetches current weather for a city
+            Rules
+            -----
+            - Use exact tool names from the `tool:` lines below.
+            - Skip the bracketed `[provider]` labels — those are NOT tools.
+            - Pick a tool when its purpose plausibly serves the user's intent, even if the description doesn't lexically match.
 
-            Example input: "thanks, that's perfect"
-            Example output:
-            NONE
-
-            \(formatCatalog(catalog, groups: groups))
+            Catalog
+            -------
+            \(formatCatalog(displayCatalog, groups: groups))
             """
 
         do {
             let response = try await llm(query, systemPrompt)
-            return parseJustifiedPicks(from: response, catalog: catalog, cap: cap)
+            let picks = parseJustifiedPicks(
+                from: response,
+                catalog: validationCatalog,
+                cap: cap
+            )
+            return (picks, response, systemPrompt, nil)
         } catch {
             logger.info("Pre-flight tool selection skipped: \(error)")
-            return []
+            return ([], nil, systemPrompt, String(describing: error))
         }
     }
 
@@ -426,16 +646,22 @@ enum PreflightCapabilitySearch {
 
     // MARK: Response Parsing
 
-    /// Parse the model's per-line `<name> | <reason>` response into canonical
-    /// tool names. Picks without a reason are dropped — the justification
-    /// requirement is the anti-padding mechanism. A standalone `NONE` line
-    /// (case-insensitive) **abstains** when no valid pick has been collected
-    /// yet, and **terminates** parsing (preserving prior picks) otherwise —
-    /// this salvages the common failure mode where a model emits a real pick
-    /// followed by a stray `NONE`. `[provider]` group tokens are silently
-    /// ignored (the previous implementation expanded them to every tool in
-    /// the group, which was the single biggest over-selection vector).
-    /// Output is capped at `cap`.
+    /// Parse the model's response into canonical tool names. Accepts two
+    /// shapes per line: `<name> | <reason>` (preferred — easy to read in
+    /// logs) and bare `<name>` (small models routinely forget the pipe).
+    /// The anti-padding contract that justifications used to enforce is
+    /// now carried by `applyEmbeddingGuardrail`: every pick gets gated
+    /// against the query embedding, so a "padding" pick whose semantics
+    /// don't match the request gets dropped post-parse anyway.
+    ///
+    /// A standalone `NONE` line (case-insensitive) **abstains** when no
+    /// valid pick has been collected yet, and **terminates** parsing
+    /// (preserving prior picks) otherwise — this salvages the common
+    /// failure mode where a model emits a real pick followed by a stray
+    /// `NONE`. `[provider]` group tokens are silently ignored (the
+    /// previous implementation expanded them to every tool in the group,
+    /// which was the single biggest over-selection vector). Output is
+    /// capped at `cap`.
     static func parseJustifiedPicks(
         from response: String,
         catalog: [ToolRegistry.ToolEntry],
@@ -454,44 +680,79 @@ enum PreflightCapabilitySearch {
 
         for rawLine in trimmed.components(separatedBy: "\n") {
             guard selected.count < cap else { break }
-            let line =
+            // Strip bullets + line-level wrapping (`<name | reason>`)
+            // BEFORE the `|` split so Apple Foundation's most common
+            // output shape unwraps cleanly.
+            let line = stripWrapping(
                 rawLine
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .replacingOccurrences(of: "^[-•*]\\s*", with: "", options: .regularExpression)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .replacingOccurrences(of: "^[-•*]\\s*", with: "", options: .regularExpression)
+            )
             guard !line.isEmpty else { continue }
-            // `NONE` is the abstain signal when emitted alone (selected is
-            // still empty) and a "no more picks" terminator otherwise. The
-            // common failure mode it salvages: a valid pick followed by a
-            // stray `NONE` line. See the docstring for the full rationale.
+            // `NONE` is the abstain signal when emitted alone (selected
+            // is still empty) and a "no more picks" terminator
+            // otherwise — salvages the common `pick\nNONE` failure mode.
             if line.uppercased() == "NONE" { break }
 
-            // Required `name | reason` shape. No `|` ⇒ no justification ⇒
-            // drop. This is the anti-padding contract.
-            let parts = line.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
-            guard parts.count == 2 else { continue }
-            let reason = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !reason.isEmpty else { continue }
-
-            var name = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            // Reject bare `[provider]`-style group tokens outright. Must come
-            // before the trailing-bracket strip below or `[spotify]` would
-            // collapse to an empty name and silently fall through to the
-            // canonical-name check.
-            if name.hasPrefix("[") { continue }
-            // Strip a trailing `[provider]` annotation if the model echoed
-            // the catalog formatting back at us (`play [spotify]` → `play`).
-            if let bracket = name.firstIndex(of: "[") {
-                name = String(name[..<bracket]).trimmingCharacters(in: .whitespaces)
-            }
-
-            guard let canonical = validNames[name.lowercased()] else { continue }
-            if seen.insert(canonical).inserted {
-                selected.append(canonical)
-            }
+            // The pipe is just diagnostic now — the post-pick embedding
+            // guardrail enforces relevance, so bare `<name>` is fine.
+            let nameToken =
+                line
+                .split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let canonical = canonicalize(nameToken: nameToken, validNames: validNames),
+                seen.insert(canonical).inserted
+            else { continue }
+            selected.append(canonical)
         }
 
         logger.info("Pre-flight: LLM selected \(selected.count) tools: \(selected.joined(separator: ", "))")
         return selected
+    }
+
+    /// Resolve a parsed name token to a canonical tool name, handling
+    /// every "model echoed the catalog formatting" variant we've
+    /// observed in the wild. Returns `nil` when the token is a
+    /// `[provider]` group label (silently dropped) or doesn't resolve
+    /// to a known tool.
+    private static func canonicalize(
+        nameToken: String,
+        validNames: [String: String]
+    ) -> String? {
+        var name = nameToken
+        // `[provider]` group labels: must reject BEFORE the trailing-
+        // bracket strip below, or `[spotify]` collapses to an empty
+        // name and falls through to the lookup.
+        if name.hasPrefix("[") { return nil }
+        // Trailing `[provider]` annotation echoed from the catalog
+        // (`play [spotify]` → `play`).
+        if let bracket = name.firstIndex(of: "[") {
+            name = String(name[..<bracket]).trimmingCharacters(in: .whitespaces)
+        }
+        // Leading `tool:` prefix echoed from the catalog
+        // (`tool: play` → `play`).
+        if name.lowercased().hasPrefix("tool:") {
+            name = String(name.dropFirst("tool:".count)).trimmingCharacters(in: .whitespaces)
+        }
+        // Per-name wrapping — catches `<name>` without a reason,
+        // which the line-level strip in the caller can't see.
+        name = stripWrapping(name)
+        return validNames[name.lowercased()]
+    }
+
+    /// Strip a single layer of common wrapping characters around a tool
+    /// name token. Small models echo the prompt's placeholder syntax —
+    /// Apple Foundation almost always wraps in `<...>`, others use
+    /// backticks or quotes. One layer only; doubly-wrapped tokens
+    /// aren't a real failure mode.
+    static func stripWrapping(_ name: String) -> String {
+        let pairs: [(open: Character, close: Character)] = [
+            ("<", ">"), ("`", "`"), ("\"", "\""), ("'", "'"),
+        ]
+        for pair in pairs where name.first == pair.open && name.last == pair.close && name.count >= 2 {
+            return String(name.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+        }
+        return name
     }
 
     // MARK: Embedding Guardrail

--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -68,8 +68,26 @@ struct PreflightCapabilityItem: Equatable, Sendable {
 struct PreflightResult: Sendable {
     let toolSpecs: [Tool]
     let items: [PreflightCapabilityItem]
+    /// Phase-2 "teaser" capabilities the model can pull in via
+    /// `capabilities_load`. Derived from `toolSpecs` by grouping picks back
+    /// to their plugin and surfacing the plugin's enabled sibling tools and
+    /// bundled skill. Empty when no pick belongs to a plugin or the plugin
+    /// has no other enabled tools / skill. Cached on `SessionToolState` so
+    /// the rendered "Plugin Companions" prompt section is byte-stable
+    /// across turns (KV-cache friendly).
+    let companions: [PluginCompanion]
 
     static let empty = PreflightResult(toolSpecs: [], items: [])
+
+    init(
+        toolSpecs: [Tool],
+        items: [PreflightCapabilityItem],
+        companions: [PluginCompanion] = []
+    ) {
+        self.toolSpecs = toolSpecs
+        self.items = items
+        self.companions = companions
+    }
 }
 
 /// Per-session record of the initial preflight selection plus every tool the
@@ -248,17 +266,27 @@ enum PreflightCapabilitySearch {
         )
         guard !selectedNames.isEmpty else { return .empty }
 
-        let (toolSpecs, items) = await MainActor.run {
+        let (toolSpecs, items, companions) = await MainActor.run {
             let specs = ToolRegistry.shared.specs(forTools: selectedNames)
             let items = selectedNames.compactMap { name -> PreflightCapabilityItem? in
                 guard let desc = nameToDesc[name] else { return nil }
                 return .init(type: .tool, name: name, description: desc)
             }
-            return (specs, items)
+            // Phase 2: derive plugin companions (sibling tools + plugin
+            // skill) for any pick that belongs to a plugin/provider. The
+            // model pulls these in on demand via `capabilities_load`,
+            // so they don't inflate the schema this turn.
+            let companions = PreflightCompanions.derive(
+                selectedNames: selectedNames,
+                query: query
+            )
+            return (specs, items, companions)
         }
 
-        logger.info("Pre-flight loaded \(toolSpecs.count) tools")
-        return PreflightResult(toolSpecs: toolSpecs, items: items)
+        logger.info(
+            "Pre-flight loaded \(toolSpecs.count) tools, \(companions.count) companion plugin(s)"
+        )
+        return PreflightResult(toolSpecs: toolSpecs, items: items, companions: companions)
     }
 
     /// Snapshot the dynamic-tool catalog and its `tool → group` map from the

--- a/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
@@ -1,0 +1,256 @@
+//
+//  PreflightCompanions.swift
+//  osaurus
+//
+//  Phase-2 preflight: when the LLM picks a tool that belongs to a plugin
+//  (e.g. `browser_navigate` from `osaurus.browser`), surface the plugin's
+//  *other* enabled tools and bundled skill as a compact teaser. The model
+//  loads anything it needs via the existing `capabilities_load` tool — no
+//  new ABI, no schema inflation, no extra round-trip in the common case.
+//
+//  The single biggest under-use of plugins today is that the model gets
+//  one tool from a cohesive plugin and never learns that the rest exist.
+//  This file fixes that by deriving + rendering the companion section.
+//
+
+import Foundation
+
+// MARK: - Data
+
+/// One sibling tool from the same plugin as a picked tool. Mirrors only
+/// the fields needed to render the teaser line — the full `Tool` spec is
+/// re-resolved from `ToolRegistry` if/when the model calls
+/// `capabilities_load`.
+struct ToolTeaser: Equatable, Sendable {
+    let name: String
+    let description: String
+}
+
+/// One plugin-bundled skill the model can pull in via
+/// `capabilities_load("skill/<name>")`. Only carries the surface
+/// description — the full instructions remain in `SkillManager` and load
+/// on demand, keeping the system prompt small.
+struct SkillTeaser: Equatable, Sendable {
+    let name: String
+    let description: String
+}
+
+/// All companion capabilities (siblings + skill) attached to one plugin
+/// that contributed at least one tool to this turn's preflight selection.
+/// Empty when both `siblingTools` and `skill` would be empty — the
+/// derivation step skips those plugins entirely.
+struct PluginCompanion: Equatable, Sendable {
+    /// Provider/group identifier from `ToolRegistry.groupName(for:)`.
+    /// For native plugins this matches `PluginManifest.plugin_id`
+    /// (e.g. `osaurus.browser`); for MCP it's the provider name; for
+    /// sandbox plugins it's the sandbox plugin id.
+    let pluginId: String
+    /// Friendly name for prompt rendering. Falls back to `pluginId` when
+    /// no display name is available (MCP / sandbox plugins).
+    let pluginDisplay: String
+    /// `nil` when the plugin ships no enabled skill. The teaser still
+    /// renders if `siblingTools` is non-empty.
+    let skill: SkillTeaser?
+    /// Already deduped against picked tools, deterministically ordered,
+    /// and capped (see `PreflightCompanions.maxSiblingTools`).
+    let siblingTools: [ToolTeaser]
+}
+
+// MARK: - Derivation
+
+enum PreflightCompanions {
+
+    /// Hard cap on sibling tools rendered per plugin. Big plugins (the
+    /// browser plugin ships ~22 tools) would otherwise blow the prompt
+    /// budget. The model can always run `capabilities_search` for more.
+    static let maxSiblingTools: Int = 6
+
+    /// Build the companion list from a finalized preflight selection.
+    /// MUST run on the main actor — touches `ToolRegistry`, `SkillManager`
+    /// and `PluginManager`, which are all main-actor-isolated.
+    @MainActor
+    static func derive(
+        selectedNames: [String],
+        query: String
+    ) -> [PluginCompanion] {
+        guard !selectedNames.isEmpty else { return [] }
+
+        // Bucket picks by their plugin/provider group. Tools without a
+        // group (built-in / runtime-managed) carry no companion notion
+        // and are dropped here.
+        var pluginIds: [String] = []
+        var seenPluginIds: Set<String> = []
+        for name in selectedNames {
+            guard let group = ToolRegistry.shared.groupName(for: name),
+                !group.isEmpty
+            else { continue }
+            if seenPluginIds.insert(group).inserted {
+                pluginIds.append(group)
+            }
+        }
+        guard !pluginIds.isEmpty else { return [] }
+
+        let pickedSet = Set(selectedNames)
+        let allDynamic = ToolRegistry.shared.listDynamicTools()
+        // Pre-bucket dynamic tools by group in one pass so we don't walk
+        // the catalog once per picked plugin.
+        var byGroup: [String: [ToolRegistry.ToolEntry]] = [:]
+        for entry in allDynamic {
+            guard let group = ToolRegistry.shared.groupName(for: entry.name),
+                !group.isEmpty
+            else { continue }
+            byGroup[group, default: []].append(entry)
+        }
+
+        var companions: [PluginCompanion] = []
+        companions.reserveCapacity(pluginIds.count)
+
+        for pluginId in pluginIds {
+            let display = pluginDisplayName(for: pluginId)
+            let siblingsRaw = (byGroup[pluginId] ?? []).filter { !pickedSet.contains($0.name) }
+            let siblings = selectSiblings(from: siblingsRaw, query: query)
+            let skill = pluginSkillTeaser(for: pluginId)
+
+            // Skip plugins where there's literally nothing to surface. A
+            // plugin with one tool, no sibling, no skill contributes only
+            // noise to the prompt.
+            if siblings.isEmpty, skill == nil { continue }
+
+            companions.append(
+                PluginCompanion(
+                    pluginId: pluginId,
+                    pluginDisplay: display,
+                    skill: skill,
+                    siblingTools: siblings
+                )
+            )
+        }
+
+        return companions
+    }
+
+    /// Score-then-cap sibling tools. Scoring is intentionally cheap (word
+    /// overlap with the query) — embeddings are an optional dependency
+    /// throughout preflight and we don't want to add a second async hop
+    /// just to order a teaser. Final ordering is alphabetical so two
+    /// equally-scored tools render in a deterministic, KV-cache-stable
+    /// order across runs.
+    static func selectSiblings(
+        from candidates: [ToolRegistry.ToolEntry],
+        query: String
+    ) -> [ToolTeaser] {
+        guard !candidates.isEmpty else { return [] }
+        let queryTokens = tokenize(query)
+
+        let scored: [(entry: ToolRegistry.ToolEntry, score: Int)] = candidates.map { entry in
+            let haystack = tokenize("\(entry.name) \(entry.description)")
+            // Count overlap with the query so e.g. "log in to amazon" lifts
+            // `browser_open_login` ahead of `browser_set_user_agent`.
+            let overlap = queryTokens.intersection(haystack).count
+            return (entry, overlap)
+        }
+
+        let topByScore = scored
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                return lhs.entry.name < rhs.entry.name
+            }
+            .prefix(maxSiblingTools)
+
+        // Re-sort the kept slice alphabetically so prompt rendering is
+        // byte-stable independent of dictionary ordering inside the
+        // catalog source.
+        return topByScore
+            .map { ToolTeaser(name: $0.entry.name, description: $0.entry.description) }
+            .sorted { $0.name < $1.name }
+    }
+
+    /// Lowercase-alphanumeric word split. Strips punctuation so a query
+    /// like "amazon-orders?" still tokenises to ["amazon", "orders"].
+    static func tokenize(_ text: String) -> Set<String> {
+        let lowered = text.lowercased()
+        let pieces = lowered.split { !$0.isLetter && !$0.isNumber }
+        var tokens: Set<String> = []
+        for piece in pieces {
+            // Single-char tokens are noise (a, e, i, etc.) and drag the
+            // overlap score around without adding signal.
+            guard piece.count >= 2 else { continue }
+            tokens.insert(String(piece))
+        }
+        return tokens
+    }
+
+    @MainActor
+    private static func pluginSkillTeaser(for pluginId: String) -> SkillTeaser? {
+        let skills = SkillManager.shared.pluginSkills(for: pluginId)
+        guard let skill = skills.first(where: { $0.enabled }) else { return nil }
+        return SkillTeaser(name: skill.name, description: skill.description)
+    }
+
+    /// Friendly plugin name for the rendered teaser. Native plugins carry
+    /// a `name` in their manifest (e.g. "Browser"); MCP/sandbox-plugin
+    /// groups don't — we fall back to the raw id so the section still
+    /// renders something sensible.
+    @MainActor
+    private static func pluginDisplayName(for pluginId: String) -> String {
+        if let loaded = PluginManager.shared.loadedPlugin(for: pluginId),
+            let display = loaded.plugin.manifest.name,
+            !display.isEmpty
+        {
+            return display
+        }
+        return pluginId
+    }
+
+    // MARK: - Rendering
+
+    /// Render the "Plugin Companions" prompt section. Returns `nil` when
+    /// `companions` is empty so callers can skip appending an empty
+    /// section. Skill lines come before sibling tools in each block —
+    /// the trailing nudge tells the model to load the skill first since
+    /// the skill explains when each sibling tool is appropriate.
+    static func render(_ companions: [PluginCompanion]) -> String? {
+        guard !companions.isEmpty else { return nil }
+        let body = companions.map(renderBlock).joined(separator: "\n\n")
+        return """
+            ## Plugin Companions
+
+            \(body)
+
+            \(usageNudge)
+            """
+    }
+
+    /// Render one plugin's block: header line + skill line (if any) +
+    /// sibling tool lines. Pulled out of `render` so the section/body
+    /// composition reads as a one-liner.
+    private static func renderBlock(_ companion: PluginCompanion) -> String {
+        var lines: [String] = [
+            "You loaded tools from the **\(companion.pluginDisplay)** plugin. "
+                + "These companions exist but are NOT in your schema — pull only what you need:"
+        ]
+        if let skill = companion.skill {
+            let desc = skill.description.isEmpty ? "Plugin skill." : skill.description
+            lines.append("- `skill/\(skill.name)` — \(desc)")
+        }
+        for tool in companion.siblingTools {
+            let desc = tool.description.isEmpty ? "(no description)" : tool.description
+            lines.append("- `tool/\(tool.name)` — \(desc)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Trailing instructions appended once per section. The one-shot +
+    /// call-by-name lines exist because reasoning models (Qwen3.x, etc.)
+    /// otherwise treat `capabilities_load` as the action itself and
+    /// re-load the same id every turn instead of calling the now-available
+    /// tool. See `renderNudgeWarnsAgainstReLoadingAndExplainsCallByName`
+    /// for the regression pin.
+    private static let usageNudge = """
+        How to use this section:
+        - Load: `capabilities_load({"ids": ["skill/<name>", "tool/<name>"]})`. Batch ids you'll need together in one call.
+        - Order: load the skill first when one is listed — it explains when each sibling tool is appropriate.
+        - One-shot: a successful `capabilities_load` adds the tool/skill to your schema for the rest of the conversation. Do NOT call `capabilities_load` again for an id you've already loaded.
+        - Use: after loading, call the tool directly by its name (e.g. `browser_open_login(...)`) just like any tool you already had — there is no separate "activate" step.
+        """
+}

--- a/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
@@ -150,7 +150,8 @@ enum PreflightCompanions {
             return (entry, overlap)
         }
 
-        let topByScore = scored
+        let topByScore =
+            scored
             .sorted { lhs, rhs in
                 if lhs.score != rhs.score { return lhs.score > rhs.score }
                 return lhs.entry.name < rhs.entry.name
@@ -160,7 +161,8 @@ enum PreflightCompanions {
         // Re-sort the kept slice alphabetically so prompt rendering is
         // byte-stable independent of dictionary ordering inside the
         // catalog source.
-        return topByScore
+        return
+            topByScore
             .map { ToolTeaser(name: $0.entry.name, description: $0.entry.description) }
             .sorted { $0.name < $1.name }
     }

--- a/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
@@ -99,11 +99,27 @@ public enum PreflightEvaluator {
     /// kept narrow on purpose; if future eval cases need MCP/sandbox
     /// fixture introspection too, extend this surface explicitly
     /// rather than exposing the full `PluginManager`.
+    ///
+    /// Returns an empty set if `loadInstalledPlugins()` hasn't been
+    /// called yet — `PluginManager.plugins` only lists plugins LOADED
+    /// in this process (via `dlopen`), not just installed on disk.
     public static func installedPluginIds() -> Set<String> {
         var ids: Set<String> = []
         for loaded in PluginManager.shared.plugins {
             ids.insert(loaded.plugin.id)
         }
         return ids
+    }
+
+    /// Scan the tools directory and load every installed plugin (native
+    /// dylib + sandbox plugin) into the in-process `PluginManager` /
+    /// `ToolRegistry` / `SkillManager`. The host app does this in
+    /// `AppDelegate.applicationDidFinishLaunching`; the eval CLI is its
+    /// own process and has to invoke it explicitly before preflight can
+    /// see plugin tools or before `installedPluginIds()` returns
+    /// anything. Idempotent — `PluginManager.loadAll` serializes
+    /// concurrent invocations and re-uses already-loaded dylibs.
+    public static func loadInstalledPlugins() async {
+        await PluginManager.shared.loadAll()
     }
 }

--- a/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
@@ -1,0 +1,109 @@
+//
+//  PreflightEvaluator.swift
+//  osaurus
+//
+//  Public facade over `PreflightCapabilitySearch` for off-process callers
+//  (the OsaurusEvals package, future scoreboards, etc.). Keeps the
+//  internal `PreflightResult` / `Tool` / `PluginCompanion` types
+//  encapsulated and exposes a stable, decode-friendly surface that won't
+//  shift if the internal pipeline rearranges itself.
+//
+
+import Foundation
+
+// MARK: - Public types
+
+/// Decode-friendly snapshot of one preflight run for an evaluation
+/// harness. Only carries names + descriptions (no `Tool` schemas, no
+/// JSONSchema parameter blobs) so it round-trips through JSON cleanly
+/// and stays stable as the inference plumbing evolves.
+public struct PreflightEvaluation: Sendable, Codable {
+    /// Tool names the LLM picked, in the canonical order resolved by
+    /// `PreflightCapabilitySearch`. Includes only dynamic-tool picks —
+    /// always-loaded tools (capabilities_search, etc.) are not counted
+    /// here because the evaluator's job is to score the picker, not
+    /// the schema baseline.
+    public let pickedToolNames: [String]
+    /// One entry per plugin that contributed at least one pick. Mirrors
+    /// the "Plugin Companions" prompt section the model would actually
+    /// see, so eval cases can assert on the exact teaser shape.
+    public let companions: [Companion]
+    /// Wall-clock duration of `PreflightCapabilitySearch.search`. Used
+    /// for trend tracking; not part of pass/fail by default.
+    public let latencyMs: Double
+
+    public struct Companion: Sendable, Codable {
+        public let pluginId: String
+        public let pluginDisplay: String
+        /// `nil` when the plugin ships no enabled skill.
+        public let skillName: String?
+        /// Sibling tools surfaced as `tool/<name>` lines in the teaser.
+        /// Already deduped against `pickedToolNames`, ordered, and
+        /// capped at `PreflightCompanions.maxSiblingTools`.
+        public let siblingToolNames: [String]
+    }
+}
+
+// MARK: - Evaluator
+
+/// Public entry point for behaviour evals. Wraps the internal preflight
+/// pipeline and an optional one-shot agent fixture so eval cases can
+/// just supply a query string + mode and get back a stable JSON-shaped
+/// result. Lives on the main actor because the underlying registry +
+/// agent lookups are main-actor-isolated.
+@MainActor
+public enum PreflightEvaluator {
+
+    /// Run preflight against the live `ToolRegistry` / `SkillManager` /
+    /// `PluginManager` state, using whichever model `CoreModelService`
+    /// currently routes to. Callers that want to swap the model around
+    /// the call should mutate `ChatConfigurationStore` first (see the
+    /// OsaurusEvals `ModelOverride` helper).
+    ///
+    /// `agentId` defaults to the active agent so cases can omit it; pass
+    /// an explicit id when scoping the eval to a custom agent fixture.
+    public static func evaluate(
+        query: String,
+        mode: PreflightSearchMode = .balanced,
+        agentId: UUID? = nil
+    ) async -> PreflightEvaluation {
+        let resolvedAgentId = agentId ?? AgentManager.shared.activeAgent.id
+        let started = Date()
+        let result = await PreflightCapabilitySearch.search(
+            query: query,
+            mode: mode,
+            agentId: resolvedAgentId
+        )
+        let elapsed = Date().timeIntervalSince(started) * 1000
+
+        let companions = result.companions.map { c in
+            PreflightEvaluation.Companion(
+                pluginId: c.pluginId,
+                pluginDisplay: c.pluginDisplay,
+                skillName: c.skill?.name,
+                siblingToolNames: c.siblingTools.map(\.name)
+            )
+        }
+
+        return PreflightEvaluation(
+            pickedToolNames: result.toolSpecs.map { $0.function.name },
+            companions: companions,
+            latencyMs: elapsed
+        )
+    }
+
+    /// Plugin ids currently registered with the host. Exposed for the
+    /// OsaurusEvals runner so it can `skip + warn` cases whose
+    /// `requirePlugins` aren't installed locally instead of failing
+    /// them. Includes native dylib plugins (osaurus.browser, etc.) —
+    /// kept narrow on purpose; if future eval cases need MCP/sandbox
+    /// fixture introspection too, extend this surface explicitly
+    /// rather than exposing the full `PluginManager`.
+    public static func installedPluginIds() -> Set<String> {
+        var ids: Set<String> = []
+        for loaded in PluginManager.shared.plugins {
+            ids.insert(loaded.plugin.id)
+        }
+        return ids
+    }
+}

--- a/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightEvaluator.swift
@@ -31,6 +31,31 @@ public struct PreflightEvaluation: Sendable, Codable {
     /// Wall-clock duration of `PreflightCapabilitySearch.search`. Used
     /// for trend tracking; not part of pass/fail by default.
     public let latencyMs: Double
+    /// Raw text the LLM returned for the tool-selection prompt. `nil`
+    /// when the LLM threw or preflight short-circuited (empty query /
+    /// mode .off / empty catalog). Critical for prompt-iteration evals
+    /// — when a small model picks nothing, this is the only signal that
+    /// tells you WHY (NONE, malformed picks, prose, refusal, etc.).
+    public let rawLLMResponse: String?
+    /// The exact system prompt sent to the LLM (post-template,
+    /// post-catalog-rendering). Lets eval reports show "what the model
+    /// saw" alongside "what the model said" without re-deriving the
+    /// catalog client-side.
+    public let rawLLMSystemPrompt: String?
+    /// Picks the parser extracted, BEFORE the embedding guardrail
+    /// dropped any. `pickedToolNames` is `llmPicks` minus the picks the
+    /// guardrail rejected. Lets evals tell apart "model picked nothing"
+    /// from "model picked but guardrail rejected everything".
+    public let llmPicks: [String]
+    /// Number of dynamic plugin tools the LLM saw in its catalog.
+    /// Zero is the smoking gun for a config-dir mismatch between the
+    /// eval-CLI process and the host app — the LLM call gets skipped
+    /// entirely and `pickedToolNames` is forced empty.
+    public let catalogSize: Int
+    /// Description of the error the LLM bridge threw, if any. Lets
+    /// evals distinguish "model said NONE" from "bridge timed out /
+    /// circuit-breaker open / network failed".
+    public let llmError: String?
 
     public struct Companion: Sendable, Codable {
         public let pluginId: String
@@ -41,6 +66,15 @@ public struct PreflightEvaluation: Sendable, Codable {
         /// Already deduped against `pickedToolNames`, ordered, and
         /// capped at `PreflightCompanions.maxSiblingTools`.
         public let siblingToolNames: [String]
+
+        /// Internal-to-public converter so `PreflightEvaluator.evaluate`
+        /// can map a `PluginCompanion` straight to an eval-shaped row.
+        init(_ source: PluginCompanion) {
+            self.pluginId = source.pluginId
+            self.pluginDisplay = source.pluginDisplay
+            self.skillName = source.skill?.name
+            self.siblingToolNames = source.siblingTools.map(\.name)
+        }
     }
 }
 
@@ -69,26 +103,22 @@ public enum PreflightEvaluator {
     ) async -> PreflightEvaluation {
         let resolvedAgentId = agentId ?? AgentManager.shared.activeAgent.id
         let started = Date()
-        let result = await PreflightCapabilitySearch.search(
+        let (result, diagnostic) = await PreflightCapabilitySearch.searchWithDiagnostic(
             query: query,
             mode: mode,
             agentId: resolvedAgentId
         )
         let elapsed = Date().timeIntervalSince(started) * 1000
 
-        let companions = result.companions.map { c in
-            PreflightEvaluation.Companion(
-                pluginId: c.pluginId,
-                pluginDisplay: c.pluginDisplay,
-                skillName: c.skill?.name,
-                siblingToolNames: c.siblingTools.map(\.name)
-            )
-        }
-
         return PreflightEvaluation(
             pickedToolNames: result.toolSpecs.map { $0.function.name },
-            companions: companions,
-            latencyMs: elapsed
+            companions: result.companions.map(PreflightEvaluation.Companion.init(_:)),
+            latencyMs: elapsed,
+            rawLLMResponse: diagnostic?.rawResponse,
+            rawLLMSystemPrompt: diagnostic?.systemPrompt,
+            llmPicks: diagnostic?.llmPicks ?? [],
+            catalogSize: diagnostic?.catalogSize ?? 0,
+            llmError: diagnostic?.llmError
         )
     }
 
@@ -111,15 +141,29 @@ public enum PreflightEvaluator {
         return ids
     }
 
-    /// Scan the tools directory and load every installed plugin (native
-    /// dylib + sandbox plugin) into the in-process `PluginManager` /
-    /// `ToolRegistry` / `SkillManager`. The host app does this in
-    /// `AppDelegate.applicationDidFinishLaunching`; the eval CLI is its
-    /// own process and has to invoke it explicitly before preflight can
-    /// see plugin tools or before `installedPluginIds()` returns
-    /// anything. Idempotent — `PluginManager.loadAll` serializes
-    /// concurrent invocations and re-uses already-loaded dylibs.
+    /// Boot every subsystem the chat path's preflight depends on so an
+    /// out-of-process eval CLI gets the same view the host app does.
+    /// Mirrors the relevant slice of
+    /// `AppDelegate.applicationDidFinishLaunching`:
+    ///
+    /// 1. Scan + dlopen every installed plugin into `PluginManager` /
+    ///    `ToolRegistry` / `SkillManager` so plugin tools become
+    ///    visible to `listDynamicTools()` and `installedPluginIds()`.
+    /// 2. Open the on-disk tool index database and initialise
+    ///    `ToolSearchService` so the embedding-rerank step in
+    ///    `PreflightCapabilitySearch.rankCatalog` actually has an
+    ///    index to query (without this, rerank degrades to the full
+    ///    catalog and small models with tight context windows like
+    ///    Apple Foundation reject the request before the LLM runs).
+    /// 3. Sync the tool index from the live registry so freshly
+    ///    registered plugin tools are present in the vector store.
+    ///
+    /// Idempotent — every step serializes concurrent invocations and
+    /// re-uses already-initialised state.
     public static func loadInstalledPlugins() async {
         await PluginManager.shared.loadAll()
+        try? ToolDatabase.shared.open()
+        await ToolSearchService.shared.initialize()
+        await ToolIndexService.shared.syncFromRegistry()
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -742,23 +742,27 @@ actor ModelRuntime {
                 let toolCalls = toMLXToolCalls(m.tool_calls)
                 // Skip fully-empty assistant turns (no content AND no tool calls).
                 if content.isEmpty && (toolCalls?.isEmpty ?? true) { continue }
-                out.append(MLXLMCommon.Chat.Message(
-                    role: .assistant,
-                    content: content,
-                    images: images,
-                    videos: [],
-                    toolCalls: toolCalls,
-                    toolCallId: nil
-                ))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .assistant,
+                        content: content,
+                        images: images,
+                        videos: [],
+                        toolCalls: toolCalls,
+                        toolCallId: nil
+                    )
+                )
             case "tool":
-                out.append(MLXLMCommon.Chat.Message(
-                    role: .tool,
-                    content: m.content ?? "",
-                    images: images,
-                    videos: [],
-                    toolCalls: nil,
-                    toolCallId: m.tool_call_id
-                ))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .tool,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: [],
+                        toolCalls: nil,
+                        toolCallId: m.tool_call_id
+                    )
+                )
             default:
                 out.append(.init(role: .user, content: m.content ?? "", images: images))
             }
@@ -778,7 +782,8 @@ actor ModelRuntime {
             let argsData = tc.function.arguments.data(using: .utf8) ?? Data()
             let args: [String: MLXLMCommon.JSONValue] =
                 (try? JSONDecoder().decode(
-                    [String: MLXLMCommon.JSONValue].self, from: argsData
+                    [String: MLXLMCommon.JSONValue].self,
+                    from: argsData
                 )) ?? [:]
             return MLXLMCommon.ToolCall(
                 function: .init(name: tc.function.name, arguments: args)

--- a/Packages/OsaurusCore/Services/Voice/TranscriptionCleanupService.swift
+++ b/Packages/OsaurusCore/Services/Voice/TranscriptionCleanupService.swift
@@ -17,17 +17,17 @@ public final class TranscriptionCleanupService {
     public static let shared = TranscriptionCleanupService()
 
     private static let systemPrompt = """
-    You clean up voice-to-text transcripts. Remove only non-lexical hesitation \
-    sounds: "uh", "um", "uhh", "umm", "mm", "mmm", "er", "erm", "ah", "hmm" when \
-    they appear as standalone fillers. Also remove stuttered word repetitions \
-    (e.g. "I I went" → "I went") and immediate self-corrections (e.g. "go to — \
-    I mean visit the store" → "visit the store"). Fix punctuation and \
-    capitalization. Do NOT remove real words like "like", "you know", "I mean", \
-    "so", "well", "right", "actually" — these can carry meaning and the speaker \
-    may have intended them. Preserve the speaker's wording and meaning exactly \
-    — do not paraphrase, summarize, rephrase, or add content. Return only the \
-    cleaned transcript with no preamble, quotes, or commentary.
-    """
+        You clean up voice-to-text transcripts. Remove only non-lexical hesitation \
+        sounds: "uh", "um", "uhh", "umm", "mm", "mmm", "er", "erm", "ah", "hmm" when \
+        they appear as standalone fillers. Also remove stuttered word repetitions \
+        (e.g. "I I went" → "I went") and immediate self-corrections (e.g. "go to — \
+        I mean visit the store" → "visit the store"). Fix punctuation and \
+        capitalization. Do NOT remove real words like "like", "you know", "I mean", \
+        "so", "well", "right", "actually" — these can carry meaning and the speaker \
+        may have intended them. Preserve the speaker's wording and meaning exactly \
+        — do not paraphrase, summarize, rephrase, or add content. Return only the \
+        cleaned transcript with no preamble, quotes, or commentary.
+        """
 
     private static let minWordsForCleanup = 3
     private static let minHallucinationRatio: Double = 0.3
@@ -51,12 +51,12 @@ public final class TranscriptionCleanupService {
 
         // wrap input in a delimiter so the model treats it as data not instructions
         let userPrompt = """
-        Clean up the following transcript. Return only the cleaned text.
+            Clean up the following transcript. Return only the cleaned text.
 
-        <transcript>
-        \(trimmed)
-        </transcript>
-        """
+            <transcript>
+            \(trimmed)
+            </transcript>
+            """
 
         // try the user's configured core model first.
         let coreModelId = ChatConfigurationStore.load().coreModelIdentifier ?? "<nil>"
@@ -76,7 +76,9 @@ public final class TranscriptionCleanupService {
             return await tryLocalFallback(userPrompt: userPrompt, rawText: rawText, trimmed: trimmed)
         } catch {
             let elapsed = Date().timeIntervalSince(start)
-            debugLog("[cleanup] ERROR after \(String(format: "%.2f", elapsed))s: \(error.localizedDescription) — using raw")
+            debugLog(
+                "[cleanup] ERROR after \(String(format: "%.2f", elapsed))s: \(error.localizedDescription) — using raw"
+            )
             return rawText
         }
     }
@@ -121,16 +123,21 @@ public final class TranscriptionCleanupService {
             return postProcess(response: response, rawText: rawText, trimmed: trimmed, start: start, source: "mlx")
         } catch {
             let elapsed = Date().timeIntervalSince(start)
-            debugLog("[cleanup] FALLBACK ERROR after \(String(format: "%.2f", elapsed))s: \(error.localizedDescription) — using raw")
+            debugLog(
+                "[cleanup] FALLBACK ERROR after \(String(format: "%.2f", elapsed))s: \(error.localizedDescription) — using raw"
+            )
             return rawText
         }
     }
 
     // MARK: - Shared post-processing
 
-    private func postProcess(response: String, rawText: String, trimmed: String, start: Date, source: String) -> String {
+    private func postProcess(response: String, rawText: String, trimmed: String, start: Date, source: String) -> String
+    {
         let elapsed = Date().timeIntervalSince(start)
-        debugLog("[cleanup] \(source) response in \(String(format: "%.2f", elapsed))s (\(response.count) chars): \(response)")
+        debugLog(
+            "[cleanup] \(source) response in \(String(format: "%.2f", elapsed))s (\(response.count) chars): \(response)"
+        )
 
         // strip streaming sentinel (\u{FFFE}) and anything that follows — MLX emits
         // trailing metadata like "\u{FFFE}stats:28;44.0129" after the actual text.
@@ -147,9 +154,11 @@ public final class TranscriptionCleanupService {
             return rawText
         }
         if trimmed.count > 50,
-           Double(cleaned.count) / Double(trimmed.count) < Self.minHallucinationRatio
+            Double(cleaned.count) / Double(trimmed.count) < Self.minHallucinationRatio
         {
-            debugLog("[cleanup] FALLBACK: hallucination guard (cleaned \(cleaned.count) / raw \(trimmed.count) = \(String(format: "%.2f", Double(cleaned.count) / Double(trimmed.count)))), using raw")
+            debugLog(
+                "[cleanup] FALLBACK: hallucination guard (cleaned \(cleaned.count) / raw \(trimmed.count) = \(String(format: "%.2f", Double(cleaned.count) / Double(trimmed.count)))), using raw"
+            )
             return rawText
         }
         debugLog("[cleanup] SUCCESS (\(source)): returning cleaned text")

--- a/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
@@ -111,23 +111,81 @@ struct PreflightCapabilitySearchTests {
         #expect(picks == ["play"])
     }
 
-    @Test func picksWithoutReasonAreDropped() {
-        // Bare names without `|` violate the anti-padding contract.
+    @Test func picksWithoutReasonAreAccepted() {
+        // Small models (Apple Foundation, etc.) routinely emit bare
+        // names without the `| reason` suffix. The anti-padding floor
+        // moved to `applyEmbeddingGuardrail` so we no longer punish
+        // the formatting drift — bare names are valid picks.
         let picks = PreflightCapabilitySearch.parseJustifiedPicks(
             from: "play\nsearch_songs",
             catalog: Self.makeCatalog(),
             cap: 5
         )
-        #expect(picks.isEmpty)
+        #expect(picks == ["play", "search_songs"])
     }
 
-    @Test func picksWithEmptyReasonAreDropped() {
+    @Test func picksWithEmptyReasonAreAccepted() {
+        // Empty reason is no different from no reason — same loose
+        // contract. Both rely on the embedding guardrail to drop
+        // semantic mismatches.
         let picks = PreflightCapabilitySearch.parseJustifiedPicks(
             from: "play |   \nsearch_songs | finds songs",
             catalog: Self.makeCatalog(),
             cap: 5
         )
-        #expect(picks == ["search_songs"])
+        #expect(picks == ["play", "search_songs"])
+    }
+
+    @Test func toolPrefixIsStripped() {
+        // Models occasionally echo the catalog format back at us as
+        // `tool: <name>`. Strip the prefix so it still resolves to a
+        // canonical tool name.
+        let picks = PreflightCapabilitySearch.parseJustifiedPicks(
+            from: "tool: play\ntool: search_songs | finds songs",
+            catalog: Self.makeCatalog(),
+            cap: 5
+        )
+        #expect(picks == ["play", "search_songs"])
+    }
+
+    @Test func wrappingCharactersAreStripped() {
+        // Apple Foundation echoes the prompt's `<tool_name>` placeholder
+        // syntax as literal output ("<browser_navigate | open the orders
+        // page>"). Other small models do the same with backticks and
+        // quotes. The parser must unwrap before the canonical-name
+        // lookup.
+        let picks = PreflightCapabilitySearch.parseJustifiedPicks(
+            from:
+                "<play | wrapped in angle brackets>\n`search_songs` | wrapped in backticks\n\"send_message\" | wrapped in quotes",
+            catalog: Self.makeCatalog(),
+            cap: 5
+        )
+        #expect(picks == ["play", "search_songs", "send_message"])
+    }
+
+    @Test func antiPaddingNowEnforcedByGuardrail() async {
+        // After Phase 1, `parseJustifiedPicks` accepts bare names. The
+        // anti-padding contract relocated to the embedding guardrail —
+        // a pick whose embedding is far from the query gets dropped
+        // post-parse. This test pins that the guardrail can still
+        // strip a parsed-but-irrelevant pick.
+        let nameToDesc = ["play": "playback", "send_message": "post to a channel"]
+        let embedder: PreflightCapabilitySearch.Embedder = { texts in
+            // Query orthogonal to send_message, aligned with play.
+            #expect(texts.count == 3)  // [query, play_text, send_message_text]
+            return [
+                [1.0, 0.0],  // query
+                [1.0, 0.0],  // play -> aligned, sim=1
+                [0.0, 1.0],  // send_message -> orthogonal, sim=0 (below 0.05 floor)
+            ]
+        }
+        let kept = await PreflightCapabilitySearch.applyEmbeddingGuardrail(
+            query: "play music",
+            picks: ["play", "send_message"],
+            nameToDesc: nameToDesc,
+            embedder: embedder
+        )
+        #expect(kept == ["play"])
     }
 
     @Test func unknownNameIsDropped() {

--- a/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCapabilitySearchTests.swift
@@ -333,5 +333,6 @@ struct PreflightCapabilitySearchTests {
         )
         #expect(result.items.isEmpty)
         #expect(result.toolSpecs.isEmpty)
+        #expect(result.companions.isEmpty)
     }
 }

--- a/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
@@ -210,6 +210,13 @@ struct PreflightCompanionsTests {
         // resulting companion has skill + empty siblings. Conversely a
         // plugin can ship many tools and no skill. Both must render
         // without crashing or producing dangling formatting.
+        //
+        // Match against the bullet-line pattern `` - `tool/`` (and
+        // `` - `skill/``) rather than the bare `tool/` / `skill/`
+        // substring — the trailing `usageNudge` legitimately mentions
+        // both as load-syntax examples (`capabilities_load({"ids":
+        // ["skill/<name>", "tool/<name>"]})`), so a substring check
+        // false-positives on every render.
         let skillOnly = PluginCompanion(
             pluginId: "x.example",
             pluginDisplay: "Example",
@@ -224,9 +231,9 @@ struct PreflightCompanionsTests {
         )
         let renderedSkill = PreflightCompanions.render([skillOnly]) ?? ""
         let renderedTool = PreflightCompanions.render([toolOnly]) ?? ""
-        #expect(renderedSkill.contains("skill/example-skill"))
-        #expect(renderedSkill.contains("tool/") == false)
-        #expect(renderedTool.contains("tool/y_alpha"))
-        #expect(renderedTool.contains("skill/") == false)
+        #expect(renderedSkill.contains("- `skill/example-skill`"))
+        #expect(renderedSkill.contains("- `tool/") == false)
+        #expect(renderedTool.contains("- `tool/y_alpha`"))
+        #expect(renderedTool.contains("- `skill/") == false)
     }
 }

--- a/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
@@ -1,0 +1,232 @@
+//
+//  PreflightCompanionsTests.swift
+//  osaurus
+//
+//  Pure-function tests for `PreflightCompanions` — the phase-2 teaser
+//  layer that surfaces sibling plugin tools + bundled skills after the
+//  LLM picks a tool from a cohesive plugin.
+//
+//  Tests here intentionally avoid the registry / SkillManager state path:
+//  they exercise `selectSiblings`, `tokenize`, `render`, and the no-op
+//  branches of `derive` so the suite stays runnable in any harness
+//  without plugin fixtures. The integration paths (real registry, real
+//  pluginDisplayName lookup) are exercised by the OsaurusEvals package.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct PreflightCompanionsTests {
+
+    // MARK: - PreflightResult shape
+
+    @Test func emptyResultCarriesEmptyCompanions() {
+        // The companion path is an opt-in addition to PreflightResult — the
+        // legacy `.empty` singleton must keep returning no companions so
+        // existing call sites that assert "no preflight" stay correct.
+        #expect(PreflightResult.empty.companions.isEmpty)
+    }
+
+    @Test func defaultInitOmitsCompanions() {
+        // Backwards-compat init: callers that don't pass companions get
+        // an empty list, not a crash. Mirrors the behaviour the ChatView
+        // and PluginHostAPI paths relied on before phase 2 landed.
+        let result = PreflightResult(toolSpecs: [], items: [])
+        #expect(result.companions.isEmpty)
+    }
+
+    // MARK: - derive (no-registry paths)
+
+    @Test func deriveReturnsEmptyForEmptySelection() async {
+        // No picks -> no plugins to consult -> no companions. This path
+        // doesn't touch the registry, so it's safe to run without any
+        // fixture setup.
+        let companions = await MainActor.run {
+            PreflightCompanions.derive(selectedNames: [], query: "anything")
+        }
+        #expect(companions.isEmpty)
+    }
+
+    @Test func deriveSkipsBuiltInToolPicks() async {
+        // Built-in tools have no `groupName`, so even if they show up in
+        // `selectedNames` (defensive: shouldn't, but the catalog filter
+        // could regress), companion derivation must drop them silently
+        // rather than emit a "no plugin" stub.
+        let companions = await MainActor.run {
+            PreflightCompanions.derive(
+                selectedNames: ["capabilities_search"],
+                query: "anything"
+            )
+        }
+        #expect(companions.isEmpty)
+    }
+
+    // MARK: - selectSiblings
+
+    private static func makeSiblings(_ names: [String]) -> [ToolRegistry.ToolEntry] {
+        names.map {
+            ToolRegistry.ToolEntry(
+                name: $0,
+                description: "desc for \($0)",
+                enabled: true,
+                parameters: nil
+            )
+        }
+    }
+
+    @Test func selectSiblingsCapsAtMaxSiblingTools() {
+        // Big plugins (the browser plugin ships ~22 tools) would blow the
+        // teaser budget without a cap. The exact ceiling is policy in
+        // `PreflightCompanions.maxSiblingTools` — the test asserts the
+        // contract, not the literal number.
+        let names = (0 ..< 20).map { "browser_tool_\(String(format: "%02d", $0))" }
+        let kept = PreflightCompanions.selectSiblings(
+            from: Self.makeSiblings(names),
+            query: "browse the web"
+        )
+        #expect(kept.count == PreflightCompanions.maxSiblingTools)
+    }
+
+    @Test func selectSiblingsOrdersAlphabeticallyAfterCap() {
+        // KV-cache stability requires byte-stable rendering across runs.
+        // Within the kept slice the final ordering must be alphabetical
+        // so two runs with the same inputs produce identical prompt
+        // bytes regardless of dictionary iteration order in the catalog.
+        let names = ["browser_zoom", "browser_alpha", "browser_mid", "browser_beta"]
+        let kept = PreflightCompanions.selectSiblings(
+            from: Self.makeSiblings(names),
+            // Empty query -> all overlap scores equal (zero) -> tie-break
+            // falls back to alphabetical, exercising the same path that
+            // would run for low-signal queries in production.
+            query: ""
+        )
+        let keptNames = kept.map(\.name)
+        #expect(keptNames == keptNames.sorted())
+    }
+
+    @Test func selectSiblingsPreferQueryOverlap() {
+        // The whole point of scoring before capping: a high-signal sibling
+        // (matches a query token) must survive the cap even when many
+        // low-signal siblings exist. We pad with 10 unrelated tools and
+        // check the matching one is still in the kept slice.
+        var names = (0 ..< 10).map { "browser_unrelated_\($0)" }
+        names.append("browser_open_login")
+        let kept = PreflightCompanions.selectSiblings(
+            from: Self.makeSiblings(names),
+            query: "please log me in to amazon"
+        )
+        #expect(kept.contains { $0.name == "browser_open_login" })
+    }
+
+    @Test func selectSiblingsReturnsEmptyForNoCandidates() {
+        let kept = PreflightCompanions.selectSiblings(from: [], query: "anything")
+        #expect(kept.isEmpty)
+    }
+
+    // MARK: - tokenize
+
+    @Test func tokenizeStripsPunctuationAndShortTokens() {
+        // Single-char tokens are noise (a, e, i) — they inflate overlap
+        // scores without adding signal. Punctuation like `?` and `-`
+        // must split words rather than become part of them.
+        let tokens = PreflightCompanions.tokenize("Amazon-orders? a I")
+        #expect(tokens.contains("amazon"))
+        #expect(tokens.contains("orders"))
+        #expect(tokens.contains("a") == false)
+        #expect(tokens.contains("i") == false)
+    }
+
+    // MARK: - render
+
+    @Test func renderReturnsNilForEmptyInput() {
+        // Empty companions -> no section -> caller skips append. We
+        // return `nil` rather than an empty string so the composer's
+        // `append` filter doesn't have to special-case whitespace.
+        #expect(PreflightCompanions.render([]) == nil)
+    }
+
+    @Test func renderPlacesSkillBeforeSiblingTools() {
+        // The whole behavioural nudge — "load the skill first" — depends
+        // on the skill line appearing physically before the sibling tool
+        // lines. If this ever flips, the trailing nudge becomes a lie
+        // and the rendering becomes stylistically inconsistent.
+        let companion = PluginCompanion(
+            pluginId: "osaurus.browser",
+            pluginDisplay: "Browser",
+            skill: SkillTeaser(name: "osaurus-browser", description: "Browser skill"),
+            siblingTools: [
+                ToolTeaser(name: "browser_open_login", description: "Login window"),
+                ToolTeaser(name: "browser_screenshot", description: "PNG screenshot"),
+            ]
+        )
+        let rendered = PreflightCompanions.render([companion]) ?? ""
+        guard let skillIdx = rendered.range(of: "skill/osaurus-browser"),
+            let toolIdx = rendered.range(of: "tool/browser_open_login")
+        else {
+            Issue.record("skill or tool line missing from rendered companions section")
+            return
+        }
+        #expect(skillIdx.lowerBound < toolIdx.lowerBound)
+    }
+
+    @Test func renderIncludesLoadInstructionAndPluginDisplayName() {
+        // The teaser line must call out the plugin by display name (not
+        // raw plugin id) so the model has a human-readable cue, and the
+        // closing line must reference `capabilities_load` so the model
+        // knows exactly which tool to call.
+        let companion = PluginCompanion(
+            pluginId: "osaurus.browser",
+            pluginDisplay: "Browser",
+            skill: nil,
+            siblingTools: [ToolTeaser(name: "browser_open_login", description: "Login")]
+        )
+        let rendered = PreflightCompanions.render([companion]) ?? ""
+        #expect(rendered.contains("**Browser**"))
+        #expect(rendered.contains("capabilities_load"))
+    }
+
+    @Test func renderNudgeWarnsAgainstReLoadingAndExplainsCallByName() {
+        // Reasoning models were observed treating `capabilities_load` as
+        // the action itself and re-loading the same id every turn instead
+        // of calling the now-available tool. The nudge MUST contain the
+        // one-shot contract and the "call by name" reminder so the
+        // behavioural fix doesn't silently regress in a future copy edit.
+        let companion = PluginCompanion(
+            pluginId: "osaurus.browser",
+            pluginDisplay: "Browser",
+            skill: nil,
+            siblingTools: [ToolTeaser(name: "browser_open_login", description: "Login")]
+        )
+        let rendered = PreflightCompanions.render([companion]) ?? ""
+        #expect(rendered.lowercased().contains("one-shot"))
+        #expect(rendered.contains("Do NOT call `capabilities_load` again"))
+        #expect(rendered.contains("call the tool directly by its name"))
+    }
+
+    @Test func renderHandlesSkillOnlyAndToolOnlyCompanions() {
+        // A plugin can ship a skill but only one tool (already picked) —
+        // resulting companion has skill + empty siblings. Conversely a
+        // plugin can ship many tools and no skill. Both must render
+        // without crashing or producing dangling formatting.
+        let skillOnly = PluginCompanion(
+            pluginId: "x.example",
+            pluginDisplay: "Example",
+            skill: SkillTeaser(name: "example-skill", description: "Helps"),
+            siblingTools: []
+        )
+        let toolOnly = PluginCompanion(
+            pluginId: "y.example",
+            pluginDisplay: "Y",
+            skill: nil,
+            siblingTools: [ToolTeaser(name: "y_alpha", description: "Alpha")]
+        )
+        let renderedSkill = PreflightCompanions.render([skillOnly]) ?? ""
+        let renderedTool = PreflightCompanions.render([toolOnly]) ?? ""
+        #expect(renderedSkill.contains("skill/example-skill"))
+        #expect(renderedSkill.contains("tool/") == false)
+        #expect(renderedTool.contains("tool/y_alpha"))
+        #expect(renderedTool.contains("skill/") == false)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/FoundationMLXParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/FoundationMLXParityTests.swift
@@ -72,7 +72,8 @@ struct FoundationMLXParityTests {
         let history = Self.sampleHistory()
         let foundationPrompt = OpenAIPromptBuilder.buildPrompt(from: history)
         let mlxMapped = ModelRuntime.mapOpenAIChatToMLX(history)
-        let mlxToolCallNames = mlxMapped
+        let mlxToolCallNames =
+            mlxMapped
             .flatMap { $0.toolCalls ?? [] }
             .map(\.function.name)
 

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -18,18 +18,20 @@ struct LocalGenerationDefaultsTests {
     func gemma4() {
         // Copied verbatim from
         // models--mlx-community--gemma-4-26b-a4b-it-4bit/snapshots/.../generation_config.json
-        let d = Self.defaults(fromJSON: #"""
-            {
-              "bos_token_id": 2,
-              "do_sample": true,
-              "eos_token_id": [1, 106, 50],
-              "pad_token_id": 0,
-              "temperature": 1.0,
-              "top_k": 64,
-              "top_p": 0.95,
-              "transformers_version": "5.5.0.dev0"
-            }
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "bos_token_id": 2,
+                  "do_sample": true,
+                  "eos_token_id": [1, 106, 50],
+                  "pad_token_id": 0,
+                  "temperature": 1.0,
+                  "top_k": 64,
+                  "top_p": 0.95,
+                  "transformers_version": "5.5.0.dev0"
+                }
+                """#
+        )
         #expect(d.temperature == 1.0)
         #expect(d.topK == 64)
         #expect(d.topP == 0.95)
@@ -40,18 +42,20 @@ struct LocalGenerationDefaultsTests {
     func qwen35() {
         // Qwen 3.5 specifies LOWER temperature than the 0.7 osaurus used to
         // hardcode; this is the headline reason the feature exists.
-        let d = Self.defaults(fromJSON: #"""
-            {
-              "bos_token_id": 248044,
-              "do_sample": true,
-              "eos_token_id": [248046, 248044],
-              "pad_token_id": 248044,
-              "temperature": 0.6,
-              "top_k": 20,
-              "top_p": 0.95,
-              "transformers_version": "4.57.0.dev0"
-            }
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "bos_token_id": 248044,
+                  "do_sample": true,
+                  "eos_token_id": [248046, 248044],
+                  "pad_token_id": 248044,
+                  "temperature": 0.6,
+                  "top_k": 20,
+                  "top_p": 0.95,
+                  "transformers_version": "4.57.0.dev0"
+                }
+                """#
+        )
         #expect(d.temperature == 0.6)
         #expect(d.topK == 20)
         #expect(d.topP == 0.95)
@@ -59,17 +63,19 @@ struct LocalGenerationDefaultsTests {
 
     @Test("MiniMax M2.7: top_k=40")
     func minimax() {
-        let d = Self.defaults(fromJSON: #"""
-            {
-              "bos_token_id": 200019,
-              "do_sample": true,
-              "eos_token_id": 200020,
-              "temperature": 1.0,
-              "top_p": 0.95,
-              "top_k": 40,
-              "transformers_version": "4.46.1"
-            }
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "bos_token_id": 200019,
+                  "do_sample": true,
+                  "eos_token_id": 200020,
+                  "temperature": 1.0,
+                  "top_p": 0.95,
+                  "top_k": 40,
+                  "transformers_version": "4.46.1"
+                }
+                """#
+        )
         #expect(d.temperature == 1.0)
         #expect(d.topK == 40)
         #expect(d.topP == 0.95)
@@ -80,15 +86,17 @@ struct LocalGenerationDefaultsTests {
         // Real Nemotron generation_config.json ships nothing but EOS/BOS/pad.
         // We should return `.empty` sampling defaults so the caller's existing
         // fallback ladder (request → runtime → hardcoded 0.7) kicks in.
-        let d = Self.defaults(fromJSON: #"""
-            {
-              "_from_model_config": true,
-              "bos_token_id": 1,
-              "eos_token_id": [2, 11],
-              "pad_token_id": 0,
-              "transformers_version": "4.55.4"
-            }
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "_from_model_config": true,
+                  "bos_token_id": 1,
+                  "eos_token_id": [2, 11],
+                  "pad_token_id": 0,
+                  "transformers_version": "4.55.4"
+                }
+                """#
+        )
         #expect(d.temperature == nil)
         #expect(d.topK == nil)
         #expect(d.topP == nil)
@@ -97,15 +105,17 @@ struct LocalGenerationDefaultsTests {
 
     @Test("Mistral-Small-4: sampling fields absent — defaults empty")
     func mistralNoSamplingFields() {
-        let d = Self.defaults(fromJSON: #"""
-            {
-              "bos_token_id": 1,
-              "eos_token_id": 2,
-              "max_length": 1048576,
-              "pad_token_id": 11,
-              "transformers_version": "5.3.0.dev0"
-            }
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "bos_token_id": 1,
+                  "eos_token_id": 2,
+                  "max_length": 1048576,
+                  "pad_token_id": 11,
+                  "transformers_version": "5.3.0.dev0"
+                }
+                """#
+        )
         #expect(d == .empty)
     }
 
@@ -113,9 +123,11 @@ struct LocalGenerationDefaultsTests {
     func repetitionPenaltyFieldHonored() {
         // Uncommon but permitted — HF spec allows repetition_penalty in
         // generation_config. Make sure we don't drop it on the floor.
-        let d = Self.defaults(fromJSON: #"""
-            {"temperature": 0.8, "repetition_penalty": 1.05}
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {"temperature": 0.8, "repetition_penalty": 1.05}
+                """#
+        )
         #expect(d.temperature == 0.8)
         #expect(d.repetitionPenalty == 1.05)
     }
@@ -124,9 +136,11 @@ struct LocalGenerationDefaultsTests {
     func integerTemperatureDecodes() {
         // Some generators emit `"temperature": 1` (no decimal). Without the
         // NSNumber conversion helper, Swift's `as? Double` rejects these.
-        let d = Self.defaults(fromJSON: #"""
-            {"temperature": 1, "top_k": 40}
-            """#)
+        let d = Self.defaults(
+            fromJSON: #"""
+                {"temperature": 1, "top_k": 40}
+                """#
+        )
         #expect(d.temperature == 1.0)
         #expect(d.topK == 40)
     }
@@ -158,8 +172,8 @@ struct LocalGenerationDefaultsTests {
 
         let cfg = tmp.appendingPathComponent("generation_config.json")
         try #"""
-            {"temperature": 0.6, "top_p": 0.9, "top_k": 32}
-            """#.write(to: cfg, atomically: true, encoding: .utf8)
+        {"temperature": 0.6, "top_p": 0.9, "top_k": 32}
+        """#.write(to: cfg, atomically: true, encoding: .utf8)
 
         let d = LocalGenerationDefaults.load(fromDirectory: tmp)
         #expect(d.temperature == 0.6)
@@ -189,7 +203,11 @@ struct LocalGenerationDefaultsTests {
     @Test("Precedence: client wins over model defaults")
     func clientWinsOverModel() {
         let modelDefaults = LocalGenerationDefaults.Defaults(
-            temperature: 0.6, topP: 0.95, topK: 20, repetitionPenalty: nil)
+            temperature: 0.6,
+            topP: 0.95,
+            topK: 20,
+            repetitionPenalty: nil
+        )
         let clientTemp: Float? = 0.2
         let clientTopP: Float? = 0.5
         let serverFallbackTopP: Float = 1.0
@@ -206,7 +224,11 @@ struct LocalGenerationDefaultsTests {
     @Test("Precedence: model defaults fill omitted client fields")
     func modelDefaultsFillGaps() {
         let modelDefaults = LocalGenerationDefaults.Defaults(
-            temperature: 0.6, topP: 0.95, topK: 20, repetitionPenalty: nil)
+            temperature: 0.6,
+            topP: 0.95,
+            topK: 20,
+            repetitionPenalty: nil
+        )
         let clientTemp: Float? = nil
         let clientTopP: Float? = nil
         let serverFallbackTopP: Float = 1.0
@@ -243,7 +265,11 @@ struct LocalGenerationDefaultsTests {
         // valid non-nil value — so the model's default should NOT replace it.
         // This test documents the invariant.
         let modelDefaults = LocalGenerationDefaults.Defaults(
-            temperature: 0.6, topP: nil, topK: nil, repetitionPenalty: nil)
+            temperature: 0.6,
+            topP: nil,
+            topK: nil,
+            repetitionPenalty: nil
+        )
         let clientTemp: Float? = 0.0
 
         let temp = clientTemp ?? modelDefaults.temperature ?? 0.7
@@ -257,7 +283,8 @@ struct LocalGenerationDefaultsTests {
         // install; the load path must short-circuit to `.empty` without
         // crashing or reaching the filesystem.
         let d = LocalGenerationDefaults.defaults(
-            forModelId: "definitely-not-a-real-model-\(UUID().uuidString)")
+            forModelId: "definitely-not-a-real-model-\(UUID().uuidString)"
+        )
         #expect(d == .empty)
     }
 }

--- a/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
+++ b/Packages/OsaurusCore/Utils/ChatPerfTrace.swift
@@ -43,18 +43,18 @@ final class ChatPerfTrace: @unchecked Sendable {
     /// timestamping, and file I/O have zero runtime cost in shipped binaries.
     func begin(_ label: String) {
         #if DEBUG
-        lock.lock()
-        let hadPrevious = startedAt != nil
-        lock.unlock()
-        if hadPrevious { end() }
+            lock.lock()
+            let hadPrevious = startedAt != nil
+            lock.unlock()
+            if hadPrevious { end() }
 
-        lock.lock()
-        self.label = label
-        self.startedAt = CFAbsoluteTimeGetCurrent()
-        self.counters.removeAll(keepingCapacity: true)
-        self.durations.removeAll(keepingCapacity: true)
-        self.peaks.removeAll(keepingCapacity: true)
-        lock.unlock()
+            lock.lock()
+            self.label = label
+            self.startedAt = CFAbsoluteTimeGetCurrent()
+            self.counters.removeAll(keepingCapacity: true)
+            self.durations.removeAll(keepingCapacity: true)
+            self.peaks.removeAll(keepingCapacity: true)
+            lock.unlock()
         #endif
     }
 
@@ -62,27 +62,27 @@ final class ChatPerfTrace: @unchecked Sendable {
     /// A no-op if `begin()` was never called. Debug-only.
     func end() {
         #if DEBUG
-        lock.lock()
-        guard let start = startedAt else { lock.unlock(); return }
-        let label = self.label
-        let totalSec = CFAbsoluteTimeGetCurrent() - start
-        let counters = self.counters
-        let durations = self.durations
-        let peaks = self.peaks
-        self.startedAt = nil
-        self.label = ""
-        self.counters.removeAll(keepingCapacity: true)
-        self.durations.removeAll(keepingCapacity: true)
-        self.peaks.removeAll(keepingCapacity: true)
-        lock.unlock()
+            lock.lock()
+            guard let start = startedAt else { lock.unlock(); return }
+            let label = self.label
+            let totalSec = CFAbsoluteTimeGetCurrent() - start
+            let counters = self.counters
+            let durations = self.durations
+            let peaks = self.peaks
+            self.startedAt = nil
+            self.label = ""
+            self.counters.removeAll(keepingCapacity: true)
+            self.durations.removeAll(keepingCapacity: true)
+            self.peaks.removeAll(keepingCapacity: true)
+            lock.unlock()
 
-        emit(
-            label: label,
-            totalSec: totalSec,
-            counters: counters,
-            durations: durations,
-            peaks: peaks
-        )
+            emit(
+                label: label,
+                totalSec: totalSec,
+                counters: counters,
+                durations: durations,
+                peaks: peaks
+            )
         #endif
     }
 
@@ -93,13 +93,13 @@ final class ChatPerfTrace: @unchecked Sendable {
     /// get an empty body that -O optimizes to a no-op call.
     func count(_ key: String, _ n: Int = 1) {
         #if DEBUG
-        lock.lock()
-        // Only record when a trace is active; avoids polluting counters
-        // between streams.
-        if startedAt != nil {
-            counters[key, default: 0] += n
-        }
-        lock.unlock()
+            lock.lock()
+            // Only record when a trace is active; avoids polluting counters
+            // between streams.
+            if startedAt != nil {
+                counters[key, default: 0] += n
+            }
+            lock.unlock()
         #endif
     }
 
@@ -109,19 +109,19 @@ final class ChatPerfTrace: @unchecked Sendable {
     @discardableResult
     func time<T>(_ key: String, _ block: () -> T) -> T {
         #if DEBUG
-        let t0 = CFAbsoluteTimeGetCurrent()
-        let result = block()
-        let dt = CFAbsoluteTimeGetCurrent() - t0
-        lock.lock()
-        if startedAt != nil {
-            durations[key, default: 0] += dt
-            if dt > (peaks[key] ?? 0) { peaks[key] = dt }
-            counters[key + ".n", default: 0] += 1
-        }
-        lock.unlock()
-        return result
+            let t0 = CFAbsoluteTimeGetCurrent()
+            let result = block()
+            let dt = CFAbsoluteTimeGetCurrent() - t0
+            lock.lock()
+            if startedAt != nil {
+                durations[key, default: 0] += dt
+                if dt > (peaks[key] ?? 0) { peaks[key] = dt }
+                counters[key + ".n", default: 0] += 1
+            }
+            lock.unlock()
+            return result
         #else
-        return block()
+            return block()
         #endif
     }
 
@@ -164,7 +164,10 @@ final class ChatPerfTrace: @unchecked Sendable {
                 lines.append(
                     String(
                         format: "  %@ total=%7.1f ms  peak=%6.2f ms  mean=%6.2f ms",
-                        padded, total, peak, mean
+                        padded,
+                        total,
+                        peak,
+                        mean
                     )
                 )
             }

--- a/Packages/OsaurusCore/Views/Chat/ChatMinimap.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatMinimap.swift
@@ -47,7 +47,8 @@ struct ChatMinimap: View {
 
     private var containerBackground: some View {
         let shape = RoundedRectangle(cornerRadius: isExpanded ? 10 : 8, style: .continuous)
-        return shape
+        return
+            shape
             .fill(theme.secondaryBackground.opacity(isExpanded ? 0.96 : 0.70))
             .overlay(
                 shape.strokeBorder(

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2387,7 +2387,7 @@ struct ChatView: View {
         let minimapMarkers = buildMinimapMarkers(from: blocks)
 
         return ZStack {
-           VStack(spacing: 8) {
+            VStack(spacing: 8) {
                 agentInlineBlocks
                 IsolatedThreadView(
                     store: session.visibleBlocksStore,
@@ -2409,13 +2409,12 @@ struct ChatView: View {
                     onCancelEdit: cancelEditing,
                     onUserImagePreview: openUserAttachmentPreview(attachmentId:),
                     onVisibleTopUserTurnChanged: { turnId in
-                      activeMinimapTurnId = turnId
+                        activeMinimapTurnId = turnId
                     },
                     scrollToTurnId: scrollToTurnId,
                     scrollToTurnTrigger: scrollToTurnTrigger
                 )
             }
-
 
             // Minimap overlay — sits at vertical center, right edge
             if minimapMarkers.count >= 2 {

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -137,7 +137,9 @@ struct EditableTextView: NSViewRepresentable {
     }
 
     private func syncScrollerVisibility(
-        _ textView: CustomNSTextView, scrollView: NSScrollView, coord: Coordinator
+        _ textView: CustomNSTextView,
+        scrollView: NSScrollView,
+        coord: Coordinator
     ) {
         // contentHeight runs ensureLayout (expensive) — only re-check when something
         // that could change scroller state has changed.
@@ -258,7 +260,9 @@ final class CustomNSTextView: NSTextView {
     // MARK: IME composition
 
     override func setMarkedText(
-        _ string: Any, selectedRange: NSRange, replacementRange: NSRange
+        _ string: Any,
+        selectedRange: NSRange,
+        replacementRange: NSRange
     ) {
         super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
         notifyMarkedTextChanged(hasMarkedText())

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -915,7 +915,7 @@ extension MessageTableRepresentable {
                 if row < self.blockIds.count {
                     let bid = self.blockIds[row]
                     if let h = self.heightCache[bid], let noted = self.lastNotedHeight[bid],
-                       abs(h - noted) < 0.5
+                        abs(h - noted) < 0.5
                     {
                         ChatPerfTrace.shared.count("streamingHeightUpdate.skipped")
                         return
@@ -1160,26 +1160,27 @@ extension MessageTableRepresentable {
         /// we neutralize both before kicking off our animation.
         func scrollToTurn(_ turnId: UUID) {
             guard let tableView, let scrollView else { return }
-            
+
             // Prefer the user-message block; fall back to the turn's header.
             let userBlockId = "usermsg-\(turnId.uuidString)"
             let headerBlockId = "header-\(turnId.uuidString)"
-            let row = blockIds.firstIndex(of: userBlockId)
-            ?? blockIds.firstIndex(of: headerBlockId)
+            let row =
+                blockIds.firstIndex(of: userBlockId)
+                ?? blockIds.firstIndex(of: headerBlockId)
             guard let targetRow = row, targetRow < tableView.numberOfRows else { return }
-            
+
             // drop pinned to bottom so subsequent applyBlocks restore our
             // anchor instead of snapping back to bottom
             scrollAnchor.unpinFromBottom()
-            
+
             // mark the current assistant turn as already handled so the
             // new turn auto-scroll path doesn't fire mid-animation
             lastScrolledToTurnId = ctx.lastAssistantTurnId
-            
+
             let rowRect = tableView.rect(ofRow: targetRow)
             // Leave a little breathing room above the target.
             let targetY = max(0, rowRect.origin.y - 12)
-            
+
             NSAnimationContext.runAnimationGroup { ctx in
                 ctx.duration = 0.22
                 ctx.allowsImplicitAnimation = true
@@ -1188,14 +1189,14 @@ extension MessageTableRepresentable {
                 )
                 scrollView.reflectScrolledClipView(scrollView.contentView)
             }
-            
+
             // Schedule an active-marker refresh after the animation settles so
             // the minimap highlights the newly visible turn.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
                 self?.scheduleVisibleUserTurnUpdate()
             }
         }
-        
+
         /// Auto-expand newly inserted thinking blocks by recording their id in
         /// `expandedIds` (and the session store). A block counts as "new" if
         /// its id isn't in `oldLookup`. We only seed during the owning turn's

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1087,7 +1087,8 @@ final class NativeMessageCellView: NSTableCellView {
         let targetBg: CGColor?
         let targetRadius: CGFloat
         if role == .assistant, let bubbleColor = context.theme.assistantBubbleColor {
-            targetBg = NSColor(bubbleColor)
+            targetBg =
+                NSColor(bubbleColor)
                 .withAlphaComponent(context.theme.assistantBubbleOpacity).cgColor
             targetRadius = 12
         } else {

--- a/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
@@ -645,7 +645,10 @@ private struct ThemedNSTextField: NSViewRepresentable {
         field.delegate = context.coordinator
         field.stringValue = text
         field.placeholderAttributedString = Self.attributedPlaceholder(
-            placeholder, color: placeholderColor, fontSize: fontSize)
+            placeholder,
+            color: placeholderColor,
+            fontSize: fontSize
+        )
         field.textColor = NSColor(textColor)
         field.setContentHuggingPriority(.defaultLow, for: .horizontal)
         field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -658,18 +661,24 @@ private struct ThemedNSTextField: NSViewRepresentable {
         }
         field.textColor = NSColor(textColor)
         field.placeholderAttributedString = Self.attributedPlaceholder(
-            placeholder, color: placeholderColor, fontSize: fontSize)
+            placeholder,
+            color: placeholderColor,
+            fontSize: fontSize
+        )
     }
 
     private static func attributedPlaceholder(
-        _ string: String, color: Color, fontSize: CGFloat
+        _ string: String,
+        color: Color,
+        fontSize: CGFloat
     ) -> NSAttributedString {
         NSAttributedString(
             string: string,
             attributes: [
                 .foregroundColor: NSColor(color),
                 .font: NSFont.systemFont(ofSize: fontSize),
-            ])
+            ]
+        )
     }
 
     final class Coordinator: NSObject, NSTextFieldDelegate {

--- a/Packages/OsaurusEvals/Package.swift
+++ b/Packages/OsaurusEvals/Package.swift
@@ -1,0 +1,43 @@
+// swift-tools-version: 6.2
+//
+// OsaurusEvals
+//
+// Standalone package for catalog-driven behaviour / integration tests
+// that hit a real model (Foundation, MLX, remote provider). NOT part of
+// CI — `swift test` from `Packages/OsaurusCore` does not touch this
+// package, and the CLI is invoked manually for local tuning + new-model
+// triage.
+//
+// See `README.md` for usage. The runner sets the core model via
+// `ChatConfigurationStore` per-run, so `--model` only affects the eval
+// process and never persists across runs (see `ModelOverride.swift`).
+//
+import PackageDescription
+
+let package = Package(
+    name: "OsaurusEvals",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "OsaurusEvalsKit", targets: ["OsaurusEvalsKit"]),
+        .executable(name: "osaurus-evals", targets: ["OsaurusEvalsCLI"]),
+    ],
+    dependencies: [
+        .package(path: "../OsaurusCore")
+    ],
+    targets: [
+        .target(
+            name: "OsaurusEvalsKit",
+            dependencies: [
+                .product(name: "OsaurusCore", package: "OsaurusCore")
+            ],
+            path: "Sources/OsaurusEvalsKit"
+        ),
+        .executableTarget(
+            name: "OsaurusEvalsCLI",
+            dependencies: [
+                "OsaurusEvalsKit"
+            ],
+            path: "Sources/OsaurusEvalsCLI"
+        ),
+    ]
+)

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -1,0 +1,118 @@
+# OsaurusEvals
+
+Catalog-driven behaviour / integration tests for Osaurus that hit a real model (Foundation, MLX, remote provider).
+
+These evals are deliberately **off the CI path**. They burn LLM tokens, depend on local plugin installs, and exist to help us tune capabilities and triage new models — not to gate every commit.
+
+## Structure
+
+```
+Packages/OsaurusEvals/
+  Package.swift
+  README.md (this file)
+  Sources/
+    OsaurusEvalsKit/    — library (case schema, runner, scorers, model override)
+    OsaurusEvalsCLI/    — `osaurus-evals` executable
+  Suites/
+    Preflight/          — preflight pick + companion teaser cases
+    AgentLoop/          — placeholder for future agent-loop cases
+    ...
+```
+
+A "suite" is just a directory of `*.json` case files. Add a new case by dropping a JSON file in — no Swift edit required.
+
+## Running
+
+The repo `Makefile` exposes two targets that wrap the CLI from the workspace
+root — easier than `cd`'ing into the package every time:
+
+```bash
+# From the repo root:
+make evals                                          # default model (current core model)
+make evals MODEL=foundation                         # Apple Foundation Models
+make evals MODEL=openai/gpt-4o-mini                 # remote provider
+make evals MODEL=mlx-community/Qwen3-4B-MLX-4bit    # specific local MLX model
+make evals FILTER=browser-amazon                    # single case while iterating
+make evals-report                                   # also writes build/evals.json
+make evals-report EVALS_OUT=reports/today.json      # custom output path
+make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop  # other suite
+```
+
+Or call the CLI directly if you need flags the Makefile doesn't expose:
+
+```bash
+cd Packages/OsaurusEvals
+swift run osaurus-evals run --suite Suites/Preflight --model foundation
+swift run osaurus-evals run --suite Suites/Preflight --filter browser --out report.json
+```
+
+Exit codes:
+
+- `0` — every non-skipped case passed
+- `1` — at least one case failed or errored
+- `2` — bad arguments / suite path
+
+## Case schema
+
+Minimal example:
+
+```json
+{
+  "id": "preflight.browser.amazon-orders",
+  "domain": "preflight",
+  "label": "browser • amazon orders",
+  "query": "can you help me check my orders on amazon?",
+  "fixtures": {
+    "preflightMode": "balanced",
+    "requirePlugins": ["osaurus.browser"]
+  },
+  "expect": {
+    "tools": {
+      "mustInclude": ["browser_navigate"]
+    },
+    "companions": {
+      "skills": ["osaurus-browser"],
+      "siblings": {
+        "minOverlap": 2,
+        "candidates": ["browser_open_login", "browser_do", "browser_console_messages"]
+      }
+    }
+  }
+}
+```
+
+Field reference:
+
+- `id` — unique slug; surfaced in reports for diffing across runs.
+- `domain` — selects the runner code path. Today only `preflight` is supported.
+- `label` — optional human label; falls back to `id`.
+- `query` — the user message preflight runs against.
+- `fixtures.preflightMode` — `off` / `narrow` / `balanced` / `wide`. Default `balanced`.
+- `fixtures.requirePlugins` — plugin ids the case needs locally. Cases with missing plugins are **skipped** (not failed) so an incomplete install doesn't mask real regressions.
+- `expect.tools.mustInclude` / `mustNotInclude` — picked-set assertions, equal-weighted. Partial credit is given.
+- `expect.companions.skills` — plugin skills that should surface in the teaser.
+- `expect.companions.siblings` — at-least-N overlap matcher against a candidate list (resilient to ordering churn).
+
+A case with empty `expect: {}` is a valid smoke test — it records what preflight did without scoring anything. Useful while bootstrapping.
+
+## Adding a new case
+
+1. Drop `Suites/Preflight/my-case.json` with the schema above.
+2. `swift run osaurus-evals run --suite Suites/Preflight --filter my-case` to iterate.
+3. Once green, run the whole suite to make sure you didn't break a sibling.
+
+## Adding a new domain
+
+1. Add `Suites/<NewDomain>/` with a few JSON cases.
+2. In `Sources/OsaurusEvalsKit/EvalRunner.swift`, add a `case "<newdomain>":` arm to `runOne(...)`. Keep domain runners as separate top-level functions; merging them into one branch gets messy fast.
+
+## CI isolation
+
+This package is a **separate Swift package**. CI / Xcode builds run `swift build` and `swift test` from `Packages/OsaurusCore`, never from here. Even if someone does `swift test` from inside `Packages/OsaurusEvals`, no test target exists yet — runner unit tests should be added with a `OSAURUS_EVALS_ENABLED=1` env-var gate so they never burn tokens unintentionally.
+
+## Future hooks (deliberately stubbed)
+
+- `osaurus-evals diff baseline.json current.json` — regression check against a stored baseline.
+- Per-model scoreboards under `reports/<model>/<date>.json`.
+- Auto-run on new model release (CI workflow listening for HF releases).
+- Domain growth: `Suites/AgentLoop/`, `Suites/ToolCalling/`, `Suites/SkillInjection/`.

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -71,7 +71,7 @@ Minimal example:
       "mustInclude": ["browser_navigate"]
     },
     "companions": {
-      "skills": ["osaurus-browser"],
+      "skills": ["Osaurus Browser"],
       "siblings": {
         "minOverlap": 2,
         "candidates": ["browser_open_login", "browser_do", "browser_console_messages"]
@@ -90,7 +90,7 @@ Field reference:
 - `fixtures.preflightMode` — `off` / `narrow` / `balanced` / `wide`. Default `balanced`.
 - `fixtures.requirePlugins` — plugin ids the case needs locally. Cases with missing plugins are **skipped** (not failed) so an incomplete install doesn't mask real regressions.
 - `expect.tools.mustInclude` / `mustNotInclude` — picked-set assertions, equal-weighted. Partial credit is given.
-- `expect.companions.skills` — plugin skills that should surface in the teaser.
+- `expect.companions.skills` — plugin skills that should surface in the teaser. **Use the registered display name** (e.g. `"Osaurus Browser"`), not the slug. Plugin skills authored with the agent-skills `lowercase-hyphen` form get title-cased on registration (`osaurus-browser` → `Osaurus Browser`); the companion teaser surfaces the display name and that's what `capabilities_load` looks up.
 - `expect.companions.siblings` — at-least-N overlap matcher against a candidate list (resilient to ordering churn).
 
 A case with empty `expect: {}` is a valid smoke test — it records what preflight did without scoring anything. Useful while bootstrapping.

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -1,0 +1,182 @@
+//
+//  OsaurusEvalsCLI.swift
+//  osaurus-evals
+//
+//  Tiny CLI over `OsaurusEvalsKit`. Deliberately no
+//  swift-argument-parser dependency — the surface is small enough that
+//  manual parsing is clearer than wiring a fourth-party dep just for
+//  three flags. Add a real arg parser if/when a subcommand surface
+//  appears (`run`, `diff`, `score`, ...).
+//
+//  Usage:
+//    osaurus-evals run --suite Suites/Preflight [--model foundation] [--filter browser] [--out report.json]
+//
+//  Exit codes:
+//    0  every non-skipped case passed (or no cases ran)
+//    1  at least one case failed or errored
+//    2  invalid arguments / suite path
+//
+
+import Foundation
+import OsaurusCore
+import OsaurusEvalsKit
+
+@main
+struct OsaurusEvalsCLI {
+
+    static func main() async {
+        let args = Array(CommandLine.arguments.dropFirst())
+        guard let first = args.first, first == "run" else {
+            printUsage()
+            exit(args.isEmpty ? 0 : 2)
+        }
+
+        let opts: Options
+        do {
+            opts = try Options.parse(Array(args.dropFirst()))
+        } catch {
+            FileHandle.standardError.write(
+                Data(("argument error: \(error.localizedDescription)\n").utf8)
+            )
+            printUsage()
+            exit(2)
+        }
+
+        let suite: EvalSuite
+        do {
+            suite = try EvalSuite.load(from: opts.suite)
+        } catch {
+            FileHandle.standardError.write(
+                Data(("failed to load suite: \(error.localizedDescription)\n").utf8)
+            )
+            exit(2)
+        }
+
+        let report = await EvalRunner.run(
+            suite: suite,
+            model: opts.model,
+            filter: opts.filter
+        )
+
+        print(report.formatHumanReadable())
+
+        if let outPath = opts.out {
+            do {
+                let data = try report.toJSON(prettyPrinted: true)
+                let url = URL(fileURLWithPath: outPath)
+                try data.write(to: url)
+                print("\nwrote \(report.cases.count) cases to \(url.path)")
+            } catch {
+                FileHandle.standardError.write(
+                    Data(("failed to write report: \(error.localizedDescription)\n").utf8)
+                )
+                // Don't fail the run for an output write hiccup — the
+                // human-readable report already printed and is the
+                // primary deliverable.
+            }
+        }
+
+        let counts = report.counts
+        let exitCode: Int32 = (counts.failed + counts.errored == 0) ? 0 : 1
+        exit(exitCode)
+    }
+
+    // MARK: - Args
+
+    struct Options {
+        let suite: URL
+        let model: ModelSelection
+        let filter: String?
+        let out: String?
+
+        static func parse(_ args: [String]) throws -> Options {
+            var suite: URL?
+            var modelRaw: String?
+            var filter: String?
+            var out: String?
+
+            var i = 0
+            while i < args.count {
+                let arg = args[i]
+                switch arg {
+                case "--suite":
+                    suite = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--model":
+                    modelRaw = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--filter":
+                    filter = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--out":
+                    out = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--help", "-h":
+                    printUsage()
+                    exit(0)
+                default:
+                    throw CLIError.unknownArg(arg)
+                }
+            }
+
+            guard let suite else { throw CLIError.missingFlag("--suite") }
+            return Options(
+                suite: suite,
+                model: ModelSelection.parse(modelRaw),
+                filter: filter,
+                out: out
+            )
+        }
+    }
+
+    static func valueForArg(_ args: [String], after index: Int, flag: String) throws -> String {
+        guard index + 1 < args.count else { throw CLIError.missingValue(flag) }
+        return args[index + 1]
+    }
+
+    static func urlForArg(_ args: [String], after index: Int, flag: String) throws -> URL {
+        let raw = try valueForArg(args, after: index, flag: flag)
+        return URL(fileURLWithPath: raw)
+    }
+
+    static func printUsage() {
+        let usage = """
+            osaurus-evals — run behaviour evals against a chosen model
+
+            USAGE:
+                osaurus-evals run --suite <dir> [--model <id>] [--filter <substr>] [--out <path>]
+
+            FLAGS:
+                --suite <dir>     Required. Directory of *.json eval cases
+                                  (e.g. Suites/Preflight).
+                --model <id>      Model to route through CoreModelService for
+                                  this run. Forms:
+                                    auto                — keep current config
+                                    foundation          — Apple Foundation Models
+                                    openai/gpt-4o-mini  — provider/name pair
+                                    qwen3-4b            — bare local id
+                                  Default: auto.
+                --filter <substr> Only run cases whose id contains <substr>.
+                --out <path>      Also write a JSON report to <path>.
+
+            EXAMPLES:
+                osaurus-evals run --suite Suites/Preflight --model foundation
+                osaurus-evals run --suite Suites/Preflight --filter browser --out report.json
+            """
+        print(usage)
+    }
+}
+
+enum CLIError: Error, LocalizedError {
+    case unknownArg(String)
+    case missingFlag(String)
+    case missingValue(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownArg(let a): return "unknown argument: \(a)"
+        case .missingFlag(let f): return "missing required flag: \(f)"
+        case .missingValue(let f): return "flag \(f) requires a value"
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -58,7 +58,7 @@ struct OsaurusEvalsCLI {
             filter: opts.filter
         )
 
-        print(report.formatHumanReadable())
+        print(report.formatHumanReadable(verbose: opts.verbose))
 
         if let outPath = opts.out {
             do {
@@ -88,12 +88,14 @@ struct OsaurusEvalsCLI {
         let model: ModelSelection
         let filter: String?
         let out: String?
+        let verbose: Bool
 
         static func parse(_ args: [String]) throws -> Options {
             var suite: URL?
             var modelRaw: String?
             var filter: String?
             var out: String?
+            var verbose = false
 
             var i = 0
             while i < args.count {
@@ -111,6 +113,9 @@ struct OsaurusEvalsCLI {
                 case "--out":
                     out = try valueForArg(args, after: i, flag: arg)
                     i += 2
+                case "--verbose", "-v":
+                    verbose = true
+                    i += 1
                 case "--help", "-h":
                     printUsage()
                     exit(0)
@@ -124,7 +129,8 @@ struct OsaurusEvalsCLI {
                 suite: suite,
                 model: ModelSelection.parse(modelRaw),
                 filter: filter,
-                out: out
+                out: out,
+                verbose: verbose
             )
         }
     }
@@ -158,6 +164,10 @@ struct OsaurusEvalsCLI {
                                   Default: auto.
                 --filter <substr> Only run cases whose id contains <substr>.
                 --out <path>      Also write a JSON report to <path>.
+                --verbose, -v     Print per-case diagnostics: the user query,
+                                  the raw LLM response (truncated), and the
+                                  pre-guardrail picks. Use when iterating on
+                                  the preflight prompt.
 
             EXAMPLES:
                 osaurus-evals run --suite Suites/Preflight --model foundation

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -1,0 +1,137 @@
+//
+//  EvalCase.swift
+//  OsaurusEvalsKit
+//
+//  JSON schema for a single behaviour case. Cases live as small JSON
+//  files under `Suites/<domain>/` so non-Swift contributors can add new
+//  ones with a text editor. Schema design:
+//    - `domain` is the eval family (today: "preflight"). It selects
+//      which runner code-path executes the case.
+//    - `fixtures` describes the world the case should run against
+//      (preflight mode, required plugins). The runner uses
+//      `requirePlugins` to skip cases the local install can't satisfy
+//      instead of failing them — a contributor without `osaurus.browser`
+//      should still be able to run the rest of the suite.
+//    - `expect` is what we'd score against. All matchers are optional
+//      so a case can scope to just tools, just companions, or both.
+//
+
+import Foundation
+
+public struct EvalCase: Sendable, Codable, Identifiable {
+    /// Unique slug, e.g. `preflight.browser.amazon-orders`. Surfaced in
+    /// reports for diffing across runs.
+    public let id: String
+    /// Selects the runner code path. Exactly one domain is supported
+    /// today (`preflight`); future domains will live under sibling
+    /// directories (`Suites/AgentLoop/`, `Suites/ToolCalling/`, ...).
+    public let domain: String
+    /// Optional human label for reports — falls back to `id` when nil.
+    public let label: String?
+    /// User message the case sends through preflight.
+    public let query: String
+    public let fixtures: Fixtures
+    public let expect: Expectations
+
+    public init(
+        id: String,
+        domain: String,
+        label: String? = nil,
+        query: String,
+        fixtures: Fixtures,
+        expect: Expectations
+    ) {
+        self.id = id
+        self.domain = domain
+        self.label = label
+        self.query = query
+        self.fixtures = fixtures
+        self.expect = expect
+    }
+
+    public struct Fixtures: Sendable, Codable {
+        /// Preflight aggressiveness for the case. Default `.balanced`
+        /// matches the production default — over-narrow cases should
+        /// opt down explicitly so the picker behaviour they're asserting
+        /// is the same one users see.
+        public let preflightMode: PreflightMode?
+        /// Plugin ids the case needs in the local registry. Cases with
+        /// missing requirements are SKIPPED in the report (not failed)
+        /// so an incomplete local setup doesn't mask real regressions.
+        public let requirePlugins: [String]?
+
+        public init(
+            preflightMode: PreflightMode? = nil,
+            requirePlugins: [String]? = nil
+        ) {
+            self.preflightMode = preflightMode
+            self.requirePlugins = requirePlugins
+        }
+    }
+
+    /// Mirror of `OsaurusCore.PreflightSearchMode` decoded from JSON.
+    /// We don't import the OsaurusCore enum directly because we want
+    /// the JSON to use lowercase strings (`"balanced"`) and don't want
+    /// the schema to break if the upstream enum gains cases.
+    public enum PreflightMode: String, Sendable, Codable {
+        case off, narrow, balanced, wide
+    }
+
+    /// What we score against. All sub-fields are optional so a case can
+    /// scope its assertions narrowly. An empty `Expectations` is valid
+    /// — it acts as a smoke-test that just records what preflight did
+    /// without scoring anything (useful while bootstrapping a new case).
+    public struct Expectations: Sendable, Codable {
+        public let tools: ToolExpectations?
+        public let companions: CompanionExpectations?
+
+        public init(
+            tools: ToolExpectations? = nil,
+            companions: CompanionExpectations? = nil
+        ) {
+            self.tools = tools
+            self.companions = companions
+        }
+    }
+
+    public struct ToolExpectations: Sendable, Codable {
+        /// Tool names that MUST appear in the picked set. Each missing
+        /// name costs a fixed weight (see `Scorers.scoreTools`).
+        public let mustInclude: [String]?
+        /// Tool names that must NOT appear. Each spurious pick fails
+        /// the contract.
+        public let mustNotInclude: [String]?
+
+        public init(mustInclude: [String]? = nil, mustNotInclude: [String]? = nil) {
+            self.mustInclude = mustInclude
+            self.mustNotInclude = mustNotInclude
+        }
+    }
+
+    public struct CompanionExpectations: Sendable, Codable {
+        /// Plugin skills (by name) that should surface in the teaser.
+        /// A case asserts on names rather than the full skill object so
+        /// the schema stays compact.
+        public let skills: [String]?
+        /// Sibling-tool overlap matcher: AT LEAST `minOverlap` of these
+        /// candidates should appear in the teaser. Captures "the right
+        /// SHAPE of siblings showed up" without pinning the exact list,
+        /// which is helpful when sibling ordering is query-dependent.
+        public let siblings: SiblingMatcher?
+
+        public init(skills: [String]? = nil, siblings: SiblingMatcher? = nil) {
+            self.skills = skills
+            self.siblings = siblings
+        }
+
+        public struct SiblingMatcher: Sendable, Codable {
+            public let minOverlap: Int
+            public let candidates: [String]
+
+            public init(minOverlap: Int, candidates: [String]) {
+                self.minOverlap = minOverlap
+                self.candidates = candidates
+            }
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -1,0 +1,181 @@
+//
+//  EvalReport.swift
+//  OsaurusEvalsKit
+//
+//  Result types emitted by `EvalRunner`. Codable so the CLI can dump
+//  a machine-readable report (`--out report.json`) for downstream
+//  baselining + scoreboard work; `formatHumanReadable` is what gets
+//  printed to stdout for interactive runs.
+//
+
+import Foundation
+import OsaurusCore
+
+/// Outcome bucket for one case. `skipped` exists so a missing local
+/// fixture (e.g. plugin not installed) reads as "didn't apply" rather
+/// than "regressed" — an important distinction when sharing reports
+/// across machines with different installs.
+public enum EvalCaseOutcome: String, Sendable, Codable {
+    case passed
+    case failed
+    case skipped
+    case errored
+
+    /// Fixed-width 4-char display tag — kept on the enum so any future
+    /// surface (HTML report, CI annotation, etc.) gets the same labels.
+    public var badge: String {
+        switch self {
+        case .passed: return "PASS"
+        case .failed: return "FAIL"
+        case .skipped: return "SKIP"
+        case .errored: return "ERR "
+        }
+    }
+}
+
+/// Per-case scoring breakdown. Each component is a `Float` in `[0, 1]`
+/// (component absent → `nil`), plus an aggregate `score`. Cases without
+/// any expectations score `1.0` — pure smoke tests that pass as long
+/// as preflight didn't throw.
+public struct EvalCaseScore: Sendable, Codable {
+    public let aggregate: Float
+    public let tools: Float?
+    public let companions: Float?
+
+    public init(aggregate: Float, tools: Float?, companions: Float?) {
+        self.aggregate = aggregate
+        self.tools = tools
+        self.companions = companions
+    }
+}
+
+/// Single-case row in the eval report.
+public struct EvalCaseReport: Sendable, Codable {
+    public let id: String
+    public let label: String
+    public let domain: String
+    public let outcome: EvalCaseOutcome
+    public let score: EvalCaseScore?
+    /// Preflight snapshot we ran the scorers against. `nil` for
+    /// `skipped` / `errored` outcomes.
+    public let observed: PreflightEvaluation?
+    /// One-line per-component diagnostic — populated for `failed` and
+    /// `errored` so a glance at the report tells you WHAT broke without
+    /// rerunning. Empty for clean passes.
+    public let notes: [String]
+    public let modelId: String
+    public let latencyMs: Double?
+
+    public init(
+        id: String,
+        label: String,
+        domain: String,
+        outcome: EvalCaseOutcome,
+        score: EvalCaseScore?,
+        observed: PreflightEvaluation?,
+        notes: [String],
+        modelId: String,
+        latencyMs: Double?
+    ) {
+        self.id = id
+        self.label = label
+        self.domain = domain
+        self.outcome = outcome
+        self.score = score
+        self.observed = observed
+        self.notes = notes
+        self.modelId = modelId
+        self.latencyMs = latencyMs
+    }
+
+    /// Build an early-exit row (decode failure, unknown domain, missing
+    /// fixture). All scoring fields are nil because we never invoked
+    /// preflight — the `notes` array is the only diagnostic.
+    public static func terminal(
+        id: String,
+        label: String,
+        domain: String,
+        outcome: EvalCaseOutcome,
+        notes: [String],
+        modelId: String
+    ) -> EvalCaseReport {
+        EvalCaseReport(
+            id: id,
+            label: label,
+            domain: domain,
+            outcome: outcome,
+            score: nil,
+            observed: nil,
+            notes: notes,
+            modelId: modelId,
+            latencyMs: nil
+        )
+    }
+}
+
+/// Aggregated report for one runner invocation. Carries every case row
+/// plus run-level metadata (which model, when, summary counts).
+public struct EvalReport: Sendable, Codable {
+    public let modelId: String
+    /// ISO-8601 timestamp of when the runner started. Captured here so
+    /// per-model scoreboards can stack reports without name collisions.
+    public let startedAt: String
+    public let cases: [EvalCaseReport]
+
+    public var counts: Counts { Counts(cases: cases) }
+
+    public init(modelId: String, startedAt: String, cases: [EvalCaseReport]) {
+        self.modelId = modelId
+        self.startedAt = startedAt
+        self.cases = cases
+    }
+
+    public struct Counts: Sendable, Codable {
+        public let total: Int
+        public let passed: Int
+        public let failed: Int
+        public let skipped: Int
+        public let errored: Int
+
+        public init(cases: [EvalCaseReport]) {
+            total = cases.count
+            passed = cases.filter { $0.outcome == .passed }.count
+            failed = cases.filter { $0.outcome == .failed }.count
+            skipped = cases.filter { $0.outcome == .skipped }.count
+            errored = cases.filter { $0.outcome == .errored }.count
+        }
+    }
+
+    // MARK: - Output
+
+    public func toJSON(prettyPrinted: Bool = true) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting =
+            prettyPrinted
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    /// Human-readable table — what the CLI prints to stdout. Compact
+    /// enough to scan a 6-case run in a single terminal screen.
+    public func formatHumanReadable() -> String {
+        var lines: [String] = []
+        lines.append("Eval report")
+        lines.append("  model:     \(modelId)")
+        lines.append("  startedAt: \(startedAt)")
+        let c = counts
+        lines.append(
+            "  totals:    \(c.total) total · \(c.passed) passed · \(c.failed) failed · "
+                + "\(c.skipped) skipped · \(c.errored) errored"
+        )
+        lines.append("")
+        for row in cases {
+            let scoreStr = row.score.map { String(format: "%.2f", $0.aggregate) } ?? "—"
+            let latencyStr = row.latencyMs.map { String(format: "%5.0fms", $0) } ?? "      —"
+            lines.append("[\(row.outcome.badge)] \(row.id)  score=\(scoreStr)  \(latencyStr)")
+            for note in row.notes { lines.append("       · \(note)") }
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -54,6 +54,11 @@ public struct EvalCaseReport: Sendable, Codable {
     public let id: String
     public let label: String
     public let domain: String
+    /// User-facing query that drove the case. Captured here (rather
+    /// than re-derived from the source file) so a JSON report is fully
+    /// self-describing — readers don't have to keep the suite around
+    /// to interpret a result.
+    public let query: String?
     public let outcome: EvalCaseOutcome
     public let score: EvalCaseScore?
     /// Preflight snapshot we ran the scorers against. `nil` for
@@ -70,6 +75,7 @@ public struct EvalCaseReport: Sendable, Codable {
         id: String,
         label: String,
         domain: String,
+        query: String? = nil,
         outcome: EvalCaseOutcome,
         score: EvalCaseScore?,
         observed: PreflightEvaluation?,
@@ -80,6 +86,7 @@ public struct EvalCaseReport: Sendable, Codable {
         self.id = id
         self.label = label
         self.domain = domain
+        self.query = query
         self.outcome = outcome
         self.score = score
         self.observed = observed
@@ -103,6 +110,7 @@ public struct EvalCaseReport: Sendable, Codable {
             id: id,
             label: label,
             domain: domain,
+            query: nil,
             outcome: outcome,
             score: nil,
             observed: nil,
@@ -159,7 +167,10 @@ public struct EvalReport: Sendable, Codable {
 
     /// Human-readable table — what the CLI prints to stdout. Compact
     /// enough to scan a 6-case run in a single terminal screen.
-    public func formatHumanReadable() -> String {
+    /// `verbose` adds per-case diagnostics (query + raw response +
+    /// pre-guardrail picks) — use it when iterating on the preflight
+    /// prompt or chasing a specific small-model failure.
+    public func formatHumanReadable(verbose: Bool = false) -> String {
         var lines: [String] = []
         lines.append("Eval report")
         lines.append("  model:     \(modelId)")
@@ -175,7 +186,50 @@ public struct EvalReport: Sendable, Codable {
             let latencyStr = row.latencyMs.map { String(format: "%5.0fms", $0) } ?? "      —"
             lines.append("[\(row.outcome.badge)] \(row.id)  score=\(scoreStr)  \(latencyStr)")
             for note in row.notes { lines.append("       · \(note)") }
+            if verbose { appendVerboseDiagnostics(for: row, into: &lines) }
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// Add per-case diagnostic lines (query + raw LLM response + pre-
+    /// guardrail picks + companion count) to `lines`. Pulled out of
+    /// `formatHumanReadable` so the verbose-off code path stays a tight
+    /// table; call only when `verbose == true`.
+    private func appendVerboseDiagnostics(
+        for row: EvalCaseReport,
+        into lines: inout [String]
+    ) {
+        if let query = row.query {
+            lines.append("       · query: \"\(query)\"")
+        }
+        guard let observed = row.observed else { return }
+        // catalogSize == 0 is the operator-friendly tell for "the LLM
+        // was never called because no plugin tools are enabled in this
+        // process". Always show it so a confusing FAIL doesn't read
+        // like a model failure when it's a config issue.
+        lines.append("       · catalogSize: \(observed.catalogSize)")
+        if let llmError = observed.llmError {
+            lines.append("       · llmError: \(llmError)")
+        }
+        if !observed.llmPicks.isEmpty {
+            lines.append("       · llmPicks: [\(observed.llmPicks.joined(separator: ", "))]")
+        }
+        if let raw = observed.rawLLMResponse {
+            // Truncate so a chatty model doesn't blow out the terminal.
+            // 400 chars catches the common shapes (NONE, picks, prose
+            // refusal, malformed list) without scrolling.
+            let snippet = raw.count > 400 ? String(raw.prefix(400)) + "…" : raw
+            // Indent multi-line responses so they read as one block.
+            let indented =
+                snippet
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map { "         \($0)" }
+                .joined(separator: "\n")
+            lines.append("       · raw:")
+            lines.append(indented)
+        }
+        if !observed.companions.isEmpty {
+            lines.append("       · companions: \(observed.companions.count)")
+        }
     }
 }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -1,0 +1,145 @@
+//
+//  EvalRunner.swift
+//  OsaurusEvalsKit
+//
+//  Orchestrates one suite run: applies the model selection, walks each
+//  case sequentially (avoids tripping the CoreModelService circuit
+//  breaker), and assembles an `EvalReport`.
+//
+//  Cases run on the main actor — `PreflightEvaluator.evaluate` is
+//  main-actor-isolated because the underlying registry / agent /
+//  plugin manager state is. Sequencing keeps the state guarantees
+//  simple and matches how preflight runs in the actual chat path.
+//
+
+import Foundation
+import OsaurusCore
+
+@MainActor
+public enum EvalRunner {
+
+    /// Run every case in `suite`, one at a time, and produce a report.
+    /// `filter` is a substring that must appear in `case.id` for the
+    /// case to run — the CLI exposes it via `--filter` so a contributor
+    /// debugging a single case doesn't burn tokens on the whole suite.
+    public static func run(
+        suite: EvalSuite,
+        model: ModelSelection,
+        filter: String? = nil
+    ) async -> EvalReport {
+        let modelLabel = ModelOverride.describe(model)
+        let startedAt = isoNow()
+        var rows: [EvalCaseReport] = []
+
+        // Surface decode failures up-front as `errored` rows so a
+        // contributor with a typo sees the file name in the report
+        // instead of silently losing one case.
+        for failure in suite.decodeFailures {
+            rows.append(
+                EvalCaseReport.terminal(
+                    id: failure.filename,
+                    label: failure.filename,
+                    domain: "(unknown)",
+                    outcome: .errored,
+                    notes: ["decode failure: \(failure.error)"],
+                    modelId: modelLabel
+                )
+            )
+        }
+
+        await ModelOverride.withSelection(model) {
+            for testCase in suite.cases {
+                if let filter, !testCase.id.contains(filter) { continue }
+                let row = await runOne(testCase, modelId: modelLabel)
+                rows.append(row)
+            }
+        }
+
+        return EvalReport(modelId: modelLabel, startedAt: startedAt, cases: rows)
+    }
+
+    // MARK: - Per-case
+
+    private static func runOne(_ testCase: EvalCase, modelId: String) async -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+
+        // Today the only domain is preflight. New domains add a
+        // `case` arm here and stay separate top-level functions —
+        // mixing them into one runner gets messy fast.
+        guard testCase.domain == "preflight" else {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: ["unknown domain: \(testCase.domain)"],
+                modelId: modelId
+            )
+        }
+
+        // Skip cases whose required plugins aren't installed locally.
+        // We check before calling preflight so the LLM doesn't burn
+        // a generation just to reveal a fixture mismatch.
+        if let required = testCase.fixtures.requirePlugins, !required.isEmpty {
+            let installed = PreflightEvaluator.installedPluginIds()
+            let missing = required.filter { !installed.contains($0) }
+            if !missing.isEmpty {
+                return .terminal(
+                    id: testCase.id,
+                    label: label,
+                    domain: testCase.domain,
+                    outcome: .skipped,
+                    notes: ["missing plugins: \(missing.joined(separator: ", "))"],
+                    modelId: modelId
+                )
+            }
+        }
+
+        // `EvalCase.PreflightMode` mirrors `PreflightSearchMode` raw
+        // values 1:1 (off / narrow / balanced / wide); the rawValue
+        // bridge keeps the enums decoupled without a hand-rolled
+        // mapping function.
+        let mode =
+            PreflightSearchMode(
+                rawValue: (testCase.fixtures.preflightMode ?? .balanced).rawValue
+            ) ?? .balanced
+        let observed = await PreflightEvaluator.evaluate(query: testCase.query, mode: mode)
+
+        let toolResult = Scorers.scoreTools(observed: observed, expectation: testCase.expect.tools)
+        let companionResult = Scorers.scoreCompanions(
+            observed: observed,
+            expectation: testCase.expect.companions
+        )
+        let aggregate = Scorers.aggregate(
+            tools: toolResult?.score,
+            companions: companionResult?.score
+        )
+        let score = EvalCaseScore(
+            aggregate: aggregate,
+            tools: toolResult?.score,
+            companions: companionResult?.score
+        )
+        let notes = (toolResult?.notes ?? []) + (companionResult?.notes ?? [])
+        let outcome: EvalCaseOutcome = aggregate >= 1.0 ? .passed : .failed
+
+        return EvalCaseReport(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: outcome,
+            score: score,
+            observed: observed,
+            notes: notes,
+            modelId: modelId,
+            latencyMs: observed.latencyMs
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func isoNow() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: Date())
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -27,6 +27,13 @@ public enum EvalRunner {
         model: ModelSelection,
         filter: String? = nil
     ) async -> EvalReport {
+        // The CLI is its own process — it has to scan + dlopen every
+        // installed plugin manually before preflight can see plugin
+        // tools (the host app does this in AppDelegate). Without it
+        // every `requirePlugins` case skips with "missing plugins" no
+        // matter what's actually installed on disk.
+        await PreflightEvaluator.loadInstalledPlugins()
+
         let modelLabel = ModelOverride.describe(model)
         let startedAt = isoNow()
         var rows: [EvalCaseReport] = []

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -133,6 +133,7 @@ public enum EvalRunner {
             id: testCase.id,
             label: label,
             domain: testCase.domain,
+            query: testCase.query,
             outcome: outcome,
             score: score,
             observed: observed,

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalSuite.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalSuite.swift
@@ -1,0 +1,73 @@
+//
+//  EvalSuite.swift
+//  OsaurusEvalsKit
+//
+//  Loads a directory of `*.json` eval cases. Stays a thin wrapper
+//  around `JSONDecoder` so contributors can drop a new case file in
+//  `Suites/Preflight/` and the runner picks it up automatically — no
+//  Swift edit, no test target rebuild.
+//
+
+import Foundation
+
+public struct EvalSuite: Sendable {
+    public let directory: URL
+    public let cases: [EvalCase]
+    /// Filenames the loader couldn't decode, paired with the underlying
+    /// error message. Surfaced to the runner instead of throwing so one
+    /// malformed case doesn't block an entire suite run — the report
+    /// flags them as `errored` rows so they stay visible.
+    public let decodeFailures: [(filename: String, error: String)]
+
+    public init(
+        directory: URL,
+        cases: [EvalCase],
+        decodeFailures: [(filename: String, error: String)] = []
+    ) {
+        self.directory = directory
+        self.cases = cases
+        self.decodeFailures = decodeFailures
+    }
+
+    /// Walk `directory` (non-recursive) for `*.json` files and decode
+    /// each as an `EvalCase`. Files are sorted lexicographically so
+    /// reports are stable across runs and re-orderings of the
+    /// filesystem listing.
+    public static func load(from directory: URL) throws -> EvalSuite {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
+            throw EvalSuiteError.notADirectory(directory)
+        }
+
+        let urls =
+            try fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension.lowercased() == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        let decoder = JSONDecoder()
+        var cases: [EvalCase] = []
+        var failures: [(String, String)] = []
+        for url in urls {
+            do {
+                let data = try Data(contentsOf: url)
+                let item = try decoder.decode(EvalCase.self, from: data)
+                cases.append(item)
+            } catch {
+                failures.append((url.lastPathComponent, String(describing: error)))
+            }
+        }
+        return EvalSuite(directory: directory, cases: cases, decodeFailures: failures)
+    }
+}
+
+public enum EvalSuiteError: Error, LocalizedError {
+    case notADirectory(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notADirectory(let url):
+            return "Suite path is not a directory: \(url.path)"
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/ModelOverride.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/ModelOverride.swift
@@ -1,0 +1,99 @@
+//
+//  ModelOverride.swift
+//  OsaurusEvalsKit
+//
+//  Sets the core model identifier for an eval run by writing into
+//  `ChatConfigurationStore`, then restores the previous value when the
+//  scope ends. `CoreModelService.generate` reads the identifier off
+//  the store on every call, so the override naturally affects every
+//  preflight call inside the scope without touching inference plumbing.
+//
+//  The CLI accepts a few shorthand forms ("foundation", "auto",
+//  `provider/name`); we expand them here so the runner code stays
+//  ignorant of CLI argument shape.
+//
+
+import Foundation
+import OsaurusCore
+
+public enum ModelSelection: Sendable {
+    /// Use whatever `ChatConfigurationStore` currently has — the
+    /// "don't touch anything" path. Useful for matching the
+    /// production behaviour the user is currently running with.
+    case keepCurrent
+    /// Force Apple's on-device Foundation Models for the run.
+    case foundation
+    /// Explicit provider/name pair. Slash-form (`openai/gpt-4o-mini`,
+    /// `mlx-community/Qwen3-4B-MLX-4bit`) is parsed; bare names route
+    /// to the local catalog (see `CoreModelService.generate`).
+    case explicit(provider: String?, name: String)
+
+    /// Parse a CLI value into a `ModelSelection`. `auto` and the empty
+    /// string both map to `.keepCurrent` so callers can use either
+    /// idiom interchangeably.
+    public static func parse(_ raw: String?) -> ModelSelection {
+        guard let raw, !raw.isEmpty else { return .keepCurrent }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.lowercased() == "auto" { return .keepCurrent }
+        if trimmed.lowercased() == "foundation" { return .foundation }
+        // First slash splits provider from name. Everything after
+        // belongs to the name (HF repos like `mlx-community/Qwen3...`
+        // contain a slash but the *first* slash is still the
+        // provider/name boundary as far as routing is concerned).
+        if let slash = trimmed.firstIndex(of: "/") {
+            let provider = String(trimmed[..<slash])
+            let name = String(trimmed[trimmed.index(after: slash)...])
+            return .explicit(provider: provider.isEmpty ? nil : provider, name: name)
+        }
+        return .explicit(provider: nil, name: trimmed)
+    }
+}
+
+@MainActor
+public enum ModelOverride {
+
+    /// Apply `selection` to `ChatConfigurationStore`, run `body`, and
+    /// restore the prior config in a `defer` even if `body` throws —
+    /// mirrors the contract callers expect from `withResource`-style
+    /// helpers. Returns whatever `body` returns.
+    public static func withSelection<T>(
+        _ selection: ModelSelection,
+        _ body: () async throws -> T
+    ) async rethrows -> T {
+        let prior = ChatConfigurationStore.load()
+        defer { ChatConfigurationStore.save(prior) }
+
+        switch selection {
+        case .keepCurrent:
+            break
+        case .foundation:
+            // The local Foundation service handles the literal id
+            // "foundation" (see `ModelServiceRouter.resolve` /
+            // `FoundationModelService.handles(requestedModel:)`).
+            var updated = prior
+            updated.coreModelProvider = nil
+            updated.coreModelName = "foundation"
+            ChatConfigurationStore.save(updated)
+        case .explicit(let provider, let name):
+            var updated = prior
+            updated.coreModelProvider = provider
+            updated.coreModelName = name
+            ChatConfigurationStore.save(updated)
+        }
+
+        return try await body()
+    }
+
+    /// Convenience for log lines / report metadata.
+    public static func describe(_ selection: ModelSelection) -> String {
+        switch selection {
+        case .keepCurrent:
+            return ChatConfigurationStore.load().coreModelIdentifier ?? "(unset)"
+        case .foundation:
+            return "foundation"
+        case .explicit(let provider, let name):
+            if let provider, !provider.isEmpty { return "\(provider)/\(name)" }
+            return name
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/Scorers.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/Scorers.swift
@@ -1,0 +1,131 @@
+//
+//  Scorers.swift
+//  OsaurusEvalsKit
+//
+//  Pure-function scorers that take an observed `PreflightEvaluation`
+//  and case-side `Expectations`, returning a normalised score in
+//  `[0, 1]` plus diagnostic notes for the report.
+//
+//  Kept as a single file (rather than a `Scorers/` directory) because
+//  there are only three small functions and they share helpers — the
+//  file-per-scorer split was a YAGNI from the original plan.
+//
+
+import Foundation
+import OsaurusCore
+
+public enum Scorers {
+
+    // MARK: - Tools
+
+    /// Score the picked tool set against a `mustInclude` / `mustNotInclude`
+    /// contract. Each violation costs an equal share of the total budget,
+    /// so `mustInclude: [a, b]` with one missing scores `0.5` rather than
+    /// `0.0` — partial credit reads more usefully when comparing models.
+    /// Returns `nil` when no tool expectations were declared.
+    public static func scoreTools(
+        observed: PreflightEvaluation,
+        expectation: EvalCase.ToolExpectations?
+    ) -> (score: Float, notes: [String])? {
+        guard let expectation else { return nil }
+        let mustInclude = expectation.mustInclude ?? []
+        let mustNotInclude = expectation.mustNotInclude ?? []
+        let total = mustInclude.count + mustNotInclude.count
+        guard total > 0 else { return nil }
+
+        let pickedSet = Set(observed.pickedToolNames)
+        var hits = 0
+        var notes: [String] = []
+
+        for name in mustInclude {
+            if pickedSet.contains(name) {
+                hits += 1
+            } else {
+                notes.append("missing required tool: \(name)")
+            }
+        }
+        for name in mustNotInclude {
+            if pickedSet.contains(name) {
+                notes.append("forbidden tool was picked: \(name)")
+            } else {
+                hits += 1
+            }
+        }
+
+        let score = Float(hits) / Float(total)
+        return (score, notes)
+    }
+
+    // MARK: - Companions
+
+    /// Score the companion teaser against expected skills + sibling
+    /// overlap. Skill score is the fraction of expected skill names
+    /// found across all companion sections; sibling score is `1.0`
+    /// when at least `minOverlap` candidates appear in any companion's
+    /// `siblingToolNames` list, else linearly interpolated.
+    /// Components are averaged (equal weight) into the per-case score
+    /// the report shows. Returns `nil` when no companion expectations
+    /// were declared.
+    public static func scoreCompanions(
+        observed: PreflightEvaluation,
+        expectation: EvalCase.CompanionExpectations?
+    ) -> (score: Float, notes: [String])? {
+        guard let expectation,
+            expectation.skills != nil || expectation.siblings != nil
+        else { return nil }
+
+        var components: [Float] = []
+        var notes: [String] = []
+
+        // Skill component: union of skill names across all companions
+        // — most cases involve a single plugin, but the union shape
+        // generalises cleanly to multi-plugin queries (e.g. "plot a
+        // chart from this csv" picks tools from chart + csv plugins).
+        if let expectedSkills = expectation.skills, !expectedSkills.isEmpty {
+            let surfacedSkills = Set(observed.companions.compactMap(\.skillName))
+            let hits = expectedSkills.filter { surfacedSkills.contains($0) }.count
+            let score = Float(hits) / Float(expectedSkills.count)
+            components.append(score)
+            for missing in expectedSkills where !surfacedSkills.contains(missing) {
+                notes.append("missing companion skill: \(missing)")
+            }
+        }
+
+        // Sibling overlap component.
+        if let siblings = expectation.siblings {
+            let allSiblings = Set(observed.companions.flatMap { $0.siblingToolNames })
+            let candidateSet = Set(siblings.candidates)
+            let overlap = allSiblings.intersection(candidateSet).count
+            let target = max(siblings.minOverlap, 1)
+            let score = min(1.0, Float(overlap) / Float(target))
+            components.append(score)
+            if overlap < siblings.minOverlap {
+                notes.append(
+                    "sibling overlap \(overlap)/\(siblings.minOverlap) "
+                        + "(saw: \(allSiblings.intersection(candidateSet).sorted().joined(separator: ", ")))"
+                )
+            }
+        }
+
+        guard !components.isEmpty else { return nil }
+        let avg = components.reduce(0, +) / Float(components.count)
+        return (avg, notes)
+    }
+
+    // MARK: - Aggregation
+
+    /// Combine optional component scores into one aggregate. Components
+    /// not declared by the case are ignored — a tools-only case scores
+    /// 100% on `aggregate` when its single component scores 100%, even
+    /// though companions wasn't measured. Pass threshold defaults to
+    /// `1.0` (everything must be perfect); cases that want soft passes
+    /// can adjust at runner-call time.
+    public static func aggregate(
+        tools: Float?,
+        companions: Float?
+    ) -> Float {
+        let parts = [tools, companions].compactMap { $0 }
+        guard !parts.isEmpty else { return 1.0 }
+        return parts.reduce(0, +) / Float(parts.count)
+    }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-amazon-orders.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-amazon-orders.json
@@ -1,0 +1,27 @@
+{
+  "id": "preflight.browser.amazon-orders",
+  "domain": "preflight",
+  "label": "browser • amazon orders",
+  "query": "can you help me check my orders on amazon?",
+  "fixtures": {
+    "preflightMode": "balanced",
+    "requirePlugins": ["osaurus.browser"]
+  },
+  "expect": {
+    "tools": {
+      "mustInclude": ["browser_navigate"]
+    },
+    "companions": {
+      "skills": ["osaurus-browser"],
+      "siblings": {
+        "minOverlap": 2,
+        "candidates": [
+          "browser_open_login",
+          "browser_do",
+          "browser_console_messages",
+          "browser_screenshot"
+        ]
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-amazon-orders.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-amazon-orders.json
@@ -12,7 +12,7 @@
       "mustInclude": ["browser_navigate"]
     },
     "companions": {
-      "skills": ["osaurus-browser"],
+      "skills": ["Osaurus Browser"],
       "siblings": {
         "minOverlap": 2,
         "candidates": [

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
@@ -1,0 +1,22 @@
+{
+  "id": "preflight.browser.login-flow",
+  "domain": "preflight",
+  "label": "browser • login implies open_login companion",
+  "query": "can you sign me in to my github account?",
+  "fixtures": {
+    "preflightMode": "balanced",
+    "requirePlugins": ["osaurus.browser"]
+  },
+  "expect": {
+    "tools": {
+      "mustInclude": ["browser_navigate"]
+    },
+    "companions": {
+      "skills": ["osaurus-browser"],
+      "siblings": {
+        "minOverlap": 1,
+        "candidates": ["browser_open_login"]
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
@@ -1,7 +1,7 @@
 {
   "id": "preflight.browser.login-flow",
   "domain": "preflight",
-  "label": "browser • login implies open_login companion",
+  "label": "browser • login picks open_login directly",
   "query": "can you sign me in to my github account?",
   "fixtures": {
     "preflightMode": "balanced",
@@ -9,14 +9,10 @@
   },
   "expect": {
     "tools": {
-      "mustInclude": ["browser_navigate"]
+      "mustInclude": ["browser_open_login"]
     },
     "companions": {
-      "skills": ["Osaurus Browser"],
-      "siblings": {
-        "minOverlap": 1,
-        "candidates": ["browser_open_login"]
-      }
+      "skills": ["Osaurus Browser"]
     }
   }
 }

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-login-flow.json
@@ -12,7 +12,7 @@
       "mustInclude": ["browser_navigate"]
     },
     "companions": {
-      "skills": ["osaurus-browser"],
+      "skills": ["Osaurus Browser"],
       "siblings": {
         "minOverlap": 1,
         "candidates": ["browser_open_login"]

--- a/Packages/OsaurusEvals/Suites/Preflight/music-spotify.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/music-spotify.json
@@ -1,0 +1,14 @@
+{
+  "id": "preflight.music.spotify-play",
+  "domain": "preflight",
+  "label": "music • spotify pick (multi-plugin smoke)",
+  "query": "play some lo-fi beats on spotify",
+  "fixtures": {
+    "preflightMode": "balanced"
+  },
+  "expect": {
+    "tools": {
+      "mustNotInclude": ["browser_navigate"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/no-match-abstain.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/no-match-abstain.json
@@ -1,0 +1,18 @@
+{
+  "id": "preflight.no-match.gibberish",
+  "domain": "preflight",
+  "label": "gibberish • abstain on nonsense",
+  "query": "zzz_completely_nonexistent_capability_xyz_12345 ablubblub",
+  "fixtures": {
+    "preflightMode": "balanced"
+  },
+  "expect": {
+    "tools": {
+      "mustNotInclude": [
+        "browser_navigate",
+        "sandbox_exec",
+        "render_chart"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/sandbox-plugin-creator.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/sandbox-plugin-creator.json
@@ -1,0 +1,17 @@
+{
+  "id": "preflight.sandbox.plugin-creator-noise-floor",
+  "domain": "preflight",
+  "label": "sandbox • picker doesn't pick non-existent plugin tools",
+  "query": "I need a tool to call the AcmeWidgets API",
+  "fixtures": {
+    "preflightMode": "balanced"
+  },
+  "expect": {
+    "tools": {
+      "mustNotInclude": [
+        "acmewidgets_api",
+        "acmewidgets_call"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/smalltalk-thanks.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/smalltalk-thanks.json
@@ -1,0 +1,17 @@
+{
+  "id": "preflight.smalltalk.thanks",
+  "domain": "preflight",
+  "label": "smalltalk • abstain (NONE) regression",
+  "query": "thanks, that's perfect",
+  "fixtures": {
+    "preflightMode": "balanced"
+  },
+  "expect": {
+    "tools": {
+      "mustNotInclude": [
+        "browser_navigate",
+        "sandbox_exec"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

## Improve preflight pick recall for small models + new evals package

### Why

Small models like Apple Foundation (4K context window) couldn't preflight against a real plugin install. The full dynamic catalog (~77 tools after `osaurus.browser` etc.) tokenizes to ~4.3K and overflows the window — Foundation rejected the request before the LLM even ran. Larger models (Qwen3.6, GPT-4o-mini) worked but under-used cohesive plugins because preflight only picked one tool from a multi-tool plugin and never surfaced the rest.

This PR fixes both, and ships the evals infrastructure that drove the iteration.

### What's in it

**1. Plugin Companions — surface sibling tools + plugin skills as a `capabilities_load`-ready teaser**

When preflight picks a tool from a plugin (e.g. `browser_navigate` from `osaurus.browser`), the system prompt now includes a compact "Plugin Companions" block listing the plugin's other enabled tools and bundled skill, each as a `capabilities_load` id. The model pulls them in on-demand — no schema inflation, no extra round-trip in the common case.

- New file: `Packages/OsaurusCore/Services/Context/PreflightCompanions.swift`
- Cap of 6 sibling tools per plugin, query-overlap scored, alphabetically sorted (KV-cache stable)
- Trailing nudge spells out the one-shot contract so reasoning models stop re-loading the same id every turn

**2. Preflight pick recall — three changes that unblocked Foundation Models**

- **Embedding pre-rank.** New `rankCatalog` uses the existing `ToolSearchService` to show the LLM only the top-K candidates (narrow=6 / balanced=12 / wide=24) instead of the full catalog. Full catalog still backs validation, so the model can name a tool by prior knowledge even if it didn't make the top-K. The post-pick embedding guardrail still gates relevance.
- **Reshaped prompt.** Three-step reasoning scaffold ("name the user's intent → pick → output"), three positive examples covering distinct shapes (lookup / browser / sandbox) plus two NONE examples, dropped "Prefer NONE over guessing" — examples teach the boundary better than rules for small models.
- **Loosened parser.** Bare names accepted (small models routinely forget the `| reason` shape), wrapping characters stripped (`<browser_navigate | reason>`, backticks, quotes — Foundation almost always wraps), `tool: name` echo handled. Anti-padding contract relocated from the parser to the embedding guardrail.

Result against Apple Foundation Models on the new eval suite: **6/6 pass, ~5x faster** (5.5s → 1.0s per case because the smaller prompt fits the context window).

```
[PASS] preflight.browser.amazon-orders score=1.00 1295ms
[PASS] preflight.browser.login-flow score=1.00 968ms
[PASS] preflight.music.spotify-play score=1.00 825ms
[PASS] preflight.no-match.gibberish score=1.00 1007ms
[PASS] preflight.sandbox.plugin-creator-noise-floor score=1.00 1113ms
[PASS] preflight.smalltalk.thanks score=1.00 734ms
```

**3. `OsaurusEvals` package — catalog-driven behaviour evals, off CI**

New separate Swift package under `Packages/OsaurusEvals/`. Drop a JSON case in `Suites/Preflight/`, run it against any model, get a scored report. Built specifically so we can keep iterating on preflight (and other capabilities later) without burning tokens on every commit.

```bash
make evals MODEL=foundation                          # current setup
make evals MODEL=openai/gpt-4o-mini                  # remote provider
make evals MODEL=mlx-community/Qwen3-4B-MLX-4bit     # specific local MLX
make evals FILTER=browser-amazon                     # single case
make evals-verbose MODEL=foundation                  # raw LLM responses for prompt iteration
make evals-report EVALS_OUT=reports/today.json       # JSON for baselining
```

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
