### PR TITLE
prevent cold loading large core MLX models on launch for memory distillation

### DIFF
--- a/Packages/OsaurusCore/Services/Memory/MemoryService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryService.swift
@@ -134,10 +134,38 @@ public actor MemoryService {
     }
 
     /// Startup hook: drain anything that didn't get distilled before the
-    /// previous launch was killed.
+    /// previous launch was killed. Skips when cold-loading the core model
+    /// would peg the GPU on app open (see `canDistillCheaply`).
     public func recoverOrphanedSignals() async {
+        guard await canDistillCheaply() else {
+            MemoryLogger.service.info(
+                "recoverOrphanedSignals: deferring — core model not resident, avoiding cold load on launch"
+            )
+            return
+        }
         await syncNow()
     }
+
+    /// Foundation/remote: always cheap. Local MLX: cheap iff already
+    /// cached or small (<= `coldLoadParamBudgetBillions`). Unknown
+    /// param count is treated as large
+    private func canDistillCheaply() async -> Bool {
+        guard let modelId = await MainActor.run(body: { ChatConfigurationStore.load().coreModelIdentifier }) else {
+            return false
+        }
+        guard let local = ModelManager.discoverLocalModels()
+            .first(where: { $0.id.caseInsensitiveCompare(modelId) == .orderedSame
+                || $0.name.caseInsensitiveCompare(modelId) == .orderedSame })
+        else { return true }
+
+        if await ModelRuntime.shared.isResident(name: local.name) { return true }
+        if let params = local.parameterCountBillions, params <= Self.coldLoadParamBudgetBillions {
+            return true
+        }
+        return false
+    }
+
+    private static let coldLoadParamBudgetBillions: Double = 2.0
 
     // MARK: - Distillation (one LLM call per session)
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -90,6 +90,12 @@ public actor ModelRuntime {
 
     // MARK: - Public API
 
+    /// True iff `name` is currently held in `modelCache`. Lets background
+    /// callers skip work that would otherwise trigger a heavy cold load.
+    func isResident(name: String) -> Bool {
+        return modelCache[name] != nil
+    }
+
     func cachedModelSummaries() -> [ModelCacheSummary] {
         return modelCache.values.map { holder in
             ModelCacheSummary(


### PR DESCRIPTION
## Summary

related to #969 

fixed a GPU spike on app launch when the configured core model was a large MLX model. recoverOrphanedSignals() now goes ahead with memory distillation only when the core model is Foundation/remote/small MLX models (<= 2B params)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
