### PR TITLE
fix(preflight): detect mislabeled JANGTQ bundles + vmlx fa77575 auto-correct

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -180,6 +180,14 @@ final class ChatTurn: ObservableObject, Identifiable {
     var generationTokensPerSecond: Double?
     /// Total tokens generated in this turn
     var generationTokenCount: Int?
+    /// `true` when vmlx's `GenerateCompletionInfo.unclosedReasoning` fired —
+    /// the model ended the stream still inside a `<think>` block (trapped
+    /// thinking). Reasoning-trained Qwen3.6-A3B / DeepSeek-V4 fine-tunes
+    /// hit this on validation-style prompts; the visible content channel
+    /// is typically empty while the answer is buried in `.reasoning`.
+    /// The chat UI uses this to surface a fallback banner suggesting the
+    /// user toggle "Disable Thinking" for the next turn.
+    var unclosedReasoning: Bool = false
 
     private static let maxArgPreviewLength = 500
 

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -35,7 +35,17 @@ enum ContentBlockKind: Equatable {
     case sharedArtifact(artifact: SharedArtifact)
     case pendingToolCall(toolName: String, argPreview: String?, argSize: Int)
     case preflightCapabilities(items: [PreflightCapabilityItem])
-    case generationStats(ttft: TimeInterval?, tokensPerSecond: Double?, tokenCount: Int?)
+    /// Generation benchmarks footer for a completed assistant turn.
+    /// `unclosedReasoning` is true when vmlx's `GenerateCompletionInfo.unclosedReasoning`
+    /// fires — model ended the stream still inside a `<think>` block (trapped
+    /// thinking). Cell renderer surfaces a one-line "thinking didn't close"
+    /// warning beside the tok/s chip when set.
+    case generationStats(
+        ttft: TimeInterval?,
+        tokensPerSecond: Double?,
+        tokenCount: Int?,
+        unclosedReasoning: Bool
+    )
     case typingIndicator
     case groupSpacer
     case chart(spec: ChartSpec)
@@ -81,8 +91,12 @@ enum ContentBlockKind: Equatable {
         case let (.preflightCapabilities(lItems), .preflightCapabilities(rItems)):
             return lItems == rItems
 
-        case let (.generationStats(lTtft, lTps, lCount), .generationStats(rTtft, rTps, rCount)):
+        case let (
+            .generationStats(lTtft, lTps, lCount, lUnclosed),
+            .generationStats(rTtft, rTps, rCount, rUnclosed)
+        ):
             return lTtft == rTtft && lTps == rTps && lCount == rCount
+                && lUnclosed == rUnclosed
 
         case (.typingIndicator, .typingIndicator):
             return true
@@ -245,12 +259,18 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         ttft: TimeInterval?,
         tokensPerSecond: Double?,
         tokenCount: Int?,
+        unclosedReasoning: Bool = false,
         position: BlockPosition
     ) -> ContentBlock {
         ContentBlock(
             id: "stats-\(turnId.uuidString)",
             turnId: turnId,
-            kind: .generationStats(ttft: ttft, tokensPerSecond: tokensPerSecond, tokenCount: tokenCount),
+            kind: .generationStats(
+                ttft: ttft,
+                tokensPerSecond: tokensPerSecond,
+                tokenCount: tokenCount,
+                unclosedReasoning: unclosedReasoning
+            ),
             position: position
         )
     }
@@ -469,6 +489,7 @@ extension ContentBlock {
                         ttft: turn.timeToFirstToken,
                         tokensPerSecond: turn.generationTokensPerSecond,
                         tokenCount: turn.generationTokenCount,
+                        unclosedReasoning: turn.unclosedReasoning,
                         position: .middle
                     )
                 )

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -18,13 +18,28 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // c992df9 is the first commit with `GenerateCompletionInfo.unclosedReasoning`,
+        // a7db6e5 closes the deterministic Metal-assertion crash class
+        // `notifyExternalReferencesNonZeroOnDealloc` inside
+        // `BatchEngine.stepPrefill` after `Cache disk hit`. Two upstream
+        // commits land that fix together:
+        //   - 98289d9 forces `MLX.asyncEval(slot.cache)` after disk
+        //     restore so lazy-restore graph ops don't extend into the
+        //     next request's command buffer.
+        //   - a7db6e5 sets `continuation.onTermination` on
+        //     `BatchEngine.generate`'s outStream so orphan slots get
+        //     reaped via `engine.cancel(requestId)` whenever a consumer
+        //     breaks early.
+        // Net effect: the `Task.isCancelled` break in MLXBatchAdapter
+        // line 209-222 is safe, and no `enableDiskCache: false` workaround
+        // is needed.
+        //
+        // Also includes c992df9's `GenerateCompletionInfo.unclosedReasoning`,
         // which the chat UI consumes to surface a "thinking didn't close"
         // chip when reasoning-trained models trap themselves on validation
-        // prompts. Earlier pins compile but the chip stays dark.
+        // prompts.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "c992df936879229251e9e06e2446c427c6f4cee7"
+            revision: "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -17,9 +17,14 @@ let package = Package(
         // Pinned by commit (was `branch: "main"`) so the runtime can't change
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
+        //
+        // c992df9 is the first commit with `GenerateCompletionInfo.unclosedReasoning`,
+        // which the chat UI consumes to surface a "thinking didn't close"
+        // chip when reasoning-trained models trap themselves on validation
+        // prompts. Earlier pins compile but the chip stays dark.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "070dc5b8c9829dc69b6e4831dd201537200a9c36"
+            revision: "c992df936879229251e9e06e2446c427c6f4cee7"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -182,24 +182,44 @@ enum StreamingReasoningHint: Sendable {
 
 /// In-band signaling for generation benchmarks (tok/s, token count).
 /// Uses the same `\u{FFFE}` sentinel pattern as `StreamingToolHint`.
+///
+/// Wire format: `<sentinel>stats:<tokenCount>;<tokensPerSecond>[;<flags>]`.
+/// The optional third field carries comma-separated flags so future
+/// observability signals can be added without breaking older decoders —
+/// today's only flag is `unclosed`, set when vmlx's
+/// `GenerateCompletionInfo.unclosedReasoning == true` (the model ended
+/// the stream still inside a `<think>` block, i.e. trapped-thinking).
 enum StreamingStatsHint: Sendable {
     private static let statsPrefix = "\u{FFFE}stats:"
     private static let posixLocale = Locale(identifier: "en_US_POSIX")
+    private static let unclosedFlag = "unclosed"
 
-    static func encode(tokenCount: Int, tokensPerSecond: Double) -> String {
+    static func encode(
+        tokenCount: Int,
+        tokensPerSecond: Double,
+        unclosedReasoning: Bool = false
+    ) -> String {
         let tps = String(format: "%.4f", locale: posixLocale, tokensPerSecond)
-        return "\(statsPrefix)\(tokenCount);\(tps)"
+        let suffix = unclosedReasoning ? ";\(unclosedFlag)" : ""
+        return "\(statsPrefix)\(tokenCount);\(tps)\(suffix)"
     }
 
-    static func decode(_ delta: String) -> (tokenCount: Int, tokensPerSecond: Double)? {
+    static func decode(
+        _ delta: String
+    ) -> (tokenCount: Int, tokensPerSecond: Double, unclosedReasoning: Bool)? {
         guard delta.hasPrefix(statsPrefix) else { return nil }
         let payload = delta.dropFirst(statsPrefix.count)
-        let parts = payload.split(separator: ";", maxSplits: 1)
-        guard parts.count == 2,
+        // Split into at most 3 parts: count, tps, optional flags. `maxSplits=2`
+        // means a future flags-string containing extra `;` separators stays
+        // in the third field intact — forward-compat for new flags.
+        let parts = payload.split(separator: ";", maxSplits: 2)
+        guard parts.count >= 2,
             let count = Int(parts[0]),
             let tps = Double(parts[1])
         else { return nil }
-        return (count, tps)
+        let flags = parts.count >= 3 ? parts[2].split(separator: ",") : []
+        let unclosed = flags.contains { $0 == Substring(unclosedFlag) }
+        return (count, tps, unclosed)
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -912,17 +912,35 @@ public actor ModelRuntime {
     }
 
     /// Preflight check for JANGTQ-routed models. Reads `jang_config.json`
-    /// and, if `weight_format == "mxtq"`, verifies the `jangtq_runtime.safetensors`
-    /// sidecar is present in the model directory. Throws a clear error on
-    /// mismatch so callers see a message instead of waiting for vmlx to
-    /// report the same problem later.
+    /// and validates the bundle's `weight_format` stamp against the presence
+    /// of the `jangtq_runtime.safetensors` sidecar. Throws a clear error
+    /// on either mismatch (forward or inverse) so callers see a message
+    /// instead of waiting for vmlx to report the same problem 60+ shards
+    /// later — or worse, hitting an unhandled-keys runtime crash.
     ///
-    /// As of `vmlx-swift-lm 9e647a6`, vmlx itself fails-fast with an equivalent
-    /// NSError at weight-load time, so this osaurus-side check is primarily a
-    /// speed optimization: we refuse before the 60+ safetensors shards start
-    /// loading, giving users an instant error instead of a multi-second wait.
-    /// It also defends against older vmlx pins where the same mismatch would
-    /// instead reach `TurboQuantSwitchLinear.fatalError` and abort the process.
+    /// Two failure modes detected:
+    ///
+    /// 1. **Forward mismatch**: `weight_format == "mxtq"` declared but the
+    ///    sidecar is absent. vmlx's `LLMModelFactory.dispatchDeepseekV4`
+    ///    routes to the JANGTQ class purely on the stamp, then
+    ///    `TurboQuantSwitchLinear.callAsFunction` `fatalError`s on the first
+    ///    forward pass when the runtime cache is empty. (As of
+    ///    `vmlx-swift-lm 9e647a6` vmlx fails-fast with an NSError at load
+    ///    time instead of aborting, but defense-in-depth costs nothing.)
+    ///
+    /// 2. **Inverse mismatch (mislabeled bundle)**: sidecar IS present but
+    ///    `weight_format != "mxtq"` (typically stamped `"bf16"` from a
+    ///    quantization pipeline that forgot to update the label after
+    ///    swapping in TurboQuant codebooks). vmlx's factory then dispatches
+    ///    to the BASE `DeepseekV4Model` / `MiniMaxModel` / etc. class, hits
+    ///    the `tq_norms` / `tq_packed` keys in the safetensors, and the
+    ///    parameter loader throws `Unhandled keys [...]`. Confirmed in the
+    ///    wild on early DSV4-Flash JANGTQ bundles (live-repro 2026-04-25).
+    ///    The vmlx integration doc explicitly notes this case via the
+    ///    `DSV4_FORCE_JANGTQ=1` env-var workaround. Throwing here gives the
+    ///    user a remediation step (patch `weight_format` to `"mxtq"` or
+    ///    re-download from a corrected source) before vmlx loads any shards.
+    ///
     /// Exposed at module scope for unit testing (same pattern as
     /// `resolveLocalModelDirectory`).
     static func validateJANGTQSidecarIfRequired(at directory: URL, name: String) throws {
@@ -936,25 +954,49 @@ public actor ModelRuntime {
             let weight_format: String?
         }
         guard let data = try? Data(contentsOf: jangConfigURL),
-            let probe = try? JSONDecoder().decode(JangConfigProbe.self, from: data),
-            probe.weight_format == "mxtq"
+            let probe = try? JSONDecoder().decode(JangConfigProbe.self, from: data)
         else {
             return
         }
 
         let sidecarURL = directory.appendingPathComponent("jangtq_runtime.safetensors")
-        guard !FileManager.default.fileExists(atPath: sidecarURL.path) else { return }
+        let sidecarPresent = FileManager.default.fileExists(atPath: sidecarURL.path)
+        let isMxtq = probe.weight_format == "mxtq"
 
-        throw NSError(
-            domain: "ModelRuntime",
-            code: 2,
-            userInfo: [
-                NSLocalizedDescriptionKey:
-                    "Model '\(name)' declares JANGTQ (weight_format: \"mxtq\") but is missing "
-                    + "required sidecar file 'jangtq_runtime.safetensors'. "
-                    + "Re-download the full model or obtain the sidecar from the original publisher."
-            ]
-        )
+        // Forward mismatch: declared JANGTQ, sidecar missing.
+        if isMxtq && !sidecarPresent {
+            throw NSError(
+                domain: "ModelRuntime",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Model '\(name)' declares JANGTQ (weight_format: \"mxtq\") but is missing "
+                        + "required sidecar file 'jangtq_runtime.safetensors'. "
+                        + "Re-download the full model or obtain the sidecar from the original publisher."
+                ]
+            )
+        }
+
+        // Inverse mismatch: sidecar present but stamp says non-JANGTQ. The
+        // safetensors carry `tq_norms` / `tq_packed` keys vmlx's base class
+        // can't decode → "Unhandled keys" runtime error. Catch it here.
+        if sidecarPresent && !isMxtq {
+            let actualStamp = probe.weight_format ?? "absent"
+            throw NSError(
+                domain: "ModelRuntime",
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Model '\(name)' ships the JANGTQ runtime sidecar "
+                        + "('jangtq_runtime.safetensors') but its jang_config.json "
+                        + "declares weight_format: \"\(actualStamp)\". This is a mislabeled "
+                        + "bundle — the safetensors carry TurboQuant tensors (tq_norms / "
+                        + "tq_packed) that vmlx's base model class cannot decode. "
+                        + "Fix: set weight_format to \"mxtq\" in jang_config.json, "
+                        + "or re-download from a corrected source."
+                ]
+            )
+        }
     }
 
     /// Pure, testable sibling of `findLocalDirectory` that takes the root

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -636,11 +636,12 @@ public actor ModelRuntime {
                         pendingTools.append(
                             ServiceToolInvocation(toolName: name, jsonArguments: argsJSON)
                         )
-                    case .completionInfo(let tokenCount, let tokensPerSecond):
+                    case .completionInfo(let tokenCount, let tokensPerSecond, let unclosedReasoning):
                         continuation.yield(
                             StreamingStatsHint.encode(
                                 tokenCount: tokenCount,
-                                tokensPerSecond: tokensPerSecond
+                                tokensPerSecond: tokensPerSecond,
+                                unclosedReasoning: unclosedReasoning
                             )
                         )
                     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
@@ -18,5 +18,16 @@ enum ModelRuntimeEvent: Sendable {
     /// streaming hint.
     case reasoning(String)
     case toolInvocation(name: String, argsJSON: String)
-    case completionInfo(tokenCount: Int, tokensPerSecond: Double)
+    /// Completion stats for the just-finished generation.
+    ///
+    /// `unclosedReasoning` mirrors vmlx's `GenerateCompletionInfo.unclosedReasoning`:
+    /// `true` when the stream ended while the reasoning parser was still
+    /// inside a `<think>…</think>` block — i.e. the model got "trapped"
+    /// in chain-of-thought without emitting a final answer in the visible
+    /// content channel. Reasoning-trained Qwen3.6-A3B / DeepSeek-V4
+    /// fine-tunes hit this on validation-style prompts ("give me a 20-digit
+    /// number") because their training data extends thought through
+    /// arbitrary self-verification. `false` for non-reasoning models or
+    /// for streams that emitted `</think>` cleanly.
+    case completionInfo(tokenCount: Int, tokensPerSecond: Double, unclosedReasoning: Bool)
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -73,7 +73,8 @@ enum GenerationEventMapper {
                         continuation.yield(
                             .completionInfo(
                                 tokenCount: info.generationTokenCount,
-                                tokensPerSecond: info.tokensPerSecond
+                                tokensPerSecond: info.tokensPerSecond,
+                                unclosedReasoning: info.unclosedReasoning
                             )
                         )
 
@@ -109,7 +110,7 @@ enum GenerationEventMapper {
     /// it actually is.
     private static func logCompletionInfo(_ info: GenerateCompletionInfo) {
         mapperLog.info(
-            "[perf] mlxStats promptTokens=\(info.promptTokenCount, privacy: .public) promptTps=\(info.promptTokensPerSecond, privacy: .public) promptMs=\(Int(info.promptTime * 1000), privacy: .public) genTokens=\(info.generationTokenCount, privacy: .public) genTps=\(info.tokensPerSecond, privacy: .public) genMs=\(Int(info.generateTime * 1000), privacy: .public)"
+            "[perf] mlxStats promptTokens=\(info.promptTokenCount, privacy: .public) promptTps=\(info.promptTokensPerSecond, privacy: .public) promptMs=\(Int(info.promptTime * 1000), privacy: .public) genTokens=\(info.generationTokenCount, privacy: .public) genTps=\(info.tokensPerSecond, privacy: .public) genMs=\(Int(info.generateTime * 1000), privacy: .public) stop=\(String(describing: info.stopReason), privacy: .public) unclosedReasoning=\(info.unclosedReasoning, privacy: .public)"
         )
         mapperSignposter.emitEvent(
             "mlxStats",

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -83,12 +83,34 @@ struct GenerationEventMapperTests {
         )
         let events: [Generation] = [.chunk("ok"), .info(info)]
         let out = try await collect(events: events)
-        guard case .completionInfo(let count, let tps) = out.last else {
+        guard case .completionInfo(let count, let tps, let unclosed) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
         #expect(count == 8)
         #expect(tps > 0)
+        // Default-constructed GenerateCompletionInfo carries unclosedReasoning=false;
+        // a healthy stream that emitted </think> properly should mirror that here.
+        #expect(unclosed == false)
+    }
+
+    @Test func info_propagates_unclosedReasoning_when_trapped() async throws {
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 11,
+            generationTokenCount: 1024,
+            promptTime: 0.1,
+            generationTime: 90.0,
+            stopReason: .length,
+            unclosedReasoning: true
+        )
+        let events: [Generation] = [.reasoning("Self-Correction…"), .info(info)]
+        let out = try await collect(events: events)
+        guard case .completionInfo(_, _, let unclosed) = out.last else {
+            Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
+            return
+        }
+        #expect(unclosed == true,
+            "vmlx flagged trapped-thinking; mapper must surface it on the runtime event.")
     }
 
     @Test func empty_chunks_are_ignored() async throws {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -107,6 +107,48 @@ struct ModelRuntimeFindDirectoryTests {
         try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Gemma-vanilla")
     }
 
+    /// Inverse mismatch (the live-repro from 2026-04-25): bundle ships the
+    /// JANGTQ sidecar but jang_config.json was stamped as `bf16`. vmlx's
+    /// factory then dispatches to the BASE DeepSeekV4 / MiniMax / etc. class,
+    /// hits `tq_norms` / `tq_packed` tensors in the safetensors, and the
+    /// parameter loader throws `Unhandled keys [...]`. The preflight catches
+    /// it before any shards load and tells the user how to fix it.
+    @Test("Mislabeled bundle (bf16 stamp + sidecar present) throws inverse-mismatch error")
+    func jangtq_mislabeledBundle_bf16WithSidecar_throws() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "bf16", at: dir)
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+        #expect(throws: Error.self) {
+            try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "DSV4-mislabeled")
+        }
+    }
+
+    /// Inverse mismatch with no `weight_format` field at all. Same failure
+    /// shape — bundle ships the sidecar so the safetensors carry TurboQuant
+    /// tensors, but no stamp tells vmlx's factory to dispatch JANGTQ.
+    @Test("Mislabeled bundle (absent weight_format + sidecar present) throws inverse-mismatch error")
+    func jangtq_mislabeledBundle_absentStampWithSidecar_throws() throws {
+        let dir = try makeIsolatedDir()
+        // jang_config exists but omits weight_format entirely.
+        let json = #"{"profile":"unknown"}"#
+        try Data(json.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+        #expect(throws: Error.self) {
+            try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Generic-mislabeled")
+        }
+    }
+
+    /// Genuine bf16 dense bundle: stamp says bf16 AND no sidecar. This is
+    /// the common case for non-quantized JANG bundles (DSV4-Flash-JANG_2L,
+    /// Mistral-Small-4-JANG_2L, etc.) — must pass through cleanly.
+    @Test("Genuine bf16 bundle (no sidecar) passes through")
+    func jangtq_bf16NoSidecar_passes() throws {
+        let dir = try makeIsolatedDir()
+        try writeJangConfig(weightFormat: "bf16", at: dir)
+        // No sidecar — this is a real dense bf16 bundle, must not throw.
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "DSV4-bf16-dense")
+    }
+
     // MARK: - Existing resolveLocalModelDirectory tests (below)
 
     @Test("Nonexistent path returns nil")

--- a/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
@@ -59,6 +59,61 @@ struct StreamingHintTests {
         #expect(StreamingToolHint.decodeArgs(statsEncoded) == nil)
     }
 
+    // MARK: - StreamingStatsHint — unclosedReasoning flag
+
+    @Test func statsHint_encode_omitsFlagsWhenUnclosedFalse() {
+        // Default-false: encoded payload must NOT contain the trailing
+        // `;unclosed` field — keeps the wire compact and matches the legacy
+        // 2-field form so the bumped pin doesn't change wire bytes for
+        // healthy generations.
+        let encoded = StreamingStatsHint.encode(
+            tokenCount: 50, tokensPerSecond: 12.5)
+        #expect(!encoded.contains("unclosed"))
+    }
+
+    @Test func statsHint_encode_includesFlagWhenUnclosedTrue() {
+        let encoded = StreamingStatsHint.encode(
+            tokenCount: 1024, tokensPerSecond: 12.27, unclosedReasoning: true)
+        #expect(encoded.hasPrefix("\u{FFFE}stats:"))
+        #expect(encoded.hasSuffix(";unclosed"))
+    }
+
+    @Test func statsHint_decode_recoversUnclosedFlagWhenPresent() {
+        let encoded = StreamingStatsHint.encode(
+            tokenCount: 424, tokensPerSecond: 7.8, unclosedReasoning: true)
+        let decoded = StreamingStatsHint.decode(encoded)
+        #expect(decoded?.tokenCount == 424)
+        #expect(abs((decoded?.tokensPerSecond ?? 0) - 7.8) < 0.0001)
+        #expect(decoded?.unclosedReasoning == true)
+    }
+
+    @Test func statsHint_decode_defaultsUnclosedFalseOnLegacyTwoFieldPayload() {
+        // Forward-compat: a payload encoded by the legacy 2-field form
+        // (no flags suffix) must still decode cleanly with unclosed=false.
+        // This guards against pin-bump asymmetry where a streaming
+        // session straddles the upgrade and still works.
+        let legacy = "\u{FFFE}stats:128;99.4321"
+        let decoded = StreamingStatsHint.decode(legacy)
+        #expect(decoded?.tokenCount == 128)
+        #expect(decoded?.unclosedReasoning == false)
+    }
+
+    @Test func statsHint_decode_ignoresUnknownFlags() {
+        // Forward-compat for future flags — an unknown flag in the third
+        // field must not crash the decoder, and unclosed stays false.
+        let payload = "\u{FFFE}stats:10;5.0;futureflag,anotherflag"
+        let decoded = StreamingStatsHint.decode(payload)
+        #expect(decoded?.tokenCount == 10)
+        #expect(decoded?.unclosedReasoning == false)
+    }
+
+    @Test func statsHint_decode_recoversUnclosedFlagAlongsideUnknownFlags() {
+        // `unclosed` mixed with future flags in a comma list — still detected.
+        let payload = "\u{FFFE}stats:10;5.0;futureflag,unclosed"
+        let decoded = StreamingStatsHint.decode(payload)
+        #expect(decoded?.unclosedReasoning == true)
+    }
+
     // Issue #856 regression: the sentinel must NEVER appear in the
     // visible text of an assistant message. ChatView filters it out
     // before render. Here we lock in the contract that the decoder

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1123,6 +1123,11 @@ final class ChatSession: ObservableObject {
                 } else if let stats = StreamingStatsHint.decode(delta) {
                     currentTurn.generationTokenCount = stats.tokenCount
                     currentTurn.generationTokensPerSecond = stats.tokensPerSecond
+                    // Vmlx tells us the model never closed `</think>` before
+                    // EOS / max_tokens. Persist on the turn so the bubble
+                    // renderer can surface a one-line banner suggesting
+                    // the user toggle Disable Thinking for this prompt class.
+                    currentTurn.unclosedReasoning = stats.unclosedReasoning
                 } else if let reasoning = StreamingReasoningHint.decode(delta) {
                     processor.receiveReasoning(reasoning)
                 } else if !delta.isEmpty {

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -757,6 +757,7 @@ final class NativeStatsView: NSView {
         ttft: TimeInterval?,
         tokensPerSecond: Double?,
         tokenCount: Int?,
+        unclosedReasoning: Bool = false,
         theme: any ThemeProtocol
     ) {
         var parts: [String] = []
@@ -772,6 +773,23 @@ final class NativeStatsView: NSView {
         }
         if let count = tokenCount {
             parts.append("\(count) tokens")
+        }
+        // Trailing diagnostic chip — vmlx tells us the model never emitted
+        // `</think>` (or the family's close tag) before EOS / max_tokens.
+        // Three observed scenarios all benefit from the same hint:
+        //   1. Reasoning-trained Qwen3.6-A3B / DSV4 fine-tunes loop on
+        //      validation prompts ("give me a 20-digit number") — answer
+        //      buried in reasoning; user should toggle the model's
+        //      "Disable Thinking" option for the next turn (verified live).
+        //   2. Gemma-4 / harmony-channel models capped early by
+        //      `max_tokens` — analysis channel didn't close; user should
+        //      raise the cap (verified live, gemma-4-e2b at 32 tok cap).
+        //   3. Any thinking model that emitted EOS while still in
+        //      reasoning — answer is in the pane above.
+        // Text intentionally does NOT name a specific toggle so the chip
+        // reads accurately for every model family.
+        if unclosedReasoning {
+            parts.append("⚠ thinking didn't close — answer may be in reasoning above")
         }
         label.stringValue = parts.joined(separator: " \u{2022} ")
         label.font = NSFont.monospacedDigitSystemFont(
@@ -961,11 +979,12 @@ final class NativeMessageCellView: NSTableCellView {
         case let .preflightCapabilities(items):
             configureAsPreflight(block: block, items: items, context: context, sameKind: sameKind)
 
-        case let .generationStats(ttft, tokensPerSecond, tokenCount):
+        case let .generationStats(ttft, tokensPerSecond, tokenCount, unclosedReasoning):
             configureAsStats(
                 ttft: ttft,
                 tokensPerSecond: tokensPerSecond,
                 tokenCount: tokenCount,
+                unclosedReasoning: unclosedReasoning,
                 context: context,
                 sameKind: sameKind
             )
@@ -1532,6 +1551,7 @@ final class NativeMessageCellView: NSTableCellView {
         ttft: TimeInterval?,
         tokensPerSecond: Double?,
         tokenCount: Int?,
+        unclosedReasoning: Bool,
         context: CellRenderingContext,
         sameKind: Bool
     ) {
@@ -1553,6 +1573,7 @@ final class NativeMessageCellView: NSTableCellView {
             ttft: ttft,
             tokensPerSecond: tokensPerSecond,
             tokenCount: tokenCount,
+            unclosedReasoning: unclosedReasoning,
             theme: context.theme
         )
     }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -401,7 +401,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "070dc5b8c9829dc69b6e4831dd201537200a9c36"
+        "revision" : "c992df936879229251e9e06e2446c427c6f4cee7"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -401,7 +401,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "c992df936879229251e9e06e2446c427c6f4cee7"
+        "revision" : "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
       }
     },
     {


### PR DESCRIPTION
## Summary

Catch mislabeled JANGTQ bundles up front (the inverse of the missing-sidecar case) and bump vmlx-swift-lm to pick up the matching runtime-level auto-correction.

### The bug class

A bundle that ships `jangtq_runtime.safetensors` but whose `jang_config.json` stamps `weight_format: "bf16"` (or omits the field entirely) causes vmlx's factory to dispatch to the BASE `DeepseekV4Model` / `MiniMaxModel` / etc. class. The safetensors then carry `tq_norms` / `tq_packed` tensors the base parameter loader can't decode, surfacing 60+ shards into the load as:

```
Error: Unhandled keys ["tq_norms", "tq_packed"] in
model.layers.0.mlp.switch_mlp.up_proj in
DeepseekV4Model.DeepseekV4ModelInner.DeepseekV4DecoderLayer.DeepseekV4MoE.SwitchGLU.SwitchLinear
```

Live-confirmed 2026-04-25 on an early DSV4-Flash JANGTQ bundle stamped `"bf16"`. The vmlx integration doc explicitly notes this case via the `DSV4_FORCE_JANGTQ=1` env-var workaround.

### Two-layer fix (defense-in-depth)

| Layer | Purpose |
|---|---|
| **osaurus preflight throw** (this PR) | Operator-visible error that fires BEFORE vmlx loads any shards. Tells the user how to repair the bundle at source. |
| **vmlx runtime auto-correct** (paired pin bump) | Library-level resilience for non-osaurus consumers. Detects the same condition via the deterministic codebook signal and flips the in-memory dict's `weight_format` to `"mxtq"` before dispatch fires, with a clear stderr diagnostic. |

The two layers complement each other — osaurus users get the loud actionable error encouraging them to fix the bundle, non-osaurus consumers get silent auto-recovery for legacy mislabeled bundles.

### What changed

`Packages/OsaurusCore/Services/ModelRuntime.swift`:
- `validateJANGTQSidecarIfRequired` now detects two failure shapes:
  1. **Forward mismatch** (existing): `weight_format == "mxtq"` declared but sidecar absent.
  2. **Inverse mismatch** (new): sidecar present but `weight_format != "mxtq"`.
- Throws a remediation-shaped error in both cases.

`Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift`:
- 3 new tests:
  - Mislabeled (`bf16` stamp + sidecar present) → throws inverse-mismatch error.
  - Mislabeled (absent `weight_format` + sidecar present) → throws inverse-mismatch error.
  - Genuine bf16 dense bundle (no sidecar) → passes through cleanly. (Regression guard for the common dense-JANG case: `DSV4-Flash-JANG_2L`, `Mistral-Small-4-JANG_2L`, etc.)

`osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`:
- vmlx-swift-lm pin: `070dc5b` → `fa77575` (runtime auto-correction commit).

## Test plan

- [x] `swift test --filter ModelRuntimeFindDirectoryTests` → 12/12 pass (4 pre-existing + 3 new mislabel tests + 5 unrelated symlink-resolution tests)
- [x] `swift test --parallel` → 1020/1020 pass (one flaky pre-existing parallel-mode SQLite race in `DispatchRateLimitTests` cleared on re-run; unrelated to this PR)
- [x] Live verified on `DeepSeekV4-Flash-JANGTQ` bundle that originally produced the unhandled-keys error: after patching `weight_format` to `"mxtq"`, the bundle now dispatches to `DeepseekV4JANGTQModel` and loads cleanly.
- [x] Live verified the genuine bf16 dense bundle path (`DeepSeekV4-Flash-JANG_2L`, no sidecar) still passes preflight and dispatches to the base class.
