### PR TITLE
feat: jang_config.json chat metadata + LFM false-thinking-block fix

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -952,6 +952,7 @@ extension ModelManager {
         cachedLocalModels = nil
         localModelsCacheLock.unlock()
         LocalReasoningCapability.invalidate()
+        LocalGenerationDefaults.invalidate()
     }
 
     /// Discover locally downloaded models. Cached until invalidated by model download/delete.

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -2,25 +2,39 @@
 //  LocalGenerationDefaults.swift
 //  osaurus
 //
-//  Reads `generation_config.json` from a locally-installed model bundle and
-//  surfaces the sampling defaults (temperature / top_p / top_k / repetition_
-//  penalty) so osaurus can honor them when the OpenAI-wire request omits
-//  the corresponding field.
+//  Reads sampling defaults from a locally-installed model bundle and
+//  surfaces them (temperature / top_p / top_k / repetition_penalty) so
+//  osaurus can honor them when the OpenAI-wire request omits the
+//  corresponding field.
 //
-//  Hugging Face ships these defaults alongside every instruction-tuned
-//  checkpoint. Ignoring them serves, e.g., Qwen 3.5 397B-A17B at 0.7
-//  temperature when its training recipe specifies 0.6, or Gemma-4 26B-A4B
-//  with top_k disabled when the recipe specifies top_k=64. vmlx's
-//  `GenerationConfigFile` (Libraries/MLXLMCommon/GenerationConfigFile.swift)
-//  only decodes `eos_token_id` from this file, so reading sampling fields
-//  is osaurus's job.
+//  Two sources are consulted, in priority order:
 //
-//  JANG / JANGTQ bundles that ship a `generation_config.json` are read like
-//  any other model. Bundles that don't ship one (some JANG snapshots) fall
-//  back to vmlx defaults (the caller supplies those) — we do NOT chase
-//  `jang_config.source_model.name` to re-resolve here; that's an
-//  indirection LocalReasoningCapability already does for chat templates
-//  and would couple cache invalidation between the two caches.
+//    1. `jang_config.json > chat > sampling_defaults` — present on JANG /
+//       JANGTQ bundles that ship the newer chat-metadata schema (DSV4,
+//       Kimi K2.6, newer Gemma-4 / Qwen-3.6 JANG snapshots). These are
+//       authoritative for JANG converters — the DSV4 `convert_dsv4_jangtq.py`
+//       reads `inference/generate.py` defaults directly and stamps them
+//       here, which may differ from the source model's generic
+//       `generation_config.json` (e.g. DSV4 uses temp=0.6, while the
+//       upstream HF config specifies temp=1.0).
+//
+//    2. `generation_config.json` — Hugging Face's standard sampling-default
+//       file, present on every instruction-tuned checkpoint regardless of
+//       quantization. vmlx's `GenerationConfigFile`
+//       (Libraries/MLXLMCommon/GenerationConfigFile.swift) only decodes
+//       `eos_token_id` from this file, so reading the sampling fields is
+//       osaurus's job.
+//
+//  Ignoring these served, e.g., Qwen 3.5 397B-A17B at 0.7 temperature when
+//  its training recipe specifies 0.6, Gemma-4 26B-A4B with top_k disabled
+//  when the recipe specifies top_k=64, and (critically) DSV4-Flash-JANGTQ
+//  with the upstream HF config's temp=1.0 rather than DeepSeek's tuned
+//  temp=0.6 shipped in the JANG config.
+//
+//  JANG bundles that ship BOTH files get the JANG chat.sampling_defaults
+//  applied first, with any fields the JANG config omits filled from
+//  generation_config.json. Bundles that ship neither return `.empty` and
+//  the caller's hardcoded fallback ladder takes over.
 //
 
 import Foundation
@@ -76,11 +90,30 @@ enum LocalGenerationDefaults {
         return load(fromDirectory: dir)
     }
 
-    /// Read `generation_config.json` from an on-disk model directory. Exposed
-    /// so integration tests can exercise the full filesystem path without
-    /// needing `ModelManager.findInstalledModel` to resolve a real install.
-    /// Returns `.empty` if the file is missing, unreadable, or malformed.
+    /// Read sampling defaults from an on-disk model directory. Checks both
+    /// `jang_config.json` (authoritative when present) and
+    /// `generation_config.json` (HF fallback), merging so that every field
+    /// is filled from whichever file sets it first. Exposed so integration
+    /// tests can exercise the full filesystem path without needing
+    /// `ModelManager.findInstalledModel` to resolve a real install.
+    /// Returns `.empty` if neither file is present or all parses fail.
     static func load(fromDirectory dir: URL) -> Defaults {
+        let jang = loadJangConfigDefaults(at: dir)
+        let hf = loadHuggingFaceGenerationDefaults(at: dir)
+        return merge(primary: jang, fallback: hf)
+    }
+
+    private static func loadJangConfigDefaults(at dir: URL) -> Defaults {
+        let url = dir.appendingPathComponent("jang_config.json")
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return .empty
+        }
+        return parseJangConfig(data: data)
+    }
+
+    private static func loadHuggingFaceGenerationDefaults(at dir: URL) -> Defaults {
         let url = dir.appendingPathComponent("generation_config.json")
         guard FileManager.default.fileExists(atPath: url.path),
             let data = try? Data(contentsOf: url)
@@ -99,12 +132,47 @@ enum LocalGenerationDefaults {
         return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
     }
 
-    /// Pure, testable JSON parse. Extracted so unit tests can feed in
-    /// bundled fixtures without touching the filesystem.
+    // MARK: - Parsers
+
+    /// Pure, testable JSON parse for HuggingFace `generation_config.json`.
+    /// Extracted so unit tests can feed in bundled fixtures without touching
+    /// the filesystem.
     static func parse(data: Data) -> Defaults {
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return .empty
         }
+        return extractSamplingFields(from: obj)
+    }
+
+    /// Pure, testable JSON parse for `jang_config.json`'s
+    /// `chat.sampling_defaults` sub-object. The JANG schema (per
+    /// `jang-tools/dsv4_prune/convert_dsv4_jangtq.py`) places sampling
+    /// defaults at a dotted path — anything else at the top level
+    /// (quantization, source_model, crack_surgery, etc.) is ignored by
+    /// this function.
+    static func parseJangConfig(data: Data) -> Defaults {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let chat = root["chat"] as? [String: Any],
+            let sampling = chat["sampling_defaults"] as? [String: Any]
+        else {
+            return .empty
+        }
+        return extractSamplingFields(from: sampling)
+    }
+
+    /// Merge two `Defaults` values field-by-field, preferring `primary` for
+    /// any field it sets. Used to overlay `jang_config.json` over
+    /// `generation_config.json`.
+    static func merge(primary: Defaults, fallback: Defaults) -> Defaults {
+        var out = primary
+        if out.temperature == nil { out.temperature = fallback.temperature }
+        if out.topP == nil { out.topP = fallback.topP }
+        if out.topK == nil { out.topK = fallback.topK }
+        if out.repetitionPenalty == nil { out.repetitionPenalty = fallback.repetitionPenalty }
+        return out
+    }
+
+    private static func extractSamplingFields(from obj: [String: Any]) -> Defaults {
         var out = Defaults()
         if let t = readFloat(obj["temperature"]) { out.temperature = t }
         if let p = readFloat(obj["top_p"]) { out.topP = p }

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -73,6 +73,14 @@ enum LocalGenerationDefaults {
         guard let dir = localDirectory(forModelId: modelId) else {
             return .empty
         }
+        return load(fromDirectory: dir)
+    }
+
+    /// Read `generation_config.json` from an on-disk model directory. Exposed
+    /// so integration tests can exercise the full filesystem path without
+    /// needing `ModelManager.findInstalledModel` to resolve a real install.
+    /// Returns `.empty` if the file is missing, unreadable, or malformed.
+    static func load(fromDirectory dir: URL) -> Defaults {
         let url = dir.appendingPathComponent("generation_config.json")
         guard FileManager.default.fileExists(atPath: url.path),
             let data = try? Data(contentsOf: url)

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -1,0 +1,121 @@
+//
+//  LocalGenerationDefaults.swift
+//  osaurus
+//
+//  Reads `generation_config.json` from a locally-installed model bundle and
+//  surfaces the sampling defaults (temperature / top_p / top_k / repetition_
+//  penalty) so osaurus can honor them when the OpenAI-wire request omits
+//  the corresponding field.
+//
+//  Hugging Face ships these defaults alongside every instruction-tuned
+//  checkpoint. Ignoring them serves, e.g., Qwen 3.5 397B-A17B at 0.7
+//  temperature when its training recipe specifies 0.6, or Gemma-4 26B-A4B
+//  with top_k disabled when the recipe specifies top_k=64. vmlx's
+//  `GenerationConfigFile` (Libraries/MLXLMCommon/GenerationConfigFile.swift)
+//  only decodes `eos_token_id` from this file, so reading sampling fields
+//  is osaurus's job.
+//
+//  JANG / JANGTQ bundles that ship a `generation_config.json` are read like
+//  any other model. Bundles that don't ship one (some JANG snapshots) fall
+//  back to vmlx defaults (the caller supplies those) — we do NOT chase
+//  `jang_config.source_model.name` to re-resolve here; that's an
+//  indirection LocalReasoningCapability already does for chat templates
+//  and would couple cache invalidation between the two caches.
+//
+
+import Foundation
+
+enum LocalGenerationDefaults {
+
+    struct Defaults: Sendable, Equatable {
+        var temperature: Float?
+        var topP: Float?
+        var topK: Int?
+        var repetitionPenalty: Float?
+
+        static let empty = Defaults()
+    }
+
+    private static nonisolated let lock = NSLock()
+    private static nonisolated(unsafe) var cache: [String: Defaults] = [:]
+
+    /// Resolve and cache the sampling defaults for `modelId`. The id may be
+    /// either the short picker name or the full `ORG/REPO` identifier; both
+    /// are supported via `ModelManager.findInstalledModel`.
+    static func defaults(forModelId modelId: String) -> Defaults {
+        let key = modelId.lowercased()
+        lock.lock()
+        if let hit = cache[key] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        let resolved = load(modelId: modelId)
+
+        lock.lock()
+        cache[key] = resolved
+        lock.unlock()
+        return resolved
+    }
+
+    /// Invalidate the cache. Call when models are added/removed so the next
+    /// lookup re-reads the file from disk.
+    static func invalidate() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+
+    // MARK: - File loading
+
+    private static func load(modelId: String) -> Defaults {
+        guard let dir = localDirectory(forModelId: modelId) else {
+            return .empty
+        }
+        let url = dir.appendingPathComponent("generation_config.json")
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return .empty
+        }
+        return parse(data: data)
+    }
+
+    private static func localDirectory(forModelId modelId: String) -> URL? {
+        guard let found = ModelManager.findInstalledModel(named: modelId) else {
+            return nil
+        }
+        let parts = found.id.split(separator: "/").map(String.init)
+        let base = DirectoryPickerService.effectiveModelsDirectory()
+        return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
+    }
+
+    /// Pure, testable JSON parse. Extracted so unit tests can feed in
+    /// bundled fixtures without touching the filesystem.
+    static func parse(data: Data) -> Defaults {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .empty
+        }
+        var out = Defaults()
+        if let t = readFloat(obj["temperature"]) { out.temperature = t }
+        if let p = readFloat(obj["top_p"]) { out.topP = p }
+        if let k = readInt(obj["top_k"]) { out.topK = k }
+        if let rp = readFloat(obj["repetition_penalty"]) { out.repetitionPenalty = rp }
+        return out
+    }
+
+    /// JSON numbers land as `NSNumber` once bridged through `JSONSerialization`.
+    /// Int/Double are interchangeable at the Obj-C layer but Swift's `as? Double`
+    /// rejects `NSNumber` backed by an integer literal, so we funnel through
+    /// the explicit helpers instead of a single conditional cast.
+    private static func readFloat(_ any: Any?) -> Float? {
+        if let n = any as? NSNumber { return n.floatValue }
+        return nil
+    }
+
+    private static func readInt(_ any: Any?) -> Int? {
+        if let n = any as? NSNumber { return n.intValue }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -680,6 +680,7 @@ actor ModelRuntime {
         temperature: Float,
         maxTokens: Int,
         topP: Float,
+        topK: Int = 0,
         repetitionPenalty: Float?,
         stopSequences: [String] = []
     ) -> MLXLMCommon.GenerateParameters {
@@ -687,6 +688,7 @@ actor ModelRuntime {
             maxTokens: maxTokens,
             temperature: temperature,
             topP: topP,
+            topK: topK,
             repetitionPenalty: repetitionPenalty,
             repetitionContextSize: 20,
             extraStopStrings: stopSequences

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -500,7 +500,27 @@ actor ModelRuntime {
             await ModelLease.shared.release(modelName)
         }
 
-        return GenerationEventMapper.map(events: prepared.stream)
+        // vmlx's reasoning-parser heuristic routes ANY model_type that
+        // doesn't match `gemma4` / `mistral` / `gemma` prefixes to
+        // `think_xml` with `startInReasoning: true`. For families that
+        // genuinely don't emit `<think>` tags (LFM2 / LFM2-MoE, classic
+        // Llama instruct checkpoints, etc.), that mis-classification
+        // surfaces the model's first bytes as `.reasoning` events and
+        // the osaurus UI renders them in the think pane. Passing
+        // `supportsThinking: false` makes the event mapper re-route
+        // `.reasoning` → `.tokens` for those models so the content
+        // lands in the response block where it belongs.
+        //
+        // Detection relies on `LocalReasoningCapability.analyze`, which
+        // reads the model's chat template text for `<think>` / `<|think|>`
+        // / `enable_thinking` signals. Templates with none of those
+        // markers flip `supportsThinking` to false here.
+        let supportsThinking = LocalReasoningCapability
+            .capability(forModelId: modelId).supportsThinking
+        return GenerationEventMapper.map(
+            events: prepared.stream,
+            supportsThinking: supportsThinking
+        )
     }
 
     // MARK: - New message-based (OpenAI ChatMessage) APIs

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -30,8 +30,27 @@ enum GenerationEventMapper {
 
     /// Map a `Generation` stream into the typed `ModelRuntimeEvent` stream
     /// callers (HTTP handlers, ChatView, plugin runners) consume.
+    ///
+    /// `supportsThinking`: when `false`, any `.reasoning(text)` emitted by
+    /// vmlx is re-classified as visible `.tokens(text)` instead of a hidden
+    /// CoT delta. This closes the "non-thinking model's response appears in
+    /// the thinking block" UI bug caused by vmlx's `LLMModelFactory`
+    /// reasoning-parser heuristic: any model_type that doesn't match the
+    /// `gemma4` / `mistral` / `gemma` prefixes falls through to
+    /// `think_xml`, including `lfm2*`, `lfm2_moe*`, and other families that
+    /// don't actually emit `<think>` tags. With `startInReasoning: true`
+    /// baked into `think_xml`, the model's FIRST output byte is labelled
+    /// reasoning by vmlx's `ReasoningParser`, which then shows up as a
+    /// thinking block in the osaurus UI even though the model never
+    /// produced one. Coercing to `.tokens` preserves the content (the
+    /// reasoning text IS the user-facing answer in this case) and moves it
+    /// to the correct UI affordance.
+    ///
+    /// When `supportsThinking` is `true` (default), events flow through
+    /// unchanged — `.reasoning` stays `.reasoning`.
     static func map(
-        events: AsyncStream<Generation>
+        events: AsyncStream<Generation>,
+        supportsThinking: Bool = true
     ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
         AsyncThrowingStream<ModelRuntimeEvent, Error> { continuation in
             let task = Task {
@@ -56,7 +75,20 @@ enum GenerationEventMapper {
 
                     case .reasoning(let text):
                         guard !text.isEmpty else { continue }
-                        continuation.yield(.reasoning(text))
+                        if supportsThinking {
+                            continuation.yield(.reasoning(text))
+                        } else {
+                            // Model doesn't actually emit CoT — vmlx's
+                            // heuristic mis-classified the output. Route
+                            // it through as visible tokens so the UI
+                            // renders it as the response, not a think
+                            // pane.
+                            if firstChunk {
+                                firstChunk = false
+                                InferenceProgressManager.shared.prefillDidFinishAsync()
+                            }
+                            continuation.yield(.tokens(text))
+                        }
 
                     case .toolCall(let call):
                         let argsJSON = serializeArguments(

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -168,11 +168,20 @@ struct MLXBatchAdapter {
             maxBatchSize: maxBatchSize
         )
 
+        // Honor the model's shipped sampling defaults (Hugging Face
+        // `generation_config.json`) when the OpenAI-wire request omits a
+        // field. Without this overlay osaurus served, e.g., Qwen 3.5 397B
+        // at 0.7 temperature when its recipe specifies 0.6, and Gemma-4
+        // 26B-A4B with top_k disabled when the recipe specifies top_k=64.
+        // Explicit client values still win — the `?? modelDefaults`
+        // ordering only applies when `generation.*` is nil.
+        let modelDefaults = LocalGenerationDefaults.defaults(forModelId: modelName)
         let mlxParams = ModelRuntime.makeGenerateParameters(
-            temperature: generation.temperature ?? 0.7,
+            temperature: generation.temperature ?? modelDefaults.temperature ?? 0.7,
             maxTokens: generation.maxTokens,
-            topP: generation.topPOverride ?? runtime.topP,
-            repetitionPenalty: generation.repetitionPenalty,
+            topP: generation.topPOverride ?? modelDefaults.topP ?? runtime.topP,
+            topK: modelDefaults.topK ?? 0,
+            repetitionPenalty: generation.repetitionPenalty ?? modelDefaults.repetitionPenalty,
             stopSequences: stopSequences
         )
 

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -24,9 +24,15 @@ struct GenerationEventMapperTests {
         }
     }
 
-    private func collect(events: [Generation]) async throws -> [ModelRuntimeEvent] {
+    private func collect(
+        events: [Generation],
+        supportsThinking: Bool = true
+    ) async throws -> [ModelRuntimeEvent] {
         let stream = makeStream(events)
-        let mapped = GenerationEventMapper.map(events: stream)
+        let mapped = GenerationEventMapper.map(
+            events: stream,
+            supportsThinking: supportsThinking
+        )
         var out: [ModelRuntimeEvent] = []
         for try await ev in mapped { out.append(ev) }
         return out
@@ -136,6 +142,79 @@ struct GenerationEventMapperTests {
             if case .reasoning(let s) = $0 { return s } else { return nil }
         }
         #expect(reasoning == ["kept"])
+    }
+
+    // MARK: - supportsThinking: false coercion (LFM false-thinking-block fix)
+
+    /// When the caller asserts the model does NOT emit CoT (e.g. LFM2,
+    /// LFM2-MoE, classic Llama instruct), vmlx's reasoning-parser heuristic
+    /// may still route the model's first bytes through `.reasoning` events
+    /// because `think_xml` with `startInReasoning: true` is the fallback
+    /// branch. The mapper must re-label those as `.tokens` so the osaurus UI
+    /// renders them in the response block, not the think pane.
+    @Test func nonThinking_reasoning_coerces_to_tokens() async throws {
+        let events: [Generation] = [
+            .reasoning("The capital of France is Paris."),
+        ]
+        let out = try await collect(events: events, supportsThinking: false)
+
+        // No `.reasoning` events should leak out — every reasoning delta
+        // gets re-classified as visible tokens.
+        let reasoningPieces: [String] = out.compactMap {
+            if case .reasoning(let s) = $0 { return s } else { return nil }
+        }
+        #expect(reasoningPieces.isEmpty)
+
+        let tokenPieces: [String] = out.compactMap {
+            if case .tokens(let s) = $0 { return s } else { return nil }
+        }
+        #expect(tokenPieces == ["The capital of France is Paris."])
+    }
+
+    @Test func nonThinking_mixed_chunks_and_reasoning_interleave_as_tokens() async throws {
+        // In practice vmlx rarely emits a mix of `.chunk` and `.reasoning`
+        // for a non-thinking model — but if it does (e.g. a template that
+        // briefly enters / exits the reasoning parser's state), the
+        // coerced output must preserve the ORIGINAL delivery order so the
+        // answer reads coherently.
+        let events: [Generation] = [
+            .reasoning("Let me think. "),
+            .chunk("The answer is 42."),
+            .reasoning(" Done."),
+        ]
+        let out = try await collect(events: events, supportsThinking: false)
+
+        let tokenPieces: [String] = out.compactMap {
+            if case .tokens(let s) = $0 { return s } else { return nil }
+        }
+        // Order preserved: reasoning → chunk → reasoning, all coerced to tokens.
+        #expect(tokenPieces == ["Let me think. ", "The answer is 42.", " Done."])
+    }
+
+    @Test func nonThinking_still_skips_empty_reasoning_deltas() async throws {
+        let events: [Generation] = [
+            .reasoning(""),
+            .reasoning("kept"),
+            .reasoning(""),
+        ]
+        let out = try await collect(events: events, supportsThinking: false)
+        let tokenPieces: [String] = out.compactMap {
+            if case .tokens(let s) = $0 { return s } else { return nil }
+        }
+        // Empty reasoning deltas are filtered BEFORE the coercion branch,
+        // matching `.chunk` behaviour for empty strings.
+        #expect(tokenPieces == ["kept"])
+    }
+
+    @Test func supportsThinking_true_is_default_and_forwards_reasoning_unchanged() async throws {
+        // Guard against a future caller that flips the default accidentally —
+        // the public overload must keep `supportsThinking: true` as its default.
+        let events: [Generation] = [.reasoning("think-text")]
+        let out = try await collect(events: events)  // uses default
+        let reasoning: [String] = out.compactMap {
+            if case .reasoning(let s) = $0 { return s } else { return nil }
+        }
+        #expect(reasoning == ["think-text"])
     }
 
     @Test func toolCall_serialization_failure_emits_error_envelope() async throws {

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -1,0 +1,145 @@
+//
+//  LocalGenerationDefaultsTests.swift
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("LocalGenerationDefaults parse")
+struct LocalGenerationDefaultsTests {
+
+    private static func defaults(fromJSON json: String) -> LocalGenerationDefaults.Defaults {
+        LocalGenerationDefaults.parse(data: Data(json.utf8))
+    }
+
+    @Test("Gemma-4 26B-A4B-it: temperature=1.0, top_k=64, top_p=0.95")
+    func gemma4() {
+        // Copied verbatim from
+        // models--mlx-community--gemma-4-26b-a4b-it-4bit/snapshots/.../generation_config.json
+        let d = Self.defaults(fromJSON: #"""
+            {
+              "bos_token_id": 2,
+              "do_sample": true,
+              "eos_token_id": [1, 106, 50],
+              "pad_token_id": 0,
+              "temperature": 1.0,
+              "top_k": 64,
+              "top_p": 0.95,
+              "transformers_version": "5.5.0.dev0"
+            }
+            """#)
+        #expect(d.temperature == 1.0)
+        #expect(d.topK == 64)
+        #expect(d.topP == 0.95)
+        #expect(d.repetitionPenalty == nil)
+    }
+
+    @Test("Qwen 3.5 397B-A17B-JANG_2L: temperature=0.6")
+    func qwen35() {
+        // Qwen 3.5 specifies LOWER temperature than the 0.7 osaurus used to
+        // hardcode; this is the headline reason the feature exists.
+        let d = Self.defaults(fromJSON: #"""
+            {
+              "bos_token_id": 248044,
+              "do_sample": true,
+              "eos_token_id": [248046, 248044],
+              "pad_token_id": 248044,
+              "temperature": 0.6,
+              "top_k": 20,
+              "top_p": 0.95,
+              "transformers_version": "4.57.0.dev0"
+            }
+            """#)
+        #expect(d.temperature == 0.6)
+        #expect(d.topK == 20)
+        #expect(d.topP == 0.95)
+    }
+
+    @Test("MiniMax M2.7: top_k=40")
+    func minimax() {
+        let d = Self.defaults(fromJSON: #"""
+            {
+              "bos_token_id": 200019,
+              "do_sample": true,
+              "eos_token_id": 200020,
+              "temperature": 1.0,
+              "top_p": 0.95,
+              "top_k": 40,
+              "transformers_version": "4.46.1"
+            }
+            """#)
+        #expect(d.temperature == 1.0)
+        #expect(d.topK == 40)
+        #expect(d.topP == 0.95)
+    }
+
+    @Test("Nemotron-Cascade-2: no sampling fields, only EOS")
+    func nemotronNoSamplingFields() {
+        // Real Nemotron generation_config.json ships nothing but EOS/BOS/pad.
+        // We should return `.empty` sampling defaults so the caller's existing
+        // fallback ladder (request → runtime → hardcoded 0.7) kicks in.
+        let d = Self.defaults(fromJSON: #"""
+            {
+              "_from_model_config": true,
+              "bos_token_id": 1,
+              "eos_token_id": [2, 11],
+              "pad_token_id": 0,
+              "transformers_version": "4.55.4"
+            }
+            """#)
+        #expect(d.temperature == nil)
+        #expect(d.topK == nil)
+        #expect(d.topP == nil)
+        #expect(d.repetitionPenalty == nil)
+    }
+
+    @Test("Mistral-Small-4: sampling fields absent — defaults empty")
+    func mistralNoSamplingFields() {
+        let d = Self.defaults(fromJSON: #"""
+            {
+              "bos_token_id": 1,
+              "eos_token_id": 2,
+              "max_length": 1048576,
+              "pad_token_id": 11,
+              "transformers_version": "5.3.0.dev0"
+            }
+            """#)
+        #expect(d == .empty)
+    }
+
+    @Test("repetition_penalty field honored when present")
+    func repetitionPenaltyFieldHonored() {
+        // Uncommon but permitted — HF spec allows repetition_penalty in
+        // generation_config. Make sure we don't drop it on the floor.
+        let d = Self.defaults(fromJSON: #"""
+            {"temperature": 0.8, "repetition_penalty": 1.05}
+            """#)
+        #expect(d.temperature == 0.8)
+        #expect(d.repetitionPenalty == 1.05)
+    }
+
+    @Test("Integer-typed temperature decodes as Float")
+    func integerTemperatureDecodes() {
+        // Some generators emit `"temperature": 1` (no decimal). Without the
+        // NSNumber conversion helper, Swift's `as? Double` rejects these.
+        let d = Self.defaults(fromJSON: #"""
+            {"temperature": 1, "top_k": 40}
+            """#)
+        #expect(d.temperature == 1.0)
+        #expect(d.topK == 40)
+    }
+
+    @Test("Malformed JSON returns empty defaults, does not throw")
+    func malformedJsonReturnsEmpty() {
+        let d = Self.defaults(fromJSON: #"not json"#)
+        #expect(d == .empty)
+    }
+
+    @Test("Empty object returns empty defaults")
+    func emptyObject() {
+        let d = Self.defaults(fromJSON: #"{}"#)
+        #expect(d == .empty)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -260,4 +260,165 @@ struct LocalGenerationDefaultsTests {
             forModelId: "definitely-not-a-real-model-\(UUID().uuidString)")
         #expect(d == .empty)
     }
+
+    // MARK: - jang_config.json chat.sampling_defaults
+
+    /// DSV4-Flash-JANGTQ4: upstream HF config says temp=1.0 but DeepSeek's
+    /// own `inference/generate.py` uses 0.6. The JANG converter stamps the
+    /// latter into `jang_config.json > chat > sampling_defaults`, and
+    /// osaurus should prefer it when present.
+    @Test("jang_config: DSV4 chat.sampling_defaults (temp=0.6)")
+    func jangConfigDSV4() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "model_family": "deepseek_v4",
+              "chat": {
+                "encoder": "encoding_dsv4",
+                "reasoning": {"supported": true, "modes": ["chat", "thinking"]},
+                "tool_calling": {"parser": "dsml"},
+                "sampling_defaults": {
+                  "temperature": 0.6,
+                  "top_p": 0.95,
+                  "max_new_tokens": 300
+                }
+              },
+              "quantization": {"profile": "JANGTQ4"}
+            }
+            """#.utf8))
+        #expect(d.temperature == 0.6)
+        #expect(d.topP == 0.95)
+        #expect(d.topK == nil)
+        #expect(d.repetitionPenalty == nil)
+    }
+
+    @Test("jang_config: all sampling fields populate when present")
+    func jangConfigAllFields() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "chat": {
+                "sampling_defaults": {
+                  "temperature": 0.8,
+                  "top_p": 0.9,
+                  "top_k": 50,
+                  "repetition_penalty": 1.05
+                }
+              }
+            }
+            """#.utf8))
+        #expect(d.temperature == 0.8)
+        #expect(d.topP == 0.9)
+        #expect(d.topK == 50)
+        #expect(d.repetitionPenalty == 1.05)
+    }
+
+    @Test("jang_config: missing chat subtree returns empty")
+    func jangConfigNoChatSubtree() {
+        // Older JANG bundles without chat-metadata — quantization /
+        // source_model / crack_surgery only. Should return empty, not throw.
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "quantization": {"profile": "JANG_2S", "actual_bits": 2.11},
+              "source_model": {"name": "Qwen3.5-122B-A10B"},
+              "format": "jang"
+            }
+            """#.utf8))
+        #expect(d == .empty)
+    }
+
+    @Test("jang_config: sampling_defaults absent but chat present")
+    func jangConfigChatWithoutSampling() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {"chat": {"reasoning": {"supported": true}}}
+            """#.utf8))
+        #expect(d == .empty)
+    }
+
+    @Test("jang_config: malformed JSON returns empty")
+    func jangConfigMalformed() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data("not json".utf8))
+        #expect(d == .empty)
+    }
+
+    // MARK: - merge(primary:fallback:) — overlay semantics
+
+    @Test("merge: primary fills first, fallback fills gaps")
+    func mergePrimaryWinsFallbackFills() {
+        let jang = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: nil, topK: nil, repetitionPenalty: nil)
+        let hf = LocalGenerationDefaults.Defaults(
+            temperature: 1.0, topP: 0.95, topK: 64, repetitionPenalty: nil)
+        let merged = LocalGenerationDefaults.merge(primary: jang, fallback: hf)
+        #expect(merged.temperature == 0.6)
+        #expect(merged.topP == 0.95)
+        #expect(merged.topK == 64)
+    }
+
+    @Test("merge: primary-only fields preserved")
+    func mergePrimaryOnly() {
+        let jang = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: 0.9, topK: 32, repetitionPenalty: 1.05)
+        let merged = LocalGenerationDefaults.merge(
+            primary: jang, fallback: LocalGenerationDefaults.Defaults.empty)
+        #expect(merged.temperature == 0.6)
+        #expect(merged.topP == 0.9)
+        #expect(merged.topK == 32)
+        #expect(merged.repetitionPenalty == 1.05)
+    }
+
+    @Test("merge: fallback-only fields preserved when primary empty")
+    func mergeFallbackOnly() {
+        let hf = LocalGenerationDefaults.Defaults(
+            temperature: 1.0, topP: 0.95, topK: 64, repetitionPenalty: nil)
+        let merged = LocalGenerationDefaults.merge(
+            primary: LocalGenerationDefaults.Defaults.empty, fallback: hf)
+        #expect(merged.temperature == 1.0)
+        #expect(merged.topP == 0.95)
+        #expect(merged.topK == 64)
+    }
+
+    // MARK: - Integration: bundle that ships BOTH files
+
+    @Test("Filesystem: bundle with BOTH jang_config and generation_config merges correctly")
+    func bothFilesMerge() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("osaurus-gencfg-both-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"""
+            {"temperature": 1.0, "top_p": 0.95, "top_k": 64}
+            """#.write(
+                to: tmp.appendingPathComponent("generation_config.json"),
+                atomically: true, encoding: .utf8)
+        try #"""
+            {"chat": {"sampling_defaults": {"temperature": 0.6}}}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        // JANG overrides the one field it sets…
+        #expect(d.temperature == 0.6)
+        // …HF fills the rest.
+        #expect(d.topP == 0.95)
+        #expect(d.topK == 64)
+    }
+
+    @Test("Filesystem: jang_config alone is enough (HF file absent)")
+    func jangOnlyLoad() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("osaurus-gencfg-jang-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"""
+            {"chat": {"sampling_defaults": {"temperature": 0.6, "top_p": 0.95}}}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        #expect(d.temperature == 0.6)
+        #expect(d.topP == 0.95)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -142,4 +142,122 @@ struct LocalGenerationDefaultsTests {
         let d = Self.defaults(fromJSON: #"{}"#)
         #expect(d == .empty)
     }
+
+    // MARK: - Filesystem round-trip (integration)
+
+    /// Write a `generation_config.json` to a scratch directory and verify
+    /// the `load(fromDirectory:)` entry point hits the full filesystem path.
+    /// This protects against silent breakage of the file-lookup side of the
+    /// feature (e.g. mis-named filename, wrong subpath assumption, etc.).
+    @Test("Filesystem round-trip: writes and reads generation_config.json")
+    func filesystemRoundTrip() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("osaurus-gencfg-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let cfg = tmp.appendingPathComponent("generation_config.json")
+        try #"""
+            {"temperature": 0.6, "top_p": 0.9, "top_k": 32}
+            """#.write(to: cfg, atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        #expect(d.temperature == 0.6)
+        #expect(d.topP == 0.9)
+        #expect(d.topK == 32)
+    }
+
+    @Test("Missing generation_config.json returns empty, does not throw")
+    func missingFile() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("osaurus-gencfg-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        #expect(d == .empty)
+    }
+
+    // MARK: - Edge cases for the overlay precedence ladder
+
+    /// Verify the `?? modelDefaults ?? fallback` ladder pattern used in
+    /// `MLXBatchAdapter.generate`. Client-supplied values MUST win over
+    /// model defaults; model defaults win over the hardcoded fallback.
+    ///
+    /// This test documents the exact semantics the adapter relies on — if
+    /// this test fails, the adapter's precedence contract is broken.
+    @Test("Precedence: client wins over model defaults")
+    func clientWinsOverModel() {
+        let modelDefaults = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: 0.95, topK: 20, repetitionPenalty: nil)
+        let clientTemp: Float? = 0.2
+        let clientTopP: Float? = 0.5
+        let serverFallbackTopP: Float = 1.0
+
+        let temp = clientTemp ?? modelDefaults.temperature ?? 0.7
+        let topP = clientTopP ?? modelDefaults.topP ?? serverFallbackTopP
+        let topK = modelDefaults.topK ?? 0
+
+        #expect(temp == 0.2)
+        #expect(topP == 0.5)
+        #expect(topK == 20)
+    }
+
+    @Test("Precedence: model defaults fill omitted client fields")
+    func modelDefaultsFillGaps() {
+        let modelDefaults = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: 0.95, topK: 20, repetitionPenalty: nil)
+        let clientTemp: Float? = nil
+        let clientTopP: Float? = nil
+        let serverFallbackTopP: Float = 1.0
+
+        let temp = clientTemp ?? modelDefaults.temperature ?? 0.7
+        let topP = clientTopP ?? modelDefaults.topP ?? serverFallbackTopP
+        let topK = modelDefaults.topK ?? 0
+
+        #expect(temp == 0.6)
+        #expect(topP == 0.95)
+        #expect(topK == 20)
+    }
+
+    @Test("Precedence: hardcoded fallback when neither client nor model set fields")
+    func hardcodedFallbackWhenBothAbsent() {
+        let modelDefaults = LocalGenerationDefaults.Defaults.empty
+        let clientTemp: Float? = nil
+        let clientTopP: Float? = nil
+        let serverFallbackTopP: Float = 1.0
+
+        let temp = clientTemp ?? modelDefaults.temperature ?? 0.7
+        let topP = clientTopP ?? modelDefaults.topP ?? serverFallbackTopP
+        let topK = modelDefaults.topK ?? 0
+
+        #expect(temp == 0.7)
+        #expect(topP == 1.0)
+        #expect(topK == 0)
+    }
+
+    @Test("Precedence: temperature=0 (greedy) from client is honored, NOT replaced")
+    func greedyDecodingHonored() {
+        // OpenAI clients send `temperature: 0` to request deterministic
+        // greedy decoding. Our overlay uses `??` which treats 0 as a
+        // valid non-nil value — so the model's default should NOT replace it.
+        // This test documents the invariant.
+        let modelDefaults = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: nil, topK: nil, repetitionPenalty: nil)
+        let clientTemp: Float? = 0.0
+
+        let temp = clientTemp ?? modelDefaults.temperature ?? 0.7
+
+        #expect(temp == 0.0)
+    }
+
+    @Test("Cache: defaults(forModelId:) returns empty for unknown model")
+    func unknownModelReturnsEmpty() {
+        // `findInstalledModel` returns nil for a name we definitely didn't
+        // install; the load path must short-circuit to `.empty` without
+        // crashing or reaching the filesystem.
+        let d = LocalGenerationDefaults.defaults(
+            forModelId: "definitely-not-a-real-model-\(UUID().uuidString)")
+        #expect(d == .empty)
+    }
 }


### PR DESCRIPTION
Two features prepping osaurus for the DSV4 / Kimi K2.6 model-family rollout and fixing a user-visible bug already reported on LFM2-class models. **Stacked on top of #932** — review / merge #932 first.

## 1. `jang_config.json > chat > sampling_defaults` support

New JANG / JANGTQ bundles (DSV4-Flash-JANGTQ, Kimi K2.6 JANG snapshots, newer Gemma-4 / Qwen-3.6 JANG converters) stamp authoritative sampling defaults into `jang_config.json`. These can differ from the source model's generic `generation_config.json` — critically, **DSV4's `convert_dsv4_jangtq.py` reads `inference/generate.py` defaults directly and stamps `temperature=0.6`, while upstream HF ships `temperature=1.0`.**

`LocalGenerationDefaults` now consults both files and merges:

1. `jang_config.json > chat > sampling_defaults` (authoritative)
2. `generation_config.json` (HF fallback)

Merge semantics: primary fills first, fallback fills any field the primary omits. A DSV4 bundle with `jang_config` `temp=0.6` and HF `top_k=64` produces `{temp=0.6, top_p=0.95, top_k=64}` — the expected cross-file overlay.

Schema recognised (subset osaurus honors):

```json
{
  "model_family": "deepseek_v4",
  "chat": {
    "sampling_defaults": {
      "temperature": 0.6,
      "top_p": 0.95,
      "top_k": 20,
      "repetition_penalty": 1.05
    }
  }
}
```

Fields outside `chat.sampling_defaults` (quantization, source_model, crack_surgery, architecture, reasoning mode tables, tool_calling parser stamp) are intentionally ignored here — they belong to vmlx's model loader, not osaurus's sampling overlay.

## 2. LFM non-thinking-model false-positive fix

**Bug report:** \"even if the model doesn't support thinking, the response gets rendered in the thinking block.\"

**Root cause:** vmlx's reasoning-parser heuristic (`LLMModelFactory.swift:720-750`) routes ANY `model_type` that doesn't match `gemma4` / `mistral` / `gemma` prefixes to `think_xml` with `startInReasoning: true`. For LFM2 / LFM2-MoE / LFM2.5 (`lfm2*`), classic Llama instruct checkpoints, and other families that genuinely don't emit `<think>` tags, that mis-classification surfaces the model's **first output bytes** as `Generation.reasoning` events — which osaurus's UI renders in the thinking pane.

**Fix:** `GenerationEventMapper.map` grows a `supportsThinking: Bool` parameter (default `true`, backwards compatible). When `false`, `.reasoning(text)` events are re-labelled as `.tokens(text)` so the UI renders them in the response block — preserving delivery order across interleaved events and still filtering empty strings.

`ModelRuntime.generateEventStream` wires this up from `LocalReasoningCapability.capability(forModelId:).supportsThinking`, which reads the model's template text for `<think>` / `<|think|>` / `enable_thinking` markers. Models with none of those → `supportsThinking=false` → coercion engages → thinking block disappears for LFM2 et al.

This is an osaurus-side mitigation for a vmlx heuristic gap. A permanent upstream fix would widen the `none` branch of the reasoning-parser heuristic to cover `lfm2*`, but the osaurus mitigation is correct either way — the source of truth stays the local template capability.

## Test plan

- [x] **LocalGenerationDefaults** — 10 new tests covering DSV4 fixture, full-field population, missing-chat-subtree, malformed JSON, merge overlay semantics, filesystem round-trip for BOTH files / JANG-only
- [x] **GenerationEventMapper** — 4 new tests covering non-thinking coercion, interleaved order preservation, empty-delta filtering, default-value guard
- [x] `swift test --parallel`: **913 / 913 pass** across 121 suites
- [x] `swift build` clean
- [ ] Manual: chat with LFM2-1.5B — verify response renders in response block, NOT thinking pane
- [ ] Manual: chat with DSV4-JANGTQ4 once vmlx ships model_type registration — verify temp=0.6 applies

## Not in this PR (vmlx side)

- `deepseek_v4` model_type registration in `LLMModelFactory`
- DSML tool-call parser (new `.dsml` case in `ToolCallFormat`)
- Widening reasoning-parser heuristic's `.none` branch to include `lfm2*`

Osaurus doesn't need any of those to build / run; when vmlx ships them the PR's wiring picks them up transparently.