### PR TITLE
reinforced with more unit tests, fixed kv caching calls, tighten up code. Enabled TurboQuant by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CONFIG := Release
 PROJECT := App/osaurus.xcodeproj
 DERIVED := build/DerivedData
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals evals-verbose evals-report
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report
 
 help:
 	@echo "Targets:"
@@ -22,9 +22,12 @@ help:
 	@echo "  bench-ingest-chunks Fast chunk-only backfill (no LLM, ~minutes)"
 	@echo "  bench-run           Run LOCOMO benchmark only (skip ingestion)"
 	@echo "  bench               Full ingest + run LOCOMO benchmark"
-	@echo "  evals               Run OsaurusEvals preflight suite (MODEL=, FILTER=, EVALS_SUITE=)"
+	@echo "  evals               Run one OsaurusEvals suite (MODEL=, FILTER=, EVALS_SUITE=)"
 	@echo "  evals-verbose       Same as 'evals' plus per-case raw LLM response (debugging prompt iter)"
 	@echo "  evals-report        Same as 'evals' but also writes JSON to EVALS_OUT (build/evals.json)"
+	@echo "  evals-all           Run every suite under Packages/OsaurusEvals/Suites/* (MODEL=, FILTER=)"
+	@echo "  evals-all-verbose   Same as 'evals-all' plus per-case raw LLM response"
+	@echo "  evals-all-report    Same as 'evals-all' but writes per-suite JSON to EVALS_OUT_DIR (build/evals/)"
 	@echo "  test           Run OsaurusCore package tests via 'swift test'"
 	@echo "  ci-test        Reproduce the CI test-core job locally (xcodebuild + xcbeautify)"
 	@echo "  clean          Remove DerivedData build output"
@@ -140,8 +143,14 @@ bench: bench-ingest bench-run
 # Default model is `auto` (whatever ChatConfigurationStore is set to);
 # see Packages/OsaurusEvals/README.md for the full --model grammar.
 
-EVALS_SUITE ?= Packages/OsaurusEvals/Suites/Preflight
+EVALS_ROOT := Packages/OsaurusEvals/Suites
+EVALS_SUITE ?= $(EVALS_ROOT)/Preflight
 EVALS_OUT ?= build/evals.json
+EVALS_OUT_DIR ?= build/evals
+# Auto-discovered list of every subdirectory under Suites/. Adding a new
+# `Suites/MyDomain/` automatically picks it up here — no Makefile edit
+# required when a new suite lands.
+EVALS_ALL_SUITES := $(sort $(dir $(wildcard $(EVALS_ROOT)/*/)))
 
 evals:
 	@echo "Running OsaurusEvals against $(EVALS_SUITE)…"
@@ -166,6 +175,57 @@ evals-report:
 		$(if $(FILTER),--filter $(FILTER),) \
 		--out $(EVALS_OUT)
 	@echo "Wrote $(EVALS_OUT)"
+
+# Run every suite directory under $(EVALS_ROOT). The CLI exits 1 on any
+# failed/errored case, so we run each suite independently (don't `set -e`)
+# and aggregate exit codes so a single failure doesn't mask later suites.
+# Final exit is non-zero if ANY suite failed.
+evals-all:
+	@echo "Discovered suites: $(notdir $(patsubst %/,%,$(EVALS_ALL_SUITES)))"
+	@rc=0; for suite in $(EVALS_ALL_SUITES); do \
+		echo ""; \
+		echo "── $$suite ──"; \
+		swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+			--suite $$suite \
+			$(if $(MODEL),--model $(MODEL),) \
+			$(if $(FILTER),--filter $(FILTER),) \
+			|| rc=$$?; \
+	done; \
+	exit $$rc
+
+evals-all-verbose:
+	@echo "Discovered suites: $(notdir $(patsubst %/,%,$(EVALS_ALL_SUITES)))"
+	@rc=0; for suite in $(EVALS_ALL_SUITES); do \
+		echo ""; \
+		echo "── $$suite ──"; \
+		swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+			--suite $$suite \
+			--verbose \
+			$(if $(MODEL),--model $(MODEL),) \
+			$(if $(FILTER),--filter $(FILTER),) \
+			|| rc=$$?; \
+	done; \
+	exit $$rc
+
+# Writes one JSON report per suite under $(EVALS_OUT_DIR), named after
+# the suite directory. Useful for CI dashboards / cross-run diffing.
+evals-all-report:
+	@mkdir -p $(EVALS_OUT_DIR)
+	@rc=0; for suite in $(EVALS_ALL_SUITES); do \
+		name=$$(basename $$suite); \
+		out="$(EVALS_OUT_DIR)/$$name.json"; \
+		echo ""; \
+		echo "── $$suite → $$out ──"; \
+		swift run --package-path Packages/OsaurusEvals osaurus-evals run \
+			--suite $$suite \
+			$(if $(MODEL),--model $(MODEL),) \
+			$(if $(FILTER),--filter $(FILTER),) \
+			--out $$out \
+			|| rc=$$?; \
+	done; \
+	echo ""; \
+	echo "Wrote per-suite reports to $(EVALS_OUT_DIR)/"; \
+	exit $$rc
 
 ## ── Housekeeping ─────────────────────────────────────────────────
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -518,7 +518,6 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         let closedAgentId = windows[id]?.agentId
         Task {
             if let sid = closedSessionId {
-                await ModelRuntime.shared.invalidateSession(sid.uuidString)
                 PluginHostContext.invalidatePreflightCache(sessionId: sid.uuidString)
             }
             if let aid = closedAgentId {

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -351,14 +351,21 @@ struct ChatCompletionRequest: Codable, Sendable {
     let tools: [Tool]?
     /// OpenAI tool_choice ("none" | "auto" | {"type":"function","function":{"name":...}})
     let tool_choice: ToolChoiceOption?
-    /// Optional session identifier for KV cache reuse across turns
+    /// Optional session identifier for chat/history grouping. Not a KV cache key —
+    /// vmlx-swift-lm's `CacheCoordinator` is content-addressed and discovers
+    /// reusable prefixes autonomously.
     var session_id: String? = nil
-    /// Optional prefix cache hint for sharing a cached KV prefix across requests
-    var cache_hint: String? = nil
+    /// Deterministic-sampling seed (OpenAI v1.x). When set, identical
+    /// requests should yield identical completions on the same backend.
+    var seed: Int? = nil
+    /// `{"type":"json_object"}` for OpenAI JSON mode. Other shapes
+    /// (`text`, `json_schema`) are rejected at request validation.
+    var response_format: ResponseFormat? = nil
+    /// `{"include_usage": true}` instructs the SSE producer to emit a
+    /// final chunk carrying `usage` (prompt/completion/total tokens).
+    var stream_options: StreamOptions? = nil
     /// Model-specific options from the active ModelProfile (not serialized to JSON).
     var modelOptions: [String: ModelOptionValue]? = nil
-    /// Static system prompt content for prefix cache building (not serialized to JSON).
-    var staticPrefix: String? = nil
     /// Optional TTFT trace for diagnostic timing (not serialized to JSON).
     var ttftTrace: TTFTTrace? = nil
 
@@ -368,7 +375,8 @@ struct ChatCompletionRequest: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case model, messages, temperature, max_tokens, max_completion_tokens, stream, top_p
         case frequency_penalty, presence_penalty, stop, n
-        case tools, tool_choice, session_id, cache_hint
+        case tools, tool_choice, session_id
+        case seed, response_format, stream_options
     }
 
     func withModel(_ newModel: String) -> ChatCompletionRequest {
@@ -386,12 +394,25 @@ struct ChatCompletionRequest: Codable, Sendable {
             tools: tools,
             tool_choice: tool_choice,
             session_id: session_id,
-            cache_hint: cache_hint
+            seed: seed,
+            response_format: response_format,
+            stream_options: stream_options
         )
         copy.modelOptions = modelOptions
-        copy.staticPrefix = staticPrefix
         return copy
     }
+}
+
+/// OpenAI `response_format`. We only act on `json_object`; other kinds
+/// (`text`, `json_schema`) flow through unchanged so the request
+/// validator can accept or reject them with a clear, specific error.
+struct ResponseFormat: Codable, Sendable, Equatable {
+    let type: String
+}
+
+/// OpenAI `stream_options` shape. Today we only honor `include_usage`.
+struct StreamOptions: Codable, Sendable, Equatable {
+    let include_usage: Bool?
 }
 
 /// Chat completion choice
@@ -418,8 +439,9 @@ struct ChatCompletionResponse: Codable, Sendable {
     let usage: Usage
     var system_fingerprint: String? = nil
     /// Content hash of the system prompt + tool names used for this request.
-    /// API callers can pass this value back as `cache_hint` to reuse the
-    /// prefix KV cache on subsequent requests.
+    /// Informational only — clients can use it to detect when the system
+    /// prefix changed across requests. KV reuse itself is handled
+    /// autonomously by vmlx's `CacheCoordinator` (content-addressed).
     var prefix_hash: String? = nil
 }
 
@@ -470,6 +492,9 @@ struct ChatCompletionChunk: Codable, Sendable {
     var system_fingerprint: String? = nil
     /// Included only in the first chunk; see `ChatCompletionResponse.prefix_hash`.
     var prefix_hash: String? = nil
+    /// Final usage chunk (OpenAI `stream_options.include_usage`). Populated
+    /// only on the dedicated penultimate SSE chunk; nil on every other.
+    var usage: Usage? = nil
 }
 
 // MARK: - Error Response

--- a/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
+++ b/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
@@ -302,6 +302,44 @@ final class SSEResponseWriter: ResponseWriter {
             ctx.value.close(promise: nil)
         }
     }
+
+    /// Emit a single SSE comment line as a keepalive heartbeat. SSE comment
+    /// lines start with `:` and are ignored by clients per the SSE spec, but
+    /// they keep intermediate proxies / load balancers from idling out long
+    /// tool/thinking pauses. Safe to call mid-stream.
+    func writePing(_ context: ChannelHandlerContext) {
+        var buf = context.channel.allocator.buffer(capacity: 16)
+        buf.writeString(": ping\n\n")
+        context.write(NIOAny(HTTPServerResponsePart.body(.byteBuffer(buf))), promise: nil)
+        context.flush()
+    }
+
+    /// Emit the OpenAI `stream_options.include_usage` final chunk: an
+    /// extra SSE chunk with empty `choices` and a populated `usage`
+    /// field, sent right before `data: [DONE]`. Per OpenAI spec this
+    /// chunk is only present when the request opts in.
+    func writeUsageChunk(
+        promptTokens: Int,
+        completionTokens: Int,
+        model: String,
+        responseId: String,
+        created: Int,
+        context: ChannelHandlerContext
+    ) {
+        var chunk = ChatCompletionChunk(
+            id: responseId,
+            created: created,
+            model: model,
+            choices: [],
+            system_fingerprint: nil
+        )
+        chunk.usage = Usage(
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            total_tokens: promptTokens + completionTokens
+        )
+        writeSSEChunk(chunk, context: context)
+    }
 }
 
 final class NDJSONResponseWriter: ResponseWriter {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -229,26 +229,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     startTime: startTime
                 )
             } else if head.method == .GET, path == "/health" {
-                let obj: [String: Any] = ["status": "healthy", "timestamp": Date().ISO8601Format()]
-                let data = try? JSONSerialization.data(withJSONObject: obj)
-                var headers = [("Content-Type", "application/json; charset=utf-8")]
-                headers.append(contentsOf: stateRef.value.corsHeaders)
-                let healthBody = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
-                sendResponse(
+                handleHealthEndpoint(
+                    head: head,
                     context: context,
-                    version: head.version,
-                    status: .ok,
-                    headers: headers,
-                    body: healthBody
-                )
-                logRequest(
-                    method: method,
-                    path: path,
+                    startTime: startTime,
                     userAgent: userAgent,
-                    requestBody: nil,
-                    responseBody: healthBody,
-                    responseStatus: 200,
-                    startTime: startTime
+                    method: method,
+                    path: path
                 )
             } else if head.method == .GET, path == "/models" {
                 handleModelsEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
@@ -1312,15 +1299,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         var enriched = request
         let query = request.messages.last(where: { $0.role == "user" })?.content ?? ""
-        let (hint, prefix) = await SystemPromptComposer.injectAgentContext(
+        await SystemPromptComposer.injectAgentContext(
             agentId: agentUUID,
             query: query,
             into: &enriched.messages
         )
-        if enriched.cache_hint == nil {
-            enriched.cache_hint = hint
-            enriched.staticPrefix = prefix
-        }
         return enriched
     }
 
@@ -1987,7 +1970,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // per-session schema. Bare `alwaysLoadedSpecs(mode:)` keeps the
             // HTTP schema predictable and avoids per-request preflight cost.
             // See docs/AGENT_LOOP.md before "fixing" this onto resolveTools.
-            let tools = await MainActor.run {
+            //
+            // Tools resolution:
+            //   1. Always-loaded specs from the agent's execution mode form
+            //      the base set (sandbox, folder, etc.).
+            //   2. Client-supplied `req.tools` are appended (deduped by
+            //      function name, client wins on conflicts) so callers can
+            //      ship custom function definitions without losing the
+            //      agent surface.
+            let baseTools = await MainActor.run {
                 let autonomousEnabled = AgentManager.shared.effectiveAutonomousExec(for: agentId)?.enabled == true
                 let mode = ToolRegistry.shared.resolveExecutionMode(
                     folderContext: nil,
@@ -1995,6 +1986,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 )
                 return ToolRegistry.shared.alwaysLoadedSpecs(mode: mode)
             }
+            let tools: [Tool] = {
+                guard let clientTools = req.tools, !clientTools.isEmpty else { return baseTools }
+                let clientNames = Set(clientTools.map { $0.function.name })
+                let kept = baseTools.filter { !clientNames.contains($0.function.name) }
+                return kept + clientTools
+            }()
+            // Honor client `tool_choice` when supplied (`none`, `auto`, or
+            // a forced function). Default to `.auto` so existing clients
+            // that set `tools` without `tool_choice` keep working.
+            let resolvedToolChoice: ToolChoiceOption? = {
+                if tools.isEmpty { return nil }
+                return req.tool_choice ?? .auto
+            }()
 
             let maxIterations = 30
             var iteration = 0
@@ -2026,8 +2030,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     stop: req.stop,
                     n: nil,
                     tools: tools.isEmpty ? nil : tools,
-                    tool_choice: tools.isEmpty ? nil : .auto,
-                    session_id: req.session_id
+                    tool_choice: resolvedToolChoice,
+                    session_id: req.session_id,
+                    seed: req.seed,
+                    response_format: req.response_format,
+                    stream_options: req.stream_options
                 )
 
                 var responseContent = ""
@@ -2071,6 +2078,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 } catch let inv as ServiceToolInvocation {
                     pendingInvocations = [inv]
                 } catch {
+                    // SSE response head was already written as 200 — the
+                    // failure surfaces as an in-band SSE error chunk. Log
+                    // the actual on-wire status (200) so dashboards don't
+                    // mis-attribute a delivered stream as a 500.
                     hop {
                         writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                         writerBound.value.writeEnd(ctx.value)
@@ -2080,7 +2091,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         path: path,
                         userAgent: logUserAgent,
                         requestBody: logRequestBody,
-                        responseStatus: 500,
+                        responseStatus: 200,
                         startTime: logStartTime,
                         errorMessage: error.localizedDescription
                     )
@@ -2093,16 +2104,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     break
                 }
 
-                // Execute every parsed tool call, streaming hint+done frames
-                // for each, then append ONE assistant message with all
-                // tool_calls and the matching tool-result messages. This is
-                // the OpenAI shape that downstream clients expect for
-                // multi-call completions.
+                // Execute every parsed tool call. Independent calls run
+                // in parallel via a TaskGroup so wall-clock time stays
+                // proportional to the slowest call rather than the sum.
+                // Per-call errors land as `ToolEnvelope.fromError` so a
+                // single bad call never aborts the rest of the batch.
+                let outcomes = await Self.runToolBatchInParallel(
+                    pendingInvocations,
+                    requestId: requestId,
+                    agentId: agentId
+                )
+
                 var assistantToolCalls: [ToolCall] = []
                 var toolResultsByCallId: [(String, String)] = []
-                for invocation in pendingInvocations {
-                    let callId = invocation.toolCallId ?? Self.shortId(prefix: "call_")
-
+                for outcome in outcomes {
+                    let invocation = outcome.invocation
+                    let callId = outcome.callId
                     hop {
                         writerBound.value.writeContent(
                             StreamingToolHint.encode(invocation.toolName),
@@ -2118,29 +2135,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             created: created,
                             context: ctx.value
                         )
-                    }
-
-                    let toolResult: String
-                    do {
-                        toolResult = try await ChatExecutionContext.$currentSessionId.withValue(requestId) {
-                            try await ChatExecutionContext.$currentAgentId.withValue(agentId) {
-                                try await ToolRegistry.shared.execute(
-                                    name: invocation.toolName,
-                                    argumentsJSON: invocation.jsonArguments
-                                )
-                            }
-                        }
-                    } catch {
-                        toolResult = ToolEnvelope.fromError(error, tool: invocation.toolName)
-                    }
-
-                    hop {
                         writerBound.value.writeContent(
                             StreamingToolHint.encodeDone(
                                 callId: callId,
                                 name: invocation.toolName,
                                 arguments: invocation.jsonArguments,
-                                result: toolResult
+                                result: outcome.result
                             ),
                             model: model,
                             responseId: responseId,
@@ -2148,7 +2148,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             context: ctx.value
                         )
                     }
-
                     assistantToolCalls.append(
                         ToolCall(
                             id: callId,
@@ -2159,7 +2158,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             )
                         )
                     )
-                    toolResultsByCallId.append((callId, toolResult))
+                    toolResultsByCallId.append((callId, outcome.result))
                 }
 
                 messages.append(
@@ -2177,6 +2176,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             }
 
+            // If we exited via the iteration cap without producing a
+            // final text turn (i.e. the last loop body still required
+            // tools), stream a synthetic notice so the client sees a
+            // reason instead of a silent stop.
+            let exitedAtCap = (iteration >= maxIterations)
+            if exitedAtCap, let last = messages.last, last.tool_calls?.isEmpty == false {
+                let notice =
+                    "Tool-loop budget of \(maxIterations) iterations exhausted without a final answer."
+                hop {
+                    writerBound.value.writeContent(
+                        notice,
+                        model: model,
+                        responseId: responseId,
+                        created: created,
+                        context: ctx.value
+                    )
+                }
+            }
             hop {
                 writerBound.value.writeFinish(model, responseId: responseId, created: created, context: ctx.value)
                 writerBound.value.writeEnd(ctx.value)
@@ -2723,12 +2740,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         guard let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
+            let body = Self.errorBody(.openai(type: "invalid_request_error"), message: "Invalid request format")
             sendResponse(
                 context: context,
                 version: head.version,
                 status: .badRequest,
-                headers: [("Content-Type", "text/plain; charset=utf-8")],
-                body: "Invalid request format"
+                headers: [("Content-Type", "application/json; charset=utf-8")],
+                body: body
             )
             logRequest(
                 method: "POST",
@@ -2738,6 +2756,33 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 responseStatus: 400,
                 startTime: startTime,
                 errorMessage: "Invalid request format"
+            )
+            return
+        }
+
+        // Reject unsupported sampler params explicitly with HTTP 400
+        // rather than silently ignoring — silent ignoring is the worst
+        // behavior for an OpenAI-compatible harness.
+        if let unsupported = Self.unsupportedSamplerReason(req) {
+            let body = Self.errorBody(
+                .openai(type: "invalid_request_error"),
+                message: unsupported
+            )
+            sendResponse(
+                context: context,
+                version: head.version,
+                status: .badRequest,
+                headers: [("Content-Type", "application/json; charset=utf-8")],
+                body: body
+            )
+            logRequest(
+                method: "POST",
+                path: "/chat/completions",
+                userAgent: userAgent,
+                requestBody: requestBodyString,
+                responseStatus: 400,
+                startTime: startTime,
+                errorMessage: unsupported
             )
             return
         }
@@ -2781,7 +2826,18 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let logTemperature = req.temperature ?? 0.7
             let logMaxTokens = req.max_tokens ?? 1024
             let logSelf = self
+            // SSE keepalive: emit a `: ping` comment line every 15s so
+            // intermediate proxies / load balancers do not idle out long
+            // tool-execution / reasoning pauses. Cancelled when the
+            // producer task finishes.
+            let keepaliveTask = Self.startSSEKeepalive(
+                writer: writerBound,
+                channel: context.channel,
+                loop: loop,
+                ctx: ctx
+            )
             Task(priority: .userInitiated) {
+                defer { keepaliveTask.cancel() }
                 do {
                     let chatEngine = self.chatEngine
                     let enrichedReq = await Self.enrichWithAgentContext(req, agentId: memoryAgentId)
@@ -2830,6 +2886,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             )
                         }
                     }
+                    let includeUsage = req.stream_options?.include_usage == true
+                    let promptTokens = Self.estimatePromptTokens(enrichedReq.messages)
+                    let completionTokens = max(1, accumulatedContent.count / 4)
                     hop {
                         writerBound.value.writeFinish(
                             model,
@@ -2837,6 +2896,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             created: created,
                             context: ctx.value
                         )
+                        if includeUsage {
+                            writerBound.value.writeUsageChunk(
+                                promptTokens: promptTokens,
+                                completionTokens: completionTokens,
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                        }
                         writerBound.value.writeEnd(ctx.value)
                     }
                     if persistOnSuccess {
@@ -2871,6 +2940,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // Multi-tool MLX completion: emit one tool_call delta
                     // per invocation, sharing one finish_reason="tool_calls".
                     // OpenAI clients deduplicate by `index`.
+                    let includeUsage = req.stream_options?.include_usage == true
+                    // Use `req.messages` here (not `enrichedReq.messages`)
+                    // because the enriched value is scoped to the `do` block
+                    // and unavailable in this catch — at worst we under-
+                    // count by the agent system-prompt fragment.
+                    let promptTokens = Self.estimatePromptTokens(req.messages)
                     hop {
                         for (idx, inv) in invs.invocations.enumerated() {
                             self.writeOpenAIToolCallSSE(
@@ -2890,6 +2965,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             created: created,
                             context: ctx.value
                         )
+                        if includeUsage {
+                            writerBound.value.writeUsageChunk(
+                                promptTokens: promptTokens,
+                                completionTokens: 0,
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                        }
                         writerBound.value.writeEnd(ctx.value)
                     }
                     let toolLogs = invs.invocations.map {
@@ -2910,6 +2995,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     )
                 } catch let inv as ServiceToolInvocation {
                     // Single tool invocation — same emission as above.
+                    let includeUsage = req.stream_options?.include_usage == true
+                    let promptTokens = Self.estimatePromptTokens(req.messages)
                     hop {
                         self.writeOpenAIToolCallSSE(
                             inv,
@@ -2927,6 +3014,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             created: created,
                             context: ctx.value
                         )
+                        if includeUsage {
+                            writerBound.value.writeUsageChunk(
+                                promptTokens: promptTokens,
+                                completionTokens: 0,
+                                model: model,
+                                responseId: responseId,
+                                created: created,
+                                context: ctx.value
+                            )
+                        }
                         writerBound.value.writeEnd(ctx.value)
                     }
                     let toolLog = ToolCallLog(name: inv.toolName, arguments: inv.jsonArguments)
@@ -2944,6 +3041,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         finishReason: .toolCalls
                     )
                 } catch {
+                    // SSE response head was already written as 200 — the
+                    // failure surfaces as an in-band SSE error chunk. Log
+                    // the actual on-wire status (200) so dashboards don't
+                    // mis-attribute a delivered stream as a 500.
                     hop {
                         writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                         writerBound.value.writeEnd(ctx.value)
@@ -2953,7 +3054,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         path: "/chat/completions",
                         userAgent: logUserAgent,
                         requestBody: logRequestBody,
-                        responseStatus: 500,
+                        responseStatus: 200,
                         startTime: logStartTime,
                         model: logModel,
                         temperature: logTemperature,
@@ -3049,21 +3150,27 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         finishReason: finishReason
                     )
                 } catch {
-                    // Map ChatEngine.EngineError to its intended HTTP
-                    // status (e.g. 404 for unknown model) instead of
-                    // blanket-500 on every failure. External API
-                    // consumers rely on the status code to give users
-                    // actionable feedback. See PR #863 / issue #858.
+                    // Map known errors to their intended HTTP status (e.g.
+                    // 404 for unknown model) instead of blanket-500. The
+                    // body is always OpenAI-shaped JSON so external clients
+                    // can parse it uniformly. See PR #863 / issue #858.
                     let status: HTTPResponseStatus
-                    let body: String
+                    let errorType: String
+                    let message: String
                     if let engineError = error as? ChatEngine.EngineError {
                         status = HTTPResponseStatus(statusCode: engineError.httpStatus)
-                        body = engineError.errorDescription ?? error.localizedDescription
+                        errorType =
+                            engineError.httpStatus == 404
+                            ? "invalid_request_error" : "service_unavailable"
+                        message = engineError.errorDescription ?? error.localizedDescription
                     } else {
                         status = .internalServerError
-                        body = "Internal error: \(error.localizedDescription)"
+                        errorType = "internal_error"
+                        message = error.localizedDescription
                     }
-                    let headers: [(String, String)] = [("Content-Type", "text/plain; charset=utf-8")]
+                    let body = Self.errorBody(.openai(type: errorType), message: message)
+                    let actualStatus = Int(status.code)
+                    let headers: [(String, String)] = [("Content-Type", "application/json; charset=utf-8")]
                     let headersCopy = headers
                     hop {
                         var responseHead = HTTPResponseHead(version: head.version, status: status)
@@ -3087,7 +3194,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         path: "/chat/completions",
                         userAgent: logUserAgent,
                         requestBody: logRequestBody,
-                        responseStatus: 500,
+                        responseStatus: actualStatus,
                         startTime: logStartTime,
                         model: logModel,
                         errorMessage: error.localizedDescription
@@ -3197,6 +3304,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .stop
                 )
             } catch {
+                // NDJSON response head was already 200 — surface as in-band
+                // NDJSON error chunk and log actual on-wire status.
                 hop {
                     writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
@@ -3206,7 +3315,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     path: "/chat",
                     userAgent: logUserAgent,
                     requestBody: logRequestBody,
-                    responseStatus: 500,
+                    responseStatus: 200,
                     startTime: logStartTime,
                     model: logModel,
                     temperature: logTemperature,
@@ -3215,6 +3324,206 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     errorMessage: error.localizedDescription
                 )
             }
+        }
+    }
+
+    // MARK: - SSE keepalive
+
+    /// Spawn a background task that emits a `: ping\n\n` SSE comment
+    /// every 15s, hopping back to the channel's event loop for each
+    /// write. Comment lines are ignored by SSE clients per the spec
+    /// but keep intermediate proxies from idling out long
+    /// tool-execution or reasoning pauses. Callers must `cancel()` the
+    /// returned task when their producer finishes.
+    static func startSSEKeepalive(
+        writer: NIOLoopBound<SSEResponseWriter>,
+        channel: Channel,
+        loop: EventLoop,
+        ctx: NIOLoopBound<ChannelHandlerContext>
+    ) -> Task<Void, Never> {
+        Task<Void, Never>(priority: .background) {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                if Task.isCancelled { return }
+                guard channel.isActive else { return }
+                loop.execute { writer.value.writePing(ctx.value) }
+            }
+        }
+    }
+
+    // MARK: - Tool batch execution
+
+    /// One executed tool call carrying everything the SSE writer + the
+    /// follow-up assistant/tool message construction need. Returned in
+    /// the same order as the input invocations so the SSE frame order
+    /// matches the model's own tool_call sequence.
+    struct ToolOutcome: Sendable {
+        let invocation: ServiceToolInvocation
+        let callId: String
+        let result: String
+    }
+
+    /// Run every invocation in parallel via a TaskGroup, then restore
+    /// the input order for deterministic SSE framing. Each task scopes
+    /// `ChatExecutionContext` so tools see the same session/agent ids
+    /// they would on a sequential dispatch. Per-call errors are caught
+    /// and converted to `ToolEnvelope.fromError` so a single bad call
+    /// never aborts the rest of the batch.
+    static func runToolBatchInParallel(
+        _ invocations: [ServiceToolInvocation],
+        requestId: String,
+        agentId: UUID
+    ) async -> [ToolOutcome] {
+        // Pre-allocate call ids so the parallel tasks don't race the
+        // shortId generator and reorder ids vs invocation indices.
+        let calls: [(index: Int, callId: String, invocation: ServiceToolInvocation)] =
+            invocations.enumerated().map { idx, inv in
+                (idx, inv.toolCallId ?? shortId(prefix: "call_"), inv)
+            }
+
+        let indexed: [(Int, ToolOutcome)] = await withTaskGroup(
+            of: (Int, ToolOutcome).self
+        ) { group in
+            for call in calls {
+                group.addTask {
+                    let result: String
+                    do {
+                        result = try await ChatExecutionContext.$currentSessionId.withValue(requestId) {
+                            try await ChatExecutionContext.$currentAgentId.withValue(agentId) {
+                                try await ToolRegistry.shared.execute(
+                                    name: call.invocation.toolName,
+                                    argumentsJSON: call.invocation.jsonArguments
+                                )
+                            }
+                        }
+                    } catch {
+                        result = ToolEnvelope.fromError(error, tool: call.invocation.toolName)
+                    }
+                    let outcome = ToolOutcome(
+                        invocation: call.invocation,
+                        callId: call.callId,
+                        result: result
+                    )
+                    return (call.index, outcome)
+                }
+            }
+            var collected: [(Int, ToolOutcome)] = []
+            for await item in group { collected.append(item) }
+            return collected
+        }
+
+        return indexed.sorted { $0.0 < $1.0 }.map { $0.1 }
+    }
+
+    // MARK: - Request validation
+
+    /// Reasons we reject a `ChatCompletionRequest` outright with HTTP 400.
+    /// We only flag the cases our docs declare unsupported (`n>1`,
+    /// `response_format=json_schema`, etc.) — any field we silently
+    /// ignored historically continues to be ignored here so we don't
+    /// regress on existing clients.
+    nonisolated static func unsupportedSamplerReason(_ req: ChatCompletionRequest) -> String? {
+        if let n = req.n, n > 1 {
+            return "Parameter 'n' > 1 is not supported. Submit one request per completion."
+        }
+        if let rf = req.response_format {
+            switch rf.type {
+            case "json_object", "text":
+                break  // supported / no-op
+            default:
+                return
+                    "response_format type '\(rf.type)' is not supported. Use 'json_object' for JSON mode."
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Token estimation
+
+    /// Cheap char-based prompt-token estimate, mirrored on
+    /// `ChatEngine.estimateInputTokens` so SSE `usage` chunks and
+    /// non-stream `usage` totals are consistent. Includes assistant
+    /// `tool_calls` payloads and `tool` role bodies.
+    nonisolated static func estimatePromptTokens(_ messages: [ChatMessage]) -> Int {
+        let totalChars = messages.reduce(0) { sum, msg in
+            var chars = msg.content?.count ?? 0
+            if let calls = msg.tool_calls {
+                for call in calls {
+                    chars += call.function.name.count
+                    chars += call.function.arguments.count
+                    chars += 20  // ~20 chars overhead per call envelope
+                }
+            }
+            return sum + chars
+        }
+        return max(1, totalChars / 4)
+    }
+
+    // MARK: - Health Endpoint
+
+    /// `/health` returns liveness plus per-model in-flight counts and the
+    /// list of currently-loaded models. External observers can use this to
+    /// detect contention without scraping logs (one model starving the
+    /// others, eviction churn under sustained load, etc.).
+    private func handleHealthEndpoint(
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext,
+        startTime: Date,
+        userAgent: String?,
+        method: String,
+        path: String
+    ) {
+        let loop = context.eventLoop
+        let ctx = NIOLoopBound(context, eventLoop: loop)
+        let cors = stateRef.value.corsHeaders
+        let hop = Self.makeHop(channel: context.channel, loop: loop)
+        let version = head.version
+        let logSelf = self
+        let logStartTime = startTime
+        let logUserAgent = userAgent
+        let logMethod = method
+        let logPath = path
+
+        Task(priority: .userInitiated) {
+            let inflight = await ModelLease.shared.snapshot()
+            let cached = await ModelRuntime.shared.cachedModelSummaries()
+            let loaded = cached.map { $0.name }
+            let current = cached.first(where: { $0.isCurrent })?.name as Any? ?? NSNull()
+
+            var inflightObj: [String: Any] = [:]
+            for (name, count) in inflight { inflightObj[name] = count }
+
+            let obj: [String: Any] = [
+                "status": "healthy",
+                "timestamp": Date().ISO8601Format(),
+                "loaded": loaded,
+                "current_model": current,
+                "inflight": inflightObj,
+            ]
+            let data = try? JSONSerialization.data(withJSONObject: obj)
+            let body = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
+            let headers: [(String, String)] =
+                [("Content-Type", "application/json; charset=utf-8")]
+                + cors
+
+            hop {
+                logSelf.sendResponse(
+                    context: ctx.value,
+                    version: version,
+                    status: .ok,
+                    headers: headers,
+                    body: body
+                )
+            }
+            logSelf.logRequest(
+                method: logMethod,
+                path: logPath,
+                userAgent: logUserAgent,
+                requestBody: nil,
+                responseBody: body,
+                responseStatus: 200,
+                startTime: logStartTime
+            )
         }
     }
 
@@ -4048,6 +4357,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .toolCalls
                 )
             } catch {
+                // SSE response head was already 200 — surface as in-band
+                // SSE error chunk and log actual on-wire status.
                 hop {
                     writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
@@ -4057,7 +4368,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     path: "/messages",
                     userAgent: logUserAgent,
                     requestBody: logRequestBody,
-                    responseStatus: 500,
+                    responseStatus: 200,
                     startTime: logStartTime,
                     model: logModel,
                     finishReason: .error,
@@ -4716,6 +5027,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     finishReason: .toolCalls
                 )
             } catch {
+                // SSE response head was already 200 — surface as in-band
+                // SSE error chunk and log actual on-wire status.
                 hop {
                     writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
@@ -4725,7 +5038,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     path: "/responses",
                     userAgent: logUserAgent,
                     requestBody: logRequestBody,
-                    responseStatus: 500,
+                    responseStatus: 200,
                     startTime: logStartTime,
                     model: logModel,
                     finishReason: .error,

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3417,25 +3417,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     // MARK: - Request validation
 
-    /// Reasons we reject a `ChatCompletionRequest` outright with HTTP 400.
-    /// We only flag the cases our docs declare unsupported (`n>1`,
-    /// `response_format=json_schema`, etc.) — any field we silently
-    /// ignored historically continues to be ignored here so we don't
-    /// regress on existing clients.
+    /// Convenience adapter over `RequestValidator.unsupportedSamplerReason`
+    /// that pulls the relevant fields off a `ChatCompletionRequest`. The
+    /// underlying logic lives at module scope so the eval kit can exercise
+    /// it without depending on `HTTPHandler` / `ChatCompletionRequest`.
     nonisolated static func unsupportedSamplerReason(_ req: ChatCompletionRequest) -> String? {
-        if let n = req.n, n > 1 {
-            return "Parameter 'n' > 1 is not supported. Submit one request per completion."
-        }
-        if let rf = req.response_format {
-            switch rf.type {
-            case "json_object", "text":
-                break  // supported / no-op
-            default:
-                return
-                    "response_format type '\(rf.type)' is not supported. Use 'json_object' for JSON mode."
-            }
-        }
-        return nil
+        RequestValidator.unsupportedSamplerReason(
+            n: req.n,
+            responseFormatType: req.response_format?.type
+        )
     }
 
     // MARK: - Token estimation

--- a/Packages/OsaurusCore/Networking/RequestValidator.swift
+++ b/Packages/OsaurusCore/Networking/RequestValidator.swift
@@ -1,0 +1,43 @@
+//
+//  RequestValidator.swift
+//  OsaurusCore
+//
+//  Pure helper for accepting/rejecting sampler params before they reach
+//  the chat engine. Lives in OsaurusCore at module level (not on
+//  HTTPHandler) so external packages — notably OsaurusEvalsKit — can
+//  exercise it as a regression suite without taking a dependency on
+//  the NIO ChannelHandler. The HTTP layer wraps this helper to keep the
+//  reject-with-400 logic in one place.
+//
+
+import Foundation
+
+public enum RequestValidator {
+
+    /// Reasons we reject a `ChatCompletionRequest` (or its primitive
+    /// equivalents) outright with HTTP 400. We only flag the cases our
+    /// docs declare unsupported (`n>1`, `response_format=json_schema`,
+    /// etc.) — any field we silently ignored historically continues to
+    /// be ignored here so we don't regress on existing clients.
+    ///
+    /// Returns `nil` when the request is acceptable; otherwise a
+    /// human-readable explanation suitable for the 400 body.
+    public static func unsupportedSamplerReason(
+        n: Int?,
+        responseFormatType: String?
+    ) -> String? {
+        if let n, n > 1 {
+            return "Parameter 'n' > 1 is not supported. Submit one request per completion."
+        }
+        if let type = responseFormatType {
+            switch type {
+            case "json_object", "text":
+                break  // supported / no-op
+            default:
+                return
+                    "response_format type '\(type)' is not supported. Use 'json_object' for JSON mode."
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -90,22 +90,28 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
     ) async -> Dispatch {
         let temperature = request.temperature
         let maxTokens = request.max_tokens ?? 16384
+        // Map only OpenAI `frequency_penalty` to repetition_penalty here.
+        // `presence_penalty` has no MLX analog — leaving the previous
+        // "either-or" mapping in place silently collapsed two distinct
+        // knobs. Both raw values are forwarded on `GenerationParameters`
+        // so remote services can pass them through natively.
         let repPenalty: Float? = {
-            // Map OpenAI penalties (presence/frequency) to a simple
-            // repetition penalty when supplied.
             if let fp = request.frequency_penalty, fp > 0 { return 1.0 + fp }
-            if let pp = request.presence_penalty, pp > 0 { return 1.0 + pp }
             return nil
         }()
+        let seedBits: UInt64? = request.seed.map { UInt64(bitPattern: Int64($0)) }
+        let isJSONObject = (request.response_format?.type == "json_object")
         let params = GenerationParameters(
             temperature: temperature,
             maxTokens: maxTokens,
             topPOverride: request.top_p,
             repetitionPenalty: repPenalty,
+            frequencyPenalty: request.frequency_penalty,
+            presencePenalty: request.presence_penalty,
+            seed: seedBits,
+            jsonMode: isJSONObject,
             modelOptions: request.modelOptions ?? [:],
             sessionId: request.session_id,
-            cacheHint: request.cache_hint,
-            staticPrefix: request.staticPrefix,
             ttftTrace: trace
         )
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -680,7 +680,11 @@ public struct SystemPromptComposer: Sendable {
     /// Compose agent base prompt and inject into an existing message array.
     /// Memory is now prepended to the latest user message instead of the
     /// system prompt so the system message stays byte-stable across turns.
-    /// Returns `(cacheHint, staticPrefix)` for the caller to set on the request.
+    /// The returned `(cacheHint, staticPrefix)` tuple is informational —
+    /// vmlx's `CacheCoordinator` is content-addressed and discovers
+    /// reusable prefixes autonomously, so callers no longer need to
+    /// thread these into the request. Kept on the signature for
+    /// preflight-cache bookkeeping callers (e.g. `SessionToolStateStore`).
     @discardableResult
     static func injectAgentContext(
         agentId: UUID,

--- a/Packages/OsaurusCore/Services/Inference/FoundationModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/FoundationModelService.swift
@@ -11,9 +11,27 @@ import Foundation
     import FoundationModels
 #endif
 
-enum FoundationModelServiceError: Error {
+enum FoundationModelServiceError: Error, LocalizedError {
     case notAvailable
     case generationFailed
+    /// The Foundation Models system model is text-only on macOS 26.
+    /// When the request carries image parts we surface this instead of
+    /// silently degrading to text — callers can choose to retry against
+    /// an MLX VLM or a remote provider with vision support.
+    case visionUnsupported
+
+    var errorDescription: String? {
+        switch self {
+        case .notAvailable:
+            return "Foundation Models is not available on this device."
+        case .generationFailed:
+            return "Foundation Models generation failed."
+        case .visionUnsupported:
+            return
+                "Foundation Models is text-only and cannot accept image inputs. "
+                + "Use an MLX VLM (e.g. Qwen3.5-VL) or a remote provider with vision support."
+        }
+    }
 }
 
 actor FoundationModelService: ToolCapableService {
@@ -72,6 +90,9 @@ actor FoundationModelService: ToolCapableService {
         requestedModel: String?,
         stopSequences: [String]
     ) async throws -> AsyncThrowingStream<String, Error> {
+        if Self.hasImageContent(messages) {
+            throw FoundationModelServiceError.visionUnsupported
+        }
         let prompt = OpenAIPromptBuilder.buildPrompt(from: messages)
         #if canImport(FoundationModels)
             if #available(macOS 26.0, *) {
@@ -141,6 +162,9 @@ actor FoundationModelService: ToolCapableService {
         parameters: GenerationParameters,
         requestedModel: String?
     ) async throws -> String {
+        if Self.hasImageContent(messages) {
+            throw FoundationModelServiceError.visionUnsupported
+        }
         let prompt = OpenAIPromptBuilder.buildPrompt(from: messages)
         return try await Self.generateOneShot(
             prompt: prompt,
@@ -159,6 +183,9 @@ actor FoundationModelService: ToolCapableService {
         toolChoice: ToolChoiceOption?,
         requestedModel: String?
     ) async throws -> String {
+        if Self.hasImageContent(messages) {
+            throw FoundationModelServiceError.visionUnsupported
+        }
         let prompt = OpenAIPromptBuilder.buildPrompt(from: messages)
         #if canImport(FoundationModels)
             if #available(macOS 26.0, *) {
@@ -209,6 +236,9 @@ actor FoundationModelService: ToolCapableService {
         toolChoice: ToolChoiceOption?,
         requestedModel: String?
     ) async throws -> AsyncThrowingStream<String, Error> {
+        if Self.hasImageContent(messages) {
+            throw FoundationModelServiceError.visionUnsupported
+        }
         let prompt = OpenAIPromptBuilder.buildPrompt(from: messages)
         #if canImport(FoundationModels)
             if #available(macOS 26.0, *) {
@@ -286,6 +316,19 @@ actor FoundationModelService: ToolCapableService {
         #else
             throw FoundationModelServiceError.notAvailable
         #endif
+    }
+
+    // MARK: - Capability detection
+
+    /// True when any message carries image content (either an `image_url`
+    /// part or a non-empty `imageUrls` accessor). Used to fast-fail the
+    /// FoundationModels path with `visionUnsupported` instead of silently
+    /// dropping images at the prompt builder.
+    nonisolated static func hasImageContent(_ messages: [ChatMessage]) -> Bool {
+        for msg in messages {
+            if !msg.imageUrls.isEmpty { return true }
+        }
+        return false
     }
 
     // MARK: - Private helpers

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -108,17 +108,17 @@ struct ServiceToolInvocations: Error, Sendable {
 /// The stream type is `AsyncThrowingStream<String, Error>`, so we encode the
 /// detected tool name (and argument fragments) as sentinel strings using a
 /// Unicode non-character prefix that can never appear in normal LLM output.
-enum StreamingToolHint: Sendable {
+public enum StreamingToolHint: Sendable {
     private static let sentinel: Character = "\u{FFFE}"
     private static let toolPrefix = "\u{FFFE}tool:"
     private static let argsPrefix = "\u{FFFE}args:"
     private static let donePrefix = "\u{FFFE}done:"
 
-    static func encode(_ toolName: String) -> String { toolPrefix + toolName }
-    static func encodeArgs(_ fragment: String) -> String { argsPrefix + fragment }
+    public static func encode(_ toolName: String) -> String { toolPrefix + toolName }
+    public static func encodeArgs(_ fragment: String) -> String { argsPrefix + fragment }
 
     /// Encodes a completed server-side tool call so the client can display it in the chat log.
-    static func encodeDone(callId: String, name: String, arguments: String, result: String) -> String {
+    public static func encodeDone(callId: String, name: String, arguments: String, result: String) -> String {
         struct Payload: Encodable { let id, name, arguments, result: String }
         let json =
             (try? JSONEncoder().encode(Payload(id: callId, name: name, arguments: arguments, result: result)))
@@ -127,14 +127,14 @@ enum StreamingToolHint: Sendable {
     }
 
     /// Decoded payload from a done sentinel.
-    struct ToolCallDone {
-        let callId: String
-        let name: String
-        let arguments: String
-        let result: String
+    public struct ToolCallDone: Sendable, Equatable {
+        public let callId: String
+        public let name: String
+        public let arguments: String
+        public let result: String
     }
 
-    static func decodeDone(_ delta: String) -> ToolCallDone? {
+    public static func decodeDone(_ delta: String) -> ToolCallDone? {
         guard delta.hasPrefix(donePrefix) else { return nil }
         let json = String(delta.dropFirst(donePrefix.count))
         struct Payload: Decodable { let id, name, arguments, result: String }
@@ -145,16 +145,16 @@ enum StreamingToolHint: Sendable {
     }
 
     /// O(1) check — only inspects the first character. Covers both tool and args sentinels.
-    static func isSentinel(_ delta: String) -> Bool { delta.first == sentinel }
+    public static func isSentinel(_ delta: String) -> Bool { delta.first == sentinel }
 
     /// Extracts the tool name from a sentinel delta, or nil if not a sentinel.
-    static func decode(_ delta: String) -> String? {
+    public static func decode(_ delta: String) -> String? {
         guard delta.hasPrefix(toolPrefix) else { return nil }
         return String(delta.dropFirst(toolPrefix.count))
     }
 
     /// Extracts an argument fragment from a sentinel delta, or nil if not an args sentinel.
-    static func decodeArgs(_ delta: String) -> String? {
+    public static func decodeArgs(_ delta: String) -> String? {
         guard delta.hasPrefix(argsPrefix) else { return nil }
         return String(delta.dropFirst(argsPrefix.count))
     }

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -12,20 +12,33 @@ struct GenerationParameters: Sendable {
     let maxTokens: Int
     /// Optional per-request top_p override (falls back to server configuration when nil)
     let topPOverride: Float?
-    /// Optional repetition penalty (applies when supported by backend)
+    /// Optional repetition penalty (applies when supported by backend).
+    /// Mapped from OpenAI `frequency_penalty` only — `presence_penalty`
+    /// has no MLX analog. The raw OpenAI values below are kept on the
+    /// struct so remote services that natively support both can forward
+    /// them straight through.
     let repetitionPenalty: Float?
+    /// Raw OpenAI `frequency_penalty`, forwarded as-is to remote services
+    /// that support it (most OpenAI-compatible upstreams).
+    let frequencyPenalty: Float?
+    /// Raw OpenAI `presence_penalty`, forwarded as-is to remote services
+    /// that support it. Has no MLX analog so local services ignore it.
+    let presencePenalty: Float?
+    /// Deterministic sampling seed. When non-nil, services that support
+    /// it (MLX via `MLXRandom.seed`, OpenAI-compatible remotes) will
+    /// produce reproducible output for identical inputs.
+    let seed: UInt64?
+    /// Whether the response must be a JSON object (`response_format:
+    /// {type: json_object}`). Local services inject a system instruction
+    /// + post-validate; remotes forward natively when the upstream
+    /// supports it.
+    let jsonMode: Bool
     /// Model-specific options resolved from the active `ModelProfile` (e.g. aspect ratio).
     let modelOptions: [String: ModelOptionValue]
-    /// Session identifier for KV cache reuse across turns
+    /// Session identifier for chat/history grouping. Not threaded into the
+    /// MLX cache layer — vmlx's `CacheCoordinator` handles prefix reuse
+    /// autonomously via content addressing.
     let sessionId: String?
-    /// Explicit prefix cache key override (API callers can use this to share a
-    /// prefix cache across requests with varying system prompts).
-    let cacheHint: String?
-    /// Static system prompt content for prefix cache building.
-    /// When set, the prefix cache is built from this content only (excluding
-    /// dynamic sections like memory), producing a KV cache that exactly matches
-    /// the reusable portion across requests.
-    let staticPrefix: String?
     /// Optional TTFT trace for diagnostic timing instrumentation.
     let ttftTrace: TTFTTrace?
 
@@ -34,20 +47,24 @@ struct GenerationParameters: Sendable {
         maxTokens: Int,
         topPOverride: Float? = nil,
         repetitionPenalty: Float? = nil,
+        frequencyPenalty: Float? = nil,
+        presencePenalty: Float? = nil,
+        seed: UInt64? = nil,
+        jsonMode: Bool = false,
         modelOptions: [String: ModelOptionValue] = [:],
         sessionId: String? = nil,
-        cacheHint: String? = nil,
-        staticPrefix: String? = nil,
         ttftTrace: TTFTTrace? = nil
     ) {
         self.temperature = temperature
         self.maxTokens = maxTokens
         self.topPOverride = topPOverride
         self.repetitionPenalty = repetitionPenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.presencePenalty = presencePenalty
+        self.seed = seed
+        self.jsonMode = jsonMode
         self.modelOptions = modelOptions
         self.sessionId = sessionId
-        self.cacheHint = cacheHint
-        self.staticPrefix = staticPrefix
         self.ttftTrace = ttftTrace
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -28,7 +28,7 @@ private let genLog = Logger(subsystem: "com.dinoki.osaurus", category: "Generati
 private let _vlmFactory = MLXVLM.VLMModelFactory.shared
 private let _llmFactory = MLXLLM.LLMModelFactory.shared
 
-actor ModelRuntime {
+public actor ModelRuntime {
     // MARK: - Types
 
     struct ModelCacheSummary: Sendable {
@@ -670,7 +670,7 @@ actor ModelRuntime {
 
     /// Computes a deterministic hash from system content and tool names.
     /// Used by the HTTP API to expose a prefix_hash field in responses.
-    nonisolated static func computePrefixHash(
+    public nonisolated static func computePrefixHash(
         systemContent: String,
         toolNames: [String]
     ) -> String {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -198,13 +198,6 @@ actor ModelRuntime {
         cachedConfig = nil
     }
 
-    /// Called when a chat window closes. With the package-level CacheCoordinator
-    /// the paged cache is content-addressed and bounded internally, so
-    /// per-session invalidation is not needed — stale blocks are LRU-evicted.
-    func invalidateSession(_ sessionId: String) {
-        // No-op: CacheCoordinator handles eviction via LRU on PagedCacheManager.
-    }
-
     // MARK: - Internals
 
     private func getConfig() async -> RuntimeConfig {
@@ -334,20 +327,32 @@ actor ModelRuntime {
     // selects model-aware cache types per layer (rotating for sliding-window
     // attention, paged for global attention, SSM state for Mamba layers),
     // sizes them based on the loaded model, and auto-flips into hybrid mode
-    // when the first SSM slot is admitted. Per OSAURUS-INTEGRATION.md,
-    // osaurus must not duplicate that work at the app layer — the only
-    // knobs we legitimately set here are:
-    //   - `modelKey`     — required for per-model isolation across loads
-    //   - `diskCacheDir` — osaurus-managed disk path (under our sandbox)
-    //   - `enableDiskCache=false` when the dir is not writable, so the
-    //     coordinator falls back to memory-only instead of crashing
+    // when the first SSM slot is admitted.
+    //
+    // Per OSAURUS-INTEGRATION.md §"Coordinator-owned KV sizing", osaurus
+    // adopts the four recommended knobs the library now ships defaults for:
+    //
+    //   - `usePagedCache: true`            — content-addressed paged blocks
+    //                                        (multi-turn cache reuse path)
+    //   - `defaultKVMode: .turboQuant(3,3)`— ~5x KV memory savings on slots
+    //                                        that submit `kvMode: .none`
+    //   - `defaultMaxKVSize: 8192`         — 8K ring window for slots that
+    //                                        submit `maxKVSize: nil`
+    //   - `longPromptMultiplier: 2.0`      — cap kicks in only past 16K
+    //                                        (8192 * 2.0) prompt tokens,
+    //                                        so short prompts keep full
+    //                                        attention.
+    //
+    // Per-request explicit values still override these. We continue to
+    // pass `modelKey` (per-model isolation) and `diskCacheDir` /
+    // `enableDiskCache` (osaurus-managed disk path, sandbox-aware).
     // Everything else (`maxCacheBlocks`, `diskCacheMaxGB`, `pagedBlockSize`,
-    // `ssmMaxEntries`) is left at the library default so vmlx can ship a
-    // single tuned answer per release.
+    // `ssmMaxEntries`) is left at the library default.
 
-    /// Builds a `CacheCoordinatorConfig` with the minimum overrides
-    /// required for osaurus's environment. See the file-level comment for
-    /// the rationale on why every other field is intentionally untouched.
+    /// Builds a `CacheCoordinatorConfig` with the overrides recommended
+    /// by vmlx-swift-lm's `OSAURUS-INTEGRATION.md` (Coordinator-owned KV
+    /// sizing) plus osaurus's per-environment disk-path config. See the
+    /// file-level comment for rationale on each knob.
     private nonisolated static func buildCacheCoordinatorConfig(
         modelName: String
     ) -> CacheCoordinatorConfig {
@@ -360,11 +365,15 @@ actor ModelRuntime {
             )
         }
 
-        var cacheConfig = CacheCoordinatorConfig()
-        cacheConfig.modelKey = modelName
-        cacheConfig.diskCacheDir = diskCacheDir
-        cacheConfig.enableDiskCache = diskDirUsable
-        return cacheConfig
+        return CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: diskDirUsable,
+            diskCacheDir: diskCacheDir,
+            modelKey: modelName,
+            defaultKVMode: .turboQuant(keyBits: 3, valueBits: 3),
+            defaultMaxKVSize: 8192,
+            longPromptMultiplier: 2.0
+        )
     }
 
     /// Best-effort writability probe for the disk cache directory. Uses a
@@ -529,8 +538,9 @@ actor ModelRuntime {
     ) async throws -> String {
         var accumulated = ""
         var pendingTools: [ServiceToolInvocation] = []
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(messages) },
+            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented) },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -572,8 +582,9 @@ actor ModelRuntime {
         modelId: String,
         modelName: String
     ) async throws -> AsyncThrowingStream<String, Error> {
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(messages) },
+            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented) },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -720,6 +731,40 @@ actor ModelRuntime {
         } else {
             return tools.map { $0.toTokenizerToolSpec() }
         }
+    }
+
+    /// When `jsonMode` is true, prepend (or augment) a system instruction
+    /// telling the model to respond with a single valid JSON object.
+    /// OpenAI's `response_format: {type: json_object}` semantics — local
+    /// models honor it via prompt injection (vmlx does not yet ship a
+    /// constraint-grammar sampler hook). Returns `messages` unchanged
+    /// when `jsonMode` is false so the no-op path is free.
+    nonisolated static func applyJSONMode(
+        _ messages: [ChatMessage],
+        jsonMode: Bool
+    ) -> [ChatMessage] {
+        guard jsonMode else { return messages }
+        let directive = """
+            You must respond with a single valid JSON object and nothing else. \
+            Do not include markdown code fences, prose, or explanations — output \
+            only the JSON.
+            """
+        var out = messages
+        if let firstSystemIdx = out.firstIndex(where: { $0.role == "system" }) {
+            let existing = out[firstSystemIdx].content ?? ""
+            out[firstSystemIdx] = ChatMessage(
+                role: "system",
+                content: existing.isEmpty ? directive : existing + "\n\n" + directive,
+                tool_calls: out[firstSystemIdx].tool_calls,
+                tool_call_id: out[firstSystemIdx].tool_call_id
+            )
+        } else {
+            out.insert(
+                ChatMessage(role: "system", content: directive, tool_calls: nil, tool_call_id: nil),
+                at: 0
+            )
+        }
+        return out
     }
 
     /// Map OpenAI-format chat messages to MLX `Chat.Message`s.

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -24,6 +24,7 @@ import CoreImage
 import Foundation
 import MLX
 @preconcurrency import MLXLMCommon
+import MLXRandom
 import MLXVLM  // MediaProcessing for image downscaling
 import os.log
 
@@ -184,6 +185,16 @@ struct MLXBatchAdapter {
             repetitionPenalty: generation.repetitionPenalty ?? modelDefaults.repetitionPenalty,
             stopSequences: stopSequences
         )
+
+        // Best-effort per-request determinism: seed the MLX global random
+        // state immediately before submission. Note: vmlx's `Sampler`
+        // constructs its own `RandomState()` from time-of-day inside the
+        // engine, so concurrent seeded requests against the same model
+        // are NOT guaranteed reproducible. Single-request seeding still
+        // benefits any MLX code path that consults `MLXRandom.globalState`.
+        if let seed = generation.seed {
+            MLXRandom.seed(seed)
+        }
 
         // `engine.generate` returns `AsyncStream<Generation>` directly with
         // reasoning + tool-call extraction handled inside vmlx. We re-wrap

--- a/Packages/OsaurusCore/Services/ModelRuntime/ModelLease.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ModelLease.swift
@@ -97,4 +97,11 @@ public actor ModelLease {
     public func count(for name: String) -> Int {
         counts[name] ?? 0
     }
+
+    /// Atomic snapshot of all per-model in-flight counts. Used by `/health`
+    /// to surface contention so external observers can detect when one
+    /// model is starving the others without having to scrape logs.
+    public func snapshot() -> [String: Int] {
+        counts
+    }
 }

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -351,24 +351,6 @@ final class PluginHostContext: @unchecked Sendable {
         let maxTokens: Int?
         let tools: [Tool]?
         let executionMode: ExecutionMode
-        var cacheHint: String?
-        var staticPrefix: String?
-
-        func prependingSystemContent(_ content: String) -> AgentContext {
-            var ctx = self
-            ctx = AgentContext(
-                agentId: agentId,
-                systemPrompt: content + "\n\n" + systemPrompt,
-                model: model,
-                temperature: temperature,
-                maxTokens: maxTokens,
-                tools: tools,
-                executionMode: executionMode,
-                cacheHint: cacheHint,
-                staticPrefix: staticPrefix
-            )
-            return ctx
-        }
 
         func withSystemPrompt(_ newPrompt: String) -> AgentContext {
             AgentContext(
@@ -378,10 +360,12 @@ final class PluginHostContext: @unchecked Sendable {
                 temperature: temperature,
                 maxTokens: maxTokens,
                 tools: tools,
-                executionMode: executionMode,
-                cacheHint: cacheHint,
-                staticPrefix: staticPrefix
+                executionMode: executionMode
             )
+        }
+
+        func prependingSystemContent(_ content: String) -> AgentContext {
+            withSystemPrompt(content + "\n\n" + systemPrompt)
         }
     }
 
@@ -530,9 +514,7 @@ final class PluginHostContext: @unchecked Sendable {
                 temperature: mgr.effectiveTemperature(for: agentId),
                 maxTokens: mgr.effectiveMaxTokens(for: agentId),
                 tools: composed.tools.isEmpty ? nil : composed.tools,
-                executionMode: execMode,
-                cacheHint: composed.cacheHint,
-                staticPrefix: composed.staticPrefix
+                executionMode: execMode
             )
         }
     }
@@ -568,7 +550,7 @@ final class PluginHostContext: @unchecked Sendable {
             effectiveTools = nil
         }
 
-        var enriched = ChatCompletionRequest(
+        let enriched = ChatCompletionRequest(
             model: model,
             messages: messages,
             temperature: request.temperature ?? ctx.temperature,
@@ -583,8 +565,6 @@ final class PluginHostContext: @unchecked Sendable {
             tool_choice: request.tool_choice,
             session_id: request.session_id
         )
-        enriched.cache_hint = ctx.cacheHint
-        enriched.staticPrefix = ctx.staticPrefix
         return EnrichedInference(request: enriched, tools: effectiveTools)
     }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -445,6 +445,57 @@ public actor RemoteProviderService: ToolCapableService {
     /// stream — which avoids the iterator-corruption mode where racing
     /// `iterator.next()` against a sleep would leave the underlying URLSession
     /// task in a half-cancelled state and silently truncate the stream.
+    /// Idempotent connect-phase retry. Wraps `URLSession.bytes(for:)` so
+    /// transient TCP / DNS / TLS failures and 5xx-without-body upstream
+    /// hiccups don't surface as fatal errors before the consumer has
+    /// seen any bytes. Once the response head arrives (or we've tried
+    /// `maxAttempts` times) we hand the result back to the caller and
+    /// retry never happens again — by design, mid-stream errors are not
+    /// retried because the consumer has already begun seeing tokens.
+    ///
+    /// Backoff: 200ms, 800ms (exponential, capped). Total wall time at
+    /// `maxAttempts = 3` is therefore ≤ ~1s of added latency on success.
+    static func connectWithRetry(
+        session: URLSession,
+        urlRequest: URLRequest,
+        maxAttempts: Int = 3
+    ) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        var lastError: Error?
+        for attempt in 0 ..< maxAttempts {
+            if attempt > 0 {
+                let delayMs: UInt64 = attempt == 1 ? 200_000_000 : 800_000_000
+                try? await Task.sleep(nanoseconds: delayMs)
+            }
+            do {
+                return try await session.bytes(for: urlRequest)
+            } catch {
+                if Task.isCancelled { throw error }
+                lastError = error
+                // Only retry on classic transient categories. Auth /
+                // bad-request type errors are not retried.
+                guard Self.isRetryableConnectError(error) else { throw error }
+            }
+        }
+        throw lastError ?? RemoteProviderServiceError.invalidResponse
+    }
+
+    /// Heuristic: classify a URLError as a connect-phase transient. We
+    /// retry the connection on these and treat everything else as
+    /// terminal. Errors on auth / DNS-permanent / cancelled fall through
+    /// to the caller untouched.
+    private static func isRetryableConnectError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .timedOut, .cannotFindHost, .cannotConnectToHost,
+            .networkConnectionLost, .dnsLookupFailed, .notConnectedToInternet,
+            .secureConnectionFailed, .serverCertificateUntrusted,
+            .resourceUnavailable:
+            return true
+        default:
+            return false
+        }
+    }
+
     static func makeChunkStream(
         from bytes: URLSession.AsyncBytes
     ) -> AsyncThrowingStream<Data, Error> {
@@ -1105,7 +1156,15 @@ public actor RemoteProviderService: ToolCapableService {
 
         let producerTask = Task {
             do {
-                let (bytes, response) = try await currentSession.bytes(for: urlRequest)
+                // Idempotent connect-phase retry: only retries the
+                // `bytes(for:)` call (no stream data has been delivered
+                // upstream yet, so retrying is safe). Once we start
+                // iterating bytes / dispatching SSE chunks we never
+                // retry — the consumer has already begun seeing output.
+                let (bytes, response) = try await Self.connectWithRetry(
+                    session: currentSession,
+                    urlRequest: urlRequest
+                )
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     continuation.finish(throwing: RemoteProviderServiceError.invalidResponse)
@@ -1463,8 +1522,11 @@ public actor RemoteProviderService: ToolCapableService {
             max_completion_tokens: parameters.maxTokens,
             stream: stream,
             top_p: isReasoningModel ? nil : parameters.topPOverride,
-            frequency_penalty: nil,
-            presence_penalty: nil,
+            // Forward the raw OpenAI penalties — most upstream OpenAI-
+            // compatible providers accept these natively, and stripping
+            // them silently was a previous gap that surprised clients.
+            frequency_penalty: isReasoningModel ? nil : parameters.frequencyPenalty,
+            presence_penalty: isReasoningModel ? nil : parameters.presencePenalty,
             stop: nil,
             tools: tools,
             tool_choice: toolChoice,

--- a/Packages/OsaurusCore/Tests/Networking/ErrorBodyShapeTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ErrorBodyShapeTests.swift
@@ -1,0 +1,70 @@
+//
+//  ErrorBodyShapeTests.swift
+//  osaurusTests
+//
+//  Coverage for `HTTPHandler.errorBody(_:message:)` — the helper that
+//  unifies error JSON shapes across the three supported wire flavors
+//  (OpenAI, Anthropic, OpenResponses). After §1.5 of the audit every
+//  4xx/5xx body returned to clients goes through this helper instead
+//  of inline string concatenation, so a regression here would propagate
+//  to every endpoint at once.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ErrorBodyShapeTests {
+
+    private func decode(_ json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    @Test func openaiFlavorMatchesOpenAIErrorEnvelope() throws {
+        let body = HTTPHandler.errorBody(
+            .openai(type: "invalid_request_error"),
+            message: "Bad arguments"
+        )
+        let dict = try #require(decode(body))
+        let error = try #require(dict["error"] as? [String: Any])
+        #expect(error["type"] as? String == "invalid_request_error")
+        #expect(error["message"] as? String == "Bad arguments")
+    }
+
+    @Test func anthropicFlavorMatchesMessagesAPIShape() throws {
+        let body = HTTPHandler.errorBody(
+            .anthropic(errorType: "invalid_request_error"),
+            message: "Bad input"
+        )
+        let dict = try #require(decode(body))
+        #expect(dict["type"] as? String == "error")
+        let error = try #require(dict["error"] as? [String: Any])
+        #expect(error["type"] as? String == "invalid_request_error")
+        #expect(error["message"] as? String == "Bad input")
+    }
+
+    @Test func openResponsesFlavorCarriesCode() throws {
+        let body = HTTPHandler.errorBody(
+            .openResponses(code: "model_not_found"),
+            message: "Unknown model"
+        )
+        let dict = try #require(decode(body))
+        let error = try #require(dict["error"] as? [String: Any])
+        #expect(error["type"] as? String == "error")
+        #expect(error["code"] as? String == "model_not_found")
+        #expect(error["message"] as? String == "Unknown model")
+    }
+
+    @Test func messagesContainingQuotesAndNewlinesAreEscaped() throws {
+        let raw = "User said \"hi\"\nand pressed enter"
+        let body = HTTPHandler.errorBody(.openai(type: "internal_error"), message: raw)
+        let dict = try #require(decode(body))
+        let error = try #require(dict["error"] as? [String: Any])
+        // After JSON decode the escaped sequences must round-trip back
+        // to the original raw string.
+        #expect(error["message"] as? String == raw)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
@@ -1,0 +1,79 @@
+//
+//  RequestValidationTests.swift
+//  osaurusTests
+//
+//  Coverage for `HTTPHandler.unsupportedSamplerReason` — the request
+//  validator added in §1.4 of the inference-and-tool-calling gap audit.
+//  Silent ignoring of unsupported sampler params is the worst behavior
+//  for an OpenAI-compatible harness; this test pins the reject-with-400
+//  contract for `n>1` and `response_format=json_schema`, and verifies
+//  the supported flavors (`json_object`, `text`, default) pass through.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct RequestValidationTests {
+
+    private func makeRequest(
+        n: Int? = nil,
+        responseFormatType: String? = nil
+    ) -> ChatCompletionRequest {
+        var req = ChatCompletionRequest(
+            model: "default",
+            messages: [ChatMessage(role: "user", content: "hello")],
+            temperature: 0.7,
+            max_tokens: 32,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: n,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+        if let type = responseFormatType {
+            req.response_format = ResponseFormat(type: type)
+        }
+        return req
+    }
+
+    @Test func defaultRequestIsAccepted() {
+        let req = makeRequest()
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+    }
+
+    @Test func nEqualToOneIsAccepted() {
+        let req = makeRequest(n: 1)
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+    }
+
+    @Test func nGreaterThanOneIsRejected() {
+        let req = makeRequest(n: 2)
+        let reason = HTTPHandler.unsupportedSamplerReason(req)
+        #expect(reason != nil)
+        #expect((reason ?? "").contains("n"))
+    }
+
+    @Test func responseFormatJSONObjectIsAccepted() {
+        let req = makeRequest(responseFormatType: "json_object")
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+    }
+
+    @Test func responseFormatTextIsAccepted() {
+        let req = makeRequest(responseFormatType: "text")
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+    }
+
+    @Test func responseFormatJSONSchemaIsRejected() {
+        let req = makeRequest(responseFormatType: "json_schema")
+        let reason = HTTPHandler.unsupportedSamplerReason(req)
+        #expect(reason != nil)
+        #expect((reason ?? "").contains("json_schema"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/JSONModeInjectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/JSONModeInjectionTests.swift
@@ -1,0 +1,67 @@
+//
+//  JSONModeInjectionTests.swift
+//  osaurusTests
+//
+//  Coverage for `ModelRuntime.applyJSONMode` — the local-side JSON-mode
+//  prompt injection added when a request carries
+//  `response_format: {type: "json_object"}`. The helper must:
+//    1. Be a no-op when jsonMode is false.
+//    2. Append the JSON directive to an existing system message.
+//    3. Insert a fresh system message at index 0 when none exists.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct JSONModeInjectionTests {
+
+    @Test func disabledModeReturnsMessagesUnchanged() {
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "system", content: "You are helpful."),
+            ChatMessage(role: "user", content: "Hi"),
+        ]
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: false)
+        #expect(augmented.count == messages.count)
+        #expect(augmented[0].content == "You are helpful.")
+    }
+
+    @Test func enabledModeAppendsDirectiveToExistingSystemMessage() {
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "system", content: "You are helpful."),
+            ChatMessage(role: "user", content: "Give me an order."),
+        ]
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: true)
+        #expect(augmented.count == messages.count)
+        #expect(augmented[0].role == "system")
+        let sysContent = augmented[0].content ?? ""
+        #expect(sysContent.contains("You are helpful."))
+        #expect(sysContent.contains("single valid JSON object"))
+    }
+
+    @Test func enabledModeInsertsSystemMessageWhenAbsent() {
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: "Give me an order.")
+        ]
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: true)
+        #expect(augmented.count == messages.count + 1)
+        #expect(augmented[0].role == "system")
+        #expect((augmented[0].content ?? "").contains("single valid JSON object"))
+    }
+
+    @Test func enabledModePreservesNonSystemMessageOrder() {
+        let messages: [ChatMessage] = [
+            ChatMessage(role: "user", content: "first user"),
+            ChatMessage(role: "assistant", content: "first assistant"),
+            ChatMessage(role: "user", content: "second user"),
+        ]
+        let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: true)
+        // System inserted at index 0 — original ordering shifted by one.
+        #expect(augmented[0].role == "system")
+        #expect(augmented[1].content == "first user")
+        #expect(augmented[2].content == "first assistant")
+        #expect(augmented[3].content == "second user")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/SchemaCoercionTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SchemaCoercionTests.swift
@@ -1,0 +1,159 @@
+//
+//  SchemaCoercionTests.swift
+//  osaurusTests
+//
+//  Coverage for `SchemaValidator.coerceArguments` — the rescue layer
+//  that unwraps stringified arrays / objects / scalars to native types
+//  before the validator and tool body see them. Without this rescue,
+//  quantized models that emit `"actions": "[{\"action\":\"type\"}]"`
+//  (instead of the native array the schema declares) hit a confusing
+//  "Required: actions (array)" error from the tool body.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SchemaCoercionTests {
+
+    // MARK: - browser_do regression
+
+    /// Exact shape the bug report screenshot showed: `actions` is a
+    /// JSON-encoded string, the schema declares it as `array`. After
+    /// coercion the value must be a real `[Any]` so the tool body's
+    /// `requireArray("actions")` succeeds.
+    @Test func unwrapsStringifiedArrayToNative() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "actions": .object([
+                    "type": .string("array"),
+                    "items": .object(["type": .string("object")]),
+                ])
+            ]),
+            "required": .array([.string("actions")]),
+        ])
+        let raw: [String: Any] = [
+            "actions":
+                #"[{"action": "type", "ref": "E10", "text": "box of tissues"}, {"action": "click", "ref": "E11"}]"#
+        ]
+        let coerced = SchemaValidator.coerceArguments(raw, against: schema) as? [String: Any]
+        let actions = try #require(coerced?["actions"] as? [Any])
+        #expect(actions.count == 2)
+        let first = try #require(actions[0] as? [String: Any])
+        #expect(first["action"] as? String == "type")
+        #expect(first["ref"] as? String == "E10")
+    }
+
+    @Test func unwrapsStringifiedObjectToNative() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "config": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "depth": .object(["type": .string("integer")])
+                    ]),
+                ])
+            ]),
+        ])
+        let raw: [String: Any] = ["config": #"{"depth": 3}"#]
+        let coerced = SchemaValidator.coerceArguments(raw, against: schema) as? [String: Any]
+        let config = try #require(coerced?["config"] as? [String: Any])
+        #expect((config["depth"] as? Int) == 3 || (config["depth"] as? NSNumber)?.intValue == 3)
+    }
+
+    // MARK: - Scalar string coercion (mirrors ArgumentCoercion)
+
+    @Test func unwrapsStringifiedIntegerToNative() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "limit": .object(["type": .string("integer")])
+            ]),
+        ])
+        let coerced =
+            SchemaValidator.coerceArguments(["limit": "42"], against: schema)
+            as? [String: Any]
+        #expect((coerced?["limit"] as? Int) == 42)
+    }
+
+    @Test func unwrapsStringifiedBooleanToNative() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "enabled": .object(["type": .string("boolean")])
+            ]),
+        ])
+        let coerced =
+            SchemaValidator.coerceArguments(["enabled": "yes"], against: schema)
+            as? [String: Any]
+        #expect((coerced?["enabled"] as? Bool) == true)
+    }
+
+    // MARK: - No-op behaviour
+
+    @Test func nativeArrayIsLeftUnchanged() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "tags": .object([
+                    "type": .string("array"),
+                    "items": .object(["type": .string("string")]),
+                ])
+            ]),
+        ])
+        let raw: [String: Any] = ["tags": ["alpha", "beta"]]
+        let coerced = SchemaValidator.coerceArguments(raw, against: schema) as? [String: Any]
+        let tags = try #require(coerced?["tags"] as? [Any])
+        #expect((tags[0] as? String) == "alpha")
+    }
+
+    @Test func unrelatedPropertiesArePreserved() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "actions": .object(["type": .string("array")]),
+                "note": .object(["type": .string("string")]),
+            ]),
+        ])
+        let raw: [String: Any] = [
+            "actions": #"[{"a": 1}]"#,
+            "note": "leave me alone",
+        ]
+        let coerced = SchemaValidator.coerceArguments(raw, against: schema) as? [String: Any]
+        #expect((coerced?["note"] as? String) == "leave me alone")
+        #expect(coerced?["actions"] is [Any])
+    }
+
+    @Test func openSchemaWithoutTypeDoesNothing() throws {
+        // No `type` declared — coercion has no rules to apply, so we
+        // pass the value through unchanged. (Matches our docs: cases
+        // without a type get the lenient validator + raw payload.)
+        let schema: JSONValue = .object([:])
+        let coerced =
+            SchemaValidator.coerceArguments(["x": "42"], against: schema)
+            as? [String: Any]
+        #expect((coerced?["x"] as? String) == "42")
+    }
+
+    // MARK: - Idempotence
+
+    @Test func coercionIsIdempotent() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "actions": .object(["type": .string("array")])
+            ]),
+        ])
+        let raw: [String: Any] = ["actions": #"[1,2,3]"#]
+        let once = SchemaValidator.coerceArguments(raw, against: schema)
+        let twice = SchemaValidator.coerceArguments(once, against: schema)
+        let firstActions = (once as? [String: Any])?["actions"] as? [Any]
+        let secondActions = (twice as? [String: Any])?["actions"] as? [Any]
+        #expect(firstActions?.count == 3)
+        #expect(secondActions?.count == 3)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/SchemaValidatorAdvancedTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SchemaValidatorAdvancedTests.swift
@@ -1,0 +1,144 @@
+//
+//  SchemaValidatorAdvancedTests.swift
+//  osaurusTests
+//
+//  Coverage for the rules added in §2.3 of the inference-and-tool-calling
+//  gap audit: `oneOf` / `anyOf` (first-match), `items` element validation,
+//  `pattern` regex, and numeric `minimum` / `maximum` ranges. Without
+//  these tests a schema regression would silently re-accept the previously
+//  permissive shape.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SchemaValidatorAdvancedTests {
+
+    // MARK: - oneOf / anyOf
+
+    private let oneOfSchema: JSONValue = .object([
+        "oneOf": .array([
+            .object(["type": .string("string")]),
+            .object(["type": .string("integer"), "minimum": .number(0)]),
+        ])
+    ])
+
+    @Test func oneOfMatchesStringBranch() {
+        let result = SchemaValidator.validate(arguments: "hello", against: oneOfSchema)
+        #expect(result.isValid)
+    }
+
+    @Test func oneOfMatchesIntegerBranchHonoringMinimum() {
+        let result = SchemaValidator.validate(arguments: 5, against: oneOfSchema)
+        #expect(result.isValid)
+    }
+
+    @Test func oneOfRejectsWhenNoBranchMatches() {
+        // Negative integer fails the `minimum: 0` branch, and a number
+        // is not a string, so neither branch accepts it.
+        let result = SchemaValidator.validate(arguments: -1, against: oneOfSchema)
+        #expect(!result.isValid)
+        #expect((result.errorMessage ?? "").contains("did not match"))
+    }
+
+    // MARK: - items (array element validation)
+
+    private let arrayOfStringsSchema: JSONValue = .object([
+        "type": .string("array"),
+        "items": .object(["type": .string("string")]),
+    ])
+
+    @Test func arrayItemsAcceptedWhenAllMatch() {
+        let result = SchemaValidator.validate(
+            arguments: ["a", "b", "c"],
+            against: arrayOfStringsSchema
+        )
+        #expect(result.isValid)
+    }
+
+    @Test func arrayItemsRejectedOnTypeMismatch() {
+        let result = SchemaValidator.validate(
+            arguments: ["a", 42, "c"],
+            against: arrayOfStringsSchema
+        )
+        #expect(!result.isValid)
+        // The validator emits a synthetic indexed key like `[1]` for
+        // top-level array element failures.
+        #expect((result.field ?? "").contains("[1]"))
+    }
+
+    // MARK: - pattern (string regex)
+
+    private let semverSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "version": .object([
+                "type": .string("string"),
+                "pattern": .string(#"^\d+\.\d+\.\d+$"#),
+            ])
+        ]),
+        "required": .array([.string("version")]),
+    ])
+
+    @Test func patternAcceptsMatchingString() {
+        let result = SchemaValidator.validate(
+            arguments: ["version": "1.2.3"],
+            against: semverSchema
+        )
+        #expect(result.isValid)
+    }
+
+    @Test func patternRejectsNonMatchingString() {
+        let result = SchemaValidator.validate(
+            arguments: ["version": "v1"],
+            against: semverSchema
+        )
+        #expect(!result.isValid)
+        #expect(result.field == "version")
+        #expect((result.errorMessage ?? "").contains("pattern"))
+    }
+
+    // MARK: - minimum / maximum
+
+    private let rangeSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "score": .object([
+                "type": .string("number"),
+                "minimum": .number(0),
+                "maximum": .number(100),
+            ])
+        ]),
+        "required": .array([.string("score")]),
+    ])
+
+    @Test func minimumRejectsBelowBound() {
+        let result = SchemaValidator.validate(
+            arguments: ["score": -1],
+            against: rangeSchema
+        )
+        #expect(!result.isValid)
+        #expect(result.field == "score")
+        #expect((result.errorMessage ?? "").contains(">="))
+    }
+
+    @Test func maximumRejectsAboveBound() {
+        let result = SchemaValidator.validate(
+            arguments: ["score": 101],
+            against: rangeSchema
+        )
+        #expect(!result.isValid)
+        #expect(result.field == "score")
+        #expect((result.errorMessage ?? "").contains("<="))
+    }
+
+    @Test func rangeAcceptsValuesAtBoundsInclusive() {
+        let lower = SchemaValidator.validate(arguments: ["score": 0], against: rangeSchema)
+        let upper = SchemaValidator.validate(arguments: ["score": 100], against: rangeSchema)
+        #expect(lower.isValid)
+        #expect(upper.isValid)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/ToolRegistryTimeoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolRegistryTimeoutTests.swift
@@ -51,19 +51,28 @@ struct ToolRegistryTimeoutTests {
         let result = try await ToolRegistry.runToolBody(
             tool,
             argumentsJSON: "{}",
-            timeoutSeconds: 0.2
+            timeoutSeconds: 0.5
         )
         let elapsed = Date().timeIntervalSince(started)
 
-        // Must surface as a timeout envelope, not the slow-tool's success body.
+        // Race correctness: the envelope kind is the authoritative
+        // signal that the timeout sleeper won — the body's success
+        // payload is never `kind: timeout`, so this can't be a flake.
         #expect(ToolEnvelope.isError(result))
         let data = result.data(using: .utf8)!
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(parsed?["kind"] as? String == "timeout")
         #expect(parsed?["tool"] as? String == tool.name)
         #expect(parsed?["retryable"] as? Bool == true)
-        // Wall-clock must be close to the timeout, never the full 5s sleep.
-        #expect(elapsed < 1.0, "took \(elapsed)s — expected <1s if timeout fires")
+        // Wall-clock budget: body sleeps 5s, so anything under 4s
+        // proves cancellation actually fired and we didn't accidentally
+        // wait for the body to finish. Looser than the previous <1s
+        // because xctest's parallel scheduler + Swift Concurrency
+        // cooperative pool can add seconds of latency under load —
+        // observed at ~3s under Xcode test runner vs ~0.2s on
+        // `swift test`. The race is the same; only the wake-up
+        // latency differs.
+        #expect(elapsed < 4.0, "took \(elapsed)s — expected <4s if timeout race fired")
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Tool/ToolRegistryTimeoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolRegistryTimeoutTests.swift
@@ -1,0 +1,85 @@
+//
+//  ToolRegistryTimeoutTests.swift
+//  osaurusTests
+//
+//  Coverage for the global per-tool wall-clock timeout added in §2.4 of
+//  the inference-and-tool-calling gap audit. A misbehaving tool body
+//  must surface a structured `kind: .timeout` envelope rather than
+//  hanging the agent loop indefinitely.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ToolRegistryTimeoutTests {
+
+    /// Tool body that sleeps longer than the test timeout. Mirrors a
+    /// hung subprocess / blocked network call in production. Returns a
+    /// success envelope only if it somehow completes — that branch is
+    /// the failure signal for the test.
+    private struct SlowSleepTool: OsaurusTool {
+        let name: String = "test_slow_sleep"
+        let description: String = "Test fixture: sleeps 5 seconds, exceeding the test timeout."
+        let parameters: JSONValue? = .object(["type": .string("object")])
+
+        func execute(argumentsJSON: String) async throws -> String {
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            return ToolEnvelope.success(tool: name, text: "did not time out")
+        }
+    }
+
+    /// Tool body that completes well within the test timeout. Used as a
+    /// happy-path control to confirm the timeout race doesn't fire
+    /// spuriously on fast tools.
+    private struct FastEchoTool: OsaurusTool {
+        let name: String = "test_fast_echo"
+        let description: String = "Test fixture: returns immediately."
+        let parameters: JSONValue? = .object(["type": .string("object")])
+
+        func execute(argumentsJSON: String) async throws -> String {
+            return ToolEnvelope.success(tool: name, text: "ok")
+        }
+    }
+
+    @Test
+    func slowToolReturnsTimeoutEnvelopeBeforeBudgetExpires() async throws {
+        let tool = SlowSleepTool()
+        let started = Date()
+        let result = try await ToolRegistry.runToolBody(
+            tool,
+            argumentsJSON: "{}",
+            timeoutSeconds: 0.2
+        )
+        let elapsed = Date().timeIntervalSince(started)
+
+        // Must surface as a timeout envelope, not the slow-tool's success body.
+        #expect(ToolEnvelope.isError(result))
+        let data = result.data(using: .utf8)!
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["kind"] as? String == "timeout")
+        #expect(parsed?["tool"] as? String == tool.name)
+        #expect(parsed?["retryable"] as? Bool == true)
+        // Wall-clock must be close to the timeout, never the full 5s sleep.
+        #expect(elapsed < 1.0, "took \(elapsed)s — expected <1s if timeout fires")
+    }
+
+    @Test
+    func fastToolReturnsItsOwnResultBeforeTimeoutFires() async throws {
+        let tool = FastEchoTool()
+        let result = try await ToolRegistry.runToolBody(
+            tool,
+            argumentsJSON: "{}",
+            timeoutSeconds: 5
+        )
+        // Happy path — must NOT come back as a timeout envelope.
+        #expect(!ToolEnvelope.isError(result))
+        // Optional sanity: pulled-out text should match the tool body.
+        let payload = ToolEnvelope.successPayload(result)
+        if let text = (payload as? [String: Any])?["text"] as? String {
+            #expect(text == "ok")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/OsaurusTool.swift
+++ b/Packages/OsaurusCore/Tools/OsaurusTool.swift
@@ -258,10 +258,10 @@ enum ArgumentRequirement<T> {
 /// Shared coercion helpers for tool arguments. Local/quantized models frequently
 /// serialize values with wrong JSON types (arrays as strings, numbers as strings, etc.).
 /// These helpers normalize common mistakes so tool execution succeeds.
-enum ArgumentCoercion {
+public enum ArgumentCoercion {
     /// Coerce to `[String]`: actual array, JSON-encoded string (`"[\"a\"]"`),
     /// or bare string wrapped into a single-element array.
-    static func stringArray(_ value: Any?) -> [String]? {
+    public static func stringArray(_ value: Any?) -> [String]? {
         if let arr = value as? [String] { return arr }
         if let str = value as? String {
             if let data = str.data(using: .utf8),
@@ -276,7 +276,7 @@ enum ArgumentCoercion {
     }
 
     /// Coerce to `Int`: native int, `NSNumber`, or string-encoded integer (`"30"`).
-    static func int(_ value: Any?) -> Int? {
+    public static func int(_ value: Any?) -> Int? {
         if let n = value as? Int { return n }
         if let n = (value as? NSNumber)?.intValue { return n }
         if let s = value as? String, let n = Int(s) { return n }
@@ -284,7 +284,7 @@ enum ArgumentCoercion {
     }
 
     /// Coerce to `Bool`: native bool, string variants (`"true"`, `"1"`, `"yes"`), or `NSNumber`.
-    static func bool(_ value: Any?) -> Bool? {
+    public static func bool(_ value: Any?) -> Bool? {
         if let b = value as? Bool { return b }
         if let s = value as? String {
             switch s.lowercased() {

--- a/Packages/OsaurusCore/Tools/OsaurusTool.swift
+++ b/Packages/OsaurusCore/Tools/OsaurusTool.swift
@@ -15,7 +15,16 @@ protocol OsaurusTool: Sendable {
     /// JSON schema for function parameters (OpenAI-compatible minimal subset)
     var parameters: JSONValue? { get }
 
-    /// Execute the tool with arguments provided as a JSON string
+    /// Execute the tool with arguments provided as a JSON string.
+    ///
+    /// **Cancellation contract:** the registry wraps every call with a
+    /// `withThrowingTaskGroup` that races the body against a wall-clock
+    /// timeout (`ToolRegistry.defaultToolTimeoutSeconds`). When the
+    /// surrounding stream is cancelled by the client, the wrapping task
+    /// is cancelled. Long-running tools (network, shell, file walk)
+    /// SHOULD periodically check `Task.isCancelled` and short-circuit
+    /// with a `ToolEnvelope.failure(kind: .executionError, …,
+    /// retryable: false)` so resources are released promptly.
     func execute(argumentsJSON: String) async throws -> String
 }
 

--- a/Packages/OsaurusCore/Tools/SchemaValidator.swift
+++ b/Packages/OsaurusCore/Tools/SchemaValidator.swift
@@ -16,15 +16,15 @@
 
 import Foundation
 
-struct SchemaValidator {
-    struct ValidationResult {
-        let isValid: Bool
-        let errorMessage: String?
+public struct SchemaValidator {
+    public struct ValidationResult {
+        public let isValid: Bool
+        public let errorMessage: String?
         /// Offending property name when failure is tied to a specific arg
         /// (wrong type, missing required, unknown key under
         /// `additionalProperties: false`). Nil for structural failures.
         /// Surfaced as `field` in the `ToolEnvelope.failure(...)`.
-        let field: String?
+        public let field: String?
 
         static func ok() -> ValidationResult {
             .init(isValid: true, errorMessage: nil, field: nil)
@@ -35,12 +35,27 @@ struct SchemaValidator {
         }
     }
 
-    static func validate(arguments: Any, against schema: JSONValue) -> ValidationResult {
+    public static func validate(arguments: Any, against schema: JSONValue) -> ValidationResult {
         guard case .object(let schemaObj) = schema else {
             return .fail("Schema must be an object")
         }
-        // Non-object top-level schema: validate the raw value directly.
-        if case .string(let t)? = schemaObj["type"], t != "object" {
+        // Non-object top-level schema (or untyped combinator-only schema):
+        // validate the raw value directly. Combinator-only schemas
+        // (`{oneOf: [...]}` with no `type`) are common when a parameter
+        // accepts e.g. either a string or an integer — we must NOT
+        // require the input to be a JSON object in that case.
+        let topType: String?
+        if case .string(let t)? = schemaObj["type"] {
+            topType = t
+        } else {
+            topType = nil
+        }
+        let hasCombinator =
+            schemaObj["oneOf"] != nil || schemaObj["anyOf"] != nil
+        if let t = topType, t != "object" {
+            return validateValue(arguments, schemaObject: schemaObj, key: nil)
+        }
+        if topType == nil && hasCombinator {
             return validateValue(arguments, schemaObject: schemaObj, key: nil)
         }
         guard let dict = arguments as? [String: Any] else {
@@ -92,15 +107,33 @@ struct SchemaValidator {
 
     // MARK: - Value validation (single value against its schema)
 
-    /// Run the type and `enum` checks for one value against its schema.
-    /// Used for object properties (via `validateObject`) and for top-level
-    /// non-object schemas. Does NOT recurse into nested objects — that's
-    /// `validateObject`'s job.
+    /// Run the type, range, format, and `enum` checks for one value
+    /// against its schema. Used for object properties (via
+    /// `validateObject`) and for top-level non-object schemas. Does NOT
+    /// recurse into nested objects — that's `validateObject`'s job.
     private static func validateValue(
         _ value: Any,
         schemaObject: [String: JSONValue],
         key: String?
     ) -> ValidationResult {
+        // First-match dispatch on combinators. We match OpenAI's
+        // observed JSON-Schema usage: `oneOf` and `anyOf` are common
+        // tool-arg patterns; `allOf` is rare. We treat `oneOf` and
+        // `anyOf` interchangeably (first matching branch wins) — this
+        // is permissive but matches what GPT-4 emits in practice.
+        if case .array(let branches)? = schemaObject["oneOf"] ?? schemaObject["anyOf"] {
+            for branch in branches {
+                guard case .object(let branchObj) = branch else { continue }
+                let res = validateValue(value, schemaObject: branchObj, key: key)
+                if res.isValid { return res }
+            }
+            let label = key.map { " '\($0)'" } ?? ""
+            return .fail(
+                "Property\(label) did not match any of the allowed schema branches.",
+                field: key
+            )
+        }
+
         if case .string(let t)? = schemaObject["type"] {
             switch t {
             case "string":
@@ -115,12 +148,82 @@ struct SchemaValidator {
                 guard value is [String: Any] else { return typeMismatch("object", key: key) }
             case "array":
                 guard isArrayLike(value) else { return typeMismatch("array", key: key) }
-            // Item-level validation is intentionally not implemented.
             default:
                 break
             }
         }
+
+        // String-specific constraints: `pattern` (regex) + `minLength` /
+        // `maxLength`. Pattern compilation failures are tolerated — a
+        // bad regex in the schema shouldn't break the tool call.
+        if let s = value as? String {
+            if case .string(let pat)? = schemaObject["pattern"] {
+                if let regex = try? NSRegularExpression(pattern: pat),
+                    regex.firstMatch(
+                        in: s,
+                        range: NSRange(s.startIndex..., in: s)
+                    ) == nil
+                {
+                    let label = key.map { " '\($0)'" } ?? ""
+                    return .fail(
+                        "Property\(label) does not match required pattern `\(pat)`.",
+                        field: key
+                    )
+                }
+            }
+        }
+
+        // Numeric range constraints: `minimum` and `maximum`. Inclusive
+        // bounds (the JSON Schema default). `exclusiveMinimum` /
+        // `exclusiveMaximum` are not implemented yet — flag them
+        // silently rather than miscompare.
+        if let bound = numericValue(value) {
+            if case .number(let min)? = schemaObject["minimum"], bound < min {
+                let label = key.map { " '\($0)'" } ?? ""
+                return .fail(
+                    "Property\(label) must be >= \(min) (got \(bound)).",
+                    field: key
+                )
+            }
+            if case .number(let max)? = schemaObject["maximum"], bound > max {
+                let label = key.map { " '\($0)'" } ?? ""
+                return .fail(
+                    "Property\(label) must be <= \(max) (got \(bound)).",
+                    field: key
+                )
+            }
+        }
+
+        // Array element validation: `items` (single schema applied to
+        // every element). Tuple-form `items: [schema, schema, ...]` is
+        // not implemented — defer to the caller for that rarer shape.
+        if case .object(let itemsSchema)? = schemaObject["items"],
+            let arr = value as? [Any]
+        {
+            for (idx, element) in arr.enumerated() {
+                let elementKey = key.map { "\($0)[\(idx)]" } ?? "[\(idx)]"
+                let res = validateValue(element, schemaObject: itemsSchema, key: elementKey)
+                if !res.isValid { return res }
+                if case .string("object")? = itemsSchema["type"],
+                    case .object? = itemsSchema["properties"],
+                    let nested = element as? [String: Any]
+                {
+                    let inner = validateObject(nested, schemaObject: itemsSchema)
+                    if !inner.isValid { return inner }
+                }
+            }
+        }
+
         return enumCheck(value: value, schemaObject: schemaObject, key: key)
+    }
+
+    /// Coerce the value to a `Double` for numeric range checks. Mirrors
+    /// `isNumberLike` but returns the parsed value so we can compare.
+    /// Excludes booleans (NSNumber tag).
+    private static func numericValue(_ value: Any) -> Double? {
+        if let n = value as? NSNumber, !isObjCBool(n) { return n.doubleValue }
+        if let s = value as? String, let d = Double(s) { return d }
+        return nil
     }
 
     // MARK: - Shared helpers

--- a/Packages/OsaurusCore/Tools/SchemaValidator.swift
+++ b/Packages/OsaurusCore/Tools/SchemaValidator.swift
@@ -348,6 +348,134 @@ public struct SchemaValidator {
         default: return false
         }
     }
+
+    // MARK: - Schema-aware coercion
+    //
+    // Quantized local models routinely emit nested arrays and objects as
+    // JSON-encoded strings instead of native types — e.g. they send
+    //
+    //   {"actions": "[{\"action\": \"type\", \"ref\": \"E10\"}]"}
+    //
+    // when the schema declares `actions: array`. The validator's lenient
+    // `isArrayLike` check would let that through, but the tool body
+    // ultimately reads `args["actions"]` as a `String` and rejects with
+    // "Required: actions (array)" — confusing for a model that thinks it
+    // sent the right shape.
+    //
+    // `coerceArguments` walks the schema and, for each declared property,
+    // attempts the obvious unwrap (string → array via JSON parse, string
+    // → object via JSON parse, string → number via Double parse, etc.).
+    // It always returns a value, falling through unchanged when no
+    // coercion rule applies, so callers can run it unconditionally
+    // before validation + dispatch. Together with `validate`, this gives
+    // the tool body native types whenever the model gets close enough.
+
+    /// Coerce `arguments` toward the types declared in `schema`.
+    /// Recursive — descends into object properties and array items —
+    /// and idempotent: passing already-coerced arguments is a no-op.
+    /// Schemas without enough type information (no `type`, untyped
+    /// `oneOf` / `anyOf`) fall through unchanged.
+    public static func coerceArguments(_ arguments: Any, against schema: JSONValue) -> Any {
+        guard case .object(let schemaObj) = schema else { return arguments }
+        return coerceValue(arguments, schemaObject: schemaObj)
+    }
+
+    /// Recursive worker. `schemaObject` is the unwrapped schema dict
+    /// for the current value. We dispatch on the declared `type`:
+    ///   - `object` → recurse into each declared property
+    ///   - `array`  → recurse into items
+    ///   - `integer` / `number` / `boolean` → unwrap a string scalar
+    ///   - everything else → return the value unchanged
+    /// String inputs that look like JSON (`"[…]"` / `"{…}"`) are
+    /// upgraded to native arrays / objects when the schema asks for
+    /// the matching collection type.
+    private static func coerceValue(
+        _ value: Any,
+        schemaObject: [String: JSONValue]
+    ) -> Any {
+        let typeName: String? = {
+            if case .string(let t)? = schemaObject["type"] { return t }
+            return nil
+        }()
+
+        switch typeName {
+        case "object":
+            // Unwrap stringified object first.
+            let target = unwrapJSONString(value, expecting: .object) ?? value
+            guard let dict = target as? [String: Any] else { return target }
+            return coerceObject(dict, schemaObject: schemaObject)
+        case "array":
+            let target = unwrapJSONString(value, expecting: .array) ?? value
+            guard let arr = target as? [Any] else { return target }
+            return coerceArray(arr, schemaObject: schemaObject)
+        case "integer":
+            return coerceScalarString(value) { ArgumentCoercion.int($0) as Any? } ?? value
+        case "number":
+            if let s = value as? String, let d = Double(s) { return d }
+            return value
+        case "boolean":
+            return coerceScalarString(value) { ArgumentCoercion.bool($0) as Any? } ?? value
+        default:
+            return value
+        }
+    }
+
+    private static func coerceObject(
+        _ obj: [String: Any],
+        schemaObject: [String: JSONValue]
+    ) -> [String: Any] {
+        guard case .object(let propsDict)? = schemaObject["properties"] else { return obj }
+        var out = obj
+        for (key, value) in obj {
+            guard case .object(let propSchema)? = propsDict[key] else { continue }
+            out[key] = coerceValue(value, schemaObject: propSchema)
+        }
+        return out
+    }
+
+    private static func coerceArray(
+        _ arr: [Any],
+        schemaObject: [String: JSONValue]
+    ) -> [Any] {
+        guard case .object(let itemsSchema)? = schemaObject["items"] else { return arr }
+        return arr.map { coerceValue($0, schemaObject: itemsSchema) }
+    }
+
+    /// What we expect to find when JSON-parsing a string scalar that
+    /// the schema typed as a collection. The two cases the validator
+    /// rescues today are array-encoded-as-string and
+    /// object-encoded-as-string; everything else is intentionally left
+    /// to the unwrapped scalar coercion path.
+    private enum ExpectedJSONShape { case array, object }
+
+    /// If `value` is a `String` that JSON-decodes to the requested
+    /// shape, return the decoded native object. Otherwise nil so the
+    /// caller can fall back to whatever the input was.
+    private static func unwrapJSONString(
+        _ value: Any,
+        expecting shape: ExpectedJSONShape
+    ) -> Any? {
+        guard let s = value as? String,
+            let data = s.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data)
+        else { return nil }
+        switch shape {
+        case .array where parsed is [Any]: return parsed
+        case .object where parsed is [String: Any]: return parsed
+        default: return nil
+        }
+    }
+
+    /// Apply `coercer` only when `value` is a `String` AND the result
+    /// is non-nil. Otherwise return nil so the caller knows nothing
+    /// changed and can keep the original value.
+    private static func coerceScalarString(
+        _ value: Any,
+        _ coercer: (String) -> Any?
+    ) -> Any? {
+        guard let s = value as? String, let coerced = coercer(s) else { return nil }
+        return coerced
+    }
 }
 
 private extension JSONValue {

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -332,38 +332,70 @@ final class ToolRegistry: ObservableObject {
     /// sees a structured signal instead of a hung agent loop. Internal so
     /// tests can drive it with a small `timeoutSeconds` value without
     /// waiting for the full 120s production budget.
+    ///
+    /// Each branch of the race converts thrown errors (including
+    /// `CancellationError` from the loser when we `cancelAll`) into a
+    /// structured `ToolEnvelope` *inside* its child task. That keeps
+    /// `withTaskGroup` non-throwing and prevents the cancelled sibling's
+    /// post-return throw from reaching the caller as the function's
+    /// error — historically the slow-tool case rethrew CancellationError
+    /// and stalled while the group drained.
     internal nonisolated static func runToolBody(
         _ tool: OsaurusTool,
         argumentsJSON: String,
         timeoutSeconds: TimeInterval
     ) async throws -> String {
         let toolName = tool.name
-        return try await withThrowingTaskGroup(of: String.self) { group in
+        let timeoutEnvelope = ToolEnvelope.failure(
+            kind: .timeout,
+            message:
+                "Tool '\(toolName)' exceeded the \(Int(timeoutSeconds))s execution budget.",
+            tool: toolName,
+            retryable: true
+        )
+        // Sentinel returned by the cancelled loser branch so the
+        // consumer loop knows to ignore it. Cannot collide with any
+        // legitimate envelope because real envelopes are JSON.
+        let cancelledSentinel = "__osaurus_runToolBody_cancelled__"
+
+        return await withTaskGroup(of: String.self) { group in
             group.addTask {
-                try await tool.execute(argumentsJSON: argumentsJSON)
+                do {
+                    return try await tool.execute(argumentsJSON: argumentsJSON)
+                } catch is CancellationError {
+                    return cancelledSentinel
+                } catch {
+                    return ToolEnvelope.fromError(error, tool: toolName)
+                }
             }
             group.addTask {
                 let nanos = UInt64(timeoutSeconds * 1_000_000_000)
-                try await Task.sleep(nanoseconds: nanos)
-                return ToolEnvelope.failure(
-                    kind: .timeout,
-                    message:
-                        "Tool '\(toolName)' exceeded the \(Int(timeoutSeconds))s execution budget.",
-                    tool: toolName,
-                    retryable: true
-                )
+                do {
+                    try await Task.sleep(nanoseconds: nanos)
+                } catch {
+                    // Cancelled because the body finished first — yield
+                    // the sentinel so the caller's first non-sentinel
+                    // result wins.
+                    return cancelledSentinel
+                }
+                return timeoutEnvelope
             }
-            // First result wins (either the body completed or the timeout
-            // fired). Cancel the loser so we don't leak work.
-            guard let first = try await group.next() else {
-                return ToolEnvelope.failure(
-                    kind: .executionError,
-                    message: "Tool '\(toolName)' produced no result.",
-                    tool: toolName
-                )
+
+            // The first non-sentinel result is the winner; cancel the
+            // sibling and drain it to keep the task group well-behaved.
+            for await result in group {
+                if result == cancelledSentinel { continue }
+                group.cancelAll()
+                // Drain the cancelled sibling so the closure exits
+                // promptly instead of waiting on it implicitly.
+                for await _ in group {}
+                return result
             }
-            group.cancelAll()
-            return first
+            return ToolEnvelope.failure(
+                kind: .executionError,
+                message: "Tool '\(toolName)' produced no result.",
+                tool: toolName
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -288,36 +288,91 @@ final class ToolRegistry: ObservableObject {
                 }
             }
         }
-        // Schema preflight: catches `additionalProperties: false` violations
-        // and obvious type mismatches before the tool body sees them. Parse
-        // failure and missing schema are tolerated — tool bodies typically
-        // have richer field-aware `require…` helpers.
-        if let schema = tool.parameters,
+        // Coerce + preflight against the tool's schema. Returns either
+        // a (possibly rewritten) `argumentsJSON` ready for dispatch, or
+        // a structured failure envelope to short-circuit with.
+        switch Self.preflight(argumentsJSON: argumentsJSON, schema: tool.parameters, toolName: name) {
+        case .rejected(let envelopeJSON):
+            return envelopeJSON
+        case .ready(let effectiveArgumentsJSON):
+            // Run the tool body off MainActor so long-running tools (file
+            // I/O, network, shell) don't contend with SwiftUI layout on the
+            // main thread. A global timeout caps every tool body so a
+            // misbehaving tool can never block the agent loop forever —
+            // tools that legitimately need longer (sandbox shell, model
+            // evaluation) still own their own tighter timeout internally.
+            return try await Self.runToolBody(
+                tool,
+                argumentsJSON: effectiveArgumentsJSON,
+                timeoutSeconds: Self.defaultToolTimeoutSeconds
+            )
+        }
+    }
+
+    /// Outcome of `preflight`: either the cleaned arguments to dispatch
+    /// with, or a ready-to-return failure envelope JSON string.
+    private enum PreflightOutcome {
+        case ready(argumentsJSON: String)
+        case rejected(envelopeJSON: String)
+    }
+
+    /// Pre-dispatch step that applies schema-aware coercion and then
+    /// validation. Coercion runs FIRST so quantized models that send
+    /// arrays / objects as JSON-encoded strings (e.g.
+    /// `"actions": "[{\"action\":\"type\"}]"` for a schema declaring
+    /// `actions: array`) get auto-unwrapped before either the validator
+    /// or the tool body sees them.
+    ///
+    /// Returns `.rejected` when the validator finds the (post-coercion)
+    /// arguments invalid; otherwise `.ready` with the JSON the tool body
+    /// should consume. Re-serialisation only happens when coercion
+    /// actually changed the shape — when the model sent native types we
+    /// preserve the original literal byte-for-byte so downstream
+    /// consumers (logging, storage) see what the client sent.
+    ///
+    /// Tools without a declared schema or with un-parseable JSON args
+    /// fall through unchanged: parsing is best-effort, and tool bodies
+    /// keep their richer `requireXxx` helpers as the second line of
+    /// defence.
+    private nonisolated static func preflight(
+        argumentsJSON: String,
+        schema: JSONValue?,
+        toolName: String
+    ) -> PreflightOutcome {
+        guard let schema,
             let data = argumentsJSON.data(using: .utf8),
             let parsed = try? JSONSerialization.jsonObject(with: data)
-        {
-            let result = SchemaValidator.validate(arguments: parsed, against: schema)
-            if !result.isValid, let message = result.errorMessage {
-                return ToolEnvelope.failure(
+        else { return .ready(argumentsJSON: argumentsJSON) }
+
+        let coerced = SchemaValidator.coerceArguments(parsed, against: schema)
+        let result = SchemaValidator.validate(arguments: coerced, against: schema)
+        if !result.isValid, let message = result.errorMessage {
+            return .rejected(
+                envelopeJSON: ToolEnvelope.failure(
                     kind: .invalidArgs,
                     message: message,
                     field: result.field,
-                    tool: name
+                    tool: toolName
                 )
-            }
+            )
         }
 
-        // Run the tool body off MainActor so long-running tools (file I/O,
-        // network, shell) don't contend with SwiftUI layout on the main thread.
-        // A global timeout caps every tool body so a misbehaving tool can
-        // never block the agent loop forever — tools that legitimately need
-        // longer (sandbox shell, model evaluation) still own their own
-        // tighter timeout internally.
-        return try await Self.runToolBody(
-            tool,
-            argumentsJSON: argumentsJSON,
-            timeoutSeconds: Self.defaultToolTimeoutSeconds
-        )
+        // Try to detect "coercion changed the shape" via canonicalised
+        // JSON byte equality. When the bytes match, hand back the
+        // original literal; otherwise re-serialise so the tool body
+        // gets native types.
+        let opts: JSONSerialization.WritingOptions = [.sortedKeys]
+        guard let coercedData = try? JSONSerialization.data(withJSONObject: coerced, options: opts),
+            let originalData = try? JSONSerialization.data(withJSONObject: parsed, options: opts)
+        else { return .ready(argumentsJSON: argumentsJSON) }
+
+        if coercedData == originalData {
+            return .ready(argumentsJSON: argumentsJSON)
+        }
+        guard let coercedJSON = String(data: coercedData, encoding: .utf8) else {
+            return .ready(argumentsJSON: argumentsJSON)
+        }
+        return .ready(argumentsJSON: coercedJSON)
     }
 
     /// Default per-tool wall-clock cap (seconds). Mirrors
@@ -382,13 +437,13 @@ final class ToolRegistry: ObservableObject {
             }
 
             // The first non-sentinel result is the winner; cancel the
-            // sibling and drain it to keep the task group well-behaved.
+            // sibling and let `withTaskGroup` auto-drain on closure
+            // return. The drain is safe because every child branch
+            // converts its own errors into envelope strings — there
+            // are no uncaught throws to surface.
             for await result in group {
                 if result == cancelledSentinel { continue }
                 group.cancelAll()
-                // Drain the cancelled sibling so the closure exits
-                // promptly instead of waiting on it implicitly.
-                for await _ in group {}
                 return result
             }
             return ToolEnvelope.failure(

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -309,15 +309,62 @@ final class ToolRegistry: ObservableObject {
 
         // Run the tool body off MainActor so long-running tools (file I/O,
         // network, shell) don't contend with SwiftUI layout on the main thread.
-        return try await Self.runToolBody(tool, argumentsJSON: argumentsJSON)
+        // A global timeout caps every tool body so a misbehaving tool can
+        // never block the agent loop forever — tools that legitimately need
+        // longer (sandbox shell, model evaluation) still own their own
+        // tighter timeout internally.
+        return try await Self.runToolBody(
+            tool,
+            argumentsJSON: argumentsJSON,
+            timeoutSeconds: Self.defaultToolTimeoutSeconds
+        )
     }
 
-    /// Trampoline that executes the tool outside of MainActor isolation.
-    private nonisolated static func runToolBody(
+    /// Default per-tool wall-clock cap (seconds). Mirrors
+    /// `PluginHostAPI.toolExecutionTimeout` so the chat-side and plugin-side
+    /// loops have matching semantics. Tools that need a tighter or looser
+    /// budget (e.g. sandbox shell, MCP provider) still set their own.
+    public static let defaultToolTimeoutSeconds: TimeInterval = 120
+
+    /// Trampoline that executes the tool outside of MainActor isolation,
+    /// racing the body against a wall-clock timeout. On timeout we cancel
+    /// the body task and return a `kind: .timeout` envelope so the model
+    /// sees a structured signal instead of a hung agent loop. Internal so
+    /// tests can drive it with a small `timeoutSeconds` value without
+    /// waiting for the full 120s production budget.
+    internal nonisolated static func runToolBody(
         _ tool: OsaurusTool,
-        argumentsJSON: String
+        argumentsJSON: String,
+        timeoutSeconds: TimeInterval
     ) async throws -> String {
-        try await tool.execute(argumentsJSON: argumentsJSON)
+        let toolName = tool.name
+        return try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await tool.execute(argumentsJSON: argumentsJSON)
+            }
+            group.addTask {
+                let nanos = UInt64(timeoutSeconds * 1_000_000_000)
+                try await Task.sleep(nanoseconds: nanos)
+                return ToolEnvelope.failure(
+                    kind: .timeout,
+                    message:
+                        "Tool '\(toolName)' exceeded the \(Int(timeoutSeconds))s execution budget.",
+                    tool: toolName,
+                    retryable: true
+                )
+            }
+            // First result wins (either the body completed or the timeout
+            // fired). Cancel the loser so we don't leak work.
+            guard let first = try await group.next() else {
+                return ToolEnvelope.failure(
+                    kind: .executionError,
+                    message: "Tool '\(toolName)' produced no result.",
+                    tool: toolName
+                )
+            }
+            group.cancelAll()
+            return first
+        }
     }
 
     // MARK: - Listing / Enablement

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1466,8 +1466,6 @@ final class ChatSession: ObservableObject {
                         tool_choice: toolSpecs.isEmpty ? nil : .auto,
                         session_id: sessionId?.uuidString
                     )
-                    req.cache_hint = context.cacheHint
-                    req.staticPrefix = context.staticPrefix
                     req.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
                     req.ttftTrace = ttftTrace
                     debugLog(

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -91,15 +91,30 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// `oneOf` / `anyOf` / `pattern` / `items` / `minimum` /
         /// `maximum` rules from regressing.
         public let schema: SchemaExpectations?
+        public let toolEnvelope: ToolEnvelopeExpectations?
+        public let streamingHint: StreamingHintExpectations?
+        public let prefixHash: PrefixHashExpectations?
+        public let argumentCoercion: ArgumentCoercionExpectations?
+        public let requestValidation: RequestValidationExpectations?
 
         public init(
             tools: ToolExpectations? = nil,
             companions: CompanionExpectations? = nil,
-            schema: SchemaExpectations? = nil
+            schema: SchemaExpectations? = nil,
+            toolEnvelope: ToolEnvelopeExpectations? = nil,
+            streamingHint: StreamingHintExpectations? = nil,
+            prefixHash: PrefixHashExpectations? = nil,
+            argumentCoercion: ArgumentCoercionExpectations? = nil,
+            requestValidation: RequestValidationExpectations? = nil
         ) {
             self.tools = tools
             self.companions = companions
             self.schema = schema
+            self.toolEnvelope = toolEnvelope
+            self.streamingHint = streamingHint
+            self.prefixHash = prefixHash
+            self.argumentCoercion = argumentCoercion
+            self.requestValidation = requestValidation
         }
     }
 
@@ -126,6 +141,169 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.arguments = arguments
             self.expectValid = expectValid
             self.expectField = expectField
+        }
+    }
+
+    /// Expectation for `domain == "tool_envelope"` cases. Drives one
+    /// of the `ToolEnvelope.{success,failure}` builders and asserts the
+    /// resulting JSON parses back into a dict whose top-level keys
+    /// match the expectations. `expectKeys` lets a case pin the
+    /// envelope's discriminator (`ok`, `kind`, `tool`, `retryable`)
+    /// without having to spell out the entire payload.
+    public struct ToolEnvelopeExpectations: Sendable, Codable {
+        /// Which builder to invoke. Mirrors the `ToolEnvelope` API.
+        ///   - `failure`: `ToolEnvelope.failure(kind:message:tool:)`
+        ///   - `successText`: `ToolEnvelope.success(tool:text:)`
+        public enum Builder: String, Sendable, Codable {
+            case failure
+            case successText
+        }
+        public let builder: Builder
+        /// Inputs to the builder. Unused fields are ignored — e.g.
+        /// `text` is read only by `successText`, `kind` only by
+        /// `failure`.
+        public let kind: String?
+        public let message: String?
+        public let text: String?
+        public let tool: String?
+        /// Top-level fields of the parsed envelope JSON the case
+        /// requires. Each value must equal the corresponding field
+        /// (string/bool/number); use `JSONValue` so the case file
+        /// matches the runtime types exactly.
+        public let expectKeys: [String: JSONValue]
+
+        public init(
+            builder: Builder,
+            kind: String? = nil,
+            message: String? = nil,
+            text: String? = nil,
+            tool: String? = nil,
+            expectKeys: [String: JSONValue]
+        ) {
+            self.builder = builder
+            self.kind = kind
+            self.message = message
+            self.text = text
+            self.tool = tool
+            self.expectKeys = expectKeys
+        }
+    }
+
+    /// Expectation for `domain == "streaming_hint"` cases. Drives one
+    /// of the `StreamingToolHint.{encode,encodeArgs,encodeDone}`
+    /// helpers, then assertions on the resulting sentinel: that
+    /// `isSentinel` reports true, and that the matching `decode*`
+    /// helper round-trips back to the original payload.
+    public struct StreamingHintExpectations: Sendable, Codable {
+        public enum Operation: String, Sendable, Codable {
+            case encode  // tool name → `\u{FFFE}tool:<name>`
+            case encodeArgs  // args fragment → `\u{FFFE}args:<frag>`
+            case encodeDone  // {id,name,args,result} → `\u{FFFE}done:<json>`
+        }
+        public let op: Operation
+        /// For `.encode` and `.encodeArgs` — the single string payload.
+        public let payload: String?
+        /// For `.encodeDone` — structured payload fields.
+        public let callId: String?
+        public let name: String?
+        public let arguments: String?
+        public let result: String?
+
+        public init(
+            op: Operation,
+            payload: String? = nil,
+            callId: String? = nil,
+            name: String? = nil,
+            arguments: String? = nil,
+            result: String? = nil
+        ) {
+            self.op = op
+            self.payload = payload
+            self.callId = callId
+            self.name = name
+            self.arguments = arguments
+            self.result = result
+        }
+    }
+
+    /// Expectation for `domain == "prefix_hash"` cases. Two flavors:
+    ///   - `expectHash` set → assert `computePrefixHash(a) == expectHash`
+    ///   - `compareTo` set → assert `computePrefixHash(a)` and
+    ///                       `computePrefixHash(compareTo)` are equal /
+    ///                       not equal per `expectEqual`
+    /// Cases use this to pin both stability (hash matches a literal)
+    /// and structural invariants (tool-order independence, no
+    /// delimiter collisions).
+    public struct PrefixHashExpectations: Sendable, Codable {
+        public let systemContent: String
+        public let toolNames: [String]
+        public let expectHash: String?
+        public let compareTo: ComparisonInput?
+        public let expectEqual: Bool?
+
+        public init(
+            systemContent: String,
+            toolNames: [String],
+            expectHash: String? = nil,
+            compareTo: ComparisonInput? = nil,
+            expectEqual: Bool? = nil
+        ) {
+            self.systemContent = systemContent
+            self.toolNames = toolNames
+            self.expectHash = expectHash
+            self.compareTo = compareTo
+            self.expectEqual = expectEqual
+        }
+
+        public struct ComparisonInput: Sendable, Codable {
+            public let systemContent: String
+            public let toolNames: [String]
+
+            public init(systemContent: String, toolNames: [String]) {
+                self.systemContent = systemContent
+                self.toolNames = toolNames
+            }
+        }
+    }
+
+    /// Expectation for `domain == "argument_coercion"` cases. Drives
+    /// one of `ArgumentCoercion.{stringArray,int,bool}` against an
+    /// arbitrary JSON value and asserts the coerced output matches
+    /// `expect`. Use `expect: null` to pin the "rejected, returns nil"
+    /// branch — extremely valuable for the boolean / numeric edge
+    /// cases that quantized models ship.
+    public struct ArgumentCoercionExpectations: Sendable, Codable {
+        public enum Helper: String, Sendable, Codable {
+            case stringArray
+            case int
+            case bool
+        }
+        public let helper: Helper
+        public let value: JSONValue
+        public let expect: JSONValue?  // nil expectation → coercion must return nil
+    }
+
+    /// Expectation for `domain == "request_validation"` cases. Pins
+    /// the accept/reject decision of `RequestValidator.unsupportedSamplerReason`
+    /// for the (`n`, `response_format.type`) tuple. `expectAccept: true`
+    /// asserts no rejection; otherwise the reason string must contain
+    /// `expectReasonContains`.
+    public struct RequestValidationExpectations: Sendable, Codable {
+        public let n: Int?
+        public let responseFormatType: String?
+        public let expectAccept: Bool
+        public let expectReasonContains: String?
+
+        public init(
+            n: Int? = nil,
+            responseFormatType: String? = nil,
+            expectAccept: Bool,
+            expectReasonContains: String? = nil
+        ) {
+            self.n = n
+            self.responseFormatType = responseFormatType
+            self.expectAccept = expectAccept
+            self.expectReasonContains = expectReasonContains
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import OsaurusCore
 
 public struct EvalCase: Sendable, Codable, Identifiable {
     /// Unique slug, e.g. `preflight.browser.amazon-orders`. Surfaced in
@@ -84,13 +85,47 @@ public struct EvalCase: Sendable, Codable, Identifiable {
     public struct Expectations: Sendable, Codable {
         public let tools: ToolExpectations?
         public let companions: CompanionExpectations?
+        /// Schema-validation expectation for `domain == "schema"` cases.
+        /// Lets us pin the SchemaValidator's behaviour against canned
+        /// schema/arg pairs — extremely useful for keeping the new
+        /// `oneOf` / `anyOf` / `pattern` / `items` / `minimum` /
+        /// `maximum` rules from regressing.
+        public let schema: SchemaExpectations?
 
         public init(
             tools: ToolExpectations? = nil,
-            companions: CompanionExpectations? = nil
+            companions: CompanionExpectations? = nil,
+            schema: SchemaExpectations? = nil
         ) {
             self.tools = tools
             self.companions = companions
+            self.schema = schema
+        }
+    }
+
+    /// Expectation for `domain == "schema"` cases. Pure data — the
+    /// runner feeds `arguments` through `SchemaValidator.validate`
+    /// against `schema` and asserts the outcome matches `expectValid`.
+    /// When `expectField` is set, the failure must additionally surface
+    /// that field name. Both `schema` and `arguments` are decoded as
+    /// `JSONValue` so the JSON literal in the case file maps 1:1 onto
+    /// what the validator sees at runtime.
+    public struct SchemaExpectations: Sendable, Codable {
+        public let schema: JSONValue
+        public let arguments: JSONValue
+        public let expectValid: Bool
+        public let expectField: String?
+
+        public init(
+            schema: JSONValue,
+            arguments: JSONValue,
+            expectValid: Bool,
+            expectField: String? = nil
+        ) {
+            self.schema = schema
+            self.arguments = arguments
+            self.expectValid = expectValid
+            self.expectField = expectField
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -172,11 +172,13 @@ public enum EvalRunner {
 
     // MARK: - Schema domain
 
-    /// Pure-data evaluator for the `schema` domain. Drives
-    /// `SchemaValidator.validate` against a canned schema/args pair so
-    /// SchemaValidator regressions (added rules: oneOf/anyOf, items,
-    /// pattern, min/max) get caught without needing a real LLM.
-    /// Always main-actor-safe — no engine state touched.
+    /// Pure-data evaluator for the `schema` domain. Mirrors what
+    /// `ToolRegistry.execute` does in production: coerce → validate.
+    /// Coercion is the rescue layer that unwraps stringified arrays /
+    /// objects / scalars before validation sees them, so cases that
+    /// pin its behaviour against quantized-model output (e.g. the
+    /// browser_do `actions` regression) verify the full path the
+    /// chat tool dispatch takes — not just the validator in isolation.
     private static func runSchemaCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
         let label = testCase.label ?? testCase.id
         guard let expectation = testCase.expect.schema else {
@@ -189,7 +191,8 @@ public enum EvalRunner {
                 modelId: modelId
             )
         }
-        let argsAny = jsonValueToAny(expectation.arguments)
+        let rawArgs = jsonValueToAny(expectation.arguments)
+        let argsAny = SchemaValidator.coerceArguments(rawArgs, against: expectation.schema)
         let result = SchemaValidator.validate(
             arguments: argsAny,
             against: expectation.schema

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -75,6 +75,16 @@ public enum EvalRunner {
             break  // fall through to the existing preflight body below
         case "schema":
             return runSchemaCase(testCase, modelId: modelId)
+        case "tool_envelope":
+            return runToolEnvelopeCase(testCase, modelId: modelId)
+        case "streaming_hint":
+            return runStreamingHintCase(testCase, modelId: modelId)
+        case "prefix_hash":
+            return runPrefixHashCase(testCase, modelId: modelId)
+        case "argument_coercion":
+            return runArgumentCoercionCase(testCase, modelId: modelId)
+        case "request_validation":
+            return runRequestValidationCase(testCase, modelId: modelId)
         case "tools", "streaming", "contract":
             // Scaffolded domains — runner implementation lives in a
             // follow-up so cases can be authored against the format
@@ -207,6 +217,26 @@ public enum EvalRunner {
         )
     }
 
+    /// Build an `.errored` terminal row for cases that fail their
+    /// own preconditions (missing required expectation field,
+    /// malformed enum value, etc.). Pulls the `id`/`domain`/`label`
+    /// from `testCase` so the call site stays a one-liner.
+    private static func errored(
+        _ testCase: EvalCase,
+        label: String,
+        modelId: String,
+        note: String
+    ) -> EvalCaseReport {
+        .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: .errored,
+            notes: [note],
+            modelId: modelId
+        )
+    }
+
     /// Convert a `JSONValue` (decoded from the case JSON) into the
     /// `Any` shape `SchemaValidator.validate` consumes. Mirrors the
     /// private `JSONValue.foundationValue` extension in SchemaValidator.
@@ -219,6 +249,354 @@ public enum EvalRunner {
         case .array(let arr): return arr.map { jsonValueToAny($0) }
         case .object(let obj): return obj.mapValues { jsonValueToAny($0) }
         }
+    }
+
+    // MARK: - Tool envelope domain
+
+    /// Pure-data evaluator for `domain == "tool_envelope"`. Drives one
+    /// of the `ToolEnvelope.{success,failure}` builders and asserts the
+    /// resulting JSON parses back into a dict whose top-level keys
+    /// match the expectations.
+    private static func runToolEnvelopeCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.toolEnvelope else {
+            return Self.errored(testCase, label: label, modelId: modelId, note: "missing `expect.toolEnvelope`")
+        }
+        let result: String
+        switch exp.builder {
+        case .failure:
+            guard let kindRaw = exp.kind, let kind = ToolEnvelope.Kind(rawValue: kindRaw) else {
+                return Self.errored(
+                    testCase,
+                    label: label,
+                    modelId: modelId,
+                    note: "failure builder needs `kind` matching ToolEnvelope.Kind raw values"
+                )
+            }
+            result = ToolEnvelope.failure(
+                kind: kind,
+                message: exp.message ?? "",
+                tool: exp.tool
+            )
+        case .successText:
+            result = ToolEnvelope.success(tool: exp.tool, text: exp.text ?? "")
+        }
+        let mismatches = compareTopLevelKeys(result, expectKeys: exp.expectKeys)
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: mismatches.isEmpty ? .passed : .failed,
+            notes: mismatches.isEmpty ? ["envelope: \(result)"] : mismatches,
+            modelId: modelId
+        )
+    }
+
+    /// Compare every entry in `expectKeys` against the parsed top-level
+    /// dict from `envelopeJSON`. Returns one mismatch line per key that
+    /// disagrees; an empty array means full pass.
+    private static func compareTopLevelKeys(
+        _ envelopeJSON: String,
+        expectKeys: [String: JSONValue]
+    ) -> [String] {
+        guard let data = envelopeJSON.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return ["envelope did not parse as a JSON object: \(envelopeJSON)"]
+        }
+        var mismatches: [String] = []
+        for (key, expected) in expectKeys {
+            let actual = dict[key]
+            if !equalsJSONValue(actual, expected) {
+                mismatches.append("key '\(key)': expected \(expected), got \(actual ?? "<missing>")")
+            }
+        }
+        return mismatches
+    }
+
+    /// Equality between a Foundation-decoded `Any?` and a `JSONValue`
+    /// literal from the case file. Bool/Number/String/Null are compared
+    /// directly; arrays and objects are not used by the Tier 1 suites
+    /// (would need recursion if a future case needs them).
+    private static func equalsJSONValue(_ actual: Any?, _ expected: JSONValue) -> Bool {
+        switch expected {
+        case .null:
+            return actual == nil || actual is NSNull
+        case .bool(let b):
+            if let n = actual as? NSNumber, CFGetTypeID(n) == CFBooleanGetTypeID() {
+                return n.boolValue == b
+            }
+            return false
+        case .number(let n):
+            if let actualN = actual as? NSNumber, CFGetTypeID(actualN) != CFBooleanGetTypeID() {
+                return actualN.doubleValue == n
+            }
+            return false
+        case .string(let s):
+            return (actual as? String) == s
+        case .array, .object:
+            return false
+        }
+    }
+
+    // MARK: - Streaming hint domain
+
+    /// Pure-data evaluator for `domain == "streaming_hint"`. Verifies
+    /// the encode → isSentinel → decode round-trip for every supported
+    /// `StreamingToolHint` operation.
+    private static func runStreamingHintCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.streamingHint else {
+            return Self.errored(testCase, label: label, modelId: modelId, note: "missing `expect.streamingHint`")
+        }
+
+        var notes: [String] = []
+        var passed = true
+        switch exp.op {
+        case .encode:
+            guard let payload = exp.payload else {
+                return Self.errored(testCase, label: label, modelId: modelId, note: "encode op needs `payload`")
+            }
+            let encoded = StreamingToolHint.encode(payload)
+            if !StreamingToolHint.isSentinel(encoded) {
+                passed = false
+                notes.append("isSentinel returned false on encoded payload")
+            }
+            if StreamingToolHint.decode(encoded) != payload {
+                passed = false
+                notes.append("decode did not round-trip payload")
+            }
+        case .encodeArgs:
+            guard let payload = exp.payload else {
+                return Self.errored(testCase, label: label, modelId: modelId, note: "encodeArgs op needs `payload`")
+            }
+            let encoded = StreamingToolHint.encodeArgs(payload)
+            if !StreamingToolHint.isSentinel(encoded) {
+                passed = false
+                notes.append("isSentinel returned false on encoded args")
+            }
+            if StreamingToolHint.decodeArgs(encoded) != payload {
+                passed = false
+                notes.append("decodeArgs did not round-trip payload")
+            }
+        case .encodeDone:
+            guard let callId = exp.callId, let name = exp.name,
+                let arguments = exp.arguments, let result = exp.result
+            else {
+                return Self.errored(
+                    testCase,
+                    label: label,
+                    modelId: modelId,
+                    note: "encodeDone needs callId/name/arguments/result"
+                )
+            }
+            let encoded = StreamingToolHint.encodeDone(
+                callId: callId,
+                name: name,
+                arguments: arguments,
+                result: result
+            )
+            if !StreamingToolHint.isSentinel(encoded) {
+                passed = false
+                notes.append("isSentinel returned false on encoded done")
+            }
+            guard let decoded = StreamingToolHint.decodeDone(encoded) else {
+                passed = false
+                notes.append("decodeDone returned nil")
+                break
+            }
+            if decoded.callId != callId { passed = false; notes.append("callId drift: \(decoded.callId)") }
+            if decoded.name != name { passed = false; notes.append("name drift: \(decoded.name)") }
+            if decoded.arguments != arguments { passed = false; notes.append("arguments drift") }
+            if decoded.result != result { passed = false; notes.append("result drift") }
+        }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: passed ? .passed : .failed,
+            notes: notes,
+            modelId: modelId
+        )
+    }
+
+    // MARK: - Prefix hash domain
+
+    /// Pure-data evaluator for `domain == "prefix_hash"`. Pins both
+    /// hash stability against literal hex strings and structural
+    /// invariants between two input pairs.
+    private static func runPrefixHashCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.prefixHash else {
+            return Self.errored(testCase, label: label, modelId: modelId, note: "missing `expect.prefixHash`")
+        }
+        let h1 = ModelRuntime.computePrefixHash(
+            systemContent: exp.systemContent,
+            toolNames: exp.toolNames
+        )
+        var notes: [String] = []
+        var passed = true
+
+        if let expectedHash = exp.expectHash, h1 != expectedHash {
+            passed = false
+            notes.append("hash drift: expected \(expectedHash), got \(h1)")
+        }
+        if let other = exp.compareTo {
+            let h2 = ModelRuntime.computePrefixHash(
+                systemContent: other.systemContent,
+                toolNames: other.toolNames
+            )
+            let shouldBeEqual = exp.expectEqual ?? false
+            let actuallyEqual = (h1 == h2)
+            if shouldBeEqual != actuallyEqual {
+                passed = false
+                notes.append(
+                    "comparison: expected equal=\(shouldBeEqual), got \(h1) vs \(h2) (equal=\(actuallyEqual))"
+                )
+            }
+        }
+        if exp.expectHash == nil && exp.compareTo == nil {
+            // Smoke-test: just record the hash. Useful for bootstrapping
+            // a new case before pinning a literal value.
+            notes.append("hash: \(h1)")
+        }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: passed ? .passed : .failed,
+            notes: notes,
+            modelId: modelId
+        )
+    }
+
+    // MARK: - Argument coercion domain
+
+    /// Pure-data evaluator for `domain == "argument_coercion"`. Drives
+    /// one of `ArgumentCoercion.{stringArray,int,bool}` and pins the
+    /// result against the case's `expect` value (or `nil` for the
+    /// rejection branch).
+    private static func runArgumentCoercionCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.argumentCoercion else {
+            return Self.errored(testCase, label: label, modelId: modelId, note: "missing `expect.argumentCoercion`")
+        }
+        let valueAny = jsonValueToAny(exp.value)
+        let outcome: (passed: Bool, note: String)
+        switch exp.helper {
+        case .stringArray:
+            let got = ArgumentCoercion.stringArray(valueAny)
+            outcome = compareCoerced(
+                got: got.map { JSONValue.array($0.map { .string($0) }) },
+                expect: exp.expect
+            )
+        case .int:
+            let got = ArgumentCoercion.int(valueAny)
+            outcome = compareCoerced(got: got.map { JSONValue.number(Double($0)) }, expect: exp.expect)
+        case .bool:
+            let got = ArgumentCoercion.bool(valueAny)
+            outcome = compareCoerced(got: got.map { JSONValue.bool($0) }, expect: exp.expect)
+        }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: outcome.passed ? .passed : .failed,
+            notes: [outcome.note],
+            modelId: modelId
+        )
+    }
+
+    private static func compareCoerced(
+        got: JSONValue?,
+        expect: JSONValue?
+    ) -> (passed: Bool, note: String) {
+        switch (got, expect) {
+        case (nil, nil), (nil, .null?), (.null?, nil):
+            return (true, "coerced: nil (matches expectation)")
+        case (let g?, let e?) where jsonValuesEqual(g, e):
+            return (true, "coerced: \(g)")
+        default:
+            return (false, "coerced: \(String(describing: got)), expected: \(String(describing: expect))")
+        }
+    }
+
+    /// Structural equality on `JSONValue`. Handles the
+    /// number/string/bool leaves the coercion suite produces.
+    private static func jsonValuesEqual(_ a: JSONValue, _ b: JSONValue) -> Bool {
+        switch (a, b) {
+        case (.null, .null): return true
+        case (.bool(let x), .bool(let y)): return x == y
+        case (.number(let x), .number(let y)): return x == y
+        case (.string(let x), .string(let y)): return x == y
+        case (.array(let x), .array(let y)):
+            guard x.count == y.count else { return false }
+            return zip(x, y).allSatisfy { jsonValuesEqual($0.0, $0.1) }
+        case (.object(let x), .object(let y)):
+            guard x.keys.sorted() == y.keys.sorted() else { return false }
+            return x.allSatisfy { key, value in
+                guard let other = y[key] else { return false }
+                return jsonValuesEqual(value, other)
+            }
+        default: return false
+        }
+    }
+
+    // MARK: - Request validation domain
+
+    /// Pure-data evaluator for `domain == "request_validation"`. Pins
+    /// the accept/reject decision of `RequestValidator.unsupportedSamplerReason`
+    /// for the (`n`, `response_format.type`) tuple.
+    private static func runRequestValidationCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let exp = testCase.expect.requestValidation else {
+            return Self.errored(
+                testCase,
+                label: label,
+                modelId: modelId,
+                note: "missing `expect.requestValidation`"
+            )
+        }
+        let reason = RequestValidator.unsupportedSamplerReason(
+            n: exp.n,
+            responseFormatType: exp.responseFormatType
+        )
+        var passed = true
+        var notes: [String] = []
+        if exp.expectAccept {
+            if let reason {
+                passed = false
+                notes.append("expected accept, got reject: \(reason)")
+            } else {
+                notes.append("accepted (as expected)")
+            }
+        } else {
+            guard let reason else {
+                passed = false
+                notes.append("expected reject, got accept")
+                return .terminal(
+                    id: testCase.id,
+                    label: label,
+                    domain: testCase.domain,
+                    outcome: .failed,
+                    notes: notes,
+                    modelId: modelId
+                )
+            }
+            notes.append("rejected: \(reason)")
+            if let needle = exp.expectReasonContains, !reason.contains(needle) {
+                passed = false
+                notes.append("expected reason to contain '\(needle)'")
+            }
+        }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: passed ? .passed : .failed,
+            notes: notes,
+            modelId: modelId
+        )
     }
 
     // MARK: - Helpers

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -70,10 +70,27 @@ public enum EvalRunner {
     private static func runOne(_ testCase: EvalCase, modelId: String) async -> EvalCaseReport {
         let label = testCase.label ?? testCase.id
 
-        // Today the only domain is preflight. New domains add a
-        // `case` arm here and stay separate top-level functions —
-        // mixing them into one runner gets messy fast.
-        guard testCase.domain == "preflight" else {
+        switch testCase.domain {
+        case "preflight":
+            break  // fall through to the existing preflight body below
+        case "schema":
+            return runSchemaCase(testCase, modelId: modelId)
+        case "tools", "streaming", "contract":
+            // Scaffolded domains — runner implementation lives in a
+            // follow-up so cases can be authored against the format
+            // without forcing a heavyweight ChatEngine entry point
+            // into the public OsaurusCore surface yet.
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .skipped,
+                notes: [
+                    "domain '\(testCase.domain)' runner not yet implemented in this build."
+                ],
+                modelId: modelId
+            )
+        default:
             return .terminal(
                 id: testCase.id,
                 label: label,
@@ -141,6 +158,67 @@ public enum EvalRunner {
             modelId: modelId,
             latencyMs: observed.latencyMs
         )
+    }
+
+    // MARK: - Schema domain
+
+    /// Pure-data evaluator for the `schema` domain. Drives
+    /// `SchemaValidator.validate` against a canned schema/args pair so
+    /// SchemaValidator regressions (added rules: oneOf/anyOf, items,
+    /// pattern, min/max) get caught without needing a real LLM.
+    /// Always main-actor-safe — no engine state touched.
+    private static func runSchemaCase(_ testCase: EvalCase, modelId: String) -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+        guard let expectation = testCase.expect.schema else {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: ["schema case missing `expect.schema` block"],
+                modelId: modelId
+            )
+        }
+        let argsAny = jsonValueToAny(expectation.arguments)
+        let result = SchemaValidator.validate(
+            arguments: argsAny,
+            against: expectation.schema
+        )
+        var notes: [String] = []
+        var passed = (result.isValid == expectation.expectValid)
+        if !result.isValid, let msg = result.errorMessage {
+            notes.append("validator: \(msg)")
+        }
+        if let expectField = expectation.expectField {
+            if result.field != expectField {
+                passed = false
+                notes.append(
+                    "field mismatch: expected '\(expectField)', got '\(result.field ?? "nil")'"
+                )
+            }
+        }
+        return .terminal(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            outcome: passed ? .passed : .failed,
+            notes: notes,
+            modelId: modelId
+        )
+    }
+
+    /// Convert a `JSONValue` (decoded from the case JSON) into the
+    /// `Any` shape `SchemaValidator.validate` consumes. Mirrors the
+    /// private `JSONValue.foundationValue` extension in SchemaValidator.
+    private static func jsonValueToAny(_ value: JSONValue) -> Any {
+        switch value {
+        case .null: return NSNull()
+        case .bool(let b): return b
+        case .number(let n): return n
+        case .string(let s): return s
+        case .array(let arr): return arr.map { jsonValueToAny($0) }
+        case .object(let obj): return obj.mapValues { jsonValueToAny($0) }
+        }
     }
 
     // MARK: - Helpers

--- a/Packages/OsaurusEvals/Suites/ArgumentCoercion/bool-rejects-arbitrary-string.json
+++ b/Packages/OsaurusEvals/Suites/ArgumentCoercion/bool-rejects-arbitrary-string.json
@@ -1,0 +1,14 @@
+{
+  "id": "argument_coercion.bool-rejects-arbitrary-string",
+  "domain": "argument_coercion",
+  "label": "coercion • bool rejects strings outside the known vocabulary (returns nil)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "argumentCoercion": {
+      "helper": "bool",
+      "value": "maybe",
+      "expect": null
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ArgumentCoercion/bool-yes.json
+++ b/Packages/OsaurusEvals/Suites/ArgumentCoercion/bool-yes.json
@@ -1,0 +1,14 @@
+{
+  "id": "argument_coercion.bool-yes",
+  "domain": "argument_coercion",
+  "label": "coercion • 'YES' coerces to true (case-insensitive vocabulary)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "argumentCoercion": {
+      "helper": "bool",
+      "value": "YES",
+      "expect": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ArgumentCoercion/int-from-string.json
+++ b/Packages/OsaurusEvals/Suites/ArgumentCoercion/int-from-string.json
@@ -1,0 +1,14 @@
+{
+  "id": "argument_coercion.int-from-string",
+  "domain": "argument_coercion",
+  "label": "coercion • '42' (a string) coerces to integer 42",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "argumentCoercion": {
+      "helper": "int",
+      "value": "42",
+      "expect": 42
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ArgumentCoercion/string-array-from-json-string.json
+++ b/Packages/OsaurusEvals/Suites/ArgumentCoercion/string-array-from-json-string.json
@@ -1,0 +1,14 @@
+{
+  "id": "argument_coercion.string-array-from-json-string",
+  "domain": "argument_coercion",
+  "label": "coercion • '[\"a\",\"b\"]' (a JSON-encoded string) coerces to [\"a\",\"b\"]",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "argumentCoercion": {
+      "helper": "stringArray",
+      "value": "[\"a\",\"b\"]",
+      "expect": ["a", "b"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PrefixHash/delimiter-collision-safe.json
+++ b/Packages/OsaurusEvals/Suites/PrefixHash/delimiter-collision-safe.json
@@ -1,0 +1,18 @@
+{
+  "id": "prefix_hash.delimiter-collision-safe",
+  "domain": "prefix_hash",
+  "label": "prefix_hash • a tool name containing the delimiter does not collide with two tools",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "prefixHash": {
+      "systemContent": "sys",
+      "toolNames": ["a,b"],
+      "compareTo": {
+        "systemContent": "sys",
+        "toolNames": ["a", "b"]
+      },
+      "expectEqual": false
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PrefixHash/deterministic.json
+++ b/Packages/OsaurusEvals/Suites/PrefixHash/deterministic.json
@@ -1,0 +1,18 @@
+{
+  "id": "prefix_hash.deterministic-stability",
+  "domain": "prefix_hash",
+  "label": "prefix_hash • same inputs produce the same hash (regression pin)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "prefixHash": {
+      "systemContent": "You are a helpful assistant.",
+      "toolNames": ["search", "browse"],
+      "compareTo": {
+        "systemContent": "You are a helpful assistant.",
+        "toolNames": ["search", "browse"]
+      },
+      "expectEqual": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PrefixHash/tool-order-invariant.json
+++ b/Packages/OsaurusEvals/Suites/PrefixHash/tool-order-invariant.json
@@ -1,0 +1,18 @@
+{
+  "id": "prefix_hash.tool-order-invariant",
+  "domain": "prefix_hash",
+  "label": "prefix_hash • tool list order does not change the hash",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "prefixHash": {
+      "systemContent": "sys",
+      "toolNames": ["alpha", "beta", "gamma"],
+      "compareTo": {
+        "systemContent": "sys",
+        "toolNames": ["gamma", "alpha", "beta"]
+      },
+      "expectEqual": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/RequestValidation/default-accepted.json
+++ b/Packages/OsaurusEvals/Suites/RequestValidation/default-accepted.json
@@ -1,0 +1,12 @@
+{
+  "id": "request_validation.default-accepted",
+  "domain": "request_validation",
+  "label": "request_validation • default request (no n, no response_format) is accepted",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "requestValidation": {
+      "expectAccept": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/RequestValidation/json-object-accepted.json
+++ b/Packages/OsaurusEvals/Suites/RequestValidation/json-object-accepted.json
@@ -1,0 +1,13 @@
+{
+  "id": "request_validation.json-object-accepted",
+  "domain": "request_validation",
+  "label": "request_validation • response_format=json_object is supported",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "requestValidation": {
+      "responseFormatType": "json_object",
+      "expectAccept": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/RequestValidation/json-schema-rejected.json
+++ b/Packages/OsaurusEvals/Suites/RequestValidation/json-schema-rejected.json
@@ -1,0 +1,14 @@
+{
+  "id": "request_validation.json-schema-rejected",
+  "domain": "request_validation",
+  "label": "request_validation • response_format=json_schema rejected (structured outputs not supported)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "requestValidation": {
+      "responseFormatType": "json_schema",
+      "expectAccept": false,
+      "expectReasonContains": "json_schema"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/RequestValidation/n-greater-than-one-rejected.json
+++ b/Packages/OsaurusEvals/Suites/RequestValidation/n-greater-than-one-rejected.json
@@ -1,0 +1,14 @@
+{
+  "id": "request_validation.n-greater-than-one-rejected",
+  "domain": "request_validation",
+  "label": "request_validation • n>1 rejected with HTTP 400 (no batched completions)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "requestValidation": {
+      "n": 2,
+      "expectAccept": false,
+      "expectReasonContains": "n"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Schema/coerces-stringified-array.json
+++ b/Packages/OsaurusEvals/Suites/Schema/coerces-stringified-array.json
@@ -1,0 +1,25 @@
+{
+  "id": "schema.coerces-stringified-array-to-native",
+  "domain": "schema",
+  "label": "schema • stringified array auto-unwrapped to native (browser_do regression)",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "schema": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": { "type": "object" }
+          }
+        },
+        "required": ["actions"]
+      },
+      "arguments": {
+        "actions": "[{\"action\": \"type\", \"ref\": \"E10\"}, {\"action\": \"click\", \"ref\": \"E11\"}]"
+      },
+      "expectValid": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Schema/minimum-bound.json
+++ b/Packages/OsaurusEvals/Suites/Schema/minimum-bound.json
@@ -1,0 +1,26 @@
+{
+  "id": "schema.minimum-bound-rejected",
+  "domain": "schema",
+  "label": "schema • numeric minimum constraint enforcement",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "schema": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": ["count"]
+      },
+      "arguments": {
+        "count": 0
+      },
+      "expectValid": false,
+      "expectField": "count"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Schema/oneof-string-or-int.json
+++ b/Packages/OsaurusEvals/Suites/Schema/oneof-string-or-int.json
@@ -1,0 +1,27 @@
+{
+  "id": "schema.oneof-string-or-int",
+  "domain": "schema",
+  "label": "schema • oneOf first-match accepts either branch",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "schema": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "integer", "minimum": 0 }
+            ]
+          }
+        },
+        "required": ["value"]
+      },
+      "arguments": {
+        "value": "hello"
+      },
+      "expectValid": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/StreamingHint/encode-args-with-quotes.json
+++ b/Packages/OsaurusEvals/Suites/StreamingHint/encode-args-with-quotes.json
@@ -1,0 +1,13 @@
+{
+  "id": "streaming_hint.encode-args-with-quotes",
+  "domain": "streaming_hint",
+  "label": "streaming_hint • encodeArgs round-trips JSON with quotes/newlines intact",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "streamingHint": {
+      "op": "encodeArgs",
+      "payload": "{\"query\": \"line one\\nline two\", \"limit\": 5}"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/StreamingHint/encode-done-roundtrip.json
+++ b/Packages/OsaurusEvals/Suites/StreamingHint/encode-done-roundtrip.json
@@ -1,0 +1,16 @@
+{
+  "id": "streaming_hint.encode-done-roundtrip",
+  "domain": "streaming_hint",
+  "label": "streaming_hint • encodeDone preserves all four payload fields",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "streamingHint": {
+      "op": "encodeDone",
+      "callId": "call_abc123",
+      "name": "search_memory",
+      "arguments": "{\"query\":\"alpha\"}",
+      "result": "{\"ok\":true,\"result\":{\"hits\":2}}"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/StreamingHint/encode-roundtrip.json
+++ b/Packages/OsaurusEvals/Suites/StreamingHint/encode-roundtrip.json
@@ -1,0 +1,13 @@
+{
+  "id": "streaming_hint.encode-roundtrip",
+  "domain": "streaming_hint",
+  "label": "streaming_hint • encode/decode round-trip on a tool name",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "streamingHint": {
+      "op": "encode",
+      "payload": "search_memory"
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ToolEnvelope/failure-timeout-retryable.json
+++ b/Packages/OsaurusEvals/Suites/ToolEnvelope/failure-timeout-retryable.json
@@ -1,0 +1,21 @@
+{
+  "id": "tool_envelope.failure-timeout-retryable",
+  "domain": "tool_envelope",
+  "label": "tool_envelope • timeout failures default to retryable=true",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "toolEnvelope": {
+      "builder": "failure",
+      "kind": "timeout",
+      "message": "Tool exceeded the 120s execution budget.",
+      "tool": "shell",
+      "expectKeys": {
+        "ok": false,
+        "kind": "timeout",
+        "tool": "shell",
+        "retryable": true
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ToolEnvelope/failure-tool-not-found.json
+++ b/Packages/OsaurusEvals/Suites/ToolEnvelope/failure-tool-not-found.json
@@ -1,0 +1,21 @@
+{
+  "id": "tool_envelope.failure-tool-not-found",
+  "domain": "tool_envelope",
+  "label": "tool_envelope • failure(toolNotFound) carries the right discriminator",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "toolEnvelope": {
+      "builder": "failure",
+      "kind": "tool_not_found",
+      "message": "Tool 'browse' is not available in this session.",
+      "tool": "browse",
+      "expectKeys": {
+        "ok": false,
+        "kind": "tool_not_found",
+        "tool": "browse",
+        "retryable": false
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ToolEnvelope/success-text.json
+++ b/Packages/OsaurusEvals/Suites/ToolEnvelope/success-text.json
@@ -1,0 +1,18 @@
+{
+  "id": "tool_envelope.success-text",
+  "domain": "tool_envelope",
+  "label": "tool_envelope • success(text:) carries ok=true and the tool name",
+  "query": "",
+  "fixtures": {},
+  "expect": {
+    "toolEnvelope": {
+      "builder": "successText",
+      "text": "Found 3 results.",
+      "tool": "search",
+      "expectKeys": {
+        "ok": true,
+        "tool": "search"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Drop-in endpoints for existing tools:
 | Anthropic | `http://127.0.0.1:1337/anthropic/v1/messages` |
 | Ollama    | `http://127.0.0.1:1337/api/chat`              |
 
-All prefixes supported (`/v1`, `/api`, `/v1/api`). Full function calling with streaming tool call deltas. See [OpenAI API Guide](docs/OpenAI_API_GUIDE.md) for tool calling, streaming, and SDK examples. Building a macOS app that connects to Osaurus? See the [Shared Configuration Guide](docs/SHARED_CONFIGURATION_GUIDE.md).
+All prefixes supported (`/v1`, `/api`, `/v1/api`). Full function calling with streaming tool call deltas. `/chat/completions` keeps **strict OpenAI semantics** — it returns `tool_calls` and the client executes them, so Osaurus drops in cleanly behind harnesses (Cursor, OpenWebUI, Continue, Aider) that already manage their own tool loop. For server-side autonomous loops use `POST /agents/{id}/run`; to expose Osaurus tools to remote MCP harnesses use `/mcp/tools` + `/mcp/call`. See [OpenAI API Guide](docs/OpenAI_API_GUIDE.md) for tool calling, streaming, and SDK examples. Building a macOS app that connects to Osaurus? See the [Shared Configuration Guide](docs/SHARED_CONFIGURATION_GUIDE.md).
 
 ## CLI
 

--- a/docs/OpenAI_API_GUIDE.md
+++ b/docs/OpenAI_API_GUIDE.md
@@ -38,6 +38,10 @@ Example response:
 
 Generate chat completions using the specified model.
 
+> **Tool calling:** `/chat/completions` follows **strict OpenAI semantics** — when the model emits `tool_calls`, the response (or final SSE chunk) returns those calls and the **client is expected to execute them and POST the results back** in the next request. Osaurus deliberately does **not** auto-execute tools on this endpoint so it can serve as a drop-in backend for harnesses that already manage their own tool loop (Cursor, OpenWebUI, Continue, Aider, etc.).
+>
+> If you want server-side autonomous loops, use `POST /agents/{id}/run` (it executes tools, manages iteration budget, and streams hint/done frames). If you want to expose Osaurus tools to a remote model harness, use the MCP endpoints (`GET /mcp/tools`, `POST /mcp/call`).
+
 #### Non-streaming Request
 
 ```bash
@@ -240,6 +244,25 @@ Notes and limitations:
 2. Assistant must return arguments as a JSON‑escaped string. The server also tolerates a nested `parameters` object and normalizes it.
 3. The parser accepts common wrappers like code fences and an `assistant:` prefix.
 4. `tool_choice` supports `"auto"`, `"none"`, and a specific function target object.
+5. **Strict OpenAI semantics**: `/chat/completions` returns the model's `tool_calls` and stops — it does not execute them server-side. The client must run the tools and POST the results back in the next request. For autonomous server-side tool loops, use `POST /agents/{id}/run` instead.
+
+### Server-side autonomous tool loops: `POST /agents/{id}/run`
+
+When you want Osaurus to execute tools on your behalf (manage the iteration budget, stream tool-execution hints, and only return when the model is done), use the agent run endpoint. This is the path the in-app chat UI uses.
+
+- Each pending `tool_call` is executed against the registered `ToolRegistry` (sandbox, folder, MCP, plugin tools — everything the agent has access to).
+- Independent tool calls within a single model turn run **in parallel**.
+- The loop is capped at 30 iterations; if the budget is exhausted while still requesting tools, a notice is appended to the stream so the client sees a clear reason rather than a silent stop.
+- Honors client-supplied `tools` (merged with the agent's always-loaded set) and `tool_choice` (defaults to `"auto"` when tools are present).
+
+### Aggregating Osaurus tools through MCP
+
+The Model Context Protocol endpoints let any MCP-aware harness (e.g. Cursor, Claude Desktop with MCP plugins) connect and discover Osaurus tools without committing to the agent endpoint:
+
+- `GET /mcp/tools` — list registered tools as MCP `Tool` definitions
+- `POST /mcp/call` — invoke a tool by name with structured arguments
+
+Combine `/chat/completions` (your harness's own tool loop) with `/mcp/tools` + `/mcp/call` (Osaurus tool surface) to keep both sides authoritative.
 
 ### Session Reuse (KV Cache)
 
@@ -265,32 +288,17 @@ curl http://127.0.0.1:1337/v1/chat/completions \
 
 Keep `session_id` stable per conversation and per model.
 
-### Prefix Caching and `cache_hint`
+### Prefix Caching and `prefix_hash`
 
-The server maintains a content-aware **prefix cache** keyed by a hash of the system prompt and tool definitions. When consecutive requests share the same context, the KV cache from the prefix is reused, skipping redundant prefill computation.
+KV cache reuse across requests is **automatic and content-addressed** — Osaurus delegates prefix cache management to vmlx-swift-lm's `CacheCoordinator`. Two requests that share the same prefix tokens (system prompt, tools, prior turns) automatically share the cached KV blocks. There is no client-side opt-in or cache key to manage.
 
-The computed `prefix_hash` is returned in every response (both streaming chunks and non-streaming):
+For visibility, every response carries a `prefix_hash` field — a stable hash of the system prompt + tool names that produced this generation. Clients can use it to detect when the system prefix changed across requests:
 
 ```json
 { "prefix_hash": "a1b2c3d4e5f67890..." }
 ```
 
-To explicitly control prefix cache matching, pass `cache_hint` in the request body. When provided, the server uses this value as the cache key instead of computing one:
-
-```bash
-curl http://127.0.0.1:1337/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "llama-3.2-3b-instruct",
-    "cache_hint": "a1b2c3d4e5f67890",
-    "messages": [
-      {"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "Hello"}
-    ]
-  }'
-```
-
-This is useful for API clients that want to guarantee cache hits across requests with identical context.
+`prefix_hash` is informational only — passing it back to the server has no effect. Keep `session_id` stable per conversation so chat history and preflight bookkeeping group correctly; cache reuse itself does not depend on it.
 
 ### Chat Templates
 
@@ -647,7 +655,7 @@ Example response:
 
 1. **Model Availability**: Only models that have been downloaded through the Osaurus UI will be available via the API.
 
-2. **Performance**: The first request to a model loads it; subsequent requests skip this step. Concurrent same-model requests share a single forward pass via vmlx-swift-lm's `BatchEngine` continuous batching. Prefix caching is available to API clients via `cache_hint` / `prefix_hash`, but prefix caches are only precomputed by the UI warm-up flow — API requests read existing prefix caches but do not create new ones. Use `session_id` for multi-turn KV cache reuse across requests.
+2. **Performance**: The first request to a model loads it; subsequent requests skip this step. Concurrent same-model requests share a single forward pass via vmlx-swift-lm's `BatchEngine` continuous batching. Multi-turn KV cache reuse is automatic and content-addressed via vmlx's `CacheCoordinator` — repeated prefixes (system prompt, tools, prior turns) are matched without any client opt-in. The `prefix_hash` response field is informational; `session_id` groups history but is not a cache key.
 
 3. **Memory Management**: Models are loaded into memory on demand and automatically unloaded when no chat window references them. KV cache geometry (paged for global attention, rotating for sliding-window, SSM state for hybrid models) is owned by vmlx-swift-lm's `CacheCoordinator`, which sizes each tier per model. Configure the model eviction policy in Settings > Local Inference > Model Management.
 


### PR DESCRIPTION
## Summary

For a typical workload (one user, one local 30B model, mixed chat + tool calls):

Memory: ~3–5 GB lower peak on long-context turns.
Wall-clock: ~10–30% faster on multi-tool turns; ~1% slower TTFT when JSON-mode is enabled; otherwise unchanged.
Reliability: noticeably lower failure rate on long thinking sessions (keepalive) and on flaky upstream remotes (connect retry).
Operability: /health now exposes per-model contention, and every error response is OpenAI-shape JSON for uniform client parsing.
The single biggest decision is the TurboQuant 3/3 default. If you ever observe quality regressions, dropping back to defaultKVMode: .none (vmlx's old default) is a one-line revert in ModelRuntime.buildCacheCoordinatorConfig.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
