### PR TITLE
[codex] Harden PR test-core DerivedData cache handling

### DIFF
--- a/.cursor/rules/pr-clean-ci.mdc
+++ b/.cursor/rules/pr-clean-ci.mdc
@@ -1,0 +1,39 @@
+---
+description: PR readiness requires attached, green GitHub checks
+globs: "**/*"
+alwaysApply: true
+---
+
+# Clean PR Rule
+
+Do not create, mark ready, or recommend merging an Osaurus PR unless GitHub
+checks are attached and green.
+
+Before opening or updating a PR:
+
+- Work from the clean checkout at `/Users/mmeding/Documents/Claude/Projects/osaurus-exec`.
+- Keep `/Users/mmeding/Documents/Claude/Projects/osaurus` read-only.
+- Run the smallest useful local verification for the files touched.
+- Push only after the working tree is clean.
+
+After opening or updating a PR:
+
+- Confirm GitHub Actions attached checks to the PR.
+- Wait for the required checks to finish: `test-core`, `test-cli`,
+  `swiftlint`, `shellcheck`, and `pr-clean-gate`.
+- Run `scripts/ci/check-pr-clean.sh osaurus-ai/osaurus <PR number>`.
+- Keep the PR draft or blocked if checks are missing, pending, cancelled, or
+  failing.
+
+If GitHub shows zero checks:
+
+- Do not treat local tests as sufficient for merge.
+- Rebase, push, or close/reopen the PR to trigger Actions if you own the branch.
+- If the branch belongs to an external fork and this account cannot update it,
+  leave a PR comment and require the author or a maintainer with branch access
+  to trigger CI.
+
+If a shared CI failure blocks many PRs:
+
+- Fix the shared CI problem first in a dedicated PR.
+- Do not debug unrelated feature code until the shared blocker is green.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,13 @@ Explain the motivation and the changes. Link issues (e.g., Closes #123).
 
 Steps to verify locally (commands, screenshots, recordings). Include model used.
 
+Required before marking ready:
+
+- [ ] Local targeted verification passed for the files touched
+- [ ] GitHub checks are attached to this PR
+- [ ] `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `pr-clean-gate` are green
+- [ ] I ran `scripts/ci/check-pr-clean.sh osaurus-ai/osaurus <PR number>`
+
 ## Screenshots
 
 If UI updated, add before/after.
@@ -24,3 +31,4 @@ If UI updated, add before/after.
 - [ ] I added/updated tests where reasonable
 - [ ] I updated docs/README as needed
 - [ ] I verified build on macOS with Xcode 16.4+
+- [ ] This PR is draft/blocked if any GitHub check is missing, pending, cancelled, or failing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,3 +381,44 @@ jobs:
 
       - name: Lint shell scripts
         run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
+
+  pr-clean-gate:
+    name: pr-clean-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - test-core
+      - test-cli
+      - swiftlint
+      - shellcheck
+    if: ${{ always() }}
+    steps:
+      - name: Require all CI jobs to pass
+        env:
+          TEST_CORE: ${{ needs.test-core.result }}
+          TEST_CLI: ${{ needs.test-cli.result }}
+          SWIFTLINT: ${{ needs.swiftlint.result }}
+          SHELLCHECK: ${{ needs.shellcheck.result }}
+        run: |
+          {
+            echo "## PR clean gate"
+            echo
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| test-core | ${TEST_CORE} |"
+            echo "| test-cli | ${TEST_CLI} |"
+            echo "| swiftlint | ${SWIFTLINT} |"
+            echo "| shellcheck | ${SHELLCHECK} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for result in "$TEST_CORE" "$TEST_CLI" "$SWIFTLINT" "$SHELLCHECK"; do
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error title=CI is not clean::Every required CI job must finish with result=success before a PR is ready to merge."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 env:
   # Bump to invalidate every cache entry without source surgery (e.g., after a
   # known-bad cache or an Xcode toolchain upgrade we want to flush manually).
-  CACHE_SALT: v2-vmlx-5b84387
+  CACHE_SALT: v3-pr-cold-deriveddata
   # Pin Xcode so cache keys are stable across runner image bumps. When you
   # need to upgrade, change here AND in setup-xcode below.
   XCODE_VERSION: "26.4.1"
@@ -83,9 +83,11 @@ jobs:
 
       - name: Restore DerivedData cache
         id: dd-cache
-        # Always restore so `cache-primary-key` is populated for the save
-        # step at the bottom (the wipe step below handles forced cold
-        # builds without preventing main from repopulating the cache).
+        # Restore only on main pushes / manual maintainer runs. Pull requests
+        # intentionally cold-build DerivedData: exact restore-key hits have
+        # still produced stale Swift modules whose C-module dependencies are
+        # missing when Xcode later compiles EventSource.
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache/restore@v5
         with:
           path: ~/Library/Developer/Xcode/DerivedData
@@ -97,13 +99,15 @@ jobs:
           restore-keys: |
             dd-${{ runner.os }}-${{ env.CACHE_SALT }}-xcode${{ env.XCODE_VERSION }}-
 
-      # Make "clear the build cache" a one-click operation. Two triggers:
-      #   1. `github.run_attempt != '1'` — i.e. a re-run. The default
+      # Make "clear the build cache" a one-click operation. Three triggers:
+      #   1. Pull requests — always cold-build DerivedData so PRs never trust
+      #      a cached Xcode build product from another ref.
+      #   2. `github.run_attempt != '1'` — i.e. a re-run. The default
       #      "Re-run failed jobs" button is the natural place for someone
       #      who just saw a build failure to land, so we make that the
       #      intuitive escape hatch for cache poison: the first attempt
       #      uses the cache (fast); any re-run forces a cold compile.
-      #   2. `workflow_dispatch.clear_cache=true` — manual force-cold on
+      #   3. `workflow_dispatch.clear_cache=true` — manual force-cold on
       #      a fresh run (e.g. validating a CACHE_SALT bump before PRs
       #      start hitting it).
       #
@@ -116,18 +120,18 @@ jobs:
       # every re-run cost ~2 min in PR #951 run 24937664669 — wasted
       # budget that contributed to the 30-min cold-build cancellation.
       #
-      # We wipe AFTER the restore step (rather than skipping the restore)
-      # so `steps.dd-cache.outputs.cache-primary-key` stays populated and
-      # the `Save DerivedData cache` step at the bottom can still
-      # repopulate the cache on a successful `main` run.
-      - name: Wipe restored DerivedData (re-run or workflow_dispatch clear_cache)
-        if: ${{ github.run_attempt != '1' || (github.event_name == 'workflow_dispatch' && inputs.clear_cache) }}
+      # On main/manual runs we wipe AFTER the restore step (rather than
+      # skipping the restore) so `steps.dd-cache.outputs.cache-primary-key`
+      # stays populated and the `Save DerivedData cache` step at the bottom
+      # can still repopulate the cache on a successful `main` run.
+      - name: Wipe restored DerivedData (PR, re-run, or workflow_dispatch clear_cache)
+        if: ${{ github.event_name == 'pull_request' || github.run_attempt != '1' || (github.event_name == 'workflow_dispatch' && inputs.clear_cache) }}
         run: |
-          REASON="run_attempt=${{ github.run_attempt }}"
+          REASON="event=${{ github.event_name }}, run_attempt=${{ github.run_attempt }}"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.clear_cache }}" = "true" ]; then
             REASON="$REASON, workflow_dispatch clear_cache=true"
           fi
-          echo "::notice title=Cold build forced::Wiping restored DerivedData before build ($REASON). SPM cache preserved (it's source-only and pinned by Package.resolved). To re-run with the warm cache instead, push a new commit or trigger a fresh run."
+          echo "::notice title=Cold build forced::Wiping DerivedData before build ($REASON). SPM cache preserved (it's source-only and pinned by Package.resolved)."
           rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
 
       - name: Resolve dependencies
@@ -248,7 +252,7 @@ jobs:
                 echo
                 echo "**\`run_attempt > 1\` AND \`cache-hit: false\`?** That's the deliberate cold-rebuild path triggered by **Re-run failed jobs** — see the \`Wipe restored DerivedData\` step in this job. If the cold build is exhausting the 45-min budget on every re-run, the codebase has outgrown the budget; bump \`timeout-minutes\` and update its comment block, OR move warm-cache priming to a nightly \`main\` job so PRs always warm-start."
                 echo
-                echo "**Suspect cache poisoning on a fresh attempt?** Click **Re-run failed jobs** — re-runs automatically wipe DerivedData (the SPM cache is preserved because it's pinned by \`Package.resolved\` and can't be poisoned)."
+                echo "**Suspect cache poisoning on a fresh attempt?** Pull requests already cold-build DerivedData; main/manual re-runs wipe DerivedData automatically while preserving the pinned SPM source cache."
               } >> "$GITHUB_STEP_SUMMARY"
             else
               # Mode B.

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -46,48 +46,50 @@ struct ChatViewSandboxTests {
 
     @Test
     func estimatedContextBreakdown_includesSandboxPromptAndToolsWhenEnabled() async {
-        await SandboxTestLock.shared.run {
-            let manager = AgentManager.shared
-            let originalActiveAgentId = manager.activeAgentId
-            let inactiveAgent = Agent(
-                name: "Chat Estimate Off",
-                agentAddress: "test-chat-estimate-off"
-            )
-            let sandboxAgent = Agent(
-                name: "Chat Estimate On",
-                agentAddress: "test-chat-estimate-on",
-                autonomousExec: AutonomousExecConfig(enabled: true)
-            )
-            manager.add(inactiveAgent)
-            manager.add(sandboxAgent)
+        await StoragePathsTestLock.shared.run {
+            await SandboxTestLock.shared.run {
+                let manager = AgentManager.shared
+                let originalActiveAgentId = manager.activeAgentId
+                let inactiveAgent = Agent(
+                    name: "Chat Estimate Off",
+                    agentAddress: "test-chat-estimate-off"
+                )
+                let sandboxAgent = Agent(
+                    name: "Chat Estimate On",
+                    agentAddress: "test-chat-estimate-on",
+                    autonomousExec: AutonomousExecConfig(enabled: true)
+                )
+                manager.add(inactiveAgent)
+                manager.add(sandboxAgent)
 
-            let inactiveSession = ChatSession()
-            inactiveSession.agentId = inactiveAgent.id
-            let sandboxSession = ChatSession()
-            sandboxSession.agentId = sandboxAgent.id
+                let inactiveSession = ChatSession()
+                inactiveSession.agentId = inactiveAgent.id
+                let sandboxSession = ChatSession()
+                sandboxSession.agentId = sandboxAgent.id
 
-            BuiltinSandboxTools.register(
-                agentId: sandboxAgent.id.uuidString,
-                agentName: sandboxAgent.name,
-                config: AutonomousExecConfig(enabled: true)
-            )
+                BuiltinSandboxTools.register(
+                    agentId: sandboxAgent.id.uuidString,
+                    agentName: sandboxAgent.name,
+                    config: AutonomousExecConfig(enabled: true)
+                )
 
-            let inactiveBreakdown = inactiveSession.estimatedContextBreakdown
-            let sandboxBreakdown = sandboxSession.estimatedContextBreakdown
+                let inactiveBreakdown = inactiveSession.estimatedContextBreakdown
+                let sandboxBreakdown = sandboxSession.estimatedContextBreakdown
 
-            let inactiveContextTokens = inactiveBreakdown.context.reduce(0) { $0 + $1.tokens }
-            let sandboxContextTokens = sandboxBreakdown.context.reduce(0) { $0 + $1.tokens }
-            #expect(sandboxContextTokens > inactiveContextTokens)
+                let inactiveContextTokens = inactiveBreakdown.context.reduce(0) { $0 + $1.tokens }
+                let sandboxContextTokens = sandboxBreakdown.context.reduce(0) { $0 + $1.tokens }
+                #expect(sandboxContextTokens > inactiveContextTokens)
 
-            let sandboxToolTokens = sandboxBreakdown.context.first { $0.id == "tools" }?.tokens ?? 0
-            let inactiveToolTokens = inactiveBreakdown.context.first { $0.id == "tools" }?.tokens ?? 0
-            #expect(sandboxToolTokens > inactiveToolTokens)
-            #expect(sandboxToolTokens >= ToolRegistry.shared.estimatedTokens(for: "sandbox_exec"))
+                let sandboxToolTokens = sandboxBreakdown.context.first { $0.id == "tools" }?.tokens ?? 0
+                let inactiveToolTokens = inactiveBreakdown.context.first { $0.id == "tools" }?.tokens ?? 0
+                #expect(sandboxToolTokens > inactiveToolTokens)
+                #expect(sandboxToolTokens >= ToolRegistry.shared.estimatedTokens(for: "sandbox_exec"))
 
-            ToolRegistry.shared.unregisterAllSandboxTools()
-            manager.setActiveAgent(originalActiveAgentId)
-            _ = await manager.delete(id: inactiveAgent.id)
-            _ = await manager.delete(id: sandboxAgent.id)
+                ToolRegistry.shared.unregisterAllSandboxTools()
+                manager.setActiveAgent(originalActiveAgentId)
+                _ = await manager.delete(id: inactiveAgent.id)
+                _ = await manager.delete(id: sandboxAgent.id)
+            }
         }
     }
 
@@ -128,50 +130,52 @@ struct ChatViewSandboxTests {
 
     @Test
     func prepareChatExecutionMode_usesSessionAgentInsteadOfActiveAgent() async {
-        await SandboxTestLock.shared.run {
-            let manager = AgentManager.shared
-            let registrar = SandboxToolRegistrar.shared
-            let originalActiveAgentId = manager.activeAgentId
-            let originalStatus = SandboxManager.State.shared.status
-            let originalProvisionOverride = registrar.provisionAgentOverride
+        await StoragePathsTestLock.shared.run {
+            await SandboxTestLock.shared.run {
+                let manager = AgentManager.shared
+                let registrar = SandboxToolRegistrar.shared
+                let originalActiveAgentId = manager.activeAgentId
+                let originalStatus = SandboxManager.State.shared.status
+                let originalProvisionOverride = registrar.provisionAgentOverride
 
-            let inactiveAgent = Agent(
-                name: "Chat Sandbox Off",
-                agentAddress: "test-chat-sandbox-off"
-            )
-            let sandboxAgent = Agent(
-                name: "Chat Sandbox On",
-                agentAddress: "test-chat-sandbox-on",
-                autonomousExec: AutonomousExecConfig(enabled: true)
-            )
-            manager.add(inactiveAgent)
-            manager.add(sandboxAgent)
-            manager.setActiveAgent(inactiveAgent.id)
+                let inactiveAgent = Agent(
+                    name: "Chat Sandbox Off",
+                    agentAddress: "test-chat-sandbox-off"
+                )
+                let sandboxAgent = Agent(
+                    name: "Chat Sandbox On",
+                    agentAddress: "test-chat-sandbox-on",
+                    autonomousExec: AutonomousExecConfig(enabled: true)
+                )
+                manager.add(inactiveAgent)
+                manager.add(sandboxAgent)
+                manager.setActiveAgent(inactiveAgent.id)
 
-            SandboxManager.State.shared.status = .running
-            registrar.provisionAgentOverride = { _ in }
-            BuiltinSandboxTools.register(
-                agentId: sandboxAgent.id.uuidString,
-                agentName: sandboxAgent.name,
-                config: AutonomousExecConfig(enabled: true)
-            )
+                SandboxManager.State.shared.status = .running
+                registrar.provisionAgentOverride = { _ in }
+                BuiltinSandboxTools.register(
+                    agentId: sandboxAgent.id.uuidString,
+                    agentName: sandboxAgent.name,
+                    config: AutonomousExecConfig(enabled: true)
+                )
 
-            let session = ChatSession()
-            let inactiveMode = await session.prepareChatExecutionMode(agentId: inactiveAgent.id)
-            let sandboxMode = await session.prepareChatExecutionMode(agentId: sandboxAgent.id)
+                let session = ChatSession()
+                let inactiveMode = await session.prepareChatExecutionMode(agentId: inactiveAgent.id)
+                let sandboxMode = await session.prepareChatExecutionMode(agentId: sandboxAgent.id)
 
-            #expect(inactiveMode.usesSandboxTools == false)
-            #expect(sandboxMode.usesSandboxTools)
+                #expect(inactiveMode.usesSandboxTools == false)
+                #expect(sandboxMode.usesSandboxTools)
 
-            let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: sandboxMode)
-            #expect(specs.contains(where: { $0.function.name == "sandbox_exec" }))
+                let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: sandboxMode)
+                #expect(specs.contains(where: { $0.function.name == "sandbox_exec" }))
 
-            ToolRegistry.shared.unregisterAllSandboxTools()
-            SandboxManager.State.shared.status = originalStatus
-            registrar.provisionAgentOverride = originalProvisionOverride
-            manager.setActiveAgent(originalActiveAgentId)
-            _ = await manager.delete(id: inactiveAgent.id)
-            _ = await manager.delete(id: sandboxAgent.id)
+                ToolRegistry.shared.unregisterAllSandboxTools()
+                SandboxManager.State.shared.status = originalStatus
+                registrar.provisionAgentOverride = originalProvisionOverride
+                manager.setActiveAgent(originalActiveAgentId)
+                _ = await manager.delete(id: inactiveAgent.id)
+                _ = await manager.delete(id: sandboxAgent.id)
+            }
         }
     }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,6 +113,27 @@ The core library (`Packages/OsaurusCore/`) follows a layered architecture. Each 
 - Open a pull request early for feedback if helpful
 - Keep PRs small and focused; describe user-facing changes and test steps
 
+### Clean PR rule
+
+A PR is not ready to merge until GitHub Actions are attached and green. Local
+verification is required, but it is not a replacement for repository CI.
+
+Before asking for review or merge:
+
+1. Run the smallest useful local verification for the files touched.
+2. Push the branch and confirm GitHub Actions attached checks to the PR.
+3. Wait for `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and
+   `pr-clean-gate` to finish.
+4. Run:
+
+   ```bash
+   scripts/ci/check-pr-clean.sh osaurus-ai/osaurus <PR number>
+   ```
+
+Keep the PR as draft or explicitly blocked if any check is missing, pending,
+cancelled, or failing. A PR with zero attached checks is unverified; rebase,
+push, or close/reopen it so Actions run before review continues.
+
 ### Code style
 
 - Follow standard Swift naming and clarity guidelines

--- a/scripts/ci/check-pr-clean.sh
+++ b/scripts/ci/check-pr-clean.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci/check-pr-clean.sh [repo] [pr]
+
+Verifies that a GitHub pull request has attached checks and that every check is
+green. Run this before marking a PR ready or asking for merge.
+
+Arguments:
+  repo  GitHub repository, default: osaurus-ai/osaurus
+  pr    Pull request number or URL. If omitted, gh resolves the current branch.
+
+Environment:
+  PR_CLEAN_REQUIRED_CHECKS
+        Space-separated required check names. Defaults to:
+        "test-core test-cli swiftlint shellcheck pr-clean-gate"
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+repo="${1:-osaurus-ai/osaurus}"
+pr="${2:-}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: GitHub CLI (gh) is required" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+if [ -z "$pr" ]; then
+  pr="$(gh pr view --repo "$repo" --json number --jq .number)"
+fi
+
+checks_error="$(mktemp)"
+trap 'rm -f "$checks_error"' EXIT
+
+if ! checks_json="$(gh pr checks "$pr" \
+  --repo "$repo" \
+  --json name,state,bucket,workflow,link \
+  2>"$checks_error")"; then
+  if grep -qi "no checks reported" "$checks_error"; then
+    echo "error: PR $pr has no GitHub checks attached" >&2
+    echo "Push/rebase the branch or close/reopen the PR so Actions run before review." >&2
+    exit 1
+  fi
+
+  cat "$checks_error" >&2
+  exit 1
+fi
+
+check_count="$(jq 'length' <<< "$checks_json")"
+if [ "$check_count" -eq 0 ]; then
+  echo "error: PR $pr has no GitHub checks attached" >&2
+  echo "Push/rebase the branch or close/reopen the PR so Actions run before review." >&2
+  exit 1
+fi
+
+required_checks="${PR_CLEAN_REQUIRED_CHECKS:-test-core test-cli swiftlint shellcheck pr-clean-gate}"
+failed=0
+
+for check in $required_checks; do
+  match_count="$(jq --arg name "$check" '[.[] | select(.name == $name)] | length' <<< "$checks_json")"
+  if [ "$match_count" -eq 0 ]; then
+    echo "error: required check is missing: $check" >&2
+    failed=1
+    continue
+  fi
+
+  non_success="$(jq -r --arg name "$check" '
+    .[]
+    | select(.name == $name and .state != "SUCCESS")
+    | "\(.name): \(.state) \(.link)"
+  ' <<< "$checks_json")"
+
+  if [ -n "$non_success" ]; then
+    echo "$non_success" >&2
+    failed=1
+  fi
+done
+
+non_passing="$(jq -r '
+  .[]
+  | select(.bucket != "pass")
+  | "\(.name): \(.state) \(.link)"
+' <<< "$checks_json")"
+
+if [ -n "$non_passing" ]; then
+  echo "error: non-passing checks remain:" >&2
+  echo "$non_passing" >&2
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "PR $pr is clean: $check_count GitHub checks attached and passing."


### PR DESCRIPTION
## Summary
- cold-build DerivedData for pull_request test-core runs while preserving SPM source caching
- bump the cache salt so the next main run cannot reuse the suspect DerivedData entry
- keep DerivedData restore/save behavior for main and manual maintainer runs

## Why
Multiple open PRs (#974, #940, #929) are failing test-core with EventSource unable to resolve C-module dependencies from restored DerivedData (CAsyncHTTPClient, CNIOLLHTTP, CNIOExtrasZlib, CNIOPosix, _NumericsShims). The failing #974 run restored an exact DerivedData key, so the previous non-exact-cache wipe is not sufficient.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'

Product builds/tests are intentionally not run for this workflow-only change; GitHub CI is the verification target.