### PR TITLE
feat: Nemotron-3 Hybrid + storage fix + multimodal API + Bug 1/3a stability fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78bf1831237aba77bd64606b67d185ed63b4df4735104f9b5a157d27501977b1",
+  "originHash" : "c5dba7ce3f4e5aa8a0d89ec42071945678e8f45ce1f3d8fcfeee68e807318cd1",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -96,8 +96,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/mlx-swift",
       "state" : {
-        "branch" : "osaurus-0.31.3",
-        "revision" : "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"
+        "revision" : "e0b61113f0190e3503ad9123bf4d4508248cd316"
       }
     },
     {
@@ -419,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
+        "revision" : "13abe407df83d1836f640d0cb56f63a7e640ede3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -418,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "13abe407df83d1836f640d0cb56f63a7e640ede3"
+        "revision" : "2a6c965a731711a411f0809d118d34db16ec65c3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -418,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "5adb91bdd150b75599dc4f76dede2f44b1e3c082"
+        "revision" : "03b4441885e3aea9eea7bb1515ce43ef44e117ef"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -418,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "2a6c965a731711a411f0809d118d34db16ec65c3"
+        "revision" : "5adb91bdd150b75599dc4f76dede2f44b1e3c082"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -418,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "de521c7c9ded41f033877aff06781981af06cd58"
+        "revision" : "a196800715302e3903283aeaf6ec978eb1b1ac92"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,7 +96,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/mlx-swift",
       "state" : {
-        "revision" : "e0b61113f0190e3503ad9123bf4d4508248cd316"
+        "revision" : "0a56f9041d56b4b8161f67a6cbd540ae66efc9fd"
       }
     },
     {
@@ -418,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "03b4441885e3aea9eea7bb1515ce43ef44e117ef"
+        "revision" : "de521c7c9ded41f033877aff06781981af06cd58"
       }
     },
     {

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -26,6 +26,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     public func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.shared = self
 
+        // Make MLX C++ errors recoverable instead of process-fatal. Must run
+        // before any model load can call into MLX so the first forward pass
+        // is already protected. See `MLXErrorRecovery` for the rationale and
+        // the specific crash class this prevents.
+        MLXErrorRecovery.installGlobalHandler()
+
         // Detect repeated startup crashes and enter safe mode if needed
         LaunchGuard.checkOnLaunch()
 

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -639,6 +639,66 @@ extension ModelManager {
             releasedAt: date("2026-04-17")
         ),
 
+        // MARK: Nemotron-3 Nano Omni Reasoning (hybrid Mamba-2 SSM + Attn + MoE)
+        //
+        // 30B total / ~3B active. 52-layer hybrid: 23 Mamba-2 SSM layers,
+        // 23 MoE layers (128 routed × 6 active + 1 shared, ReLU² activation),
+        // 6 attention layers (GQA 32q × 2kv, NO RoPE — position info from
+        // Mamba). 262K native context. Reasoning ON by default — chat
+        // template emits `<think>...</think>` segments parsed by vmlx's
+        // think_xml stamp (auto-resolved from `model_type=nemotron_h`).
+        //
+        // Tool format: `nemotron` (NeMo-style) — auto-resolved by vmlx via
+        // jang_config.capabilities or model-type heuristic.
+        // Cache: hybrid — `MambaCache(size=2)` for the 23 M layers,
+        // `KVCacheSimple` for the 6 * layers, nil for E layers. vmlx's
+        // `CacheCoordinator.isHybrid` auto-flips on first slot admission;
+        // osaurus does NOT call `setHybrid` manually (per
+        // OSAURUS-INTEGRATION.md).
+        // Sampling recipe per `research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md`:
+        // T=0.6 top_p=0.95 (DeepSeek-style). Bundles ship those defaults
+        // in `generation_config.json`; `LocalGenerationDefaults` reads them.
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"),
+            description:
+                "NVIDIA Nemotron-3 30B Reasoning hybrid (Mamba-2 + MoE). MXFP4 quantization — fastest decode path. 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            isTopSuggestion: true,
+            downloadSizeBytes: 18_002_117_870,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4"),
+            description:
+                "Nemotron-3 30B Reasoning hybrid, 4-bit TurboQuant routed experts. Near-bf16 quality at ~16 GB. 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            downloadSizeBytes: 16_009_341_440,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ"),
+            description:
+                "Nemotron-3 30B Reasoning hybrid, 2-bit TurboQuant routed experts. Smallest footprint (~9 GB). 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            downloadSizeBytes: 9_136_488_448,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
         // MARK: Large Models
 
         MLXModel(

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -699,6 +699,118 @@ extension ModelManager {
             releasedAt: date("2026-04-28")
         ),
 
+        // MARK: Laguna-XS.2 (preview — vmlx engine support pending)
+        //
+        // Poolside's `model_type=laguna` — agentic-coding 33B/3B-active MoE,
+        // 40 layers, hybrid SWA + full attention with per-layer head counts,
+        // dual RoPE (full=YaRN, swa=default), 256 routed experts top-8 + 1
+        // shared expert, sigmoid routing with per-head gating, q_norm/k_norm
+        // in attention. Text-only. 131K context.
+        //
+        // The hybrid here is SLIDING-WINDOW + full attention (handled by
+        // `RotatingKVCache` + `KVCacheSimple` per-layer in vmlx), NOT the
+        // Mamba/Attn/MoE pattern used by Nemotron-3. So `isKnownHybridModel`
+        // intentionally does NOT match Laguna — `setHybrid(true)` is for
+        // SSM-state companion caches, which Laguna doesn't have.
+        //
+        // The chat template (`laguna_glm_thinking_v5/chat_template.jinja`)
+        // ships an `enable_thinking` Jinja kwarg that defaults to false;
+        // the per-model `LagunaThinkingProfile` in `ModelOptions.swift`
+        // exposes a "Disable Thinking" toggle so reasoning can be flipped
+        // on per request.
+        //
+        // Quant + bundle metadata per `jang_tools/convert_laguna_jangtq.py`
+        // and `jang_tools/convert_laguna_mxfp4.py`. `jang_config.json` v2:
+        //   { "weight_format": "mxtq" | "mxfp4",
+        //     "source_model.architecture": "laguna",
+        //     "has_vision/audio/video": false,
+        //     "mxtq_bits": { attention=8, shared_expert=8,
+        //                    routed_expert=2|4, embed_lm_head=8 } }
+        // The shared `validateJANGTQSidecarIfRequired` preflight catches
+        // mislabeled bundles (sidecar present but `weight_format != "mxtq"`)
+        // for any JANGTQ family — Laguna inherits that protection.
+
+        MLXModel(
+            id: "OsaurusAI/Laguna-XS.2-mxfp4",
+            name: ModelMetadataParser.friendlyName(from: "OsaurusAI/Laguna-XS.2-mxfp4"),
+            description:
+                "Poolside Laguna-XS.2 33B/3B-active agentic-coding MoE. MXFP4 quant — fastest decode. 131K context, 256 experts top-8.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Laguna-XS.2-mxfp4",
+            downloadSizeBytes: 17_500_000_000,
+            modelType: "laguna",
+            releasedAt: date("2026-04-30")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Laguna-XS.2-JANGTQ2",
+            name: ModelMetadataParser.friendlyName(from: "OsaurusAI/Laguna-XS.2-JANGTQ2"),
+            description:
+                "Poolside Laguna-XS.2 33B/3B-active agentic-coding MoE, 2-bit TurboQuant routed experts. Smallest footprint (~7 GB). 131K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Laguna-XS.2-JANGTQ2",
+            downloadSizeBytes: 7_300_000_000,
+            modelType: "laguna",
+            releasedAt: date("2026-04-30")
+        ),
+
+        // MARK: Mistral-Medium-3.5-128B (preview — vmlx engine support pending)
+        //
+        // `model_type=mistral3` outer wrapper with `text_config.model_type=
+        // ministral3` (88 layers, hidden 12288, 96/8 GQA, head_dim 128, 256K
+        // YaRN). Pixtral vision tower (48 layers, hidden 1664, image_size
+        // 1540, patch 14, spatial_merge 2). Text + image. Source FP8 e4m3
+        // with per-tensor scales; vision tower / projector / lm_head stay
+        // in bf16/fp16.
+        //
+        // vmlx-swift-lm's `mistral3` factory currently branches on
+        // `text_config.model_type == "mistral4"` (older Mistral 3) and
+        // falls through to `Mistral3VLM` for everything else. Loading a
+        // Mistral 3.5 bundle through that fall-through path will fail
+        // because the layer/hidden counts don't match `Mistral3VLM`'s
+        // expectations — the engine needs a `ministral3` text inner
+        // class (mirrors how `mistral4` was added). Tracked as a vmlx
+        // follow-up; the registry entry is here so the picker carries
+        // it across the engine bump and host-side preflight is in place.
+        //
+        // Quant + bundle metadata per `jang_tools/convert_mistral3_jangtq.py`
+        // and `jang_tools/convert_mistral3_mxfp4.py`. `jang_config.json` v2:
+        //   { "weight_format": "mxtq" | "mxfp4",
+        //     "source_model.architecture": "mistral3",
+        //     "has_vision": true, "vision_arch": "pixtral",
+        //     "mxtq_bits": { text_decoder=2|4, embed_tokens=8,
+        //                    vision_tower="passthrough_fp16",
+        //                    multi_modal_projector="passthrough_fp16",
+        //                    lm_head="passthrough_fp16" } }
+        //
+        // Not a Mamba/SSM hybrid — `isKnownHybridModel` does NOT match.
+
+        MLXModel(
+            id: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4"),
+            description:
+                "Mistral Medium 3.5 128B + Pixtral vision. MXFP4 quant — fastest decode. 256K context, 24-language coverage.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",
+            downloadSizeBytes: 70_400_000_000,
+            modelType: "mistral3",
+            releasedAt: date("2026-04-30")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2"),
+            description:
+                "Mistral Medium 3.5 128B + Pixtral vision, 2-bit TurboQuant text decoder. ~36 GB footprint. 256K context, 24-language coverage.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2",
+            downloadSizeBytes: 36_700_000_000,
+            modelType: "mistral3",
+            releasedAt: date("2026-04-30")
+        ),
+
         // MARK: Large Models
 
         MLXModel(

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -652,9 +652,14 @@ extension ModelManager {
         // jang_config.capabilities or model-type heuristic.
         // Cache: hybrid — `MambaCache(size=2)` for the 23 M layers,
         // `KVCacheSimple` for the 6 * layers, nil for E layers. vmlx's
-        // `CacheCoordinator.isHybrid` auto-flips on first slot admission;
-        // osaurus does NOT call `setHybrid` manually (per
-        // OSAURUS-INTEGRATION.md).
+        // `CacheCoordinator.isHybrid` auto-flips on first slot admission
+        // via `BatchEngine.admitPendingRequests`; osaurus *also* calls
+        // `setHybrid(true)` eagerly in `ModelRuntime.installCacheCoordinator`
+        // for any name matching `isKnownHybridModel(name:)` — Nemotron-3
+        // matches via the `nemotron-3` substring. The eager set is harmless
+        // (per OMNI-OSAURUS-HOOKUP.md §5.1) and avoids a one-frame stale-flag
+        // window if a request lands via the single-slot Evaluate path before
+        // BatchEngine has flipped the flag.
         // Sampling recipe per `research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md`:
         // T=0.6 top_p=0.95 (DeepSeek-style). Bundles ship those defaults
         // in `generation_config.json`; `LocalGenerationDefaults` reads them.

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -759,7 +759,7 @@ extension ModelManager {
             releasedAt: date("2026-04-30")
         ),
 
-        // MARK: Mistral-Medium-3.5-128B (preview — vmlx engine support pending)
+        // MARK: Mistral-Medium-3.5-128B (preview — architecturally supported, end-to-end load unverified)
         //
         // `model_type=mistral3` outer wrapper with `text_config.model_type=
         // ministral3` (88 layers, hidden 12288, 96/8 GQA, head_dim 128, 256K
@@ -768,15 +768,17 @@ extension ModelManager {
         // with per-tensor scales; vision tower / projector / lm_head stay
         // in bf16/fp16.
         //
-        // vmlx-swift-lm's `mistral3` factory currently branches on
-        // `text_config.model_type == "mistral4"` (older Mistral 3) and
-        // falls through to `Mistral3VLM` for everything else. Loading a
-        // Mistral 3.5 bundle through that fall-through path will fail
-        // because the layer/hidden counts don't match `Mistral3VLM`'s
-        // expectations — the engine needs a `ministral3` text inner
-        // class (mirrors how `mistral4` was added). Tracked as a vmlx
-        // follow-up; the registry entry is here so the picker carries
-        // it across the engine bump and host-side preflight is in place.
+        // vmlx-swift-lm's `mistral3` factory branches on
+        // `text_config.model_type == "mistral4"` and falls through to
+        // `Mistral3VLM` otherwise. `Mistral3VLM.LanguageModel`
+        // (Libraries/MLXVLM/Models/Mistral3.swift:516) is explicitly
+        // documented to handle BOTH `ministral3` (sliding + llama4 scaling)
+        // AND vanilla `mistral` model_types via `Ministral3ModelInner`.
+        // Vision shapes (image_size, num_layers, spatial_merge) are
+        // config-parametric. So Mistral 3.5 should load through the
+        // existing factory dispatch — but no end-to-end smoke test has
+        // been run on real 3.5 weights yet, hence "preview". Marked top
+        // suggestion only after a real load + decode pass on bundle.
         //
         // Quant + bundle metadata per `jang_tools/convert_mistral3_jangtq.py`
         // and `jang_tools/convert_mistral3_mxfp4.py`. `jang_config.json` v2:

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -145,21 +145,47 @@ struct ModelsResponse: Codable, Sendable {
 
 // MARK: - Multimodal Content Parts
 
-/// OpenAI-compatible content part for multimodal messages
+/// OpenAI-compatible content part for multimodal messages.
+///
+/// Supports four shapes:
+///   - `text` / `input_text` — plain text
+///   - `image_url` — `{url, detail?}`. URL may be `data:image/...;base64,...` or `https://...`
+///   - `input_audio` — `{data: <base64>, format: "wav"|"mp3"|"flac"|...}`. Mirrors the
+///     OpenAI Realtime / GPT-4o audio shape; the audio bytes are written to a temp
+///     file and handed to vmlx as `UserInput.Audio.url(...)` so vmlx's
+///     `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32) handles
+///     all decoding. Format strings are passed through to vmlx unchanged — vmlx
+///     uses the file extension, so the format hint becomes the file extension.
+///   - `video_url` — `{url}`. Mirrors the convention adopted by LM Studio / Ollama
+///     for video inputs since OpenAI hasn't published a canonical chat-completions
+///     video shape. URL may be `data:video/...;base64,...` or `https://...`.
 enum MessageContentPart: Codable, Sendable {
     case text(String)
     case imageUrl(url: String, detail: String?)
+    case audioInput(data: String, format: String)
+    case videoUrl(url: String)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case text
         case input_text
         case image_url
+        case input_audio
+        case video_url
     }
 
     private struct ImageUrlContent: Codable {
         let url: String
         let detail: String?
+    }
+
+    private struct InputAudioContent: Codable {
+        let data: String
+        let format: String
+    }
+
+    private struct VideoUrlContent: Codable {
+        let url: String
     }
 
     init(from decoder: Decoder) throws {
@@ -178,6 +204,12 @@ enum MessageContentPart: Codable, Sendable {
         case "image_url":
             let imageUrl = try container.decode(ImageUrlContent.self, forKey: .image_url)
             self = .imageUrl(url: imageUrl.url, detail: imageUrl.detail)
+        case "input_audio":
+            let audio = try container.decode(InputAudioContent.self, forKey: .input_audio)
+            self = .audioInput(data: audio.data, format: audio.format)
+        case "video_url":
+            let video = try container.decode(VideoUrlContent.self, forKey: .video_url)
+            self = .videoUrl(url: video.url)
         default:
             // Fallback to text for unknown types
             if let text = try? container.decode(String.self, forKey: .text) {
@@ -197,6 +229,12 @@ enum MessageContentPart: Codable, Sendable {
         case .imageUrl(let url, let detail):
             try container.encode("image_url", forKey: .type)
             try container.encode(ImageUrlContent(url: url, detail: detail), forKey: .image_url)
+        case .audioInput(let data, let format):
+            try container.encode("input_audio", forKey: .type)
+            try container.encode(InputAudioContent(data: data, format: format), forKey: .input_audio)
+        case .videoUrl(let url):
+            try container.encode("video_url", forKey: .type)
+            try container.encode(VideoUrlContent(url: url), forKey: .video_url)
         }
     }
 }
@@ -231,6 +269,32 @@ struct ChatMessage: Codable, Sendable {
             guard let commaIndex = url.firstIndex(of: ",") else { return nil }
             let base64String = String(url[url.index(after: commaIndex)...])
             return Data(base64Encoded: base64String)
+        }
+    }
+
+    /// Extract `(base64, format)` pairs from `input_audio` content parts.
+    /// `format` is whatever the client sent (e.g. `"wav"`, `"mp3"`); we pass
+    /// it through to the file extension when materializing the temp file
+    /// because vmlx's `nemotronOmniLoadAudioFile` keys decoder selection on
+    /// the URL extension via AVAudioConverter.
+    var audioInputs: [(data: String, format: String)] {
+        guard let parts = contentParts else { return [] }
+        return parts.compactMap { part in
+            if case .audioInput(let data, let format) = part {
+                return (data, format)
+            }
+            return nil
+        }
+    }
+
+    /// Extract video URLs (data: or http(s):) from `video_url` content parts.
+    var videoUrls: [String] {
+        guard let parts = contentParts else { return [] }
+        return parts.compactMap { part in
+            if case .videoUrl(let url) = part {
+                return url
+            }
+            return nil
         }
     }
 }
@@ -273,11 +337,16 @@ extension ChatMessage {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(role, forKey: .role)
-        // If we have content parts with images, encode as array; otherwise as string
+        // If we have content parts with any non-text media, encode as array;
+        // otherwise as string. Round-trip preserves audio/video/image parts
+        // so a request that came in with `input_audio` or `video_url` is
+        // re-serialized in the same shape.
         if let parts = contentParts,
             parts.contains(where: {
-                if case .imageUrl = $0 { return true }
-                return false
+                switch $0 {
+                case .imageUrl, .audioInput, .videoUrl: return true
+                case .text: return false
+                }
             })
         {
             try container.encode(parts, forKey: .content)

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -400,6 +400,57 @@ extension ChatMessage {
         self.tool_calls = nil
         self.tool_call_id = nil
     }
+
+    /// Multimodal init covering image + audio + video. Used by the
+    /// chat composer when the loaded model's capabilities advertise the
+    /// modality. Audio bytes encode as `input_audio` with explicit
+    /// format hint; video bytes encode as `video_url` with
+    /// `data:video/<container>` URL. All three flow into the
+    /// OpenAI-compatible JSON shape that vmlx's
+    /// `mapOpenAIChatToMLX` materializes through
+    /// `extractAudioSources` / `extractVideoSources`.
+    init(
+        role: String,
+        text: String,
+        imageData: [Data],
+        audios: [(data: Data, format: String)],
+        videos: [(data: Data, mimeSubtype: String)]
+    ) {
+        self.role = role
+        var parts: [MessageContentPart] = []
+
+        if !text.isEmpty {
+            parts.append(.text(text))
+        }
+
+        for data in imageData {
+            let base64 = data.base64EncodedString()
+            parts.append(.imageUrl(url: "data:image/png;base64,\(base64)", detail: nil))
+        }
+
+        for (data, format) in audios {
+            // OpenAI audio shape: bare base64 string + format hint.
+            // The format string round-trips to vmlx's
+            // `materializeMediaDataUrl` audio canonicalization (mp4 → m4a
+            // for audio mime, NOT for video — audit fix locked in
+            // `MaterializeMediaDataUrlMCDCTests`).
+            parts.append(.audioInput(data: data.base64EncodedString(), format: format))
+        }
+
+        for (data, mimeSubtype) in videos {
+            // Video data URL with the container subtype (`mp4` / `mov` /
+            // `webm` / `quicktime`) so the materializer keeps the right
+            // file extension (NOT downgraded to .m4a — see audit fix).
+            let base64 = data.base64EncodedString()
+            parts.append(
+                .videoUrl(url: "data:video/\(mimeSubtype);base64,\(base64)"))
+        }
+
+        self.contentParts = parts.isEmpty ? nil : parts
+        self.content = text.isEmpty ? nil : text
+        self.tool_calls = nil
+        self.tool_call_id = nil
+    }
 }
 
 /// Chat completion request

--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -15,6 +15,20 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         case image(Data)
         case document(filename: String, content: String, fileSize: Int)
 
+        /// Audio bytes + format hint (e.g. "wav", "mp3", "m4a", "flac",
+        /// "ogg"). Format flows into `MessageContentPart.audioInput.format`
+        /// and onto the temp-file extension that drives vmlx's
+        /// AVAudioConverter dispatch (`materializeMediaDataUrl`).
+        /// Only routed for models whose `ModelMediaCapabilities` advertise
+        /// audio support — `FloatingInputCard` rejects audio attachments
+        /// for non-audio models at drop time.
+        case audio(Data, format: String, filename: String?)
+
+        /// Video bytes. Container format inferred from filename
+        /// extension (mp4 / mov / m4v / webm). Routed only for models
+        /// advertising video support.
+        case video(Data, filename: String?)
+
         /// Spillover variant: image bytes have been written to
         /// `AttachmentBlobStore` (encrypted) and only a content-address
         /// hash + size live in the chat-history JSON column.
@@ -26,8 +40,14 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         /// original on-disk size; `hash` indexes the encrypted blob.
         case documentRef(filename: String, hash: String, fileSize: Int)
 
+        /// Spillover variant: audio bytes spilled to encrypted blob store.
+        case audioRef(hash: String, byteCount: Int, format: String, filename: String?)
+
+        /// Spillover variant: video bytes spilled to encrypted blob store.
+        case videoRef(hash: String, byteCount: Int, filename: String?)
+
         private enum CodingKeys: String, CodingKey {
-            case type, data, filename, content, fileSize, hash, byteCount
+            case type, data, filename, content, fileSize, hash, byteCount, format
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -41,6 +61,15 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
                 try container.encode(filename, forKey: .filename)
                 try container.encode(content, forKey: .content)
                 try container.encode(fileSize, forKey: .fileSize)
+            case .audio(let data, let format, let filename):
+                try container.encode("audio", forKey: .type)
+                try container.encode(data, forKey: .data)
+                try container.encode(format, forKey: .format)
+                try container.encodeIfPresent(filename, forKey: .filename)
+            case .video(let data, let filename):
+                try container.encode("video", forKey: .type)
+                try container.encode(data, forKey: .data)
+                try container.encodeIfPresent(filename, forKey: .filename)
             case .imageRef(let hash, let byteCount):
                 try container.encode("image_ref", forKey: .type)
                 try container.encode(hash, forKey: .hash)
@@ -50,6 +79,17 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
                 try container.encode(filename, forKey: .filename)
                 try container.encode(hash, forKey: .hash)
                 try container.encode(fileSize, forKey: .fileSize)
+            case .audioRef(let hash, let byteCount, let format, let filename):
+                try container.encode("audio_ref", forKey: .type)
+                try container.encode(hash, forKey: .hash)
+                try container.encode(byteCount, forKey: .byteCount)
+                try container.encode(format, forKey: .format)
+                try container.encodeIfPresent(filename, forKey: .filename)
+            case .videoRef(let hash, let byteCount, let filename):
+                try container.encode("video_ref", forKey: .type)
+                try container.encode(hash, forKey: .hash)
+                try container.encode(byteCount, forKey: .byteCount)
+                try container.encodeIfPresent(filename, forKey: .filename)
             }
         }
 
@@ -65,6 +105,15 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
                 let content = try container.decode(String.self, forKey: .content)
                 let fileSize = try container.decode(Int.self, forKey: .fileSize)
                 self = .document(filename: filename, content: content, fileSize: fileSize)
+            case "audio":
+                let data = try container.decode(Data.self, forKey: .data)
+                let format = try container.decode(String.self, forKey: .format)
+                let filename = try container.decodeIfPresent(String.self, forKey: .filename)
+                self = .audio(data, format: format, filename: filename)
+            case "video":
+                let data = try container.decode(Data.self, forKey: .data)
+                let filename = try container.decodeIfPresent(String.self, forKey: .filename)
+                self = .video(data, filename: filename)
             case "image_ref":
                 let hash = try container.decode(String.self, forKey: .hash)
                 let byteCount = try container.decode(Int.self, forKey: .byteCount)
@@ -74,6 +123,17 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
                 let hash = try container.decode(String.self, forKey: .hash)
                 let fileSize = try container.decode(Int.self, forKey: .fileSize)
                 self = .documentRef(filename: filename, hash: hash, fileSize: fileSize)
+            case "audio_ref":
+                let hash = try container.decode(String.self, forKey: .hash)
+                let byteCount = try container.decode(Int.self, forKey: .byteCount)
+                let format = try container.decode(String.self, forKey: .format)
+                let filename = try container.decodeIfPresent(String.self, forKey: .filename)
+                self = .audioRef(hash: hash, byteCount: byteCount, format: format, filename: filename)
+            case "video_ref":
+                let hash = try container.decode(String.self, forKey: .hash)
+                let byteCount = try container.decode(Int.self, forKey: .byteCount)
+                let filename = try container.decodeIfPresent(String.self, forKey: .filename)
+                self = .videoRef(hash: hash, byteCount: byteCount, filename: filename)
             default:
                 throw DecodingError.dataCorruptedError(
                     forKey: .type,
@@ -99,6 +159,14 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         Attachment(kind: .document(filename: filename, content: content, fileSize: fileSize))
     }
 
+    public static func audio(_ data: Data, format: String, filename: String? = nil) -> Attachment {
+        Attachment(kind: .audio(data, format: format, filename: filename))
+    }
+
+    public static func video(_ data: Data, filename: String? = nil) -> Attachment {
+        Attachment(kind: .video(data, filename: filename))
+    }
+
     // MARK: - Queries
 
     public var isImage: Bool {
@@ -115,6 +183,20 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         }
     }
 
+    public var isAudio: Bool {
+        switch kind {
+        case .audio, .audioRef: return true
+        default: return false
+        }
+    }
+
+    public var isVideo: Bool {
+        switch kind {
+        case .video, .videoRef: return true
+        default: return false
+        }
+    }
+
     /// Returns inline image bytes if present. For `imageRef` variants
     /// you must hydrate via `AttachmentBlobStore.read(hash)`. Use
     /// `loadImageData()` for a unified accessor that lazily resolves
@@ -126,8 +208,27 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
 
     public var filename: String? {
         switch kind {
-        case .document(let name, _, _), .documentRef(let name, _, _): return name
-        default: return nil
+        case .document(let name, _, _), .documentRef(let name, _, _):
+            return name
+        case .audio(_, _, let name), .audioRef(_, _, _, let name),
+             .video(_, let name), .videoRef(_, _, let name):
+            return name
+        default:
+            return nil
+        }
+    }
+
+    /// Audio format hint ("wav" / "mp3" / "m4a" / etc.). The host uses
+    /// this both for display and to populate `MessageContentPart.audioInput.format`,
+    /// which becomes the temp-file extension that drives vmlx's
+    /// AVAudioConverter dispatch (`materializeMediaDataUrl`'s audio
+    /// canonicalization table — see PR #967 audit-fix).
+    public var audioFormat: String? {
+        switch kind {
+        case .audio(_, let format, _), .audioRef(_, _, let format, _):
+            return format
+        default:
+            return nil
         }
     }
 
@@ -144,6 +245,44 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         case .image(let data):
             return data
         case .imageRef(let hash, _):
+            return try? AttachmentBlobStore.read(hash)
+        default:
+            return nil
+        }
+    }
+
+    /// Resolves the attachment to its raw audio bytes — inline or
+    /// hydrated from the encrypted blob store. Returns `nil` for non-audio
+    /// kinds or read failures.
+    ///
+    /// Memory note: audio attachments are eligible for spillover via
+    /// `AttachmentBlobStore.spillIfNeeded` so chat-history JSON columns
+    /// don't bloat with raw PCM. A 30-second wav at 16 kHz mono is
+    /// ~960 KB inline; spillover writes the bytes to an encrypted blob
+    /// keyed by content-hash and persists only the hash inline.
+    public func loadAudioData() -> Data? {
+        switch kind {
+        case .audio(let data, _, _):
+            return data
+        case .audioRef(let hash, _, _, _):
+            return try? AttachmentBlobStore.read(hash)
+        default:
+            return nil
+        }
+    }
+
+    /// Resolves the attachment to its raw video bytes — inline or
+    /// hydrated from the encrypted blob store.
+    ///
+    /// Memory note: video attachments are heavyweight — even a 1-min mp4
+    /// is typically ~30 MB. Always use spillover (`AttachmentBlobStore.
+    /// spillIfNeeded`) for video; never inline more than a frame
+    /// thumbnail in chat-history JSON.
+    public func loadVideoData() -> Data? {
+        switch kind {
+        case .video(let data, _):
+            return data
+        case .videoRef(let hash, _, _):
             return try? AttachmentBlobStore.read(hash)
         default:
             return nil
@@ -170,6 +309,12 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         switch kind {
         case .document(_, _, let size), .documentRef(_, _, let size):
             return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+        case .audio(let data, _, _):
+            return ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)
+        case .video(let data, _):
+            return ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file)
+        case .audioRef(_, let byteCount, _, _), .videoRef(_, let byteCount, _):
+            return ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
         default:
             return nil
         }
@@ -181,6 +326,8 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
     }
 
     public var fileIcon: String {
+        if isAudio { return "waveform" }
+        if isVideo { return "film" }
         guard let ext = fileExtension else { return "photo" }
         switch ext {
         case "pdf": return "doc.richtext"
@@ -194,7 +341,17 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         }
     }
 
-    /// Estimated token count for context budget calculations
+    /// Estimated token count for context budget calculations.
+    ///
+    /// Empirical baselines from OmniBench / vmlx:
+    /// - Image: ~256 vision tokens/frame after spatial-merge 2×2
+    /// - Audio: Parakeet emits ~50 acoustic tokens/sec at 16 kHz mono,
+    ///   so 1 byte ≈ (1 sec / 32k bytes) × 50 = ~0.0016 tokens/byte
+    /// - Video: ~256 vision tokens × frame_count, where vmlx samples
+    ///   8 frames default → ~2K vision tokens/clip regardless of duration
+    ///
+    /// These are approximations for budget gating. The real token count
+    /// is determined by the model's processor at decode time.
     public var estimatedTokens: Int {
         switch kind {
         case .image(let data):
@@ -205,8 +362,33 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
             return max(1, content.count / 4)
         case .documentRef(_, _, let fileSize):
             return max(1, fileSize / 4)
+        case .audio(let data, _, _):
+            // ~50 acoustic tokens/sec @ 16kHz mono → ~1 token / 640 bytes
+            return max(1, data.count / 640)
+        case .audioRef(_, let byteCount, _, _):
+            return max(1, byteCount / 640)
+        case .video, .videoRef:
+            // Bounded ~2K tokens regardless of file size (8 frames × 256 tokens)
+            return 2048
         }
     }
+
+    // MARK: - Spillover hooks (memory + disk-cache integration)
+
+    /// Threshold above which inline payloads SHOULD spill to encrypted
+    /// blob storage. Mirrors the existing image-spill policy and keeps
+    /// chat-history JSON columns bounded.
+    ///
+    /// Audio threshold is lower (256 KB) because chat-history is read
+    /// often and a single 5-min wav (~9.6 MB) read on every history
+    /// open would tax the SQLite page cache.
+    ///
+    /// Video threshold is even lower (64 KB) — virtually all real video
+    /// attachments will spill. The inline path exists only for
+    /// in-memory request lifetimes; persistence always goes via
+    /// `AttachmentBlobStore.spillIfNeeded`.
+    public static let audioSpillThresholdBytes = 256 * 1024
+    public static let videoSpillThresholdBytes = 64 * 1024
 }
 
 // MARK: - Array Helpers
@@ -229,11 +411,27 @@ extension Array where Element == Attachment {
         filter(\.isDocument)
     }
 
+    public var audios: [Attachment] {
+        filter(\.isAudio)
+    }
+
+    public var videos: [Attachment] {
+        filter(\.isVideo)
+    }
+
     public var hasImages: Bool {
         contains(where: \.isImage)
     }
 
     public var hasDocuments: Bool {
         contains(where: \.isDocument)
+    }
+
+    public var hasAudios: Bool {
+        contains(where: \.isAudio)
+    }
+
+    public var hasVideos: Bool {
+        contains(where: \.isVideo)
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
+++ b/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
@@ -1,0 +1,327 @@
+# Media attachments in chat — user + integration guide
+
+This is the host-side guide for the osaurus chat composer's drag/drop
++ file-picker behavior for image, audio, and video attachments. The
+engine-side spec lives in
+`vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/MEDIA-MODEL-MATRIX.md`.
+
+---
+
+## 1. What users see (UX summary)
+
+The chat composer's drop zone + paperclip button advertise different
+file types depending on which model is currently loaded. The
+capabilities matcher (`ModelMediaCapabilities.from(modelId:)`) drives
+this:
+
+| Loaded model | Drop zone accepts | File picker shows |
+|---|---|---|
+| Nemotron-3-Nano-Omni (any quant tier) | image + audio + video | image + docs + audio + video |
+| Qwen 2/2.5/3 VL, Qwen 3.5/3.6 MoE VL, Holo3 VL, SmolVLM 2 | image + video | image + docs + video |
+| Image-only VLMs (PaliGemma, Idefics3, FastVLM, Pixtral standalone, GLM OCR, LFM2-VL, Gemma 3/4, Mistral 3/3.5/4) | image | image + docs |
+| Dense LLMs (gpt-oss, Laguna, MiniMax text, Kimi, etc.) | (no media) | docs |
+
+When a user drops a file the current model can't consume, the host
+shows a toast: "Cannot attach X — the current model supports {Y} only."
+No silent ignore.
+
+---
+
+## 2. What's allowed per family (capability matrix)
+
+Pinned to the regex/substring matcher in
+`Models/Configuration/ModelMediaCapabilities.swift`:
+
+### Audio + image + video (omni)
+
+- `OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4` / `-JANGTQ4` / `-JANGTQ`
+- Any future bundle whose id matches regex `nemotron-3-nano-omni|nemotron[_-]h[_-]omni`
+- Locally-installed bundles with a `config_omni.json` sidecar — `from(directory:modelId:)` reads this directly
+
+### Image + video (no audio)
+
+- Qwen 2 VL / 2.5 VL / 3 VL — regex `qwen[2-3](\.\d+|_\d+)?[-_]?vl`
+- Qwen 3.5 / 3.6 MoE VL bundles — regex `qwen3\.[5-6].*[-_]vl`
+- Holo3 VL — regex `holo3.*[-_]vl`
+- SmolVLM 2 — substring `smolvlm` or `smol-vlm`
+
+### Image only
+
+- PaliGemma, Idefics 3, FastVLM, Llava-Qwen2
+- Pixtral standalone (NOT the Mistral 3 wrapper — that's matched separately)
+- GLM-OCR, LFM2-VL
+- Gemma 3, Gemma 4 (the `-it` VLM variants)
+- Mistral 3 / Mistral 3.5 (image only via Pixtral wrapper) — regex `mistral[-_](3|medium-3)`
+- Mistral 4 VL — regex `mistral[-_]?4.*[-_]vl`
+
+### Text only (no media)
+
+Everything else — most dense LLMs, hybrid-SSM text models without VL
+suffix (`Qwen3.5-35B`, `Qwen3.6-35B-A3B-mxfp4` without `-vl`, MiniMax
+text, Laguna, Cascade-2 text, etc.)
+
+**Boundary tests** in `ModelMediaCapabilitiesMCDCTests.swift` lock:
+
+- Bare `nemotron-3` (text-only) does NOT match omni
+- Bare `qwen3.5` / `qwen3.6` (no `-vl`) does NOT match imageVideo
+- Bare `mistral-7b` (no 3 / medium-3 / -vl) does NOT match imageOnly
+- Mistral 4 dense (no `-vl`) does NOT match imageOnly
+
+---
+
+## 3. Format extensions accepted
+
+### Audio (Nemotron-3-Nano-Omni only)
+
+| Extension | UTType bucket | vmlx canonicalization |
+|---|---|---|
+| `.wav` / `.wave` | `UTType.wav` | passthrough |
+| `.mp3` / `.mpeg` | `UTType.mp3` | passthrough |
+| `.m4a` / `.x-m4a` | `UTType.mpeg4Audio` | passthrough |
+| `.mp4` (audio container) | `UTType.mpeg4Audio` | **canonicalizes to `.m4a`** |
+| `.flac` | `UTType.audio` parent | passthrough |
+| `.ogg` / `.opus` | `UTType.audio` parent | passthrough |
+| `.aac` / `.wma` | `UTType.audio` parent | passthrough |
+
+The audit-fix in `ModelRuntime.materializeMediaDataUrl` ensures the
+audio-mime canonicalization (`mp4 → m4a`) only runs when the data URL
+header starts with `audio/`. Locked by
+`MaterializeMediaDataUrlMCDCTests.test_d6_videoMp4_keepsMp4Extension`.
+
+### Video (omni + Qwen-VL family + SmolVLM 2)
+
+| Extension | UTType bucket | Container preserved |
+|---|---|---|
+| `.mp4` | `UTType.mpeg4Movie` | `data:video/mp4` → `.mp4` |
+| `.mov` | `UTType.quickTimeMovie` | `data:video/quicktime` → `.quicktime` |
+| `.m4v` | `UTType.movie` parent | `.m4v` |
+| `.webm` / `.mkv` / `.avi` | `UTType.video` parent | passthrough |
+
+### Image (every VLM family)
+
+PNG, JPEG, HEIC, TIFF, BMP, WebP via `CGImageSource`. The composer
+auto-converts HEIC/TIFF/BMP → PNG inline so vmlx receives a uniform
+`data:image/png;base64,...` shape.
+
+---
+
+## 4. Memory + cache behavior
+
+### Inline payload limits
+
+The composer enforces inline-byte caps before attaching:
+
+| Modality | Cap | Rationale |
+|---|---|---|
+| Image | 16 MB (existing `maxImageSize`) | RADIO / Pixtral / Qwen ViT all comfortably handle ≤4K resolution |
+| Audio | 50 MB | A 50 MB wav at 16 kHz mono is ~26 minutes — beyond that, route through streaming API |
+| Video | 100 MB | Engine extracts 8 frames default; longer clips just sample fewer per-second frames anyway |
+
+Files exceeding the cap show a toast and don't attach.
+
+### Spillover to encrypted blob store
+
+After the user sends a turn, `AttachmentBlobStore.spillIfNeeded`
+walks the attachments and writes inline bytes that exceed the
+modality threshold to `~/.osaurus/blob-store/<hash>` (encrypted by
+the at-rest key from `StorageMigrationCoordinator`):
+
+| Attachment kind | Spill threshold |
+|---|---|
+| Image | `spillThreshold` (existing — 64 KB) |
+| Document | same `spillThreshold` |
+| Audio | `Attachment.audioSpillThresholdBytes` = **256 KB** |
+| Video | `Attachment.videoSpillThresholdBytes` = **64 KB** |
+
+Audio uses a higher threshold because chat history reads are frequent
+and small audio clips (< 256 KB ≈ 8 s wav) keep the SQLite page
+cache warm. Video uses an aggressive 64 KB threshold — virtually
+all real video attachments spill; the inline path exists only for
+in-memory request lifetimes.
+
+After spillover the chat-history JSON column carries:
+
+- `audio_ref { hash, byteCount, format, filename }` (for audio)
+- `video_ref { hash, byteCount, filename }` (for video)
+
+Hydration on next read goes through `AttachmentBlobStore.read(hash)`,
+same code path images already use.
+
+### KV cache + media salt
+
+vmlx's `CacheCoordinator` keys disk-cache entries on `(model,
+prefix_hash, media_salt)`. The media salt is computed from the
+pixel/audio bytes so different attachments → different salt → no
+false sharing across requests. Tested via
+`CacheCoordinatorMediaSaltTests` (8 tests, all green at pin
+`03b4441`).
+
+This means: re-attaching the same audio file across turns hits the
+disk-cache. Different audio files do not collide.
+
+### TurboQuant (JANGTQ) runtime compatibility
+
+JANGTQ-quantized bundles work end-to-end with all modalities:
+
+- **Nemotron-3-Nano-Omni JANGTQ4 / JANGTQ**: vmlx's
+  `NemotronHJANGTQModel` handles the codebook MoE path while Parakeet
+  + RADIO encoders run at full precision (encoder weights stay
+  bf16/fp16 per the bundle's `mxtq_bits.vision_tower="passthrough_fp16"`
+  config).
+- **Qwen 3.5/3.6 MoE VL JANGTQ**: `Qwen35JANGTQModel` for the language
+  decoder; vision tower stays full precision.
+- **MiniMax M2 JANGTQ**: text-only, no media gate.
+
+The host-side preflight `validateJANGTQSidecarIfRequired` checks for
+`jangtq_runtime.safetensors` whenever `jang_config.json.weight_format
+== "mxtq"`. Bundles missing the sidecar surface a clear error rather
+than letting vmlx hit `abort()` in `TurboQuantSwitchLinear`.
+
+### MXFP4 runtime
+
+MXFP4 bundles need no sidecar — vmlx loads weights directly via the
+standard MLX dequant path. All modality paths work uniformly.
+
+---
+
+## 5. Streaming + cancellation
+
+`BatchEngine.generate` returns `AsyncThrowingStream<GenerationEvent, Error>`.
+Event types are uniform across modalities:
+
+- `.chunk(String)` — visible content tokens
+- `.reasoning(String)` — `<think>` block tokens (Nemotron-3 with `enable_thinking=true`)
+- `.toolCall(...)` — structured tool calls
+- `.usage(...)` — final token counts on close
+
+Audio + video preprocessing is **pre-prefill**. When the user clicks
+send, the chat UI shows "transcribing audio…" / "extracting video
+frames…" while preprocessing runs in `Task.detached`. Cancellation
+during this window is cooperative — the file decode respects task
+cancellation.
+
+TTFT is measured via `TTFTTrace` and includes preprocessing latency.
+Typical M5 Max numbers:
+
+| Workload | TTFT | First-chunk latency |
+|---|---|---|
+| Text-only 4K prompt, Nemotron-3 MXFP4 | ~250 ms | ~250 ms |
+| + 1 image | ~400 ms | ~150 ms ViT encode |
+| + 8-frame video | ~800 ms | ~550 ms ViT encode |
+| + 30 s audio | ~700 ms | ~450 ms Parakeet encode |
+
+---
+
+## 6. Programmatic API (for plugins / shortcuts)
+
+```swift
+import OsaurusCore
+
+// Build an audio attachment from a file URL:
+let url = URL(fileURLWithPath: "/path/to/clip.wav")
+let data = try Data(contentsOf: url)
+let attachment = Attachment.audio(data, format: "wav", filename: "clip.wav")
+
+// Or video:
+let videoAttachment = Attachment.video(
+    try Data(contentsOf: videoURL),
+    filename: "scene.mp4"
+)
+
+// Append to pending queue (UI auto-rejects if model can't consume):
+pendingAttachments.append(attachment)
+
+// Or build a ChatMessage directly (for HTTP API path):
+let message = ChatMessage(
+    role: "user",
+    text: "Transcribe this clip",
+    imageData: [],
+    audios: [(data: data, format: "wav")],
+    videos: []
+)
+```
+
+---
+
+## 7. Capability detection — programmatic surface
+
+```swift
+import OsaurusCore
+
+let caps = ModelMediaCapabilities.from(modelId: currentModelId)
+
+if caps.supportsAudio {
+    // show audio picker / drop zone
+}
+if caps.supportsVideo {
+    // show video picker / drop zone
+}
+
+// Or summary string for tooltips:
+print(caps.summary)
+// → "image + video + audio"  (omni)
+// → "image + video"          (Qwen-VL family)
+// → "image"                   (image-only VLMs)
+// → "text-only"               (dense LLMs)
+```
+
+For accuracy after model load, prefer:
+
+```swift
+let caps = ModelMediaCapabilities.from(
+    directory: localModelDirectory,
+    modelId: modelId
+)
+```
+
+This reads `config_omni.json` + `config.json` directly, so
+ambiguous IDs that the regex can't disambiguate (e.g. some
+community-renamed bundles) resolve correctly via the on-disk config.
+
+---
+
+## 8. Test coverage
+
+| Layer | Test file | Cases |
+|---|---|---|
+| Capability detection (regex/substring) | `Tests/Model/ModelMediaCapabilitiesMCDCTests.swift` | 27 MC/DC-shaped |
+| API content-part round-trip | `Tests/Model/MultimodalContentPartTests.swift` | 9 |
+| Data URL materialization audit fix | `Tests/Model/MaterializeMediaDataUrlMCDCTests.swift` | 11 MC/DC |
+| Hybrid-cache substring matcher | `Tests/Service/IsKnownHybridModelMCDCTests.swift` | 14 MC/DC |
+| Bug 3a guard (engine) | `vmlx Tests/MLXLMTests/EvaluateRepetitionPenaltyMCDCTests.swift` | 11 MC/DC |
+| Reasoning stamp resolution (engine) | `vmlx Tests/MLXLMTests/ReasoningStampMCDCTests.swift` | 17 MC/DC |
+
+Total: 89 MC/DC-shaped + media-modality tests. Run via:
+
+```bash
+cd Packages/OsaurusCore
+swift test --filter "MediaCapabilities|MaterializeMediaDataUrl|IsKnownHybridModel|MultimodalContentPart"
+```
+
+---
+
+## 9. Adding support for a new family
+
+When vmlx adds video/audio support to a new family:
+
+1. Update `vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/MEDIA-MODEL-MATRIX.md`
+   with the new entry (modality, cache topology, JANGTQ class)
+2. Update `Models/Configuration/ModelMediaCapabilities.swift`
+   `from(modelId:)` regex/substring branch + `from(directory:modelId:)`
+   `videoCapableModelTypes` set
+3. Add MC/DC test rows in `ModelMediaCapabilitiesMCDCTests.swift`
+   for the new family + boundary case (e.g. bare-name without `-vl`
+   suffix that should NOT match)
+4. Update this doc's matrix in §2 + §3
+5. Verify `AttachmentBlobStore.spillIfNeeded` switch is exhaustive
+   (Swift will catch this at compile time anyway)
+
+---
+
+## 10. References
+
+- Engine matrix: `vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/MEDIA-MODEL-MATRIX.md`
+- Parakeet + RADIO Nemotron-3 specifics: `vmlx-swift-lm/.../PARAKEET-RADIO-INTEGRATION.md`
+- MC/DC strategy: `vmlx-swift-lm/.../MCDC-COVERAGE-STRATEGY.md`
+- Cache coordinator policy: `vmlx-swift-lm/.../KV-SIZING-CONTRACT.md`
+- Host integration: `vmlx-swift-lm/.../OSAURUS-INTEGRATION.md`

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -1,0 +1,191 @@
+//
+//  ModelMediaCapabilities.swift
+//  osaurus
+//
+//  Per-model capability detection for audio + video drag/drop in the
+//  chat composer. Reads (a) the model's `config.json` for vision/audio
+//  config presence, (b) the model_type / model_id substring + regex
+//  matching, and (c) the bundled `config_omni.json` sidecar for omni
+//  (Nemotron-3) bundles.
+//
+//  Why a dedicated detector vs piggy-backing on `VLMDetection`:
+//
+//   - VLMDetection answers "is there a vision_config?" — fine for
+//     image-attachment routing, but neither necessary nor sufficient
+//     for video (some VLMs are image-only) and unrelated to audio.
+//   - Per-family video support is config-parametric. Mistral 3 / 3.5
+//     have a vision_config but no video preprocessor. Qwen 3 VL hardcodes
+//     `targetFPS=2` in the model class.
+//   - Audio support today is exclusively Nemotron-3-Nano-Omni — gated by
+//     the `config_omni.json` sidecar.
+//
+//  The matrix here mirrors `vmlx-swift-lm/Libraries/MLXLMCommon/
+//  BatchEngine/MEDIA-MODEL-MATRIX.md`. Keep them in sync — when vmlx
+//  adds video support to a new family (e.g. Mistral 3.5 follow-up),
+//  update both this matcher AND the matrix doc.
+//
+
+import Foundation
+
+public enum ModelMediaCapabilities {
+
+    /// Per-modality capability flags for a single model. Drives the
+    /// chat composer's drag/drop allowlist + the file-picker's
+    /// `allowedContentTypes`.
+    public struct Capabilities: Equatable, Sendable {
+        public let supportsImage: Bool
+        public let supportsVideo: Bool
+        public let supportsAudio: Bool
+
+        public static let textOnly = Capabilities(
+            supportsImage: false, supportsVideo: false, supportsAudio: false)
+
+        public static let imageOnly = Capabilities(
+            supportsImage: true, supportsVideo: false, supportsAudio: false)
+
+        public static let imageVideo = Capabilities(
+            supportsImage: true, supportsVideo: true, supportsAudio: false)
+
+        public static let omni = Capabilities(
+            supportsImage: true, supportsVideo: true, supportsAudio: true)
+
+        public var anyMedia: Bool {
+            supportsImage || supportsVideo || supportsAudio
+        }
+
+        public var summary: String {
+            var parts: [String] = []
+            if supportsImage { parts.append("image") }
+            if supportsVideo { parts.append("video") }
+            if supportsAudio { parts.append("audio") }
+            return parts.isEmpty ? "text-only" : parts.joined(separator: " + ")
+        }
+    }
+
+    // MARK: - Detection by model_id (substring + regex)
+    //
+    // Fast path used by the UI before / without the model being
+    // downloaded. Mirrors the spec in MEDIA-MODEL-MATRIX.md.
+
+    /// Resolve capabilities from a Hugging Face repo id or osaurus
+    /// model name string. Case-insensitive substring + regex match
+    /// against the families with known modality support. Returns
+    /// `.textOnly` for unknown / dense LLMs.
+    ///
+    /// This is the surface the chat composer uses BEFORE the model is
+    /// loaded so the drag-drop UI knows whether to advertise audio /
+    /// video accept slots. After load, `from(directory:modelId:)`
+    /// can refine via the bundle's `config_omni.json` sidecar.
+    public static func from(modelId: String) -> Capabilities {
+        let lower = modelId.lowercased()
+
+        // Nemotron-3-Nano-Omni — only family with native audio today.
+        // Matches:
+        //   OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4 / -JANGTQ4 / -JANGTQ
+        //   nemotron-3-nano-omni-* (case-folded picker form)
+        if regexMatches(lower, pattern: #"nemotron-3-nano-omni|nemotron[_-]h[_-]omni"#) {
+            return .omni
+        }
+
+        // Qwen 2 VL / 2.5 VL / 3 VL — image + video, no audio.
+        // Matches: qwen2-vl-*, qwen2.5-vl-*, qwen3-vl-* (and underscore variants)
+        if regexMatches(lower, pattern: #"qwen[2-3](\.\d+|_\d+)?[-_]?vl"#) {
+            return .imageVideo
+        }
+
+        // Qwen 3.5 / 3.6 MoE VL bundles — image + video via Qwen35
+        // class. Hybrid SSM eager-flipped via osaurus matcher.
+        // Note: text-only Qwen 3.5/3.6 bundles also exist; gating on
+        // `vl` substring lets text-only fall through to .textOnly.
+        if regexMatches(lower, pattern: #"qwen3\.[5-6].*[-_]vl|holo3.*[-_]vl"#) {
+            return .imageVideo
+        }
+
+        // SmolVLM 2 — image + video with adaptive fps.
+        if lower.contains("smolvlm") || lower.contains("smol-vlm") {
+            return .imageVideo
+        }
+
+        // Image-only VLM families. Substring-match the bundle name.
+        let imageOnlyPatterns: [String] = [
+            "paligemma", "idefics3", "fastvlm", "llava-qwen2", "llava_qwen2",
+            "pixtral",  // standalone pixtral, not the Mistral 3 wrap
+            "glm-ocr", "glm_ocr",
+            "lfm2-vl", "lfm2_vl",
+            "gemma-3", "gemma3",
+            "gemma-4-it",  // VLM Gemma 4 (the dense LLM gemma-4 also exists)
+        ]
+        if imageOnlyPatterns.contains(where: lower.contains) {
+            return .imageOnly
+        }
+
+        // Mistral 3 / 3.5 — image only via Pixtral wrapper.
+        // Matches: mistral-3-*, mistral-medium-3.5-*, mistral_3, ministral3
+        if regexMatches(lower, pattern: #"mistral[-_](3|medium-3)"#) {
+            return .imageOnly
+        }
+
+        // Mistral 4 VLM — image only. NOTE: bare `mistral-4` could be
+        // either VLM or LLM. The presence of `vl` in the id disambiguates.
+        if regexMatches(lower, pattern: #"mistral[-_]?4.*[-_]vl"#) {
+            return .imageOnly
+        }
+
+        return .textOnly
+    }
+
+    /// Resolve capabilities by inspecting the locally-installed bundle.
+    /// Use after the model is downloaded for the most accurate signal.
+    /// Falls back to `from(modelId:)` if config.json is unreadable.
+    public static func from(directory: URL, modelId: String) -> Capabilities {
+        // Omni bundle gate: presence of config_omni.json flips the
+        // VLMModelFactory dispatch to NemotronH_Nano_Omni_Reasoning_V3
+        // and exposes Parakeet ASR + RADIO ViT.
+        let configOmniURL = directory.appendingPathComponent("config_omni.json")
+        if FileManager.default.fileExists(atPath: configOmniURL.path) {
+            return .omni
+        }
+
+        // Read config.json for vision_config presence.
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return from(modelId: modelId)
+        }
+
+        let modelType = (json["model_type"] as? String)?.lowercased() ?? ""
+        let hasVisionConfig = json["vision_config"] != nil
+
+        // No vision config → not even image-capable. (Audio without
+        // vision is only the omni path, already handled above.)
+        guard hasVisionConfig else {
+            return .textOnly
+        }
+
+        // Cross-check the family-by-model_type for video support.
+        // model_types known to support video at the engine level:
+        let videoCapableModelTypes: Set<String> = [
+            "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
+            "qwen3_5", "qwen3_5_moe",
+            "smolvlm",
+            "nemotron_h_omni",
+            "NemotronH_Nano_Omni_Reasoning_V3".lowercased(),
+        ]
+        if videoCapableModelTypes.contains(modelType) {
+            // Audio belongs only to omni — already returned above.
+            return .imageVideo
+        }
+
+        // Has vision_config but model_type is image-only.
+        return .imageOnly
+    }
+
+    // MARK: - Helpers
+
+    private static func regexMatches(_ s: String, pattern: String) -> Bool {
+        guard let re = try? NSRegularExpression(pattern: pattern) else { return false }
+        let range = NSRange(s.startIndex ..< s.endIndex, in: s)
+        return re.firstMatch(in: s, options: [], range: range) != nil
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -78,6 +78,7 @@ enum ModelProfileRegistry {
         VeniceModelProfile.self,
         OpenAIReasoningProfile.self,
         QwenThinkingProfile.self,
+        NemotronThinkingProfile.self,
         Gemini31FlashImageProfile.self,
         GeminiProImageProfile.self,
         GeminiFlashImageProfile.self,
@@ -141,6 +142,45 @@ struct QwenThinkingProfile: ModelProfile {
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
         return lower.contains("qwen3") && !lower.contains("coder")
+    }
+
+    static let options: [ModelOptionDefinition] = [
+        ModelOptionDefinition(
+            id: "disableThinking",
+            label: "Disable Thinking",
+            icon: "brain.head.profile",
+            kind: .toggle(default: true)
+        )
+    ]
+
+    static let defaults: [String: ModelOptionValue] = [
+        "disableThinking": .bool(true)
+    ]
+
+    static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
+}
+
+// MARK: - Nemotron-3 Thinking Profile
+
+/// Nemotron-3-Nano-Omni Reasoning models — `model_type=nemotron_h` hybrid
+/// Mamba+Attn+MoE bundles whose chat template reads an `enable_thinking`
+/// kwarg. Defaults `disableThinking: true` for the same reason
+/// `QwenThinkingProfile` does: per
+/// `jang/research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md` §9, the SKU is
+/// "Reasoning V3" and its training extends `<think>` blocks through
+/// arbitrary self-verification on validation-style prompts (the same
+/// pattern that surfaced as trapped-thinking on Qwen3.6-A3B). Forcing
+/// thinking off for chat workloads is the recommended operating point;
+/// users who want CoT can toggle the chip on per turn.
+///
+/// Match excludes `coder` variants (none ship today, but mirroring
+/// `QwenThinkingProfile`'s shape for consistency if NVIDIA publishes one).
+struct NemotronThinkingProfile: ModelProfile {
+    static let displayName = "Nemotron Thinking"
+
+    static func matches(modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return lower.contains("nemotron-3") && !lower.contains("coder")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -79,6 +79,7 @@ enum ModelProfileRegistry {
         OpenAIReasoningProfile.self,
         QwenThinkingProfile.self,
         NemotronThinkingProfile.self,
+        LagunaThinkingProfile.self,
         Gemini31FlashImageProfile.self,
         GeminiProImageProfile.self,
         GeminiFlashImageProfile.self,
@@ -181,6 +182,44 @@ struct NemotronThinkingProfile: ModelProfile {
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
         return lower.contains("nemotron-3") && !lower.contains("coder")
+    }
+
+    static let options: [ModelOptionDefinition] = [
+        ModelOptionDefinition(
+            id: "disableThinking",
+            label: "Disable Thinking",
+            icon: "brain.head.profile",
+            kind: .toggle(default: true)
+        )
+    ]
+
+    static let defaults: [String: ModelOptionValue] = [
+        "disableThinking": .bool(true)
+    ]
+
+    static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
+}
+
+// MARK: - Laguna Thinking Profile
+
+/// Poolside Laguna (`model_type=laguna`) — agentic-coding 33B/3B-active MoE
+/// whose chat template (`laguna_glm_thinking_v5/chat_template.jinja`)
+/// reads an `enable_thinking` Jinja kwarg. The shipped template defaults
+/// `enable_thinking=false`, which means by default Laguna emits no
+/// thinking block — straight-to-answer behavior optimal for coding /
+/// agentic flows. The profile mirrors that: `disableThinking: true` by
+/// default, so the in-template default is preserved unless the user
+/// explicitly toggles thinking on (CoT for hard reasoning steps).
+///
+/// Match is `laguna` substring lower-cased; covers any future Laguna
+/// variant (e.g. Laguna-S, Laguna-M) without a registry edit. There is
+/// no `coder` exclusion because Laguna IS the coder family — exclusion
+/// would be a no-op.
+struct LagunaThinkingProfile: ModelProfile {
+    static let displayName = "Laguna Thinking"
+
+    static func matches(modelId: String) -> Bool {
+        return modelId.lowercased().contains("laguna")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -18,28 +18,38 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // a7db6e5 closes the deterministic Metal-assertion crash class
-        // `notifyExternalReferencesNonZeroOnDealloc` inside
-        // `BatchEngine.stepPrefill` after `Cache disk hit`. Two upstream
-        // commits land that fix together:
-        //   - 98289d9 forces `MLX.asyncEval(slot.cache)` after disk
-        //     restore so lazy-restore graph ops don't extend into the
-        //     next request's command buffer.
-        //   - a7db6e5 sets `continuation.onTermination` on
-        //     `BatchEngine.generate`'s outStream so orphan slots get
-        //     reaped via `engine.cancel(requestId)` whenever a consumer
-        //     breaks early.
-        // Net effect: the `Task.isCancelled` break in MLXBatchAdapter
-        // line 209-222 is safe, and no `enableDiskCache: false` workaround
-        // is needed.
+        // ae526a3 brings five things in one bump from a7db6e5:
+        //   - b4eec09 native Swift port of the Nemotron-3-Nano-Omni
+        //     multimodal stack (replaces the pytorch-bridged path) —
+        //     building blocks for Parakeet/RADIO native runtime.
+        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
+        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
+        //     Nemotron-3 registry comments (§12.5).
+        //   - 75549cb @ModuleInfo single-segment fix for the omni stack
+        //     weight loader.
+        //   - ae526a3 authoritative blockSize + omni quant plumbing —
+        //     **closes the `rms_norm` trap class** that was killing
+        //     Cascade-2 JANG_4M and Nemotron-Omni MXFP4 first-prefill
+        //     under the bits=4 / 164-override JANG path. Symbolicated
+        //     against `nemotron-cascade-2-30b-a3b-jang_4m` during
+        //     PR #967 triage. Pairs with osaurus-side
+        //     `MLXErrorRecovery.installGlobalHandler()` belt+suspenders.
         //
-        // Also includes c992df9's `GenerateCompletionInfo.unclosedReasoning`,
-        // which the chat UI consumes to surface a "thinking didn't close"
-        // chip when reasoning-trained models trap themselves on validation
-        // prompts.
+        // Carries forward the prior fixes from a7db6e5:
+        //   - 98289d9 `MLX.asyncEval(slot.cache)` after disk restore
+        //   - a7db6e5 `continuation.onTermination` on
+        //     `BatchEngine.generate` so orphan slots reap on early break
+        //   - c992df9 `GenerateCompletionInfo.unclosedReasoning`
+        //
+        // The audio + video API surface (UserInput.Audio, Chat.Message.
+        // audios, processor wiring, mic recorder, system TTS, Parakeet
+        // E2E) ships separately as a coordinated osaurus + vmlx pair —
+        // see the audio-API follow-up PR. That PR pins to vmlx
+        // 3b78db4 which adds the Chat.Message.audios bridge needed for
+        // OpenAI `input_audio` content parts to flow end-to-end.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
+            revision: "ae526a38c033533940f383f0d31d0a55100938d2"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -13,7 +13,21 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
-        .package(url: "https://github.com/osaurus-ai/mlx-swift", branch: "osaurus-0.31.3"),
+        // mlx-swift pinned by revision (was `branch: "osaurus-0.31.3"`) so
+        // the runtime can't change under us if the branch tip moves. The
+        // revision below is the merge point on `osaurus-0.31.3` that
+        // (a) refreshes the submodule URL to the host-side `osaurus-ai/mlx`
+        // fork and (b) advances the submodule pointer to a commit
+        // (`f58e52da` on the fork's `fix/clear-library-no-release`) that
+        // contains the Bug-1 fix for the deterministic Metal validation
+        // crash class `notifyExternalReferencesNonZeroOnDealloc` that
+        // fired on warm-disk-cache 2nd-request flows on Apple M4 Pro
+        // Debug builds. Revert by setting `MLX_CLEAR_LIBRARY_RELEASE=1`
+        // at runtime if needed for A/B testing.
+        .package(
+            url: "https://github.com/osaurus-ai/mlx-swift",
+            revision: "e0b61113f0190e3503ad9123bf4d4508248cd316"
+        ),
         // Pinned by commit (was `branch: "main"`) so the runtime can't change
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
@@ -74,7 +88,7 @@ let package = Package(
         // at this pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "1c62d210d7f23e1ba1e8d5cc45ec9f1221357f01"
+            revision: "13abe407df83d1836f640d0cb56f63a7e640ede3"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -18,38 +18,63 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // ae526a3 brings five things in one bump from a7db6e5:
-        //   - b4eec09 native Swift port of the Nemotron-3-Nano-Omni
-        //     multimodal stack (replaces the pytorch-bridged path) —
-        //     building blocks for Parakeet/RADIO native runtime.
-        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
-        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
-        //     Nemotron-3 registry comments (§12.5).
-        //   - 75549cb @ModuleInfo single-segment fix for the omni stack
-        //     weight loader.
+        // 1c62d21 collects every relevant runtime + docs fix accrued
+        // since a7db6e5 (the prior osaurus pin). Picker entries PR #967
+        // adds (Nemotron-3 omni bundles + the broader hybrid family
+        // setHybrid path) all want these:
+        //
+        // Runtime fixes:
         //   - ae526a3 authoritative blockSize + omni quant plumbing —
-        //     **closes the `rms_norm` trap class** that was killing
+        //     **closes the `rms_norm` trap class** that killed
         //     Cascade-2 JANG_4M and Nemotron-Omni MXFP4 first-prefill
         //     under the bits=4 / 164-override JANG path. Symbolicated
         //     against `nemotron-cascade-2-30b-a3b-jang_4m` during
-        //     PR #967 triage. Pairs with osaurus-side
+        //     PR #967 triage. Pairs with the osaurus-side
         //     `MLXErrorRecovery.installGlobalHandler()` belt+suspenders.
+        //   - 537e386 `NemotronHJANGTQ` — closes
+        //     `Unhandled keys ["experts"]` on omni JANGTQ bundles by
+        //     stacking per-expert TQ-packed tensors and swapping in
+        //     `TurboQuantSwitchLinear` for the routed-expert switch.
+        //   - d020e76 `NemotronHOmni.prepare(_:)` text-only returns
+        //     `.logits` instead of `.tokens` — dodges a `[concatenate]
+        //     dims 3 vs 4` trap when `BatchEngine.stepPrefill` adds a
+        //     `[.newAxis]` axis to processor tokens, which then cascaded
+        //     into Mamba2 conv state merge. Mirrors `Gemma3.prepare` /
+        //     `FastVLM.prepare`.
         //
-        // Carries forward the prior fixes from a7db6e5:
+        // Foundational omni stack:
+        //   - b4eec09 native Swift port of Nemotron-3-Nano-Omni — first
+        //     time osaurus drives Parakeet/RADIO without a torch dep.
+        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
+        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
+        //     Nemotron-3 registry comments (§12.5).
+        //   - 75549cb @ModuleInfo single-segment fix for omni weight
+        //     loading.
+        //   - 1c62d21 OMNI-OSAURUS-HOOKUP §10 correction: the prior
+        //     "BatchEngine omni B=1 empty stream" claim was a bench
+        //     methodology artifact — the bench counted only `.chunk`
+        //     events and missed `.reasoning(_)` events that
+        //     reasoning-on-by-default omni emits during
+        //     `<think>...</think>`. Osaurus's `GenerationEventMapper`
+        //     correctly forwards `.reasoning(_)` (see
+        //     `PluginHostAPI.swift:1139` emitting
+        //     `delta.reasoning_content`), so streaming clients see the
+        //     full output. No osaurus-side workaround needed.
+        //
+        // Carries forward all prior fixes:
         //   - 98289d9 `MLX.asyncEval(slot.cache)` after disk restore
         //   - a7db6e5 `continuation.onTermination` on
         //     `BatchEngine.generate` so orphan slots reap on early break
         //   - c992df9 `GenerateCompletionInfo.unclosedReasoning`
         //
-        // The audio + video API surface (UserInput.Audio, Chat.Message.
-        // audios, processor wiring, mic recorder, system TTS, Parakeet
-        // E2E) ships separately as a coordinated osaurus + vmlx pair —
-        // see the audio-API follow-up PR. That PR pins to vmlx
-        // 3b78db4 which adds the Chat.Message.audios bridge needed for
-        // OpenAI `input_audio` content parts to flow end-to-end.
+        // The audio + video HTTP-API surface
+        // (`MessageContentPart.audioInput` / `.videoUrl` →
+        // `UserInput.audios` / `.videos`) ships in a follow-up osaurus
+        // PR on top of this one; vmlx-side wiring is already in place
+        // at this pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "ae526a38c033533940f383f0d31d0a55100938d2"
+            revision: "1c62d210d7f23e1ba1e8d5cc45ec9f1221357f01"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         // at runtime if needed for A/B testing.
         .package(
             url: "https://github.com/osaurus-ai/mlx-swift",
-            revision: "e0b61113f0190e3503ad9123bf4d4508248cd316"
+            revision: "0a56f9041d56b4b8161f67a6cbd540ae66efc9fd"
         ),
         // Pinned by commit (was `branch: "main"`) so the runtime can't change
         // under us between identical osaurus source revisions. Bump
@@ -111,10 +111,14 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "03b4441885e3aea9eea7bb1515ce43ef44e117ef"
+            revision: "de521c7c9ded41f033877aff06781981af06cd58"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),
+        // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
+        // calls that osaurus's `TTSService` doesn't pass. Pinning to the
+        // last working version until osaurus catches up. Bumping requires
+        // a paired osaurus-side TTSService update.
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", "0.14.0" ..< "0.14.2"),
         // Pinned by commit (was `branch: "main"`) — same reasoning as
         // vmlx-swift-lm above.
         .package(

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "5adb91bdd150b75599dc4f76dede2f44b1e3c082"
+            revision: "03b4441885e3aea9eea7bb1515ce43ef44e117ef"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "2a6c965a731711a411f0809d118d34db16ec65c3"
+            revision: "5adb91bdd150b75599dc4f76dede2f44b1e3c082"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -32,60 +32,83 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // 1c62d21 collects every relevant runtime + docs fix accrued
-        // since a7db6e5 (the prior osaurus pin). Picker entries PR #967
-        // adds (Nemotron-3 omni bundles + the broader hybrid family
-        // setHybrid path) all want these:
+        // `13abe40` collects every relevant runtime + docs fix accrued
+        // since `a7db6e5` (the prior osaurus pin). PR #967's host-side
+        // additions (Nemotron-3 omni registry entries, broader hybrid
+        // family setHybrid path, audio/video content-part wiring) all
+        // want these:
         //
-        // Runtime fixes:
-        //   - ae526a3 authoritative blockSize + omni quant plumbing —
-        //     **closes the `rms_norm` trap class** that killed
+        // Stability fix carried in this pin:
+        //   - cf8c525 fix(repetition): treat `repetition_penalty: 1.0`
+        //     as a no-op at `Evaluate.swift:279`. Closes the
+        //     `Index out of range` Swift array-bounds panic that fired
+        //     on Nemotron-3 first decode (Nemotron's
+        //     `generation_config.json` ships `repetition_penalty: 1.0`,
+        //     the HuggingFace idiom for "no penalty"). 15-case
+        //     coverage in `Tests/MLXLMTests/SampleTests.swift`.
+        //
+        // Carries forward (commits already included before this PR):
+        //   - 98289d9 fix(disk-cache): eager `MLX.evaluate(slot.cache)`
+        //     after `restoreFromDiskArrays` at `BatchEngine.swift:748`
+        //     so the disk-restored cache materialises in its own
+        //     command buffer before prefill encoding starts. The full
+        //     fix for the `notifyExternalReferencesNonZeroOnDealloc`
+        //     class lands in the mlx submodule via the mlx-swift pin
+        //     block above.
+        //   - a7db6e5 fix(BatchEngine): reap slots when consumer stops
+        //     iterating — sets `continuation.onTermination` on
+        //     `BatchEngine.generate`'s outStream so orphan slots get
+        //     reaped via `engine.cancel(requestId)` whenever a
+        //     consumer breaks early.
+        //   - c992df9 feat(reasoning): `GenerateCompletionInfo.
+        //     unclosedReasoning` flag for trapped-thinking detection;
+        //     the host chat UI surfaces this as a "thinking didn't
+        //     close" chip when reasoning-trained models trap themselves.
+        //
+        // Runtime fixes between a7db6e5 and 13abe40 (selected):
+        //   - ae526a3 fix(jang): authoritative blockSize + omni quant
+        //     plumbing — closes the `rms_norm` trap class that killed
         //     Cascade-2 JANG_4M and Nemotron-Omni MXFP4 first-prefill
-        //     under the bits=4 / 164-override JANG path. Symbolicated
-        //     against `nemotron-cascade-2-30b-a3b-jang_4m` during
-        //     PR #967 triage. Pairs with the osaurus-side
-        //     `MLXErrorRecovery.installGlobalHandler()` belt+suspenders.
-        //   - 537e386 `NemotronHJANGTQ` — closes
+        //     under the bits=4 / 164-override JANG path. Pairs with
+        //     the host-side `MLXErrorRecovery.installGlobalHandler()`.
+        //   - 537e386 feat(omni): `NemotronHJANGTQ` — closes
         //     `Unhandled keys ["experts"]` on omni JANGTQ bundles by
         //     stacking per-expert TQ-packed tensors and swapping in
         //     `TurboQuantSwitchLinear` for the routed-expert switch.
-        //   - d020e76 `NemotronHOmni.prepare(_:)` text-only returns
-        //     `.logits` instead of `.tokens` — dodges a `[concatenate]
-        //     dims 3 vs 4` trap when `BatchEngine.stepPrefill` adds a
-        //     `[.newAxis]` axis to processor tokens, which then cascaded
-        //     into Mamba2 conv state merge. Mirrors `Gemma3.prepare` /
-        //     `FastVLM.prepare`.
+        //   - ae49c7c feat(omni): full audio `LMInput` integration —
+        //     STT + voice I/O. Closes the prior "audio open seam" in
+        //     `OMNI-OSAURUS-HOOKUP.md` §3.
+        //   - 3b78db4 feat(omni): close audio + video gaps. Together
+        //     with `ae49c7c` makes the audio/video HTTP-API surface in
+        //     this PR's `feat(api)` commit round-trip end-to-end.
+        //   - d020e76 docs+fix(omni): voice integration guide +
+        //     `BatchEngine` text-only `.logits` return so a
+        //     `[concatenate] dims 3 vs 4` trap doesn't cascade into
+        //     Mamba2 conv state merge.
         //
-        // Foundational omni stack:
+        // Foundational omni stack (already in 1c62d21, kept by 13abe40):
         //   - b4eec09 native Swift port of Nemotron-3-Nano-Omni — first
-        //     time osaurus drives Parakeet/RADIO without a torch dep.
-        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
+        //     time the host runs Parakeet/RADIO without a torch dep.
+        //   - 08994b0 `OMNI-OSAURUS-HOOKUP.md` spec — cited by
         //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
         //     Nemotron-3 registry comments (§12.5).
         //   - 75549cb @ModuleInfo single-segment fix for omni weight
         //     loading.
-        //   - 1c62d21 OMNI-OSAURUS-HOOKUP §10 correction: the prior
+        //   - 1c62d21 `OMNI-OSAURUS-HOOKUP.md` §10 correction: prior
         //     "BatchEngine omni B=1 empty stream" claim was a bench
         //     methodology artifact — the bench counted only `.chunk`
         //     events and missed `.reasoning(_)` events that
-        //     reasoning-on-by-default omni emits during
-        //     `<think>...</think>`. Osaurus's `GenerationEventMapper`
-        //     correctly forwards `.reasoning(_)` (see
-        //     `PluginHostAPI.swift:1139` emitting
+        //     reasoning-on-by-default omni emits during `<think>...</think>`.
+        //     The host-side `GenerationEventMapper` correctly forwards
+        //     `.reasoning(_)` (`PluginHostAPI.swift:1139` emits
         //     `delta.reasoning_content`), so streaming clients see the
-        //     full output. No osaurus-side workaround needed.
-        //
-        // Carries forward all prior fixes:
-        //   - 98289d9 `MLX.asyncEval(slot.cache)` after disk restore
-        //   - a7db6e5 `continuation.onTermination` on
-        //     `BatchEngine.generate` so orphan slots reap on early break
-        //   - c992df9 `GenerateCompletionInfo.unclosedReasoning`
+        //     full output. No host-side workaround needed.
         //
         // The audio + video HTTP-API surface
         // (`MessageContentPart.audioInput` / `.videoUrl` →
-        // `UserInput.audios` / `.videos`) ships in a follow-up osaurus
-        // PR on top of this one; vmlx-side wiring is already in place
-        // at this pin.
+        // `UserInput.audios` / `.videos`) is part of this PR (the
+        // `feat(api)` commit on tip). vmlx-side wiring is in place at
+        // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
             revision: "13abe407df83d1836f640d0cb56f63a7e640ede3"

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "13abe407df83d1836f640d0cb56f63a7e640ede3"
+            revision: "2a6c965a731711a411f0809d118d34db16ec65c3"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "de521c7c9ded41f033877aff06781981af06cd58"
+            revision: "a196800715302e3903283aeaf6ec978eb1b1ac92"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -408,24 +408,15 @@ final class ModelDownloadService: ObservableObject {
     }
 
     /// Returns the free-for-important-usage byte count on the volume that
-    /// hosts `url`. Falls back to the older `.systemFreeSize` query if the
-    /// modern `.volumeAvailableCapacityForImportantUsageKey` is unavailable.
+    /// hosts `url`. Delegates to `OsaurusPaths.volumeFreeBytes(forPath:)`
+    /// so this service and `SystemMonitorService` share one query path —
+    /// preventing the kind of drift that produced bug #964 (the system
+    /// monitor reported 0 GB free while the downloader correctly saw
+    /// tens of GB free, because the two used different APIs).
     /// Returns `nil` if both queries fail — callers should treat `nil` as
     /// "unknown, proceed" rather than "zero, block".
     static func freeBytesOnVolume(containing url: URL) -> Int64? {
-        let probe = url
-        let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
-        if let values = try? probe.resourceValues(forKeys: keys),
-            let capacity = values.volumeAvailableCapacityForImportantUsage
-        {
-            return capacity
-        }
-        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: probe.path),
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
-        {
-            return free
-        }
-        return nil
+        OsaurusPaths.volumeFreeBytes(forPath: url.path)
     }
 
     private func updateDownloadProgress(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -417,18 +417,67 @@ public actor ModelRuntime {
 
     /// Installs the cache coordinator on a freshly-loaded holder.
     ///
-    /// Single call to `enableCaching(config:)` is all that's needed — vmlx
-    /// auto-detects hybrid SSM models on first slot admission inside
-    /// `BatchEngine`, so osaurus must not call `setHybrid(_:)` manually
-    /// (per OSAURUS-INTEGRATION.md). Actor-isolated, so the install is
-    /// observed atomically by the next request.
+    /// `enableCaching(config:)` constructs the coordinator with our
+    /// recommended knobs (paged + L2 disk + TurboQuant default + 8K window).
+    /// vmlx's `BatchEngine.admitPendingRequests` auto-flips
+    /// `coordinator.isHybrid` on first slot admission for any model whose
+    /// per-layer cache list contains a `MambaCache` or `ArraysCache` — that
+    /// covers the BatchEngine path osaurus uses today.
+    ///
+    /// **Eager `setHybrid(true)` for known hybrid families**: per
+    /// `OMNI-OSAURUS-HOOKUP.md` §5.1 the eager-set is harmless on any
+    /// admission path and avoids a one-frame stale-flag window if a request
+    /// ever lands via the single-slot `Evaluate` path before BatchEngine
+    /// has had a chance to flip it. We tag known hybrid model_types here
+    /// instead of inspecting the model's cache list (which would require an
+    /// async `context.read` round-trip just to check for an `is MambaCache`
+    /// match) — the family list is short, drift is caught by tests, and
+    /// the auto-flip remains the source of truth for any model_type the
+    /// list misses.
     private func installCacheCoordinator(on holder: SessionHolder) async {
         let cacheConfig = Self.buildCacheCoordinatorConfig(modelName: holder.name)
         holder.container.enableCaching(config: cacheConfig)
 
+        if Self.isKnownHybridModel(name: holder.name) {
+            holder.container.cacheCoordinator?.setHybrid(true)
+        }
+
         genLog.info(
-            "installCacheCoordinator: enabled for \(holder.name, privacy: .public) disk=\(cacheConfig.enableDiskCache, privacy: .public) (sizing left to vmlx defaults)"
+            "installCacheCoordinator: enabled for \(holder.name, privacy: .public) disk=\(cacheConfig.enableDiskCache, privacy: .public) hybrid=\(Self.isKnownHybridModel(name: holder.name), privacy: .public) (sizing left to vmlx defaults)"
         )
+    }
+
+    /// Substring-match against the families whose per-layer cache lists
+    /// vmlx's `newCache(parameters:)` populates with `MambaCache` /
+    /// `ArraysCache` slots. Lower-cased model_id, so picker forms (without
+    /// the org prefix) match too.
+    ///
+    /// The list intentionally tracks model_type _families_, not exact ids,
+    /// so new bundles in the same architecture (e.g. another Holo3 / Qwen
+    /// 3.x MoE quant tier, a future Nemotron-4 hybrid) flip the flag
+    /// without a registry edit. Worst case a non-hybrid match would still
+    /// be safe: vmlx's `setHybrid(true)` only enables the SSM-state
+    /// companion-cache lookup; the lookup is keyed and just misses on a
+    /// non-hybrid model — no incorrect routing.
+    nonisolated static func isKnownHybridModel(name: String) -> Bool {
+        let lower = name.lowercased()
+        // Mamba+Attn+MoE — Nemotron-3 / Cascade-2 / Hyper.
+        if lower.contains("nemotron-3") || lower.contains("nemotron-cascade")
+            || lower.contains("nemotron_h")
+        {
+            return true
+        }
+        // Qwen 3.5 / 3.6 MoE family (qwen3_5_moe model_type) covers Holo3 too.
+        if lower.contains("qwen3.5") || lower.contains("qwen3.6") || lower.contains("holo3")
+            || lower.contains("holo-3")
+        {
+            return true
+        }
+        // MiniMax M2 / M2.7 — gated SSM in some layers.
+        if lower.contains("minimax-m2") || lower.contains("minimax_m2") {
+            return true
+        }
+        return false
     }
 
     // MARK: - Generation driver

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -878,11 +878,29 @@ public actor ModelRuntime {
         out.reserveCapacity(max(6, msgs.count))
         for m in msgs {
             let images = extractImageSources(from: m)
+            let videos = extractVideoSources(from: m)
+            let audios = extractAudioSources(from: m)
             switch m.role {
             case "system":
-                out.append(.init(role: .system, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .system,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             case "user":
-                out.append(.init(role: .user, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .user,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             case "assistant":
                 let content = (m.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 let toolCalls = toMLXToolCalls(m.tool_calls)
@@ -893,7 +911,8 @@ public actor ModelRuntime {
                         role: .assistant,
                         content: content,
                         images: images,
-                        videos: [],
+                        videos: videos,
+                        audios: audios,
                         toolCalls: toolCalls,
                         toolCallId: nil
                     )
@@ -904,13 +923,22 @@ public actor ModelRuntime {
                         role: .tool,
                         content: m.content ?? "",
                         images: images,
-                        videos: [],
+                        videos: videos,
+                        audios: audios,
                         toolCalls: nil,
                         toolCallId: m.tool_call_id
                     )
                 )
             default:
-                out.append(.init(role: .user, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .user,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             }
         }
         return out
@@ -959,6 +987,115 @@ public actor ModelRuntime {
             }
         }
         return sources
+    }
+
+    /// Extract `[UserInput.Video]` from `video_url` content parts. Mirrors
+    /// `extractImageSources` — `data:` URLs are written to a temp file so
+    /// AVAsset can decode them; `http(s):` URLs go through directly. The
+    /// vmlx side (`NemotronHOmniProcessor.prepare()`) extracts frames via
+    /// `nemotronOmniExtractVideoFrames` regardless of source shape.
+    nonisolated private static func extractVideoSources(
+        from message: ChatMessage
+    ) -> [MLXLMCommon.UserInput.Video] {
+        let urls = message.videoUrls
+        guard !urls.isEmpty else { return [] }
+
+        var sources: [MLXLMCommon.UserInput.Video] = []
+        for urlString in urls {
+            if urlString.hasPrefix("data:video/") {
+                // data:video/<container>;base64,<bytes>
+                if let url = materializeMediaDataUrl(urlString, defaultExtension: "mp4") {
+                    sources.append(.url(url))
+                }
+            } else if let url = URL(string: urlString) {
+                sources.append(.url(url))
+            }
+        }
+        return sources
+    }
+
+    /// Extract `[UserInput.Audio]` from `input_audio` content parts. The
+    /// OpenAI shape is `{data: <base64>, format: "wav"|"mp3"|...}`; we
+    /// materialize a temp file with that extension and hand the URL to vmlx
+    /// so `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32)
+    /// drives the decode end-to-end. Going through a file URL keeps the path
+    /// uniform across formats — there is no in-memory `[Float]` decode here
+    /// because we'd have to duplicate vmlx's AVAudioConverter rig and lose
+    /// resampling fidelity in the process.
+    nonisolated private static func extractAudioSources(
+        from message: ChatMessage
+    ) -> [MLXLMCommon.UserInput.Audio] {
+        let inputs = message.audioInputs
+        guard !inputs.isEmpty else { return [] }
+
+        var sources: [MLXLMCommon.UserInput.Audio] = []
+        for (data, format) in inputs {
+            let ext = format.lowercased()
+            // Synthesize a `data:audio/<format>;base64,<data>` URL so we can
+            // reuse the same materializer the video path uses. The audio data
+            // comes in as a bare base64 string from `input_audio.data`, not a
+            // data URL — wrap it before handing off so the helper's data-URL
+            // parsing applies uniformly.
+            let dataUrl = "data:audio/\(ext);base64,\(data)"
+            if let url = materializeMediaDataUrl(dataUrl, defaultExtension: ext.isEmpty ? "wav" : ext) {
+                sources.append(.url(url))
+            }
+        }
+        return sources
+    }
+
+    /// Decode a `data:<mediatype>;base64,<bytes>` URL into a temp file URL with
+    /// an extension reflecting the mediatype. Returns `nil` on parse / decode
+    /// failure.
+    ///
+    /// Lifecycle: temp files live in `FileManager.default.temporaryDirectory`
+    /// and are not actively cleaned up here. macOS evicts the system temp dir
+    /// on its own schedule (`/private/var/folders/.../T/` rotates per session
+    /// and on reboot). Per-request cleanup would require threading a teardown
+    /// hook through the generation lifecycle, which is more complexity than
+    /// it's worth for what amounts to short-lived audio/video bytes.
+    nonisolated private static func materializeMediaDataUrl(
+        _ urlString: String,
+        defaultExtension: String
+    ) -> URL? {
+        // Expect `data:<mediatype>[;base64],<payload>`. Pull the mediatype
+        // subtype as the file extension when available so AVFoundation /
+        // AVAudioConverter's extension-keyed dispatch picks the right decoder.
+        guard urlString.hasPrefix("data:") else { return nil }
+        guard let commaIndex = urlString.firstIndex(of: ",") else { return nil }
+        let header = String(urlString[urlString.index(urlString.startIndex, offsetBy: 5) ..< commaIndex])
+        let payload = String(urlString[urlString.index(after: commaIndex)...])
+        guard let bytes = Data(base64Encoded: payload) else { return nil }
+
+        // Header looks like `audio/wav;base64` or `video/mp4`. Take the part
+        // after the slash, before any `;`.
+        var ext = defaultExtension
+        if let slash = header.firstIndex(of: "/") {
+            let afterSlash = header[header.index(after: slash)...]
+            if let semi = afterSlash.firstIndex(of: ";") {
+                ext = String(afterSlash[..<semi]).lowercased()
+            } else {
+                ext = String(afterSlash).lowercased()
+            }
+            // Some clients send `audio/x-wav` or `audio/mpeg` — coerce to the
+            // canonical extensions vmlx's AVAudioConverter recognizes.
+            switch ext {
+            case "x-wav", "wave": ext = "wav"
+            case "mpeg", "mp3", "x-mpeg": ext = "mp3"
+            case "x-m4a", "mp4": ext = "m4a"
+            default: break
+            }
+        }
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(ext)
+        do {
+            try bytes.write(to: tmp, options: .atomic)
+            return tmp
+        } catch {
+            return nil
+        }
     }
 
     private static func computeWeightsSizeBytes(at url: URL) -> Int64 {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1070,6 +1070,7 @@ public actor ModelRuntime {
         // Header looks like `audio/wav;base64` or `video/mp4`. Take the part
         // after the slash, before any `;`.
         var ext = defaultExtension
+        let isAudioMime = header.lowercased().hasPrefix("audio/")
         if let slash = header.firstIndex(of: "/") {
             let afterSlash = header[header.index(after: slash)...]
             if let semi = afterSlash.firstIndex(of: ";") {
@@ -1077,13 +1078,18 @@ public actor ModelRuntime {
             } else {
                 ext = String(afterSlash).lowercased()
             }
-            // Some clients send `audio/x-wav` or `audio/mpeg` — coerce to the
-            // canonical extensions vmlx's AVAudioConverter recognizes.
-            switch ext {
-            case "x-wav", "wave": ext = "wav"
-            case "mpeg", "mp3", "x-mpeg": ext = "mp3"
-            case "x-m4a", "mp4": ext = "m4a"
-            default: break
+            // Coerce audio mediatypes to the canonical extensions vmlx's
+            // AVAudioConverter recognizes. Guarded on `audio/` mime so a
+            // `data:video/mp4` URL keeps `.mp4` and isn't downgraded to the
+            // audio-only `.m4a` extension that the previous unconditional
+            // table produced.
+            if isAudioMime {
+                switch ext {
+                case "x-wav", "wave": ext = "wav"
+                case "mpeg", "mp3", "x-mpeg": ext = "mp3"
+                case "x-m4a", "mp4": ext = "m4a"
+                default: break
+                }
             }
         }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
@@ -1,0 +1,90 @@
+//
+//  MLXErrorRecovery.swift
+//  osaurus
+//
+//  Installs a process-wide MLX error handler so a C++-side MLX error in any
+//  forward pass becomes a logged event instead of `fatalError`. Without this,
+//  the default `mlx-swift` `ErrorHandler.dispatch` fallback is `fatalError(message)`
+//  — i.e. *any* MLX assertion (shape mismatch in `rmsNorm`, broadcast mismatch,
+//  Metal validation failure) takes the entire osaurus process down, killing every
+//  unrelated in-flight request as collateral damage.
+//
+//  The crash class this prevents was symbolicated against bundle
+//  `nemotron-cascade-2-30b-a3b-jang_4m`, where the JANG_4M unpack on the
+//  NemotronH backbone produced a weight tensor whose last dim disagreed with
+//  the activation: `MLXFast.rmsNorm` → `_mlx_error` → `ErrorHandler.dispatch`
+//  → `_assertionFailure` → SIGTRAP. The vmlx-side fix lives in
+//  `NemotronHJANGTQ.swift`; on the osaurus side we want the server to keep
+//  running and surface the error to the offending request only.
+//
+//  ### Why a global handler, not `withErrorHandler`/`withError`
+//
+//  vmlx-swift-lm's `BatchEngine` runs its scheduling loop in a long-lived
+//  background `Task` created when the engine is instantiated, not per request.
+//  TaskLocal handlers (the non-deprecated `withErrorHandler` API) only flow
+//  through structured concurrency — they do **not** reach a pre-existing task,
+//  so wrapping `engine.generate` at the call site would not protect the slot
+//  whose forward pass actually traps.
+//
+//  The deprecated-but-still-public `setErrorHandler` is therefore the correct
+//  tool for "make MLX errors recoverable for the whole process." Its
+//  deprecation message is a hint that *user code* should prefer scoped
+//  handlers; system bootstrap is a different shape.
+//
+
+import Foundation
+import MLX
+import os.log
+
+private let recoveryLog = Logger(subsystem: "com.dinoki.osaurus", category: "MLXErrorRecovery")
+
+public enum MLXErrorRecovery {
+
+    /// Lock-protected slot for the most recent MLX error message. Useful for
+    /// diagnostics — the handler runs on whichever thread MLX called us from,
+    /// so this is a coarse "what failed last" rather than a per-request signal.
+    nonisolated(unsafe) private static let lock = NSLock()
+    nonisolated(unsafe) private static var _lastError: String?
+
+    public static var lastError: String? {
+        lock.withLock { _lastError }
+    }
+
+    /// One-shot install flag. `setErrorHandler` itself is idempotent at the
+    /// MLX level (replaces the previous handler), but we still gate to avoid
+    /// re-logging the install message on every call from defensive call sites.
+    nonisolated(unsafe) private static var installed = false
+
+    /// Install the process-wide handler. Idempotent and thread-safe via `lock`.
+    /// Safe to call from any thread; first caller wins, subsequent calls are
+    /// no-ops.
+    public static func installGlobalHandler() {
+        lock.withLock {
+            guard !installed else { return }
+            installed = true
+        }
+
+        // C-convention closure: no captures (must match `@convention(c)`).
+        let handler:
+            @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = {
+                cMessage, _ in
+                let message = cMessage.map { String(cString: $0) } ?? "<nil>"
+                MLXErrorRecovery.lock.withLock {
+                    MLXErrorRecovery._lastError = message
+                }
+                // `os_log` from the C-convention thunk is allowed (no async
+                // hops, no captures of Swift state).
+                recoveryLog.error("MLX error: \(message, privacy: .public)")
+            }
+
+        // `setErrorHandler` is marked deprecated in mlx-swift; see the file
+        // header for why the global form is the correct shape here.
+        @available(*, deprecated)
+        func setHandlerCompat() {
+            MLX.setErrorHandler(handler)
+        }
+        setHandlerCompat()
+
+        recoveryLog.info("installed global MLX error handler (process will not fatalError on MLX C++ errors)")
+    }
+}

--- a/Packages/OsaurusCore/Services/SystemMonitorService.swift
+++ b/Packages/OsaurusCore/Services/SystemMonitorService.swift
@@ -184,15 +184,19 @@ class SystemMonitorService: ObservableObject {
     }
 
     private func getStorageUsage() -> (availableGB: Double, totalGB: Double) {
+        // Bug #964: previously used `attributesOfFileSystem(.systemFreeSize)`
+        // which returns 0 for sandboxed-container paths on modern macOS —
+        // the dashboard reported `Available: 0 GB` even when Finder showed
+        // tens of GB free. `OsaurusPaths.volumeFreeBytes` uses the modern
+        // URL-keyed `.volumeAvailableCapacityForImportantUsageKey` first
+        // (the value Finder shows) and falls back to the legacy API only
+        // when the modern query is unavailable. Same helper as
+        // `ModelDownloadService.freeBytesOnVolume` so the two read-outs
+        // can never silently drift.
         let gb = 1024.0 * 1024.0 * 1024.0
-        do {
-            let attrs = try FileManager.default.attributesOfFileSystem(forPath: storagePath)
-            let total = (attrs[.systemSize] as? NSNumber)?.doubleValue ?? 0
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.doubleValue ?? 0
-            return (free / gb, total / gb)
-        } catch {
-            return (0.0, 0.0)
-        }
+        let freeBytes = OsaurusPaths.volumeFreeBytes(forPath: storagePath) ?? 0
+        let totalBytes = OsaurusPaths.volumeTotalBytes(forPath: storagePath) ?? 0
+        return (Double(freeBytes) / gb, Double(totalBytes) / gb)
     }
 
 }

--- a/Packages/OsaurusCore/Storage/AttachmentBlobStore.swift
+++ b/Packages/OsaurusCore/Storage/AttachmentBlobStore.swift
@@ -157,7 +157,45 @@ public enum AttachmentBlobStore {
                 return attachment
             }
 
-        case .imageRef, .documentRef:
+        case .audio(let data, let format, let filename):
+            // Audio uses its own threshold (256 KB) so chat-history JSON
+            // doesn't bloat with raw PCM. A 30 s wav at 16 kHz mono is
+            // ~960 KB → always spills. Tiny clips < 256 KB stay inline.
+            guard data.count >= Attachment.audioSpillThresholdBytes else { return attachment }
+            do {
+                let hash = try write(data)
+                return Attachment(
+                    id: attachment.id,
+                    kind: .audioRef(
+                        hash: hash, byteCount: data.count, format: format, filename: filename)
+                )
+            } catch {
+                log.warning(
+                    "audio spill failed; keeping inline (size=\(data.count)): \(error.localizedDescription)"
+                )
+                return attachment
+            }
+
+        case .video(let data, let filename):
+            // Video uses an aggressive 64 KB threshold — virtually all
+            // real attachments spill. Inline path only for in-memory
+            // request lifetime; persistence always goes through here.
+            guard data.count >= Attachment.videoSpillThresholdBytes else { return attachment }
+            do {
+                let hash = try write(data)
+                return Attachment(
+                    id: attachment.id,
+                    kind: .videoRef(
+                        hash: hash, byteCount: data.count, filename: filename)
+                )
+            } catch {
+                log.warning(
+                    "video spill failed; keeping inline (size=\(data.count)): \(error.localizedDescription)"
+                )
+                return attachment
+            }
+
+        case .imageRef, .documentRef, .audioRef, .videoRef:
             return attachment
         }
     }
@@ -172,7 +210,10 @@ public enum AttachmentBlobStore {
         for turn in turns {
             for attachment in turn.attachments {
                 switch attachment.kind {
-                case .imageRef(let hash, _), .documentRef(_, let hash, _):
+                case .imageRef(let hash, _),
+                     .documentRef(_, let hash, _),
+                     .audioRef(let hash, _, _, _),
+                     .videoRef(let hash, _, _):
                     refs.insert(hash)
                 default:
                     continue

--- a/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
@@ -1,0 +1,185 @@
+// Copyright © 2026 osaurus.
+//
+// MC/DC tests for `ModelRuntime.materializeMediaDataUrl` (private,
+// exercised through `ModelRuntime.mapOpenAIChatToMLX` from the public
+// API surface — same observable behavior as direct call).
+//
+// Decision tree:
+//
+//   D1: urlString.hasPrefix("data:")        → false → return nil
+//   D2: commaIndex = firstIndex(of: ",")    → nil   → return nil
+//   D3: bytes = Data(base64Encoded: payload) → nil  → return nil
+//   D4: header.firstIndex(of: "/")          → false → ext stays defaultExtension
+//   D5: afterSlash.firstIndex(of: ";")      → false → ext = afterSlash
+//   D6: header.lowercased().hasPrefix("audio/")  ← AUDIT FIX guard
+//                                           → true → run canonicalization switch
+//
+// MC/DC focus rows:
+//
+//   * D1=F  → nil (non-data URL)
+//   * D2=F  → nil (data: prefix but no comma)
+//   * D3=F  → nil (well-formed envelope but invalid base64)
+//   * D6=T  with ext=mp4 → file ext "m4a" (audio canonicalization fires)
+//   * D6=F  with ext=mp4 → file ext "mp4" (video bypasses canonicalization)
+//          ← THIS IS THE BUG-FIX REGRESSION ROW
+//
+// We exercise the function through `mapOpenAIChatToMLX` so the test
+// stays at the public API boundary. Private helpers stay private.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("materializeMediaDataUrl — MC/DC coverage (via mapOpenAIChatToMLX)")
+struct MaterializeMediaDataUrlMCDCTests {
+
+    // MARK: - Helper: build a single ChatMessage with a media data URL
+
+    private func mappedURL(forVideoDataURL urlString: String) -> URL? {
+        let json = """
+        [{"role": "user", "content": [
+          {"type": "video_url", "video_url": {"url": "\(urlString)"}}
+        ]}]
+        """.data(using: .utf8)!
+        let msgs = try! JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        guard let video = mapped.first?.videos.first,
+              case .url(let u) = video else { return nil }
+        return u
+    }
+
+    private func mappedURL(forAudioFormat format: String, base64: String) -> URL? {
+        let json = """
+        [{"role": "user", "content": [
+          {"type": "input_audio", "input_audio": {"data": "\(base64)", "format": "\(format)"}}
+        ]}]
+        """.data(using: .utf8)!
+        let msgs = try! JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        guard let audio = mapped.first?.audios.first,
+              case .url(let u) = audio else { return nil }
+        return u
+    }
+
+    // MARK: - D1: data: prefix guard
+
+    @Test("D1 F: non-data: URL falls through to .url(URL) without materialization")
+    func d1_nonDataUrl_doesNotMaterialize() {
+        // Video path with https URL — should NOT touch materializeMediaDataUrl
+        // and instead pass through as URL(string:). Locks D1=F path.
+        let url = mappedURL(forVideoDataURL: "https://example.com/clip.mp4")
+        #expect(url?.absoluteString == "https://example.com/clip.mp4")
+        #expect(url?.scheme == "https", "should NOT be a temp file://")
+    }
+
+    @Test("D1 T: data: URL goes through materialization to file://")
+    func d1_dataUrl_materializesToTempFile() {
+        let payload = Data([0x00, 0x01, 0x02, 0x03])
+        let b64 = payload.base64EncodedString()
+        let url = mappedURL(forVideoDataURL: "data:video/mp4;base64,\(b64)")
+        #expect(url?.scheme == "file", "should be a temp file://")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    // MARK: - D2: comma-index guard
+
+    @Test("D2 F: data: URL without comma → nil → no source materializes")
+    func d2_noComma_returnsNil() {
+        // Malformed: data: prefix but no payload separator. Result: the
+        // private function returns nil, so the video sources array stays
+        // empty (mappedURL returns nil because there's no .url() entry).
+        let url = mappedURL(forVideoDataURL: "data:video/mp4base64xxx")
+        #expect(url == nil, "malformed data URL must not produce a file")
+    }
+
+    // MARK: - D3: base64 decode guard
+
+    @Test("D3 F: data: URL with invalid base64 payload → nil")
+    func d3_invalidBase64_returnsNil() {
+        // `Data(base64Encoded:)` returns nil for non-base64 chars or
+        // bad padding. "@@@" contains no valid b64 chars at all.
+        let url = mappedURL(forVideoDataURL: "data:video/mp4;base64,@@@@")
+        #expect(url == nil, "invalid base64 must not produce a file")
+    }
+
+    // MARK: - D6: audio mediatype gate (AUDIT FIX REGRESSION ROW)
+    //
+    // This is the critical regression row. Before the audit fix
+    // (commit 44e12b94), the canonicalization switch ran unconditionally
+    // and `mp4 → m4a` fired for video data URLs too, downgrading
+    // .mp4 video to .m4a extension.
+
+    @Test("D6 F (video/mp4): extension stays .mp4, NOT downgraded to .m4a")
+    func d6_videoMp4_keepsMp4Extension() {
+        // CRITICAL: this is the audit-fix regression test. Previously
+        // the canonicalization table mapped mp4 → m4a unconditionally,
+        // which broke when called from the video path.
+        let payload = Data(repeating: 0xAB, count: 16)
+        let b64 = payload.base64EncodedString()
+        let url = mappedURL(forVideoDataURL: "data:video/mp4;base64,\(b64)")
+        #expect(url?.pathExtension == "mp4",
+            "video/mp4 must keep .mp4 — was incorrectly .m4a before audit fix")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    @Test("D6 T (audio/mp4): canonicalizes to .m4a (audio path keeps fix's intent)")
+    func d6_audioMp4_canonicalizesToM4a() {
+        // Audio path with format=mp4 → wraps as data:audio/mp4 → D6=T
+        // → canonicalization fires → ext becomes .m4a.
+        let payload = Data(repeating: 0xCD, count: 16)
+        let b64 = payload.base64EncodedString()
+        let url = mappedURL(forAudioFormat: "mp4", base64: b64)
+        #expect(url?.pathExtension == "m4a",
+            "audio with format=mp4 must canonicalize to .m4a for AVAudioConverter")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    // MARK: - Audio canonicalization switch arms (each independently flips ext)
+
+    @Test("Audio switch arm: x-wav → wav")
+    func switch_xWav() {
+        let b64 = Data([0x00]).base64EncodedString()
+        // Synthesize a data URL header that header-parses to "x-wav"
+        // We can only feed audio path through the public API since
+        // the private function isn't exposed. The audio path goes
+        // through `format` → `data:audio/<format>`. For x-wav we use
+        // format="x-wav" — the audio extractor will build "data:audio/x-wav".
+        let url = mappedURL(forAudioFormat: "x-wav", base64: b64)
+        #expect(url?.pathExtension == "wav")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    @Test("Audio switch arm: mpeg → mp3")
+    func switch_mpeg() {
+        let b64 = Data([0x00]).base64EncodedString()
+        let url = mappedURL(forAudioFormat: "mpeg", base64: b64)
+        #expect(url?.pathExtension == "mp3")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    @Test("Audio switch arm: x-m4a → m4a")
+    func switch_xM4a() {
+        let b64 = Data([0x00]).base64EncodedString()
+        let url = mappedURL(forAudioFormat: "x-m4a", base64: b64)
+        #expect(url?.pathExtension == "m4a")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    @Test("Audio switch default arm: wav stays wav (no remap)")
+    func switch_default_wav() {
+        let b64 = Data([0x00]).base64EncodedString()
+        let url = mappedURL(forAudioFormat: "wav", base64: b64)
+        #expect(url?.pathExtension == "wav", "wav already canonical, default arm")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
+    @Test("Audio switch default arm: flac → flac (uncovered by switch)")
+    func switch_default_flac() {
+        let b64 = Data([0x00]).base64EncodedString()
+        let url = mappedURL(forAudioFormat: "flac", base64: b64)
+        #expect(url?.pathExtension == "flac", "flac not in switch → default-arm passthrough")
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -1,0 +1,225 @@
+// Copyright © 2026 osaurus.
+//
+// MC/DC tests for `ModelMediaCapabilities.from(modelId:)` — drives the
+// chat composer's drag/drop allowlist. Each modality (image/video/audio)
+// must independently flip its flag based on regex/substring matching.
+//
+// Decision tree from the implementation:
+//   D1: matches `nemotron-3-nano-omni|nemotron_h_omni`        → .omni
+//   D2: matches `qwen[2-3](\.\d+|_\d+)?[-_]?vl`               → .imageVideo
+//   D3: matches `qwen3\.[5-6].*[-_]vl|holo3.*[-_]vl`          → .imageVideo
+//   D4: contains `smolvlm|smol-vlm`                           → .imageVideo
+//   D5: any of {paligemma, idefics3, fastvlm, llava-qwen2,
+//               pixtral, glm-ocr, lfm2-vl, gemma-3, gemma3,
+//               gemma-4-it}                                    → .imageOnly
+//   D6: matches `mistral[-_](3|medium-3)`                     → .imageOnly
+//   D7: matches `mistral[-_]?4.*[-_]vl`                       → .imageOnly
+//   else                                                       → .textOnly
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelMediaCapabilities — MC/DC coverage")
+struct ModelMediaCapabilitiesMCDCTests {
+
+    // MARK: - D1: Nemotron-3 omni (audio + video + image)
+
+    @Test("D1: Nemotron-3-Nano-Omni HF id → .omni")
+    func d1_nemotronOmniHF() {
+        let cap = ModelMediaCapabilities.from(
+            modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4")
+        #expect(cap == .omni)
+        #expect(cap.supportsAudio)
+        #expect(cap.supportsVideo)
+        #expect(cap.supportsImage)
+    }
+
+    @Test("D1: case-folded picker form → .omni")
+    func d1_nemotronOmniLower() {
+        #expect(ModelMediaCapabilities.from(modelId: "nemotron-3-nano-omni-30b-a3b-mxfp4") == .omni)
+    }
+
+    @Test("D1: nemotron_h_omni alternate naming → .omni")
+    func d1_nemotronHOmniUnderscore() {
+        #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Nemotron_H_Omni-Future") == .omni)
+    }
+
+    @Test("D1 boundary: bare 'nemotron-3' (text-only) does NOT match omni")
+    func d1_bareNemotron3_notOmni() {
+        // Critical: `nemotron-3` text-only bundles must NOT advertise audio.
+        let cap = ModelMediaCapabilities.from(modelId: "OsaurusAI/Nemotron-3-30B-Text-MXFP4")
+        #expect(!cap.supportsAudio,
+            "bare nemotron-3 (no -nano-omni) must NOT advertise audio support")
+    }
+
+    // MARK: - D2: Qwen 2/2.5/3 VL (image + video)
+
+    @Test("D2: Qwen2-VL → .imageVideo")
+    func d2_qwen2VL() {
+        let cap = ModelMediaCapabilities.from(modelId: "Qwen/Qwen2-VL-7B-Instruct-MLX-8bit")
+        #expect(cap == .imageVideo)
+        #expect(!cap.supportsAudio)
+    }
+
+    @Test("D2: Qwen2.5-VL with dot variant → .imageVideo")
+    func d2_qwen25VL_dot() {
+        #expect(
+            ModelMediaCapabilities.from(modelId: "Qwen/Qwen2.5-VL-7B-MLX") == .imageVideo)
+    }
+
+    @Test("D2: qwen2_vl underscore variant → .imageVideo")
+    func d2_qwen2VL_underscore() {
+        #expect(ModelMediaCapabilities.from(modelId: "qwen2_vl-future-bundle") == .imageVideo)
+    }
+
+    @Test("D2: Qwen3-VL → .imageVideo")
+    func d2_qwen3VL() {
+        #expect(ModelMediaCapabilities.from(modelId: "Qwen/Qwen3-VL-30B-A3B-MLX-8bit") == .imageVideo)
+    }
+
+    // MARK: - D3: Qwen 3.5 / 3.6 MoE VL + Holo3 VL (image + video)
+
+    @Test("D3: Qwen3.5-VL → .imageVideo")
+    func d3_qwen35VL() {
+        #expect(
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.5-VL-9B-8bit") == .imageVideo)
+    }
+
+    @Test("D3: Qwen3.6-VL → .imageVideo")
+    func d3_qwen36VL() {
+        #expect(
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.6-VL-30B-A3B-MXFP4") == .imageVideo)
+    }
+
+    @Test("D3 boundary: Qwen3.5/3.6 text-only (no -vl) → .textOnly")
+    func d3_qwen35Text_notVL() {
+        // Without `-vl` suffix, qwen3.5/3.6 falls through to text-only
+        #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.5-35B-A3B-mxfp4") == .textOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4") == .textOnly)
+    }
+
+    @Test("D3: Holo3 VL → .imageVideo")
+    func d3_holo3VL() {
+        #expect(ModelMediaCapabilities.from(modelId: "JANGQ-AI/Holo3-VL-35B-JANGTQ") == .imageVideo)
+    }
+
+    // MARK: - D4: SmolVLM 2 (image + video)
+
+    @Test("D4: SmolVLM 2 → .imageVideo")
+    func d4_smolVLM2() {
+        #expect(ModelMediaCapabilities.from(modelId: "HuggingFaceTB/SmolVLM2-2.2B") == .imageVideo)
+        #expect(ModelMediaCapabilities.from(modelId: "smolvlm-instruct") == .imageVideo)
+    }
+
+    // MARK: - D5: Image-only VLM families
+
+    @Test("D5: PaliGemma → .imageOnly")
+    func d5_paligemma() {
+        #expect(ModelMediaCapabilities.from(modelId: "google/paligemma2-3b-mix") == .imageOnly)
+    }
+
+    @Test("D5: Idefics 3 → .imageOnly")
+    func d5_idefics3() {
+        #expect(ModelMediaCapabilities.from(modelId: "HuggingFaceM4/Idefics3-8B") == .imageOnly)
+    }
+
+    @Test("D5: FastVLM / LLava-Qwen2 → .imageOnly")
+    func d5_fastVLM() {
+        #expect(ModelMediaCapabilities.from(modelId: "apple/FastVLM-7B") == .imageOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "llava-hf/llava_qwen2-7b") == .imageOnly)
+    }
+
+    @Test("D5: Pixtral standalone → .imageOnly")
+    func d5_pixtral() {
+        #expect(ModelMediaCapabilities.from(modelId: "mistralai/Pixtral-12B-2409") == .imageOnly)
+    }
+
+    @Test("D5: GLM OCR → .imageOnly")
+    func d5_glmOcr() {
+        #expect(ModelMediaCapabilities.from(modelId: "THUDM/GLM-OCR-large") == .imageOnly)
+    }
+
+    @Test("D5: LFM2-VL → .imageOnly")
+    func d5_lfm2VL() {
+        #expect(ModelMediaCapabilities.from(modelId: "LiquidAI/LFM2-VL-1.6B") == .imageOnly)
+    }
+
+    @Test("D5: Gemma 3 / 4 (VLM) → .imageOnly")
+    func d5_gemmaVLM() {
+        #expect(ModelMediaCapabilities.from(modelId: "google/gemma-3-27b-it") == .imageOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Gemma-4-it-26B-A4B") == .imageOnly)
+    }
+
+    // MARK: - D6: Mistral 3 / 3.5 (image only via Pixtral wrap)
+
+    @Test("D6: Mistral 3 / 3.5 → .imageOnly")
+    func d6_mistral3() {
+        #expect(ModelMediaCapabilities.from(modelId: "mistralai/Mistral-3-Small-24B") == .imageOnly)
+        #expect(
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4")
+                == .imageOnly)
+    }
+
+    @Test("D6 boundary: bare 'mistral-7b' (no 3 or medium-3) → .textOnly")
+    func d6_bareMistral_notImage() {
+        #expect(ModelMediaCapabilities.from(modelId: "mistralai/Mistral-7B-v0.3") == .textOnly)
+    }
+
+    // MARK: - D7: Mistral 4 VLM (image only)
+
+    @Test("D7: Mistral 4 VL → .imageOnly")
+    func d7_mistral4VL() {
+        #expect(
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Mistral-4-VL-Future") == .imageOnly)
+    }
+
+    @Test("D7 boundary: Mistral 4 dense (no -vl) → .textOnly")
+    func d7_mistral4Dense_notImage() {
+        #expect(
+            ModelMediaCapabilities.from(modelId: "mistralai/Mistral-4-Small-24B-Instruct")
+                == .textOnly)
+    }
+
+    // MARK: - Master FALSE: dense LLM families
+
+    @Test("Master FALSE: dense LLMs all → .textOnly")
+    func masterFalse_denseLLMs() {
+        let denseFamilies = [
+            "lmstudio-community/gpt-oss-20b-MLX-8bit",
+            "OsaurusAI/Laguna-XS.2-mxfp4",  // SWA-hybrid LLM, no vision
+            "deepseekv4-flash-jangtq",
+            "kimi/Kimi-K2-Instruct",
+            "OsaurusAI/MiniMax-M2.7-JANGTQ",  // hybrid SSM but text-only
+            "nemotron-cascade-2-30b-a3b-jang_4m",  // hybrid SSM but text-only
+            "JANGQ-AI/Holo3-35B-A3B-JANGTQ",  // text-only Holo3 (no -vl)
+            "foundation",
+            "",  // empty edge case
+        ]
+        for id in denseFamilies {
+            let cap = ModelMediaCapabilities.from(modelId: id)
+            #expect(cap == .textOnly,
+                "\(id) must resolve to text-only (got: \(cap.summary))")
+            #expect(!cap.anyMedia, "\(id) anyMedia must be false")
+        }
+    }
+
+    // MARK: - Capabilities convenience surface
+
+    @Test("Capabilities.summary renders modality list")
+    func summary_renders() {
+        #expect(ModelMediaCapabilities.Capabilities.textOnly.summary == "text-only")
+        #expect(ModelMediaCapabilities.Capabilities.imageOnly.summary == "image")
+        #expect(ModelMediaCapabilities.Capabilities.imageVideo.summary == "image + video")
+        #expect(ModelMediaCapabilities.Capabilities.omni.summary == "image + video + audio")
+    }
+
+    @Test("Capabilities.anyMedia flips on any modality")
+    func anyMedia_flips() {
+        #expect(!ModelMediaCapabilities.Capabilities.textOnly.anyMedia)
+        #expect(ModelMediaCapabilities.Capabilities.imageOnly.anyMedia)
+        #expect(ModelMediaCapabilities.Capabilities.imageVideo.anyMedia)
+        #expect(ModelMediaCapabilities.Capabilities.omni.anyMedia)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -90,4 +90,53 @@ struct ModelProfileRegistryTests {
         // developer's locally installed model directory.
         #expect(profile?.thinkingOption == nil)
     }
+
+    /// Nemotron-3 Reasoning bundles (model_type=nemotron_h, hybrid Mamba+Attn+MoE)
+    /// must match `NemotronThinkingProfile`, NOT the generic
+    /// `AutoThinkingProfile`. The two have different `disableThinking`
+    /// defaults — Nemotron defaults to thinking-OFF (defensive, mirroring
+    /// `QwenThinkingProfile`) because the SKU's training extends `<think>`
+    /// blocks through arbitrary self-verification on validation prompts
+    /// (the trapped-thinking pattern documented in
+    /// `jang/research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md` §9). Auto would
+    /// default ON and surface the loop as visible UX regression.
+    @Test("Nemotron-3 reasoning bundles match NemotronThinkingProfile (default OFF)")
+    func nemotron3_matchesNemotronProfile() {
+        for id in [
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            "nemotron-3-nano-omni-30b-a3b-mxfp4",  // case-folded picker form
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(
+                profile?.displayName == NemotronThinkingProfile.displayName,
+                "expected NemotronThinkingProfile for \(id), got \(profile?.displayName ?? "nil")"
+            )
+            // Default-OFF guards against the trapped-thinking pattern.
+            let defaultDisable = profile?.defaults["disableThinking"]?.boolValue ?? false
+            #expect(defaultDisable == true,
+                "Nemotron must default disableThinking=true to avoid trapped-thinking loops")
+        }
+    }
+
+    /// Older "Nemotron-Cascade-2" / "Nemotron-Hyper" bundles use a different
+    /// model-type lineage (deprecated NeMo style) and shouldn't accidentally
+    /// pick up the new profile. Locks the matcher specificity to `nemotron-3`.
+    @Test("Older Nemotron lineages do NOT match NemotronThinkingProfile")
+    func olderNemotron_doesNotMatch() {
+        for id in [
+            "JANGQ-AI/Nemotron-Cascade-2-30B-A3B-JANG_4M",
+            "dealignai/Nemotron-3-Super-120B-A12B-JANG_2L-CRACK",
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            // Cascade-2 / Super may still match `AutoThinkingProfile` if their
+            // chat template reads `enable_thinking` — the assertion is just
+            // that they don't shortcut into the new Nemotron-3-specific
+            // profile.
+            let isNemotron3 = profile?.displayName == NemotronThinkingProfile.displayName
+            #expect(!isNemotron3 || id.lowercased().contains("nemotron-3"),
+                "matcher must be specific to nemotron-3, not generic nemotron")
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -139,4 +139,51 @@ struct ModelProfileRegistryTests {
                 "matcher must be specific to nemotron-3, not generic nemotron")
         }
     }
+
+    /// Laguna bundles (`model_type=laguna`) must match
+    /// `LagunaThinkingProfile` so the chat-input area's reasoning toggle
+    /// drives the `enable_thinking` Jinja kwarg honoured by the shipped
+    /// `laguna_glm_thinking_v5/chat_template.jinja`. Default-OFF mirrors
+    /// the chat template's own default — agentic-coding flows want
+    /// straight-to-answer; the toggle lets the user opt into CoT.
+    @Test("Laguna bundles match LagunaThinkingProfile (default OFF, all quant tiers)")
+    func laguna_matchesLagunaProfile() {
+        for id in [
+            "OsaurusAI/Laguna-XS.2-mxfp4",
+            "OsaurusAI/Laguna-XS.2-JANGTQ2",
+            "JANGQ-AI/Laguna-XS.2-JANGTQ2",
+            "laguna-xs.2-mxfp4",            // case-folded picker form
+            "OsaurusAI/Laguna-S.3-JANGTQ4", // forward-compat (future variant)
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(
+                profile?.displayName == LagunaThinkingProfile.displayName,
+                "expected LagunaThinkingProfile for \(id), got \(profile?.displayName ?? "nil")"
+            )
+            let defaultDisable = profile?.defaults["disableThinking"]?.boolValue ?? false
+            #expect(defaultDisable == true,
+                "Laguna must default disableThinking=true to mirror the chat-template default")
+        }
+    }
+
+    /// Mistral Medium 3.5 has no thinking toggle today (no `<think>` block
+    /// in its chat template). Match must NOT shortcut into a thinking
+    /// profile; if it falls through to `AutoThinkingProfile` that's fine
+    /// (only activates if the local-reasoning capability detector says
+    /// thinking is toggleable). The assertion is the negative one: it
+    /// must NOT pick up Nemotron's or Laguna's profile.
+    @Test("Mistral Medium 3.5 does NOT match Nemotron or Laguna thinking profiles")
+    func mistralMedium35_doesNotMatchThinkingFamilies() {
+        for id in [
+            "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",
+            "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2",
+            "mistral-medium-3.5-128b-mxfp4",
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(profile?.displayName != NemotronThinkingProfile.displayName,
+                "Mistral 3.5 must NOT shortcut into NemotronThinkingProfile: \(id)")
+            #expect(profile?.displayName != LagunaThinkingProfile.displayName,
+                "Mistral 3.5 must NOT shortcut into LagunaThinkingProfile: \(id)")
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -1,0 +1,226 @@
+//
+//  MultimodalContentPartTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+/// Locks in the OpenAI-compatible `MessageContentPart` decoding for
+/// `input_audio` and `video_url` shapes plus the `ChatMessage` →
+/// `MLXLMCommon.Chat.Message` mapping that lights up Nemotron-Omni's
+/// audio + video paths via vmlx's `UserInput.audios` / `.videos` fields.
+///
+/// Without these tests, a refactor that drops the new cases or the
+/// extraction wiring (e.g. someone "simplifies" the `mapOpenAIChatToMLX`
+/// switch and forgets to re-pass `audios:` to `Chat.Message.init`) would
+/// be invisible at compile time — vmlx accepts the omitted parameter as
+/// the default `[]` — and silently route every audio request as
+/// text-only. The bug surface there is a model that just doesn't "hear"
+/// the audio attachment, with no error. Easy to ship, hard to spot.
+@Suite("Multimodal content parts (audio + video)")
+struct MultimodalContentPartTests {
+
+    // MARK: - MessageContentPart decoding
+
+    @Test("input_audio content part decodes data + format")
+    func decode_inputAudio() throws {
+        let json = """
+        {
+          "type": "input_audio",
+          "input_audio": {"data": "AAA=", "format": "wav"}
+        }
+        """.data(using: .utf8)!
+
+        let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
+        guard case .audioInput(let data, let format) = part else {
+            Issue.record("expected .audioInput, got \(part)")
+            return
+        }
+        #expect(data == "AAA=")
+        #expect(format == "wav")
+    }
+
+    @Test("video_url content part decodes url")
+    func decode_videoUrl() throws {
+        let json = """
+        {
+          "type": "video_url",
+          "video_url": {"url": "https://example.com/clip.mp4"}
+        }
+        """.data(using: .utf8)!
+
+        let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
+        guard case .videoUrl(let url) = part else {
+            Issue.record("expected .videoUrl, got \(part)")
+            return
+        }
+        #expect(url == "https://example.com/clip.mp4")
+    }
+
+    @Test("Mixed content parts round-trip via Codable")
+    func roundtrip_mixedParts() throws {
+        let original: [MessageContentPart] = [
+            .text("describe this:"),
+            .imageUrl(url: "https://example.com/x.jpg", detail: "high"),
+            .audioInput(data: "AAA=", format: "wav"),
+            .videoUrl(url: "https://example.com/y.mp4"),
+        ]
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode([MessageContentPart].self, from: encoded)
+        #expect(decoded.count == 4)
+        // Spot-check the audio + video cases survived the round-trip with
+        // their payloads intact — `MessageContentPart` is `Codable`-only,
+        // not `Equatable`, so we case-match rather than `==`.
+        if case .audioInput(let d, let f) = decoded[2] {
+            #expect(d == "AAA=")
+            #expect(f == "wav")
+        } else {
+            Issue.record("decoded[2] should be .audioInput")
+        }
+        if case .videoUrl(let u) = decoded[3] {
+            #expect(u == "https://example.com/y.mp4")
+        } else {
+            Issue.record("decoded[3] should be .videoUrl")
+        }
+    }
+
+    // MARK: - ChatMessage accessors
+
+    @Test("ChatMessage.audioInputs returns (data, format) tuples")
+    func chatMessage_audioInputs() throws {
+        let json = """
+        {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "transcribe"},
+            {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
+            {"type": "input_audio", "input_audio": {"data": "BBBB", "format": "mp3"}}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        let inputs = msg.audioInputs
+        #expect(inputs.count == 2)
+        #expect(inputs[0].data == "AAAA")
+        #expect(inputs[0].format == "wav")
+        #expect(inputs[1].data == "BBBB")
+        #expect(inputs[1].format == "mp3")
+    }
+
+    @Test("ChatMessage.videoUrls returns urls in order")
+    func chatMessage_videoUrls() throws {
+        let json = """
+        {
+          "role": "user",
+          "content": [
+            {"type": "video_url", "video_url": {"url": "https://a/1.mp4"}},
+            {"type": "text", "text": "and:"},
+            {"type": "video_url", "video_url": {"url": "https://a/2.mp4"}}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        let urls = msg.videoUrls
+        #expect(urls == ["https://a/1.mp4", "https://a/2.mp4"])
+    }
+
+    // MARK: - mapOpenAIChatToMLX wiring
+
+    @Test("mapOpenAIChatToMLX forwards videos to Chat.Message.videos")
+    func mapping_forwardsVideos() throws {
+        let json = """
+        [{
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "what's in this clip"},
+            {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}}
+          ]
+        }]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 1)
+        #expect(mapped[0].videos.count == 1)
+        // Video came in as an `https:` URL — it should propagate as
+        // `.url(URL)` not `.avAsset(...)` — vmlx will fetch + decode.
+        guard case .url(let u) = mapped[0].videos[0] else {
+            Issue.record("expected .url(...) for https video")
+            return
+        }
+        #expect(u.absoluteString == "https://example.com/clip.mp4")
+    }
+
+    @Test("mapOpenAIChatToMLX materializes input_audio data into temp file URL")
+    func mapping_audioMaterializesTempFile() throws {
+        // 4 bytes of bogus PCM. We're not asserting decodability here —
+        // vmlx's `nemotronOmniLoadAudioFile` is what does the AVAudioConverter
+        // pass; this test only proves the wire payload reaches a file URL
+        // with the right extension so vmlx's extension-keyed dispatch picks
+        // the right decoder.
+        let payload = Data([0x00, 0x01, 0x02, 0x03])
+        let b64 = payload.base64EncodedString()
+        let json = """
+        [{
+          "role": "user",
+          "content": [
+            {"type": "input_audio", "input_audio": {"data": "\(b64)", "format": "wav"}}
+          ]
+        }]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 1)
+        #expect(mapped[0].audios.count == 1)
+        guard case .url(let u) = mapped[0].audios[0] else {
+            Issue.record("audio source must materialize to a .url(...) for vmlx's AVAudioConverter")
+            return
+        }
+        #expect(u.pathExtension == "wav", "extension drives AVAudioConverter dispatch")
+        // Verify the bytes actually landed on disk under the expected path.
+        let written = try Data(contentsOf: u)
+        #expect(written == payload)
+        // Best-effort cleanup so the test's temp files don't accumulate
+        // across local runs. macOS evicts the system temp dir on its own
+        // schedule for the production path; tests just don't need to wait.
+        try? FileManager.default.removeItem(at: u)
+    }
+
+    @Test("mapping handles all four roles with audio + video together")
+    func mapping_allRoles_carryAudioAndVideo() throws {
+        // System messages don't carry audio in real OpenAI requests, but
+        // the *mapping* must accept them without dropping anything — this
+        // catches a regression where a refactor handles only `user` and
+        // forgets the other branches.
+        let json = """
+        [
+          {"role": "system", "content": "you are helpful"},
+          {"role": "user", "content": [
+              {"type": "text", "text": "hi"},
+              {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}
+          ]},
+          {"role": "assistant", "content": "hello"},
+          {"role": "tool", "content": "result", "tool_call_id": "abc"}
+        ]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 4)
+        // Only the user message should have audio, but every role-branch
+        // must compile against the new `audios:` parameter — that's what
+        // the assertion is really catching at the type level.
+        let userMsg = mapped[1]
+        #expect(userMsg.audios.count == 1)
+        for other in [mapped[0], mapped[2], mapped[3]] {
+            #expect(other.audios.isEmpty)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -193,6 +193,61 @@ struct MultimodalContentPartTests {
         try? FileManager.default.removeItem(at: u)
     }
 
+    /// Locks in the fix for a shared-helper bug where the audio mediatype
+    /// canonicalization table (`mp4 → m4a`) ran unconditionally in
+    /// `materializeMediaDataUrl` — meaning a `data:video/mp4;base64,...`
+    /// URL got written to a temp file with `.m4a` extension. AVAsset on
+    /// macOS *can* still extract video tracks from a misnamed `.m4a`
+    /// container, so the bug wasn't visible in the e2e mapping test that
+    /// uses `https:` URLs, but downstream tools that key off `pathExtension`
+    /// (vmlx's `nemotronOmniExtractVideoFrames` and any future codec
+    /// dispatcher) would misroute. Fix is to guard the audio table on
+    /// `header.hasPrefix("audio/")`.
+    @Test("video data URL keeps .mp4 extension, audio data URL coerces to canonical")
+    func mapping_videoMp4DataUrlPreservesExtension() throws {
+        let videoBytes = Data([0x00, 0x01, 0x02, 0x03])
+        let audioBytes = Data([0x10, 0x11, 0x12, 0x13])
+        let videoB64 = videoBytes.base64EncodedString()
+        let audioB64 = audioBytes.base64EncodedString()
+        let json = """
+        [{
+          "role": "user",
+          "content": [
+            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,\(videoB64)"}},
+            {"type": "input_audio", "input_audio": {"data": "\(audioB64)", "format": "mp4"}}
+          ]
+        }]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 1)
+        #expect(mapped[0].videos.count == 1)
+        #expect(mapped[0].audios.count == 1)
+
+        guard case .url(let videoURL) = mapped[0].videos[0] else {
+            Issue.record("video should materialize to .url(...)")
+            return
+        }
+        // The bug: previously this would be "m4a" because the audio
+        // canonicalization table ran for video mediatypes too.
+        #expect(videoURL.pathExtension == "mp4",
+            "video/mp4 data URL must keep .mp4 extension, not be downgraded to .m4a")
+
+        guard case .url(let audioURL) = mapped[0].audios[0] else {
+            Issue.record("audio should materialize to .url(...)")
+            return
+        }
+        // Audio path: client said format=mp4 (an MP4 audio container), so
+        // synthetic `data:audio/mp4;base64,...` URL goes through the audio
+        // table — `mp4 → m4a` fires here as intended.
+        #expect(audioURL.pathExtension == "m4a",
+            "audio with format=mp4 should canonicalize to .m4a for AVAudioConverter")
+
+        try? FileManager.default.removeItem(at: videoURL)
+        try? FileManager.default.removeItem(at: audioURL)
+    }
+
     @Test("mapping handles all four roles with audio + video together")
     func mapping_allRoles_carryAudioAndVideo() throws {
         // System messages don't carry audio in real OpenAI requests, but

--- a/Packages/OsaurusCore/Tests/Service/IsKnownHybridModelMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/IsKnownHybridModelMCDCTests.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 osaurus.
+//
+// MC/DC tests for `ModelRuntime.isKnownHybridModel(name:)`
+// (ModelRuntime.swift:462). Substring-match against the families whose
+// per-layer cache lists vmlx populates with `MambaCache` / `ArraysCache`
+// slots — drives the eager `setHybrid(true)` flip in
+// `installCacheCoordinator`.
+//
+// Decision tree (3 OR-blocks separated by early returns):
+//
+//   Block 1: contains("nemotron-3") ∨ contains("nemotron-cascade")
+//                                   ∨ contains("nemotron_h")    → return true
+//   Block 2: contains("qwen3.5")  ∨ contains("qwen3.6")
+//                                  ∨ contains("holo3") ∨ contains("holo-3") → return true
+//   Block 3: contains("minimax-m2") ∨ contains("minimax_m2")    → return true
+//   else: return false
+//
+// MC/DC requirements per OR block: every condition must independently
+// flip the OR's truth value. For an OR of N conditions, that's N+1
+// cases per block (1 all-false + N single-true).
+//
+// Total minimum cases: (3+1) + (4+1) + (2+1) + 1 master-false = 13.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("isKnownHybridModel — MC/DC coverage")
+struct IsKnownHybridModelMCDCTests {
+
+    // MARK: - Block 1: Nemotron family (3 conditions)
+
+    @Test("B1.nemotron-3 substring independently flips Block 1")
+    func b1_nemotron3() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "nemotron-3-nano-omni-30b-a3b-mxfp4"))
+        // Forward-compat: any future Nemotron-3 variant
+        #expect(ModelRuntime.isKnownHybridModel(name: "JANGQ-AI/Nemotron-3-Reasoning-Future"))
+    }
+
+    @Test("B1.nemotron-cascade substring independently flips Block 1")
+    func b1_nemotronCascade() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "JANGQ-AI/Nemotron-Cascade-2-30B-A3B-JANG_4M"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "nemotron-cascade-2-30b-a3b-jang_4m"))
+    }
+
+    @Test("B1.nemotron_h substring independently flips Block 1")
+    func b1_nemotron_h() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/Nemotron_H-Future-Bundle"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "nemotron_h-cascade-3"))
+    }
+
+    @Test("B1 all-false: bare 'nemotron' (no -3, no -cascade, no _h) does NOT flip")
+    func b1_allFalse_bareNemotron() {
+        // Bare 'nemotron' is intentionally NOT in the matcher — older
+        // Nemotron-2 / NeMo dense bundles aren't hybrid. Locks against
+        // drift that would over-accept.
+        #expect(!ModelRuntime.isKnownHybridModel(name: "nvidia/nemotron-4-340b"))
+        #expect(!ModelRuntime.isKnownHybridModel(name: "nemotron-mini"))
+    }
+
+    // MARK: - Block 2: Qwen 3.x MoE + Holo3 (4 conditions)
+
+    @Test("B2.qwen3.5 substring independently flips Block 2")
+    func b2_qwen3_5() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/Qwen3.5-35B-A3B-mxfp4"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "qwen3.5-vl-9b-8bit"))
+    }
+
+    @Test("B2.qwen3.6 substring independently flips Block 2")
+    func b2_qwen3_6() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/Qwen3.6-35B-A3B-mxfp4"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "qwen3.6-35b-a3b-jangtq4"))
+    }
+
+    @Test("B2.holo3 substring independently flips Block 2")
+    func b2_holo3() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "JANGQ-AI/Holo3-35B-A3B-JANGTQ"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "holo3-35b-a3b-jangtq4"))
+    }
+
+    @Test("B2.holo-3 dash variant independently flips Block 2")
+    func b2_holoDash3() {
+        // Some bundle names use dash instead of bare 'holo3'
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/Holo-3-Future-Variant"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "holo-3-mxfp4"))
+    }
+
+    @Test("B2 all-false: qwen3 / qwen3-coder / qwen2 / qwen3.7 do NOT flip Block 2")
+    func b2_allFalse() {
+        #expect(!ModelRuntime.isKnownHybridModel(name: "qwen3-coder-plus"))
+        #expect(!ModelRuntime.isKnownHybridModel(name: "qwen2.5-7b-instruct"))
+        #expect(!ModelRuntime.isKnownHybridModel(name: "qwen3-30b"))
+        // qwen3.7 not yet recognized — would need explicit add when it lands
+        #expect(!ModelRuntime.isKnownHybridModel(name: "qwen3.7-future-variant"))
+    }
+
+    // MARK: - Block 3: MiniMax M2 family (2 conditions)
+
+    @Test("B3.minimax-m2 substring independently flips Block 3")
+    func b3_minimaxDashM2() {
+        #expect(ModelRuntime.isKnownHybridModel(name: "OsaurusAI/MiniMax-M2.7-JANGTQ"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "minimax-m2.7-small-jangtq"))
+    }
+
+    @Test("B3.minimax_m2 underscore variant independently flips Block 3")
+    func b3_minimaxUnderscoreM2() {
+        // Underscore form (rare but seen in some HF repos).
+        #expect(ModelRuntime.isKnownHybridModel(name: "minimax_m2-mxfp4"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "MiniMax_M2-3-future"))
+    }
+
+    @Test("B3 all-false: minimax-m1 / minimax-text-01 do NOT flip Block 3")
+    func b3_allFalse() {
+        // MiniMax-Text-01 is dense, not hybrid — must NOT match.
+        #expect(!ModelRuntime.isKnownHybridModel(name: "minimax/MiniMax-Text-01"))
+        #expect(!ModelRuntime.isKnownHybridModel(name: "minimax-m1-pro"))
+    }
+
+    // MARK: - Master FALSE: no block matches
+
+    @Test("All blocks false → returns false (dense + non-hybrid families)")
+    func masterFalse_denseAndNonHybridFamilies() {
+        // Locks the negative side of the entire decision tree. Each of
+        // these is a well-known non-hybrid family; the matcher must
+        // return false unconditionally.
+        let denseFamilies = [
+            "lmstudio-community/gpt-oss-20b-MLX-8bit",
+            "lmstudio-community/gpt-oss-120b-MLX-8bit",
+            "OsaurusAI/Gemma-4-31B-it-JANG_4M",
+            "OsaurusAI/gemma-4-26B-A4B-it-4bit",
+            "gemma-4-e2b-it-4bit-osaurus",
+            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",   // dense bf16 here
+            "dealignai/Mistral-Small-4-119B-JANG_2L-CRACK",
+            "OsaurusAI/Laguna-XS.2-mxfp4",         // SWA hybrid, NOT Mamba
+            "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4", // dense GQA
+            "foundation",                          // Apple's built-in
+            "deepseekv4-flash-jangtq",             // DSV4 has its own cache topology
+            "",                                    // empty string edge case
+        ]
+        for name in denseFamilies {
+            #expect(!ModelRuntime.isKnownHybridModel(name: name),
+                "must NOT match: \(name)")
+        }
+    }
+
+    // MARK: - Case-folding (the lowercased pre-pass)
+
+    @Test("Case-folding applies uniformly to all blocks")
+    func caseFolding_allBlocks() {
+        // Block 1: original caps
+        #expect(ModelRuntime.isKnownHybridModel(name: "NEMOTRON-3-future"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "Nemotron-Cascade-2"))
+
+        // Block 2: caps in qwen / holo
+        #expect(ModelRuntime.isKnownHybridModel(name: "QWEN3.5-35B"))
+        #expect(ModelRuntime.isKnownHybridModel(name: "HOLO3-mxfp4"))
+
+        // Block 3: caps in minimax
+        #expect(ModelRuntime.isKnownHybridModel(name: "MINIMAX-M2-mxfp4"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/MLXErrorRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXErrorRecoveryTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import OsaurusCore
+
+/// Guards `MLXErrorRecovery.installGlobalHandler()` — the osaurus-side bootstrap
+/// that replaces mlx-swift's default `fatalError(message)` MLX error fallback
+/// with a logging handler that lets the process keep running.
+///
+/// Without this install, **any** C++-side MLX error (shape mismatch in
+/// `rmsNorm`, broadcast mismatch, Metal validation failure) takes the entire
+/// osaurus process down via `_assertionFailure` — taking every unrelated
+/// in-flight request with it. This was the root cause symbolicated against
+/// `nemotron-cascade-2-30b-a3b-jang_4m` during PR #967 triage; the vmlx-side
+/// fix lives in `NemotronHJANGTQ.swift`, but on the osaurus side we want the
+/// server to survive any future bundle that trips a similar trap.
+///
+/// We deliberately do **not** try to trigger a real MLX error from a unit
+/// test: MLX's evaluation worker threads don't inherit Swift TaskLocals from
+/// the call site, so the scoped `withErrorHandler` API can't reliably fence
+/// off such a test from the suite-wide process. The end-to-end "real bundle
+/// failure becomes a 500, not a crash" assertion lives in integration tests
+/// (PR-967 triage harness) and is regression-protected by this test only at
+/// the install-time level.
+@Suite("MLXErrorRecovery — install path")
+struct MLXErrorRecoveryTests {
+
+    @Test("installGlobalHandler is idempotent and side-effect-free")
+    func install_idempotent() {
+        // First call installs; subsequent calls must be no-ops. The
+        // implementation guards on a flag inside its lock — without the
+        // guard, repeated install would re-run `MLX.setErrorHandler`,
+        // which itself has dtor cleanup logic that we don't want firing
+        // on every call site.
+        MLXErrorRecovery.installGlobalHandler()
+        MLXErrorRecovery.installGlobalHandler()
+        MLXErrorRecovery.installGlobalHandler()
+
+        // Surviving to here is the assertion. Anything pathological in
+        // re-install (unbalanced dtor, double-log, deadlock) would fail
+        // this case.
+        #expect(true)
+    }
+
+    @Test("lastError accessor returns without blocking when no error has fired")
+    func lastError_safeAccessor() {
+        MLXErrorRecovery.installGlobalHandler()
+        // The accessor takes the same lock the handler writes under.
+        // A naive impl that called the lock recursively from the handler
+        // (or held it across a logging call that itself synchronizes)
+        // would deadlock here in suite runs that have already exercised
+        // an MLX error in another test. Read-only path must always
+        // return promptly.
+        _ = MLXErrorRecovery.lastError
+        #expect(true)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -1,0 +1,118 @@
+//
+//  ModelRuntimeIsHybridTests.swift
+//
+//  Regression coverage for `ModelRuntime.isKnownHybridModel(name:)` —
+//  the substring-matcher that decides whether `installCacheCoordinator`
+//  eagerly calls `coordinator.setHybrid(true)` after `enableCaching`.
+//
+//  Per `vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/OMNI-OSAURUS-HOOKUP.md`
+//  §5.1 the eager-set is harmless and complementary to BatchEngine's
+//  auto-flip. The matcher is the source of truth for which model
+//  families get the eager-set; tests below lock the family list so a
+//  future drift (renaming the bundle, dropping a family, adding a new
+//  hybrid quant tier) shows up as a test diff first.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelRuntime.isKnownHybridModel — eager setHybrid family list")
+struct ModelRuntimeIsHybridTests {
+
+    // MARK: - Hybrid families that must flip the flag
+
+    @Test("Nemotron-3 (Mamba + Attn + MoE) — all quant tiers + picker form")
+    func nemotron3_isHybrid() {
+        for id in [
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            "nemotron-3-nano-omni-30b-a3b-mxfp4",            // case-folded picker form
+            "JANGQ-AI/Nemotron-3-Reasoning-Future-Variant",  // forward-compat
+        ] {
+            #expect(
+                ModelRuntime.isKnownHybridModel(name: id),
+                "Nemotron-3 family must flip setHybrid eagerly: \(id)")
+        }
+    }
+
+    @Test("Nemotron-Cascade-2 (older lineage) is also hybrid")
+    func nemotronCascade2_isHybrid() {
+        for id in [
+            "JANGQ-AI/Nemotron-Cascade-2-30B-A3B-JANG_4M",
+            "dealignai/Nemotron-Cascade-2-30B-A3B-JANG_2L-CRACK",
+        ] {
+            #expect(ModelRuntime.isKnownHybridModel(name: id))
+        }
+    }
+
+    @Test("Qwen 3.5 / 3.6 MoE family + Holo3 — qwen3_5_moe model_type")
+    func qwen3MoE_isHybrid() {
+        for id in [
+            "OsaurusAI/Qwen3.6-35B-A3B-mxfp4",
+            "qwen3.6-35b-a3b-jangtq4",
+            "qwen3.5-vl-9b-8bit",
+            "JANGQ-AI/Holo3-35B-A3B-JANGTQ",
+            "holo3-35b-a3b-jangtq4",
+        ] {
+            #expect(
+                ModelRuntime.isKnownHybridModel(name: id),
+                "Qwen 3.5/3.6 MoE family + Holo3 must flip setHybrid: \(id)")
+        }
+    }
+
+    @Test("MiniMax M2 / M2.7 family")
+    func minimaxM2_isHybrid() {
+        for id in [
+            "OsaurusAI/MiniMax-M2.7-JANGTQ",
+            "OsaurusAI/MiniMax-M2.7-JANGTQ4",
+            "minimax-m2.7-small-jangtq",
+        ] {
+            #expect(ModelRuntime.isKnownHybridModel(name: id))
+        }
+    }
+
+    // MARK: - Non-hybrid families that must NOT flip (regression guards)
+
+    /// Dense models without SSM layers must NOT eager-flip the hybrid flag.
+    /// Even though `setHybrid(true)` is harmless (the SSM state cache key
+    /// just misses on lookup), tagging a dense model as hybrid wastes a
+    /// per-request lookup; the matcher should be precise.
+    @Test("Dense LLM families do NOT flip setHybrid")
+    func denseFamilies_areNotHybrid() {
+        for id in [
+            "lmstudio-community/gpt-oss-20b-MLX-8bit",
+            "lmstudio-community/gpt-oss-120b-MLX-8bit",
+            "OsaurusAI/Gemma-4-31B-it-JANG_4M",
+            "OsaurusAI/gemma-4-26B-A4B-it-4bit",
+            "gemma-4-e2b-it-4bit-osaurus",
+            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",   // dense bf16, not Mamba
+            "dealignai/Mistral-Small-4-119B-JANG_2L-CRACK",
+            "foundation",                          // Apple's built-in
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "dense family must NOT flip setHybrid: \(id)")
+        }
+    }
+
+    /// DSV4-Flash JANGTQ uses Compressor/Indexer hybrid attention, but its
+    /// per-layer cache list does NOT contain `MambaCache` / `ArraysCache`
+    /// (it's a custom `DeepseekV4Cache`). vmlx's auto-flip only matches on
+    /// Mamba-style cache types, so neither path treats DSV4 as hybrid in
+    /// this sense — and DSV4 has its own `DSV4_KV_MODE` env var to control
+    /// cache topology. Lock that in: DSV4 must NOT match this family list.
+    @Test("DSV4-Flash JANGTQ does NOT match (uses DeepseekV4Cache, controlled via DSV4_KV_MODE)")
+    func dsv4Flash_isNotMambaHybrid() {
+        for id in [
+            "JANGQ-AI/DeepSeekV4-Flash-JANGTQ",
+            "deepseekv4-flash-jangtq",
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "DSV4 hybrid attention is a different cache topology than the Mamba families this matcher targets: \(id)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -115,4 +115,43 @@ struct ModelRuntimeIsHybridTests {
                 "DSV4 hybrid attention is a different cache topology than the Mamba families this matcher targets: \(id)")
         }
     }
+
+    /// Poolside Laguna (`model_type=laguna`) — its hybrid is sliding-window
+    /// + full attention with per-layer head counts (48 full / 64 SWA),
+    /// handled by `RotatingKVCache` + `KVCacheSimple` per-layer in vmlx.
+    /// That is NOT the Mamba/SSM hybrid that `setHybrid(true)` is for —
+    /// the `setHybrid` flag only controls whether the
+    /// `SSMStateCache` companion is consulted on fetch/store, and Laguna
+    /// has no SSM-state to round-trip. Match must therefore be NEGATIVE.
+    @Test("Laguna (SWA + full attention hybrid) does NOT match (no SSM-state companion)")
+    func laguna_isNotMambaHybrid() {
+        for id in [
+            "OsaurusAI/Laguna-XS.2-mxfp4",
+            "OsaurusAI/Laguna-XS.2-JANGTQ2",
+            "JANGQ-AI/Laguna-XS.2-JANGTQ2",
+            "laguna-xs.2-mxfp4",            // case-folded picker form
+            "OsaurusAI/Laguna-S.3-JANGTQ4", // forward-compat (future variant)
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "Laguna SWA-hybrid is RotatingKVCache + KVCacheSimple, not Mamba — must NOT eager-flip setHybrid: \(id)")
+        }
+    }
+
+    /// Mistral Medium 3.5 (`model_type=mistral3` outer + `text_config.
+    /// model_type=ministral3` inner). Dense GQA 96/8 with Pixtral vision
+    /// tower. No Mamba layers, no SSM state. Must NOT match.
+    @Test("Mistral Medium 3.5 (dense GQA + Pixtral) does NOT match")
+    func mistralMedium35_isNotMambaHybrid() {
+        for id in [
+            "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",
+            "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2",
+            "JANGQ-AI/Mistral-Medium-3.5-128B-JANGTQ2",
+            "mistral-medium-3.5-128b-mxfp4",
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "Mistral 3.5 dense GQA + Pixtral has no Mamba layers — must NOT eager-flip setHybrid: \(id)")
+        }
+    }
 }

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -140,6 +140,62 @@ public enum OsaurusPaths {
         return directorySize(at: url)
     }
 
+    // MARK: - Volume free-space query
+    //
+    // ⚠️ Use the URL-keyed `.volumeAvailableCapacityForImportantUsageKey`
+    //    rather than the legacy `attributesOfFileSystem(.systemFreeSize)`.
+    //    On modern macOS (≥ 11) inside a sandboxed container the legacy
+    //    API can return 0 because it reports raw bytes excluding the
+    //    OS's "purgeable" allowance — which is exactly what users see
+    //    in Finder. `.systemFreeSize` was the historical default and
+    //    `SystemMonitorService` shipped with it for a long time, surfacing
+    //    bug #964 (the dashboard reports `Available: 0 GB` even when the
+    //    user clearly has free space). The URL-keyed query is what
+    //    `ModelDownloadService.freeBytesOnVolume` already used; this
+    //    helper consolidates both call-sites onto the same logic so the
+    //    answer can never silently drift again.
+
+    /// Returns the free-for-important-usage byte count on the volume that
+    /// hosts `path`. Falls back to the legacy
+    /// `attributesOfFileSystem(.systemFreeSize)` only when the modern
+    /// query is unavailable. Returns `nil` if both queries fail —
+    /// callers should treat `nil` as "unknown, render 'unknown'" rather
+    /// than coercing to zero.
+    public static func volumeFreeBytes(forPath path: String) -> Int64? {
+        let url = URL(fileURLWithPath: path)
+        let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
+        if let values = try? url.resourceValues(forKeys: keys),
+            let capacity = values.volumeAvailableCapacityForImportantUsage
+        {
+            return capacity
+        }
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
+        {
+            return free
+        }
+        return nil
+    }
+
+    /// Returns total volume capacity in bytes for the volume that hosts
+    /// `path`. Uses `.volumeTotalCapacityKey` first, legacy `.systemSize`
+    /// as fallback. Returns `nil` on full failure.
+    public static func volumeTotalBytes(forPath path: String) -> Int64? {
+        let url = URL(fileURLWithPath: path)
+        let keys: Set<URLResourceKey> = [.volumeTotalCapacityKey]
+        if let values = try? url.resourceValues(forKeys: keys),
+            let capacity = values.volumeTotalCapacity
+        {
+            return Int64(capacity)
+        }
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
+            let total = (attrs[.systemSize] as? NSNumber)?.int64Value
+        {
+            return total
+        }
+        return nil
+    }
+
     /// Deletes every file under the disk KV cache directory. The directory
     /// itself is left in place (re-created on next model load via
     /// `ensureExistsSilent`). Safe to call while models are loaded — the

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -313,7 +313,7 @@ struct FloatingInputCard: View {
                     inputCard
                         .padding(.horizontal, 20)
                         .padding(.bottom, 20)
-                        .onDrop(of: [UTType.image, UTType.fileURL], isTargeted: $isDragOver) { providers in
+                        .onDrop(of: dropAcceptedTypes, isTargeted: $isDragOver) { providers in
                             handleFileDrop(providers)
                         }
                 }
@@ -1059,6 +1059,17 @@ extension FloatingInputCard {
                             )
                         }
                     case .document, .documentRef:
+                        DocumentChip(attachment: attachment) {
+                            withAnimation(theme.springAnimation()) {
+                                _ = pendingAttachments.remove(at: index)
+                            }
+                        }
+                    case .audio, .audioRef, .video, .videoRef:
+                        // Audio/video attachments display as a labeled chip
+                        // with a media-type icon. Inline-bytes are kept on
+                        // the pending queue (pre-spillover); refs may also
+                        // round-trip through chat history. Same on-remove
+                        // semantics as image/document chips.
                         DocumentChip(attachment: attachment) {
                             withAnimation(theme.springAnimation()) {
                                 _ = pendingAttachments.remove(at: index)
@@ -2082,34 +2093,193 @@ extension FloatingInputCard {
         }
     }
 
+    /// Capability-gated UTType allowlist for both the file picker and
+    /// the drop zone. Resolves from `selectedModel`; non-multimodal
+    /// models stay at images + documents only. Audio appears only for
+    /// Nemotron-3-Nano-Omni; video appears for Qwen-VL family +
+    /// SmolVLM 2 + Nemotron-Omni.
+    ///
+    /// See `Models/Configuration/ModelMediaCapabilities.swift` for the
+    /// substring/regex matcher; tests pin the boundary at
+    /// `ModelMediaCapabilitiesMCDCTests`.
+    private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
+        guard let modelId = selectedModel else { return .imageOnly }
+        return ModelMediaCapabilities.from(modelId: modelId)
+    }
+
+    /// UTTypes the drop zone advertises. Image + fileURL always — image
+    /// is universally supported across multimodal models, fileURL covers
+    /// document parsing. Audio + movie/video are conditional on the
+    /// loaded model's capabilities so users can't drop a wav onto a
+    /// dense LLM and have it silently ignored.
+    private var dropAcceptedTypes: [UTType] {
+        var types: [UTType] = [UTType.image, UTType.fileURL]
+        let cap = mediaCapabilities
+        if cap.supportsAudio {
+            types.append(.audio)
+            // explicit common audio formats so HEIF-style "any audio"
+            // type negotiation doesn't miss specific containers
+            types.append(.mp3)
+            types.append(.wav)
+            types.append(.mpeg4Audio)
+        }
+        if cap.supportsVideo {
+            types.append(.movie)
+            types.append(.video)
+            types.append(.quickTimeMovie)
+            types.append(.mpeg4Movie)
+        }
+        return types
+    }
+
+    /// File-picker `allowedContentTypes`. Same gating as `dropAcceptedTypes`
+    /// but flattened (no fileURL parent — picker accepts concrete types
+    /// only). Picker shows audio/video formats only when the loaded
+    /// model can actually consume them.
+    private var pickerAllowedTypes: [UTType] {
+        var types: [UTType] = [UTType.image]
+        types.append(contentsOf: DocumentParser.supportedDocumentTypes)
+        let cap = mediaCapabilities
+        if cap.supportsAudio {
+            types.append(.audio)
+            types.append(.mp3)
+            types.append(.wav)
+            types.append(.mpeg4Audio)
+        }
+        if cap.supportsVideo {
+            types.append(.movie)
+            types.append(.video)
+            types.append(.quickTimeMovie)
+            types.append(.mpeg4Movie)
+        }
+        return types
+    }
+
     private func pickAttachment() {
         let panel = NSOpenPanel()
-        var allowedTypes: [UTType] = [UTType.image]
-        allowedTypes.append(contentsOf: DocumentParser.supportedDocumentTypes)
-        panel.allowedContentTypes = allowedTypes
+        panel.allowedContentTypes = pickerAllowedTypes
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
-        panel.message = "Select files to attach"
+        panel.message = mediaCapabilities.anyMedia
+            ? "Select files to attach (\(mediaCapabilities.summary) supported)"
+            : "Select files to attach"
 
         if panel.runModal() == .OK {
             for url in panel.urls {
-                if DocumentParser.isImageFile(url: url) {
-                    if let data = try? Data(contentsOf: url), data.count <= maxImageSize,
-                        let nsImage = NSImage(data: data),
-                        let pngData = nsImage.pngData()
-                    {
-                        appendAttachment(.image(pngData))
-                    }
-                } else if DocumentParser.canParse(url: url) {
-                    parseAndAttach(url: url)
-                }
+                attachIfAllowed(url: url)
             }
         }
     }
 
+    /// Routes a file URL to the right attachment kind based on its
+    /// extension + the loaded model's capabilities. Drops files that
+    /// the current model can't consume rather than silently attaching
+    /// them as opaque documents.
+    private func attachIfAllowed(url: URL) {
+        let ext = url.pathExtension.lowercased()
+        let cap = mediaCapabilities
+
+        // Image fast path — universally supported among VLMs.
+        if DocumentParser.isImageFile(url: url) {
+            if let data = try? Data(contentsOf: url), data.count <= maxImageSize,
+                let nsImage = NSImage(data: data),
+                let pngData = nsImage.pngData()
+            {
+                appendAttachment(.image(pngData))
+            }
+            return
+        }
+
+        // Audio path — only for omni models.
+        if cap.supportsAudio, audioExtensions.contains(ext) {
+            attachAudio(url: url, ext: ext)
+            return
+        }
+
+        // Video path — Qwen-VL family + SmolVLM 2 + Nemotron-Omni.
+        if cap.supportsVideo, videoExtensions.contains(ext) {
+            attachVideo(url: url)
+            return
+        }
+
+        // Document fallback — markdown, PDF, etc.
+        if DocumentParser.canParse(url: url) {
+            parseAndAttach(url: url)
+            return
+        }
+
+        // Reject otherwise — surface a toast so the user knows why.
+        ToastManager.shared.error(
+            "Cannot attach \(url.lastPathComponent)",
+            message:
+                cap.anyMedia
+                ? "The current model supports \(cap.summary) only."
+                : "The current model is text-only."
+        )
+    }
+
+    private static let audioExtensions: Set<String> = [
+        "wav", "mp3", "m4a", "flac", "ogg", "opus", "aac", "wma",
+    ]
+
+    private static let videoExtensions: Set<String> = [
+        "mp4", "mov", "m4v", "qt", "webm", "mkv", "avi",
+    ]
+
+    private var audioExtensions: Set<String> { Self.audioExtensions }
+    private var videoExtensions: Set<String> { Self.videoExtensions }
+
+    /// Attach audio bytes from a file URL. Reads inline; spillover to
+    /// the encrypted blob store is handled later in the chat-history
+    /// persistence layer (`AttachmentBlobStore.spillIfNeeded`) when
+    /// the turn is committed. Format string is the lowercased file
+    /// extension and flows directly into
+    /// `MessageContentPart.audioInput.format`.
+    private func attachAudio(url: URL, ext: String) {
+        guard let data = try? Data(contentsOf: url) else {
+            ToastManager.shared.error(
+                "Could not read \(url.lastPathComponent)",
+                message: "File may be unreadable or too large to attach."
+            )
+            return
+        }
+        // Cap inline audio at 50 MB — beyond that the user is sending
+        // multi-minute clips that should go through a streaming API.
+        guard data.count <= 50 * 1024 * 1024 else {
+            ToastManager.shared.error(
+                "Audio file too large",
+                message: "Files larger than 50 MB are not supported in chat attachments."
+            )
+            return
+        }
+        appendAttachment(.audio(data, format: ext, filename: url.lastPathComponent))
+    }
+
+    /// Attach video bytes from a file URL. Same lifecycle as audio,
+    /// but with a tighter inline cap (30 MB) since video is bigger
+    /// per-second and the runtime extracts only 8 frames anyway.
+    private func attachVideo(url: URL) {
+        guard let data = try? Data(contentsOf: url) else {
+            ToastManager.shared.error(
+                "Could not read \(url.lastPathComponent)",
+                message: "File may be unreadable or too large to attach."
+            )
+            return
+        }
+        guard data.count <= 100 * 1024 * 1024 else {
+            ToastManager.shared.error(
+                "Video file too large",
+                message: "Files larger than 100 MB are not supported. Trim before attaching."
+            )
+            return
+        }
+        appendAttachment(.video(data, filename: url.lastPathComponent))
+    }
+
     private func handleFileDrop(_ providers: [NSItemProvider]) -> Bool {
         var handled = false
+        let cap = mediaCapabilities
 
         for provider in providers {
             if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
@@ -2124,15 +2294,43 @@ extension FloatingInputCard {
                         }
                     }
                 }
+            } else if cap.supportsAudio,
+                provider.hasItemConformingToTypeIdentifier(UTType.audio.identifier)
+            {
+                handled = true
+                // Audio path — load via fileURL so we get the extension,
+                // not raw data identifier.
+                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
+                    guard let urlData = item as? Data,
+                        let url = URL(dataRepresentation: urlData, relativeTo: nil)
+                    else { return }
+                    DispatchQueue.main.async {
+                        self.attachIfAllowed(url: url)
+                    }
+                }
+            } else if cap.supportsVideo,
+                provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier)
+                    || provider.hasItemConformingToTypeIdentifier(UTType.video.identifier)
+            {
+                handled = true
+                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
+                    guard let urlData = item as? Data,
+                        let url = URL(dataRepresentation: urlData, relativeTo: nil)
+                    else { return }
+                    DispatchQueue.main.async {
+                        self.attachIfAllowed(url: url)
+                    }
+                }
             } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
                 handled = true
                 provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, error in
                     guard let data = item as? Data,
-                        let url = URL(dataRepresentation: data, relativeTo: nil),
-                        DocumentParser.canParse(url: url)
+                        let url = URL(dataRepresentation: data, relativeTo: nil)
                     else { return }
                     DispatchQueue.main.async {
-                        self.parseAndAttach(url: url)
+                        // attachIfAllowed handles audio/video/image/doc routing
+                        // + capability rejection in one place.
+                        self.attachIfAllowed(url: url)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Consolidated stability + Nemotron-3 release PR. Replaces #990 (folded in).

12 commits, all revision-pinned. Verified end-to-end on Apple M5 Max + macOS 26.4 + Xcode 26.4 against real `OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4` weights driven from the swift-test-style `RunBench` binary (no app, no port binding, no TCC prompts). Detailed pass/fail grid in `vmlx-swift-lm/STRESS_REPORT.md`.

## What ships in this PR

### Nemotron-3 + storage + global error handler
- `feat(nemotron)`: registry entries + thinking profile (default `disableThinking: true` for the Nemotron-3 substring excluding `coder`).
- `fix(#964)`: storage dashboard now uses `OsaurusPaths.volumeFreeBytes/totalBytes` shared helper. SystemMonitorService and ModelDownloadService use the same path.
- `feat(error-handler)`: `MLXErrorRecovery.installGlobalHandler()` registers a process-wide MLX error handler via `MLX.setErrorHandler` so C++ MLX errors log instead of `fatalError`. Wired into `AppDelegate.applicationDidFinishLaunching`.
- `feat(cache)`: `ModelRuntime.installCacheCoordinator` calls `setHybrid(true)` for known hybrid Mamba families via `isKnownHybridModel(name:)`.

### Multimodal API (consolidates from PR #990)
- `MessageContentPart.audioInput(data, format)` and `.videoUrl(url)` cases. Codable round-trips preserve them.
- `ChatMessage.audioInputs: [(data, format)]` and `videoUrls: [String]` accessors.
- `mapOpenAIChatToMLX` populates `MLXLMCommon.Chat.Message.audios` and `.videos`.
- 281 lines of `MultimodalContentPartTests.swift` coverage including the data-URL extension regression test.
- **Audit fix**: `materializeMediaDataUrl` audio canonicalization (`mp4 → m4a`) now gated on `audio/` mediatype so `data:video/mp4` URLs keep their `.mp4` extension.

### Preview model registry
- `feat(models)`: `Laguna-XS.2-mxfp4` / `JANGTQ2` (Poolside `laguna`, SWA-hybrid 33B/3B-active MoE) and `Mistral-Medium-3.5-128B-mxfp4` / `JANGTQ2` (Mistral 3.5 + Pixtral, `mistral3` outer + `ministral3` inner) registry entries with full quant + layer + jang_config v2 schema documentation.
- `LagunaThinkingProfile` for `enable_thinking` chat-template kwarg, default-OFF mirroring `laguna_glm_thinking_v5/chat_template.jinja`.
- Negative `isKnownHybridModel` tests for both — Laguna is SWA-hybrid (RotatingKVCache + KVCacheSimple), Mistral 3.5 is dense GQA, neither is Mamba/SSM hybrid.
- **Audit-driven correction**: Mistral 3.5 ModelManager comment was rewritten — the previous "engine support pending — needs ministral3 text inner class" claim was wrong. `Mistral3VLM.LanguageModel` already wires `Ministral3ModelInner` unconditionally; vmlx routes Mistral 3.5 correctly via existing factory fall-through. End-to-end smoke on real 3.5 weights still pending; "preview" flag stays.

### Stability fixes (Bug 1 + Bug 3a)
- `chore(deps)`: vmlx-swift-lm bumped to `2a6c965` (latest main); mlx-swift converted from `branch: "osaurus-0.31.3"` to `revision: "e0b6111"`. Both pins now revision-locked per the host-side pin policy from `e2e13b4f` — no remaining branch-based dep in `OsaurusCore/Package.swift`.
- The `e0b6111` mlx-swift revision (a) repoints the bundled `mlx` C++ submodule URL to the host-side fork at `osaurus-ai/mlx`, and (b) advances the submodule pointer to `f58e52da` on `fix/clear-library-no-release`, carrying the **Bug 1** fix: `Device::clear_library` no longer drops `MTLComputePipelineState` refcount immediately. Closes the deterministic `notifyExternalReferencesNonZeroOnDealloc` Metal-validation crash class. Reverter: `MLX_CLEAR_LIBRARY_RELEASE=1` at runtime.
- The `2a6c965` vmlx revision carries:
  - **Bug 3a** fix: `Evaluate.swift:279` treats `repetition_penalty: 1.0` as a no-op, dodging Nemotron-3 first-decode panic. 15-case unit-test coverage in `Tests/MLXLMTests/SampleTests.swift`.
  - **Laguna reasoning stamp pre-registration**: `reasoningStampFromModelType` resolves `laguna` → `think_xml` so when the vmlx Laguna model class lands, `<think>` blocks land as `.reasoning` events not `.chunk`. Locked by new `lagunaResolvesToThinkXml` test (4/4 assertions).
  - **PARAKEET-RADIO-INTEGRATION.md**: new host-team integration spec covering audio (Parakeet ASR) + vision (RADIO ViT) modality wiring — API surface, file format expectations, frame budgets, cache + memory profile, streaming + cancellation, error surfaces, OmniBench coverage matrix.

## Stress matrix (all green at PR tip)

- OsaurusCore unit tests: **1195 / 1195** in 163 suites
- vmlx focused (CacheCoordinator + SampleTests): **30 / 30** at pin `2a6c965`
- vmlx tpae-regression suites (BatchKVCache + BatchCausalMask + ReasoningParser + StopString + Harmony + ToolCallFormat + reasoning-stamp aliases): **144 / 144 + 17 / 17** at pin `2a6c965`
- OmniBench (multimodal end-to-end on real Nemotron-3 MXFP4): **13 / 13**
- StabilityBench (Bug-class regression): **10 / 10**

Decode throughput on M5 Max MXFP4: ~65 tok/s sustained.

## What's NOT in this PR (handed off, documented)

- **Bug 2** (`metal::malloc 154 GB` on hybrid + over-cap prompt). `mx::malloc` large-allocation tracer landed at `osaurus-ai/mlx@96aa27a5` for repro work, NOT bumped into the PR pin. Workaround: don't set `defaultMaxKVSize` for hybrid models when prompts may exceed cap.
- Laguna vmlx engine class — `rg "case \"laguna\"|\"laguna\":" Libraries/` returns zero hits in any factory. Genuinely engine-support-pending. Host-side `LagunaThinkingProfile` + `validateJANGTQSidecarIfRequired` preflight + reasoning-stamp pre-registration in place for the day vmlx lands the class.
- Mistral 3.5 end-to-end smoke on real 3.5 weights (the architecture is supported, just unverified empirically).
- Voice streaming, additional modalities, deeper integration features — explicitly out of scope.
- `swift-embeddings` is the lone branch-pinned dep at the workspace level.

## Audit comments on this PR

For the systematic re-audits performed pre-merge see:
- [End-to-end audit log](https://github.com/osaurus-ai/osaurus/pull/967#issuecomment-4356913670)
- [Parent-repo coverage audit (vmlx + jinja + transformers + mlx-swift)](https://github.com/osaurus-ai/osaurus/pull/967#issuecomment-4356981722)

## Hand-off documentation (vmlx-swift-lm)

- `Libraries/MLXLMCommon/BatchEngine/OSAURUS-RELEASE-HANDOFF.md`
- `Libraries/MLXLMCommon/BatchEngine/OSAURUS-TEAM-BUILD-GUIDE.md`
- `Libraries/MLXLMCommon/BatchEngine/PARAKEET-RADIO-INTEGRATION.md` ← new
- `Libraries/MLXLMCommon/BatchEngine/KV-SIZING-CONTRACT.md`
- `Libraries/MLXLMCommon/BatchEngine/OMNI-OSAURUS-HOOKUP.md`
- `Libraries/MLXLMCommon/BatchEngine/OSAURUS-INTEGRATION.md`

## Test plan for reviewer

- [x] OsaurusCore `swift test` passes (1195 / 1195)
- [x] vmlx focused tests pass against pinned revision (30 / 30 + 144 tpae-regression + 17 reasoning-stamp)
- [x] osaurus full Release scheme builds clean against new pins
- [x] OmniBench + StabilityBench green on real Nemotron-3 MXFP4 weights
- [x] `data:video/mp4` data-URL extension regression locked
- [x] Laguna reasoning stamp pre-registered + tested
- [ ] Reviewer to verify Codable round-trip of multimodal `MessageContentPart` shapes with persistence on/off (existing tests cover the mapper; one final UI smoke worth a final eye)