### PR TITLE
feat: jang_config.json chat metadata + vmlx bump (DSV4 / Kimi K2.6 / LFM factory fix)

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -29,6 +29,35 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // Detect repeated startup crashes and enter safe mode if needed
         LaunchGuard.checkOnLaunch()
 
+        // vmlx-swift-lm DSV4 cache-mode default. Process-wide env var read
+        // by `LLMModelFactory.dispatchDeepseekV4` at model-load time.
+        //
+        // DSV4-Flash's stock default is `RotatingKVCache(maxSize: 128)` per
+        // layer — fine for FIM / short Q&A but loses prompt visibility on
+        // any decode > 128 tokens, which means any chat conversation /
+        // reasoning-mode trace / multi-turn response drifts off-topic
+        // (live-confirmed 2026-04-25 on DSV4-Flash JANGTQ: thinking traces
+        // produced random SQL queries because the original prompt scrolled
+        // out of attention).
+        //
+        // Setting `DSV4_KV_MODE=full` switches new caches to `KVCacheSimple`
+        // — full attention across the entire prompt + decode. Memory cost
+        // ~360 MB at 8K output (vs. ~6 MB rotating), which is a non-issue
+        // on any machine that can load DSV4 in the first place (79.5 GB+
+        // bundles).
+        //
+        // No effect on non-DSV4 models — vmlx ignores the var unless the
+        // factory dispatch hits the `deepseek_v4` model_type. Setting this
+        // unconditionally at launch is the recommended osaurus-side
+        // operating point per vmlx
+        // `Libraries/MLXLMCommon/BatchEngine/OSAURUS-INTEGRATION.md`
+        // §"DeepSeek-V4 — runtime knobs" (2026-04-25 update). Users who
+        // want the rotating-window memory savings can override by exporting
+        // a different value before launching osaurus.
+        if ProcessInfo.processInfo.environment["DSV4_KV_MODE"] == nil {
+            setenv("DSV4_KV_MODE", "full", 1)
+        }
+
         // Configure as regular app (show Dock icon) by default, or accessory if hidden
         let hideDockIcon = ServerConfigurationStore.load()?.hideDockIcon ?? false
         if hideDockIcon {

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -16,14 +16,29 @@ public enum SystemPromptTemplates {
     /// Default identity used when the user has not configured a base prompt.
     /// Frames the agent as tool-driven so models don't reflexively say
     /// "I cannot do that" when they actually can.
+    ///
+    /// **Tool names are deliberately NOT mentioned here.** Naming `todo` /
+    /// `complete` / `share_artifact` / `clarify` / `capabilities_search`
+    /// in the unconditional identity caused MiniMax M2.7 Small JANGTQ
+    /// (and other low-bit MoE models) to fall into a recitation loop on
+    /// any chat where those tools weren't actually in the request's
+    /// `tools[]` array — the model saw the names in the system prompt,
+    /// expected the schema to back them, found a mismatch, and degenerated
+    /// into emitting tool-spec text from its training distribution
+    /// (live-confirmed 2026-04-25).
+    ///
+    /// Each chat-layer-intercepted tool's how-to lives in the gated
+    /// `agentLoopGuidance` / `capabilityDiscoveryNudge` blocks below,
+    /// which fire ONLY when the corresponding tool is actually resolved
+    /// into the schema. Sandbox-/folder-tool hints are similarly gated
+    /// at their composer call-sites.
     public static let defaultIdentity = """
         You are an Osaurus chat agent running locally on the user's Mac.
 
-        You have a tool registry. Call tools when they raise correctness or \
-        ground a claim in real data; do not narrate intent before acting. \
-        When the task involves more than two obvious steps, write a `todo` \
-        checklist; when you finish, call `complete` with a one-paragraph \
-        summary of what you did and how you verified it.
+        Use the tools available in this conversation when they raise \
+        correctness or ground a claim in real data; do not narrate intent \
+        before acting. If no tools are listed, answer directly from your \
+        own knowledge.
         """
 
     /// Returns the effective base prompt, falling back to `defaultIdentity`

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -2,25 +2,47 @@
 //  LocalGenerationDefaults.swift
 //  osaurus
 //
-//  Reads `generation_config.json` from a locally-installed model bundle and
-//  surfaces the sampling defaults (temperature / top_p / top_k / repetition_
-//  penalty) so osaurus can honor them when the OpenAI-wire request omits
-//  the corresponding field.
+//  Reads sampling defaults from a locally-installed model bundle and
+//  surfaces them (temperature / top_p / top_k / repetition_penalty) so
+//  osaurus can honor them when the OpenAI-wire request omits the
+//  corresponding field.
 //
-//  Hugging Face ships these defaults alongside every instruction-tuned
-//  checkpoint. Ignoring them serves, e.g., Qwen 3.5 397B-A17B at 0.7
-//  temperature when its training recipe specifies 0.6, or Gemma-4 26B-A4B
-//  with top_k disabled when the recipe specifies top_k=64. vmlx's
-//  `GenerationConfigFile` (Libraries/MLXLMCommon/GenerationConfigFile.swift)
-//  only decodes `eos_token_id` from this file, so reading sampling fields
-//  is osaurus's job.
+//  Two sources are consulted, primary → fallback:
 //
-//  JANG / JANGTQ bundles that ship a `generation_config.json` are read like
-//  any other model. Bundles that don't ship one (some JANG snapshots) fall
-//  back to vmlx defaults (the caller supplies those) — we do NOT chase
-//  `jang_config.source_model.name` to re-resolve here; that's an
-//  indirection LocalReasoningCapability already does for chat templates
-//  and would couple cache invalidation between the two caches.
+//    1. `jang_config.json > chat > sampling_defaults` — present on JANG /
+//       JANGTQ bundles that ship the newer chat-metadata schema (DSV4,
+//       Kimi K2.6, newer Gemma-4 / Qwen-3.6 JANG snapshots). These are
+//       authoritative for JANG converters — the DSV4
+//       `convert_dsv4_jangtq.py` reads `inference/generate.py` defaults
+//       directly and stamps them here, which may differ from the source
+//       model's generic `generation_config.json` (e.g. DSV4 uses
+//       temp=0.6, while upstream HF ships temp=1.0).
+//
+//    2. `generation_config.json` — Hugging Face's standard
+//       sampling-defaults file, shipped with every instruction-tuned
+//       checkpoint regardless of quantization format (base MLX, MXFP4,
+//       JANG, JANGTQ, FP16, …). vmlx's `GenerationConfigFile`
+//       (Libraries/MLXLMCommon/GenerationConfigFile.swift) only decodes
+//       `eos_token_id` from this file, so reading the sampling fields is
+//       osaurus's job.
+//
+//  Ignoring these served, e.g., Qwen 3.5 397B-A17B at 0.7 temperature when
+//  its recipe specifies 0.6, Gemma-4 26B-A4B with top_k disabled when the
+//  recipe specifies top_k=64, and (with the new JANG schema)
+//  DSV4-Flash-JANGTQ at upstream's temp=1.0 rather than DeepSeek's tuned
+//  temp=0.6 shipped in the JANG config.
+//
+//  Bundles that ship BOTH files get the JANG `chat.sampling_defaults`
+//  applied first, with any fields the JANG config omits filled from
+//  `generation_config.json`. Bundles that ship neither return `.empty`
+//  and the caller's hardcoded fallback ladder takes over (unchanged from
+//  pre-PR behaviour).
+//
+//  We intentionally do NOT chase `jang_config.source_model.name` to
+//  re-resolve from the source model's own config directory — that
+//  indirection would couple cache invalidation between two caches, and
+//  the JANG converter already stamps whatever defaults it wants honored
+//  into `chat.sampling_defaults` directly.
 //
 
 import Foundation
@@ -76,11 +98,43 @@ enum LocalGenerationDefaults {
         return load(fromDirectory: dir)
     }
 
-    /// Read `generation_config.json` from an on-disk model directory. Exposed
-    /// so integration tests can exercise the full filesystem path without
-    /// needing `ModelManager.findInstalledModel` to resolve a real install.
-    /// Returns `.empty` if the file is missing, unreadable, or malformed.
+    /// Read sampling defaults from an on-disk model directory. Merges two
+    /// sources in priority order, primary → fallback:
+    ///
+    ///   1. `jang_config.json > chat > sampling_defaults` — authoritative
+    ///      when present. JANG / JANGTQ converters (DSV4, Kimi K2.6,
+    ///      newer Gemma-4 / Qwen-3.6 JANG snapshots) stamp
+    ///      training-recipe defaults here that can differ from the
+    ///      upstream HF `generation_config.json`. Per
+    ///      `jang/jang-tools/dsv4_prune/convert_dsv4_jangtq.py`, DSV4's
+    ///      chat.sampling_defaults carries `temperature: 0.6` from
+    ///      `inference/generate.py`, while upstream HF ships `1.0`.
+    ///
+    ///   2. `generation_config.json` — HuggingFace standard, present on
+    ///      every instruction-tuned checkpoint. Fills any field the JANG
+    ///      config left unset.
+    ///
+    /// Exposed so integration tests can exercise the full filesystem path
+    /// without needing `ModelManager.findInstalledModel` to resolve a real
+    /// install. Returns `.empty` if neither file is present or all parses
+    /// fail.
     static func load(fromDirectory dir: URL) -> Defaults {
+        let jang = loadJangConfigDefaults(at: dir)
+        let hf = loadHuggingFaceGenerationDefaults(at: dir)
+        return merge(primary: jang, fallback: hf)
+    }
+
+    private static func loadJangConfigDefaults(at dir: URL) -> Defaults {
+        let url = dir.appendingPathComponent("jang_config.json")
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return .empty
+        }
+        return parseJangConfig(data: data)
+    }
+
+    private static func loadHuggingFaceGenerationDefaults(at dir: URL) -> Defaults {
         let url = dir.appendingPathComponent("generation_config.json")
         guard FileManager.default.fileExists(atPath: url.path),
             let data = try? Data(contentsOf: url)
@@ -99,12 +153,52 @@ enum LocalGenerationDefaults {
         return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
     }
 
-    /// Pure, testable JSON parse. Extracted so unit tests can feed in
-    /// bundled fixtures without touching the filesystem.
+    // MARK: - Parsers
+
+    /// Pure, testable JSON parse for HuggingFace `generation_config.json`.
+    /// Extracted so unit tests can feed in bundled fixtures without touching
+    /// the filesystem.
     static func parse(data: Data) -> Defaults {
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return .empty
         }
+        return extractSamplingFields(from: obj)
+    }
+
+    /// Pure, testable JSON parse for `jang_config.json`'s
+    /// `chat.sampling_defaults` sub-object. The JANG schema (per
+    /// `jang/jang-tools/dsv4_prune/convert_dsv4_jangtq.py`) places sampling
+    /// defaults at a dotted path — everything else at the top level
+    /// (quantization, source_model, crack_surgery, architecture, format,
+    /// chat.reasoning mode tables, chat.tool_calling parser stamp, …) is
+    /// ignored by this function. Those other fields belong to vmlx's model
+    /// loader and tool-parser / reasoning-parser resolvers, not osaurus's
+    /// sampling overlay.
+    static func parseJangConfig(data: Data) -> Defaults {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let chat = root["chat"] as? [String: Any],
+            let sampling = chat["sampling_defaults"] as? [String: Any]
+        else {
+            return .empty
+        }
+        return extractSamplingFields(from: sampling)
+    }
+
+    /// Merge two `Defaults` values field-by-field, preferring `primary` for
+    /// any field it sets. Used to overlay `jang_config.json` over
+    /// `generation_config.json` so a JANG bundle that sets only
+    /// `temperature` gets its temperature plus whatever `top_p` / `top_k`
+    /// the source model's HF config specifies.
+    static func merge(primary: Defaults, fallback: Defaults) -> Defaults {
+        var out = primary
+        if out.temperature == nil { out.temperature = fallback.temperature }
+        if out.topP == nil { out.topP = fallback.topP }
+        if out.topK == nil { out.topK = fallback.topK }
+        if out.repetitionPenalty == nil { out.repetitionPenalty = fallback.repetitionPenalty }
+        return out
+    }
+
+    private static func extractSamplingFields(from obj: [String: Any]) -> Defaults {
         var out = Defaults()
         if let t = readFloat(obj["temperature"]) { out.temperature = t }
         if let p = readFloat(obj["top_p"]) { out.topP = p }

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -8,6 +8,12 @@
 //  middleware so new reasoning model families (JANG, MiniMax, Mistral-Small-4,
 //  etc.) are picked up automatically as long as they ship a chat template.
 //
+//  JANG bundles that omit a chat template entirely — DSV4-Flash is the
+//  canonical case, it ships `encoding/encoding_dsv4.py` instead of a Jinja
+//  template — are detected via a `jang_config.json > chat > reasoning`
+//  fallback so their `.reasoning` events don't get coerced to content by
+//  the #934 mitigation in `ModelRuntime.streamWithTools`.
+//
 
 import Foundation
 
@@ -59,12 +65,23 @@ enum LocalReasoningCapability {
     // MARK: - Detection
 
     private static func detect(modelId: String) -> Capability {
-        guard let dir = localDirectory(forModelId: modelId),
-            let template = readChatTemplate(at: dir)
-        else {
+        guard let dir = localDirectory(forModelId: modelId) else {
             return .none
         }
-        return analyze(template: template)
+        if let template = readChatTemplate(at: dir) {
+            return analyze(template: template)
+        }
+        // Fallback for JANG bundles that ship no chat template (DSV4-Flash
+        // ships `encoding/encoding_dsv4.py` instead; the JANG converter
+        // stamps `has_tokenizer_chat_template: false` plus an authoritative
+        // `chat.reasoning.supported` flag into `jang_config.json`). Without
+        // this fallback, `detect()` returned `.none` for DSV4 → `supportsThinking
+        // = false` → PR #934's `streamWithTools` coercion merged the model's
+        // `.reasoning` deltas into content, wiping out the thinking split.
+        if let cap = readJangConfigReasoning(at: dir) {
+            return cap
+        }
+        return .none
     }
 
     /// Pure, testable template analysis.
@@ -117,6 +134,64 @@ enum LocalReasoningCapability {
         let parts = found.id.split(separator: "/").map(String.init)
         let base = DirectoryPickerService.effectiveModelsDirectory()
         return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
+    }
+
+    /// Read `jang_config.json > chat > reasoning` and surface it as a
+    /// `Capability`. Returns nil when the file is missing, malformed, or
+    /// doesn't carry the `chat.reasoning` sub-object — the caller should
+    /// then return `.none`. Exposed (`static`, not `private`) so unit tests
+    /// can exercise fixtures without writing to disk.
+    ///
+    /// Schema this recognises (a subset of the DSV4-Flash converter's
+    /// output; newer JANG bundles are free to add more fields and we'll
+    /// ignore them forward-compatibly):
+    ///
+    ///     {
+    ///       "chat": {
+    ///         "reasoning": {
+    ///           "supported": true,
+    ///           "modes": ["chat", "thinking"],
+    ///           "default_mode": "chat",
+    ///           "thinking_start": "<think>",
+    ///           "thinking_end": "</think>"
+    ///         }
+    ///       }
+    ///     }
+    ///
+    /// Note: we do NOT set `hasEnableThinkingKwarg: true` here — that flag
+    /// is template-driven (does the Jinja template branch on
+    /// `enable_thinking | default(...)`). DSV4's chat-encoder module
+    /// reads a `thinking_mode` argument directly, so the kwarg flag
+    /// stays false; callers plumb thinking-on/off through
+    /// `modelOptions["disableThinking"]` as usual and vmlx's
+    /// `additionalContext` passes it to whatever renderer the model uses.
+    static func readJangConfigReasoning(at dir: URL) -> Capability? {
+        let url = dir.appendingPathComponent("jang_config.json")
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+        return analyzeJangConfig(data: data)
+    }
+
+    /// Pure, testable JSON parse for `jang_config.json`'s
+    /// `chat.reasoning` sub-object. Separated from `readJangConfigReasoning`
+    /// so unit tests can feed in fixtures without a filesystem.
+    static func analyzeJangConfig(data: Data) -> Capability? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let chat = root["chat"] as? [String: Any],
+            let reasoning = chat["reasoning"] as? [String: Any],
+            let supported = reasoning["supported"] as? Bool,
+            supported
+        else {
+            return nil
+        }
+        return Capability(
+            supportsThinking: true,
+            hasEnableThinkingKwarg: false,
+            templateInjectsThinkTag: false
+        )
     }
 
     private static func readChatTemplate(at dir: URL) -> String? {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -602,6 +602,14 @@ public actor ModelRuntime {
             // `.toolCall` event, so we keep iterating until the stream
             // finishes naturally instead of bailing on the first invocation.
             var pendingTools: [ServiceToolInvocation] = []
+            // Defensive scrubber for orphan `<think>` / `</think>` markers
+            // that vmlx's reasoning parser leaves in `.chunk` text when a
+            // low-bit MoE checkpoint emits a closer without a matching
+            // opener (or vice versa). Only engaged when the model
+            // declares thinking support — non-thinking models route
+            // through the untouched passthrough so legitimate `<think>`
+            // text in code blocks stays intact.
+            var scrubber = ThinkTagScrubber()
             do {
                 for try await ev in events {
                     if Task.isCancelled {
@@ -610,7 +618,10 @@ public actor ModelRuntime {
                     }
                     switch ev {
                     case .tokens(let s):
-                        if !s.isEmpty { continuation.yield(s) }
+                        if !s.isEmpty {
+                            let cleaned = modelSupportsThinking ? scrubber.scrub(s) : s
+                            if !cleaned.isEmpty { continuation.yield(cleaned) }
+                        }
                     case .reasoning(let s):
                         if !s.isEmpty {
                             if modelSupportsThinking {
@@ -634,6 +645,13 @@ public actor ModelRuntime {
                         )
                     }
                 }
+                // Drain any tail bytes the scrubber held back as a
+                // partial-tag candidate. If the stream ended without a
+                // following chunk to complete the candidate, those bytes
+                // are real content (the model just happened to end on
+                // `<` or `<th` etc.) and must be surfaced.
+                let tail = scrubber.flush()
+                if !tail.isEmpty { continuation.yield(tail) }
                 do {
                     try Self.throwIfTools(pendingTools)
                     continuation.finish()

--- a/Packages/OsaurusCore/Services/ModelRuntime/ThinkTagScrubber.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ThinkTagScrubber.swift
@@ -1,0 +1,110 @@
+//
+//  ThinkTagScrubber.swift
+//  osaurus
+//
+//  Defensive post-filter for `Generation.chunk(String)` text on models
+//  that have `LocalReasoningCapability.supportsThinking == true`.
+//
+//  vmlx's `ReasoningParser` only toggles state on a SEEN opener:
+//  - In `content` mode it scans for `<think>` and switches to reasoning.
+//  - In `reasoning` mode it scans for `</think>` and switches to content.
+//
+//  When a low-bit MoE checkpoint (MiniMax M2.7 Small JANGTQ 2-bit, GLM
+//  JANG_2L, DSV4-Flash JANGTQ_2L, Kimi K2.6 REAP-30 JANGTQ_2L, etc.)
+//  emits an ORPHAN `</think>` while the parser is in `content` mode —
+//  i.e. without a matching `<think>` opener earlier — vmlx's parser
+//  leaves the literal tag in the buffer and surfaces it as part of
+//  `.content(text)` → osaurus receives `Generation.chunk("…</think>…")`
+//  → tag leaks into the visible response. Symmetric leak for orphan
+//  `<think>` while in reasoning mode.
+//
+//  This scrubber buffers up to `max(startTag, endTag).count - 1` bytes
+//  at the chunk-stream tail (mirroring vmlx's partial-tag handling) so
+//  literal `<think>` / `</think>` substrings get dropped even when the
+//  model emits them across two adjacent tokens (e.g. `<` + `think>`).
+//
+//  Only engaged when `modelSupportsThinking == true` — non-thinking
+//  models route through `ModelRuntime.streamWithTools`'s untouched
+//  passthrough so legitimate `<think>` text in code blocks / technical
+//  prose isn't molested.
+//
+
+import Foundation
+
+/// Stateful, streaming-safe substring scrubber for `<think>` / `</think>`.
+/// Mirrors the buffering pattern of vmlx's `ReasoningParser` but only
+/// REMOVES the tags — never toggles a state machine. The actual reasoning
+/// split is owned by vmlx; this is a defensive layer that catches
+/// orphan-tag leakage from low-bit MoE checkpoints whose token stream
+/// confuses the parser's state machine.
+struct ThinkTagScrubber {
+
+    private static let openTag = "<think>"
+    private static let closeTag = "</think>"
+    private static let holdLength = max(openTag.count, closeTag.count) - 1  // 7
+
+    /// Buffered tail that MIGHT be the prefix of an `<think>` or `</think>`
+    /// tag we're about to receive in the next chunk. Drained on flush.
+    private var pending: String = ""
+
+    /// Feed a chunk text. Returns the scrubbed text safe to forward to
+    /// downstream consumers. May return an empty string if the entire
+    /// input was buffered as a partial-tag candidate.
+    mutating func scrub(_ chunk: String) -> String {
+        // Concatenate any buffered tail with the new chunk so split-token
+        // tags (`<` + `think>`) get caught at the boundary.
+        var working = pending + chunk
+        pending = ""
+
+        // Remove every WHOLE occurrence of either tag. Cheap String API
+        // — both tags are short literals, no regex compile cost.
+        if working.contains(Self.openTag) {
+            working = working.replacingOccurrences(of: Self.openTag, with: "")
+        }
+        if working.contains(Self.closeTag) {
+            working = working.replacingOccurrences(of: Self.closeTag, with: "")
+        }
+
+        // Hold the tail bytes that COULD be the start of a tag arriving
+        // in the next chunk. We only need to hold `holdLength` bytes
+        // (one less than the longest tag) because anything shorter than
+        // that can't be a full match yet, and anything longer would
+        // already have been matched above.
+        guard !working.isEmpty else { return "" }
+
+        if let suffix = Self.maybeTagPrefix(of: working) {
+            pending = String(suffix)
+            return String(working.dropLast(suffix.count))
+        }
+        return working
+    }
+
+    /// Drain any held tail. Called once when the upstream stream
+    /// finishes; whatever's left in the buffer is yielded as-is because
+    /// no further chunks will arrive to complete a tag.
+    mutating func flush() -> String {
+        let drained = pending
+        pending = ""
+        return drained
+    }
+
+    /// Returns the longest suffix of `text` that could be a prefix of
+    /// either `<think>` or `</think>`. `nil` when no tail bytes need
+    /// to be held back. Operates on Swift `Character` (grapheme
+    /// clusters) so it never splits a multi-byte emoji that happens
+    /// to start with `<` (the `<` ASCII byte isn't a leading byte for
+    /// any non-ASCII grapheme, but the grapheme-cluster discipline keeps
+    /// us safe for any future tag rename).
+    private static func maybeTagPrefix(of text: String) -> Substring? {
+        let maxHold = min(holdLength, text.count)
+        guard maxHold > 0 else { return nil }
+        // Walk longest-first so we hold the largest plausible partial tag.
+        for length in stride(from: maxHold, through: 1, by: -1) {
+            let suffix = text.suffix(length)
+            if Self.openTag.hasPrefix(suffix) || Self.closeTag.hasPrefix(suffix) {
+                return suffix
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
@@ -1,0 +1,136 @@
+//
+//  SystemPromptDefaultIdentityTests.swift
+//
+//  Regression: the unconditional `defaultIdentity` block in
+//  `SystemPromptTemplates` must NOT name any chat-layer-intercepted tools
+//  (`todo`, `complete`, `share_artifact`, `clarify`, `capabilities_search`)
+//  or sandbox / folder tools. Naming them in the always-on system prompt
+//  caused MiniMax M2.7 Small JANGTQ (and other low-bit MoE models) to fall
+//  into a recitation loop on chats where those tools weren't actually in
+//  the request's `tools[]` array — the model saw the names in the system
+//  prompt, expected the schema to back them, found a mismatch, and
+//  degenerated into emitting tool-spec text from its training distribution
+//  (live-confirmed 2026-04-25).
+//
+//  The how-to lives in the gated `agentLoopGuidance` /
+//  `capabilityDiscoveryNudge` / sandbox / folder blocks, which fire ONLY
+//  when the corresponding tool is actually resolved into the schema.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("SystemPromptTemplates default identity tool-name leak guard")
+struct SystemPromptDefaultIdentityTests {
+
+    /// The set of tool names that MUST NOT appear in `defaultIdentity`.
+    /// Each one has a separately-gated guidance block that only fires
+    /// when the tool is actually in the resolved schema.
+    private static let leakedToolNames: [String] = [
+        // Chat-layer intercepted (gated by `agentLoopGuidance`)
+        "todo",
+        "complete",
+        "clarify",
+        "share_artifact",
+        // Capability discovery (gated by `capabilityDiscoveryNudge`)
+        "capabilities_search",
+        "capabilities_load",
+        // Sandbox tools (gated by sandbox-section composer)
+        "sandbox_read_file",
+        "sandbox_edit_file",
+        "sandbox_write_file",
+        "sandbox_find_files",
+        "sandbox_search_files",
+        "sandbox_list_directory",
+        "sandbox_run_script",
+        "sandbox_exec",
+        "sandbox_exec_background",
+        "sandbox_pip_install",
+        "sandbox_npm_install",
+        "sandbox_install",
+        // Folder tools (gated by `folderContext` composer)
+        "file_tree",
+        "file_search",
+        "file_read",
+        "file_edit",
+        "file_write",
+        "file_move",
+        "file_copy",
+        "file_delete",
+        "dir_create",
+        // Misc tools the model might know from training but that osaurus
+        // does not register by default
+        "render_chart",
+        "search_memory",
+    ]
+
+    @Test("defaultIdentity does not name any chat-layer or sandbox tool")
+    func defaultIdentityDoesNotLeakToolNames() {
+        let identity = SystemPromptTemplates.defaultIdentity
+        for name in Self.leakedToolNames {
+            #expect(
+                !identity.contains(name),
+                "defaultIdentity must not mention `\(name)` — it leaked tool names cause low-bit MoE models (MiniMax M2.7 Small JANGTQ) to recite tool-spec text in a loop when the tool isn't in the request's tools[] array. Move the mention into the gated agentLoopGuidance / capabilityDiscoveryNudge / sandbox / folderContext block."
+            )
+        }
+    }
+
+    /// Empty / whitespace base prompt → falls back to defaultIdentity.
+    /// Same leak guard applies after the fallback path.
+    @Test("effectiveBasePrompt('') falls back to defaultIdentity and stays clean")
+    func emptyBasePromptStaysClean() {
+        let resolved = SystemPromptTemplates.effectiveBasePrompt("")
+        for name in Self.leakedToolNames {
+            #expect(
+                !resolved.contains(name),
+                "effectiveBasePrompt('') leaked `\(name)` via the defaultIdentity fallback"
+            )
+        }
+    }
+
+    @Test("effectiveBasePrompt(whitespace) also stays clean")
+    func whitespaceBasePromptStaysClean() {
+        let resolved = SystemPromptTemplates.effectiveBasePrompt("   \n\t  ")
+        for name in Self.leakedToolNames {
+            #expect(!resolved.contains(name))
+        }
+    }
+
+    /// User-customised base prompt is passed through verbatim — we do NOT
+    /// scrub their content. This test confirms the `?:` semantic in
+    /// `effectiveBasePrompt` so a future refactor doesn't accidentally
+    /// auto-strip user content.
+    @Test("user-supplied base prompt is passed through unchanged")
+    func userBasePromptIsRespected() {
+        let userPrompt = "I am a custom assistant. Use `my_special_tool` always."
+        let resolved = SystemPromptTemplates.effectiveBasePrompt(userPrompt)
+        #expect(resolved == userPrompt)
+    }
+
+    /// Sanity: the gated `agentLoopGuidance` block IS allowed to mention
+    /// the four chat-layer-intercepted tool names, since it only fires
+    /// when those tools are present in the resolved schema (per
+    /// `SystemPromptComposer.swift:265-277`). This test guards against a
+    /// future "clean everything" refactor that strips the names from
+    /// EVERYWHERE — that would break the actual agent-loop UX.
+    @Test("agentLoopGuidance still names todo / complete / clarify / share_artifact")
+    func agentLoopGuidanceStillCarriesTheNames() {
+        let block = SystemPromptTemplates.agentLoopGuidance
+        #expect(block.contains("todo"))
+        #expect(block.contains("complete"))
+        #expect(block.contains("clarify"))
+        #expect(block.contains("share_artifact"))
+    }
+
+    /// Same sanity for the capability-discovery nudge — still names
+    /// `capabilities_search` / `capabilities_load` because that block is
+    /// gated on `capabilities_search` actually being in the tools[] array.
+    @Test("capabilityDiscoveryNudge still names capabilities_search / capabilities_load")
+    func capabilityNudgeStillCarriesTheNames() {
+        let block = SystemPromptTemplates.capabilityDiscoveryNudge
+        #expect(block.contains("capabilities_search"))
+        #expect(block.contains("capabilities_load"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -287,4 +287,210 @@ struct LocalGenerationDefaultsTests {
         )
         #expect(d == .empty)
     }
+
+    // MARK: - jang_config.json chat.sampling_defaults
+
+    /// DSV4-Flash-JANGTQ: upstream HF `generation_config.json` specifies
+    /// temperature=1.0, but DeepSeek's own `inference/generate.py` uses 0.6,
+    /// and `convert_dsv4_jangtq.py` stamps the latter into
+    /// `jang_config.json > chat > sampling_defaults`. osaurus must prefer it.
+    @Test("jang_config: DSV4 chat.sampling_defaults (temp=0.6)")
+    func jangConfigDSV4() {
+        // Trimmed to the relevant keys; real jang_config.json carries
+        // quantization + source_model + crack_surgery + more.
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "model_family": "deepseek_v4",
+              "chat": {
+                "encoder": "encoding_dsv4",
+                "reasoning": {"supported": true, "modes": ["chat", "thinking"]},
+                "tool_calling": {"parser": "dsml"},
+                "sampling_defaults": {
+                  "temperature": 0.6,
+                  "top_p": 0.95,
+                  "max_new_tokens": 300
+                }
+              },
+              "quantization": {"profile": "JANGTQ4"}
+            }
+            """#.utf8))
+        #expect(d.temperature == 0.6)
+        #expect(d.topP == 0.95)
+        // `max_new_tokens` is not a GenerationParameters field we honor at
+        // the sampling layer; intentionally ignored.
+        #expect(d.topK == nil)
+        #expect(d.repetitionPenalty == nil)
+    }
+
+    @Test("jang_config: all sampling fields populate when present")
+    func jangConfigAllFields() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "chat": {
+                "sampling_defaults": {
+                  "temperature": 0.8,
+                  "top_p": 0.9,
+                  "top_k": 50,
+                  "repetition_penalty": 1.05
+                }
+              }
+            }
+            """#.utf8))
+        #expect(d.temperature == 0.8)
+        #expect(d.topP == 0.9)
+        #expect(d.topK == 50)
+        #expect(d.repetitionPenalty == 1.05)
+    }
+
+    @Test("jang_config: older JANG bundles without chat subtree return empty")
+    func jangConfigNoChatSubtree() {
+        // Older JANG schema — only quantization + source_model + crack_surgery.
+        // No chat metadata. Must return empty, not throw.
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {
+              "quantization": {"profile": "JANG_2S", "actual_bits": 2.11},
+              "source_model": {"name": "Qwen3.5-122B-A10B"},
+              "format": "jang"
+            }
+            """#.utf8))
+        #expect(d == .empty)
+    }
+
+    @Test("jang_config: chat present but no sampling_defaults returns empty")
+    func jangConfigChatWithoutSampling() {
+        // Schema transition: a bundle might have `chat.reasoning` and
+        // `chat.tool_calling` but omit `chat.sampling_defaults`. Must not
+        // throw; must return empty so caller falls through to HF file.
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data(#"""
+            {"chat": {"reasoning": {"supported": true}}}
+            """#.utf8))
+        #expect(d == .empty)
+    }
+
+    @Test("jang_config: malformed JSON returns empty")
+    func jangConfigMalformed() {
+        let d = LocalGenerationDefaults.parseJangConfig(data: Data("not json".utf8))
+        #expect(d == .empty)
+    }
+
+    // MARK: - merge(primary:fallback:) — overlay semantics
+
+    @Test("merge: primary fills first, fallback fills gaps (DSV4 real case)")
+    func mergePrimaryWinsFallbackFills() {
+        // jang_config says temp=0.6. generation_config.json says
+        // temp=1.0, top_k=64 (Gemma-4 shape). Result: temp from JANG
+        // (primary), top_k from HF (fallback).
+        let jang = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: nil, topK: nil, repetitionPenalty: nil)
+        let hf = LocalGenerationDefaults.Defaults(
+            temperature: 1.0, topP: 0.95, topK: 64, repetitionPenalty: nil)
+        let merged = LocalGenerationDefaults.merge(primary: jang, fallback: hf)
+        #expect(merged.temperature == 0.6)
+        #expect(merged.topP == 0.95)
+        #expect(merged.topK == 64)
+    }
+
+    @Test("merge: primary-only fields preserved")
+    func mergePrimaryOnly() {
+        let jang = LocalGenerationDefaults.Defaults(
+            temperature: 0.6, topP: 0.9, topK: 32, repetitionPenalty: 1.05)
+        let merged = LocalGenerationDefaults.merge(
+            primary: jang, fallback: LocalGenerationDefaults.Defaults.empty)
+        #expect(merged.temperature == 0.6)
+        #expect(merged.topP == 0.9)
+        #expect(merged.topK == 32)
+        #expect(merged.repetitionPenalty == 1.05)
+    }
+
+    @Test("merge: fallback-only fields preserved when primary empty")
+    func mergeFallbackOnly() {
+        let hf = LocalGenerationDefaults.Defaults(
+            temperature: 1.0, topP: 0.95, topK: 64, repetitionPenalty: nil)
+        let merged = LocalGenerationDefaults.merge(
+            primary: LocalGenerationDefaults.Defaults.empty, fallback: hf)
+        #expect(merged.temperature == 1.0)
+        #expect(merged.topP == 0.95)
+        #expect(merged.topK == 64)
+    }
+
+    // MARK: - Integration: filesystem with BOTH files
+
+    @Test("Filesystem: bundle with BOTH jang_config and generation_config merges")
+    func bothFilesMerge() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-gencfg-both-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // HF file ships upstream's training defaults.
+        try #"""
+            {"temperature": 1.0, "top_p": 0.95, "top_k": 64}
+            """#.write(
+                to: tmp.appendingPathComponent("generation_config.json"),
+                atomically: true, encoding: .utf8)
+        // JANG config overrides ONLY temperature (DSV4 pattern).
+        try #"""
+            {"chat": {"sampling_defaults": {"temperature": 0.6}}}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        // JANG overrides for the field it sets…
+        #expect(d.temperature == 0.6)
+        // …HF fills the rest.
+        #expect(d.topP == 0.95)
+        #expect(d.topK == 64)
+    }
+
+    @Test("Filesystem: jang_config alone suffices (HF file absent)")
+    func jangOnlyLoad() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-gencfg-jang-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"""
+            {"chat": {"sampling_defaults": {"temperature": 0.6, "top_p": 0.95}}}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        #expect(d.temperature == 0.6)
+        #expect(d.topP == 0.95)
+    }
+
+    @Test("Filesystem: jang_config with NO sampling_defaults, HF file has them")
+    func jangConfigNoSamplingFallsThroughToHF() throws {
+        // An older JANG bundle (no chat metadata) alongside an HF
+        // generation_config.json. Merge must NOT use jang_config (nothing
+        // useful in it) and must surface HF's values.
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-gencfg-jang-noop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"""
+            {"quantization": {"profile": "JANG_2S"}, "format": "jang"}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+        try #"""
+            {"temperature": 1.0, "top_k": 64, "top_p": 0.95}
+            """#.write(
+                to: tmp.appendingPathComponent("generation_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let d = LocalGenerationDefaults.load(fromDirectory: tmp)
+        #expect(d.temperature == 1.0)
+        #expect(d.topK == 64)
+        #expect(d.topP == 0.95)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -2,6 +2,7 @@
 //  LocalReasoningCapabilityTests.swift
 //
 
+import Foundation
 import Testing
 
 @testable import OsaurusCore
@@ -82,5 +83,122 @@ struct LocalReasoningCapabilityTests {
         #expect(cap.supportsThinking)
         #expect(cap.hasEnableThinkingKwarg)
         #expect(cap.templateInjectsThinkTag)
+    }
+
+    // MARK: - jang_config.json chat.reasoning fallback (DSV4-class bundles)
+
+    /// DSV4-Flash ships NO chat_template in tokenizer_config.json — the
+    /// template lives in a Python module `encoding/encoding_dsv4.py` that
+    /// only the Python / Swift runtime knows about. Without a fallback,
+    /// `LocalReasoningCapability.detect()` returned `.none`, `supportsThinking`
+    /// flipped to false, and PR #934's `streamWithTools` coercion merged
+    /// DSV4's `.reasoning` deltas into content — the thinking split was
+    /// destroyed. Fallback reads `jang_config.json > chat > reasoning.supported`
+    /// from the bundle root.
+    @Test("jang_config fallback: DSV4 reasoning.supported=true → supportsThinking")
+    func jangConfigDSV4Reasoning() {
+        let data = Data(#"""
+            {
+              "model_family": "deepseek_v4",
+              "chat": {
+                "encoder": "encoding_dsv4",
+                "chat_template_source": "builtin_encoding_module",
+                "has_tokenizer_chat_template": false,
+                "reasoning": {
+                  "supported": true,
+                  "modes": ["chat", "thinking"],
+                  "default_mode": "chat",
+                  "thinking_start": "<think>",
+                  "thinking_end": "</think>"
+                },
+                "tool_calling": {"parser": "dsml"}
+              }
+            }
+            """#.utf8)
+        let cap = LocalReasoningCapability.analyzeJangConfig(data: data)
+        #expect(cap?.supportsThinking == true)
+        // `enable_thinking` kwarg is Jinja-template driven; DSV4's
+        // Python encoder takes `thinking_mode` as a positional argument
+        // instead, so the kwarg flag stays false.
+        #expect(cap?.hasEnableThinkingKwarg == false)
+        // DSV4's template is outside the bundle (Python module) — vmlx
+        // injects the thinking tag itself when the caller picks thinking
+        // mode. From osaurus's perspective there is no on-disk Jinja to
+        // analyse for an injection regex, so this signal is false.
+        #expect(cap?.templateInjectsThinkTag == false)
+    }
+
+    @Test("jang_config: reasoning.supported=false → nil (fall through to .none)")
+    func jangConfigReasoningNotSupported() {
+        // A bundle that declares reasoning explicitly unsupported. The
+        // fallback returns nil so `detect()` returns `.none` and the
+        // rest of the pipeline routes `.chunk` events as content.
+        let data = Data(#"""
+            {"chat": {"reasoning": {"supported": false}}}
+            """#.utf8)
+        #expect(LocalReasoningCapability.analyzeJangConfig(data: data) == nil)
+    }
+
+    @Test("jang_config: missing chat subtree → nil")
+    func jangConfigNoChatSubtree() {
+        // Older JANG bundles with only quantization / source_model metadata.
+        let data = Data(#"""
+            {
+              "quantization": {"profile": "JANG_2L"},
+              "source_model": {"name": "Qwen3.5-122B-A10B"}
+            }
+            """#.utf8)
+        #expect(LocalReasoningCapability.analyzeJangConfig(data: data) == nil)
+    }
+
+    @Test("jang_config: chat present but no reasoning sub-object → nil")
+    func jangConfigChatWithoutReasoning() {
+        let data = Data(#"""
+            {"chat": {"tool_calling": {"parser": "dsml"}}}
+            """#.utf8)
+        #expect(LocalReasoningCapability.analyzeJangConfig(data: data) == nil)
+    }
+
+    @Test("jang_config: malformed JSON → nil (does not throw)")
+    func jangConfigMalformed() {
+        let data = Data("not json".utf8)
+        #expect(LocalReasoningCapability.analyzeJangConfig(data: data) == nil)
+    }
+
+    // MARK: - Filesystem integration
+
+    /// End-to-end: scratch directory with NO chat template but WITH a
+    /// jang_config that declares reasoning support — the DSV4 shape.
+    /// `readJangConfigReasoning(at:)` must hit disk, parse, and return
+    /// a capability with `supportsThinking = true`.
+    @Test("Filesystem: DSV4-shaped bundle (no chat template, jang_config reasoning)")
+    func filesystemDSV4Shape() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-reasoning-dsv4-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"""
+            {"chat": {"reasoning": {"supported": true}}}
+            """#.write(
+                to: tmp.appendingPathComponent("jang_config.json"),
+                atomically: true, encoding: .utf8)
+
+        let cap = LocalReasoningCapability.readJangConfigReasoning(at: tmp)
+        #expect(cap?.supportsThinking == true)
+    }
+
+    @Test("Filesystem: missing jang_config.json returns nil, does not throw")
+    func filesystemNoJangConfig() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-reasoning-empty-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        #expect(LocalReasoningCapability.readJangConfigReasoning(at: tmp) == nil)
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/ThinkTagScrubberTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ThinkTagScrubberTests.swift
@@ -1,0 +1,148 @@
+//
+//  ThinkTagScrubberTests.swift
+//
+//  Regression coverage for `ThinkTagScrubber` — the defensive layer that
+//  strips orphan `<think>` / `</think>` markers from `Generation.chunk`
+//  text on models that have `LocalReasoningCapability.supportsThinking
+//  == true`. See `ThinkTagScrubber.swift` header for context.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ThinkTagScrubber orphan-tag defense")
+struct ThinkTagScrubberTests {
+
+    // MARK: - Whole-tag occurrences in a single chunk
+
+    @Test("orphan </think> in single chunk is removed")
+    func orphanCloseTag() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("Here is the answer.</think>")
+        #expect(out == "Here is the answer.")
+        #expect(s.flush() == "")
+    }
+
+    @Test("orphan <think> in single chunk is removed")
+    func orphanOpenTag() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("<think>Some text after.")
+        #expect(out == "Some text after.")
+        #expect(s.flush() == "")
+    }
+
+    @Test("multiple tags in a single chunk are all removed")
+    func multipleTagsInChunk() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("<think>x</think>y<think>z</think>w")
+        #expect(out == "xyzw")
+    }
+
+    @Test("chunk with no tags passes through unchanged")
+    func noTagPassthrough() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("Hello, world!")
+        #expect(out == "Hello, world!")
+        #expect(s.flush() == "")
+    }
+
+    // MARK: - Split-token tags (the hard case)
+
+    /// MiniMax M2.7 Small JANGTQ at 2-bit can emit a tag across two
+    /// adjacent tokens (e.g. token 1 = `<`, token 2 = `think>`). The
+    /// scrubber must hold a partial-tag suffix in its buffer until the
+    /// next chunk arrives so the full tag gets matched and stripped.
+    @Test("split-token <think> across two chunks is stripped")
+    func splitOpenTagAcrossChunks() {
+        var s = ThinkTagScrubber()
+        let first = s.scrub("Some prefix <")
+        let second = s.scrub("think>visible")
+        let combined = first + second
+        #expect(combined == "Some prefix visible")
+    }
+
+    @Test("split-token </think> across two chunks is stripped")
+    func splitCloseTagAcrossChunks() {
+        var s = ThinkTagScrubber()
+        let first = s.scrub("Answer<")
+        let second = s.scrub("/think>more text")
+        let combined = first + second
+        #expect(combined == "Answermore text")
+    }
+
+    @Test("three-way split <think> is stripped")
+    func threeWaySplitOpenTag() {
+        var s = ThinkTagScrubber()
+        var combined = s.scrub("prefix <th")
+        combined += s.scrub("ink")
+        combined += s.scrub(">tail")
+        #expect(combined == "prefix tail")
+    }
+
+    /// If the chunk ends on `<` and no continuation arrives, we MUST
+    /// surface that `<` on flush — it was real content (e.g. a math
+    /// expression or HTML), not a partial tag.
+    @Test("trailing < with no continuation surfaces on flush")
+    func trailingPartialFlushed() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("a < b means less than: <")
+        // `<` is held as potential `<think>` start.
+        #expect(out == "a < b means less than: ")
+        let tail = s.flush()
+        #expect(tail == "<")
+    }
+
+    @Test("trailing <th with no continuation surfaces on flush")
+    func trailingPartialThFlushed() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("ends with <th")
+        #expect(out == "ends with ")
+        let tail = s.flush()
+        #expect(tail == "<th")
+    }
+
+    /// Tail `<thinkX` does NOT match `<think>` exactly — but its longest
+    /// would-be suffix is `<thinkX`, which is NOT a prefix of `<think>`.
+    /// So nothing is held; the whole text passes through.
+    @Test("non-matching prefix that contains < is held only at the boundary")
+    func nonMatchingPrefixPassesThrough() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("ends with <thinkX")
+        // `<thinkX` is not a prefix of `<think>` or `</think>` so no
+        // suffix is held. Whole text surfaces.
+        #expect(out == "ends with <thinkX")
+    }
+
+    // MARK: - Real-world scenario from MiniMax M2.7 Small JANGTQ
+
+    /// Exact pattern reported 2026-04-25: model emits visible response
+    /// with literal `</think>` interspersed. Scrubber must produce the
+    /// clean visible answer.
+    @Test("real-world MiniMax leakage pattern")
+    func realWorldMiniMaxPattern() {
+        var s = ThinkTagScrubber()
+        let out = s.scrub("Here's what I can do:\n• Read files</think>\n• Run commands</think>\n• Write task lists")
+        #expect(out == "Here's what I can do:\n• Read files\n• Run commands\n• Write task lists")
+    }
+
+    @Test("flush yields empty when no buffer pending")
+    func flushEmptyWhenClean() {
+        var s = ThinkTagScrubber()
+        _ = s.scrub("clean text")
+        #expect(s.flush() == "")
+    }
+
+    /// Calling flush twice in a row is idempotent — the second call
+    /// returns empty because the first drained the buffer.
+    @Test("flush is idempotent")
+    func flushIdempotent() {
+        var s = ThinkTagScrubber()
+        _ = s.scrub("trailing <th")
+        let first = s.flush()
+        let second = s.flush()
+        #expect(first == "<th")
+        #expect(second == "")
+    }
+}

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "dade305a96012951f30d3cc1073e84820f413ed2"
+        "revision" : "c98ae5cdbaa1e3d8650be7f717d5123965681690"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "104b6a5dbce668111f5e2c2b7fd2f8287277ae0c"
+        "revision" : "dade305a96012951f30d3cc1073e84820f413ed2"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "eda0c81fbee8259b70168bee8006ba7b541b580c"
+        "revision" : "104b6a5dbce668111f5e2c2b7fd2f8287277ae0c"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "c98ae5cdbaa1e3d8650be7f717d5123965681690"
+        "revision" : "cdfe40b846a140ed6d61cadaae7a991c6071a295"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "cdfe40b846a140ed6d61cadaae7a991c6071a295"
+        "revision" : "b9779d19521886a8cdc7c7ad0b12bbe81853632a"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -403,7 +403,7 @@
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
         "branch" : "main",
-        "revision" : "b9779d19521886a8cdc7c7ad0b12bbe81853632a"
+        "revision" : "070dc5b8c9829dc69b6e4831dd201537200a9c36"
       }
     },
     {


### PR DESCRIPTION
osaurus-side prep so the app is ready the moment vmlx-swift-lm ships DSV4-Flash + Kimi K2.6 support. **Two commits, additive only — no changes to any existing reasoning / tool / cache / inference code path. No vmlx pin bump needed (main already on `eda0c81`).**

Audit verified: zero overlap with #932 (sampling defaults), #934 (LFM thinking-block fix), #935 (Preflight Search), #946 (Performance filter), or current main.

## Commit 1: `jang_config.json > chat > sampling_defaults` overlay

New JANG / JANGTQ bundles stamp training-recipe defaults into `jang_config.json > chat > sampling_defaults`. The DSV4 converter (`jang/jang-tools/dsv4/convert_dsv4_jangtq.py`) reads `inference/generate.py` directly:

| Model | upstream `generation_config.json` | JANG `chat.sampling_defaults` |
|---|---|---|
| **DSV4-Flash-JANGTQ** | `temperature: 1.0` | **`temperature: 0.6`** ← recipe |
| **DSV4-Flash-JANGTQ4** | `temperature: 1.0` | **`temperature: 0.6`** |
| **DSV4-Flash-JANG_2L** | `temperature: 1.0` | **`temperature: 0.6`** |

`LocalGenerationDefaults` consults BOTH files, primary (JANG) → fallback (HF). Bundles that ship neither fall through to osaurus's hardcoded defaults — pre-PR behaviour preserved.

## Commit 2: `jang_config.json > chat > reasoning.supported` fallback (CRITICAL for DSV4)

DSV4-Flash ships **NO chat_template** in `tokenizer_config.json` — the template lives in a Python module `encoding/encoding_dsv4.py` (per `jang/research/DSV-FAMILY-RUNTIME-GUIDE.md §6`). Without this fallback:

```
LocalReasoningCapability.detect()  →  no chat_template  →  .none
                                                            ↓
ModelRuntime.streamWithTools (#934)  →  supportsThinking=false
                                                            ↓
.reasoning(text)  →  yielded as plain content  →  thinking split DESTROYED
```

The fix reads `jang_config.json > chat > reasoning.supported` as a second source of truth when the chat template is absent. Returns `Capability(supportsThinking: true)` for DSV4-style bundles.

## Coverage matrix

| Bundle / model_type | Detection path | Status |
|---|---|---|
| **DSV4-Flash-JANGTQ** (79.5 GB, profile 2) | jang_config fallback | ✅ Commit 2 |
| **DSV4-Flash-JANGTQ4** (~140 GB, profile 4) | jang_config fallback | ✅ Commit 2 |
| **DSV4-Flash-JANG_2L** (96.6 GB) | jang_config fallback | ✅ Commit 2 |
| **Kimi K2.6** (`kimi_k25`) | tokenizer_config Jinja template (`<think>` always-on) | ✅ existing path; user `disableThinking` override available via `modelOptions` |
| **All other JANG bundles** (Qwen 3.x, Gemma-4, MiniMax, Nemotron, GLM) | tokenizer_config Jinja template | ✅ existing path unchanged |
| **Non-JANG bundles** | tokenizer_config Jinja template | ✅ no behaviour change |

## Schema accepted (forward-compatible — ignores unknown fields)

```json
{
  "model_family": "deepseek_v4" | "kimi_k25" | …,
  "chat": {
    "sampling_defaults": {
      "temperature": 0.6,
      "top_p": 0.95,
      "top_k": 20,
      "repetition_penalty": 1.05
    },
    "reasoning": {
      "supported": true
    }
  }
}
```

Fields **deliberately not consumed** (vmlx's domain, not osaurus):

- `chat.encoder` / `chat.encoder_fn` / `chat.chat_template_source` — vmlx renderer dispatch
- `chat.role_tokens.*` — vmlx tokenizer
- `chat.reasoning.modes` / `default_mode` / `thinking_start` / `thinking_end` / `reasoning_effort_levels` — vmlx ReasoningParser already routes via `think_xml` stamp for `deepseek*`; mode-selector UI is intentional P2
- `chat.tool_calling.*` (DSML parser, dsml_token, etc.) — vmlx `7df9ad8` shipped DSML parser already

These can be layered on as separate PRs without breaking this one.

## Cohesion audit (no overlapping logic, no zombie code, no cache interference)

| Area | State after this PR |
|---|---|
| `LocalReasoningCapability.detect` | Existing chat-template path unchanged + new jang_config fallback when template missing |
| `ModelRuntime.streamWithTools` | #934 `supportsThinking` coercion still correct; now correctly fires for DSV4 bundles |
| `GenerationEventMapper.map` | Untouched |
| `MLXBatchAdapter.prepareInput` | `enable_thinking: true` default preserved; user override via `modelOptions["disableThinking"]` still works |
| `LocalGenerationDefaults` | Adds jang_config priority over HF generation_config.json |
| Caches (`invalidateLocalModelsCache`) | Hooks BOTH `LocalReasoningCapability` + `LocalGenerationDefaults` |
| UI (`StreamingDeltaProcessor`) | No self-driven `<think>` scan |
| vmlx pin | `eda0c81` — already on main, not bumped here |

## Test plan

- [x] **16 new tests** (9 sampling_defaults + 7 reasoning fallback) — all parse + filesystem + edge cases
- [x] `swift test --parallel`: **998 / 998 pass** across 134 suites
- [x] `swift build` clean
- [ ] Manual when vmlx ships DSV4 Swift port: load `DSV4-Flash-JANGTQ` — verify `temp=0.6` applied, thinking pane fills, no `.reasoning` deltas leak into content
- [ ] Manual when vmlx ships Kimi K2.6 Swift port: load `Kimi-K2.6-REAP-30-JANGTQ_1L` — verify `<think>` envelopes route to thinking pane (template-text path)