### PR TITLE
feat(api): OpenAI input_audio + video_url content parts → vmlx audios/videos

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78bf1831237aba77bd64606b67d185ed63b4df4735104f9b5a157d27501977b1",
+  "originHash" : "c5dba7ce3f4e5aa8a0d89ec42071945678e8f45ce1f3d8fcfeee68e807318cd1",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -96,8 +96,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/mlx-swift",
       "state" : {
-        "branch" : "osaurus-0.31.3",
-        "revision" : "02b01f07e8c5cae22cd7fd1187e673d8d5de0db6"
+        "revision" : "e0b61113f0190e3503ad9123bf4d4508248cd316"
       }
     },
     {
@@ -419,7 +418,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
+        "revision" : "13abe407df83d1836f640d0cb56f63a7e640ede3"
       }
     },
     {

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -26,6 +26,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     public func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.shared = self
 
+        // Make MLX C++ errors recoverable instead of process-fatal. Must run
+        // before any model load can call into MLX so the first forward pass
+        // is already protected. See `MLXErrorRecovery` for the rationale and
+        // the specific crash class this prevents.
+        MLXErrorRecovery.installGlobalHandler()
+
         // Detect repeated startup crashes and enter safe mode if needed
         LaunchGuard.checkOnLaunch()
 

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -639,6 +639,66 @@ extension ModelManager {
             releasedAt: date("2026-04-17")
         ),
 
+        // MARK: Nemotron-3 Nano Omni Reasoning (hybrid Mamba-2 SSM + Attn + MoE)
+        //
+        // 30B total / ~3B active. 52-layer hybrid: 23 Mamba-2 SSM layers,
+        // 23 MoE layers (128 routed × 6 active + 1 shared, ReLU² activation),
+        // 6 attention layers (GQA 32q × 2kv, NO RoPE — position info from
+        // Mamba). 262K native context. Reasoning ON by default — chat
+        // template emits `<think>...</think>` segments parsed by vmlx's
+        // think_xml stamp (auto-resolved from `model_type=nemotron_h`).
+        //
+        // Tool format: `nemotron` (NeMo-style) — auto-resolved by vmlx via
+        // jang_config.capabilities or model-type heuristic.
+        // Cache: hybrid — `MambaCache(size=2)` for the 23 M layers,
+        // `KVCacheSimple` for the 6 * layers, nil for E layers. vmlx's
+        // `CacheCoordinator.isHybrid` auto-flips on first slot admission;
+        // osaurus does NOT call `setHybrid` manually (per
+        // OSAURUS-INTEGRATION.md).
+        // Sampling recipe per `research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md`:
+        // T=0.6 top_p=0.95 (DeepSeek-style). Bundles ship those defaults
+        // in `generation_config.json`; `LocalGenerationDefaults` reads them.
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"),
+            description:
+                "NVIDIA Nemotron-3 30B Reasoning hybrid (Mamba-2 + MoE). MXFP4 quantization — fastest decode path. 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            isTopSuggestion: true,
+            downloadSizeBytes: 18_002_117_870,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4"),
+            description:
+                "Nemotron-3 30B Reasoning hybrid, 4-bit TurboQuant routed experts. Near-bf16 quality at ~16 GB. 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            downloadSizeBytes: 16_009_341_440,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
+        MLXModel(
+            id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            name: ModelMetadataParser.friendlyName(
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ"),
+            description:
+                "Nemotron-3 30B Reasoning hybrid, 2-bit TurboQuant routed experts. Smallest footprint (~9 GB). 262K context.",
+            downloadURL:
+                "https://huggingface.co/OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            downloadSizeBytes: 9_136_488_448,
+            modelType: "nemotron_h",
+            releasedAt: date("2026-04-28")
+        ),
+
         // MARK: Large Models
 
         MLXModel(

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -145,21 +145,47 @@ struct ModelsResponse: Codable, Sendable {
 
 // MARK: - Multimodal Content Parts
 
-/// OpenAI-compatible content part for multimodal messages
+/// OpenAI-compatible content part for multimodal messages.
+///
+/// Supports four shapes:
+///   - `text` / `input_text` — plain text
+///   - `image_url` — `{url, detail?}`. URL may be `data:image/...;base64,...` or `https://...`
+///   - `input_audio` — `{data: <base64>, format: "wav"|"mp3"|"flac"|...}`. Mirrors the
+///     OpenAI Realtime / GPT-4o audio shape; the audio bytes are written to a temp
+///     file and handed to vmlx as `UserInput.Audio.url(...)` so vmlx's
+///     `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32) handles
+///     all decoding. Format strings are passed through to vmlx unchanged — vmlx
+///     uses the file extension, so the format hint becomes the file extension.
+///   - `video_url` — `{url}`. Mirrors the convention adopted by LM Studio / Ollama
+///     for video inputs since OpenAI hasn't published a canonical chat-completions
+///     video shape. URL may be `data:video/...;base64,...` or `https://...`.
 enum MessageContentPart: Codable, Sendable {
     case text(String)
     case imageUrl(url: String, detail: String?)
+    case audioInput(data: String, format: String)
+    case videoUrl(url: String)
 
     private enum CodingKeys: String, CodingKey {
         case type
         case text
         case input_text
         case image_url
+        case input_audio
+        case video_url
     }
 
     private struct ImageUrlContent: Codable {
         let url: String
         let detail: String?
+    }
+
+    private struct InputAudioContent: Codable {
+        let data: String
+        let format: String
+    }
+
+    private struct VideoUrlContent: Codable {
+        let url: String
     }
 
     init(from decoder: Decoder) throws {
@@ -178,6 +204,12 @@ enum MessageContentPart: Codable, Sendable {
         case "image_url":
             let imageUrl = try container.decode(ImageUrlContent.self, forKey: .image_url)
             self = .imageUrl(url: imageUrl.url, detail: imageUrl.detail)
+        case "input_audio":
+            let audio = try container.decode(InputAudioContent.self, forKey: .input_audio)
+            self = .audioInput(data: audio.data, format: audio.format)
+        case "video_url":
+            let video = try container.decode(VideoUrlContent.self, forKey: .video_url)
+            self = .videoUrl(url: video.url)
         default:
             // Fallback to text for unknown types
             if let text = try? container.decode(String.self, forKey: .text) {
@@ -197,6 +229,12 @@ enum MessageContentPart: Codable, Sendable {
         case .imageUrl(let url, let detail):
             try container.encode("image_url", forKey: .type)
             try container.encode(ImageUrlContent(url: url, detail: detail), forKey: .image_url)
+        case .audioInput(let data, let format):
+            try container.encode("input_audio", forKey: .type)
+            try container.encode(InputAudioContent(data: data, format: format), forKey: .input_audio)
+        case .videoUrl(let url):
+            try container.encode("video_url", forKey: .type)
+            try container.encode(VideoUrlContent(url: url), forKey: .video_url)
         }
     }
 }
@@ -231,6 +269,32 @@ struct ChatMessage: Codable, Sendable {
             guard let commaIndex = url.firstIndex(of: ",") else { return nil }
             let base64String = String(url[url.index(after: commaIndex)...])
             return Data(base64Encoded: base64String)
+        }
+    }
+
+    /// Extract `(base64, format)` pairs from `input_audio` content parts.
+    /// `format` is whatever the client sent (e.g. `"wav"`, `"mp3"`); we pass
+    /// it through to the file extension when materializing the temp file
+    /// because vmlx's `nemotronOmniLoadAudioFile` keys decoder selection on
+    /// the URL extension via AVAudioConverter.
+    var audioInputs: [(data: String, format: String)] {
+        guard let parts = contentParts else { return [] }
+        return parts.compactMap { part in
+            if case .audioInput(let data, let format) = part {
+                return (data, format)
+            }
+            return nil
+        }
+    }
+
+    /// Extract video URLs (data: or http(s):) from `video_url` content parts.
+    var videoUrls: [String] {
+        guard let parts = contentParts else { return [] }
+        return parts.compactMap { part in
+            if case .videoUrl(let url) = part {
+                return url
+            }
+            return nil
         }
     }
 }
@@ -273,11 +337,16 @@ extension ChatMessage {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(role, forKey: .role)
-        // If we have content parts with images, encode as array; otherwise as string
+        // If we have content parts with any non-text media, encode as array;
+        // otherwise as string. Round-trip preserves audio/video/image parts
+        // so a request that came in with `input_audio` or `video_url` is
+        // re-serialized in the same shape.
         if let parts = contentParts,
             parts.contains(where: {
-                if case .imageUrl = $0 { return true }
-                return false
+                switch $0 {
+                case .imageUrl, .audioInput, .videoUrl: return true
+                case .text: return false
+                }
             })
         {
             try container.encode(parts, forKey: .content)

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -78,6 +78,7 @@ enum ModelProfileRegistry {
         VeniceModelProfile.self,
         OpenAIReasoningProfile.self,
         QwenThinkingProfile.self,
+        NemotronThinkingProfile.self,
         Gemini31FlashImageProfile.self,
         GeminiProImageProfile.self,
         GeminiFlashImageProfile.self,
@@ -141,6 +142,45 @@ struct QwenThinkingProfile: ModelProfile {
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
         return lower.contains("qwen3") && !lower.contains("coder")
+    }
+
+    static let options: [ModelOptionDefinition] = [
+        ModelOptionDefinition(
+            id: "disableThinking",
+            label: "Disable Thinking",
+            icon: "brain.head.profile",
+            kind: .toggle(default: true)
+        )
+    ]
+
+    static let defaults: [String: ModelOptionValue] = [
+        "disableThinking": .bool(true)
+    ]
+
+    static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
+}
+
+// MARK: - Nemotron-3 Thinking Profile
+
+/// Nemotron-3-Nano-Omni Reasoning models — `model_type=nemotron_h` hybrid
+/// Mamba+Attn+MoE bundles whose chat template reads an `enable_thinking`
+/// kwarg. Defaults `disableThinking: true` for the same reason
+/// `QwenThinkingProfile` does: per
+/// `jang/research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md` §9, the SKU is
+/// "Reasoning V3" and its training extends `<think>` blocks through
+/// arbitrary self-verification on validation-style prompts (the same
+/// pattern that surfaced as trapped-thinking on Qwen3.6-A3B). Forcing
+/// thinking off for chat workloads is the recommended operating point;
+/// users who want CoT can toggle the chip on per turn.
+///
+/// Match excludes `coder` variants (none ship today, but mirroring
+/// `QwenThinkingProfile`'s shape for consistency if NVIDIA publishes one).
+struct NemotronThinkingProfile: ModelProfile {
+    static let displayName = "Nemotron Thinking"
+
+    static func matches(modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return lower.contains("nemotron-3") && !lower.contains("coder")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -18,28 +18,38 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // a7db6e5 closes the deterministic Metal-assertion crash class
-        // `notifyExternalReferencesNonZeroOnDealloc` inside
-        // `BatchEngine.stepPrefill` after `Cache disk hit`. Two upstream
-        // commits land that fix together:
-        //   - 98289d9 forces `MLX.asyncEval(slot.cache)` after disk
-        //     restore so lazy-restore graph ops don't extend into the
-        //     next request's command buffer.
-        //   - a7db6e5 sets `continuation.onTermination` on
-        //     `BatchEngine.generate`'s outStream so orphan slots get
-        //     reaped via `engine.cancel(requestId)` whenever a consumer
-        //     breaks early.
-        // Net effect: the `Task.isCancelled` break in MLXBatchAdapter
-        // line 209-222 is safe, and no `enableDiskCache: false` workaround
-        // is needed.
+        // ae526a3 brings five things in one bump from a7db6e5:
+        //   - b4eec09 native Swift port of the Nemotron-3-Nano-Omni
+        //     multimodal stack (replaces the pytorch-bridged path) —
+        //     building blocks for Parakeet/RADIO native runtime.
+        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
+        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
+        //     Nemotron-3 registry comments (§12.5).
+        //   - 75549cb @ModuleInfo single-segment fix for the omni stack
+        //     weight loader.
+        //   - ae526a3 authoritative blockSize + omni quant plumbing —
+        //     **closes the `rms_norm` trap class** that was killing
+        //     Cascade-2 JANG_4M and Nemotron-Omni MXFP4 first-prefill
+        //     under the bits=4 / 164-override JANG path. Symbolicated
+        //     against `nemotron-cascade-2-30b-a3b-jang_4m` during
+        //     PR #967 triage. Pairs with osaurus-side
+        //     `MLXErrorRecovery.installGlobalHandler()` belt+suspenders.
         //
-        // Also includes c992df9's `GenerateCompletionInfo.unclosedReasoning`,
-        // which the chat UI consumes to surface a "thinking didn't close"
-        // chip when reasoning-trained models trap themselves on validation
-        // prompts.
+        // Carries forward the prior fixes from a7db6e5:
+        //   - 98289d9 `MLX.asyncEval(slot.cache)` after disk restore
+        //   - a7db6e5 `continuation.onTermination` on
+        //     `BatchEngine.generate` so orphan slots reap on early break
+        //   - c992df9 `GenerateCompletionInfo.unclosedReasoning`
+        //
+        // The audio + video API surface (UserInput.Audio, Chat.Message.
+        // audios, processor wiring, mic recorder, system TTS, Parakeet
+        // E2E) ships separately as a coordinated osaurus + vmlx pair —
+        // see the audio-API follow-up PR. That PR pins to vmlx
+        // 3b78db4 which adds the Chat.Message.audios bridge needed for
+        // OpenAI `input_audio` content parts to flow end-to-end.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "a7db6e5fdde525c43f72ba48df8ba12a07451ee9"
+            revision: "ae526a38c033533940f383f0d31d0a55100938d2"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -13,7 +13,21 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
-        .package(url: "https://github.com/osaurus-ai/mlx-swift", branch: "osaurus-0.31.3"),
+        // mlx-swift pinned by revision (was `branch: "osaurus-0.31.3"`) so
+        // the runtime can't change under us if the branch tip moves. The
+        // revision below is the merge point on `osaurus-0.31.3` that
+        // (a) refreshes the submodule URL to the host-side `osaurus-ai/mlx`
+        // fork and (b) advances the submodule pointer to a commit
+        // (`f58e52da` on the fork's `fix/clear-library-no-release`) that
+        // contains the Bug-1 fix for the deterministic Metal validation
+        // crash class `notifyExternalReferencesNonZeroOnDealloc` that
+        // fired on warm-disk-cache 2nd-request flows on Apple M4 Pro
+        // Debug builds. Revert by setting `MLX_CLEAR_LIBRARY_RELEASE=1`
+        // at runtime if needed for A/B testing.
+        .package(
+            url: "https://github.com/osaurus-ai/mlx-swift",
+            revision: "e0b61113f0190e3503ad9123bf4d4508248cd316"
+        ),
         // Pinned by commit (was `branch: "main"`) so the runtime can't change
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
@@ -74,7 +88,7 @@ let package = Package(
         // at this pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "1c62d210d7f23e1ba1e8d5cc45ec9f1221357f01"
+            revision: "13abe407df83d1836f640d0cb56f63a7e640ede3"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -18,38 +18,63 @@ let package = Package(
         // under us between identical osaurus source revisions. Bump
         // intentionally when validating a new upstream commit.
         //
-        // ae526a3 brings five things in one bump from a7db6e5:
-        //   - b4eec09 native Swift port of the Nemotron-3-Nano-Omni
-        //     multimodal stack (replaces the pytorch-bridged path) —
-        //     building blocks for Parakeet/RADIO native runtime.
-        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
-        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
-        //     Nemotron-3 registry comments (§12.5).
-        //   - 75549cb @ModuleInfo single-segment fix for the omni stack
-        //     weight loader.
+        // 1c62d21 collects every relevant runtime + docs fix accrued
+        // since a7db6e5 (the prior osaurus pin). Picker entries PR #967
+        // adds (Nemotron-3 omni bundles + the broader hybrid family
+        // setHybrid path) all want these:
+        //
+        // Runtime fixes:
         //   - ae526a3 authoritative blockSize + omni quant plumbing —
-        //     **closes the `rms_norm` trap class** that was killing
+        //     **closes the `rms_norm` trap class** that killed
         //     Cascade-2 JANG_4M and Nemotron-Omni MXFP4 first-prefill
         //     under the bits=4 / 164-override JANG path. Symbolicated
         //     against `nemotron-cascade-2-30b-a3b-jang_4m` during
-        //     PR #967 triage. Pairs with osaurus-side
+        //     PR #967 triage. Pairs with the osaurus-side
         //     `MLXErrorRecovery.installGlobalHandler()` belt+suspenders.
+        //   - 537e386 `NemotronHJANGTQ` — closes
+        //     `Unhandled keys ["experts"]` on omni JANGTQ bundles by
+        //     stacking per-expert TQ-packed tensors and swapping in
+        //     `TurboQuantSwitchLinear` for the routed-expert switch.
+        //   - d020e76 `NemotronHOmni.prepare(_:)` text-only returns
+        //     `.logits` instead of `.tokens` — dodges a `[concatenate]
+        //     dims 3 vs 4` trap when `BatchEngine.stepPrefill` adds a
+        //     `[.newAxis]` axis to processor tokens, which then cascaded
+        //     into Mamba2 conv state merge. Mirrors `Gemma3.prepare` /
+        //     `FastVLM.prepare`.
         //
-        // Carries forward the prior fixes from a7db6e5:
+        // Foundational omni stack:
+        //   - b4eec09 native Swift port of Nemotron-3-Nano-Omni — first
+        //     time osaurus drives Parakeet/RADIO without a torch dep.
+        //   - 08994b0 OMNI-OSAURUS-HOOKUP.md spec — cited by
+        //     `ModelRuntime.installCacheCoordinator` (§5.1) and the
+        //     Nemotron-3 registry comments (§12.5).
+        //   - 75549cb @ModuleInfo single-segment fix for omni weight
+        //     loading.
+        //   - 1c62d21 OMNI-OSAURUS-HOOKUP §10 correction: the prior
+        //     "BatchEngine omni B=1 empty stream" claim was a bench
+        //     methodology artifact — the bench counted only `.chunk`
+        //     events and missed `.reasoning(_)` events that
+        //     reasoning-on-by-default omni emits during
+        //     `<think>...</think>`. Osaurus's `GenerationEventMapper`
+        //     correctly forwards `.reasoning(_)` (see
+        //     `PluginHostAPI.swift:1139` emitting
+        //     `delta.reasoning_content`), so streaming clients see the
+        //     full output. No osaurus-side workaround needed.
+        //
+        // Carries forward all prior fixes:
         //   - 98289d9 `MLX.asyncEval(slot.cache)` after disk restore
         //   - a7db6e5 `continuation.onTermination` on
         //     `BatchEngine.generate` so orphan slots reap on early break
         //   - c992df9 `GenerateCompletionInfo.unclosedReasoning`
         //
-        // The audio + video API surface (UserInput.Audio, Chat.Message.
-        // audios, processor wiring, mic recorder, system TTS, Parakeet
-        // E2E) ships separately as a coordinated osaurus + vmlx pair —
-        // see the audio-API follow-up PR. That PR pins to vmlx
-        // 3b78db4 which adds the Chat.Message.audios bridge needed for
-        // OpenAI `input_audio` content parts to flow end-to-end.
+        // The audio + video HTTP-API surface
+        // (`MessageContentPart.audioInput` / `.videoUrl` →
+        // `UserInput.audios` / `.videos`) ships in a follow-up osaurus
+        // PR on top of this one; vmlx-side wiring is already in place
+        // at this pin.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "ae526a38c033533940f383f0d31d0a55100938d2"
+            revision: "1c62d210d7f23e1ba1e8d5cc45ec9f1221357f01"
         ),
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.1.6"),
         .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.14.0"),

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -408,24 +408,15 @@ final class ModelDownloadService: ObservableObject {
     }
 
     /// Returns the free-for-important-usage byte count on the volume that
-    /// hosts `url`. Falls back to the older `.systemFreeSize` query if the
-    /// modern `.volumeAvailableCapacityForImportantUsageKey` is unavailable.
+    /// hosts `url`. Delegates to `OsaurusPaths.volumeFreeBytes(forPath:)`
+    /// so this service and `SystemMonitorService` share one query path —
+    /// preventing the kind of drift that produced bug #964 (the system
+    /// monitor reported 0 GB free while the downloader correctly saw
+    /// tens of GB free, because the two used different APIs).
     /// Returns `nil` if both queries fail — callers should treat `nil` as
     /// "unknown, proceed" rather than "zero, block".
     static func freeBytesOnVolume(containing url: URL) -> Int64? {
-        let probe = url
-        let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
-        if let values = try? probe.resourceValues(forKeys: keys),
-            let capacity = values.volumeAvailableCapacityForImportantUsage
-        {
-            return capacity
-        }
-        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: probe.path),
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
-        {
-            return free
-        }
-        return nil
+        OsaurusPaths.volumeFreeBytes(forPath: url.path)
     }
 
     private func updateDownloadProgress(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -417,18 +417,67 @@ public actor ModelRuntime {
 
     /// Installs the cache coordinator on a freshly-loaded holder.
     ///
-    /// Single call to `enableCaching(config:)` is all that's needed — vmlx
-    /// auto-detects hybrid SSM models on first slot admission inside
-    /// `BatchEngine`, so osaurus must not call `setHybrid(_:)` manually
-    /// (per OSAURUS-INTEGRATION.md). Actor-isolated, so the install is
-    /// observed atomically by the next request.
+    /// `enableCaching(config:)` constructs the coordinator with our
+    /// recommended knobs (paged + L2 disk + TurboQuant default + 8K window).
+    /// vmlx's `BatchEngine.admitPendingRequests` auto-flips
+    /// `coordinator.isHybrid` on first slot admission for any model whose
+    /// per-layer cache list contains a `MambaCache` or `ArraysCache` — that
+    /// covers the BatchEngine path osaurus uses today.
+    ///
+    /// **Eager `setHybrid(true)` for known hybrid families**: per
+    /// `OMNI-OSAURUS-HOOKUP.md` §5.1 the eager-set is harmless on any
+    /// admission path and avoids a one-frame stale-flag window if a request
+    /// ever lands via the single-slot `Evaluate` path before BatchEngine
+    /// has had a chance to flip it. We tag known hybrid model_types here
+    /// instead of inspecting the model's cache list (which would require an
+    /// async `context.read` round-trip just to check for an `is MambaCache`
+    /// match) — the family list is short, drift is caught by tests, and
+    /// the auto-flip remains the source of truth for any model_type the
+    /// list misses.
     private func installCacheCoordinator(on holder: SessionHolder) async {
         let cacheConfig = Self.buildCacheCoordinatorConfig(modelName: holder.name)
         holder.container.enableCaching(config: cacheConfig)
 
+        if Self.isKnownHybridModel(name: holder.name) {
+            holder.container.cacheCoordinator?.setHybrid(true)
+        }
+
         genLog.info(
-            "installCacheCoordinator: enabled for \(holder.name, privacy: .public) disk=\(cacheConfig.enableDiskCache, privacy: .public) (sizing left to vmlx defaults)"
+            "installCacheCoordinator: enabled for \(holder.name, privacy: .public) disk=\(cacheConfig.enableDiskCache, privacy: .public) hybrid=\(Self.isKnownHybridModel(name: holder.name), privacy: .public) (sizing left to vmlx defaults)"
         )
+    }
+
+    /// Substring-match against the families whose per-layer cache lists
+    /// vmlx's `newCache(parameters:)` populates with `MambaCache` /
+    /// `ArraysCache` slots. Lower-cased model_id, so picker forms (without
+    /// the org prefix) match too.
+    ///
+    /// The list intentionally tracks model_type _families_, not exact ids,
+    /// so new bundles in the same architecture (e.g. another Holo3 / Qwen
+    /// 3.x MoE quant tier, a future Nemotron-4 hybrid) flip the flag
+    /// without a registry edit. Worst case a non-hybrid match would still
+    /// be safe: vmlx's `setHybrid(true)` only enables the SSM-state
+    /// companion-cache lookup; the lookup is keyed and just misses on a
+    /// non-hybrid model — no incorrect routing.
+    nonisolated static func isKnownHybridModel(name: String) -> Bool {
+        let lower = name.lowercased()
+        // Mamba+Attn+MoE — Nemotron-3 / Cascade-2 / Hyper.
+        if lower.contains("nemotron-3") || lower.contains("nemotron-cascade")
+            || lower.contains("nemotron_h")
+        {
+            return true
+        }
+        // Qwen 3.5 / 3.6 MoE family (qwen3_5_moe model_type) covers Holo3 too.
+        if lower.contains("qwen3.5") || lower.contains("qwen3.6") || lower.contains("holo3")
+            || lower.contains("holo-3")
+        {
+            return true
+        }
+        // MiniMax M2 / M2.7 — gated SSM in some layers.
+        if lower.contains("minimax-m2") || lower.contains("minimax_m2") {
+            return true
+        }
+        return false
     }
 
     // MARK: - Generation driver

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -878,11 +878,29 @@ public actor ModelRuntime {
         out.reserveCapacity(max(6, msgs.count))
         for m in msgs {
             let images = extractImageSources(from: m)
+            let videos = extractVideoSources(from: m)
+            let audios = extractAudioSources(from: m)
             switch m.role {
             case "system":
-                out.append(.init(role: .system, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .system,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             case "user":
-                out.append(.init(role: .user, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .user,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             case "assistant":
                 let content = (m.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 let toolCalls = toMLXToolCalls(m.tool_calls)
@@ -893,7 +911,8 @@ public actor ModelRuntime {
                         role: .assistant,
                         content: content,
                         images: images,
-                        videos: [],
+                        videos: videos,
+                        audios: audios,
                         toolCalls: toolCalls,
                         toolCallId: nil
                     )
@@ -904,13 +923,22 @@ public actor ModelRuntime {
                         role: .tool,
                         content: m.content ?? "",
                         images: images,
-                        videos: [],
+                        videos: videos,
+                        audios: audios,
                         toolCalls: nil,
                         toolCallId: m.tool_call_id
                     )
                 )
             default:
-                out.append(.init(role: .user, content: m.content ?? "", images: images))
+                out.append(
+                    MLXLMCommon.Chat.Message(
+                        role: .user,
+                        content: m.content ?? "",
+                        images: images,
+                        videos: videos,
+                        audios: audios
+                    )
+                )
             }
         }
         return out
@@ -959,6 +987,115 @@ public actor ModelRuntime {
             }
         }
         return sources
+    }
+
+    /// Extract `[UserInput.Video]` from `video_url` content parts. Mirrors
+    /// `extractImageSources` — `data:` URLs are written to a temp file so
+    /// AVAsset can decode them; `http(s):` URLs go through directly. The
+    /// vmlx side (`NemotronHOmniProcessor.prepare()`) extracts frames via
+    /// `nemotronOmniExtractVideoFrames` regardless of source shape.
+    nonisolated private static func extractVideoSources(
+        from message: ChatMessage
+    ) -> [MLXLMCommon.UserInput.Video] {
+        let urls = message.videoUrls
+        guard !urls.isEmpty else { return [] }
+
+        var sources: [MLXLMCommon.UserInput.Video] = []
+        for urlString in urls {
+            if urlString.hasPrefix("data:video/") {
+                // data:video/<container>;base64,<bytes>
+                if let url = materializeMediaDataUrl(urlString, defaultExtension: "mp4") {
+                    sources.append(.url(url))
+                }
+            } else if let url = URL(string: urlString) {
+                sources.append(.url(url))
+            }
+        }
+        return sources
+    }
+
+    /// Extract `[UserInput.Audio]` from `input_audio` content parts. The
+    /// OpenAI shape is `{data: <base64>, format: "wav"|"mp3"|...}`; we
+    /// materialize a temp file with that extension and hand the URL to vmlx
+    /// so `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32)
+    /// drives the decode end-to-end. Going through a file URL keeps the path
+    /// uniform across formats — there is no in-memory `[Float]` decode here
+    /// because we'd have to duplicate vmlx's AVAudioConverter rig and lose
+    /// resampling fidelity in the process.
+    nonisolated private static func extractAudioSources(
+        from message: ChatMessage
+    ) -> [MLXLMCommon.UserInput.Audio] {
+        let inputs = message.audioInputs
+        guard !inputs.isEmpty else { return [] }
+
+        var sources: [MLXLMCommon.UserInput.Audio] = []
+        for (data, format) in inputs {
+            let ext = format.lowercased()
+            // Synthesize a `data:audio/<format>;base64,<data>` URL so we can
+            // reuse the same materializer the video path uses. The audio data
+            // comes in as a bare base64 string from `input_audio.data`, not a
+            // data URL — wrap it before handing off so the helper's data-URL
+            // parsing applies uniformly.
+            let dataUrl = "data:audio/\(ext);base64,\(data)"
+            if let url = materializeMediaDataUrl(dataUrl, defaultExtension: ext.isEmpty ? "wav" : ext) {
+                sources.append(.url(url))
+            }
+        }
+        return sources
+    }
+
+    /// Decode a `data:<mediatype>;base64,<bytes>` URL into a temp file URL with
+    /// an extension reflecting the mediatype. Returns `nil` on parse / decode
+    /// failure.
+    ///
+    /// Lifecycle: temp files live in `FileManager.default.temporaryDirectory`
+    /// and are not actively cleaned up here. macOS evicts the system temp dir
+    /// on its own schedule (`/private/var/folders/.../T/` rotates per session
+    /// and on reboot). Per-request cleanup would require threading a teardown
+    /// hook through the generation lifecycle, which is more complexity than
+    /// it's worth for what amounts to short-lived audio/video bytes.
+    nonisolated private static func materializeMediaDataUrl(
+        _ urlString: String,
+        defaultExtension: String
+    ) -> URL? {
+        // Expect `data:<mediatype>[;base64],<payload>`. Pull the mediatype
+        // subtype as the file extension when available so AVFoundation /
+        // AVAudioConverter's extension-keyed dispatch picks the right decoder.
+        guard urlString.hasPrefix("data:") else { return nil }
+        guard let commaIndex = urlString.firstIndex(of: ",") else { return nil }
+        let header = String(urlString[urlString.index(urlString.startIndex, offsetBy: 5) ..< commaIndex])
+        let payload = String(urlString[urlString.index(after: commaIndex)...])
+        guard let bytes = Data(base64Encoded: payload) else { return nil }
+
+        // Header looks like `audio/wav;base64` or `video/mp4`. Take the part
+        // after the slash, before any `;`.
+        var ext = defaultExtension
+        if let slash = header.firstIndex(of: "/") {
+            let afterSlash = header[header.index(after: slash)...]
+            if let semi = afterSlash.firstIndex(of: ";") {
+                ext = String(afterSlash[..<semi]).lowercased()
+            } else {
+                ext = String(afterSlash).lowercased()
+            }
+            // Some clients send `audio/x-wav` or `audio/mpeg` — coerce to the
+            // canonical extensions vmlx's AVAudioConverter recognizes.
+            switch ext {
+            case "x-wav", "wave": ext = "wav"
+            case "mpeg", "mp3", "x-mpeg": ext = "mp3"
+            case "x-m4a", "mp4": ext = "m4a"
+            default: break
+            }
+        }
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(ext)
+        do {
+            try bytes.write(to: tmp, options: .atomic)
+            return tmp
+        } catch {
+            return nil
+        }
     }
 
     private static func computeWeightsSizeBytes(at url: URL) -> Int64 {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
@@ -1,0 +1,90 @@
+//
+//  MLXErrorRecovery.swift
+//  osaurus
+//
+//  Installs a process-wide MLX error handler so a C++-side MLX error in any
+//  forward pass becomes a logged event instead of `fatalError`. Without this,
+//  the default `mlx-swift` `ErrorHandler.dispatch` fallback is `fatalError(message)`
+//  — i.e. *any* MLX assertion (shape mismatch in `rmsNorm`, broadcast mismatch,
+//  Metal validation failure) takes the entire osaurus process down, killing every
+//  unrelated in-flight request as collateral damage.
+//
+//  The crash class this prevents was symbolicated against bundle
+//  `nemotron-cascade-2-30b-a3b-jang_4m`, where the JANG_4M unpack on the
+//  NemotronH backbone produced a weight tensor whose last dim disagreed with
+//  the activation: `MLXFast.rmsNorm` → `_mlx_error` → `ErrorHandler.dispatch`
+//  → `_assertionFailure` → SIGTRAP. The vmlx-side fix lives in
+//  `NemotronHJANGTQ.swift`; on the osaurus side we want the server to keep
+//  running and surface the error to the offending request only.
+//
+//  ### Why a global handler, not `withErrorHandler`/`withError`
+//
+//  vmlx-swift-lm's `BatchEngine` runs its scheduling loop in a long-lived
+//  background `Task` created when the engine is instantiated, not per request.
+//  TaskLocal handlers (the non-deprecated `withErrorHandler` API) only flow
+//  through structured concurrency — they do **not** reach a pre-existing task,
+//  so wrapping `engine.generate` at the call site would not protect the slot
+//  whose forward pass actually traps.
+//
+//  The deprecated-but-still-public `setErrorHandler` is therefore the correct
+//  tool for "make MLX errors recoverable for the whole process." Its
+//  deprecation message is a hint that *user code* should prefer scoped
+//  handlers; system bootstrap is a different shape.
+//
+
+import Foundation
+import MLX
+import os.log
+
+private let recoveryLog = Logger(subsystem: "com.dinoki.osaurus", category: "MLXErrorRecovery")
+
+public enum MLXErrorRecovery {
+
+    /// Lock-protected slot for the most recent MLX error message. Useful for
+    /// diagnostics — the handler runs on whichever thread MLX called us from,
+    /// so this is a coarse "what failed last" rather than a per-request signal.
+    nonisolated(unsafe) private static let lock = NSLock()
+    nonisolated(unsafe) private static var _lastError: String?
+
+    public static var lastError: String? {
+        lock.withLock { _lastError }
+    }
+
+    /// One-shot install flag. `setErrorHandler` itself is idempotent at the
+    /// MLX level (replaces the previous handler), but we still gate to avoid
+    /// re-logging the install message on every call from defensive call sites.
+    nonisolated(unsafe) private static var installed = false
+
+    /// Install the process-wide handler. Idempotent and thread-safe via `lock`.
+    /// Safe to call from any thread; first caller wins, subsequent calls are
+    /// no-ops.
+    public static func installGlobalHandler() {
+        lock.withLock {
+            guard !installed else { return }
+            installed = true
+        }
+
+        // C-convention closure: no captures (must match `@convention(c)`).
+        let handler:
+            @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = {
+                cMessage, _ in
+                let message = cMessage.map { String(cString: $0) } ?? "<nil>"
+                MLXErrorRecovery.lock.withLock {
+                    MLXErrorRecovery._lastError = message
+                }
+                // `os_log` from the C-convention thunk is allowed (no async
+                // hops, no captures of Swift state).
+                recoveryLog.error("MLX error: \(message, privacy: .public)")
+            }
+
+        // `setErrorHandler` is marked deprecated in mlx-swift; see the file
+        // header for why the global form is the correct shape here.
+        @available(*, deprecated)
+        func setHandlerCompat() {
+            MLX.setErrorHandler(handler)
+        }
+        setHandlerCompat()
+
+        recoveryLog.info("installed global MLX error handler (process will not fatalError on MLX C++ errors)")
+    }
+}

--- a/Packages/OsaurusCore/Services/SystemMonitorService.swift
+++ b/Packages/OsaurusCore/Services/SystemMonitorService.swift
@@ -184,15 +184,19 @@ class SystemMonitorService: ObservableObject {
     }
 
     private func getStorageUsage() -> (availableGB: Double, totalGB: Double) {
+        // Bug #964: previously used `attributesOfFileSystem(.systemFreeSize)`
+        // which returns 0 for sandboxed-container paths on modern macOS —
+        // the dashboard reported `Available: 0 GB` even when Finder showed
+        // tens of GB free. `OsaurusPaths.volumeFreeBytes` uses the modern
+        // URL-keyed `.volumeAvailableCapacityForImportantUsageKey` first
+        // (the value Finder shows) and falls back to the legacy API only
+        // when the modern query is unavailable. Same helper as
+        // `ModelDownloadService.freeBytesOnVolume` so the two read-outs
+        // can never silently drift.
         let gb = 1024.0 * 1024.0 * 1024.0
-        do {
-            let attrs = try FileManager.default.attributesOfFileSystem(forPath: storagePath)
-            let total = (attrs[.systemSize] as? NSNumber)?.doubleValue ?? 0
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.doubleValue ?? 0
-            return (free / gb, total / gb)
-        } catch {
-            return (0.0, 0.0)
-        }
+        let freeBytes = OsaurusPaths.volumeFreeBytes(forPath: storagePath) ?? 0
+        let totalBytes = OsaurusPaths.volumeTotalBytes(forPath: storagePath) ?? 0
+        return (Double(freeBytes) / gb, Double(totalBytes) / gb)
     }
 
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -90,4 +90,53 @@ struct ModelProfileRegistryTests {
         // developer's locally installed model directory.
         #expect(profile?.thinkingOption == nil)
     }
+
+    /// Nemotron-3 Reasoning bundles (model_type=nemotron_h, hybrid Mamba+Attn+MoE)
+    /// must match `NemotronThinkingProfile`, NOT the generic
+    /// `AutoThinkingProfile`. The two have different `disableThinking`
+    /// defaults — Nemotron defaults to thinking-OFF (defensive, mirroring
+    /// `QwenThinkingProfile`) because the SKU's training extends `<think>`
+    /// blocks through arbitrary self-verification on validation prompts
+    /// (the trapped-thinking pattern documented in
+    /// `jang/research/NEMOTRON-OMNI-RUNTIME-2026-04-28.md` §9). Auto would
+    /// default ON and surface the loop as visible UX regression.
+    @Test("Nemotron-3 reasoning bundles match NemotronThinkingProfile (default OFF)")
+    func nemotron3_matchesNemotronProfile() {
+        for id in [
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            "nemotron-3-nano-omni-30b-a3b-mxfp4",  // case-folded picker form
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            #expect(
+                profile?.displayName == NemotronThinkingProfile.displayName,
+                "expected NemotronThinkingProfile for \(id), got \(profile?.displayName ?? "nil")"
+            )
+            // Default-OFF guards against the trapped-thinking pattern.
+            let defaultDisable = profile?.defaults["disableThinking"]?.boolValue ?? false
+            #expect(defaultDisable == true,
+                "Nemotron must default disableThinking=true to avoid trapped-thinking loops")
+        }
+    }
+
+    /// Older "Nemotron-Cascade-2" / "Nemotron-Hyper" bundles use a different
+    /// model-type lineage (deprecated NeMo style) and shouldn't accidentally
+    /// pick up the new profile. Locks the matcher specificity to `nemotron-3`.
+    @Test("Older Nemotron lineages do NOT match NemotronThinkingProfile")
+    func olderNemotron_doesNotMatch() {
+        for id in [
+            "JANGQ-AI/Nemotron-Cascade-2-30B-A3B-JANG_4M",
+            "dealignai/Nemotron-3-Super-120B-A12B-JANG_2L-CRACK",
+        ] {
+            let profile = ModelProfileRegistry.profile(for: id)
+            // Cascade-2 / Super may still match `AutoThinkingProfile` if their
+            // chat template reads `enable_thinking` — the assertion is just
+            // that they don't shortcut into the new Nemotron-3-specific
+            // profile.
+            let isNemotron3 = profile?.displayName == NemotronThinkingProfile.displayName
+            #expect(!isNemotron3 || id.lowercased().contains("nemotron-3"),
+                "matcher must be specific to nemotron-3, not generic nemotron")
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -1,0 +1,226 @@
+//
+//  MultimodalContentPartTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+/// Locks in the OpenAI-compatible `MessageContentPart` decoding for
+/// `input_audio` and `video_url` shapes plus the `ChatMessage` →
+/// `MLXLMCommon.Chat.Message` mapping that lights up Nemotron-Omni's
+/// audio + video paths via vmlx's `UserInput.audios` / `.videos` fields.
+///
+/// Without these tests, a refactor that drops the new cases or the
+/// extraction wiring (e.g. someone "simplifies" the `mapOpenAIChatToMLX`
+/// switch and forgets to re-pass `audios:` to `Chat.Message.init`) would
+/// be invisible at compile time — vmlx accepts the omitted parameter as
+/// the default `[]` — and silently route every audio request as
+/// text-only. The bug surface there is a model that just doesn't "hear"
+/// the audio attachment, with no error. Easy to ship, hard to spot.
+@Suite("Multimodal content parts (audio + video)")
+struct MultimodalContentPartTests {
+
+    // MARK: - MessageContentPart decoding
+
+    @Test("input_audio content part decodes data + format")
+    func decode_inputAudio() throws {
+        let json = """
+        {
+          "type": "input_audio",
+          "input_audio": {"data": "AAA=", "format": "wav"}
+        }
+        """.data(using: .utf8)!
+
+        let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
+        guard case .audioInput(let data, let format) = part else {
+            Issue.record("expected .audioInput, got \(part)")
+            return
+        }
+        #expect(data == "AAA=")
+        #expect(format == "wav")
+    }
+
+    @Test("video_url content part decodes url")
+    func decode_videoUrl() throws {
+        let json = """
+        {
+          "type": "video_url",
+          "video_url": {"url": "https://example.com/clip.mp4"}
+        }
+        """.data(using: .utf8)!
+
+        let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
+        guard case .videoUrl(let url) = part else {
+            Issue.record("expected .videoUrl, got \(part)")
+            return
+        }
+        #expect(url == "https://example.com/clip.mp4")
+    }
+
+    @Test("Mixed content parts round-trip via Codable")
+    func roundtrip_mixedParts() throws {
+        let original: [MessageContentPart] = [
+            .text("describe this:"),
+            .imageUrl(url: "https://example.com/x.jpg", detail: "high"),
+            .audioInput(data: "AAA=", format: "wav"),
+            .videoUrl(url: "https://example.com/y.mp4"),
+        ]
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode([MessageContentPart].self, from: encoded)
+        #expect(decoded.count == 4)
+        // Spot-check the audio + video cases survived the round-trip with
+        // their payloads intact — `MessageContentPart` is `Codable`-only,
+        // not `Equatable`, so we case-match rather than `==`.
+        if case .audioInput(let d, let f) = decoded[2] {
+            #expect(d == "AAA=")
+            #expect(f == "wav")
+        } else {
+            Issue.record("decoded[2] should be .audioInput")
+        }
+        if case .videoUrl(let u) = decoded[3] {
+            #expect(u == "https://example.com/y.mp4")
+        } else {
+            Issue.record("decoded[3] should be .videoUrl")
+        }
+    }
+
+    // MARK: - ChatMessage accessors
+
+    @Test("ChatMessage.audioInputs returns (data, format) tuples")
+    func chatMessage_audioInputs() throws {
+        let json = """
+        {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "transcribe"},
+            {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
+            {"type": "input_audio", "input_audio": {"data": "BBBB", "format": "mp3"}}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        let inputs = msg.audioInputs
+        #expect(inputs.count == 2)
+        #expect(inputs[0].data == "AAAA")
+        #expect(inputs[0].format == "wav")
+        #expect(inputs[1].data == "BBBB")
+        #expect(inputs[1].format == "mp3")
+    }
+
+    @Test("ChatMessage.videoUrls returns urls in order")
+    func chatMessage_videoUrls() throws {
+        let json = """
+        {
+          "role": "user",
+          "content": [
+            {"type": "video_url", "video_url": {"url": "https://a/1.mp4"}},
+            {"type": "text", "text": "and:"},
+            {"type": "video_url", "video_url": {"url": "https://a/2.mp4"}}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
+        let urls = msg.videoUrls
+        #expect(urls == ["https://a/1.mp4", "https://a/2.mp4"])
+    }
+
+    // MARK: - mapOpenAIChatToMLX wiring
+
+    @Test("mapOpenAIChatToMLX forwards videos to Chat.Message.videos")
+    func mapping_forwardsVideos() throws {
+        let json = """
+        [{
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "what's in this clip"},
+            {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}}
+          ]
+        }]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 1)
+        #expect(mapped[0].videos.count == 1)
+        // Video came in as an `https:` URL — it should propagate as
+        // `.url(URL)` not `.avAsset(...)` — vmlx will fetch + decode.
+        guard case .url(let u) = mapped[0].videos[0] else {
+            Issue.record("expected .url(...) for https video")
+            return
+        }
+        #expect(u.absoluteString == "https://example.com/clip.mp4")
+    }
+
+    @Test("mapOpenAIChatToMLX materializes input_audio data into temp file URL")
+    func mapping_audioMaterializesTempFile() throws {
+        // 4 bytes of bogus PCM. We're not asserting decodability here —
+        // vmlx's `nemotronOmniLoadAudioFile` is what does the AVAudioConverter
+        // pass; this test only proves the wire payload reaches a file URL
+        // with the right extension so vmlx's extension-keyed dispatch picks
+        // the right decoder.
+        let payload = Data([0x00, 0x01, 0x02, 0x03])
+        let b64 = payload.base64EncodedString()
+        let json = """
+        [{
+          "role": "user",
+          "content": [
+            {"type": "input_audio", "input_audio": {"data": "\(b64)", "format": "wav"}}
+          ]
+        }]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 1)
+        #expect(mapped[0].audios.count == 1)
+        guard case .url(let u) = mapped[0].audios[0] else {
+            Issue.record("audio source must materialize to a .url(...) for vmlx's AVAudioConverter")
+            return
+        }
+        #expect(u.pathExtension == "wav", "extension drives AVAudioConverter dispatch")
+        // Verify the bytes actually landed on disk under the expected path.
+        let written = try Data(contentsOf: u)
+        #expect(written == payload)
+        // Best-effort cleanup so the test's temp files don't accumulate
+        // across local runs. macOS evicts the system temp dir on its own
+        // schedule for the production path; tests just don't need to wait.
+        try? FileManager.default.removeItem(at: u)
+    }
+
+    @Test("mapping handles all four roles with audio + video together")
+    func mapping_allRoles_carryAudioAndVideo() throws {
+        // System messages don't carry audio in real OpenAI requests, but
+        // the *mapping* must accept them without dropping anything — this
+        // catches a regression where a refactor handles only `user` and
+        // forgets the other branches.
+        let json = """
+        [
+          {"role": "system", "content": "you are helpful"},
+          {"role": "user", "content": [
+              {"type": "text", "text": "hi"},
+              {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}
+          ]},
+          {"role": "assistant", "content": "hello"},
+          {"role": "tool", "content": "result", "tool_call_id": "abc"}
+        ]
+        """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+        #expect(mapped.count == 4)
+        // Only the user message should have audio, but every role-branch
+        // must compile against the new `audios:` parameter — that's what
+        // the assertion is really catching at the type level.
+        let userMsg = mapped[1]
+        #expect(userMsg.audios.count == 1)
+        for other in [mapped[0], mapped[2], mapped[3]] {
+            #expect(other.audios.isEmpty)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/MLXErrorRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXErrorRecoveryTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import OsaurusCore
+
+/// Guards `MLXErrorRecovery.installGlobalHandler()` — the osaurus-side bootstrap
+/// that replaces mlx-swift's default `fatalError(message)` MLX error fallback
+/// with a logging handler that lets the process keep running.
+///
+/// Without this install, **any** C++-side MLX error (shape mismatch in
+/// `rmsNorm`, broadcast mismatch, Metal validation failure) takes the entire
+/// osaurus process down via `_assertionFailure` — taking every unrelated
+/// in-flight request with it. This was the root cause symbolicated against
+/// `nemotron-cascade-2-30b-a3b-jang_4m` during PR #967 triage; the vmlx-side
+/// fix lives in `NemotronHJANGTQ.swift`, but on the osaurus side we want the
+/// server to survive any future bundle that trips a similar trap.
+///
+/// We deliberately do **not** try to trigger a real MLX error from a unit
+/// test: MLX's evaluation worker threads don't inherit Swift TaskLocals from
+/// the call site, so the scoped `withErrorHandler` API can't reliably fence
+/// off such a test from the suite-wide process. The end-to-end "real bundle
+/// failure becomes a 500, not a crash" assertion lives in integration tests
+/// (PR-967 triage harness) and is regression-protected by this test only at
+/// the install-time level.
+@Suite("MLXErrorRecovery — install path")
+struct MLXErrorRecoveryTests {
+
+    @Test("installGlobalHandler is idempotent and side-effect-free")
+    func install_idempotent() {
+        // First call installs; subsequent calls must be no-ops. The
+        // implementation guards on a flag inside its lock — without the
+        // guard, repeated install would re-run `MLX.setErrorHandler`,
+        // which itself has dtor cleanup logic that we don't want firing
+        // on every call site.
+        MLXErrorRecovery.installGlobalHandler()
+        MLXErrorRecovery.installGlobalHandler()
+        MLXErrorRecovery.installGlobalHandler()
+
+        // Surviving to here is the assertion. Anything pathological in
+        // re-install (unbalanced dtor, double-log, deadlock) would fail
+        // this case.
+        #expect(true)
+    }
+
+    @Test("lastError accessor returns without blocking when no error has fired")
+    func lastError_safeAccessor() {
+        MLXErrorRecovery.installGlobalHandler()
+        // The accessor takes the same lock the handler writes under.
+        // A naive impl that called the lock recursively from the handler
+        // (or held it across a logging call that itself synchronizes)
+        // would deadlock here in suite runs that have already exercised
+        // an MLX error in another test. Read-only path must always
+        // return promptly.
+        _ = MLXErrorRecovery.lastError
+        #expect(true)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -1,0 +1,118 @@
+//
+//  ModelRuntimeIsHybridTests.swift
+//
+//  Regression coverage for `ModelRuntime.isKnownHybridModel(name:)` —
+//  the substring-matcher that decides whether `installCacheCoordinator`
+//  eagerly calls `coordinator.setHybrid(true)` after `enableCaching`.
+//
+//  Per `vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/OMNI-OSAURUS-HOOKUP.md`
+//  §5.1 the eager-set is harmless and complementary to BatchEngine's
+//  auto-flip. The matcher is the source of truth for which model
+//  families get the eager-set; tests below lock the family list so a
+//  future drift (renaming the bundle, dropping a family, adding a new
+//  hybrid quant tier) shows up as a test diff first.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ModelRuntime.isKnownHybridModel — eager setHybrid family list")
+struct ModelRuntimeIsHybridTests {
+
+    // MARK: - Hybrid families that must flip the flag
+
+    @Test("Nemotron-3 (Mamba + Attn + MoE) — all quant tiers + picker form")
+    func nemotron3_isHybrid() {
+        for id in [
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            "nemotron-3-nano-omni-30b-a3b-mxfp4",            // case-folded picker form
+            "JANGQ-AI/Nemotron-3-Reasoning-Future-Variant",  // forward-compat
+        ] {
+            #expect(
+                ModelRuntime.isKnownHybridModel(name: id),
+                "Nemotron-3 family must flip setHybrid eagerly: \(id)")
+        }
+    }
+
+    @Test("Nemotron-Cascade-2 (older lineage) is also hybrid")
+    func nemotronCascade2_isHybrid() {
+        for id in [
+            "JANGQ-AI/Nemotron-Cascade-2-30B-A3B-JANG_4M",
+            "dealignai/Nemotron-Cascade-2-30B-A3B-JANG_2L-CRACK",
+        ] {
+            #expect(ModelRuntime.isKnownHybridModel(name: id))
+        }
+    }
+
+    @Test("Qwen 3.5 / 3.6 MoE family + Holo3 — qwen3_5_moe model_type")
+    func qwen3MoE_isHybrid() {
+        for id in [
+            "OsaurusAI/Qwen3.6-35B-A3B-mxfp4",
+            "qwen3.6-35b-a3b-jangtq4",
+            "qwen3.5-vl-9b-8bit",
+            "JANGQ-AI/Holo3-35B-A3B-JANGTQ",
+            "holo3-35b-a3b-jangtq4",
+        ] {
+            #expect(
+                ModelRuntime.isKnownHybridModel(name: id),
+                "Qwen 3.5/3.6 MoE family + Holo3 must flip setHybrid: \(id)")
+        }
+    }
+
+    @Test("MiniMax M2 / M2.7 family")
+    func minimaxM2_isHybrid() {
+        for id in [
+            "OsaurusAI/MiniMax-M2.7-JANGTQ",
+            "OsaurusAI/MiniMax-M2.7-JANGTQ4",
+            "minimax-m2.7-small-jangtq",
+        ] {
+            #expect(ModelRuntime.isKnownHybridModel(name: id))
+        }
+    }
+
+    // MARK: - Non-hybrid families that must NOT flip (regression guards)
+
+    /// Dense models without SSM layers must NOT eager-flip the hybrid flag.
+    /// Even though `setHybrid(true)` is harmless (the SSM state cache key
+    /// just misses on lookup), tagging a dense model as hybrid wastes a
+    /// per-request lookup; the matcher should be precise.
+    @Test("Dense LLM families do NOT flip setHybrid")
+    func denseFamilies_areNotHybrid() {
+        for id in [
+            "lmstudio-community/gpt-oss-20b-MLX-8bit",
+            "lmstudio-community/gpt-oss-120b-MLX-8bit",
+            "OsaurusAI/Gemma-4-31B-it-JANG_4M",
+            "OsaurusAI/gemma-4-26B-A4B-it-4bit",
+            "gemma-4-e2b-it-4bit-osaurus",
+            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",   // dense bf16, not Mamba
+            "dealignai/Mistral-Small-4-119B-JANG_2L-CRACK",
+            "foundation",                          // Apple's built-in
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "dense family must NOT flip setHybrid: \(id)")
+        }
+    }
+
+    /// DSV4-Flash JANGTQ uses Compressor/Indexer hybrid attention, but its
+    /// per-layer cache list does NOT contain `MambaCache` / `ArraysCache`
+    /// (it's a custom `DeepseekV4Cache`). vmlx's auto-flip only matches on
+    /// Mamba-style cache types, so neither path treats DSV4 as hybrid in
+    /// this sense — and DSV4 has its own `DSV4_KV_MODE` env var to control
+    /// cache topology. Lock that in: DSV4 must NOT match this family list.
+    @Test("DSV4-Flash JANGTQ does NOT match (uses DeepseekV4Cache, controlled via DSV4_KV_MODE)")
+    func dsv4Flash_isNotMambaHybrid() {
+        for id in [
+            "JANGQ-AI/DeepSeekV4-Flash-JANGTQ",
+            "deepseekv4-flash-jangtq",
+        ] {
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: id),
+                "DSV4 hybrid attention is a different cache topology than the Mamba families this matcher targets: \(id)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -140,6 +140,62 @@ public enum OsaurusPaths {
         return directorySize(at: url)
     }
 
+    // MARK: - Volume free-space query
+    //
+    // ⚠️ Use the URL-keyed `.volumeAvailableCapacityForImportantUsageKey`
+    //    rather than the legacy `attributesOfFileSystem(.systemFreeSize)`.
+    //    On modern macOS (≥ 11) inside a sandboxed container the legacy
+    //    API can return 0 because it reports raw bytes excluding the
+    //    OS's "purgeable" allowance — which is exactly what users see
+    //    in Finder. `.systemFreeSize` was the historical default and
+    //    `SystemMonitorService` shipped with it for a long time, surfacing
+    //    bug #964 (the dashboard reports `Available: 0 GB` even when the
+    //    user clearly has free space). The URL-keyed query is what
+    //    `ModelDownloadService.freeBytesOnVolume` already used; this
+    //    helper consolidates both call-sites onto the same logic so the
+    //    answer can never silently drift again.
+
+    /// Returns the free-for-important-usage byte count on the volume that
+    /// hosts `path`. Falls back to the legacy
+    /// `attributesOfFileSystem(.systemFreeSize)` only when the modern
+    /// query is unavailable. Returns `nil` if both queries fail —
+    /// callers should treat `nil` as "unknown, render 'unknown'" rather
+    /// than coercing to zero.
+    public static func volumeFreeBytes(forPath path: String) -> Int64? {
+        let url = URL(fileURLWithPath: path)
+        let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
+        if let values = try? url.resourceValues(forKeys: keys),
+            let capacity = values.volumeAvailableCapacityForImportantUsage
+        {
+            return capacity
+        }
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
+        {
+            return free
+        }
+        return nil
+    }
+
+    /// Returns total volume capacity in bytes for the volume that hosts
+    /// `path`. Uses `.volumeTotalCapacityKey` first, legacy `.systemSize`
+    /// as fallback. Returns `nil` on full failure.
+    public static func volumeTotalBytes(forPath path: String) -> Int64? {
+        let url = URL(fileURLWithPath: path)
+        let keys: Set<URLResourceKey> = [.volumeTotalCapacityKey]
+        if let values = try? url.resourceValues(forKeys: keys),
+            let capacity = values.volumeTotalCapacity
+        {
+            return Int64(capacity)
+        }
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
+            let total = (attrs[.systemSize] as? NSNumber)?.int64Value
+        {
+            return total
+        }
+        return nil
+    }
+
     /// Deletes every file under the disk KV cache directory. The directory
     /// itself is left in place (re-created on next model load via
     /// `ensureExistsSilent`). Safe to call while models are loaded — the


### PR DESCRIPTION
## Summary

Wire OpenAI-compatible `input_audio` and `video_url` content parts through the HTTP API into vmlx-swift-lm's `LMInput.audios` / `LMInput.videos` — closes the host-side gap so coding-agent clients (Codex, opencode, Continue) can drive multimodal inference against models like Nemotron-3-Nano-Omni without a custom client.

## API surface added

`MessageContentPart` (`Networking/HTTPHandler.swift` + `Models/Chat/ChatMessage.swift`):
- `.audioInput(data: Data, format: String)` — OpenAI `input_audio.{data, format}` (data is base64-decoded raw bytes, `format` ∈ `wav`, `mp3`, `flac`)
- `.videoUrl(String)` — OpenAI `video_url.url` (file URL or remote URL)

`ChatMessage` gains `audioInputs: [(data: Data, format: String)]` and `videoUrls: [String]` accessors. The encoder serializes any non-text content parts as arrays so requests round-trip cleanly when persistence is enabled.

`mapOpenAIChatToMLX` populates `MLXLMCommon.Chat.Message.audios` and `.videos` from these parts. With the vmlx pin bumped (already on this branch's base), `UserInput(chat:)` forwards these collections automatically — no further osaurus-side wiring needed for Nemotron-Omni's Parakeet (audio) and RADIO (video) towers.

## Stack

This PR is stacked on **#967** (Nemotron-3 + storage + ErrorHandler + revision-pinned mlx-swift fork). #967 must merge first; the rebase here is clean and green.

## Test plan

- [x] OsaurusCore unit tests: 1190 / 1190 in 163 suites pass on this branch's base
- [x] vmlx focused tests against pinned `13abe40`: 30 / 30 pass
- [x] OmniBench against real Nemotron-3-Nano-Omni-30B-A3B-MXFP4 weights: 13 / 13 pass — text + image (single + multi-turn) + video LMInput end-to-end + audio LMInput end-to-end + mixed image+audio one turn + media-salt isolation + reasoning toggle + hybrid SSM warm-pass parity
- [x] StabilityBench: 10 / 10 pass — including warm-disk-cache 2nd-request, 8-turn agent loop, 16k-token long prompt, cancel + recovery, concurrent batched B=2, TQ KV mode + disk round-trip, hybrid SSM disk round-trip
- [ ] Reviewer to verify osaurus-side OpenAI body shapes round-trip with persistence on/off (existing `LocalGenerationDefaultsTests` cover the request mapper, but a small UI smoke is worth a final eye)

## Hand-off docs

`vmlx-swift-lm/Libraries/MLXLMCommon/BatchEngine/OSAURUS-RELEASE-HANDOFF.md` and `OSAURUS-TEAM-BUILD-GUIDE.md` (`§17` "API surface (host-facing)") document the OpenAI body-shape mapping plus the entire `LMInput` surface for image / video / audio.

## Known follow-up — not in this PR

Over-cap hybrid-prompt allocation (`metal::malloc 154 GB` territory) — observed on M5 with peak 418 GB absorbed only by 128 GB unified memory + macOS swap. Smaller machines remain susceptible. Needs `mx::malloc > 1 GB` allocation tracer in the mlx fork to pin the exact site before designing the right-shape clamp. Documented in `OSAURUS-RELEASE-HANDOFF.md` "NOT in this PR" section.