### PR TITLE
[codex] Clean Azure Foundry provider support

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -78,8 +78,7 @@ public final class RemoteProviderManager: ObservableObject {
         for i in configuration.providers.indices {
             let host = configuration.providers[i].host.lowercased()
             if configuration.providers[i].providerType == .openaiLegacy
-                && host.contains("openai.com")
-            {
+                && host.contains("openai.com") {
                 configuration.providers[i].providerType = .openResponses
                 didChange = true
             }
@@ -231,8 +230,7 @@ public final class RemoteProviderManager: ObservableObject {
         do {
             if provider.authType == .openAICodexOAuth,
                 let tokens = provider.getOAuthTokens(),
-                tokens.isExpired
-            {
+                tokens.isExpired {
                 let refreshed = try await OpenAICodexOAuthService.refresh(tokens)
                 RemoteProviderKeychain.saveOAuthTokens(refreshed, for: provider.id)
             }
@@ -386,10 +384,8 @@ public final class RemoteProviderManager: ObservableObject {
 
     /// Find the service that handles a given model
     public func findService(forModel model: String) -> RemoteProviderService? {
-        for service in services.values {
-            if service.handles(requestedModel: model) {
-                return service
-            }
+        for service in services.values where service.handles(requestedModel: model) {
+            return service
         }
         return nil
     }
@@ -475,8 +471,7 @@ public final class RemoteProviderManager: ObservableObject {
         for (key, value) in testHeaders {
             // Don't log the full auth header for security
             if key.lowercased() == "authorization" || key.lowercased() == "x-api-key"
-                || key.lowercased() == "x-goog-api-key"
-            {
+                || key.lowercased() == "x-goog-api-key" {
                 print("[Osaurus] Test Connection: Adding header \(key)=***")
             } else {
                 print("[Osaurus] Test Connection: Adding header \(key)=\(value)")
@@ -560,8 +555,7 @@ public final class RemoteProviderManager: ObservableObject {
 
     /// Test Anthropic connection by fetching models from the /models endpoint
     private func testAnthropicConnection(tempProvider: RemoteProvider, testHeaders: [String: String]) async throws
-        -> [String]
-    {
+        -> [String] {
         guard let baseURL = tempProvider.url(for: "/models") else {
             print("[Osaurus] Test Connection (Anthropic): Invalid URL")
             throw RemoteProviderError.invalidURL

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -237,8 +237,18 @@ public final class RemoteProviderManager: ObservableObject {
                 RemoteProviderKeychain.saveOAuthTokens(refreshed, for: provider.id)
             }
 
-            // Fetch models from the provider
-            let models = try await RemoteProviderService.fetchModels(from: provider)
+            // Fetch models from the provider and merge any manually configured deployment IDs.
+            let discoveredModels: [String]
+            do {
+                discoveredModels = try await RemoteProviderService.fetchModels(from: provider)
+            } catch {
+                if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
+                    discoveredModels = []
+                } else {
+                    throw error
+                }
+            }
+            let models = provider.mergedModelIds(discovered: discoveredModels)
 
             // Create service instance – resolve headers eagerly on @MainActor
             // so the service actor never reads from Keychain off the main thread.
@@ -431,6 +441,10 @@ public final class RemoteProviderManager: ObservableObject {
             case .gemini:
                 if testHeaders["x-goog-api-key"] == nil {
                     testHeaders["x-goog-api-key"] = apiKey
+                }
+            case .azureOpenAI:
+                if testHeaders["api-key"] == nil {
+                    testHeaders["api-key"] = apiKey
                 }
             case .openaiLegacy, .openResponses, .openAICodex, .osaurus:
                 if testHeaders["Authorization"] == nil {

--- a/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// Unified provider presets shared across onboarding and provider management.
 enum ProviderPreset: String, CaseIterable, Identifiable {
     case anthropic
+    case azureOpenAI
     case openai
     case google
     case xai
@@ -25,6 +26,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var name: String {
         switch self {
         case .anthropic: return "Anthropic"
+        case .azureOpenAI: return "Azure OpenAI Foundry"
         case .openai: return "OpenAI"
         case .google: return "Google"
         case .xai: return "xAI"
@@ -38,6 +40,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .anthropic: return "Claude models"
+        case .azureOpenAI: return "Azure deployments"
         case .openai: return "ChatGPT/Codex or Platform API"
         case .google: return "Gemini models"
         case .xai: return "Grok models"
@@ -51,6 +54,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .anthropic: return "brain.head.profile"
+        case .azureOpenAI: return "cloud.fill"
         case .openai: return "sparkles"
         case .google: return "globe"
         case .xai: return "bolt.fill"
@@ -64,6 +68,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var gradient: [Color] {
         switch self {
         case .anthropic: return [Color(red: 0.85, green: 0.55, blue: 0.35), Color(red: 0.75, green: 0.4, blue: 0.25)]
+        case .azureOpenAI: return [Color(red: 0.0, green: 0.47, blue: 0.84), Color(red: 0.0, green: 0.62, blue: 0.72)]
         case .openai: return [Color(red: 0.0, green: 0.65, blue: 0.52), Color(red: 0.0, green: 0.5, blue: 0.4)]
         case .google: return [Color(red: 0.26, green: 0.52, blue: 0.96), Color(red: 0.18, green: 0.38, blue: 0.85)]
         case .xai: return [Color(red: 0.1, green: 0.1, blue: 0.1), Color(red: 0.2, green: 0.2, blue: 0.2)]
@@ -77,6 +82,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     var consoleURL: String {
         switch self {
         case .anthropic: return "https://console.anthropic.com/settings/keys"
+        case .azureOpenAI: return "https://ai.azure.com"
         case .openai: return "https://platform.openai.com/api-keys"
         case .google: return "https://aistudio.google.com/apikey"
         case .xai: return "https://console.x.ai/"
@@ -89,6 +95,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Optional badge label (e.g. "Privacy") shown as a highlight pill on provider cards
     var badge: String? {
         switch self {
+        case .azureOpenAI: return "Azure"
         case .venice: return "Privacy"
         default: return nil
         }
@@ -97,6 +104,7 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Optional documentation URL for the provider (shown in help sections)
     var documentationURL: String? {
         switch self {
+        case .azureOpenAI: return "https://learn.microsoft.com/azure/ai-foundry/openai/"
         case .venice: return "https://docs.venice.ai"
         default: return nil
         }
@@ -114,6 +122,13 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
     /// Help steps shown when guiding the user to create an API key
     var helpSteps: [String] {
         switch self {
+        case .azureOpenAI:
+            return [
+                "Open your Azure OpenAI resource in Azure AI Foundry",
+                "Copy the resource endpoint host and an API key",
+                "Add deployment names if they do not appear automatically",
+                "Paste the key here",
+            ]
         case .openai:
             return [
                 "Go to the OpenAI Platform API keys page",
@@ -160,6 +175,16 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
                 basePath: "/v1",
                 authType: .apiKey,
                 providerType: .anthropic
+            )
+        case .azureOpenAI:
+            return ProviderPresetConfiguration(
+                name: "Azure OpenAI Foundry",
+                host: "",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/openai/v1",
+                authType: .apiKey,
+                providerType: .azureOpenAI
             )
         case .openai:
             return ProviderPresetConfiguration(
@@ -228,9 +253,14 @@ enum ProviderPreset: String, CaseIterable, Identifiable {
 
     /// Attempts to match an existing RemoteProvider to a known preset by host.
     static func matching(provider: RemoteProvider) -> ProviderPreset? {
+        if provider.providerType == .azureOpenAI {
+            return .azureOpenAI
+        }
+
         let host = provider.host.lowercased().trimmingCharacters(in: .whitespaces)
         return knownPresets.first { preset in
-            preset.configuration.host.lowercased() == host
+            guard !preset.configuration.host.isEmpty else { return false }
+            return preset.configuration.host.lowercased() == host
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -11,8 +11,8 @@ import Foundation
 
 /// Protocol type for remote provider connections
 public enum RemoteProviderProtocol: String, Codable, Sendable, CaseIterable {
-    case http = "http"
-    case https = "https"
+    case http
+    case https
 
     public var defaultPort: Int {
         switch self {
@@ -26,9 +26,9 @@ public enum RemoteProviderProtocol: String, Codable, Sendable, CaseIterable {
 
 /// Authentication type for remote providers
 public enum RemoteProviderAuthType: String, Codable, Sendable, CaseIterable {
-    case none = "none"
-    case apiKey = "apiKey"
-    case openAICodexOAuth = "openAICodexOAuth"
+    case none
+    case apiKey
+    case openAICodexOAuth
 }
 
 // MARK: - Provider Type
@@ -188,8 +188,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
 
         // Check if host contains a port (e.g., "localhost:8080")
         if let colonIndex = actualHost.lastIndex(of: ":"),
-            let portValue = Int(String(actualHost[actualHost.index(after: colonIndex)...]))
-        {
+            let portValue = Int(String(actualHost[actualHost.index(after: colonIndex)...])) {
             // Extract port from host if not already set
             if port == nil {
                 components.port = portValue

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -36,6 +36,7 @@ public enum RemoteProviderAuthType: String, Codable, Sendable, CaseIterable {
 /// Type of remote provider (determines API format)
 public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
     case openaiLegacy = "openai"  // OpenAI-compatible /chat/completions (third-party servers, backward compat)
+    case azureOpenAI = "azureOpenAI"  // Azure OpenAI Foundry /openai/v1 OpenAI-compatible chat completions
     case anthropic = "anthropic"  // Anthropic Messages API
     case openResponses = "openResponses"  // Open Responses API — used for official OpenAI and any compatible provider
     case openAICodex = "openAICodex"  // ChatGPT/Codex OAuth backend
@@ -45,6 +46,7 @@ public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
     public var displayName: String {
         switch self {
         case .openaiLegacy: return L("OpenAI Compatible")
+        case .azureOpenAI: return L("Azure OpenAI Foundry")
         case .anthropic: return L("Anthropic")
         case .openResponses: return L("Open Responses")
         case .openAICodex: return L("OpenAI Codex")
@@ -55,7 +57,7 @@ public enum RemoteProviderType: String, Codable, Sendable, CaseIterable {
 
     public var chatEndpoint: String {
         switch self {
-        case .openaiLegacy: return "/chat/completions"
+        case .openaiLegacy, .azureOpenAI: return "/chat/completions"
         case .anthropic: return "/messages"
         case .openResponses: return "/responses"
         case .openAICodex: return "/codex/responses"
@@ -86,6 +88,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     public var enabled: Bool
     public var autoConnect: Bool
     public var timeout: TimeInterval
+    public var manualModelIds: [String]
 
     // Keys for headers that should be stored in Keychain (not persisted in config)
     public var secretHeaderKeys: [String]
@@ -100,6 +103,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, name, host, providerProtocol, port, basePath
         case customHeaders, authType, providerType, enabled, autoConnect, timeout
+        case manualModelIds
         case secretHeaderKeys, remoteAgentId, remoteAgentAddress
     }
 
@@ -116,6 +120,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled: Bool = true,
         autoConnect: Bool = true,
         timeout: TimeInterval = 60,
+        manualModelIds: [String] = [],
         secretHeaderKeys: [String] = [],
         remoteAgentId: UUID? = nil,
         remoteAgentAddress: String? = nil
@@ -132,6 +137,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         self.enabled = enabled
         self.autoConnect = autoConnect
         self.timeout = timeout
+        self.manualModelIds = manualModelIds
         self.secretHeaderKeys = secretHeaderKeys
         self.remoteAgentId = remoteAgentId
         self.remoteAgentAddress = remoteAgentAddress
@@ -154,6 +160,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         autoConnect = try container.decodeIfPresent(Bool.self, forKey: .autoConnect) ?? true
         timeout = try container.decodeIfPresent(TimeInterval.self, forKey: .timeout) ?? 60
+        manualModelIds = try container.decodeIfPresent([String].self, forKey: .manualModelIds) ?? []
         secretHeaderKeys = try container.decodeIfPresent([String].self, forKey: .secretHeaderKeys) ?? []
         remoteAgentId = try container.decodeIfPresent(UUID.self, forKey: .remoteAgentId)
         remoteAgentAddress = try container.decodeIfPresent(String.self, forKey: .remoteAgentAddress)
@@ -262,6 +269,10 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
                 if headers["x-goog-api-key"] == nil {
                     headers["x-goog-api-key"] = apiKey
                 }
+            case .azureOpenAI:
+                if headers["api-key"] == nil {
+                    headers["api-key"] = apiKey
+                }
             case .openaiLegacy, .openResponses, .openAICodex, .osaurus:
                 if headers["Authorization"] == nil {
                     headers["Authorization"] = "Bearer \(apiKey)"
@@ -288,6 +299,25 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
 
     public func getOAuthTokens() -> RemoteProviderOAuthTokens? {
         RemoteProviderKeychain.getOAuthTokens(for: id)
+    }
+
+    public func mergedModelIds(discovered: [String]) -> [String] {
+        var seen = Set<String>()
+        var merged: [String] = []
+        let sourceModels = providerType == .azureOpenAI ? manualModelIds : discovered + manualModelIds
+
+        for rawValue in sourceModels {
+            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+
+            let key = value.lowercased()
+            guard !seen.contains(key) else { continue }
+
+            seen.insert(key)
+            merged.append(value)
+        }
+
+        return merged
     }
 }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -76,6 +76,33 @@ public actor RemoteProviderService: ToolCapableService {
             || GeminiFlashImageProfile.matches(modelId: modelName)
     }
 
+    static func allowsChatCompletionsReasoningObject(
+        providerType: RemoteProviderType,
+        host: String
+    ) -> Bool {
+        switch providerType {
+        case .openaiLegacy:
+            return !host.lowercased().contains("openai.com")
+        case .azureOpenAI, .anthropic, .openResponses, .openAICodex, .gemini, .osaurus:
+            return false
+        }
+    }
+
+    static func effectiveRequestProviderType(
+        configuredProviderType: RemoteProviderType,
+        request: RemoteChatRequest
+    ) -> RemoteProviderType {
+        guard configuredProviderType == .azureOpenAI else {
+            return configuredProviderType
+        }
+
+        if request.reasoning_effort != nil || request.tools?.isEmpty == false {
+            return .openResponses
+        }
+
+        return configuredProviderType
+    }
+
     /// Inactivity timeout for streaming: if no bytes arrive within this interval,
     /// assume the provider has stalled and end the stream. Floor of 120s accommodates
     /// thinking models that pause between tokens during reasoning.
@@ -187,7 +214,11 @@ public actor RemoteProviderService: ToolCapableService {
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
-        let (content, _) = try parseResponse(data)
+        let responseProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
+        let (content, _) = try parseResponse(data, providerType: responseProviderType)
         return content ?? ""
     }
 
@@ -272,7 +303,11 @@ public actor RemoteProviderService: ToolCapableService {
             throw RemoteProviderServiceError.requestFailed("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
-        let (content, toolCalls) = try parseResponse(data)
+        let responseProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
+        let (content, toolCalls) = try parseResponse(data, providerType: responseProviderType)
 
         // Check for tool calls
         if let toolCalls = toolCalls, let firstCall = toolCalls.first {
@@ -741,7 +776,7 @@ public actor RemoteProviderService: ToolCapableService {
                 return try handleAnthropicEvent(jsonData, state: &state, yield: yield)
             case .openResponses, .openAICodex:
                 return try handleOpenResponsesEvent(jsonData, state: &state, yield: yield)
-            case .openaiLegacy, .osaurus:
+            case .openaiLegacy, .azureOpenAI, .osaurus:
                 return try handleOpenAIEvent(jsonData, state: &state, yield: yield)
             }
         } catch {
@@ -1149,7 +1184,10 @@ public actor RemoteProviderService: ToolCapableService {
         try await refreshCodexOAuthIfNeeded()
         let urlRequest = try buildURLRequest(for: request)
         let currentSession = self.session
-        let providerType = self.provider.providerType
+        let providerType = Self.effectiveRequestProviderType(
+            configuredProviderType: self.provider.providerType,
+            request: request
+        )
         let inactivityTimeout = self.streamInactivityTimeout
         let toolList = tools ?? []
         // Only the with-tools path needs accumulated text for the inline
@@ -1515,7 +1553,11 @@ public actor RemoteProviderService: ToolCapableService {
         toolChoice: ToolChoiceOption?
     ) -> RemoteChatRequest {
         let effortValue = parameters.modelOptions["reasoningEffort"]?.stringValue
-        let isOfficialOpenAI = provider.host.lowercased().contains("openai.com")
+        let allowsReasoningObject =
+            Self.allowsChatCompletionsReasoningObject(
+                providerType: provider.providerType,
+                host: provider.host
+            )
         let isReasoningModel = OpenAIReasoningProfile.matches(modelId: model)
 
         return RemoteChatRequest(
@@ -1536,7 +1578,7 @@ public actor RemoteProviderService: ToolCapableService {
             tools: tools,
             tool_choice: toolChoice,
             reasoning_effort: effortValue,
-            reasoning: isOfficialOpenAI ? nil : effortValue.map { ReasoningConfig(effort: $0) },
+            reasoning: allowsReasoningObject ? effortValue.map { ReasoningConfig(effort: $0) } : nil,
             modelOptions: parameters.modelOptions,
             veniceParameters: buildVeniceParameters(from: parameters.modelOptions)
         )
@@ -1692,8 +1734,12 @@ public actor RemoteProviderService: ToolCapableService {
     /// Build a URLRequest for the chat completions endpoint
     private func buildURLRequest(for request: RemoteChatRequest) throws -> URLRequest {
         let url: URL
+        let requestProviderType = Self.effectiveRequestProviderType(
+            configuredProviderType: provider.providerType,
+            request: request
+        )
 
-        if provider.providerType == .gemini {
+        if requestProviderType == .gemini {
             // Gemini uses model-in-URL pattern: /models/{model}:generateContent or :streamGenerateContent
             let action = request.stream ? "streamGenerateContent" : "generateContent"
             // Validate the model segment before interpolating into the
@@ -1743,7 +1789,7 @@ public actor RemoteProviderService: ToolCapableService {
             } else {
                 url = geminiURL
             }
-        } else if provider.providerType == .osaurus {
+        } else if requestProviderType == .osaurus {
             // Native Osaurus agent: POST /agents/{remoteAgentId}/run
             guard let agentId = provider.remoteAgentId else {
                 throw RemoteProviderServiceError.invalidURL
@@ -1753,7 +1799,7 @@ public actor RemoteProviderService: ToolCapableService {
             }
             url = agentURL
         } else {
-            let endpoint = provider.providerType.chatEndpoint
+            let endpoint = requestProviderType.chatEndpoint
             guard let standardURL = provider.url(for: endpoint) else {
                 throw RemoteProviderServiceError.invalidURL
             }
@@ -1792,7 +1838,7 @@ public actor RemoteProviderService: ToolCapableService {
         encoder.outputFormatting = .prettyPrinted
 
         let bodyData: Data
-        switch provider.providerType {
+        switch requestProviderType {
         case .anthropic:
             let anthropicRequest = request.toAnthropicRequest()
             bodyData = try encoder.encode(anthropicRequest)
@@ -1804,8 +1850,8 @@ public actor RemoteProviderService: ToolCapableService {
         case .gemini:
             let geminiRequest = request.toGeminiRequest()
             bodyData = try encoder.encode(geminiRequest)
-        case .openaiLegacy, .osaurus:
-            // Both providers consume the unmodified OpenAI-compatible body.
+        case .openaiLegacy, .azureOpenAI, .osaurus:
+            // These providers consume the unmodified OpenAI-compatible body.
             bodyData = try encoder.encode(request)
         }
         urlRequest.httpBody = bodyData
@@ -1813,8 +1859,11 @@ public actor RemoteProviderService: ToolCapableService {
     }
 
     /// Parse response based on provider type
-    private func parseResponse(_ data: Data) throws -> (content: String?, toolCalls: [ToolCall]?) {
-        switch provider.providerType {
+    private func parseResponse(
+        _ data: Data,
+        providerType: RemoteProviderType
+    ) throws -> (content: String?, toolCalls: [ToolCall]?) {
+        switch providerType {
         case .anthropic:
             let response = try JSONDecoder().decode(AnthropicMessagesResponse.self, from: data)
             var textContent = ""
@@ -1839,7 +1888,7 @@ public actor RemoteProviderService: ToolCapableService {
 
             return (textContent.isEmpty ? nil : textContent, toolCalls.isEmpty ? nil : toolCalls)
 
-        case .openaiLegacy:
+        case .openaiLegacy, .azureOpenAI:
             let response = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
             let content = response.choices.first?.message.content
             let toolCalls = response.choices.first?.message.tool_calls

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -44,7 +44,7 @@ public actor RemoteProviderService: ToolCapableService {
     private var session: URLSession
     private var cachedOAuthTokens: RemoteProviderOAuthTokens?
 
-    public nonisolated var id: String {
+    nonisolated public var id: String {
         "remote-\(provider.id.uuidString)"
     }
 
@@ -131,11 +131,11 @@ public actor RemoteProviderService: ToolCapableService {
 
     // MARK: - ModelService Protocol
 
-    public nonisolated func isAvailable() -> Bool {
+    nonisolated public func isAvailable() -> Bool {
         return provider.enabled
     }
 
-    public nonisolated func handles(requestedModel: String?) -> Bool {
+    nonisolated public func handles(requestedModel: String?) -> Bool {
         guard let model = requestedModel?.trimmingCharacters(in: .whitespacesAndNewlines),
             !model.isEmpty
         else {
@@ -447,6 +447,7 @@ public actor RemoteProviderService: ToolCapableService {
         // Decode the line as UTF-8. SSE field names and the optional space after
         // the colon are ASCII; lossy decoding is safe for any non-UTF-8 bytes
         // that would only appear inside the value portion.
+        // swiftlint:disable:next optional_data_string_conversion
         let lineStr = String(decoding: line, as: UTF8.self)
 
         // Comment line — entire line starts with ":" (no field name).
@@ -922,8 +923,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         case "message_delta":
             if let deltaEvent = try? JSONDecoder().decode(MessageDeltaEvent.self, from: jsonData),
-                let stopReason = deltaEvent.delta.stop_reason
-            {
+                let stopReason = deltaEvent.delta.stop_reason {
                 state.lastFinishReason = stopReason
             }
 
@@ -966,8 +966,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         case "response.output_item.added":
             if let addedEvent = try? JSONDecoder().decode(OutputItemAddedEvent.self, from: jsonData),
-                case .functionCall(let funcCall) = addedEvent.item
-            {
+                case .functionCall(let funcCall) = addedEvent.item {
                 let idx = addedEvent.output_index
                 state.accumulatedToolCalls[idx] = (
                     id: funcCall.call_id, name: funcCall.name, args: "", thoughtSignature: nil
@@ -1010,8 +1009,7 @@ public actor RemoteProviderService: ToolCapableService {
             // Final confirmed item — extract args from the completed function_call
             // when no `.delta` events landed first (common for short calls).
             if let doneEvent = try? JSONDecoder().decode(OutputItemDoneEvent.self, from: jsonData),
-                case .functionCall(let funcCall) = doneEvent.item
-            {
+                case .functionCall(let funcCall) = doneEvent.item {
                 let idx = doneEvent.output_index
                 var current =
                     state.accumulatedToolCalls[idx] ?? (
@@ -1082,16 +1080,14 @@ public actor RemoteProviderService: ToolCapableService {
         // it in the Think panel — without ever emitting `<think>` literals.
         if state.accumulatedToolCalls.isEmpty,
             let reasoning = chunk.choices.first?.delta.reasoning_content,
-            !reasoning.isEmpty
-        {
+            !reasoning.isEmpty {
             yield(StreamingReasoningHint.encode(reasoning))
         }
 
         // Only yield content if no tool calls have been detected, to avoid
         // function-call JSON leaking into the chat UI.
         if state.accumulatedToolCalls.isEmpty,
-            let delta = chunk.choices.first?.delta.content, !delta.isEmpty
-        {
+            let delta = chunk.choices.first?.delta.content, !delta.isEmpty {
             let (truncated, hitStop) = applyStopSequences(delta, stopSequences: state.stopSequences)
             state.recordYield(truncated)
             yield(truncated)
@@ -1144,8 +1140,7 @@ public actor RemoteProviderService: ToolCapableService {
                 let (name, args) = RemoteToolDetection.detectInlineToolCall(
                     in: state.accumulatedContent,
                     tools: tools
-                )
-            {
+                ) {
                 print("[Osaurus] Fallback: detected inline tool call '\(name)' in text")
                 continuation.finish(
                     throwing: ServiceToolInvocation(
@@ -1323,8 +1318,7 @@ public actor RemoteProviderService: ToolCapableService {
     private static func geminiArgsJSON(from args: [String: AnyCodableValue]?) -> String {
         let dict = (args ?? [:]).mapValues { $0.value }
         if let data = try? JSONSerialization.data(withJSONObject: dict),
-            let s = String(data: data, encoding: .utf8)
-        {
+            let s = String(data: data, encoding: .utf8) {
             return s
         }
         return "{}"
@@ -1344,7 +1338,7 @@ public actor RemoteProviderService: ToolCapableService {
     private static func makeToolInvocation(
         from accumulated: [Int: (id: String?, name: String?, args: String, thoughtSignature: String?)]
     ) -> (invocation: ServiceToolInvocation, wasRepaired: Bool)? {
-        guard let first = accumulated.sorted(by: { $0.key < $1.key }).first,
+        guard let first = accumulated.min(by: { $0.key < $1.key }),
             let name = first.value.name
         else { return nil }
 
@@ -1460,8 +1454,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         // Quick validation: try to parse as-is.
         if let data = trimmed.data(using: .utf8),
-            (try? JSONSerialization.jsonObject(with: data)) != nil
-        {
+            (try? JSONSerialization.jsonObject(with: data)) != nil {
             return ValidatedToolCallJSON(json: trimmed, wasRepaired: false)
         }
 
@@ -1532,8 +1525,7 @@ public actor RemoteProviderService: ToolCapableService {
 
         // Verify the repair worked
         if let data = repaired.data(using: .utf8),
-            (try? JSONSerialization.jsonObject(with: data)) != nil
-        {
+            (try? JSONSerialization.jsonObject(with: data)) != nil {
             print("[Osaurus] Repaired incomplete tool call JSON (\(json.count) -> \(repaired.count) chars)")
             return ValidatedToolCallJSON(json: repaired, wasRepaired: true)
         }
@@ -1684,7 +1676,7 @@ public actor RemoteProviderService: ToolCapableService {
                 )
 
                 if let parts = geminiResponse.candidates?.first?.content?.parts {
-                    var pendingToolCall: ServiceToolInvocation? = nil
+                    var pendingToolCall: ServiceToolInvocation?
 
                     for part in parts {
                         if part.thought == true { continue }
@@ -2021,8 +2013,7 @@ public actor RemoteProviderService: ToolCapableService {
 
             if let altRange = Range(match.range(at: 1), in: text),
                 let mimeRange = Range(match.range(at: 2), in: text),
-                let dataRange = Range(match.range(at: 3), in: text)
-            {
+                let dataRange = Range(match.range(at: 3), in: text) {
                 let altText = String(text[altRange])
                 let sig: String? =
                     altText.hasPrefix("image|ts:")
@@ -2087,13 +2078,16 @@ struct ReasoningConfig: Encodable {
     let effort: String
 }
 
-/// Venice-specific parameters injected into the request body for Venice AI providers.
-/// See https://docs.venice.ai/api-reference/api-spec
+// Venice-specific parameters injected into the request body for Venice AI providers.
+// See https://docs.venice.ai/api-reference/api-spec
+// Nil values intentionally omit provider-specific flags from the encoded JSON.
+// swiftlint:disable discouraged_optional_boolean
 struct VeniceParameters: Encodable {
     var enable_web_search: String?
     var disable_thinking: Bool?
     var include_venice_system_prompt: Bool?
 }
+// swiftlint:enable discouraged_optional_boolean
 
 /// Chat request structure for remote providers (matches OpenAI format)
 struct RemoteChatRequest: Encodable {
@@ -2166,7 +2160,7 @@ struct RemoteChatRequest: Encodable {
 
     /// Convert to Anthropic Messages API request format
     func toAnthropicRequest() -> AnthropicMessagesRequest {
-        var systemContent: AnthropicSystemContent? = nil
+        var systemContent: AnthropicSystemContent?
         var anthropicMessages: [AnthropicMessage] = []
 
         // Collect consecutive tool_result blocks to batch them into a single user message
@@ -2224,8 +2218,7 @@ struct RemoteChatRequest: Encodable {
                         var input: [String: AnyCodableValue] = [:]
 
                         if let argsData = toolCall.function.arguments.data(using: .utf8),
-                            let argsDict = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
-                        {
+                            let argsDict = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any] {
                             input = argsDict.mapValues { AnyCodableValue($0) }
                         }
 
@@ -2265,11 +2258,9 @@ struct RemoteChatRequest: Encodable {
                         )
                     )
                 }
-
             default:
                 // Flush any pending tool results before unknown message type
                 flushToolResults()
-                break
             }
         }
 
@@ -2278,7 +2269,7 @@ struct RemoteChatRequest: Encodable {
 
         // Convert tools
         let emptySchema: JSONValue = .object(["type": .string("object"), "properties": .object([:])])
-        var anthropicTools: [AnthropicTool]? = nil
+        var anthropicTools: [AnthropicTool]?
         if let tools = tools {
             anthropicTools = tools.map { tool in
                 AnthropicTool(
@@ -2290,7 +2281,7 @@ struct RemoteChatRequest: Encodable {
         }
 
         // Convert tool choice
-        var anthropicToolChoice: AnthropicToolChoice? = nil
+        var anthropicToolChoice: AnthropicToolChoice?
         if let choice = tool_choice {
             switch choice {
             case .auto:
@@ -2321,7 +2312,7 @@ struct RemoteChatRequest: Encodable {
     /// Convert to Gemini GenerateContent API request format
     func toGeminiRequest() -> GeminiGenerateContentRequest {
         var geminiContents: [GeminiContent] = []
-        var systemInstruction: GeminiContent? = nil
+        var systemInstruction: GeminiContent?
 
         // Collect consecutive function responses to batch them
         var pendingFunctionResponses: [GeminiPart] = []
@@ -2358,8 +2349,7 @@ struct RemoteChatRequest: Encodable {
                             // Parse data URLs: "data:<mimeType>;base64,<data>"
                             if url.hasPrefix("data:"),
                                 let semicolonIdx = url.firstIndex(of: ";"),
-                                let commaIdx = url.firstIndex(of: ",")
-                            {
+                                let commaIdx = url.firstIndex(of: ",") {
                                 let mimeType = String(url[url.index(url.startIndex, offsetBy: 5) ..< semicolonIdx])
                                 let base64Data = String(url[url.index(after: commaIdx)...])
                                 userParts.append(
@@ -2389,8 +2379,7 @@ struct RemoteChatRequest: Encodable {
                     for toolCall in toolCalls {
                         var args: [String: AnyCodableValue] = [:]
                         if let argsData = toolCall.function.arguments.data(using: .utf8),
-                            let argsDict = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any]
-                        {
+                            let argsDict = try? JSONSerialization.jsonObject(with: argsData) as? [String: Any] {
                             args = argsDict.mapValues { AnyCodableValue($0) }
                         }
                         parts.append(
@@ -2418,8 +2407,7 @@ struct RemoteChatRequest: Encodable {
 
                     // Try to parse the content as JSON first
                     if let data = content.data(using: .utf8),
-                        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-                    {
+                        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                         responseData = json.mapValues { AnyCodableValue($0) }
                     } else {
                         responseData["result"] = AnyCodableValue(content)
@@ -2442,7 +2430,7 @@ struct RemoteChatRequest: Encodable {
         flushFunctionResponses()
 
         // Convert tools
-        var geminiTools: [GeminiTool]? = nil
+        var geminiTools: [GeminiTool]?
         if let tools = tools, !tools.isEmpty {
             let declarations = tools.map { tool in
                 GeminiFunctionDeclaration(
@@ -2455,7 +2443,7 @@ struct RemoteChatRequest: Encodable {
         }
 
         // Convert tool choice
-        var toolConfig: GeminiToolConfig? = nil
+        var toolConfig: GeminiToolConfig?
         if let choice = tool_choice {
             let mode: String
             switch choice {
@@ -2491,10 +2479,9 @@ struct RemoteChatRequest: Encodable {
             return GeminiImageConfig(aspectRatio: effectiveRatio, imageSize: effectiveSize)
         }()
 
-        var generationConfig: GeminiGenerationConfig? = nil
+        var generationConfig: GeminiGenerationConfig?
         if temperature != nil || max_completion_tokens != nil || top_p != nil || stop != nil
-            || responseModalities != nil || imageConfig != nil
-        {
+            || responseModalities != nil || imageConfig != nil {
             generationConfig = GeminiGenerationConfig(
                 temperature: temperature.map { Double($0) },
                 maxOutputTokens: max_completion_tokens,
@@ -2519,7 +2506,7 @@ struct RemoteChatRequest: Encodable {
     /// Convert to Open Responses API request format
     func toOpenResponsesRequest(alwaysUseInputItems: Bool = false) -> OpenResponsesRequest {
         var inputItems: [OpenResponsesInputItem] = []
-        var instructions: String? = nil
+        var instructions: String?
 
         for msg in messages {
             switch msg.role {
@@ -2592,7 +2579,7 @@ struct RemoteChatRequest: Encodable {
         }
 
         // Convert tools
-        var openResponsesTools: [OpenResponsesTool]? = nil
+        var openResponsesTools: [OpenResponsesTool]?
         if let tools = tools {
             openResponsesTools = tools.map { tool in
                 OpenResponsesTool(
@@ -2604,7 +2591,7 @@ struct RemoteChatRequest: Encodable {
         }
 
         // Convert tool choice
-        var openResponsesToolChoice: OpenResponsesToolChoice? = nil
+        var openResponsesToolChoice: OpenResponsesToolChoice?
         if let choice = tool_choice {
             switch choice {
             case .auto:
@@ -2743,8 +2730,7 @@ extension RemoteProviderService {
             if let (data, response) = try? await URLSession.shared.data(for: req),
                 let http = response as? HTTPURLResponse, http.statusCode < 400,
                 let parsed = try? JSONDecoder().decode(ModelsResponse.self, from: data),
-                !parsed.data.isEmpty
-            {
+                !parsed.data.isEmpty {
                 return parsed.data.map { $0.id }
             }
         }
@@ -2827,7 +2813,7 @@ extension RemoteProviderService {
         timeout: TimeInterval = 30
     ) async throws -> [String] {
         var allModels: [String] = []
-        var afterId: String? = nil
+        var afterId: String?
 
         while true {
             guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -85,9 +85,159 @@ struct RemoteChatRequestEncodingTests {
         #expect(payload["store"] as? Bool == false)
     }
 
+    @Test func azureProvider_usesAPIKeyHeader() throws {
+        let providerId = UUID()
+        defer { RemoteProviderKeychain.deleteAPIKey(for: providerId) }
+
+        let provider = RemoteProvider(
+            id: providerId,
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            basePath: "/openai/v1",
+            authType: .apiKey,
+            providerType: .azureOpenAI
+        )
+
+        #expect(RemoteProviderKeychain.saveAPIKey("azure-secret", for: providerId))
+
+        let headers = provider.resolvedHeaders()
+        #expect(headers["api-key"] == "azure-secret")
+        #expect(headers["Authorization"] == nil)
+    }
+
+    @Test func azureProvider_defaultURLUsesOpenAIPath() throws {
+        let provider = RemoteProvider(
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            basePath: "/openai/v1",
+            authType: .apiKey,
+            providerType: .azureOpenAI
+        )
+
+        #expect(
+            provider.url(for: provider.providerType.chatEndpoint)?.absoluteString
+                == "https://example-resource.cognitiveservices.azure.com/openai/v1/chat/completions"
+        )
+    }
+
+    @Test func remoteProvider_mergesManualModelIdsWithDiscoveredModels() throws {
+        let provider = RemoteProvider(
+            name: "Custom",
+            host: "api.example.com",
+            providerType: .openaiLegacy,
+            manualModelIds: [" gpt-5.4 ", "", "prod-chat", "GPT-5.4"]
+        )
+
+        #expect(provider.mergedModelIds(discovered: ["gpt-4.1", "prod-chat"]) == ["gpt-4.1", "prod-chat", "gpt-5.4"])
+    }
+
+    @Test func remoteProvider_decodingDefaultsManualModelIdsToEmptyArray() throws {
+        let json = """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "name": "Custom",
+              "host": "localhost",
+              "providerProtocol": "http",
+              "basePath": "/v1",
+              "customHeaders": {},
+              "authType": "none",
+              "providerType": "openai",
+              "enabled": true,
+              "autoConnect": true,
+              "timeout": 60,
+              "secretHeaderKeys": []
+            }
+            """
+
+        let provider = try JSONDecoder().decode(RemoteProvider.self, from: Data(json.utf8))
+
+        #expect(provider.manualModelIds == [])
+    }
+
+    @Test func azureProvider_disablesOpenAICompatibleReasoningObject() throws {
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .azureOpenAI,
+                host: "example-resource.cognitiveservices.azure.com"
+            ) == false
+        )
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .openaiLegacy,
+                host: "api.openai.com"
+            )
+                == false
+        )
+        #expect(
+            RemoteProviderService.allowsChatCompletionsReasoningObject(
+                providerType: .openaiLegacy,
+                host: "api.deepseek.com"
+            )
+                == true
+        )
+    }
+
+    @Test func azureProvider_routesReasoningRequestsThroughResponses() throws {
+        let request = Self.makeRequest(
+            model: "gpt-5.5",
+            maxTokens: 1024,
+            reasoningEffort: "medium"
+        )
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .openResponses
+        )
+    }
+
+    @Test func azureProvider_routesToolRequestsThroughResponses() throws {
+        let request = Self.makeRequest(
+            model: "gpt-5.5",
+            maxTokens: 1024,
+            reasoningEffort: nil,
+            tools: [Self.weatherTool]
+        )
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .openResponses
+        )
+    }
+
+    @Test func azureProvider_keepsPlainRequestsOnChatCompletions() throws {
+        let request = Self.makeRequest(model: "gpt-4.1", maxTokens: 1024)
+
+        #expect(
+            RemoteProviderService.effectiveRequestProviderType(
+                configuredProviderType: .azureOpenAI,
+                request: request
+            ) == .azureOpenAI
+        )
+    }
+
+    @Test func azureProvider_usesOnlyManualDeploymentIdsForModels() throws {
+        let provider = RemoteProvider(
+            name: "Azure OpenAI Foundry",
+            host: "example-resource.cognitiveservices.azure.com",
+            providerType: .azureOpenAI,
+            manualModelIds: [" prod-chat ", "", "gpt-5.5", "PROD-CHAT"]
+        )
+
+        #expect(provider.mergedModelIds(discovered: ["gpt-4.1", "gpt-5.5"]) == ["prod-chat", "gpt-5.5"])
+    }
+
     // MARK: - Fixtures
 
-    private static func makeRequest(model: String, maxTokens: Int?) -> RemoteChatRequest {
+    private static func makeRequest(
+        model: String,
+        maxTokens: Int?,
+        reasoningEffort: String? = nil,
+        tools: [Tool]? = nil
+    ) -> RemoteChatRequest {
         RemoteChatRequest(
             model: model,
             messages: [ChatMessage(role: "user", content: "hi")],
@@ -98,14 +248,28 @@ struct RemoteChatRequestEncodingTests {
             frequency_penalty: nil,
             presence_penalty: nil,
             stop: nil,
-            tools: nil,
+            tools: tools,
             tool_choice: nil,
-            reasoning_effort: nil,
+            reasoning_effort: reasoningEffort,
             reasoning: nil,
             modelOptions: [:],
             veniceParameters: nil
         )
     }
+
+    private static let weatherTool = Tool(
+        type: "function",
+        function: ToolFunction(
+            name: "get_weather",
+            description: "Get weather",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "location": .object(["type": .string("string")])
+                ]),
+            ])
+        )
+    )
 
     private static func encodeAsDictionary(_ request: RemoteChatRequest) throws -> [String: Any] {
         let data = try JSONEncoder().encode(request)

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -34,7 +34,7 @@ struct RemoteProviderEditSheet: View {
     @ObservedObject private var themeManager = ThemeManager.shared
 
     let provider: RemoteProvider?
-    var initialPreset: ProviderPreset? = nil
+    var initialPreset: ProviderPreset?
     let onSave: (RemoteProvider, String?, RemoteProviderOAuthTokens?) -> Void
 
     var body: some View {
@@ -60,12 +60,12 @@ private struct AddProviderFlow: View {
     let initialPreset: ProviderPreset?
     let onSave: (RemoteProvider, String?, RemoteProviderOAuthTokens?) -> Void
 
-    @State private var selectedPreset: ProviderPreset? = nil
+    @State private var selectedPreset: ProviderPreset?
     @State private var apiKey: String = ""
     @State private var openAIAuthMode: OpenAIProviderCredentialMode = .chatGPTSubscription
-    @State private var oauthTokens: RemoteProviderOAuthTokens? = nil
+    @State private var oauthTokens: RemoteProviderOAuthTokens?
     @State private var isTesting = false
-    @State private var testResult: ProviderTestResult? = nil
+    @State private var testResult: ProviderTestResult?
     @State private var hasAppeared = false
 
     // Known provider connection overrides for presets whose endpoint is user-specific.
@@ -189,13 +189,13 @@ private struct AddProviderFlow: View {
 
             Spacer()
 
-            Button(action: { dismiss() }) {
+            Button(action: { dismiss() }, label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(theme.secondaryText)
                     .frame(width: 28, height: 28)
                     .background(Circle().fill(theme.tertiaryBackground))
-            }
+            })
             .buttonStyle(PlainButtonStyle())
             .keyboardShortcut(.escape, modifiers: [])
         }
@@ -293,8 +293,7 @@ private struct AddProviderFlow: View {
 
                     // Help section
                     if let preset = selectedPreset, preset.isKnown, !preset.consoleURL.isEmpty,
-                        preset != .openai || openAIAuthMode == .platformAPIKey
-                    {
+                        preset != .openai || openAIAuthMode == .platformAPIKey {
                         helpSection(for: preset)
                     }
 
@@ -780,7 +779,7 @@ private struct AddProviderFlow: View {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                     showAdvanced.toggle()
                 }
-            }) {
+            }, label: {
                 HStack(spacing: 8) {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
@@ -800,7 +799,7 @@ private struct AddProviderFlow: View {
                         .fill(theme.tertiaryBackground.opacity(0.5))
                 )
                 .contentShape(Rectangle())
-            }
+            })
             .buttonStyle(PlainButtonStyle())
 
             if showAdvanced {
@@ -837,13 +836,13 @@ private struct AddProviderFlow: View {
                             Spacer()
                             Button(action: {
                                 customHeaders.append(HeaderEntry(key: "", value: "", isSecret: false))
-                            }) {
+                            }, label: {
                                 Image(systemName: "plus")
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(theme.accentColor)
                                     .frame(width: 24, height: 24)
                                     .background(Circle().fill(theme.accentColor.opacity(0.1)))
-                            }
+                            })
                             .buttonStyle(PlainButtonStyle())
                         }
 
@@ -980,7 +979,7 @@ private struct AddProviderFlow: View {
 
     // MARK: - Actions
 
-    private func testKnownProvider() {
+    func testKnownProvider() {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
         let connection = knownProviderConnection(for: preset)
@@ -1054,7 +1053,7 @@ private struct AddProviderFlow: View {
         dismiss()
     }
 
-    private func testCustomProvider() {
+    func testCustomProvider() {
         let trimmedHost = customHost.trimmingCharacters(in: .whitespaces)
         let trimmedBasePath = customBasePath.trimmingCharacters(in: .whitespaces)
         let port: Int? = customPort.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(customPort)
@@ -1266,13 +1265,13 @@ private struct EditProviderFlow: View {
 
             Spacer()
 
-            Button(action: { dismiss() }) {
+            Button(action: { dismiss() }, label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(theme.secondaryText)
                     .frame(width: 28, height: 28)
                     .background(Circle().fill(theme.tertiaryBackground))
-            }
+            })
             .buttonStyle(PlainButtonStyle())
             .keyboardShortcut(.escape, modifiers: [])
         }
@@ -1522,7 +1521,7 @@ private struct EditProviderFlow: View {
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                     showAdvanced.toggle()
                 }
-            }) {
+            }, label: {
                 HStack(spacing: 8) {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
@@ -1542,7 +1541,7 @@ private struct EditProviderFlow: View {
                         .fill(theme.tertiaryBackground.opacity(0.5))
                 )
                 .contentShape(Rectangle())
-            }
+            })
             .buttonStyle(PlainButtonStyle())
 
             if showAdvanced {
@@ -1594,13 +1593,13 @@ private struct EditProviderFlow: View {
                             Spacer()
                             Button(action: {
                                 customHeaders.append(HeaderEntry(key: "", value: "", isSecret: false))
-                            }) {
+                            }, label: {
                                 Image(systemName: "plus")
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(theme.accentColor)
                                     .frame(width: 24, height: 24)
                                     .background(Circle().fill(theme.accentColor.opacity(0.1)))
-                            }
+                            })
                             .buttonStyle(PlainButtonStyle())
                         }
 
@@ -1683,7 +1682,7 @@ private struct EditProviderFlow: View {
         // Test button
         Button(action: {
             if testResult != nil { testResult = nil } else { testConnection() }
-        }) {
+        }, label: {
             HStack(spacing: 6) {
                 if isTesting {
                     ProgressView().scaleEffect(0.5).frame(width: 14, height: 14)
@@ -1708,8 +1707,8 @@ private struct EditProviderFlow: View {
                         RoundedRectangle(cornerRadius: 8)
                             .stroke(testButtonColor.opacity(0.3), lineWidth: 1)
                     )
-            )
-        }
+                )
+        })
         .buttonStyle(PlainButtonStyle())
         .disabled(isTesting)
     }
@@ -1765,7 +1764,7 @@ private struct EditProviderFlow: View {
         }
     }
 
-    private func testConnection() {
+    func testConnection() {
         isTesting = true
         testResult = nil
 
@@ -2053,7 +2052,7 @@ private struct CompactHeaderRow: View {
             )
             .foregroundColor(themeManager.currentTheme.primaryText)
 
-            Button(action: { header.isSecret.toggle() }) {
+            Button(action: { header.isSecret.toggle() }, label: {
                 Image(systemName: header.isSecret ? "lock.fill" : "lock.open")
                     .font(.system(size: 10))
                     .foregroundColor(
@@ -2061,7 +2060,7 @@ private struct CompactHeaderRow: View {
                     )
                     .frame(width: 26, height: 26)
                     .background(Circle().fill(themeManager.currentTheme.tertiaryBackground))
-            }
+            })
             .buttonStyle(PlainButtonStyle())
             .help(Text(header.isSecret ? L("This value is stored securely") : L("Click to make this a secret value")))
 

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -10,6 +10,24 @@
 import AppKit
 import SwiftUI
 
+private func parseManualModelIds(_ text: String) -> [String] {
+    var seen = Set<String>()
+    var values: [String] = []
+
+    for part in text.split(whereSeparator: { $0 == "\n" || $0 == "," }) {
+        let value = String(part).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { continue }
+
+        let key = value.lowercased()
+        guard !seen.contains(key) else { continue }
+
+        seen.insert(key)
+        values.append(value)
+    }
+
+    return values
+}
+
 // MARK: - Main View
 
 struct RemoteProviderEditSheet: View {
@@ -50,6 +68,13 @@ private struct AddProviderFlow: View {
     @State private var testResult: ProviderTestResult? = nil
     @State private var hasAppeared = false
 
+    // Known provider connection overrides for presets whose endpoint is user-specific.
+    @State private var knownHost: String = ""
+    @State private var knownProtocol: RemoteProviderProtocol = .https
+    @State private var knownPort: String = ""
+    @State private var knownBasePath: String = "/v1"
+    @State private var manualModelIdsText: String = ""
+
     // Custom provider fields
     @State private var customName: String = ""
     @State private var customHost: String = ""
@@ -68,10 +93,18 @@ private struct AddProviderFlow: View {
         if preset == .custom {
             return !customHost.trimmingCharacters(in: .whitespaces).isEmpty
         }
+        if preset == .azureOpenAI {
+            return !knownHost.trimmingCharacters(in: .whitespaces).isEmpty && !apiKey.isEmpty && apiKey.count > 5
+        }
         if preset == .openai && openAIAuthMode == .chatGPTSubscription {
             return true
         }
         return !apiKey.isEmpty && apiKey.count > 5
+    }
+
+    private var canSaveKnownProviderWithoutSuccessfulTest: Bool {
+        guard selectedPreset == .azureOpenAI else { return false }
+        return canTest && !parseManualModelIds(manualModelIdsText).isEmpty
     }
 
     var body: some View {
@@ -105,7 +138,10 @@ private struct AddProviderFlow: View {
         .scaleEffect(hasAppeared ? 1 : 0.95)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: hasAppeared)
         .onAppear {
-            selectedPreset = initialPreset
+            if let initialPreset {
+                initializeKnownConnection(for: initialPreset)
+                selectedPreset = initialPreset
+            }
             withAnimation { hasAppeared = true }
         }
     }
@@ -191,6 +227,7 @@ private struct AddProviderFlow: View {
                     ForEach(ProviderPreset.knownPresets + [.custom]) { preset in
                         ProviderSelectionCard(preset: preset) {
                             withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                                initializeKnownConnection(for: preset)
                                 selectedPreset = preset
                             }
                         }
@@ -245,6 +282,11 @@ private struct AddProviderFlow: View {
                         openAIAuthChoiceSection
                     }
 
+                    if selectedPreset == .azureOpenAI {
+                        azureConnectionSection
+                        azureDeploymentsSection
+                    }
+
                     if selectedPreset != .openai || openAIAuthMode == .platformAPIKey {
                         apiKeySection
                     }
@@ -264,7 +306,7 @@ private struct AddProviderFlow: View {
 
             // Footer
             sheetFooter(canProceed: canTest) {
-                if testResult?.isSuccess == true {
+                if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest {
                     saveKnownProvider()
                 } else {
                     testKnownProvider()
@@ -365,6 +407,11 @@ private struct AddProviderFlow: View {
                 customBasePath = "/v1"
                 customProtocol = .https
                 customAuthType = .none
+                knownHost = ""
+                knownProtocol = .https
+                knownPort = ""
+                knownBasePath = "/v1"
+                manualModelIdsText = ""
                 showAdvanced = false
                 timeout = 60
                 customHeaders = []
@@ -379,6 +426,119 @@ private struct AddProviderFlow: View {
             .foregroundColor(theme.secondaryText)
         }
         .buttonStyle(PlainButtonStyle())
+    }
+
+    private func initializeKnownConnection(for preset: ProviderPreset) {
+        let config = preset.configuration
+        knownHost = config.host
+        knownProtocol = config.providerProtocol
+        knownPort = config.port.map(String.init) ?? ""
+        knownBasePath = config.basePath
+        manualModelIdsText = ""
+        testResult = nil
+    }
+
+    private var azureConnectionSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 8) {
+                Image(systemName: "network")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text("AZURE ENDPOINT", bundle: .module)
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(theme.secondaryText)
+                    .tracking(0.5)
+            }
+
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("PROTOCOL", bundle: .module)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(theme.tertiaryText)
+                        .tracking(0.5)
+
+                    SegmentedToggle {
+                        SegmentedToggleButton("HTTPS", isSelected: knownProtocol == .https) { knownProtocol = .https }
+                        SegmentedToggleButton("HTTP", isSelected: knownProtocol == .http) { knownProtocol = .http }
+                    }
+                }
+                .frame(width: 140)
+
+                ProviderTextField(
+                    label: "Host",
+                    placeholder: "resource.cognitiveservices.azure.com",
+                    text: $knownHost,
+                    isMonospaced: true
+                )
+                .onChange(of: knownHost) { _, _ in testResult = nil }
+            }
+
+            HStack(spacing: 12) {
+                ProviderTextField(
+                    label: "Port",
+                    placeholder: knownProtocol == .https ? "443" : "80",
+                    text: $knownPort,
+                    isMonospaced: true
+                )
+                .frame(width: 90)
+                .onChange(of: knownPort) { _, _ in testResult = nil }
+
+                ProviderTextField(
+                    label: "Base Path",
+                    placeholder: "/openai/v1",
+                    text: $knownBasePath,
+                    isMonospaced: true
+                )
+                .onChange(of: knownBasePath) { _, _ in testResult = nil }
+            }
+
+            if !knownHost.trimmingCharacters(in: .whitespaces).isEmpty {
+                HStack(spacing: 8) {
+                    Image(systemName: "link")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.accentColor)
+                    Text(buildKnownEndpointPreview())
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.accentColor.opacity(0.1))
+                )
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private var azureDeploymentsSection: some View {
+        DeploymentNamesEditor(
+            text: $manualModelIdsText,
+            title: "DEPLOYMENT NAMES",
+            placeholder: "gpt-5.4\nmy-prod-chat",
+            theme: theme
+        )
+        .onChange(of: manualModelIdsText) { _, _ in testResult = nil }
+    }
+
+    private func buildKnownEndpointPreview() -> String {
+        var result = "\(knownProtocol.rawValue)://\(knownHost.trimmingCharacters(in: .whitespaces))"
+        if let port = Int(knownPort), port != knownProtocol.defaultPort {
+            result += ":\(port)"
+        }
+        let path = knownBasePath.trimmingCharacters(in: .whitespaces)
+        result += path.isEmpty ? "/openai/v1" : (path.hasPrefix("/") ? path : "/" + path)
+        return result
     }
 
     private var apiKeySection: some View {
@@ -800,7 +960,7 @@ private struct AddProviderFlow: View {
 
     private var actionButtonTitle: String {
         if isTesting { return openAIAuthMode == .chatGPTSubscription ? L("Signing in...") : L("Testing...") }
-        if testResult?.isSuccess == true { return L("Add Provider") }
+        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return L("Add Provider") }
         if case .failure = testResult { return L("Retry") }
         if selectedPreset == .openai && openAIAuthMode == .chatGPTSubscription {
             return L("Sign in with ChatGPT")
@@ -809,7 +969,7 @@ private struct AddProviderFlow: View {
     }
 
     private var actionButtonColor: Color {
-        if testResult?.isSuccess == true { return theme.successColor }
+        if testResult?.isSuccess == true || canSaveKnownProviderWithoutSuccessfulTest { return theme.successColor }
         if case .failure = testResult { return theme.errorColor }
         return theme.accentColor
     }
@@ -823,6 +983,7 @@ private struct AddProviderFlow: View {
     private func testKnownProvider() {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
+        let connection = knownProviderConnection(for: preset)
 
         isTesting = true
         testResult = nil
@@ -838,10 +999,10 @@ private struct AddProviderFlow: View {
                     models = OpenAICodexOAuthService.supportedModels
                 } else {
                     models = try await RemoteProviderManager.shared.testConnection(
-                        host: config.host,
-                        providerProtocol: config.providerProtocol,
-                        port: config.port,
-                        basePath: config.basePath,
+                        host: connection.host,
+                        providerProtocol: connection.providerProtocol,
+                        port: connection.port,
+                        basePath: connection.basePath,
                         authType: .apiKey,
                         providerType: config.providerType,
                         apiKey: apiKey,
@@ -866,6 +1027,7 @@ private struct AddProviderFlow: View {
     private func saveKnownProvider() {
         guard let preset = selectedPreset else { return }
         let config = preset.configuration
+        let connection = knownProviderConnection(for: preset)
         let (regularHeaders, secretKeys) = HeaderEntry.partition(customHeaders)
         let isCodexOAuth = preset == .openai && openAIAuthMode == .chatGPTSubscription
         let providerConfig = isCodexOAuth ? OpenAICodexOAuthService.makeProvider() : nil
@@ -873,16 +1035,17 @@ private struct AddProviderFlow: View {
         let remoteProvider = RemoteProvider(
             id: providerConfig?.id ?? UUID(),
             name: providerConfig?.name ?? config.name,
-            host: providerConfig?.host ?? config.host,
-            providerProtocol: providerConfig?.providerProtocol ?? config.providerProtocol,
-            port: providerConfig?.port ?? config.port,
-            basePath: providerConfig?.basePath ?? config.basePath,
+            host: providerConfig?.host ?? connection.host,
+            providerProtocol: providerConfig?.providerProtocol ?? connection.providerProtocol,
+            port: providerConfig?.port ?? connection.port,
+            basePath: providerConfig?.basePath ?? connection.basePath,
             customHeaders: regularHeaders,
             authType: providerConfig?.authType ?? .apiKey,
             providerType: providerConfig?.providerType ?? config.providerType,
             enabled: true,
             autoConnect: true,
             timeout: timeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
 
@@ -959,6 +1122,25 @@ private struct AddProviderFlow: View {
             RemoteProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: providerId)
         }
     }
+
+    private func knownProviderConnection(for preset: ProviderPreset) -> ProviderPresetConfiguration {
+        let config = preset.configuration
+        guard preset == .azureOpenAI else { return config }
+
+        let trimmedHost = knownHost.trimmingCharacters(in: .whitespaces)
+        let trimmedBasePath = knownBasePath.trimmingCharacters(in: .whitespaces)
+        let port: Int? = knownPort.trimmingCharacters(in: .whitespaces).isEmpty ? nil : Int(knownPort)
+
+        return ProviderPresetConfiguration(
+            name: config.name,
+            host: trimmedHost,
+            providerProtocol: knownProtocol,
+            port: port,
+            basePath: trimmedBasePath.isEmpty ? "/openai/v1" : trimmedBasePath,
+            authType: config.authType,
+            providerType: config.providerType
+        )
+    }
 }
 
 // MARK: - Edit Provider Flow (simplified)
@@ -988,6 +1170,7 @@ private struct EditProviderFlow: View {
 
     // Editable fields
     @State private var apiKey: String = ""
+    @State private var manualModelIdsText: String = ""
 
     // Advanced
     @State private var showAdvanced = false
@@ -1129,6 +1312,15 @@ private struct EditProviderFlow: View {
                 }
 
                 ProviderSecureField(placeholder: "Leave blank to keep current", text: $apiKey)
+            }
+
+            if preset == .azureOpenAI {
+                DeploymentNamesEditor(
+                    text: $manualModelIdsText,
+                    title: "DEPLOYMENT NAMES",
+                    placeholder: "gpt-5.4\nmy-prod-chat",
+                    theme: theme
+                )
             }
 
             // Help section
@@ -1546,6 +1738,9 @@ private struct EditProviderFlow: View {
     private var canSave: Bool {
         if matchedPreset != nil {
             // Known provider: always saveable (name/host come from preset or advanced)
+            if providerType == .azureOpenAI {
+                return !host.trimmingCharacters(in: .whitespaces).isEmpty
+            }
             return true
         }
         return !name.trimmingCharacters(in: .whitespaces).isEmpty
@@ -1563,6 +1758,7 @@ private struct EditProviderFlow: View {
         authType = provider.authType
         providerType = provider.providerType
         timeout = provider.timeout
+        manualModelIdsText = provider.manualModelIds.joined(separator: "\n")
         customHeaders = provider.customHeaders.map { HeaderEntry(key: $0.key, value: $0.value, isSecret: false) }
         for key in provider.secretHeaderKeys {
             customHeaders.append(HeaderEntry(key: key, value: "", isSecret: true))
@@ -1622,6 +1818,7 @@ private struct EditProviderFlow: View {
             enabled: provider.enabled,
             autoConnect: true,
             timeout: timeout,
+            manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
 
@@ -1974,6 +2171,61 @@ private struct ProviderSecureField: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+// MARK: - Deployment Names Editor
+
+private struct DeploymentNamesEditor: View {
+    @Binding var text: String
+    let title: String
+    let placeholder: String
+    let theme: ThemeProtocol
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .tracking(0.5)
+
+            ZStack(alignment: .topLeading) {
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundColor(theme.placeholderText)
+                        .padding(.horizontal, 11)
+                        .padding(.vertical, 10)
+                        .allowsHitTesting(false)
+                }
+
+                TextEditor(text: $text)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.clear)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 6)
+            }
+            .frame(minHeight: 82)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(theme.inputBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
                 )
         )
     }


### PR DESCRIPTION
Companion/replacement for #957 because the original external PR has zero GitHub checks attached and this branch can run maintainer-owned CI.

What this carries:
- Preserves the Azure OpenAI Foundry provider support from #957.
- Rebases it onto latest main.
- Cleans strict SwiftLint issues without changing provider wire behavior.

Local verification:
- `git diff --check origin/main...HEAD`
- `swiftlint --strict Packages/OsaurusCore/Managers/RemoteProviderManager.swift Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift`
- `cd Packages/OsaurusCore && swift test --filter RemoteChatRequestEncodingTests` (17 tests passed)
- `cd Packages/OsaurusCore && swift build`

Status:
- Draft until GitHub checks attach and pass.
- If GitHub test-core hits the known EventSource/DerivedData CI class before #975 lands, keep this draft and rerun after #975 is merged.

Refs #957.