### PR TITLE
Support Azure OpenAI Foundry providers

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -237,8 +237,18 @@ public final class RemoteProviderManager: ObservableObject {
                 RemoteProviderKeychain.saveOAuthTokens(refreshed, for: provider.id)
             }
 
-            // Fetch models from the provider
-            let models = try await RemoteProviderService.fetchModels(from: provider)
+            // Fetch models from the provider and merge any manually configured deployment IDs.
+            let discoveredModels: [String]
+            do {
+                discoveredModels = try await RemoteProviderService.fetchModels(from: provider)
+            } catch {
+                if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
+                    discoveredModels = []
+                } else {
+                    throw error
+                }
+            }
+            let models = provider.mergedModelIds(discovered: discoveredModels)
 
             // Create service instance – resolve headers eagerly on @MainActor
             // so the service actor never reads from Keychain off the main thread.
@@ -431,6 +441,10 @@ public final class RemoteProviderManager: ObservableObject {
             case .gemini:
                 if testHeaders["x-goog-api-key"] == nil {
                     testHeaders["x-goog-api-key"] = apiKey
+                }
+            case .azureOpenAI:
+                if testHeaders["api-key"] == nil {
+                    testHeaders["api-key"] = apiKey
                 }
             case .openaiLegacy, .openResponses, .openAICodex, .osaurus:
                 if testHeaders["Authorization"] == nil {

--- a/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// Unified provider presets shared across onboarding and provider management.
 enum ProviderPreset: String, CaseIterable, Identifiable {
     case anthropic
+    case azureOpenAI
     case openai
     case google
     case xai
@@ -25,6 +26,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var name: String {
         switch self {
         case .anthropic: return "Anthropic"
+        case .azureOpenAI: return "Azure OpenAI Foundry"
         case .openai: return "OpenAI"
         case .google: return "Google"
         case .xai: return "xAI"
@@ -38,6 +40,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .anthropic: return "Claude models"
+        case .azureOpenAI: return "Azure deployments"
         case .openai: return "ChatGPT/Codex or Platform API"
         case .google: return "Gemini models"
         case .xai: return "Grok models"
@@ -51,6 +54,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .anthropic: return "brain.head.profile"
+        case .azureOpenAI: return "cloud.fill"
         case .openai: return "sparkles"
         case .google: return "globe"
         case .xai: return "bolt.fill"
@@ -64,6 +68,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var gradient: [Color] {
         switch self {
         case .anthropic: return [Color(red: 0.85, green: 0.55, blue: 0.35), Color(red: 0.75, green: 0.4, blue: 0.25)]
+        case .azureOpenAI: return [Color(red: 0.0, green: 0.47, blue: 0.84), Color(red: 0.0, green: 0.62, blue: 0.72)]
         case .openai: return [Color(red: 0.0, green: 0.65, blue: 0.52), Color(red: 0.0, green: 0.5, blue: 0.4)]
         case .google: return [Color(red: 0.26, green: 0.52, blue: 0.96), Color(red: 0.18, green: 0.38, blue: 0.85)]
         case .xai: return [Color(red: 0.1, green: 0.1, blue: 0.1), Color(red: 0.2, green: 0.2, blue: 0.2)]
@@ -77,6 +82,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var consoleURL: String {
         switch self {
         case .anthropic: return "https://console.anthropic.com/settings/keys"
+        case .azureOpenAI: return "https://ai.azure.com"
         case .openai: return "https://platform.openai.com/api-keys"
         case .google: return "https://aistudio.google.com/apikey"
         case .xai: return "https://console.x.ai/"
@@ -89,6 +95,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Optional badge label (e.g. "Privacy") shown as a highlight pill on provider cards
     var badge: String? {
         switch self {
+        case .azureOpenAI: return "Azure"
         case .venice: return "Privacy"
         default: return nil
         }
@@ -97,6 +104,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Optional documentation URL for the provider (shown in help sections)
     var documentationURL: String? {
         switch self {
+        case .azureOpenAI: return "https://learn.microsoft.com/azure/ai-foundry/openai/"
         case .venice: return "https://docs.venice.ai"
         default: return nil
         }
@@ -114,6 +122,13 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Help steps shown when guiding the user to create an API key
     var helpSteps: [String] {
         switch self {
+        case .azureOpenAI:
+            return [
+                "Open your Azure OpenAI resource in Azure AI Foundry",
+                "Copy the resource endpoint host and an API key",
+                "Add deployment names if they do not appear automatically",
+                "Paste the key here",
+            ]
         case .openai:
             return [
                 "Go to the OpenAI Platform API keys page",
@@ -160,6 +175,16 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 basePath: "/v1",
                 authType: .apiKey,
                 providerType: .anthropic
+            )
+        case .azureOpenAI:
+            return ProviderPresetConfiguration(
+                name: "Azure OpenAI Foundry",
+                host: "",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/openai/v1",
+                authType: .apiKey,
+                providerType: .azureOpenAI
             )
         case .openai:
             return ProviderPresetConfiguration(
@@ -228,9 +253,14 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
 
     /// Attempts to match an existing RemoteProvider to a known preset by host.
     static func matching(provider: RemoteProvider) -> ProviderPreset? {
+        if provider.providerType == .azureOpenAI {
+            return .azureOpenAI
+        }
+
         let host = provider.host.lowercased().trimmingCharacters(in: .whitespaces)
         return knownPresets.first { preset in
-            preset.configuration.host.lowercased() == host
+            guard !preset.configuration.host.isEmpty else { return false }
+            return preset.configuration.host.lowercased() == host
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -36,6 +36,7 @@ public enum RemoteProviderAuthType: String, Codable, Sendable, CaseIterable {
 /// Type of remote provider (determines API format)
 public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
     case openaiLegacy = "openai"  // OpenAI-compatible /chat/completions (third-party servers, backward compat)
+    case azureOpenAI = "azureOpenAI"  // Azure OpenAI Foundry /openai/v1 OpenAI-compatible chat completions
     case anthropic = "anthropic"  // Anthropic Messages API
     case openResponses = "openResponses"  // Open Responses API — used for official OpenAI and any compatible provider
     case openAICodex = "openAICodex"  // ChatGPT/Codex OAuth backend
@@ -45,6 +46,7 @@ public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
     public var displayName: String {
         switch self {
         case .openaiLegacy: return L("OpenAI Compatible")
+        case .azureOpenAI: return L("Azure OpenAI Foundry")
         case .anthropic: return L("Anthropic")
         case .openResponses: return L("Open Responses")
         case .openAICodex: return L("OpenAI Codex")
@@ -55,7 +57,7 @@ public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
 
     public var chatEndpoint: String {
         switch self {
-        case .openaiLegacy: return "/chat/completions"
+        case .openaiLegacy, .azureOpenAI: return "/chat/completions"
         case .anthropic: return "/messages"
         case .openResponses: return "/responses"
         case .openAICodex: return "/codex/responses"
@@ -86,6 +88,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     public var enabled: Bool
     public var autoConnect: Bool
     public var timeout: TimeInterval
+    public var manualModelIds: [String]
 
     // Keys for headers that should be stored in Keychain (not persisted in config)
     public var secretHeaderKeys: [String]
@@ -100,6 +103,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, name, host, providerProtocol, port, basePath
         case customHeaders, authType, providerType, enabled, autoConnect, timeout
+        case manualModelIds
         case secretHeaderKeys, remoteAgentId, remoteAgentAddress
     }
 
@@ -116,6 +120,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled: Bool = true,
         autoConnect: Bool = true,
         timeout: TimeInterval = 60,
+        manualModelIds: [String] = [],
         secretHeaderKeys: [String] = [],
         remoteAgentId: UUID? = nil,
         remoteAgentAddress: String? = nil
@@ -132,6 +137,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         self.enabled = enabled
         self.autoConnect = autoConnect
         self.timeout = timeout
+        self.manualModelIds = manualModelIds
         self.secretHeaderKeys = secretHeaderKeys
         self.remoteAgentId = remoteAgentId
         self.remoteAgentAddress = remoteAgentAddress
@@ -154,6 +160,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         autoConnect = try container.decodeIfPresent(Bool.self, forKey: .autoConnect) ?? true
         timeout = try container.decodeIfPresent(TimeInterval.self, forKey: .timeout) ?? 60
+        manualModelIds = try container.decodeIfPresent([String].self, forKey: .manualModelIds) ?? []
         secretHeaderKeys = try container.decodeIfPresent([String].self, forKey: .secretHeaderKeys) ?? []
         remoteAgentId = try container.decodeIfPresent(UUID.self, forKey: .remoteAgentId)
         remoteAgentAddress = try container.decodeIfPresent(String.self, forKey: .remoteAgentAddress)
@@ -262,6 +269,10 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
                 if headers["x-goog-api-key"] == nil {
                     headers["x-goog-api-key"] = apiKey
                 }
+            case .azureOpenAI:
+                if headers["api-key"] == nil {
+                    headers["api-key"] = apiKey
+                }
             case .openaiLegacy, .openResponses, .openAICodex, .osaurus:
                 if headers["Authorization"] == nil {
                     headers["Authorization"] = "Bearer \(apiKey)"
@@ -288,6 +299,25 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
 
     public func getOAuthTokens() -> RemoteProviderOAuthTokens? {
         RemoteProviderKeychain.getOAuthTokens(for: id)
+    }
+
+    public func mergedModelIds(discovered: [String]) -> [String] {
+        var seen = Set<String>()
+        var merged: [String] = []
+        let sourceModels = providerType == .azureOpenAI ? manualModelIds : discovered + manualModelIds
+
+        for rawValue in sourceModels {
+            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+
+            let key = value.lowercased()
+            guard !seen.contains(key) else { continue }
+
+            seen.insert(key)
+            merged.append(value)
+        }
+
+        return merged
     }
 }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -76,6 +76,33 @@ public actor RemoteProviderService: ToolCapableService {
             || GeminiFlashImageProfile.matches(modelId: modelName)
     }
 
+    static func allowsChatCompletionsReasoningObject(
+        providerType: RemoteProviderType,
+        host: String
+    ) -> Bool {
+        switch providerType {
+        case .openaiLegacy:
+            return !host.lowercased().contains("openai.com")
+        case .azureOpenAI, .anthropic, .openResponses, .openAICodex, .gemini, .osaurus:
+            return false
+        }
+    }
+
+    static func effectiveRequestProviderType(
+        configuredProviderType: RemoteProviderType,
+        request: RemoteChatRequest
+    ) -> RemoteProviderType {
+        guard configuredProviderType == .azureOpenAI else {
+            return configuredProviderType
+        }
+
+        if request.reasoning_effort != nil || request.tools?.isEmpty == false {
+            return .openResponses
+        }
+
+        return configuredProviderType
+    }
+
     /// Inactivity timeout for streaming: if no bytes arrive within this interval,
     /// assume the provider has stalled and end the stream. Floor of 120s accommodates
     /// thinking models that pause between tokens during reasoning.
@@ -187,7 +214,11 @@ public actor RemoteProviderService: ToolCapableService {
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
-        let (content, _) = try parseResponse(data)
+        let responseProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
+        let (content, _) = try parseResponse(data, providerType: responseProviderType)
         return content ?? ""
     }
 
@@ -272,7 +303,11 @@ public actor RemoteProviderService: ToolCapableService {
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
-        let (content, toolCalls) = try parseResponse(data)
+        let responseProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
+        let (content, toolCalls) = try parseResponse(data, providerType: responseProviderType)
 
         // Check for tool calls
         if let toolCalls = toolCalls, let firstCall = toolCalls.first {
@@ -741,7 +776,7 @@ public actor RemoteProviderService: ToolCapableService {
                 return try handleAnthropicEvent(jsonData, state: &state, yield: yield)
             case .openResponses, .openAICodex:
                 return try handleOpenResponsesEvent(jsonData, state: &state, yield: yield)
-            case .openaiLegacy, .osaurus:
+            case .openaiLegacy, .azureOpenAI, .osaurus:
                 return try handleOpenAIEvent(jsonData, state: &state, yield: yield)
             }
         } catch {
@@ -1149,7 +1184,10 @@ public actor RemoteProviderService: ToolCapableService {
         try await refreshCodexOAuthIfNeeded()
         let urlRequest = try buildURLRequest(for: request)
         let currentSession = self.session
-        let providerType = self.provider.providerType
+        let providerType = Self.effectiveRequestProviderType(
+            configuredProviderType: self.provider.providerType,
+            request: request
+        )
         let inactivityTimeout = self.streamInactivityTimeout
         let toolList = tools ?? []
         // Only the with-tools path needs accumulated text for the inline
@@ -1515,7 +1553,11 @@ public actor RemoteProviderService: ToolCapableService {
         toolChoice: ToolChoiceOption?
     ) -> RemoteChatRequest {
         let effortValue = parameters.modelOptions["reasoningEffort"]?.stringValue
-        let isOfficialOpenAI = provider.host.lowercased().contains("openai.com")
+        let allowsReasoningObject =
+            Self.allowsChatCompletionsReasoningObject(
+                providerType: provider.providerType,
+                host: provider.host
+            )
         let isReasoningModel = OpenAIReasoningProfile.matches(modelId: model)
 
         return RemoteChatRequest(
@@ -1536,7 +1578,7 @@ public actor RemoteProviderService: ToolCapableService {
             tools: tools,
             tool_choice: toolChoice,
             reasoning_effort: effortValue,
-            reasoning: isOfficialOpenAI ? nil : effortValue.map { ReasoningConfig(effort: $0) },
+            reasoning: allowsReasoningObject ? effortValue.map { ReasoningConfig(effort: $0) } : nil,
             modelOptions: parameters.modelOptions,
             veniceParameters: buildVeniceParameters(from: parameters.modelOptions)
         )
@@ -1692,8 +1734,12 @@ public actor RemoteProviderService: ToolCapableService {
     /// Build a URLRequest for the chat completions endpoint
     private func buildURLRequest(for request: RemoteChatRequest) throws -> URLRequest {
         let url: URL
+        let requestProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
 
-        if provider.providerType == .gemini {
+        if requestProviderType == .gemini {
             // Gemini uses model-in-URL pattern: /models/{model}:generateContent or :streamGenerateContent
             let action = request.stream ? "streamGenerateContent" : "generateContent"
             // Validate the model segment before interpolating into the
@@ -1743,7 +1789,7 @@ public actor RemoteProviderService: ToolCapableService {
             } else {
                 url = geminiURL
             }
-        } else if provider.providerType == .osaurus {
+        } else if requestProviderType == .osaurus {
             // Native Osaurus agent: POST /agents/{remoteAgentId}/run
             guard let agentId = provider.remoteAgentId else {
                 throw RemoteProviderServiceError.invalidURL
@@ -1753,7 +1799,7 @@ public actor RemoteProviderService: ToolCapableService {
             }
             url = agentURL
         } else {
-            let endpoint = provider.providerType.chatEndpoint
+            let endpoint = requestProviderType.chatEndpoint
             guard let standardURL = provider.url(for: endpoint) else {
                 throw RemoteProviderServiceError.invalidURL
             }
@@ -1792,7 +1838,7 @@ public actor RemoteProviderService: ToolCapableService {
         encoder.outputFormatting = .prettyPrinted
 
         let bodyData: Data
-        switch provider.providerType {
+        switch requestProviderType {
         case .anthropic:
             let anthropicRequest = request.toAnthropicRequest()
             bodyData = try encoder.encode(anthropicRequest)
@@ -1804,8 +1850,8 @@ public actor RemoteProviderService: ToolCapableService {
         case .gemini:
             let geminiRequest = request.toGeminiRequest()
             bodyData = try encoder.encode(geminiRequest)
-        case .openaiLegacy, .osaurus:
-            // Both providers consume the unmodified OpenAI-compatible body.
+        case .openaiLegacy, .azureOpenAI, .osaurus:
+            // These providers consume the unmodified OpenAI-compatible body.
             bodyData = try encoder.encode(request)
         }
         urlRequest.httpBody = bodyData
@@ -1813,8 +1859,11 @@ public actor RemoteProviderService: ToolCapableService {
     }
 
     /// Parse response based on provider type
-    private func parseResponse(_ data: Data) throws -> (content: String?, toolCalls: [ToolCall]?) {
-        switch provider.providerType {
+    private func parseResponse(
+        _ data: Data,
+        providerType: RemoteProviderType
+    ) throws -> (content: String?, toolCalls: [ToolCall]?) {
+        switch providerType {
         case .anthropic:
             let response = try JSONDecoder().decode(AnthropicMessagesResponse.self, from: data)
             var textContent = ""
@@ -1839,7 +1888,7 @@ public actor RemoteProviderService: ToolCapableService {
 
             return (textContent.isEmpty ? nil : textContent, toolCalls.isEmpty ? nil : toolCalls)
 
-        case .openaiLegacy:
+        case .openaiLegacy, .azureOpenAI:
             let response = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
             let content = response.choices.first?.message.content
             let toolCalls = response.choices.first?.message.tool_calls

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -85,9 +85,159 @@ struct RemoteChatRequestEncodingTests {
         #expect(payload["store"] as? Bool == false)
     }
 
+    @Test func azureProvider_usesAPIKeyHeader() throws {
+        let providerId = UUID()
+        defer { RemoteProviderKeychain.deleteAPIKey(for: providerId) }
+
+        let provider = RemoteProvider(
+            id: providerId,
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            basePath: "/openai/v1",
+            authType: .apiKey,
+            providerType: .azureOpenAI
+        )
+
+        #expect(RemoteProviderKeychain.saveAPIKey("azure-secret", for: providerId))
+
+        let headers = provider.resolvedHeaders()
+        #expect(headers["api-key"] == "azure-secret")
+        #expect(headers["Authorization"] == nil)
+    }
+
+    @Test func azureProvider_defaultURLUsesOpenAIPath() throws {
+        let provider = RemoteProvider(
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            basePath: "/openai/v1",
+            authType: .apiKey,
+            providerType: .azureOpenAI
+        )
+
+        #expect(
+            provider.url(for: provider.providerType.chatEndpoint)?.absoluteString
+                == "https://example-resource.cognitiveservices.azure.com/openai/v1/chat/completions"
+        )
+    }
+
+    @Test func remoteProvider_mergesManualModelIdsWithDiscoveredModels() throws {
+        let provider = RemoteProvider(
+            name: "Custom",
+            host: "api.example.com",
+            providerType: .openaiLegacy,
+            manualModelIds: [" gpt-5.4 ", "", "prod-chat", "GPT-5.4"]
+        )
+
+        #expect(provider.mergedModelIds(discovered: ["gpt-4.1", "prod-chat"]) == ["gpt-4.1", "prod-chat", "gpt-5.4"])
+    }
+
+    @Test func remoteProvider_decodingDefaultsManualModelIdsToEmptyArray() throws {
+        let json = """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "name": "Custom",
+              "host": "localhost",
+              "providerProtocol": "http",
+              "basePath": "/v1",
+              "customHeaders": {},
+              "authType": "none",
+              "providerType": "openai",
+              "enabled": true,
+              "autoConnect": true,
+              "timeout": 60,
+              "secretHeaderKeys": []
+            }
+            """
+
+        let provider = try JSONDecoder().decode(RemoteProvider.self, from: Data(json.utf8))
+
+        #expect(provider.manualModelIds == [])
+    }
+
+    @Test func azureProvider_disablesOpenAICompatibleReasoningObject() throws {
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .azureOpenAI,
+                host: "example-resource.cognitiveservices.azure.com"
+            ) == false
+        )
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .openaiLegacy,
+                host: "api.openai.com"
+            )
+                == false
+        )
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .openaiLegacy,
+                host: "api.deepseek.com"
+            )
+                == true
+        )
+    }
+
+    @Test func azureProvider_routesReasoningRequestsThroughResponses() throws {
+        let request = Self.makeRequest(
+            model: "gpt-5.5",
+            maxTokens: 1024,
+            reasoningEffort: "medium"
+        )
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .openResponses
+        )
+    }
+
+    @Test func azureProvider_routesToolRequestsThroughResponses() throws {
+        let request = Self.makeRequest(
+            model: "gpt-5.5",
+            maxTokens: 1024,
+            reasoningEffort: nil,
+            tools: [Self.weatherTool]
+        )
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .openResponses
+        )
+    }
+
+    @Test func azureProvider_keepsPlainRequestsOnChatCompletions() throws {
+        let request = Self.makeRequest(model: "gpt-4.1", maxTokens: 1024)
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .azureOpenAI
+        )
+    }
+
+    @Test func azureProvider_usesOnlyManualDeploymentIdsForModels() throws {
+        let provider = RemoteProvider(
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            providerType: .azureOpenAI,
+            manualModelIds: [" prod-chat ", "", "gpt-5.5", "PROD-CHAT"]
+        )
+
+        #expect(provider.mergedModelIds(discovered: ["gpt-4.1", "gpt-5.5"]) == ["prod-chat", "gpt-5.5"])
+    }
+
     // MARK: - Fixtures
 
-    private static func makeRequest(model: String, maxTokens: Int?) -> RemoteChatRequest {
+    private static func makeRequest(
+        model: String,
+        maxTokens: Int?,
+        reasoningEffort: String? = nil,
+        tools: [Tool]? = nil
+    ) -> RemoteChatRequest {
         RemoteChatRequest(
             model: model,
             messages: [ChatMessage(role: "user", content: "hi")],
@@ -98,14 +248,28 @@ struct RemoteChatRequestEncodingTests {
             frequency_penalty: nil,
             presence_penalty: nil,
             stop: nil,
-            tools: nil,
+            tools: tools,
             tool_choice: nil,
-            reasoning_effort: nil,
+            reasoning_effort: reasoningEffort,
             reasoning: nil,
             modelOptions: [:],
             veniceParameters: nil
         )
     }
+
+    private static let weatherTool = Tool(
+        type: "function",
+        function: ToolFunction(
+            name: "get_weather",
+            description: "Get weather",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "location": .object(["type": .string("string")])
+                ]),
+            ])
+        )
+    )
 
     private static func encodeAsDictionary(_ request: RemoteChatRequest) throws -> [String: Any] {
         let data = try JSONEncoder().encode(request)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -10,6 +10,24 @@
 import AppKit
 import SwiftUI
 
+private func parseManualModelIds(_ text: String) -> [String] {
+    var seen = Set<String>()
+    var values: [String] = []
+
+    for part in text.split(whereSeparator: { $0 == "\n" || $0 == "," }) {
+        let value = String(part).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { continue }
+
+        let key = value.lowercased()
+        guard !seen.contains(key) else { continue }
+
+        seen.insert(key)
+        values.append(value)
+    }
+
+    return values
+}
+
 // MARK: - Main View
 
 struct RemoteProviderEditSheet: View {
@@ -50,6 +68,13 @@ private struct AddProviderFlow: View {
     @State private var testResult: ProviderTestResult? = nil
     @State private var hasAppeared = false
 
+    // Known provider connection overrides for presets whose endpoint is user-specific.
+    @State private var knownHost: String = ""
+    @State private var knownProtocol: RemoteProviderProtocol = .https
+    @State private var knownPort: String = ""
+    @State private var knownBasePath: String = "/v1"
+    @State private var manualModelIdsText: String = ""
+
     // Custom provider fields
     @State private var customName: String = ""
     @State private var customHost: String = ""
@@ -68,10 +93,18 @@ private struct AddProviderFlow: View {
         if preset == .custom {
             return !customHost.trimmingCharacters(in: .whitespaces).isEmpty
         }
+        if preset == .azureOpenAI {
+            return !knownHost.trimmingCharacters(in: .whitespaces).isEmpty && !apiKey.isEmpty && apiKey.count > 5
+        }
         if preset == .openai && openAIAuthMode == .chatGPTSubscription {
             return true
         }
         return !apiKey.isEmpty && apiKey.count > 5
+    }
+
+    private var canSaveKnownProviderWithoutSuccessfulTest: Bool {
+        guard selectedPreset == .azureOpenAI else { return false }
+        return canTest && !parseManualModelIds(manualModelIdsText).isEmpty
     }
 
     var body: some View {
@@ -105,7 +138,10 @@ private struct AddProviderFlow: View {
         .scaleEffect(hasAppeared ? 1 : 0.95)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: hasAppeared)
         .onAppear {
-            selectedPreset = initialPreset
+            if let initialPreset {
+                initializeKnownConnection(for: initialPreset)
+                selectedPreset = initialPreset
+            }
             withAnimation { hasAppeared = true }
         }
     }
@@ -191,6 +227,7 @@ private struct AddProviderFlow: View {
                     ForEach(ProviderPreset.knownPresets + [.custom]) { preset in
                         ProviderSelectionCard(preset: preset) {
                             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                initializeKnownConnection(for: preset)
                                 selectedPreset = preset
                             }
                         }
@@ -245,6 +282,11 @@ private struct AddProviderFlow: View {
                         openAIAuthChoiceSection
                     }
 
+                    if selectedPreset == .azureOpenAI {
+                        azureConnectionSection
+                        azureDeploymentsSection
+                    }
+
                     if selectedPreset != .openai || openAIAuthMode == .platformAPIKey {
                         apiKeySection
                     }
@@ -264,7 +306,7 @@ private struct AddProviderFlow: View {
 
             // Footer
             sheetFooter(canProceed: canTest) {
-                if testResult?.isSuccess == true {
+                if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest {
                     saveKnownProvider()
                 } else {
                     testKnownProvider()
@@ -365,6 +407,11 @@ private struct AddProviderFlow: View {
                 customBasePath = "/v1"
                 customProtocol = .https
                 customAuthType = .none
+                knownHost = ""
+                knownProtocol = .https
+                knownPort = ""
+                knownBasePath = "/v1"
+                manualModelIdsText = ""
                 showAdvanced = false
                 timeout = 60
                 customHeaders = []
@@ -379,6 +426,119 @@ private struct AddProviderFlow: View {
             .foregroundColor(theme.secondaryText)
         }
         .buttonStyle(PlainButtonStyle())
+    }
+
+    private func initializeKnownConnection(for preset: ProviderPreset) {
+        let config = preset.configuration
+        knownHost = config.host
+        knownProtocol = config.providerProtocol
+        knownPort = config.port.map(String.init) ?? ""
+        knownBasePath = config.basePath
+        manualModelIdsText = ""
+        testResult = nil
+    }
+
+    private var azureConnectionSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 8) {
+                Image(systemName: "network")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text("AZURE ENDPOINT", bundle: .module)
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(theme.secondaryText)
+                    .tracking(0.5)
+            }
+
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("PROTOCOL", bundle: .module)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(theme.tertiaryText)
+                        .tracking(0.5)
+
+                    SegmentedToggle {
+                        SegmentedToggleButton("HTTPS", isSelected: knownProtocol == .https) { knownProtocol = .https }
+                        SegmentedToggleButton("HTTP", isSelected: knownProtocol == .http) { knownProtocol = .http }
+                    }
+                }
+                .frame(width: 140)
+
+                ProviderTextField(
+                    label: "Host",
+                    placeholder: "resource.cognitiveservices.azure.com",
+                    text: $knownHost,
+                    isMonospaced: true
+                )
+                .onChange(of: knownHost) { _, _ in testResult = nil }
+            }
+
+            HStack(spacing: 12) {
+                ProviderTextField(
+                    label: "Port",
+                    placeholder: knownProtocol == .https ? "443" : "80",
+                    text: $knownPort,
+                    isMonospaced: true
+                )
+                .frame(width: 90)
+                .onChange(of: knownPort) { _, _ in testResult = nil }
+
+                ProviderTextField(
+                    label: "Base Path",
+                    placeholder: "/openai/v1",
+                    text: $knownBasePath,
+                    isMonospaced: true
+                )
+                .onChange(of: knownBasePath) { _, _ in testResult = nil }
+            }
+
+            if !knownHost.trimmingCharacters(in: .whitespaces).isEmpty {
+                HStack(spacing: 8) {
+                    Image(systemName: "link")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.accentColor)
+                    Text(buildKnownEndpointPreview())
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.accentColor.opacity(0.1))
+                )
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private var azureDeploymentsSection: some View {
+        DeploymentNamesEditor(
+            text: $manualModelIdsText,
+            title: "DEPLOYMENT NAMES",
+            placeholder: "gpt-5.4\nmy-prod-chat",
+            theme: theme
+        )
+        .onChange(of: manualModelIdsText) { _, _ in testResult = nil }
+    }
+
+    private func buildKnownEndpointPreview() -> String {
+        var result = "\(knownProtocol.rawValue)://\(knownHost.trimmingCharacters(in: .whitespaces))"
+        if let port = Int(knownPort), port != knownProtocol.defaultPort {
+            result += ":\(port)"
+        }
+        let path = knownBasePath.trimmingCharacters(in: .whitespaces)
+        result += path.isEmpty ? "/openai/v1" : (path.hasPrefix("/") ? path : "/" + path)
+        return result
     }
 
     private var apiKeySection: some View {
@@ -800,7 +960,7 @@ private struct AddProviderFlow: View {
 
     private var actionButtonTitle: String {
         if isTesting { return openAIAuthMode == .chatGPTSubscription ? L("Signing in...") : L("Testing...") }
-        if testResult?.isSuccess == true { return L("Add Provider") }
+        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return L("Add Provider") }
         if case .failure = testResult { return L("Retry") }
         if selectedPreset == .openai && openAIAuthMode == .chatGPTSubscription {
             return L("Sign in with ChatGPT")
@@ -809,7 +969,7 @@ private struct AddProviderFlow: View {
     }
 
     private var actionButtonColor: Color {
-        if testResult?.isSuccess == true { return theme.successColor }
+        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return theme.successColor }
         if case .failure = testResult { return theme.errorColor }
         return theme.accentColor
     }
@@ -823,6 +983,7 @@ private struct AddProviderFlow: View {
     private func testKnownProvider() {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
+        let connection = knownProviderConnection(for: preset)
 
         isTesting = true
         testResult = nil
@@ -838,10 +999,10 @@ private struct AddProviderFlow: View {
                     models = OpenAICodexOAuthService.supportedModels
                 } else {
                     models = try await RemoteProviderManager.shared.testConnection(
-                        host: config.host,
-                        providerProtocol: config.providerProtocol,
-                        port: config.port,
-                        basePath: config.basePath,
+                        host: connection.host,
+                        providerProtocol: connection.providerProtocol,
+                        port: connection.port,
+                        basePath: connection.basePath,
                         authType: .apiKey,
                         providerType: config.providerType,
                         apiKey: apiKey,
@@ -866,6 +1027,7 @@ private struct AddProviderFlow: View {
     private func saveKnownProvider() {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
+        let connection = knownProviderConnection(for: preset)
         let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
         let isCodexOAuth = preset == .openai && openAIAuthMode == .chatGPTSubscription
         let providerConfig = isCodexOAuth ? OpenAICodexOAuthService.makeProvider() : nil
@@ -873,16 +1035,17 @@ private struct AddProviderFlow: View {
         let remoteProvider = RemoteProvider(
             id: providerConfig?.id ?? UUID(),
             name: providerConfig?.name ?? config.name,
-            host: providerConfig?.host ?? config.host,
-            providerProtocol: providerConfig?.providerProtocol ?? config.providerProtocol,
-            port: providerConfig?.port ?? config.port,
-            basePath: providerConfig?.basePath ?? config.basePath,
+            host: providerConfig?.host ?? connection.host,
+            providerProtocol: providerConfig?.providerProtocol ?? connection.providerProtocol,
+            port: providerConfig?.port ?? connection.port,
+            basePath: providerConfig?.basePath ?? connection.basePath,
             customHeaders: regularHeaders,
             authType: providerConfig?.authType ?? .apiKey,
             providerType: providerConfig?.providerType ?? config.providerType,
             enabled: true,
             autoConnect: true,
             timeout: timeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
 
@@ -959,6 +1122,25 @@ private struct AddProviderFlow: View {
             RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: providerId)
         }
     }
+
+    private func knownProviderConnection(for preset: ProviderPreset) -> ProviderPresetConfiguration {
+        let config = preset.configuration
+        guard preset == .azureOpenAI else { return config }
+
+        let trimmedHost = knownHost.trimmingCharacters(in: .whitespaces)
+        let trimmedBasePath = knownBasePath.trimmingCharacters(in: .whitespaces)
+        let port: Int? = knownPort.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(knownPort)
+
+        return ProviderPresetConfiguration(
+            name: config.name,
+            host: trimmedHost,
+            providerProtocol: knownProtocol,
+            port: port,
+            basePath: trimmedBasePath.isEmpty ? "/openai/v1" : trimmedBasePath,
+            authType: config.authType,
+            providerType: config.providerType
+        )
+    }
 }
 
 // MARK: - Edit Provider Flow (simplified)
@@ -988,6 +1170,7 @@ private struct EditProviderFlow: View {
 
     // Editable fields
     @State private var apiKey: String = ""
+    @State private var manualModelIdsText: String = ""
 
     // Advanced
     @State private var showAdvanced = false
@@ -1129,6 +1312,15 @@ private struct EditProviderFlow: View {
                 }
 
                 ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
+            }
+
+            if preset == .azureOpenAI {
+                DeploymentNamesEditor(
+                    text: $manualModelIdsText,
+                    title: "DEPLOYMENT NAMES",
+                    placeholder: "gpt-5.4\nmy-prod-chat",
+                    theme: theme
+                )
             }
 
             // Help section
@@ -1546,6 +1738,9 @@ private struct EditProviderFlow: View {
     private var canSave: Bool {
         if matchedPreset != nil {
             // Known provider: always saveable (name/host come from preset or advanced)
+            if providerType == .azureOpenAI {
+                return !host.trimmingCharacters(in: .whitespaces).isEmpty
+            }
             return true
         }
         return !name.trimmingCharacters(in: .whitespaces).isEmpty
@@ -1563,6 +1758,7 @@ private struct EditProviderFlow: View {
         authType = provider.authType
         providerType = provider.providerType
         timeout = provider.timeout
+        manualModelIdsText = provider.manualModelIds.joined(separator: "\n")
         customHeaders = provider.customHeaders.map { HeaderEntry(key: $0.key, value: $0.value, isSecret: false) }
         for key in provider.secretHeaderKeys {
             customHeaders.append(HeaderEntry(key: key, value: "", isSecret: true))
@@ -1622,6 +1818,7 @@ private struct EditProviderFlow: View {
             enabled: provider.enabled,
             autoConnect: true,
             timeout: timeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
 
@@ -1974,6 +2171,61 @@ private struct ProviderSecureField: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+// MARK: - Deployment Names Editor
+
+private struct DeploymentNamesEditor: View {
+    @Binding var text: String
+    let title: String
+    let placeholder: String
+    let theme: ThemeProtocol
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .tracking(0.5)
+
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundColor(theme.placeholderText)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 10)
+                        .allowsHitTesting(false)
+                }
+
+                TextEditor(text: $text)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.clear)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 6)
+            }
+            .frame(minHeight: 82)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(theme.inputBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
                 )
         )
     }


### PR DESCRIPTION
## Summary

Adds Azure OpenAI Foundry as a first-class remote provider while keeping the implementation scoped to provider configuration, request shaping, model selection, and tests.

This PR fixes the Azure request failures seen when using newer reasoning-capable deployments:

- Azure rejected OpenAI-compatible `chat/completions` payloads that included the top-level `reasoning` object with `Unknown parameter: 'reasoning'`.
- Azure also rejected function-tool requests that carried `reasoning_effort` through `/v1/chat/completions`, with an error directing clients to use `/v1/responses` instead.
- The Azure model selector was showing all discovered/catalog models instead of only the deployment IDs configured by the user.

The PR intentionally does not include documentation edits, signing changes, or SQLCipher/header changes. The branch was rebuilt from `main` as a clean code-only PR branch so the diff stays focused.

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## What changed

### Azure provider preset and configuration

- Adds Azure OpenAI Foundry to the remote provider presets.
- Keeps the Azure endpoint convention on the OpenAI-compatible path (`/openai/v1/...`) so users can provide an Azure resource host and deployment IDs rather than needing to reason about raw endpoint paths.
- Ensures Azure providers use the `api-key` header instead of the standard OpenAI `Authorization: Bearer ...` header.

### Azure model selector behavior

- Changes `RemoteProvider.mergedModelIds(discovered:)` so Azure providers only expose manually configured deployment IDs.
- Keeps the existing discovered-plus-manual merge behavior for other OpenAI-compatible providers.
- Preserves trimming and case-insensitive de-duplication so duplicate deployment IDs do not produce duplicate selector entries.

This matches Azure's deployment model: the user selects from their configured deployment names, not from the global OpenAI model catalog.

### Reasoning request shaping

- Moves provider request-policy logic into `RemoteProviderService` instead of the configuration model, keeping `Models` as pure data per `CONTRIBUTING.md`.
- Adds explicit service helpers for:
  - deciding whether an OpenAI-compatible `reasoning` object is allowed on chat-completions requests;
  - deciding the effective request provider for Azure requests that need the Responses API.
- Stops Azure chat-completions requests from sending the top-level `reasoning` object.
- Preserves the top-level `reasoning` object for non-OpenAI third-party OpenAI-compatible providers that may support it.
- Keeps official OpenAI hosts on their existing handling rather than sending unsupported chat-completions reasoning payloads.

### Responses API routing for Azure

- Routes Azure requests through the Open Responses request/response path when the request contains either:
  - `reasoning_effort`; or
  - function tools.
- Keeps plain Azure chat requests on the Azure chat-completions path.
- Uses the effective provider type consistently when:
  - choosing the endpoint;
  - encoding the request body;
  - parsing non-streaming responses;
  - dispatching streaming SSE events.

The choice here is deliberately conditional rather than switching all Azure traffic to Responses. Plain chat-completions requests keep the existing Azure behavior, while requests that Azure explicitly rejects on chat-completions move to the API shape Azure asked for.

### Tests

Adds focused coverage for:

- Azure using `api-key` headers.
- Azure defaulting to OpenAI-compatible `/openai/v1/...` URL paths.
- Azure not sending the OpenAI-compatible top-level `reasoning` object.
- Azure reasoning requests using the Responses API provider path.
- Azure tool requests using the Responses API provider path.
- Plain Azure chat requests staying on chat completions.
- Azure model lists using only configured deployment IDs.
- Non-Azure OpenAI-compatible providers continuing to merge discovered and manual model IDs.

## Test Plan

Completed locally:

- [x] `git diff --check`
- [x] `PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:$HOME/.local/bin:$PATH" lefthook run pre-push`

Additional local verification performed during development before rebuilding the clean PR branch:

- [x] `swift test --package-path Packages/OsaurusCore --filter RemoteChatRequestEncodingTests` passed with 17 tests and 0 failures.
- [x] `swift test --package-path Packages/OsaurusCore` passed with 1118 tests and 0 failures.

Clean-worktree caveat:

- [ ] In a fresh worktree with the currently selected local Xcode/macOS 26.2 SDK, `swift test --package-path Packages/OsaurusCore --filter RemoteChatRequestEncodingTests` fails during package compilation before the Azure tests run. I reproduced the same failure on unmodified `main`, so this is not introduced by this PR. The compiler errors are SQLCipher/Apple SQLite module-definition conflicts such as `sqlite3_api_routines`, `Fts5ExtensionApi`, and `fts5_api` having different definitions between `OsaurusSQLCipher` and the SDK `SQLite3` modules. I left that out of this PR because it is unrelated to Azure provider support and should be handled separately.

## Screenshots

No screenshots included. The UI change is limited to provider configuration/model-selection behavior and is covered by tests.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed — no docs were changed because this PR is intentionally code-only and scoped to the Azure provider fix
- [ ] I verified build on macOS with Xcode 16.4+ — local clean-worktree Swift test is currently blocked by the SQLCipher/SQLite module-definition issue described above, which also reproduces on `main`
