### PR TITLE
feat(model-picker): add Performance filter for 'Runs Well' / 'Hide Too Large'

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -56,6 +56,7 @@ final class ModelManager: NSObject, ObservableObject {
         var sizeCategory: SizeCategory? = nil
         var family: String? = nil
         var paramCategory: ParamCategory? = nil
+        var performance: PerformanceFilter? = nil
 
         enum SizeCategory: String, CaseIterable, Identifiable {
             case small = "Small (<2 GB)"
@@ -98,8 +99,51 @@ final class ModelManager: NSObject, ObservableObject {
             }
         }
 
+        /// Filters the list by `MLXModel.compatibility(totalMemoryGB:)` —
+        /// the same hardware-fit assessment used for the per-row
+        /// "Runs Well / Tight Fit / Too Large" badges. Exposes the
+        /// already-computed attribute rather than introducing a new one.
+        /// When `totalMemoryGB == 0` (monitor hasn't reported yet) this
+        /// filter is treated as a no-op so the list isn't emptied during
+        /// startup — `compatibility` returns `.unknown` without the
+        /// hardware info and we let everything through until we know.
+        enum PerformanceFilter: String, CaseIterable, Identifiable {
+            /// Only include models whose `compatibility` is `.compatible`
+            /// (memory usage below the 75 % ratio threshold).
+            case runsWell = "Runs Well"
+            /// Exclude models whose `compatibility` is `.tooLarge`
+            /// (memory usage above the 95 % ratio threshold). Models with
+            /// unknown memory info pass through unchanged — we don't
+            /// punish ambiguity.
+            case hideTooLarge = "Hide Too Large"
+
+            var id: String { rawValue }
+
+            var displayName: String {
+                switch self {
+                case .runsWell: return L("Runs Well")
+                case .hideTooLarge: return L("Hide Too Large")
+                }
+            }
+
+            func matches(_ model: MLXModel, totalMemoryGB: Double) -> Bool {
+                guard totalMemoryGB > 0 else { return true }
+                let compat = model.compatibility(totalMemoryGB: totalMemoryGB)
+                switch self {
+                case .runsWell:
+                    return compat == .compatible
+                case .hideTooLarge:
+                    return compat != .tooLarge
+                }
+            }
+        }
+
         var isActive: Bool {
-            typeFilter != .all || sizeCategory != nil || family != nil || paramCategory != nil
+            typeFilter != .all
+                || sizeCategory != nil
+                || family != nil
+                || paramCategory != nil
+                || performance != nil
         }
 
         mutating func reset() {
@@ -107,9 +151,16 @@ final class ModelManager: NSObject, ObservableObject {
             sizeCategory = nil
             family = nil
             paramCategory = nil
+            performance = nil
         }
 
-        func apply(to models: [MLXModel]) -> [MLXModel] {
+        /// Apply all filters to a model list. `totalMemoryGB` is only
+        /// consulted when the Performance filter is active; pass `0` to
+        /// fall through for the other filter dimensions (a reasonable
+        /// default when the caller has no `SystemMonitorService` on hand,
+        /// e.g. during unit tests). The Performance filter itself no-ops
+        /// when `totalMemoryGB <= 0` so the list stays intact.
+        func apply(to models: [MLXModel], totalMemoryGB: Double = 0) -> [MLXModel] {
             models.filter { model in
                 switch typeFilter {
                 case .all: break
@@ -121,6 +172,9 @@ final class ModelManager: NSObject, ObservableObject {
                 }
                 if let fam = family, model.family != fam { return false }
                 if let paramCat = paramCategory, !paramCat.matches(billions: model.parameterCountBillions) {
+                    return false
+                }
+                if let perf = performance, !perf.matches(model, totalMemoryGB: totalMemoryGB) {
                     return false
                 }
                 return true

--- a/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
@@ -1,0 +1,198 @@
+//
+//  ModelFilterPerformanceTests.swift
+//
+//  Covers the Performance filter added to `ModelFilterState`. The filter
+//  exposes the already-computed `MLXModel.compatibility(totalMemoryGB:)`
+//  assessment — same three buckets the per-row badge renders — so picking
+//  "Runs Well" or "Hide Too Large" matches visible badges 1:1.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelFilterState Performance filter")
+struct ModelFilterPerformanceTests {
+
+    /// Mid-size dense model (~3 GB on disk, ~4.5 GB resident after
+    /// overhead multiplier). The actual multiplier lives in
+    /// `MLXModel.estimatedMemoryGB` — we use whole-GB round numbers here
+    /// so the buckets below are interpretable at a glance.
+    private static func model(_ name: String, gbOnDisk: Double) -> MLXModel {
+        let bytes = Int64(gbOnDisk * 1024 * 1024 * 1024)
+        return MLXModel(
+            id: "test/\(name)",
+            name: name,
+            description: "",
+            downloadURL: "https://example.com/\(name)",
+            downloadSizeBytes: bytes
+        )
+    }
+
+    // MARK: - Fixture bucket sanity
+
+    /// Sanity-check the fixtures: at 16 GB of RAM, our three sample
+    /// models end up in the three compatibility buckets we want to
+    /// exercise. If MLXModel's overhead multiplier or the 0.75 / 0.95
+    /// ratio thresholds ever change and the fixtures drift, this test
+    /// catches it before any filter assertion fails mysteriously.
+    @Test("Fixture buckets land in compatible / tight / tooLarge at 16 GB total")
+    func fixtureBucketsCorrect() {
+        // MLXModel applies a 1.2× overhead multiplier to disk-bytes.
+        // compatibility thresholds: <0.75 ratio → compatible,
+        // <0.95 → tight, ≥0.95 → tooLarge. At total=16 GB:
+        //   gbOnDisk=2  → 2.4 GB resident (ratio 0.15) → compatible
+        //   gbOnDisk=11 → 13.2 GB resident (ratio 0.825) → tight
+        //   gbOnDisk=14 → 16.8 GB resident (ratio 1.05) → tooLarge
+        let total = 16.0
+        let small = Self.model("small", gbOnDisk: 2.0)
+        let mid = Self.model("mid", gbOnDisk: 11.0)
+        let big = Self.model("big", gbOnDisk: 14.0)
+        #expect(small.compatibility(totalMemoryGB: total) == .compatible)
+        #expect(mid.compatibility(totalMemoryGB: total) == .tight)
+        #expect(big.compatibility(totalMemoryGB: total) == .tooLarge)
+    }
+
+    // MARK: - runsWell
+
+    @Test("runsWell keeps only .compatible entries")
+    func runsWellKeepsOnlyCompatible() {
+        let total = 16.0
+        let models = [
+            Self.model("small", gbOnDisk: 2.0),
+            Self.model("mid", gbOnDisk: 11.0),
+            Self.model("big", gbOnDisk: 14.0),
+        ]
+        var state = ModelManager.ModelFilterState()
+        state.performance = .runsWell
+        let out = state.apply(to: models, totalMemoryGB: total).map(\.name)
+        #expect(out == ["small"])
+    }
+
+    @Test("runsWell drops unknown-memory models (conservative)")
+    func runsWellDropsUnknownMemory() {
+        // A model without downloadSizeBytes has `estimatedMemoryGB == nil`
+        // → `compatibility == .unknown`. runsWell is an affirmative
+        // allowlist: only `.compatible` passes. Ambiguous models are OUT.
+        let unknown = MLXModel(
+            id: "test/unknown",
+            name: "unknown",
+            description: "",
+            downloadURL: "https://example.com/unknown"
+        )
+        var state = ModelManager.ModelFilterState()
+        state.performance = .runsWell
+        let out = state.apply(to: [unknown], totalMemoryGB: 16.0).map(\.name)
+        #expect(out.isEmpty)
+    }
+
+    // MARK: - hideTooLarge
+
+    @Test("hideTooLarge drops only .tooLarge; tight and compatible pass")
+    func hideTooLargeDropsOnlyTooLarge() {
+        let total = 16.0
+        let models = [
+            Self.model("small", gbOnDisk: 2.0),
+            Self.model("mid", gbOnDisk: 11.0),
+            Self.model("big", gbOnDisk: 14.0),
+        ]
+        var state = ModelManager.ModelFilterState()
+        state.performance = .hideTooLarge
+        let out = state.apply(to: models, totalMemoryGB: total).map(\.name)
+        // small (compatible) + mid (tight) stay; big (tooLarge) dropped.
+        #expect(out.sorted() == ["mid", "small"])
+    }
+
+    @Test("hideTooLarge keeps unknown-memory models (benefit of the doubt)")
+    func hideTooLargeKeepsUnknown() {
+        // hideTooLarge is a negative filter: we exclude ONLY models we
+        // KNOW are too large. Unknown-memory models pass through so users
+        // don't lose visibility on newly-indexed / undercounted models.
+        let unknown = MLXModel(
+            id: "test/unknown",
+            name: "unknown",
+            description: "",
+            downloadURL: "https://example.com/unknown"
+        )
+        var state = ModelManager.ModelFilterState()
+        state.performance = .hideTooLarge
+        let out = state.apply(to: [unknown], totalMemoryGB: 16.0).map(\.name)
+        #expect(out == ["unknown"])
+    }
+
+    // MARK: - No-op guards
+
+    @Test("totalMemoryGB == 0 no-ops the Performance filter (monitor not ready)")
+    func zeroMemoryIsNoOp() {
+        // `SystemMonitorService` reports `totalMemoryGB == 0` before its
+        // first sample. If we applied the filter in that window we'd
+        // empty the model list on cold launch. `PerformanceFilter.matches`
+        // short-circuits to `true` when totalMemoryGB <= 0.
+        let models = [
+            Self.model("small", gbOnDisk: 2.0),
+            Self.model("big", gbOnDisk: 14.0),
+        ]
+        var state = ModelManager.ModelFilterState()
+        state.performance = .runsWell
+        let out = state.apply(to: models, totalMemoryGB: 0).map(\.name)
+        #expect(out.sorted() == ["big", "small"])
+    }
+
+    @Test("performance = nil no-ops filter regardless of totalMemoryGB")
+    func nilPerformanceIsNoOp() {
+        let models = [
+            Self.model("small", gbOnDisk: 2.0),
+            Self.model("big", gbOnDisk: 14.0),
+        ]
+        let state = ModelManager.ModelFilterState()
+        let out = state.apply(to: models, totalMemoryGB: 16.0).map(\.name)
+        #expect(out.sorted() == ["big", "small"])
+    }
+
+    // MARK: - Interaction with other filter dimensions
+
+    @Test("Performance composes with paramCategory (logical AND)")
+    func composesWithParamCategory() {
+        // Stack paramCategory = .small ON TOP OF performance = .runsWell:
+        // both must hold. `paramCategory.matches` requires
+        // `parameterCountBillions`; we construct models with explicit
+        // param counts via the name-parsing heuristic would be fragile,
+        // so we only exercise the Performance dimension here and confirm
+        // a missing-param model drops out when paramCategory is set.
+        let models = [
+            Self.model("small", gbOnDisk: 2.0),
+        ]
+        var state = ModelManager.ModelFilterState()
+        state.performance = .runsWell
+        state.paramCategory = .small
+        let out = state.apply(to: models, totalMemoryGB: 16.0).map(\.name)
+        // `parameterCountBillions` is nil without explicit metadata →
+        // `paramCategory.matches` returns false → filtered out even
+        // though Performance would pass.
+        #expect(out.isEmpty)
+    }
+
+    // MARK: - isActive / reset
+
+    @Test("performance toggles isActive")
+    func performanceFlipsActive() {
+        var state = ModelManager.ModelFilterState()
+        #expect(!state.isActive)
+        state.performance = .runsWell
+        #expect(state.isActive)
+        state.performance = nil
+        #expect(!state.isActive)
+    }
+
+    @Test("reset clears performance too")
+    func resetClearsPerformance() {
+        var state = ModelManager.ModelFilterState()
+        state.performance = .hideTooLarge
+        state.typeFilter = .llm
+        state.reset()
+        #expect(state.performance == nil)
+        #expect(state.typeFilter == .all)
+        #expect(!state.isActive)
+    }
+}

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -274,6 +274,24 @@ struct ModelDownloadView: View {
                             }
                         }
                     }
+                    // The two Performance chips are mutually exclusive —
+                    // picking one clears the other so the filter stays a
+                    // single optional (matches SizeCategory / ParamCategory
+                    // conventions and keeps `isActive` trivially
+                    // `performance != nil`).
+                    FilterSection(title: "Performance") {
+                        HStack(spacing: 8) {
+                            ForEach(ModelManager.ModelFilterState.PerformanceFilter.allCases) { opt in
+                                FilterChip(
+                                    label: opt.displayName,
+                                    isSelected: filterState.performance == opt
+                                ) {
+                                    filterState.performance =
+                                        filterState.performance == opt ? nil : opt
+                                }
+                            }
+                        }
+                    }
                     FilterSection(title: "Model Family") {
                         let families = Array(Set(modelManager.availableModels.map { $0.family })).sorted()
                         if families.isEmpty {
@@ -613,7 +631,7 @@ struct ModelDownloadView: View {
 
     private var filteredModels: [MLXModel] {
         let searched = SearchService.filterModels(modelManager.availableModels, with: searchText)
-        let filtered = filterState.apply(to: searched)
+        let filtered = filterState.apply(to: searched, totalMemoryGB: systemMonitor.totalMemoryGB)
         return filtered.sorted { lhs, rhs in
             lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
         }
@@ -627,7 +645,7 @@ struct ModelDownloadView: View {
     /// 3. Within each tier: newer `releasedAt` first, then alphabetical.
     private var filteredSuggestedModels: [MLXModel] {
         let searched = SearchService.filterModels(modelManager.suggestedModels, with: searchText)
-        let filtered = filterState.apply(to: searched)
+        let filtered = filterState.apply(to: searched, totalMemoryGB: systemMonitor.totalMemoryGB)
         let curatedIds = ModelManager.curatedSuggestedIds
         return filtered.sorted { lhs, rhs in
             let lhsCurated = curatedIds.contains(lhs.id.lowercased())
@@ -677,7 +695,7 @@ struct ModelDownloadView: View {
         }
         // Apply search filter
         let searched = SearchService.filterModels(merged, with: searchText)
-        let filtered = filterState.apply(to: searched)
+        let filtered = filterState.apply(to: searched, totalMemoryGB: systemMonitor.totalMemoryGB)
 
         // Sort: active first, then by name
         return filtered.sorted { lhs, rhs in
@@ -698,7 +716,7 @@ struct ModelDownloadView: View {
     private var completedDownloadedModelsCount: Int {
         let completed = modelManager.deduplicatedModels().filter { $0.isDownloaded }
         let searched = SearchService.filterModels(Array(completed), with: searchText)
-        let filtered = filterState.apply(to: searched)
+        let filtered = filterState.apply(to: searched, totalMemoryGB: systemMonitor.totalMemoryGB)
         return filtered.count
     }
 


### PR DESCRIPTION
## Summary

From Slack:
> **Messina:** \"can you add a new filter for Performance that allows me to filter out those that are 'Too large', or only include those that 'Runs well'?\"
> \"i just want to see the list filtered by the attribute that's already been added\"

Adds a \"Performance\" filter section to the model picker that exposes `MLXModel.compatibility(totalMemoryGB:)` — the **same** hardware-fit assessment already driving the per-row `Runs Well` / `Tight Fit` / `Too Large` badges. No new memory or bandwidth heuristic; purely a filter over existing state.

> Eric raised memory bandwidth as a dimension the ratio check doesn't capture. Deliberately **out of scope** for this PR — that would be a new attribute, not a filter.

## Behaviour matrix

Two mutually-exclusive chips under a new `FilterSection(title: \"Performance\")`:

| Compatibility bucket | `Runs Well` | `Hide Too Large` | No filter |
|---|---|---|---|
| `.compatible` (ratio < 0.75) | ✅ keep | ✅ keep | ✅ keep |
| `.tight` (0.75 ≤ ratio < 0.95) | ❌ drop | ✅ keep | ✅ keep |
| `.tooLarge` (ratio ≥ 0.95) | ❌ drop | ❌ drop | ✅ keep |
| `.unknown` (no memory estimate) | ❌ drop | ✅ keep | ✅ keep |

Rationale: **Runs Well** is an affirmative allowlist so ambiguous (unknown-memory) models drop out. **Hide Too Large** is a negative filter so ambiguous models pass through — we only exclude models we know exceed the cap.

## Boot-safety

`SystemMonitorService` reports `totalMemoryGB == 0` before its first sample. Applying the compatibility ratio in that window would empty the list on cold launch. `PerformanceFilter.matches` short-circuits to `true` when `totalMemoryGB <= 0` so the list stays intact until the monitor reports (SwiftUI re-renders when `@ObservedObject` ticks).

## Files changed

- `Packages/OsaurusCore/Managers/Model/ModelManager.swift` — new `PerformanceFilter` enum on `ModelFilterState`, `performance` field, `apply(to:totalMemoryGB:)` signature, `isActive` + `reset` include the new field
- `Packages/OsaurusCore/Views/Model/ModelDownloadView.swift` — new `FilterSection(title: \"Performance\")`, four `filterState.apply(to:)` call sites pass `systemMonitor.totalMemoryGB`
- `Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift` — 10 new tests

## Test plan

- [x] 10 new unit tests (fixture sanity, allowlist / negative filter semantics, boot-safety, AND composition with other filter dims, `isActive`, `reset`)
- [x] `swift test --parallel`: **926 / 926 pass** across 123 suites (916 baseline + 10 new)
- [x] `swift build` clean
- [ ] Manual: open Model Picker → scroll to \"Performance\" section → tap \"Runs Well\" → verify only `.compatible` rows remain
- [ ] Manual: tap \"Hide Too Large\" → verify `Tight Fit` rows still visible, \"Too Large\" rows gone
- [ ] Manual: launch app on a fresh session — verify no flicker / empty list during the `totalMemoryGB == 0` window before monitor reports