### PR TITLE
fixed budget preview related issues, smaller context model management

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -667,7 +667,8 @@ extension ModelManager {
         MLXModel(
             id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
             name: ModelMetadataParser.friendlyName(
-                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"),
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"
+            ),
             description:
                 "NVIDIA Nemotron-3 30B Reasoning hybrid (Mamba-2 + MoE). MXFP4 quantization — fastest decode path. 262K context.",
             downloadURL:
@@ -681,7 +682,8 @@ extension ModelManager {
         MLXModel(
             id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
             name: ModelMetadataParser.friendlyName(
-                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4"),
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4"
+            ),
             description:
                 "Nemotron-3 30B Reasoning hybrid, 4-bit TurboQuant routed experts. Near-bf16 quality at ~16 GB. 262K context.",
             downloadURL:
@@ -694,7 +696,8 @@ extension ModelManager {
         MLXModel(
             id: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
             name: ModelMetadataParser.friendlyName(
-                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ"),
+                from: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ"
+            ),
             description:
                 "Nemotron-3 30B Reasoning hybrid, 2-bit TurboQuant routed experts. Smallest footprint (~9 GB). 262K context.",
             downloadURL:
@@ -795,7 +798,8 @@ extension ModelManager {
         MLXModel(
             id: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",
             name: ModelMetadataParser.friendlyName(
-                from: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4"),
+                from: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4"
+            ),
             description:
                 "Mistral Medium 3.5 128B + Pixtral vision. MXFP4 quant — fastest decode. 256K context, 24-language coverage.",
             downloadURL:
@@ -808,7 +812,8 @@ extension ModelManager {
         MLXModel(
             id: "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2",
             name: ModelMetadataParser.friendlyName(
-                from: "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2"),
+                from: "OsaurusAI/Mistral-Medium-3.5-128B-JANGTQ2"
+            ),
             description:
                 "Mistral Medium 3.5 128B + Pixtral vision, 2-bit TurboQuant text decoder. ~36 GB footprint. 256K context, 24-language coverage.",
             downloadURL:

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -443,7 +443,8 @@ extension ChatMessage {
             // file extension (NOT downgraded to .m4a — see audit fix).
             let base64 = data.base64EncodedString()
             parts.append(
-                .videoUrl(url: "data:video/\(mimeSubtype);base64,\(base64)"))
+                .videoUrl(url: "data:video/\(mimeSubtype);base64,\(base64)")
+            )
         }
 
         self.contentParts = parts.isEmpty ? nil : parts

--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -211,7 +211,7 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         case .document(let name, _, _), .documentRef(let name, _, _):
             return name
         case .audio(_, _, let name), .audioRef(_, _, _, let name),
-             .video(_, let name), .videoRef(_, _, let name):
+            .video(_, let name), .videoRef(_, _, let name):
             return name
         default:
             return nil

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -38,16 +38,28 @@ public enum ModelMediaCapabilities {
         public let supportsAudio: Bool
 
         public static let textOnly = Capabilities(
-            supportsImage: false, supportsVideo: false, supportsAudio: false)
+            supportsImage: false,
+            supportsVideo: false,
+            supportsAudio: false
+        )
 
         public static let imageOnly = Capabilities(
-            supportsImage: true, supportsVideo: false, supportsAudio: false)
+            supportsImage: true,
+            supportsVideo: false,
+            supportsAudio: false
+        )
 
         public static let imageVideo = Capabilities(
-            supportsImage: true, supportsVideo: true, supportsAudio: false)
+            supportsImage: true,
+            supportsVideo: true,
+            supportsAudio: false
+        )
 
         public static let omni = Capabilities(
-            supportsImage: true, supportsVideo: true, supportsAudio: true)
+            supportsImage: true,
+            supportsVideo: true,
+            supportsAudio: true
+        )
 
         public var anyMedia: Bool {
             supportsImage || supportsVideo || supportsAudio

--- a/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
@@ -29,6 +29,10 @@ public struct ContextBreakdown: Equatable, Sendable {
     public var context: [Entry]
     /// Conversation + input + output
     public var messages: [Entry]
+    /// When non-nil, the popover renders an italic notice explaining
+    /// which knobs the size-class auto-disable turned off and why.
+    /// Threaded from `ComposedContext.contextDisable`.
+    public var disable: ContextDisableInfo?
 
     public var total: Int {
         context.reduce(0) { $0 + $1.tokens } + messages.reduce(0) { $0 + $1.tokens }
@@ -36,7 +40,7 @@ public struct ContextBreakdown: Equatable, Sendable {
 
     public var allEntries: [Entry] { context + messages }
 
-    public static let zero = ContextBreakdown(context: [], messages: [])
+    public static let zero = ContextBreakdown(context: [], messages: [], disable: nil)
 
     /// Tint for a given prompt section ID.
     static func tint(for sectionId: String) -> Tint {
@@ -61,7 +65,7 @@ public struct ContextBreakdown: Equatable, Sendable {
         outputTokens: Int = 0
     ) -> ContextBreakdown {
         let memoryTokens = composed.memorySection.map { estimateTokens(for: $0) } ?? 0
-        return .from(
+        var breakdown = ContextBreakdown.from(
             manifest: composed.manifest,
             toolTokens: composed.toolTokens,
             memoryTokens: memoryTokens,
@@ -69,6 +73,8 @@ public struct ContextBreakdown: Equatable, Sendable {
             inputTokens: inputTokens,
             outputTokens: outputTokens
         )
+        breakdown.disable = composed.contextDisable
+        return breakdown
     }
 
     /// Build a breakdown from a manifest + tool tokens. `memoryTokens` is
@@ -100,7 +106,7 @@ public struct ContextBreakdown: Equatable, Sendable {
         if inputTokens > 0 { msgs.append(Entry(id: "input", label: "Input", tokens: inputTokens, tint: .cyan)) }
         if outputTokens > 0 { msgs.append(Entry(id: "output", label: "Output", tokens: outputTokens, tint: .green)) }
 
-        return ContextBreakdown(context: ctx, messages: msgs)
+        return ContextBreakdown(context: ctx, messages: msgs, disable: nil)
     }
 
     private static func estimateTokens(for text: String) -> Int {

--- a/Packages/OsaurusCore/Services/Chat/ContextSizeClass.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextSizeClass.swift
@@ -1,0 +1,149 @@
+//
+//  ContextSizeClass.swift
+//  osaurus
+//
+//  Per-model context-window classification used to auto-disable
+//  prompt features that don't fit into very small windows. Apple's
+//  Foundation model has a ~4K window; even before any user message
+//  the always-loaded tool schemas push past it. The system-prompt
+//  composer reads this resolver at compose time and ORs the result
+//  into the agent's effective tools/memory disable flags so we never
+//  ship a request that's already over budget.
+//
+
+import Foundation
+
+// MARK: - ContextSizeClass
+
+/// Coarse classification of a model's nominal context window. Three
+/// buckets are enough — the prompt composer only needs to decide
+/// whether to disable tools (tiny only) and/or memory (tiny + small).
+public enum ContextSizeClass: Sendable, Equatable {
+    /// `<= 4096` tokens. Apple Foundation and any equally tight
+    /// future model. Tools, memory, and skill suggestions all auto
+    /// off — at this size even the always-loaded tool JSON schemas
+    /// cost more than the available budget.
+    case tiny
+
+    /// `<= 8192` tokens. Fits a reasonable chat schema but not
+    /// memory snippets, which are the most volatile dynamic input
+    /// and the easiest to drop without breaking the loop.
+    case small
+
+    /// Larger than `8192` tokens, or unknown. No auto-overrides.
+    case normal
+
+    /// Whether this class auto-disables tools (and the entire
+    /// gated-section surface that depends on tools, including
+    /// agent-loop guidance, capability discovery, skill suggestions,
+    /// and the model-family nudge).
+    public var disablesTools: Bool { self == .tiny }
+
+    /// Whether this class auto-disables memory injection. Memory is
+    /// the per-turn snippet prepended to the user message, not part
+    /// of the system prompt, so disabling it is independent of the
+    /// tools axis.
+    public var disablesMemory: Bool { self != .normal }
+}
+
+// MARK: - ContextDisableInfo
+
+/// Surfaced on `ComposedContext` so the chat UI can render an
+/// italic "auto-disabled by context size" notice without re-deriving
+/// the decision. `nil` on `ComposedContext` means no override fired.
+public struct ContextDisableInfo: Equatable, Sendable {
+    public let sizeClass: ContextSizeClass
+    public let modelId: String?
+    public let contextLength: Int?
+    public let disabledTools: Bool
+    public let disabledMemory: Bool
+
+    public init(
+        sizeClass: ContextSizeClass,
+        modelId: String?,
+        contextLength: Int?,
+        disabledTools: Bool,
+        disabledMemory: Bool
+    ) {
+        self.sizeClass = sizeClass
+        self.modelId = modelId
+        self.contextLength = contextLength
+        self.disabledTools = disabledTools
+        self.disabledMemory = disabledMemory
+    }
+
+    /// Build the popover-facing summary for a resolved size class.
+    /// Returns `nil` when the class is `.normal` or both axes were
+    /// already off at the agent level (nothing for the auto-disable
+    /// to take credit for). Centralised so `composeChatContext` and
+    /// `composePreviewContext` produce identical info.
+    public init?(
+        sizeClass: ContextSizeClass,
+        modelId: String?,
+        contextLength: Int?,
+        agentToolsOff: Bool,
+        agentMemoryOff: Bool
+    ) {
+        let disabledTools = sizeClass.disablesTools && !agentToolsOff
+        let disabledMemory = sizeClass.disablesMemory && !agentMemoryOff
+        guard sizeClass != .normal, disabledTools || disabledMemory else { return nil }
+        self.init(
+            sizeClass: sizeClass,
+            modelId: modelId,
+            contextLength: contextLength,
+            disabledTools: disabledTools,
+            disabledMemory: disabledMemory
+        )
+    }
+}
+
+// MARK: - Resolver
+
+/// Resolves a model id to a `ContextSizeClass` and concrete context
+/// length. Pure function — no shared mutable state, no main-actor
+/// hops — so it's safe to call from `composePreviewContext` (sync)
+/// and `composeChatContext` (async) alike.
+public enum ContextSizeResolver {
+
+    /// Tiny ceiling. Anything at or below this, including all of
+    /// Foundation, is `.tiny`. Matches `FloatingInputCard`'s
+    /// hardcoded Foundation cap.
+    public static let tinyCeiling: Int = 4096
+
+    /// Small ceiling. Anything at or below this (and above `tinyCeiling`)
+    /// is `.small`. Tuned for 8K-window MLX builds (e.g. quantised
+    /// Phi-mini, smaller Qwen variants).
+    public static let smallCeiling: Int = 8192
+
+    /// Resolve the size class for a given model id.
+    /// - Parameter modelId: The picker / API model identifier. May
+    ///   be `nil` when the chat hasn't picked a model yet (preview
+    ///   composer on a fresh window) — in that case the caller
+    ///   doesn't know the budget, so we conservatively return
+    ///   `.normal` to avoid hiding tools speculatively.
+    public static func resolve(modelId: String?) -> (ContextSizeClass, Int?) {
+        guard let modelId, !modelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return (.normal, nil) }
+
+        // Foundation's nominal context isn't readable through
+        // `ModelInfo.load` (no MLX `config.json` on disk). Match the
+        // same alias rule as `FoundationModelService.handles` — that
+        // method lives on an actor (no shared singleton) so we
+        // duplicate the three-line check rather than spin one up just
+        // to call it.
+        let trimmed = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.caseInsensitiveCompare("foundation") == .orderedSame
+            || trimmed.caseInsensitiveCompare("default") == .orderedSame
+        {
+            return (.tiny, tinyCeiling)
+        }
+
+        guard let info = ModelInfo.load(modelId: modelId),
+            let ctx = info.model.contextLength
+        else { return (.normal, nil) }
+
+        if ctx <= tinyCeiling { return (.tiny, ctx) }
+        if ctx <= smallCeiling { return (.small, ctx) }
+        return (.normal, ctx)
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -158,4 +158,9 @@ struct ComposedContext: Sendable {
     /// The prefix cache should be built from this content (not the full prompt)
     /// so the cached KV exactly matches the reusable portion across requests.
     let staticPrefix: String
+    /// Auto-disable summary when the selected model's context window is
+    /// too small for the full feature set. `nil` means "no override
+    /// fired" (normal-class model). Callers surface this through
+    /// `ContextBreakdown.disable` so the popover can render a notice.
+    let contextDisable: ContextDisableInfo?
 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -167,23 +167,6 @@ public struct SystemPromptComposer: Sendable {
             : await assembleMemorySection(agentId: agentId.uuidString)
         trace?.mark("memory_done")
 
-        // Surface a "sandbox unavailable" notice when the agent wants
-        // sandbox tools but registration couldn't provide them — otherwise
-        // the model hallucinates sandbox calls that never get a result.
-        if !executionMode.usesSandboxTools,
-            autonomousEnabled,
-            let reason = SandboxToolRegistrar.shared.unavailabilityReason(for: agentId)
-        {
-            comp.append(
-                .dynamic(
-                    id: "sandboxUnavailable",
-                    label: "Sandbox Unavailable",
-                    content: Self.sandboxUnavailableNotice(reason: reason)
-                )
-            )
-            trace?.set("sandboxUnavailable", reason.kind.rawValue)
-        }
-
         let preflight: PreflightResult
         if let cachedPreflight {
             preflight = cachedPreflight
@@ -210,11 +193,12 @@ public struct SystemPromptComposer: Sendable {
         // explicitly-enabled set and aren't part of pre-flight (preflight only
         // ranks tools). Per-item Enabled toggles in the capability picker are
         // the single source of truth for what reaches the system prompt.
-        if !effectiveToolsOff,
-            let section = await SkillManager.shared.enabledSkillPromptSection(for: agentId)
-        {
-            comp.append(.dynamic(id: "skills", label: "Skills", content: section))
-        }
+        // Awaited here so `appendGatedSections` can stay synchronous and be
+        // shared with the preview composer.
+        let skillSection: String? =
+            effectiveToolsOff
+            ? nil
+            : await SkillManager.shared.enabledSkillPromptSection(for: agentId)
 
         trace?.mark("resolve_tools_start")
         let tools = resolveTools(
@@ -226,22 +210,107 @@ public struct SystemPromptComposer: Sendable {
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
         )
         trace?.mark("resolve_tools_done")
-        // Capture the always-loaded names present in this turn's schema so
-        // callers can stash the snapshot for the next turn. When a snapshot
-        // was supplied, just echo it; otherwise compute fresh from the
-        // registry. The transient `sandbox_init_pending` placeholder is
-        // dropped from a fresh snapshot so it doesn't pin into future turns
-        // — see the `filterFrozen` carve-outs in `resolveTools` for why.
-        let alwaysLoadedNames: Set<String>
-        if let frozenAlwaysLoadedNames {
-            alwaysLoadedNames = frozenAlwaysLoadedNames
-        } else {
-            let live = ToolRegistry.shared.alwaysLoadedSpecs(mode: executionMode)
-                .map { $0.function.name }
-            let resolved = Set(tools.map { $0.function.name })
-            alwaysLoadedNames = Set(live)
-                .intersection(resolved)
-                .subtracting([BuiltinSandboxTools.initPendingToolName])
+        let alwaysLoadedNames = resolveAlwaysLoadedNames(
+            tools: tools,
+            executionMode: executionMode,
+            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
+        )
+
+        appendGatedSections(
+            composer: &comp,
+            agentId: agentId,
+            executionMode: executionMode,
+            model: model,
+            tools: tools,
+            preflight: preflight,
+            effectiveToolsOff: effectiveToolsOff,
+            autonomousEnabled: autonomousEnabled,
+            canCreatePlugins: canCreatePlugins,
+            toolMode: toolMode,
+            skillSection: skillSection,
+            trace: trace
+        )
+
+        let manifest = comp.manifest()
+        let toolNames = tools.map { $0.function.name }
+        debugLog("[Context] \(manifest.debugDescription)")
+        emitToolDiagnostics(
+            tools: tools,
+            toolMode: toolMode,
+            preflight: preflight,
+            executionMode: executionMode,
+            autonomousEnabled: autonomousEnabled,
+            effectiveToolsOff: effectiveToolsOff,
+            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+            additionalToolNames: additionalToolNames,
+            trace: trace
+        )
+
+        let rendered = comp.render()
+        trace?.set("systemPromptChars", rendered.count)
+        trace?.set("toolCount", tools.count)
+        trace?.set("preflightItems", preflight.items.count)
+
+        return ComposedContext(
+            prompt: rendered,
+            manifest: manifest,
+            tools: tools,
+            toolTokens: ToolRegistry.shared.totalEstimatedTokens(for: tools),
+            preflightItems: preflight.items,
+            preflight: preflight,
+            memorySection: memorySection,
+            alwaysLoadedNames: alwaysLoadedNames,
+            cacheHint: manifest.staticPrefixHash(toolNames: toolNames),
+            staticPrefix: manifest.staticPrefixContent
+        )
+    }
+
+    /// Append every gated "deterministic" prompt section (sandbox notice,
+    /// skills, plugin companions, agent loop, capability nudge, model
+    /// family, plugin creator) given the resolved tool set + preflight.
+    ///
+    /// Shared between the real send path (`finalizeContext`) and the sync
+    /// preview path (`composePreviewContext`) so the welcome-screen budget
+    /// popover lists the same sections the next send will produce, modulo
+    /// the two query-dependent ones (preflight tools + plugin companions).
+    /// `skillSection` is awaited by the caller — keeping this body sync is
+    /// what lets the preview composer reuse it without going async.
+    @MainActor
+    private static func appendGatedSections(
+        composer: inout SystemPromptComposer,
+        agentId: UUID,
+        executionMode: ExecutionMode,
+        model: String?,
+        tools: [Tool],
+        preflight: PreflightResult,
+        effectiveToolsOff: Bool,
+        autonomousEnabled: Bool,
+        canCreatePlugins: Bool,
+        toolMode: ToolSelectionMode,
+        skillSection: String?,
+        trace: TTFTTrace? = nil
+    ) {
+        // Surface a "sandbox unavailable" notice when the agent wants
+        // sandbox tools but registration couldn't provide them — otherwise
+        // the model hallucinates sandbox calls that never get a result.
+        if !executionMode.usesSandboxTools,
+            autonomousEnabled,
+            let reason = SandboxToolRegistrar.shared.unavailabilityReason(for: agentId)
+        {
+            composer.append(
+                .dynamic(
+                    id: "sandboxUnavailable",
+                    label: "Sandbox Unavailable",
+                    content: Self.sandboxUnavailableNotice(reason: reason)
+                )
+            )
+            trace?.set("sandboxUnavailable", reason.kind.rawValue)
+        }
+
+        // `composer.append` no-ops on whitespace-only content via
+        // `PromptSection.isEmpty`, so we don't need a separate trim guard.
+        if !effectiveToolsOff, let section = skillSection {
+            composer.append(.dynamic(id: "skills", label: "Skills", content: section))
         }
 
         // Plugin Companions: when preflight picked a tool from a plugin,
@@ -259,7 +328,7 @@ public struct SystemPromptComposer: Sendable {
             tools.contains(where: { $0.function.name == "capabilities_load" }),
             let companionsSection = PreflightCompanions.render(preflight.companions)
         {
-            comp.append(
+            composer.append(
                 .dynamic(
                     id: "pluginCompanions",
                     label: "Plugin Companions",
@@ -279,7 +348,7 @@ public struct SystemPromptComposer: Sendable {
             let resolvedNames = Set(tools.map { $0.function.name })
             let loopNames: Set<String> = ["todo", "complete", "clarify", "share_artifact"]
             if !resolvedNames.isDisjoint(with: loopNames) {
-                comp.append(
+                composer.append(
                     .static(
                         id: "agentLoopGuidance",
                         label: "Agent Loop",
@@ -298,7 +367,7 @@ public struct SystemPromptComposer: Sendable {
             !effectiveToolsOff,
             tools.contains(where: { $0.function.name == "capabilities_search" })
         {
-            comp.append(
+            composer.append(
                 .static(
                     id: "capabilityNudge",
                     label: "Capability Discovery",
@@ -315,7 +384,7 @@ public struct SystemPromptComposer: Sendable {
         if !effectiveToolsOff,
             let familyGuidance = ModelFamilyGuidance.guidance(forModelId: model)
         {
-            comp.append(
+            composer.append(
                 .static(
                     id: "modelFamilyGuidance",
                     label: "Model Family Guidance",
@@ -351,7 +420,7 @@ public struct SystemPromptComposer: Sendable {
             skillEnabled: pluginCreatorSkill?.enabled ?? false
         )
         if PluginCreatorGate.shouldInject(gateInputs), let skill = pluginCreatorSkill {
-            comp.append(
+            composer.append(
                 .dynamic(
                     id: "pluginCreator",
                     label: "Plugin Creator",
@@ -363,35 +432,100 @@ public struct SystemPromptComposer: Sendable {
             )
             trace?.set("pluginCreatorInjected", "1")
         }
+    }
 
-        let manifest = comp.manifest()
-        let toolNames = tools.map { $0.function.name }
-        debugLog("[Context] \(manifest.debugDescription)")
-        emitToolDiagnostics(
-            tools: tools,
-            toolMode: toolMode,
-            preflight: preflight,
+    /// Capture the always-loaded names present in this turn's schema so
+    /// callers can stash the snapshot for the next turn. When a snapshot
+    /// was supplied, just echo it; otherwise compute fresh from the
+    /// registry. The transient `sandbox_init_pending` placeholder is
+    /// dropped from a fresh snapshot so it doesn't pin into future turns
+    /// — see the `filterFrozen` carve-outs in `resolveTools` for why.
+    /// Shared between `finalizeContext` and `composePreviewContext` so
+    /// both paths produce the same `ComposedContext.alwaysLoadedNames`.
+    @MainActor
+    private static func resolveAlwaysLoadedNames(
+        tools: [Tool],
+        executionMode: ExecutionMode,
+        frozenAlwaysLoadedNames: Set<String>?
+    ) -> Set<String> {
+        if let frozenAlwaysLoadedNames {
+            return frozenAlwaysLoadedNames
+        }
+        let live = ToolRegistry.shared.alwaysLoadedSpecs(mode: executionMode)
+            .map { $0.function.name }
+        let resolved = Set(tools.map { $0.function.name })
+        return Set(live)
+            .intersection(resolved)
+            .subtracting([BuiltinSandboxTools.initPendingToolName])
+    }
+
+    /// Synchronous preview compose for the welcome-screen Context Budget
+    /// popover. Mirrors `composeChatContext` so the popover lists the same
+    /// sections the next send will emit, with two intentional gaps:
+    ///
+    /// - **preflight tool delta**: needs a non-empty user query and an
+    ///   LLM call, so auto-mode `Tools` under-counts on turn 1.
+    /// - **`pluginCompanions`**: derived from preflight, always empty here.
+    ///
+    /// Memory is also out of scope (it's prepended to the user message,
+    /// not the system prompt) — callers feed the per-turn estimate to
+    /// `ContextBreakdown.from` separately, which surfaces the `Memory` row.
+    ///
+    /// `cachedSkillsSection` is the skill prompt section the chat session
+    /// pre-loaded asynchronously; `nil` collapses the `Skills` row.
+    @MainActor
+    static func composePreviewContext(
+        agentId: UUID,
+        executionMode: ExecutionMode,
+        model: String? = nil,
+        cachedSkillsSection: String? = nil
+    ) -> ComposedContext {
+        var composer = forChat(agentId: agentId, executionMode: executionMode, model: model)
+
+        let effectiveToolsOff = AgentManager.shared.effectiveToolsDisabled(for: agentId)
+        let autonomousConfig = AgentManager.shared.effectiveAutonomousExec(for: agentId)
+        let autonomousEnabled = autonomousConfig?.enabled == true
+        let canCreatePlugins = autonomousConfig.map { $0.enabled && $0.pluginCreate } ?? false
+        let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
+
+        let tools = resolveTools(
+            agentId: agentId,
             executionMode: executionMode,
-            autonomousEnabled: autonomousEnabled,
-            effectiveToolsOff: effectiveToolsOff,
-            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
-            additionalToolNames: additionalToolNames,
-            trace: trace
+            toolsDisabled: effectiveToolsOff
         )
 
-        let rendered = comp.render()
-        trace?.set("systemPromptChars", rendered.count)
-        trace?.set("toolCount", tools.count)
-        trace?.set("preflightItems", preflight.items.count)
+        appendGatedSections(
+            composer: &composer,
+            agentId: agentId,
+            executionMode: executionMode,
+            model: model,
+            tools: tools,
+            preflight: .empty,
+            effectiveToolsOff: effectiveToolsOff,
+            autonomousEnabled: autonomousEnabled,
+            canCreatePlugins: canCreatePlugins,
+            toolMode: toolMode,
+            skillSection: cachedSkillsSection
+        )
+
+        let alwaysLoadedNames = resolveAlwaysLoadedNames(
+            tools: tools,
+            executionMode: executionMode,
+            frozenAlwaysLoadedNames: nil
+        )
+
+        let manifest = composer.manifest()
+        let toolNames = tools.map { $0.function.name }
+        let rendered = composer.render()
 
         return ComposedContext(
             prompt: rendered,
             manifest: manifest,
             tools: tools,
             toolTokens: ToolRegistry.shared.totalEstimatedTokens(for: tools),
-            preflightItems: preflight.items,
-            preflight: preflight,
-            memorySection: memorySection,
+            preflightItems: [],
+            preflight: .empty,
+            memorySection: nil,
             alwaysLoadedNames: alwaysLoadedNames,
             cacheHint: manifest.staticPrefixHash(toolNames: toolNames),
             staticPrefix: manifest.staticPrefixContent

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -149,12 +149,31 @@ public struct SystemPromptComposer: Sendable {
     ) async -> ComposedContext {
         var comp = composer
 
-        let effectiveToolsOff = toolsDisabled || AgentManager.shared.effectiveToolsDisabled(for: agentId)
-        let memoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentId)
+        let agentToolsOff = toolsDisabled || AgentManager.shared.effectiveToolsDisabled(for: agentId)
+        let agentMemoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentId)
         let autonomousConfig = AgentManager.shared.effectiveAutonomousExec(for: agentId)
         let autonomousEnabled = autonomousConfig?.enabled == true
         let canCreatePlugins = autonomousConfig.map { $0.enabled && $0.pluginCreate } ?? false
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
+
+        // Auto-disable for small-context models (Foundation et al.).
+        // OR into the agent's flags so every downstream gate (preflight,
+        // skills, agent loop, capability nudge, model family, plugin
+        // creator, memory assembly) cascades correctly without each
+        // gate having to know about the size class itself.
+        let (sizeClass, contextLength) = ContextSizeResolver.resolve(modelId: model)
+        let effectiveToolsOff = agentToolsOff || sizeClass.disablesTools
+        let memoryOff = agentMemoryOff || sizeClass.disablesMemory
+        let contextDisable = ContextDisableInfo(
+            sizeClass: sizeClass,
+            modelId: model,
+            contextLength: contextLength,
+            agentToolsOff: agentToolsOff,
+            agentMemoryOff: agentMemoryOff
+        )
+        if contextDisable != nil {
+            trace?.set("contextSizeClass", String(describing: sizeClass))
+        }
 
         // Memory is assembled here but returned separately (see ComposedContext.memorySection).
         // We deliberately do NOT pass `query` so the cached memory snapshot
@@ -189,17 +208,6 @@ public struct SystemPromptComposer: Sendable {
             trace?.set("preflightSource", "skipped")
         }
 
-        // Skills inject in BOTH Auto and Manual modes — they're the user's
-        // explicitly-enabled set and aren't part of pre-flight (preflight only
-        // ranks tools). Per-item Enabled toggles in the capability picker are
-        // the single source of truth for what reaches the system prompt.
-        // Awaited here so `appendGatedSections` can stay synchronous and be
-        // shared with the preview composer.
-        let skillSection: String? =
-            effectiveToolsOff
-            ? nil
-            : await SkillManager.shared.enabledSkillPromptSection(for: agentId)
-
         trace?.mark("resolve_tools_start")
         let tools = resolveTools(
             agentId: agentId,
@@ -216,6 +224,30 @@ public struct SystemPromptComposer: Sendable {
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
         )
 
+        // Skill suggestions: when the user's query semantically matches
+        // a standalone (non-plugin) skill, surface it as a compact
+        // teaser the model can pull in via `capabilities_load`. Same
+        // gates as preflight (auto mode + tools on + non-empty query)
+        // plus `capabilities_load` in the schema so the loader nudge
+        // is actionable. Skills already surfaced via plugin companions
+        // or already loaded mid-session are filtered out so the model
+        // doesn't see the same name twice.
+        let skillSuggestions: [SkillTeaser] = await {
+            guard toolMode == .auto, !effectiveToolsOff, !query.isEmpty,
+                tools.contains(where: { $0.function.name == "capabilities_load" })
+            else { return [] }
+            let alreadySurfaced = Set(preflight.companions.compactMap(\.skill?.name))
+                .union(additionalToolNames)
+            trace?.mark("skill_suggestions_start")
+            let teasers = await PreflightCompanions.deriveSkillSuggestions(
+                query: query,
+                alreadyLoadedSkillNames: alreadySurfaced
+            )
+            trace?.mark("skill_suggestions_done")
+            trace?.set("skillSuggestions", String(teasers.count))
+            return teasers
+        }()
+
         appendGatedSections(
             composer: &comp,
             agentId: agentId,
@@ -223,11 +255,11 @@ public struct SystemPromptComposer: Sendable {
             model: model,
             tools: tools,
             preflight: preflight,
+            skillSuggestions: skillSuggestions,
             effectiveToolsOff: effectiveToolsOff,
             autonomousEnabled: autonomousEnabled,
             canCreatePlugins: canCreatePlugins,
             toolMode: toolMode,
-            skillSection: skillSection,
             trace: trace
         )
 
@@ -261,20 +293,26 @@ public struct SystemPromptComposer: Sendable {
             memorySection: memorySection,
             alwaysLoadedNames: alwaysLoadedNames,
             cacheHint: manifest.staticPrefixHash(toolNames: toolNames),
-            staticPrefix: manifest.staticPrefixContent
+            staticPrefix: manifest.staticPrefixContent,
+            contextDisable: contextDisable
         )
     }
 
     /// Append every gated "deterministic" prompt section (sandbox notice,
-    /// skills, plugin companions, agent loop, capability nudge, model
-    /// family, plugin creator) given the resolved tool set + preflight.
+    /// plugin companions, agent loop, capability nudge, model family,
+    /// plugin creator) given the resolved tool set + preflight.
     ///
     /// Shared between the real send path (`finalizeContext`) and the sync
     /// preview path (`composePreviewContext`) so the welcome-screen budget
     /// popover lists the same sections the next send will produce, modulo
     /// the two query-dependent ones (preflight tools + plugin companions).
-    /// `skillSection` is awaited by the caller — keeping this body sync is
-    /// what lets the preview composer reuse it without going async.
+    ///
+    /// Skills are intentionally NOT injected here — they're discovered via
+    /// `capabilities_search` and pulled in via `capabilities_load` instead.
+    /// Surfacing every enabled skill in the system prompt routinely blew
+    /// the budget on small-context models (55k+ tokens with reference
+    /// inlining); the loader path keeps the schema small and lets the
+    /// model decide which skill bodies it actually needs.
     @MainActor
     private static func appendGatedSections(
         composer: inout SystemPromptComposer,
@@ -283,11 +321,11 @@ public struct SystemPromptComposer: Sendable {
         model: String?,
         tools: [Tool],
         preflight: PreflightResult,
+        skillSuggestions: [SkillTeaser] = [],
         effectiveToolsOff: Bool,
         autonomousEnabled: Bool,
         canCreatePlugins: Bool,
         toolMode: ToolSelectionMode,
-        skillSection: String?,
         trace: TTFTTrace? = nil
     ) {
         // Surface a "sandbox unavailable" notice when the agent wants
@@ -305,12 +343,6 @@ public struct SystemPromptComposer: Sendable {
                 )
             )
             trace?.set("sandboxUnavailable", reason.kind.rawValue)
-        }
-
-        // `composer.append` no-ops on whitespace-only content via
-        // `PromptSection.isEmpty`, so we don't need a separate trim guard.
-        if !effectiveToolsOff, let section = skillSection {
-            composer.append(.dynamic(id: "skills", label: "Skills", content: section))
         }
 
         // Plugin Companions: when preflight picked a tool from a plugin,
@@ -336,6 +368,27 @@ public struct SystemPromptComposer: Sendable {
                 )
             )
             trace?.set("pluginCompanions", String(preflight.companions.count))
+        }
+
+        // Skill Suggestions: standalone (non-plugin) skills whose body
+        // semantically matches the user's query. Like `pluginCompanions`,
+        // this is a teaser-only block — the full instructions stay in
+        // `SkillManager` and the model pulls them via `capabilities_load`.
+        // Caller already gated on `auto` + tools-on + non-empty query +
+        // `capabilities_load` presence, so we just check non-empty and
+        // append. Skipping on `effectiveToolsOff` here is belt-and-braces
+        // for the preview composer which doesn't pre-gate.
+        if !effectiveToolsOff,
+            !skillSuggestions.isEmpty,
+            let suggestionsSection = PreflightCompanions.renderSkillSuggestions(skillSuggestions)
+        {
+            composer.append(
+                .dynamic(
+                    id: "skillSuggestions",
+                    label: "Skill Suggestions",
+                    content: suggestionsSection
+                )
+            )
         }
 
         // Agent-loop guidance: short cheat-sheet for the chat-layer-
@@ -470,23 +523,30 @@ public struct SystemPromptComposer: Sendable {
     /// Memory is also out of scope (it's prepended to the user message,
     /// not the system prompt) — callers feed the per-turn estimate to
     /// `ContextBreakdown.from` separately, which surfaces the `Memory` row.
-    ///
-    /// `cachedSkillsSection` is the skill prompt section the chat session
-    /// pre-loaded asynchronously; `nil` collapses the `Skills` row.
     @MainActor
     static func composePreviewContext(
         agentId: UUID,
         executionMode: ExecutionMode,
-        model: String? = nil,
-        cachedSkillsSection: String? = nil
+        model: String? = nil
     ) -> ComposedContext {
         var composer = forChat(agentId: agentId, executionMode: executionMode, model: model)
 
-        let effectiveToolsOff = AgentManager.shared.effectiveToolsDisabled(for: agentId)
+        let agentToolsOff = AgentManager.shared.effectiveToolsDisabled(for: agentId)
+        let agentMemoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentId)
         let autonomousConfig = AgentManager.shared.effectiveAutonomousExec(for: agentId)
         let autonomousEnabled = autonomousConfig?.enabled == true
         let canCreatePlugins = autonomousConfig.map { $0.enabled && $0.pluginCreate } ?? false
         let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
+
+        let (sizeClass, contextLength) = ContextSizeResolver.resolve(modelId: model)
+        let effectiveToolsOff = agentToolsOff || sizeClass.disablesTools
+        let contextDisable = ContextDisableInfo(
+            sizeClass: sizeClass,
+            modelId: model,
+            contextLength: contextLength,
+            agentToolsOff: agentToolsOff,
+            agentMemoryOff: agentMemoryOff
+        )
 
         let tools = resolveTools(
             agentId: agentId,
@@ -504,8 +564,7 @@ public struct SystemPromptComposer: Sendable {
             effectiveToolsOff: effectiveToolsOff,
             autonomousEnabled: autonomousEnabled,
             canCreatePlugins: canCreatePlugins,
-            toolMode: toolMode,
-            skillSection: cachedSkillsSection
+            toolMode: toolMode
         )
 
         let alwaysLoadedNames = resolveAlwaysLoadedNames(
@@ -528,7 +587,8 @@ public struct SystemPromptComposer: Sendable {
             memorySection: nil,
             alwaysLoadedNames: alwaysLoadedNames,
             cacheHint: manifest.staticPrefixHash(toolNames: toolNames),
-            staticPrefix: manifest.staticPrefixContent
+            staticPrefix: manifest.staticPrefixContent,
+            contextDisable: contextDisable
         )
     }
 

--- a/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCompanions.swift
@@ -255,4 +255,97 @@ enum PreflightCompanions {
         - One-shot: a successful `capabilities_load` adds the tool/skill to your schema for the rest of the conversation. Do NOT call `capabilities_load` again for an id you've already loaded.
         - Use: after loading, call the tool directly by its name (e.g. `browser_open_login(...)`) just like any tool you already had — there is no separate "activate" step.
         """
+
+    // MARK: - Skill Suggestions
+
+    /// Hard cap on standalone skill teasers per turn. Three keeps the
+    /// section visually compact and matches what `CapabilitiesSearchTool`
+    /// already returns for `topK.skills` in its hit shape.
+    static let maxSkillSuggestions: Int = 3
+
+    /// Embedding-search candidate pool. We over-fetch so post-filtering
+    /// (plugin-bundled, already-loaded) can still surface the top
+    /// `maxSkillSuggestions` standalone skills.
+    private static let skillSearchCandidatePool: Int = 12
+
+    /// Build a compact list of standalone skill teasers that semantically
+    /// match `query`. "Standalone" means **not bundled with a plugin** —
+    /// plugin skills are surfaced via the existing `derive(...)` path
+    /// when one of their plugin's tools is picked, and showing them
+    /// twice (once as a companion, once as a suggestion) is noise.
+    ///
+    /// Skills that already appear in `alreadyLoadedSkillNames` are
+    /// filtered out so re-loading prompts disappear after the first
+    /// `capabilities_load`.
+    ///
+    /// Returns at most `maxSkillSuggestions` teasers ordered by search
+    /// score, with alphabetical tie-break so prompt rendering is byte
+    /// stable when two skills tie.
+    static func deriveSkillSuggestions(
+        query: String,
+        alreadyLoadedSkillNames: Set<String> = []
+    ) async -> [SkillTeaser] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let hits = await SkillSearchService.shared.search(
+            query: trimmed,
+            topK: skillSearchCandidatePool
+        )
+        return rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: alreadyLoadedSkillNames
+        )
+    }
+
+    /// Pure post-search filter + sort + cap. Pulled out of
+    /// `deriveSkillSuggestions` so the ordering rules (plugin
+    /// exclusion, already-loaded suppression, score desc with
+    /// alphabetical tie-break, max-3 cap) can be unit-tested without
+    /// spinning up VecturaKit.
+    static func rankSkillSuggestions(
+        from hits: [SkillSearchResult],
+        alreadyLoadedSkillNames: Set<String>
+    ) -> [SkillTeaser] {
+        let standalone = hits.filter { hit in
+            hit.skill.pluginId == nil
+                && !alreadyLoadedSkillNames.contains(hit.skill.name)
+        }
+        guard !standalone.isEmpty else { return [] }
+
+        // Sort by score desc, alphabetical on ties. The search service
+        // already orders by score but does not break ties deterministically.
+        let ordered = standalone.sorted { lhs, rhs in
+            if lhs.searchScore != rhs.searchScore {
+                return lhs.searchScore > rhs.searchScore
+            }
+            return lhs.skill.name < rhs.skill.name
+        }
+
+        return Array(ordered.prefix(maxSkillSuggestions))
+            .map { SkillTeaser(name: $0.skill.name, description: $0.skill.description) }
+    }
+
+    /// Render the `## Skill Suggestions` prompt section. Returns `nil`
+    /// when `teasers` is empty so callers can skip appending an empty
+    /// block. Reuses `usageNudge` so the loader story the model reads
+    /// is identical across companions and suggestions.
+    static func renderSkillSuggestions(_ teasers: [SkillTeaser]) -> String? {
+        guard !teasers.isEmpty else { return nil }
+        var lines: [String] = [
+            "These skills semantically match the user's request. They are NOT in your schema — pull only what you'll actually use:"
+        ]
+        for skill in teasers {
+            let desc = skill.description.isEmpty ? "(no description)" : skill.description
+            lines.append("- `skill/\(skill.name)` — \(desc)")
+        }
+        let body = lines.joined(separator: "\n")
+        return """
+            ## Skill Suggestions
+
+            \(body)
+
+            \(usageNudge)
+            """
+    }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXErrorRecovery.swift
@@ -65,17 +65,17 @@ public enum MLXErrorRecovery {
         }
 
         // C-convention closure: no captures (must match `@convention(c)`).
-        let handler:
-            @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = {
-                cMessage, _ in
-                let message = cMessage.map { String(cString: $0) } ?? "<nil>"
-                MLXErrorRecovery.lock.withLock {
-                    MLXErrorRecovery._lastError = message
-                }
-                // `os_log` from the C-convention thunk is allowed (no async
-                // hops, no captures of Swift state).
-                recoveryLog.error("MLX error: \(message, privacy: .public)")
+        let handler: @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = {
+            cMessage,
+            _ in
+            let message = cMessage.map { String(cString: $0) } ?? "<nil>"
+            MLXErrorRecovery.lock.withLock {
+                MLXErrorRecovery._lastError = message
             }
+            // `os_log` from the C-convention thunk is allowed (no async
+            // hops, no captures of Swift state).
+            recoveryLog.error("MLX error: \(message, privacy: .public)")
+        }
 
         // `setErrorHandler` is marked deprecated in mlx-swift; see the file
         // header for why the global form is the correct shape here.

--- a/Packages/OsaurusCore/Storage/AttachmentBlobStore.swift
+++ b/Packages/OsaurusCore/Storage/AttachmentBlobStore.swift
@@ -167,7 +167,11 @@ public enum AttachmentBlobStore {
                 return Attachment(
                     id: attachment.id,
                     kind: .audioRef(
-                        hash: hash, byteCount: data.count, format: format, filename: filename)
+                        hash: hash,
+                        byteCount: data.count,
+                        format: format,
+                        filename: filename
+                    )
                 )
             } catch {
                 log.warning(
@@ -186,7 +190,10 @@ public enum AttachmentBlobStore {
                 return Attachment(
                     id: attachment.id,
                     kind: .videoRef(
-                        hash: hash, byteCount: data.count, filename: filename)
+                        hash: hash,
+                        byteCount: data.count,
+                        filename: filename
+                    )
                 )
             } catch {
                 log.warning(
@@ -211,9 +218,9 @@ public enum AttachmentBlobStore {
             for attachment in turn.attachments {
                 switch attachment.kind {
                 case .imageRef(let hash, _),
-                     .documentRef(_, let hash, _),
-                     .audioRef(let hash, _, _, _),
-                     .videoRef(let hash, _, _):
+                    .documentRef(_, let hash, _),
+                    .audioRef(let hash, _, _, _),
+                    .videoRef(let hash, _, _):
                     refs.insert(hash)
                 default:
                     continue

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -181,58 +181,37 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    // MARK: - Skills caching
+    // MARK: - Skills are load-on-demand only
 
-    /// Skills are async-loaded by ChatSession; the preview composer
-    /// takes the pre-resolved section as a parameter so the popover
-    /// can include the row without going async on every keystroke.
-    /// This test bypasses ChatSession and feeds the section directly
-    /// to lock the input contract.
-    @Test("preview: cachedSkillsSection injects a Skills row when tools on")
-    func toolsOn_withCachedSkillsSection_includesSkillsRow() async {
+    /// Regression for the 55k-token Skills bloat: skills MUST be
+    /// discovered via `capabilities_search` and pulled in via
+    /// `capabilities_load`, never auto-injected into the system prompt
+    /// at compose time. Both compose paths must omit the `skills`
+    /// section regardless of the agent's enabled-skills allowlist.
+    @Test("compose: no `skills` section, even when the agent has skills enabled")
+    func bagOfSkills_neverInjected() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
-            let preview = SystemPromptComposer.composePreviewContext(
-                agentId: agentId,
-                executionMode: .none,
-                cachedSkillsSection: "## Skill: Test\n\nDo the thing."
+            // Simulate the "all skills enabled" allowlist that the
+            // capability seeder used to write — exactly the state that
+            // produced the 55k Skills row in the original screenshot.
+            AgentManager.shared.updateEnabledSkillNames(
+                SkillManager.shared.skills.map(\.name),
+                for: agentId
             )
-            let ids = sectionIds(preview)
-            #expect(ids.contains("skills"))
-            // Tokens are derived from char count / 4, so the section
-            // contributing > 0 confirms the prose is being priced.
-            let skillSection = preview.manifest.section("skills")
-            #expect(skillSection?.estimatedTokens ?? 0 > 0)
-        }
-    }
 
-    /// Tools-off agents shouldn't see Skills even if the section is
-    /// non-nil — same gate as the real send path. Matches the
-    /// `effectiveToolsOff` short-circuit in `appendGatedSections`.
-    @Test("preview: cachedSkillsSection is suppressed when tools off")
-    func toolsOff_withCachedSkillsSection_suppressesSkillsRow() async {
-        await withAgent(toolsDisabled: true) { agentId in
             let preview = SystemPromptComposer.composePreviewContext(
                 agentId: agentId,
-                executionMode: .none,
-                cachedSkillsSection: "## Skill: Test\n\nDo the thing."
+                executionMode: .none
             )
-            #expect(sectionIds(preview).contains("skills") == false)
-        }
-    }
+            let real = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "",
+                cachedPreflight: .empty
+            )
 
-    /// Empty / whitespace cached sections must not produce an empty
-    /// `Skills` row that confuses the budget popover (zero-token
-    /// entries are filtered out at render time, but this avoids
-    /// even surfacing them in the manifest).
-    @Test("preview: empty cachedSkillsSection does not insert a Skills row")
-    func toolsOn_emptyCachedSkillsSection_skipsSkillsRow() async {
-        await withAgent(toolSelectionMode: .auto) { agentId in
-            let preview = SystemPromptComposer.composePreviewContext(
-                agentId: agentId,
-                executionMode: .none,
-                cachedSkillsSection: "   \n\t  "
-            )
             #expect(sectionIds(preview).contains("skills") == false)
+            #expect(real.manifest.sections.map(\.id).contains("skills") == false)
         }
     }
 
@@ -300,6 +279,99 @@ struct ContextBudgetPreviewTests {
 
             #expect(sectionIds(preview) == ["base"])
             #expect(real.manifest.sections.map(\.id) == ["base"])
+        }
+    }
+
+    // MARK: - Small-context auto-disable
+
+    /// The original screenshot regression: Foundation (~4k context)
+    /// got the full feature set and blew past its budget. The
+    /// resolver-driven auto-disable must collapse tools to zero and
+    /// flag the popover with `.tiny` so the user sees why.
+    @Test("preview: foundation model auto-disables tools + memory and emits disable info")
+    func tinyModel_disablesToolsAndMemory_andEmitsDisableInfo() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "foundation"
+            )
+            // Tools are gone — tools-off cascades to all the gated
+            // sections too, so only `base` survives.
+            #expect(preview.tools.isEmpty)
+            #expect(preview.toolTokens == 0)
+            #expect(sectionIds(preview) == ["base"])
+
+            // Disable info is populated and reports both axes.
+            guard let info = preview.contextDisable else {
+                Issue.record("contextDisable missing for foundation model")
+                return
+            }
+            #expect(info.sizeClass == .tiny)
+            #expect(info.modelId == "foundation")
+            #expect(info.disabledTools)
+            #expect(info.disabledMemory)
+        }
+    }
+
+    /// `.normal`-class models must NOT carry a disable info — that's
+    /// what suppresses the popover notice for the common case. A
+    /// regression here would dim every chat with a misleading "auto-
+    /// disabled" line.
+    @Test("preview: normal-context model has no disable info")
+    func normalModel_noOverride() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "gpt-5"
+            )
+            #expect(preview.contextDisable == nil)
+        }
+    }
+
+    /// When the agent itself already disabled tools, the auto-disable
+    /// must not double-report: `disabledTools = false` means "I would
+    /// have done it but the agent already did". Keeps the popover
+    /// notice honest for users who disabled tools deliberately.
+    @Test("preview: tiny model + agent-tools-off marks tools-disable as caused by agent")
+    func tinyModel_withAgentToolsOff_doesNotDoubleClaim() async {
+        await withAgent(toolsDisabled: true) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "foundation"
+            )
+            // Disable info still fires (memory got auto-disabled), but
+            // tools is reported as agent-driven, not size-class-driven.
+            guard let info = preview.contextDisable else {
+                Issue.record("contextDisable missing for foundation model")
+                return
+            }
+            #expect(info.sizeClass == .tiny)
+            #expect(info.disabledTools == false)
+        }
+    }
+
+    /// Parity extension: the disable info matches across preview and
+    /// send paths so the popover never lies about what the next send
+    /// will actually do.
+    @Test("parity: disable info matches between preview and composeChatContext")
+    func parity_disableInfoMatches() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "foundation"
+            )
+            let real = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "foundation",
+                query: "",
+                cachedPreflight: .empty
+            )
+            #expect(preview.contextDisable == real.contextDisable)
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -1,0 +1,305 @@
+//
+//  ContextBudgetPreviewTests.swift
+//  osaurusTests
+//
+//  Pin the welcome-screen Context Budget popover contract:
+//  `SystemPromptComposer.composePreviewContext` must list every section
+//  the next `composeChatContext(query: "")` will produce, except for the
+//  two query-dependent ones (preflight tool delta + plugin companions)
+//  which the budget UI explicitly cannot price ahead of time.
+//
+//  Why this matters: before this preview parity, the popover hid 6+
+//  sections (`Agent Loop`, `Capability Discovery`, `Skills`,
+//  `Model Family Guidance`, …) until the user hit send, making the
+//  pre-send `Tools: 2.1k / Base Prompt: 10` reading look misleading
+//  on chats that actually shipped multi-kilobyte prompts.
+//
+//  The tests cover the toggle matrix (tools on/off × memory on/off ×
+//  tool mode auto/manual × model family) plus a parity check against
+//  `composeChatContext` so the preview can never silently drift.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ContextBudgetPreviewTests {
+
+    // MARK: - Helpers
+
+    /// Run a body with a custom agent registered + cleaned up. Holds
+    /// both the storage and sandbox locks because composePreviewContext
+    /// reads `AgentManager.shared` and `ToolRegistry.shared`. The body
+    /// is async so parity tests can await `composeChatContext`.
+    private func withAgent(
+        toolsDisabled: Bool = false,
+        memoryDisabled: Bool = false,
+        toolSelectionMode: ToolSelectionMode? = nil,
+        manualToolNames: [String]? = nil,
+        autonomous: Bool = false,
+        body: @MainActor @Sendable (UUID) async -> Void
+    ) async {
+        await SandboxTestLock.runWithStoragePaths {
+            let agent = Agent(
+                name: "PreviewTestAgent-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "Test identity",
+                agentAddress: "test-preview-\(UUID().uuidString)",
+                autonomousExec: autonomous ? AutonomousExecConfig(enabled: true) : nil,
+                toolSelectionMode: toolSelectionMode,
+                manualToolNames: manualToolNames,
+                disableTools: toolsDisabled ? true : nil,
+                disableMemory: memoryDisabled ? true : nil
+            )
+            AgentManager.shared.add(agent)
+            await body(agent.id)
+            _ = await AgentManager.shared.delete(id: agent.id)
+        }
+    }
+
+    private func sectionIds(_ ctx: ComposedContext) -> [String] {
+        ctx.manifest.sections.map(\.id)
+    }
+
+    // MARK: - Tools off + memory off
+
+    /// The misleading-default fix. With both knobs off and no execution
+    /// mode, the popover collapses to just the agent identity — no
+    /// Agent Loop, no Capability Discovery, no Skills, no Tools.
+    @Test("preview: tools off + memory off → only base section")
+    func toolsOff_memoryOff_isJustBase() async {
+        await withAgent(toolsDisabled: true, memoryDisabled: true) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none
+            )
+            #expect(sectionIds(preview) == ["base"])
+            #expect(preview.tools.isEmpty)
+            #expect(preview.toolTokens == 0)
+            #expect(preview.memorySection == nil)
+            #expect(preview.preflightItems.isEmpty)
+        }
+    }
+
+    /// `Memory` doesn't ride on `composePreviewContext` — the chat view
+    /// surfaces it through `cachedMemoryTokens` so the preview manifest
+    /// stays byte-stable. Memory-on with tools-off therefore still has
+    /// a one-section manifest: the popover row comes from the separate
+    /// `memoryTokens` plumb in `ContextBreakdown.from`.
+    @Test("preview: tools off + memory on → manifest still only has base")
+    func toolsOff_memoryOn_manifestStaysMinimal() async {
+        await withAgent(toolsDisabled: true, memoryDisabled: false) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none
+            )
+            #expect(sectionIds(preview) == ["base"])
+        }
+    }
+
+    // MARK: - Tools on (auto)
+
+    /// Auto-mode with tools on hits the always-loaded baseline → which
+    /// trips the agent loop + capability discovery gates. This is the
+    /// previously-hidden surface the welcome screen used to under-report.
+    @Test("preview: tools on (auto) surfaces agent loop + capability discovery")
+    func toolsOn_auto_includesLoopAndCapabilityNudge() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none
+            )
+            let ids = sectionIds(preview)
+            #expect(ids.contains("base"))
+            #expect(ids.contains("agentLoopGuidance"))
+            #expect(ids.contains("capabilityNudge"))
+            // No model-family hint without a model id, no skills configured.
+            #expect(ids.contains("modelFamilyGuidance") == false)
+            #expect(ids.contains("skills") == false)
+            // Tools row is non-zero (always-loaded baseline JSON schemas).
+            #expect(preview.toolTokens > 0)
+            #expect(preview.tools.contains { $0.function.name == "todo" })
+            #expect(preview.tools.contains { $0.function.name == "capabilities_search" })
+        }
+    }
+
+    /// Manual mode opts out of preflight, which also opts out of the
+    /// capability-discovery nudge (the nudge is gated on auto mode so
+    /// manual agents don't see "go grow your tool list" guidance they
+    /// can't act on). Loop guidance still fires because `todo`/etc.
+    /// are always-loaded built-ins regardless of mode.
+    @Test("preview: manual mode keeps agent loop, drops capability nudge")
+    func toolsOn_manual_dropsCapabilityNudge() async {
+        await withAgent(
+            toolSelectionMode: .manual,
+            manualToolNames: ["render_chart"]
+        ) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none
+            )
+            let ids = sectionIds(preview)
+            #expect(ids.contains("agentLoopGuidance"))
+            #expect(ids.contains("capabilityNudge") == false)
+            #expect(preview.tools.contains { $0.function.name == "render_chart" })
+        }
+    }
+
+    // MARK: - Model family guidance
+
+    /// Family hints fire when the model id matches a known family
+    /// substring. Pricing them ahead of time matters because some
+    /// blocks (Gemma in particular) are several hundred tokens.
+    @Test("preview: gemma model triggers Model Family Guidance row")
+    func toolsOn_gemmaModel_includesModelFamilyGuidance() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "google/gemma-3-12b-it"
+            )
+            let ids = sectionIds(preview)
+            #expect(ids.contains("modelFamilyGuidance"))
+        }
+    }
+
+    /// Negative path: a model with no family marker (e.g. a generic
+    /// llama finetune) should not get a guidance block. Locks the
+    /// "silence is the default" rule so future entries to
+    /// `ModelFamilyGuidance` don't accidentally bias every chat.
+    @Test("preview: unknown model family → no Model Family Guidance row")
+    func toolsOn_unknownModelFamily_skipsGuidance() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "mystery/llama-finetune-x"
+            )
+            #expect(sectionIds(preview).contains("modelFamilyGuidance") == false)
+        }
+    }
+
+    // MARK: - Skills caching
+
+    /// Skills are async-loaded by ChatSession; the preview composer
+    /// takes the pre-resolved section as a parameter so the popover
+    /// can include the row without going async on every keystroke.
+    /// This test bypasses ChatSession and feeds the section directly
+    /// to lock the input contract.
+    @Test("preview: cachedSkillsSection injects a Skills row when tools on")
+    func toolsOn_withCachedSkillsSection_includesSkillsRow() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                cachedSkillsSection: "## Skill: Test\n\nDo the thing."
+            )
+            let ids = sectionIds(preview)
+            #expect(ids.contains("skills"))
+            // Tokens are derived from char count / 4, so the section
+            // contributing > 0 confirms the prose is being priced.
+            let skillSection = preview.manifest.section("skills")
+            #expect(skillSection?.estimatedTokens ?? 0 > 0)
+        }
+    }
+
+    /// Tools-off agents shouldn't see Skills even if the section is
+    /// non-nil — same gate as the real send path. Matches the
+    /// `effectiveToolsOff` short-circuit in `appendGatedSections`.
+    @Test("preview: cachedSkillsSection is suppressed when tools off")
+    func toolsOff_withCachedSkillsSection_suppressesSkillsRow() async {
+        await withAgent(toolsDisabled: true) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                cachedSkillsSection: "## Skill: Test\n\nDo the thing."
+            )
+            #expect(sectionIds(preview).contains("skills") == false)
+        }
+    }
+
+    /// Empty / whitespace cached sections must not produce an empty
+    /// `Skills` row that confuses the budget popover (zero-token
+    /// entries are filtered out at render time, but this avoids
+    /// even surfacing them in the manifest).
+    @Test("preview: empty cachedSkillsSection does not insert a Skills row")
+    func toolsOn_emptyCachedSkillsSection_skipsSkillsRow() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                cachedSkillsSection: "   \n\t  "
+            )
+            #expect(sectionIds(preview).contains("skills") == false)
+        }
+    }
+
+    // MARK: - Parity with composeChatContext(query: "")
+
+    /// The single most important guarantee: a sync preview compose
+    /// matches an async send-time compose with an empty query +
+    /// empty preflight, so the welcome-screen popover never lies
+    /// about what the model will actually see on the next send.
+    /// Differences are limited to:
+    ///   - `pluginCompanions`: query-dependent, never present here
+    ///     (preflight is empty).
+    ///   - `memorySection` body: send path may attach memory text;
+    ///     the preview surfaces tokens through `cachedMemoryTokens`
+    ///     instead, so we compare manifests with `memory` filtered
+    ///     out (not present in either path's section list anyway).
+    @Test("parity: composePreviewContext == composeChatContext(query: '') sections")
+    func parity_previewMatchesEmptyQueryCompose() async {
+        await withAgent(memoryDisabled: true, toolSelectionMode: .auto) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "gpt-5"
+            )
+            let real = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "gpt-5",
+                query: "",
+                cachedPreflight: .empty
+            )
+
+            let previewIds = sectionIds(preview).filter { $0 != "pluginCompanions" }
+            let realIds = real.manifest.sections.map(\.id).filter { $0 != "pluginCompanions" }
+            #expect(previewIds == realIds)
+
+            // Tools row matches too — both go through the same
+            // `resolveTools` baseline (no preflight, no manual picks).
+            #expect(preview.toolTokens == real.toolTokens)
+            #expect(
+                preview.tools.map(\.function.name).sorted()
+                    == real.tools.map(\.function.name).sorted()
+            )
+        }
+    }
+
+    /// Parity holds in tools-off mode too: both paths collapse to a
+    /// single-section manifest, regardless of which entry point the
+    /// caller used. Catches any future drift where `composeChatContext`
+    /// adds a tools-off-only section that `composePreviewContext`
+    /// forgets to mirror.
+    @Test("parity: tools off, both paths return only the base section")
+    func parity_toolsOff_bothCollapseToBase() async {
+        await withAgent(toolsDisabled: true, memoryDisabled: true) { agentId in
+            let preview = SystemPromptComposer.composePreviewContext(
+                agentId: agentId,
+                executionMode: .none
+            )
+            let real = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "",
+                cachedPreflight: .empty
+            )
+
+            #expect(sectionIds(preview) == ["base"])
+            #expect(real.manifest.sections.map(\.id) == ["base"])
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ContextSizeClassTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextSizeClassTests.swift
@@ -1,0 +1,139 @@
+//
+//  ContextSizeClassTests.swift
+//  osaurusTests
+//
+//  Pure-function tests for `ContextSizeResolver`. The resolver is the
+//  single source of truth for "is this model too small for tools/
+//  memory" — a regression here is what produced the original
+//  `Skills: 55k / 4.1k` blowout when Foundation got the full
+//  feature set. These tests pin:
+//
+//    - Foundation matching (canonical id + `default` alias + casing)
+//    - the tiny / small / normal threshold boundaries
+//    - the unknown-model conservative default (no auto-disable)
+//
+//  No fixtures: ModelInfo.load is exercised live where possible and
+//  treated as "could fail" everywhere else. The threshold tests use
+//  the resolver's own constants rather than literal numbers so a
+//  policy change moves the test in lock-step.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ContextSizeResolver")
+struct ContextSizeClassTests {
+
+    // MARK: - Foundation aliases
+
+    @Test("foundation canonical id maps to .tiny")
+    func foundationIdIsTiny() {
+        let (cls, ctx) = ContextSizeResolver.resolve(modelId: "foundation")
+        #expect(cls == .tiny)
+        #expect(ctx == ContextSizeResolver.tinyCeiling)
+    }
+
+    @Test("default alias maps to .tiny (matches FoundationModelService.handles)")
+    func defaultAliasIsTiny() {
+        let (cls, _) = ContextSizeResolver.resolve(modelId: "default")
+        #expect(cls == .tiny)
+    }
+
+    @Test("Foundation matching is case-insensitive")
+    func foundationCasingIsTiny() {
+        // Capitalised forms appear in persisted JSON (the migration
+        // tests in ModelOverride exercise this exact path). The
+        // resolver MUST keep matching them or the auto-disable
+        // silently breaks for users who edited the config by hand.
+        let (a, _) = ContextSizeResolver.resolve(modelId: "Foundation")
+        let (b, _) = ContextSizeResolver.resolve(modelId: "FOUNDATION")
+        let (c, _) = ContextSizeResolver.resolve(modelId: "Default")
+        #expect(a == .tiny)
+        #expect(b == .tiny)
+        #expect(c == .tiny)
+    }
+
+    @Test("foundation match wins even if ModelInfo would disagree")
+    func foundationShortCircuitsBeforeModelInfo() {
+        // Even though `ModelInfo.load(modelId: "foundation")` returns
+        // nil today (no MLX config on disk for Apple's model), the
+        // resolver does not need that branch to hit. If someone ever
+        // ships a folder named "foundation" with a bigger context
+        // length, the alias check still wins. Tests the ordering.
+        let (cls, ctx) = ContextSizeResolver.resolve(modelId: "foundation")
+        #expect(cls == .tiny)
+        #expect(ctx == ContextSizeResolver.tinyCeiling)
+    }
+
+    // MARK: - Nil / blank
+
+    @Test("nil model id returns .normal with no ctx")
+    func nilModelIsNormal() {
+        let (cls, ctx) = ContextSizeResolver.resolve(modelId: nil)
+        #expect(cls == .normal)
+        #expect(ctx == nil)
+    }
+
+    @Test("blank / whitespace model id returns .normal")
+    func blankModelIsNormal() {
+        // Mid-window state: chat hasn't picked a model yet. We should
+        // NOT speculatively hide tools — `.normal` is the safe default.
+        let (a, _) = ContextSizeResolver.resolve(modelId: "")
+        let (b, _) = ContextSizeResolver.resolve(modelId: "   \n\t  ")
+        #expect(a == .normal)
+        #expect(b == .normal)
+    }
+
+    // MARK: - Unknown model
+
+    @Test("unknown model id with no ModelInfo falls back to .normal")
+    func unknownModelIsNormal() {
+        // No installed model directory + not the Foundation alias =
+        // we don't know the budget, so don't auto-disable. Conservative
+        // by design — false positives would silently strip tools from
+        // users on niche models we haven't catalogued.
+        let (cls, ctx) = ContextSizeResolver.resolve(
+            modelId: "definitely-not-installed-\(UUID().uuidString)"
+        )
+        #expect(cls == .normal)
+        #expect(ctx == nil)
+    }
+
+    // MARK: - Disable predicates
+
+    /// Tiny disables both axes; small disables only memory; normal
+    /// is hands-off. The composer relies on these flags cascading
+    /// into `effectiveToolsOff` / `memoryOff`, so a regression here
+    /// silently hides tools (or fails to hide them) at compose time.
+    @Test("disable predicates: tiny -> tools+memory off")
+    func tinyDisablesTools() {
+        #expect(ContextSizeClass.tiny.disablesTools)
+        #expect(ContextSizeClass.tiny.disablesMemory)
+    }
+
+    @Test("disable predicates: small -> memory off only")
+    func smallDisablesMemoryOnly() {
+        #expect(ContextSizeClass.small.disablesTools == false)
+        #expect(ContextSizeClass.small.disablesMemory)
+    }
+
+    @Test("disable predicates: normal -> nothing off")
+    func normalDisablesNothing() {
+        #expect(ContextSizeClass.normal.disablesTools == false)
+        #expect(ContextSizeClass.normal.disablesMemory == false)
+    }
+
+    // MARK: - Thresholds
+
+    @Test("tinyCeiling sits at the upper bound of .tiny")
+    func tinyCeilingBoundary() {
+        // The boundary value `4096` itself is `.tiny` (inclusive). One
+        // more token should pivot to `.small`. Uses the resolver's
+        // own constants so a future policy change moves the test
+        // in lock-step.
+        #expect(ContextSizeResolver.tinyCeiling == 4096)
+        #expect(ContextSizeResolver.smallCeiling == 8192)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PreflightCompanionsTests.swift
@@ -236,4 +236,152 @@ struct PreflightCompanionsTests {
         #expect(renderedTool.contains("- `tool/y_alpha`"))
         #expect(renderedTool.contains("- `skill/") == false)
     }
+
+    // MARK: - rankSkillSuggestions
+
+    /// Helper: build a `SkillSearchResult` from a name + score, with
+    /// a default description and optional `pluginId` to mark the
+    /// skill as plugin-bundled.
+    private static func makeHit(
+        _ name: String,
+        score: Float,
+        pluginId: String? = nil
+    ) -> SkillSearchResult {
+        let skill = Skill(
+            id: UUID(),
+            name: name,
+            description: "desc for \(name)",
+            instructions: "body",
+            pluginId: pluginId
+        )
+        return SkillSearchResult(skill: skill, searchScore: score)
+    }
+
+    @Test func rankSkillSuggestionsCapsAtThree() {
+        // The whole point of this section is "compact preview" — five
+        // ranked hits must surface only the top 3. The cap is policy
+        // (`maxSkillSuggestions`), so we test the contract not the
+        // literal number.
+        let hits = (0 ..< 5).map { Self.makeHit("skill_\($0)", score: Float(10 - $0) / 10) }
+        let teasers = PreflightCompanions.rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: []
+        )
+        #expect(teasers.count == PreflightCompanions.maxSkillSuggestions)
+        // Top 3 by descending score = skill_0..skill_2.
+        #expect(teasers.map(\.name) == ["skill_0", "skill_1", "skill_2"])
+    }
+
+    @Test func rankSkillSuggestionsExcludesPluginBundledSkills() {
+        // Plugin-bundled skills are surfaced via `derive(...)` when
+        // one of their plugin's tools is picked. Showing them twice
+        // (once as a companion, once as a suggestion) is noise; the
+        // post-search filter must drop them.
+        let hits = [
+            Self.makeHit("standalone-1", score: 0.9),
+            Self.makeHit("plugin-skill", score: 0.85, pluginId: "osaurus.browser"),
+            Self.makeHit("standalone-2", score: 0.8),
+        ]
+        let teasers = PreflightCompanions.rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: []
+        )
+        #expect(teasers.map(\.name) == ["standalone-1", "standalone-2"])
+    }
+
+    @Test func rankSkillSuggestionsExcludesAlreadyLoadedSkills() {
+        // After the model calls `capabilities_load("skill/X")`, X
+        // shouldn't keep showing up as a fresh suggestion every turn —
+        // the loader already injected its full body. Callers thread
+        // the loaded names in via `alreadyLoadedSkillNames`.
+        let hits = [
+            Self.makeHit("alpha", score: 0.9),
+            Self.makeHit("beta", score: 0.8),
+            Self.makeHit("gamma", score: 0.7),
+        ]
+        let teasers = PreflightCompanions.rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: ["beta"]
+        )
+        #expect(teasers.map(\.name) == ["alpha", "gamma"])
+    }
+
+    @Test func rankSkillSuggestionsTieBreaksAlphabetically() {
+        // KV-cache stability: when two skills tie on score the
+        // rendered prompt bytes must be identical across runs. The
+        // search service doesn't promise a tie-break order, so the
+        // rank step does it explicitly. Three skills on the same
+        // score must come back in name order.
+        let hits = [
+            Self.makeHit("zulu", score: 0.5),
+            Self.makeHit("alpha", score: 0.5),
+            Self.makeHit("mike", score: 0.5),
+        ]
+        let teasers = PreflightCompanions.rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: []
+        )
+        #expect(teasers.map(\.name) == ["alpha", "mike", "zulu"])
+    }
+
+    @Test func rankSkillSuggestionsReturnsEmptyWhenNoStandaloneHits() {
+        // Pure plugin-bundled hit set -> nothing to suggest. Tests the
+        // guard that returns `[]` rather than rendering an empty section.
+        let hits = [
+            Self.makeHit("p1", score: 0.9, pluginId: "x"),
+            Self.makeHit("p2", score: 0.8, pluginId: "y"),
+        ]
+        let teasers = PreflightCompanions.rankSkillSuggestions(
+            from: hits,
+            alreadyLoadedSkillNames: []
+        )
+        #expect(teasers.isEmpty)
+    }
+
+    // MARK: - deriveSkillSuggestions short-circuits
+
+    @Test func deriveSkillSuggestionsReturnsEmptyForBlankQuery() async {
+        // No query -> no point hitting the search service. The
+        // composer wires this gate around preflight too; this test
+        // pins the same short-circuit at the function level so a
+        // future caller bypassing the gate doesn't fire a useless
+        // (and async) search call.
+        #expect(await PreflightCompanions.deriveSkillSuggestions(query: "").isEmpty)
+        #expect(await PreflightCompanions.deriveSkillSuggestions(query: "   \n\t  ").isEmpty)
+    }
+
+    // MARK: - renderSkillSuggestions
+
+    @Test func renderSkillSuggestionsReturnsNilForEmptyTeasers() {
+        // Empty teasers -> no section -> caller skips append. Same
+        // contract as `render([])` for `pluginCompanions`.
+        #expect(PreflightCompanions.renderSkillSuggestions([]) == nil)
+    }
+
+    @Test func renderSkillSuggestionsIncludesNameDescriptionAndLoaderNudge() {
+        let teasers = [
+            SkillTeaser(name: "data-viz", description: "Render charts inline"),
+            SkillTeaser(name: "code-review", description: "Catch obvious smells"),
+        ]
+        let rendered = PreflightCompanions.renderSkillSuggestions(teasers) ?? ""
+        // Name + description are surfaced in bullet rows so the model
+        // can decide whether the skill is worth loading.
+        #expect(rendered.contains("- `skill/data-viz`"))
+        #expect(rendered.contains("Render charts inline"))
+        #expect(rendered.contains("- `skill/code-review`"))
+        // Loader story is identical to plugin companions so the model
+        // doesn't see two different "how to load" sets.
+        #expect(rendered.contains("capabilities_load"))
+        #expect(rendered.lowercased().contains("one-shot"))
+    }
+
+    @Test func renderSkillSuggestionsHandlesEmptyDescriptionGracefully() {
+        // Some skills (especially user-imports) ship without a
+        // description. The teaser must still render with a stable
+        // placeholder rather than a dangling `— ` after the name.
+        let teasers = [SkillTeaser(name: "no-desc", description: "")]
+        let rendered = PreflightCompanions.renderSkillSuggestions(teasers) ?? ""
+        #expect(rendered.contains("- `skill/no-desc`"))
+        #expect(rendered.contains("(no description)"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
@@ -39,27 +39,29 @@ struct MaterializeMediaDataUrlMCDCTests {
 
     private func mappedURL(forVideoDataURL urlString: String) -> URL? {
         let json = """
-        [{"role": "user", "content": [
-          {"type": "video_url", "video_url": {"url": "\(urlString)"}}
-        ]}]
-        """.data(using: .utf8)!
+            [{"role": "user", "content": [
+              {"type": "video_url", "video_url": {"url": "\(urlString)"}}
+            ]}]
+            """.data(using: .utf8)!
         let msgs = try! JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
         guard let video = mapped.first?.videos.first,
-              case .url(let u) = video else { return nil }
+            case .url(let u) = video
+        else { return nil }
         return u
     }
 
     private func mappedURL(forAudioFormat format: String, base64: String) -> URL? {
         let json = """
-        [{"role": "user", "content": [
-          {"type": "input_audio", "input_audio": {"data": "\(base64)", "format": "\(format)"}}
-        ]}]
-        """.data(using: .utf8)!
+            [{"role": "user", "content": [
+              {"type": "input_audio", "input_audio": {"data": "\(base64)", "format": "\(format)"}}
+            ]}]
+            """.data(using: .utf8)!
         let msgs = try! JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
         guard let audio = mapped.first?.audios.first,
-              case .url(let u) = audio else { return nil }
+            case .url(let u) = audio
+        else { return nil }
         return u
     }
 
@@ -119,8 +121,10 @@ struct MaterializeMediaDataUrlMCDCTests {
         let payload = Data(repeating: 0xAB, count: 16)
         let b64 = payload.base64EncodedString()
         let url = mappedURL(forVideoDataURL: "data:video/mp4;base64,\(b64)")
-        #expect(url?.pathExtension == "mp4",
-            "video/mp4 must keep .mp4 — was incorrectly .m4a before audit fix")
+        #expect(
+            url?.pathExtension == "mp4",
+            "video/mp4 must keep .mp4 — was incorrectly .m4a before audit fix"
+        )
         if let url { try? FileManager.default.removeItem(at: url) }
     }
 
@@ -131,8 +135,10 @@ struct MaterializeMediaDataUrlMCDCTests {
         let payload = Data(repeating: 0xCD, count: 16)
         let b64 = payload.base64EncodedString()
         let url = mappedURL(forAudioFormat: "mp4", base64: b64)
-        #expect(url?.pathExtension == "m4a",
-            "audio with format=mp4 must canonicalize to .m4a for AVAudioConverter")
+        #expect(
+            url?.pathExtension == "m4a",
+            "audio with format=mp4 must canonicalize to .m4a for AVAudioConverter"
+        )
         if let url { try? FileManager.default.removeItem(at: url) }
     }
 

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -29,7 +29,8 @@ struct ModelMediaCapabilitiesMCDCTests {
     @Test("D1: Nemotron-3-Nano-Omni HF id → .omni")
     func d1_nemotronOmniHF() {
         let cap = ModelMediaCapabilities.from(
-            modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4")
+            modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"
+        )
         #expect(cap == .omni)
         #expect(cap.supportsAudio)
         #expect(cap.supportsVideo)
@@ -50,8 +51,10 @@ struct ModelMediaCapabilitiesMCDCTests {
     func d1_bareNemotron3_notOmni() {
         // Critical: `nemotron-3` text-only bundles must NOT advertise audio.
         let cap = ModelMediaCapabilities.from(modelId: "OsaurusAI/Nemotron-3-30B-Text-MXFP4")
-        #expect(!cap.supportsAudio,
-            "bare nemotron-3 (no -nano-omni) must NOT advertise audio support")
+        #expect(
+            !cap.supportsAudio,
+            "bare nemotron-3 (no -nano-omni) must NOT advertise audio support"
+        )
     }
 
     // MARK: - D2: Qwen 2/2.5/3 VL (image + video)
@@ -66,7 +69,8 @@ struct ModelMediaCapabilitiesMCDCTests {
     @Test("D2: Qwen2.5-VL with dot variant → .imageVideo")
     func d2_qwen25VL_dot() {
         #expect(
-            ModelMediaCapabilities.from(modelId: "Qwen/Qwen2.5-VL-7B-MLX") == .imageVideo)
+            ModelMediaCapabilities.from(modelId: "Qwen/Qwen2.5-VL-7B-MLX") == .imageVideo
+        )
     }
 
     @Test("D2: qwen2_vl underscore variant → .imageVideo")
@@ -84,13 +88,15 @@ struct ModelMediaCapabilitiesMCDCTests {
     @Test("D3: Qwen3.5-VL → .imageVideo")
     func d3_qwen35VL() {
         #expect(
-            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.5-VL-9B-8bit") == .imageVideo)
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.5-VL-9B-8bit") == .imageVideo
+        )
     }
 
     @Test("D3: Qwen3.6-VL → .imageVideo")
     func d3_qwen36VL() {
         #expect(
-            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.6-VL-30B-A3B-MXFP4") == .imageVideo)
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Qwen3.6-VL-30B-A3B-MXFP4") == .imageVideo
+        )
     }
 
     @Test("D3 boundary: Qwen3.5/3.6 text-only (no -vl) → .textOnly")
@@ -159,7 +165,8 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.from(modelId: "mistralai/Mistral-3-Small-24B") == .imageOnly)
         #expect(
             ModelMediaCapabilities.from(modelId: "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4")
-                == .imageOnly)
+                == .imageOnly
+        )
     }
 
     @Test("D6 boundary: bare 'mistral-7b' (no 3 or medium-3) → .textOnly")
@@ -172,14 +179,16 @@ struct ModelMediaCapabilitiesMCDCTests {
     @Test("D7: Mistral 4 VL → .imageOnly")
     func d7_mistral4VL() {
         #expect(
-            ModelMediaCapabilities.from(modelId: "OsaurusAI/Mistral-4-VL-Future") == .imageOnly)
+            ModelMediaCapabilities.from(modelId: "OsaurusAI/Mistral-4-VL-Future") == .imageOnly
+        )
     }
 
     @Test("D7 boundary: Mistral 4 dense (no -vl) → .textOnly")
     func d7_mistral4Dense_notImage() {
         #expect(
             ModelMediaCapabilities.from(modelId: "mistralai/Mistral-4-Small-24B-Instruct")
-                == .textOnly)
+                == .textOnly
+        )
     }
 
     // MARK: - Master FALSE: dense LLM families
@@ -199,8 +208,10 @@ struct ModelMediaCapabilitiesMCDCTests {
         ]
         for id in denseFamilies {
             let cap = ModelMediaCapabilities.from(modelId: id)
-            #expect(cap == .textOnly,
-                "\(id) must resolve to text-only (got: \(cap.summary))")
+            #expect(
+                cap == .textOnly,
+                "\(id) must resolve to text-only (got: \(cap.summary))"
+            )
             #expect(!cap.anyMedia, "\(id) anyMedia must be false")
         }
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -115,8 +115,10 @@ struct ModelProfileRegistryTests {
             )
             // Default-OFF guards against the trapped-thinking pattern.
             let defaultDisable = profile?.defaults["disableThinking"]?.boolValue ?? false
-            #expect(defaultDisable == true,
-                "Nemotron must default disableThinking=true to avoid trapped-thinking loops")
+            #expect(
+                defaultDisable == true,
+                "Nemotron must default disableThinking=true to avoid trapped-thinking loops"
+            )
         }
     }
 
@@ -135,8 +137,10 @@ struct ModelProfileRegistryTests {
             // that they don't shortcut into the new Nemotron-3-specific
             // profile.
             let isNemotron3 = profile?.displayName == NemotronThinkingProfile.displayName
-            #expect(!isNemotron3 || id.lowercased().contains("nemotron-3"),
-                "matcher must be specific to nemotron-3, not generic nemotron")
+            #expect(
+                !isNemotron3 || id.lowercased().contains("nemotron-3"),
+                "matcher must be specific to nemotron-3, not generic nemotron"
+            )
         }
     }
 
@@ -152,8 +156,8 @@ struct ModelProfileRegistryTests {
             "OsaurusAI/Laguna-XS.2-mxfp4",
             "OsaurusAI/Laguna-XS.2-JANGTQ2",
             "JANGQ-AI/Laguna-XS.2-JANGTQ2",
-            "laguna-xs.2-mxfp4",            // case-folded picker form
-            "OsaurusAI/Laguna-S.3-JANGTQ4", // forward-compat (future variant)
+            "laguna-xs.2-mxfp4",  // case-folded picker form
+            "OsaurusAI/Laguna-S.3-JANGTQ4",  // forward-compat (future variant)
         ] {
             let profile = ModelProfileRegistry.profile(for: id)
             #expect(
@@ -161,8 +165,10 @@ struct ModelProfileRegistryTests {
                 "expected LagunaThinkingProfile for \(id), got \(profile?.displayName ?? "nil")"
             )
             let defaultDisable = profile?.defaults["disableThinking"]?.boolValue ?? false
-            #expect(defaultDisable == true,
-                "Laguna must default disableThinking=true to mirror the chat-template default")
+            #expect(
+                defaultDisable == true,
+                "Laguna must default disableThinking=true to mirror the chat-template default"
+            )
         }
     }
 
@@ -180,10 +186,14 @@ struct ModelProfileRegistryTests {
             "mistral-medium-3.5-128b-mxfp4",
         ] {
             let profile = ModelProfileRegistry.profile(for: id)
-            #expect(profile?.displayName != NemotronThinkingProfile.displayName,
-                "Mistral 3.5 must NOT shortcut into NemotronThinkingProfile: \(id)")
-            #expect(profile?.displayName != LagunaThinkingProfile.displayName,
-                "Mistral 3.5 must NOT shortcut into LagunaThinkingProfile: \(id)")
+            #expect(
+                profile?.displayName != NemotronThinkingProfile.displayName,
+                "Mistral 3.5 must NOT shortcut into NemotronThinkingProfile: \(id)"
+            )
+            #expect(
+                profile?.displayName != LagunaThinkingProfile.displayName,
+                "Mistral 3.5 must NOT shortcut into LagunaThinkingProfile: \(id)"
+            )
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -29,11 +29,11 @@ struct MultimodalContentPartTests {
     @Test("input_audio content part decodes data + format")
     func decode_inputAudio() throws {
         let json = """
-        {
-          "type": "input_audio",
-          "input_audio": {"data": "AAA=", "format": "wav"}
-        }
-        """.data(using: .utf8)!
+            {
+              "type": "input_audio",
+              "input_audio": {"data": "AAA=", "format": "wav"}
+            }
+            """.data(using: .utf8)!
 
         let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
         guard case .audioInput(let data, let format) = part else {
@@ -47,11 +47,11 @@ struct MultimodalContentPartTests {
     @Test("video_url content part decodes url")
     func decode_videoUrl() throws {
         let json = """
-        {
-          "type": "video_url",
-          "video_url": {"url": "https://example.com/clip.mp4"}
-        }
-        """.data(using: .utf8)!
+            {
+              "type": "video_url",
+              "video_url": {"url": "https://example.com/clip.mp4"}
+            }
+            """.data(using: .utf8)!
 
         let part = try JSONDecoder().decode(MessageContentPart.self, from: json)
         guard case .videoUrl(let url) = part else {
@@ -93,15 +93,15 @@ struct MultimodalContentPartTests {
     @Test("ChatMessage.audioInputs returns (data, format) tuples")
     func chatMessage_audioInputs() throws {
         let json = """
-        {
-          "role": "user",
-          "content": [
-            {"type": "text", "text": "transcribe"},
-            {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
-            {"type": "input_audio", "input_audio": {"data": "BBBB", "format": "mp3"}}
-          ]
-        }
-        """.data(using: .utf8)!
+            {
+              "role": "user",
+              "content": [
+                {"type": "text", "text": "transcribe"},
+                {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}},
+                {"type": "input_audio", "input_audio": {"data": "BBBB", "format": "mp3"}}
+              ]
+            }
+            """.data(using: .utf8)!
 
         let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
         let inputs = msg.audioInputs
@@ -115,15 +115,15 @@ struct MultimodalContentPartTests {
     @Test("ChatMessage.videoUrls returns urls in order")
     func chatMessage_videoUrls() throws {
         let json = """
-        {
-          "role": "user",
-          "content": [
-            {"type": "video_url", "video_url": {"url": "https://a/1.mp4"}},
-            {"type": "text", "text": "and:"},
-            {"type": "video_url", "video_url": {"url": "https://a/2.mp4"}}
-          ]
-        }
-        """.data(using: .utf8)!
+            {
+              "role": "user",
+              "content": [
+                {"type": "video_url", "video_url": {"url": "https://a/1.mp4"}},
+                {"type": "text", "text": "and:"},
+                {"type": "video_url", "video_url": {"url": "https://a/2.mp4"}}
+              ]
+            }
+            """.data(using: .utf8)!
 
         let msg = try JSONDecoder().decode(ChatMessage.self, from: json)
         let urls = msg.videoUrls
@@ -135,14 +135,14 @@ struct MultimodalContentPartTests {
     @Test("mapOpenAIChatToMLX forwards videos to Chat.Message.videos")
     func mapping_forwardsVideos() throws {
         let json = """
-        [{
-          "role": "user",
-          "content": [
-            {"type": "text", "text": "what's in this clip"},
-            {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}}
-          ]
-        }]
-        """.data(using: .utf8)!
+            [{
+              "role": "user",
+              "content": [
+                {"type": "text", "text": "what's in this clip"},
+                {"type": "video_url", "video_url": {"url": "https://example.com/clip.mp4"}}
+              ]
+            }]
+            """.data(using: .utf8)!
 
         let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
@@ -167,13 +167,13 @@ struct MultimodalContentPartTests {
         let payload = Data([0x00, 0x01, 0x02, 0x03])
         let b64 = payload.base64EncodedString()
         let json = """
-        [{
-          "role": "user",
-          "content": [
-            {"type": "input_audio", "input_audio": {"data": "\(b64)", "format": "wav"}}
-          ]
-        }]
-        """.data(using: .utf8)!
+            [{
+              "role": "user",
+              "content": [
+                {"type": "input_audio", "input_audio": {"data": "\(b64)", "format": "wav"}}
+              ]
+            }]
+            """.data(using: .utf8)!
 
         let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
@@ -210,14 +210,14 @@ struct MultimodalContentPartTests {
         let videoB64 = videoBytes.base64EncodedString()
         let audioB64 = audioBytes.base64EncodedString()
         let json = """
-        [{
-          "role": "user",
-          "content": [
-            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,\(videoB64)"}},
-            {"type": "input_audio", "input_audio": {"data": "\(audioB64)", "format": "mp4"}}
-          ]
-        }]
-        """.data(using: .utf8)!
+            [{
+              "role": "user",
+              "content": [
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,\(videoB64)"}},
+                {"type": "input_audio", "input_audio": {"data": "\(audioB64)", "format": "mp4"}}
+              ]
+            }]
+            """.data(using: .utf8)!
 
         let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
@@ -231,8 +231,10 @@ struct MultimodalContentPartTests {
         }
         // The bug: previously this would be "m4a" because the audio
         // canonicalization table ran for video mediatypes too.
-        #expect(videoURL.pathExtension == "mp4",
-            "video/mp4 data URL must keep .mp4 extension, not be downgraded to .m4a")
+        #expect(
+            videoURL.pathExtension == "mp4",
+            "video/mp4 data URL must keep .mp4 extension, not be downgraded to .m4a"
+        )
 
         guard case .url(let audioURL) = mapped[0].audios[0] else {
             Issue.record("audio should materialize to .url(...)")
@@ -241,8 +243,10 @@ struct MultimodalContentPartTests {
         // Audio path: client said format=mp4 (an MP4 audio container), so
         // synthetic `data:audio/mp4;base64,...` URL goes through the audio
         // table — `mp4 → m4a` fires here as intended.
-        #expect(audioURL.pathExtension == "m4a",
-            "audio with format=mp4 should canonicalize to .m4a for AVAudioConverter")
+        #expect(
+            audioURL.pathExtension == "m4a",
+            "audio with format=mp4 should canonicalize to .m4a for AVAudioConverter"
+        )
 
         try? FileManager.default.removeItem(at: videoURL)
         try? FileManager.default.removeItem(at: audioURL)
@@ -255,16 +259,16 @@ struct MultimodalContentPartTests {
         // catches a regression where a refactor handles only `user` and
         // forgets the other branches.
         let json = """
-        [
-          {"role": "system", "content": "you are helpful"},
-          {"role": "user", "content": [
-              {"type": "text", "text": "hi"},
-              {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}
-          ]},
-          {"role": "assistant", "content": "hello"},
-          {"role": "tool", "content": "result", "tool_call_id": "abc"}
-        ]
-        """.data(using: .utf8)!
+            [
+              {"role": "system", "content": "you are helpful"},
+              {"role": "user", "content": [
+                  {"type": "text", "text": "hi"},
+                  {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}
+              ]},
+              {"role": "assistant", "content": "hello"},
+              {"role": "tool", "content": "result", "tool_call_id": "abc"}
+            ]
+            """.data(using: .utf8)!
 
         let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
         let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)

--- a/Packages/OsaurusCore/Tests/Service/IsKnownHybridModelMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/IsKnownHybridModelMCDCTests.swift
@@ -131,17 +131,19 @@ struct IsKnownHybridModelMCDCTests {
             "OsaurusAI/Gemma-4-31B-it-JANG_4M",
             "OsaurusAI/gemma-4-26B-A4B-it-4bit",
             "gemma-4-e2b-it-4bit-osaurus",
-            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",   // dense bf16 here
+            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",  // dense bf16 here
             "dealignai/Mistral-Small-4-119B-JANG_2L-CRACK",
-            "OsaurusAI/Laguna-XS.2-mxfp4",         // SWA hybrid, NOT Mamba
-            "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4", // dense GQA
-            "foundation",                          // Apple's built-in
-            "deepseekv4-flash-jangtq",             // DSV4 has its own cache topology
-            "",                                    // empty string edge case
+            "OsaurusAI/Laguna-XS.2-mxfp4",  // SWA hybrid, NOT Mamba
+            "OsaurusAI/Mistral-Medium-3.5-128B-mxfp4",  // dense GQA
+            "foundation",  // Apple's built-in
+            "deepseekv4-flash-jangtq",  // DSV4 has its own cache topology
+            "",  // empty string edge case
         ]
         for name in denseFamilies {
-            #expect(!ModelRuntime.isKnownHybridModel(name: name),
-                "must NOT match: \(name)")
+            #expect(
+                !ModelRuntime.isKnownHybridModel(name: name),
+                "must NOT match: \(name)"
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -29,12 +29,13 @@ struct ModelRuntimeIsHybridTests {
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
-            "nemotron-3-nano-omni-30b-a3b-mxfp4",            // case-folded picker form
+            "nemotron-3-nano-omni-30b-a3b-mxfp4",  // case-folded picker form
             "JANGQ-AI/Nemotron-3-Reasoning-Future-Variant",  // forward-compat
         ] {
             #expect(
                 ModelRuntime.isKnownHybridModel(name: id),
-                "Nemotron-3 family must flip setHybrid eagerly: \(id)")
+                "Nemotron-3 family must flip setHybrid eagerly: \(id)"
+            )
         }
     }
 
@@ -59,7 +60,8 @@ struct ModelRuntimeIsHybridTests {
         ] {
             #expect(
                 ModelRuntime.isKnownHybridModel(name: id),
-                "Qwen 3.5/3.6 MoE family + Holo3 must flip setHybrid: \(id)")
+                "Qwen 3.5/3.6 MoE family + Holo3 must flip setHybrid: \(id)"
+            )
         }
     }
 
@@ -88,13 +90,14 @@ struct ModelRuntimeIsHybridTests {
             "OsaurusAI/Gemma-4-31B-it-JANG_4M",
             "OsaurusAI/gemma-4-26B-A4B-it-4bit",
             "gemma-4-e2b-it-4bit-osaurus",
-            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",   // dense bf16, not Mamba
+            "JANGQ-AI/DeepSeekV4-Flash-JANG_2L",  // dense bf16, not Mamba
             "dealignai/Mistral-Small-4-119B-JANG_2L-CRACK",
-            "foundation",                          // Apple's built-in
+            "foundation",  // Apple's built-in
         ] {
             #expect(
                 !ModelRuntime.isKnownHybridModel(name: id),
-                "dense family must NOT flip setHybrid: \(id)")
+                "dense family must NOT flip setHybrid: \(id)"
+            )
         }
     }
 
@@ -112,7 +115,8 @@ struct ModelRuntimeIsHybridTests {
         ] {
             #expect(
                 !ModelRuntime.isKnownHybridModel(name: id),
-                "DSV4 hybrid attention is a different cache topology than the Mamba families this matcher targets: \(id)")
+                "DSV4 hybrid attention is a different cache topology than the Mamba families this matcher targets: \(id)"
+            )
         }
     }
 
@@ -129,12 +133,13 @@ struct ModelRuntimeIsHybridTests {
             "OsaurusAI/Laguna-XS.2-mxfp4",
             "OsaurusAI/Laguna-XS.2-JANGTQ2",
             "JANGQ-AI/Laguna-XS.2-JANGTQ2",
-            "laguna-xs.2-mxfp4",            // case-folded picker form
-            "OsaurusAI/Laguna-S.3-JANGTQ4", // forward-compat (future variant)
+            "laguna-xs.2-mxfp4",  // case-folded picker form
+            "OsaurusAI/Laguna-S.3-JANGTQ4",  // forward-compat (future variant)
         ] {
             #expect(
                 !ModelRuntime.isKnownHybridModel(name: id),
-                "Laguna SWA-hybrid is RotatingKVCache + KVCacheSimple, not Mamba — must NOT eager-flip setHybrid: \(id)")
+                "Laguna SWA-hybrid is RotatingKVCache + KVCacheSimple, not Mamba — must NOT eager-flip setHybrid: \(id)"
+            )
         }
     }
 
@@ -151,7 +156,8 @@ struct ModelRuntimeIsHybridTests {
         ] {
             #expect(
                 !ModelRuntime.isKnownHybridModel(name: id),
-                "Mistral 3.5 dense GQA + Pixtral has no Mamba layers — must NOT eager-flip setHybrid: \(id)")
+                "Mistral 3.5 dense GQA + Pixtral has no Mamba layers — must NOT eager-flip setHybrid: \(id)"
+            )
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -93,6 +93,11 @@ final class ChatSession: ObservableObject {
     /// so the Context Budget popover shows a "Memory" line even before the
     /// first send (when `cachedContext` is still nil).
     private var cachedMemoryTokens: Int = 0
+    /// Skill prompt section the agent will inject at send time. Resolved
+    /// asynchronously by `refreshSkillsSection` so the welcome-screen
+    /// preview composer (sync) can include the `Skills` row before the
+    /// first send. Mirrors the lifecycle of `cachedMemoryTokens`.
+    private var cachedSkillsSection: String?
     private let budgetTracker = ContextBudgetTracker()
 
     /// Per-session preflight + capabilities_load tool kit lives in the
@@ -294,7 +299,7 @@ final class ChatSession: ObservableObject {
             selectedModel = pickerItems.firstChatCapable?.id
         }
         isLoadingModel = false
-        Task { [weak self] in await self?.refreshMemoryTokens() }
+        Task { [weak self] in await self?.refreshContextEstimates() }
     }
 
     func refreshPickerItems() async {
@@ -453,24 +458,21 @@ final class ChatSession: ObservableObject {
             )
         }
 
-        let manifest = buildPreviewManifest(agentId: effectiveId, executionMode: executionMode)
-        // Estimate via `resolveTools` so the preview matches what the next
-        // send actually produces (manual filter, frozen snapshot). Preflight
-        // specs are not plumbed in (preview is sync) so the auto-mode
-        // estimate can under-count by the preflight delta on turn 1.
-        let toolTokens: Int
-        if AgentManager.shared.effectiveToolsDisabled(for: effectiveId) {
-            toolTokens = 0
-        } else {
-            let resolvedTools = SystemPromptComposer.resolveTools(
-                agentId: effectiveId,
-                executionMode: executionMode
-            )
-            toolTokens = ToolRegistry.shared.totalEstimatedTokens(for: resolvedTools)
-        }
+        // Mirror what `composeChatContext` will emit on the next send so
+        // the welcome-screen popover lists the same sections (Agent Loop,
+        // Capability Discovery, Skills, model family, …) instead of the
+        // base+sandbox-only stub. Preflight tool delta and Plugin
+        // Companions are query-dependent and stay deferred — the
+        // auto-mode `Tools` row can under-count by that delta on turn 1.
+        let preview = SystemPromptComposer.composePreviewContext(
+            agentId: effectiveId,
+            executionMode: executionMode,
+            model: selectedModel,
+            cachedSkillsSection: cachedSkillsSection
+        )
         return .from(
-            manifest: manifest,
-            toolTokens: toolTokens,
+            manifest: preview.manifest,
+            toolTokens: preview.toolTokens,
             memoryTokens: cachedMemoryTokens,
             conversationTokens: conversationTokens,
             inputTokens: inputTokens,
@@ -602,13 +604,18 @@ final class ChatSession: ObservableObject {
     func reset(for newAgentId: UUID?) {
         agentId = newAgentId
         reset()
-        Task { [weak self] in await self?.refreshMemoryTokens() }
+        Task { [weak self] in await self?.refreshContextEstimates() }
     }
 
     /// Invalidate the token cache (called when tools/skills change)
     func invalidateTokenCache() {
         cachedContext = nil
         budgetTracker.clear()
+        // Skills toggle through `invalidateTokenCache` (see
+        // `ChatWindowState.refreshAgentConfig`), so re-resolve the
+        // pre-loaded section so the welcome-screen preview reflects the
+        // new selection on the next render.
+        Task { [weak self] in await self?.refreshSkillsSection() }
         objectWillChange.send()
     }
 
@@ -705,7 +712,7 @@ final class ChatSession: ObservableObject {
         cachedContext = nil
         rebuildVisibleBlocks()
 
-        Task { [weak self] in await self?.refreshMemoryTokens() }
+        Task { [weak self] in await self?.refreshContextEstimates() }
     }
 
     private func refreshMemoryTokens() async {
@@ -725,6 +732,32 @@ final class ChatSession: ObservableObject {
         guard newTokens != cachedMemoryTokens else { return }
         cachedMemoryTokens = newTokens
         objectWillChange.send()
+    }
+
+    /// Pre-resolve the agent's enabled-skills prompt section so the
+    /// synchronous welcome-screen preview composer can price the `Skills`
+    /// row before the first send. Mirrors `refreshMemoryTokens`: skips
+    /// when tools are disabled (skills aren't injected then), and only
+    /// emits a change signal when the section actually shifts.
+    private func refreshSkillsSection() async {
+        let effectiveAgentId = agentId ?? Agent.defaultId
+        let toolsOff = AgentManager.shared.effectiveToolsDisabled(for: effectiveAgentId)
+        let newSection: String? =
+            toolsOff
+            ? nil
+            : await SkillManager.shared.enabledSkillPromptSection(for: effectiveAgentId)
+        guard newSection != cachedSkillsSection else { return }
+        cachedSkillsSection = newSection
+        objectWillChange.send()
+    }
+
+    /// Re-resolve every async input the welcome-screen preview composer
+    /// needs (memory tokens + skills section). One entry point so the
+    /// trigger sites — agent change, session reset, session load — stay
+    /// in lock-step instead of forgetting to kick one of the two.
+    private func refreshContextEstimates() async {
+        await refreshMemoryTokens()
+        await refreshSkillsSection()
     }
 
     /// Edit a user message and regenerate from that point
@@ -1012,21 +1045,6 @@ final class ChatSession: ObservableObject {
             folderContext: FolderContextService.shared.currentContext,
             autonomousEnabled: autonomous
         )
-    }
-
-    /// Synchronous manifest for offline token estimation (UI popover).
-    private func buildPreviewManifest(
-        agentId: UUID,
-        executionMode: ExecutionMode,
-        memoryContext: String = ""
-    ) -> PromptManifest {
-        var composer = SystemPromptComposer.forChat(
-            agentId: agentId,
-            executionMode: executionMode,
-            model: selectedModel
-        )
-        composer.append(.dynamic(id: "memory", label: "Memory", content: memoryContext))
-        return composer.manifest()
     }
 
     // MARK: - Private Helpers

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -93,11 +93,6 @@ final class ChatSession: ObservableObject {
     /// so the Context Budget popover shows a "Memory" line even before the
     /// first send (when `cachedContext` is still nil).
     private var cachedMemoryTokens: Int = 0
-    /// Skill prompt section the agent will inject at send time. Resolved
-    /// asynchronously by `refreshSkillsSection` so the welcome-screen
-    /// preview composer (sync) can include the `Skills` row before the
-    /// first send. Mirrors the lifecycle of `cachedMemoryTokens`.
-    private var cachedSkillsSection: String?
     private let budgetTracker = ContextBudgetTracker()
 
     /// Per-session preflight + capabilities_load tool kit lives in the
@@ -467,8 +462,7 @@ final class ChatSession: ObservableObject {
         let preview = SystemPromptComposer.composePreviewContext(
             agentId: effectiveId,
             executionMode: executionMode,
-            model: selectedModel,
-            cachedSkillsSection: cachedSkillsSection
+            model: selectedModel
         )
         return .from(
             manifest: preview.manifest,
@@ -611,11 +605,6 @@ final class ChatSession: ObservableObject {
     func invalidateTokenCache() {
         cachedContext = nil
         budgetTracker.clear()
-        // Skills toggle through `invalidateTokenCache` (see
-        // `ChatWindowState.refreshAgentConfig`), so re-resolve the
-        // pre-loaded section so the welcome-screen preview reflects the
-        // new selection on the next render.
-        Task { [weak self] in await self?.refreshSkillsSection() }
         objectWillChange.send()
     }
 
@@ -734,30 +723,13 @@ final class ChatSession: ObservableObject {
         objectWillChange.send()
     }
 
-    /// Pre-resolve the agent's enabled-skills prompt section so the
-    /// synchronous welcome-screen preview composer can price the `Skills`
-    /// row before the first send. Mirrors `refreshMemoryTokens`: skips
-    /// when tools are disabled (skills aren't injected then), and only
-    /// emits a change signal when the section actually shifts.
-    private func refreshSkillsSection() async {
-        let effectiveAgentId = agentId ?? Agent.defaultId
-        let toolsOff = AgentManager.shared.effectiveToolsDisabled(for: effectiveAgentId)
-        let newSection: String? =
-            toolsOff
-            ? nil
-            : await SkillManager.shared.enabledSkillPromptSection(for: effectiveAgentId)
-        guard newSection != cachedSkillsSection else { return }
-        cachedSkillsSection = newSection
-        objectWillChange.send()
-    }
-
     /// Re-resolve every async input the welcome-screen preview composer
-    /// needs (memory tokens + skills section). One entry point so the
-    /// trigger sites — agent change, session reset, session load — stay
-    /// in lock-step instead of forgetting to kick one of the two.
+    /// needs. Currently only memory tokens, but kept as a single entry
+    /// point so future async preview inputs land in one place instead of
+    /// being scattered across the trigger sites (agent change, session
+    /// reset, session load, capability config update).
     private func refreshContextEstimates() async {
         await refreshMemoryTokens()
-        await refreshSkillsSection()
     }
 
     /// Edit a user message and regenerate from that point

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2161,7 +2161,8 @@ extension FloatingInputCard {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
-        panel.message = mediaCapabilities.anyMedia
+        panel.message =
+            mediaCapabilities.anyMedia
             ? "Select files to attach (\(mediaCapabilities.summary) supported)"
             : "Select files to attach"
 

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2739,6 +2739,31 @@ private struct ContextBreakdownPopover: View {
 
     private var budgetCap: Int { maxTokens ?? breakdown.total }
 
+    /// One-line italic notice rendered above the entry list when the
+    /// composer auto-disabled features for a small-context model.
+    /// `nil` collapses the row entirely so normal-sized models render
+    /// the same popover they always did.
+    private var autoDisableNotice: String? {
+        guard let info = breakdown.disable,
+            info.disabledTools || info.disabledMemory
+        else { return nil }
+        let modelLabel =
+            info.modelId.flatMap { id in
+                id.caseInsensitiveCompare("foundation") == .orderedSame
+                    || id.caseInsensitiveCompare("default") == .orderedSame
+                    ? "Foundation" : id
+            } ?? "this model"
+        let ctxBlurb = info.contextLength.map { "(~\(formatTokenCount($0)) ctx)" } ?? ""
+        let what: String
+        switch (info.disabledTools, info.disabledMemory) {
+        case (true, true): what = "Tools and memory"
+        case (true, false): what = "Tools"
+        case (false, true): what = "Memory"
+        case (false, false): return nil
+        }
+        return "\(what) auto-disabled — \(modelLabel) \(ctxBlurb) is too small."
+    }
+
     private func color(for tint: ContextBreakdown.Tint) -> Color {
         switch tint {
         case .purple: return theme.isDark ? Color(red: 0.68, green: 0.52, blue: 1.0) : .purple
@@ -2773,6 +2798,15 @@ private struct ContextBreakdownPopover: View {
             barChart
                 .padding(.horizontal, 12)
                 .padding(.bottom, 10)
+
+            if let notice = autoDisableNotice {
+                Text(notice)
+                    .font(.system(size: 10).italic())
+                    .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 10)
+            }
 
             if !breakdown.context.isEmpty {
                 divider


### PR DESCRIPTION
## Summary

Found a bug with budget preview, and in the process, discovered a critical bug with every skills being loaded on every call.

also added model context sizes:

- tiny (sub 4k) -> disable tools and memory
- small (sub 8k) -> disable memory
- normal (8k+)

Related to #973

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
