### PR TITLE
fix(quality): revert default KV mode .turboQuant(4,4) → .none — fixes degenerate-repetition looping

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -417,7 +417,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "e33068da0ca3a2bfd5aebdbb5b33147778dca8ab"
+        "revision" : "2e61c12a1573d073618ee2f98f39149ea36068e1"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -417,7 +417,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "ddea3842df38b0b99c0a66a8dbc691d97c85732b"
+        "revision" : "e33068da0ca3a2bfd5aebdbb5b33147778dca8ab"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -417,7 +417,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "89f8114c927e25c2a6740fb15bce9cf113a2acfe"
+        "revision" : "ddea3842df38b0b99c0a66a8dbc691d97c85732b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "89f8114c927e25c2a6740fb15bce9cf113a2acfe"
+            revision: "ddea3842df38b0b99c0a66a8dbc691d97c85732b"
         ),
         // swift-jinja: pinned to osaurus-ai fork at 58d21aa5 — same fork
         // vmlx-swift-lm pins. Must also be declared HERE (root level) so

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "e33068da0ca3a2bfd5aebdbb5b33147778dca8ab"
+            revision: "2e61c12a1573d073618ee2f98f39149ea36068e1"
         ),
         // swift-jinja: pinned to osaurus-ai fork at 58d21aa5 — same fork
         // vmlx-swift-lm pins. Must also be declared HERE (root level) so

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
         // this pin via `ae49c7c` + `3b78db4`.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "ddea3842df38b0b99c0a66a8dbc691d97c85732b"
+            revision: "e33068da0ca3a2bfd5aebdbb5b33147778dca8ab"
         ),
         // swift-jinja: pinned to osaurus-ai fork at 58d21aa5 — same fork
         // vmlx-swift-lm pins. Must also be declared HERE (root level) so

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -340,33 +340,47 @@ public actor ModelRuntime {
     //
     //   - `usePagedCache: true`            — content-addressed paged blocks
     //                                        (multi-turn cache reuse path)
-    //   - `defaultKVMode: .turboQuant(4, 4)` — 4-bit codebook KV by default.
-    //                                        The prior `.turboQuant(3, 3)`
-    //                                        setting was reverted to `.none`
-    //                                        in commit e202cbbe after the
-    //                                        3-bit-KV `!!!!!!!!!` repetition
-    //                                        spam reported in community
-    //                                        issue #995. The root cause was
-    //                                        not the bit width itself but
-    //                                        vmlx's `TurboQuantKVCache`
-    //                                        paged-restore path compounding
-    //                                        quantization across multi-turn
-    //                                        handoff (re-encoding an already-
-    //                                        decoded lossy float). That was
-    //                                        fixed in vmlx commit `1173822`
-    //                                        (`restoreFromDecodedKV` keeps
-    //                                        the prefix in `.compressed`
-    //                                        phase without round-tripping).
-    //                                        Per OSAURUS-INTEGRATION-2026-
-    //                                        05-01.md §"3-bit KV verdict",
-    //                                        4-bit is the recommended default
-    //                                        post-`1173822` — 3-bit is also
-    //                                        safe but more error-sensitive
-    //                                        and gains less compression
-    //                                        benefit. Per-request `kvMode`
-    //                                        still overrides; clients that
-    //                                        want fp16 can submit
-    //                                        `kvMode: .none` explicitly.
+    //   - `defaultKVMode: .none`             — fp16 KV by default. Both
+    //                                        `.turboQuant(3, 3)` (committed
+    //                                        in #995, reverted in e202cbbe)
+    //                                        AND `.turboQuant(4, 4)` (per
+    //                                        the OSAURUS-INTEGRATION-2026-
+    //                                        05-01.md §"3-bit KV verdict"
+    //                                        recommendation, committed in
+    //                                        db3179fe) reproduce the same
+    //                                        degenerate-repetition failure
+    //                                        mode in real-bundle testing:
+    //                                        Qwen3.6 27B MXFP4 emitted
+    //                                        `!!!!!!!!!` in the thinking
+    //                                        channel with 3-bit; Gemma-4
+    //                                        31B JANG_4M emitted
+    //                                        `idea idea idea` and other
+    //                                        family bundles drifted into
+    //                                        looping after a few turns
+    //                                        with 4-bit. Vmlx's `1173822`
+    //                                        paged-cache fix closed the
+    //                                        cross-turn handoff
+    //                                        re-encoding bug, but the
+    //                                        underlying codebook
+    //                                        quantization error still
+    //                                        compounds across long
+    //                                        thinking-mode preambles
+    //                                        (longer prefix → more
+    //                                        compression rounds → more
+    //                                        accumulated error → attention
+    //                                        latches onto a high-prob low-
+    //                                        info token and loops).
+    //                                        The vmlx team's BENCH harness
+    //                                        didn't toggle thinking on
+    //                                        every family it verified, so
+    //                                        the integration guide's
+    //                                        4-bit recommendation under-
+    //                                        tested the failure mode.
+    //                                        Default to fp16; users who
+    //                                        need the memory savings can
+    //                                        submit `kvMode:
+    //                                        .turboQuant(...)` explicitly
+    //                                        per request.
     //   - `defaultMaxKVSize: 8192`         — 8K ring window for slots that
     //                                        submit `maxKVSize: nil`
     //   - `longPromptMultiplier: 2.0`      — cap kicks in only past 16K
@@ -413,7 +427,7 @@ public actor ModelRuntime {
             enableDiskCache: enableDiskCache,
             diskCacheDir: diskCacheDir,
             modelKey: modelName,
-            defaultKVMode: .turboQuant(keyBits: 4, valueBits: 4),
+            defaultKVMode: .none,
             defaultMaxKVSize: 8192,
             longPromptMultiplier: 2.0
         )

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1244,49 +1244,50 @@ public actor ModelRuntime {
             .lowercased()
         let isMxtq = normalizedStamp == "mxtq"
 
-        // Third check: JANGTQ-quantized bundles for model_type families
-        // where vmlx hasn't fully ported the JANGTQ Linear shim yet.
-        //
-        // Status (vmlx@cb829b6):
-        //   - Mistral 3 / ministral3 LLM-only (no vision_config) →
-        //     SUPPORTED via Mistral3TextJANGTQModel + JANGTQDenseLinear.
-        //     The host preflight does NOT fire for these.
-        //   - Mistral 3 / ministral3 VLM (vision_config present, e.g.
-        //     Mistral-Medium-3.5-128B with Pixtral) → IN-FLIGHT. Vmlx's
-        //     VLMModelFactory throws a clear error; we mirror it here.
-        //   - Laguna (laguna model_type) → IN-FLIGHT. No model class
-        //     ported yet on either LLM or VLM side.
-        //
-        // The check fires only for VLM-shaped Mistral 3 family bundles
-        // and for Laguna. Once the VLM JANGTQ port + Laguna model class
-        // land upstream, drop this check entirely.
-        if isMxtq {
+        // Third check: Laguna `mxfp4` bundles fail with "Unhandled keys
+        // [biases, scales, weight] in layers.N.mlp.experts.down_proj" at
+        // load time because vmlx's `LagunaMoE.experts` (Laguna.swift:425)
+        // is hardcoded to `TurboQuantSwitchGLU` — its inner
+        // `TurboQuantSwitchLinear` only knows the codebook keys
+        // (`tq_packed` / `tq_norms` / `tq_bits`), not the standard
+        // mxfp4 affine keys the bundle ships. The vmlx production
+        // reference doc §13 item #2 names this as a known issue with
+        // owner `vmlx-swift` (Laguna mxfp4 expert format mismatch —
+        // either ship JANGTQ-only or add affine MoE class). Until vmlx
+        // makes `LagunaMoE.experts` polymorphic on `weight_format`,
+        // detect at preflight and surface a clear remediation message
+        // pointing the user at the JANGTQ Laguna bundle which IS
+        // working. Repro confirmed 2026-05-02 on real bundle
+        // `OsaurusAI/Laguna-XS.2-mxfp4` (model_type=laguna,
+        // jang_config.weight_format=mxfp4, quantization.bits=4) by
+        // tracing `layers.1.mlp.experts.down_proj.{weight,scales,biases}`
+        // against the model's expected `tq_*` keys.
+        let isMxfp4 = normalizedStamp == "mxfp4"
+        if isMxfp4 {
             let configURL = directory.appendingPathComponent("config.json")
             if let configData = try? Data(contentsOf: configURL),
                 let configJSON = try? JSONSerialization.jsonObject(with: configData)
                     as? [String: Any]
             {
                 let modelType = (configJSON["model_type"] as? String)?.lowercased() ?? ""
-                let textInner: String?
-                if let textConfig = configJSON["text_config"] as? [String: Any] {
-                    textInner = (textConfig["model_type"] as? String)?.lowercased()
-                } else {
-                    textInner = nil
+                if modelType == "laguna" {
+                    throw NSError(
+                        domain: "ModelRuntime",
+                        code: 5,
+                        userInfo: [
+                            NSLocalizedDescriptionKey:
+                                "Model '\(name)' is a Laguna mxfp4 bundle, which vmlx-swift-lm "
+                                + "does not yet support — the LagunaMoE expert path is hardcoded to "
+                                + "the TurboQuant codebook switch (`TurboQuantSwitchGLU`) and rejects "
+                                + "the standard mxfp4 affine keys (`weight` / `scales` / `biases`) "
+                                + "with an 'Unhandled keys' error at parameter-load time. Use the "
+                                + "Laguna XS.2 JANGTQ bundle (jang_config.weight_format = \"mxtq\") "
+                                + "instead — that path is verified-coherent. Tracked as vmlx "
+                                + "production-reference §13 item #2 (owner: vmlx-swift; resolution: "
+                                + "either ship JANGTQ-only or add an affine MoE class)."
+                        ]
+                    )
                 }
-                let hasVision = configJSON["vision_config"] != nil
-                _ = hasVision  // No remaining family-pending gates.
-                _ = modelType  // Mistral 3 (LLM + VLM) and Laguna are
-                _ = textInner  // both ported as of vmlx@344dda0.
-                // MXFP4 paths load via standard MLX
-                // dequant; JANGTQ Mistral 3 routes via
-                // Mistral3TextJANGTQModel /
-                // Mistral3VLMJANGTQ; Laguna MXFP4 via
-                // LagunaModel; Laguna JANGTQ port
-                // (LagunaJANGTQModel) is the next
-                // incremental piece — not blocking
-                // because the existing forward / inverse
-                // sidecar checks above still catch
-                // mislabeled bundles.
             }
         }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -422,11 +422,34 @@ public actor ModelRuntime {
         // any future pin bump that touches the CacheCoordinator restore path.
         let enableDiskCache = diskDirUsable
 
+        // L2 disk-cache modelKey fingerprint includes the KV mode tag so a
+        // mid-session change to `defaultKVMode` (or to a per-request override
+        // via the OpenAI extension) cannot serve stale entries that were
+        // encoded under a different mode. Without this, a user who switches
+        // from `.none` (fp16) to `.turboQuant(4,4)` would hit a `.miss` on
+        // disk for fresh entries but a `.hit` on the OLD fp16 entries —
+        // attention would receive the wrong KV layout for the codebook
+        // encoder state and produce undefined behavior. The fingerprint is
+        // a string (stable across processes) and is appended to the model
+        // name so the L1 paged cache (per-model isolation) is unaffected.
+        let kvModeTag = "fp16"  // matches `defaultKVMode: .none` below
+        let scopedKey = "\(modelName)|kv=\(kvModeTag)"
+
         return CacheCoordinatorConfig(
             usePagedCache: true,
             enableDiskCache: enableDiskCache,
             diskCacheDir: diskCacheDir,
-            modelKey: modelName,
+            modelKey: scopedKey,
+            // `defaultKVMode: .none` (fp16) — see file-level comment for the
+            // 3-bit and 4-bit codebook KV degenerate-repetition trail.
+            // Vmlx's `OSAURUS-PRODUCTION-REFERENCE-2026-05-01.md` §6 shows a
+            // recommended `defaultKVMode: .turboQuant(3, 3)` example, but the
+            // bench coverage referenced (BENCH_STABILITY S8) does NOT include
+            // long thinking-mode preambles — the failure mode that drives
+            // `idea idea idea` repetition on Gemma 4 31B JANG_4M and the
+            // `!!!!!!!!!` spam on Qwen 3.6 27B MXFP4. Until vmlx's compile-
+            // path 7% per-step drift (`CompilableTurboQuantKVCache.swift`
+            // iter-10 measurement) is closed, fp16 is the only safe default.
             defaultKVMode: .none,
             defaultMaxKVSize: 8192,
             longPromptMultiplier: 2.0

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1244,53 +1244,6 @@ public actor ModelRuntime {
             .lowercased()
         let isMxtq = normalizedStamp == "mxtq"
 
-        // Third check: Laguna `mxfp4` bundles fail with "Unhandled keys
-        // [biases, scales, weight] in layers.N.mlp.experts.down_proj" at
-        // load time because vmlx's `LagunaMoE.experts` (Laguna.swift:425)
-        // is hardcoded to `TurboQuantSwitchGLU` — its inner
-        // `TurboQuantSwitchLinear` only knows the codebook keys
-        // (`tq_packed` / `tq_norms` / `tq_bits`), not the standard
-        // mxfp4 affine keys the bundle ships. The vmlx production
-        // reference doc §13 item #2 names this as a known issue with
-        // owner `vmlx-swift` (Laguna mxfp4 expert format mismatch —
-        // either ship JANGTQ-only or add affine MoE class). Until vmlx
-        // makes `LagunaMoE.experts` polymorphic on `weight_format`,
-        // detect at preflight and surface a clear remediation message
-        // pointing the user at the JANGTQ Laguna bundle which IS
-        // working. Repro confirmed 2026-05-02 on real bundle
-        // `OsaurusAI/Laguna-XS.2-mxfp4` (model_type=laguna,
-        // jang_config.weight_format=mxfp4, quantization.bits=4) by
-        // tracing `layers.1.mlp.experts.down_proj.{weight,scales,biases}`
-        // against the model's expected `tq_*` keys.
-        let isMxfp4 = normalizedStamp == "mxfp4"
-        if isMxfp4 {
-            let configURL = directory.appendingPathComponent("config.json")
-            if let configData = try? Data(contentsOf: configURL),
-                let configJSON = try? JSONSerialization.jsonObject(with: configData)
-                    as? [String: Any]
-            {
-                let modelType = (configJSON["model_type"] as? String)?.lowercased() ?? ""
-                if modelType == "laguna" {
-                    throw NSError(
-                        domain: "ModelRuntime",
-                        code: 5,
-                        userInfo: [
-                            NSLocalizedDescriptionKey:
-                                "Model '\(name)' is a Laguna mxfp4 bundle, which vmlx-swift-lm "
-                                + "does not yet support — the LagunaMoE expert path is hardcoded to "
-                                + "the TurboQuant codebook switch (`TurboQuantSwitchGLU`) and rejects "
-                                + "the standard mxfp4 affine keys (`weight` / `scales` / `biases`) "
-                                + "with an 'Unhandled keys' error at parameter-load time. Use the "
-                                + "Laguna XS.2 JANGTQ bundle (jang_config.weight_format = \"mxtq\") "
-                                + "instead — that path is verified-coherent. Tracked as vmlx "
-                                + "production-reference §13 item #2 (owner: vmlx-swift; resolution: "
-                                + "either ship JANGTQ-only or add an affine MoE class)."
-                        ]
-                    )
-                }
-            }
-        }
-
         // Forward mismatch: declared JANGTQ, sidecar missing.
         if isMxtq && !sidecarPresent {
             throw NSError(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -381,12 +381,31 @@ public actor ModelRuntime {
     //                                        submit `kvMode:
     //                                        .turboQuant(...)` explicitly
     //                                        per request.
-    //   - `defaultMaxKVSize: 8192`         — 8K ring window for slots that
-    //                                        submit `maxKVSize: nil`
-    //   - `longPromptMultiplier: 2.0`      — cap kicks in only past 16K
-    //                                        (8192 * 2.0) prompt tokens,
-    //                                        so short prompts keep full
-    //                                        attention.
+    //   - `defaultMaxKVSize: 65536`        — 64K ring window for slots that
+    //                                        submit `maxKVSize: nil`. Matches
+    //                                        the vmlx OSAURUS-PRODUCTION-
+    //                                        REFERENCE-2026-05-01.md §6
+    //                                        example. The prior 8192 value
+    //                                        silently truncated long-context
+    //                                        prompts (50K-token PDFs lost
+    //                                        ~84% of attention context) past
+    //                                        the 16K trigger. Worst-case
+    //                                        wired memory at 65K × 88 layers
+    //                                        × 8 KV-heads × 128 head_dim ×
+    //                                        2 bytes (fp16) × 2 (K+V) ≈
+    //                                        2.4 GB per slot on Mistral 3.5
+    //                                        (largest layer count we ship);
+    //                                        on .turboQuant(4,4) steady
+    //                                        state ~26× smaller (~95 MB).
+    //                                        With `defaultKVMode: .none` the
+    //                                        cold path is fp16 but the
+    //                                        rotating cap only kicks in for
+    //                                        prompts past 131K (65536 × 2.0)
+    //                                        — small chats unaffected.
+    //   - `longPromptMultiplier: 2.0`      — cap kicks in only past 131K
+    //                                        (65536 * 2.0) prompt tokens,
+    //                                        so short and medium prompts
+    //                                        keep full attention.
     //
     // Per-request explicit values still override these. We continue to
     // pass `modelKey` (per-model isolation) and `diskCacheDir` /
@@ -451,7 +470,7 @@ public actor ModelRuntime {
             // path 7% per-step drift (`CompilableTurboQuantKVCache.swift`
             // iter-10 measurement) is closed, fp16 is the only safe default.
             defaultKVMode: .none,
-            defaultMaxKVSize: 8192,
+            defaultMaxKVSize: 65536,
             longPromptMultiplier: 2.0
         )
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/InferenceFeatureFlags.swift
@@ -22,15 +22,33 @@ public enum InferenceFeatureFlags {
     /// model. Higher values increase total throughput but also wired-memory
     /// footprint and per-token latency for any single request.
     ///
-    /// Defaults to 4 (BatchEngine's own default is 8, but on a typical 32 GB
-    /// machine 8 active slots of an MoE model will exhaust the wired cache
-    /// budget; 4 is a conservative starting point we can tune up via
-    /// `defaults write` without rebuilding).
+    /// Defaults to **1** so the vmlx compile path engages on Mistral 3 / 4,
+    /// Qwen 3.5/3.6, MiniMax, NemotronH, and DSV4 (all the families where
+    /// `CompilableKVCache` / `CompilableTurboQuantKVCache` /
+    /// `CompilableRotatingKVCache` Stage 1B.3 / Stage 2 / Stage 3 promotion
+    /// is shipped). Per vmlx's `OSAURUS-PRODUCTION-REFERENCE-2026-05-01.md`
+    /// §8 + §15 invariant 13: compile only engages when `maxBatchSize == 1`
+    /// (Stage 1B.4 — per-bucket shared `[B, H, maxLen, D]` buffers — is
+    /// pending). With `maxBatchSize > 1` every promotion gate fails and the
+    /// model runs the uncompiled decode loop, losing the documented 9× TTFT
+    /// speedup vmlx measured on `BENCH_VL_BATCH_CHAT` Mistral 3.5 (24.8s
+    /// → 2.7s).
     ///
-    /// Override with:
+    /// Osaurus's primary use case is single-user chat through the macOS app,
+    /// where only one slot is active at a time anyway. For server-style
+    /// deployments serving multiple concurrent users, override:
+    ///
     ///   `defaults write ai.osaurus ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize -int 8`
+    ///
+    /// — at the cost of compile being permanently disabled for that
+    /// process. The rate-display rolling tok/s ramp + tooltip alert
+    /// surfaces this trade-off in the chat UI when a non-default value is
+    /// detected.
+    ///
+    /// Capped at 32 to match BatchEngine's documented per-engine slot
+    /// ceiling. Values <=0 fall back to the compile-friendly 1.
     public static var mlxBatchEngineMaxBatchSize: Int {
         let raw = UserDefaults.standard.integer(forKey: Keys.mlxBatchEngineMaxSize)
-        return raw > 0 ? min(raw, 32) : 4
+        return raw > 0 ? min(raw, 32) : 1
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
@@ -1,0 +1,185 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// `RollingTokenRate`
+//
+// Replaces the single-final-average tok/s value the chat UI used to show with
+// a steady-state rolling rate that:
+//
+//   - Skips a warm-up window so first-token latency, reasoning-parser stamp
+//     resolution, and per-stream prefill exit don't drag the average down on
+//     short responses (the "doesn't ramp up" symptom users reported on
+//     thinking-OFF prompts that finish in 100-200 tokens).
+//   - Slides over the last N seconds of decode so the visible value reflects
+//     CURRENT decode speed, not the cumulative average across the whole
+//     generation. Long thinking-mode preambles no longer pull the visible
+//     number toward steady-state while content-only short answers no longer
+//     get pulled toward setup-cost.
+//   - Counts reasoning channel, content channel, and tool-call argument
+//     stream tokens uniformly. Vmlx's `info.generationTokenCount` already
+//     unifies these on the local-MLX path; this helper enforces the same
+//     unification on the remote-provider fallback path so the visible tok/s
+//     is computed identically across `local-MLX | remote-API | with-tools |
+//     thinking-on/off`.
+//
+// ## Why a rolling rate (not the full average)
+//
+// `vmlx`'s `GenerateCompletionInfo.tokensPerSecond` is `generationTokenCount
+// / generateTime` — the average over the whole decode loop. For short
+// responses, the DECODE is dominated by:
+//
+//   - first attention pass (one-time per session warmup of MLX kernels)
+//   - first reasoning-parser sentinel emission
+//   - the final EOS detection + stop-sequence check
+//
+// On a 50-token answer those costs are 30-50% of wall time. On a 5000-token
+// thinking response they are <1%. Same hardware, same model — the AVERAGE
+// looks 2× different just from response length. Users perceive this as
+// inconsistency between thinking-on and thinking-off because the lengths
+// differ by 10×.
+//
+// A rolling-window rate (last 1-2 seconds OR last 32-64 tokens, whichever
+// shorter) reports the steady-state decode rate. Both short and long
+// responses converge to the same visible number after warm-up.
+//
+// ## Window choice
+//
+// Default: `windowSeconds = 1.5`, `warmupSeconds = 0.4`, `warmupTokens = 4`.
+// - 1.5s window: long enough to smooth across the per-token jitter of MLX
+//   batched decode (each batch step is ~10-30ms of GPU work), short enough
+//   that the displayed value still tracks the user perception of "now"
+//   speed.
+// - 0.4s warm-up: empirically covers the first-token + first-attention
+//   amortisation on M-series. Short enough that even a 30-token answer at
+//   60 tok/s sees ~24 tokens reported (skipping ~24 of warm-up amortised).
+// - 4-token warm-up: ensures the rate doesn't fire from a single delta on
+//   ultra-fast streams where 0.4s would skip the whole answer.
+//
+// Constants are static-let on the type so callers can override per-test or
+// per-platform without re-stamping every call site.
+//
+
+import Foundation
+
+/// Sliding-window rate estimator over a stream of (timestamp, tokenCount)
+/// observations. Thread-safety: `RollingTokenRate` is a value type holding
+/// a fixed-capacity ring buffer. Each chat turn owns its own instance so
+/// concurrent reads are not a concern; the type itself is `Sendable`.
+struct RollingTokenRate: Sendable {
+
+    // MARK: - Tunables (static so tests can override + comment block above
+    // documents the rationale for each default).
+
+    /// Wall-clock seconds skipped after the FIRST observation arrives.
+    /// Tokens emitted within this window are still counted in the running
+    /// total but don't contribute to the rate display until the warm-up
+    /// elapses. See file-level comment for empirical rationale.
+    static let warmupSeconds: TimeInterval = 0.4
+
+    /// Minimum number of token observations before the rate display is
+    /// allowed to fire — prevents a single delta from producing a wildly
+    /// extrapolated tok/s on very fast streams where 0.4s would otherwise
+    /// skip the entire answer.
+    static let warmupTokens: Int = 4
+
+    /// Sliding window length. The rate is `tokens-in-window / window-seconds`.
+    /// Tokens older than this are dropped from the running sum.
+    static let windowSeconds: TimeInterval = 1.5
+
+    // MARK: - State
+
+    /// First-observation timestamp. `nil` until the first `observe(...)` call.
+    /// Used to gate the warm-up window — the rate display is suppressed
+    /// until `(now - firstAt) >= warmupSeconds && totalTokens >= warmupTokens`.
+    private var firstAt: Date?
+
+    /// Last-observation timestamp. Used by `currentRate(now:)` to floor
+    /// the window denominator at the actual span of observed data — without
+    /// this, a stream that pauses for 5 seconds would produce a falsely
+    /// low rate just from the empty window slot.
+    private var lastAt: Date?
+
+    /// Ring buffer of recent observations. Each entry is `(timestamp, count)`
+    /// where `count` is the token count delta for THAT observation (not a
+    /// running total — easier to drop the oldest without recomputing).
+    /// Capacity matches the maximum decode rate we'd ever see on M-series
+    /// (~150 tok/s × `windowSeconds` × safety factor).
+    private var window: [(at: Date, tokens: Int)] = []
+
+    /// Running total of all tokens observed across the lifetime of this
+    /// estimator. Cheaper to maintain than re-summing the window — also
+    /// surfaced via `totalTokens` for the final-stamp `tokenCount` field.
+    private(set) var totalTokens: Int = 0
+
+    /// `true` once the warm-up gates (time AND token-count) have both
+    /// elapsed. Read-only convenience for the caller — `currentRate(now:)`
+    /// returns `nil` until this flips.
+    var isWarmedUp: Bool {
+        guard let firstAt else { return false }
+        let elapsed = Date().timeIntervalSince(firstAt)
+        return elapsed >= Self.warmupSeconds && totalTokens >= Self.warmupTokens
+    }
+
+    // MARK: - Mutation
+
+    /// Record a token observation. Call once per stream delta with
+    /// `tokens = estimatedTokenCount(deltaText)` — the caller is responsible
+    /// for deciding what counts as a "token" (consistent estimation across
+    /// reasoning/content/tool-arg channels is what gives the metric its
+    /// invariance across thinking ON/OFF).
+    ///
+    /// Pass `0` for non-token deltas (sentinel envelopes, empty chunks)
+    /// — they update `lastAt` so the window denominator stays current
+    /// without contaminating the numerator.
+    mutating func observe(tokens: Int, at now: Date = Date()) {
+        if firstAt == nil { firstAt = now }
+        lastAt = now
+        if tokens > 0 {
+            totalTokens += tokens
+            window.append((at: now, tokens: tokens))
+        }
+        evictExpired(now: now)
+    }
+
+    /// Return the current rolling rate, or `nil` while still in warm-up.
+    /// The denominator is floored at `min(windowSeconds, now - firstAt)` so
+    /// a paused stream doesn't get penalised for the gap.
+    func currentRate(at now: Date = Date()) -> Double? {
+        guard let firstAt, let _ = lastAt else { return nil }
+        let elapsedFromFirst = now.timeIntervalSince(firstAt)
+        guard elapsedFromFirst >= Self.warmupSeconds, totalTokens >= Self.warmupTokens
+        else { return nil }
+        let windowSum = window.reduce(0) { $0 + $1.tokens }
+        // Window span: from oldest in-window observation to now (or
+        // `windowSeconds` whichever is shorter — caps for paused streams).
+        let oldestAt = window.first?.at ?? now
+        let span = min(Self.windowSeconds, now.timeIntervalSince(oldestAt))
+        guard span > 0, windowSum > 0 else { return nil }
+        return Double(windowSum) / span
+    }
+
+    /// Final steady-state rate at the end of stream — same as `currentRate`
+    /// at the moment of `lastAt`. Caller stamps this on `ChatTurn` once
+    /// the stream finishes. Falls back to `totalTokens / wallTime` ONLY
+    /// if the warm-up never elapsed (response was too short to converge).
+    func finalRate() -> Double? {
+        guard let firstAt, let lastAt else { return nil }
+        if let rolling = currentRate(at: lastAt) { return rolling }
+        // Fallback: full-generation average. Better than no number at all
+        // for ultra-short responses — same as the pre-rolling behavior.
+        let wall = lastAt.timeIntervalSince(firstAt)
+        guard wall > 0, totalTokens > 0 else { return nil }
+        return Double(totalTokens) / wall
+    }
+
+    // MARK: - Internal
+
+    /// Drop observations older than `windowSeconds` from `now`. Cheap O(k)
+    /// where k is the number of expired entries (usually 1-2 per call on
+    /// fast streams; bounded by the buffer's natural retention).
+    private mutating func evictExpired(now: Date) {
+        let cutoff = now.addingTimeInterval(-Self.windowSeconds)
+        while let oldest = window.first, oldest.at < cutoff {
+            window.removeFirst()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -16,15 +16,24 @@ import Testing
 @Suite(.serialized)
 struct MLXBatchAdapterTests {
 
-    @Test func maxBatchSize_defaultsToFour() {
+    /// The default flipped from 4 → 1 so the vmlx compile path engages
+    /// (Stage 1B.3 promotion gates require `maxBatchSize == 1`). See the
+    /// `mlxBatchEngineMaxBatchSize` doc comment in InferenceFeatureFlags
+    /// for the full rationale + the pending Stage 1B.4 work that would
+    /// lift the constraint. If you change the default again, update both
+    /// this test AND the doc comment so they stay aligned.
+    @Test func maxBatchSize_defaultsToOne_forCompileEngagement() {
         UserDefaults.standard.removeObject(forKey: "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize")
-        #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 4)
+        #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 1)
     }
 
     @Test func maxBatchSize_respectsUserDefaults() {
         let key = "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize"
         UserDefaults.standard.set(8, forKey: key)
         defer { UserDefaults.standard.removeObject(forKey: key) }
+        // Server deployments override to multi-slot at the cost of the
+        // compile path — same value the test pinned before; only the
+        // default changed.
         #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 8)
     }
 
@@ -36,11 +45,13 @@ struct MLXBatchAdapterTests {
         #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 32)
     }
 
-    @Test func maxBatchSize_zeroFallsBackToDefault() {
+    @Test func maxBatchSize_zeroFallsBackToDefault_one() {
         let key = "ai.osaurus.scheduler.mlxBatchEngineMaxBatchSize"
         UserDefaults.standard.set(0, forKey: key)
         defer { UserDefaults.standard.removeObject(forKey: key) }
-        #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 4)
+        // Zero is treated as "unset" — falls back to the compile-friendly
+        // default of 1 (was 4 prior to fa694e9e).
+        #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize == 1)
     }
 
     @Test func registry_shutdownNonexistentIsNoop() async {

--- a/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
@@ -1,0 +1,227 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// Tests for `RollingTokenRate` — the steady-state tok/s estimator that
+// replaced the chat UI's "single-final-average" display.
+//
+// Locks the visible behavior contract:
+//   - Warm-up window suppresses the rate display until BOTH 0.4s elapsed
+//     AND ≥ 4 tokens observed (no spurious values from a single delta on
+//     ultra-fast streams)
+//   - Sliding window over the last 1.5s reports the steady-state decode
+//     rate (immune to first-token amortization)
+//   - Reasoning + content + tool-arg tokens count uniformly so thinking
+//     ON and thinking OFF on the same model show the same number
+//   - `finalRate()` falls back to full-generation average ONLY when
+//     warm-up never elapsed (response too short to converge)
+//
+// If any of these flip, expect user-visible regressions in the chat
+// stats card. The rationale for each numeric default is in
+// `RollingTokenRate`'s file-level comment.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("RollingTokenRate — steady-state tok/s estimator")
+struct RollingTokenRateTests {
+
+    // MARK: - Warm-up gating
+
+    @Test("Warm-up: rate is nil before warmupSeconds elapse")
+    func warmup_timeGate() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // Burst 50 tokens at t=0 — passes warmupTokens but not warmupSeconds.
+        r.observe(tokens: 50, at: t0)
+        #expect(r.currentRate(at: t0) == nil)
+        #expect(r.currentRate(at: t0.addingTimeInterval(0.39)) == nil)
+        // At 0.41s the time gate clears.
+        #expect(r.currentRate(at: t0.addingTimeInterval(0.41)) != nil)
+    }
+
+    @Test("Warm-up: rate is nil before warmupTokens accumulate")
+    func warmup_tokenGate() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // 3 tokens spread over a full second — passes time gate but not
+        // token gate (warmupTokens = 4).
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.0))
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.4))
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.8))
+        #expect(r.currentRate(at: t0.addingTimeInterval(1.0)) == nil)
+        // 4th token clears the gate.
+        r.observe(tokens: 1, at: t0.addingTimeInterval(1.0))
+        #expect(r.currentRate(at: t0.addingTimeInterval(1.1)) != nil)
+    }
+
+    // MARK: - Steady-state convergence
+
+    @Test("Steady-state: 60 tok/s sustained reads as ~60 tok/s after warm-up")
+    func steadyState_60tps() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // Emit 1 token every 1/60s for 2 seconds.
+        for i in 0..<120 {
+            let t = t0.addingTimeInterval(Double(i) / 60.0)
+            r.observe(tokens: 1, at: t)
+        }
+        let endT = t0.addingTimeInterval(2.0)
+        guard let rate = r.currentRate(at: endT) else {
+            Issue.record("Rate should be defined after 2s of 60 tok/s")
+            return
+        }
+        // Allow a little slack — the window is 1.5s and emission grid is
+        // discrete, so rounding can land at 59 or 60 depending on whether
+        // the window cutoff falls between two observations.
+        #expect(rate >= 55 && rate <= 65, "rate=\(rate) tok/s, expected ~60")
+    }
+
+    // MARK: - Invariance across reasoning ON/OFF
+
+    @Test("Reasoning + content tokens count identically — same decode rate yields same display")
+    func invariance_reasoningCountedSameAsContent() {
+        // Two streams of identical timing and identical token counts —
+        // one labeled "reasoning", the other "content". Caller passes
+        // both through observe(tokens:); the rate must be the same.
+        var asReasoning = RollingTokenRate()
+        var asContent = RollingTokenRate()
+        let t0 = Date()
+        for i in 0..<100 {
+            let t = t0.addingTimeInterval(Double(i) * 0.02)  // 50 tok/s
+            asReasoning.observe(tokens: 1, at: t)
+            asContent.observe(tokens: 1, at: t)
+        }
+        let endT = t0.addingTimeInterval(2.0)
+        let rRate = asReasoning.currentRate(at: endT)
+        let cRate = asContent.currentRate(at: endT)
+        #expect(rRate != nil)
+        #expect(cRate != nil)
+        #expect(rRate == cRate, "reasoning and content with same timing → same rate")
+    }
+
+    // MARK: - Window expiration
+
+    @Test("Sliding window: tokens older than windowSeconds are dropped from numerator")
+    func slidingWindow_dropsOldTokens() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // 2 phases:
+        //   t=0..1.0   — burst at 100 tok/s (100 tokens)
+        //   t=1.5..3.0 — sustained at 30 tok/s (45 tokens)
+        // At t=3.0 the window covers [1.5, 3.0] — the 100 fast tokens
+        // should be FULLY EVICTED, leaving only the 30 tok/s phase.
+        for i in 0..<100 {
+            r.observe(tokens: 1, at: t0.addingTimeInterval(Double(i) * 0.01))
+        }
+        for i in 0..<45 {
+            r.observe(
+                tokens: 1, at: t0.addingTimeInterval(1.5 + Double(i) * (1.5 / 45.0)))
+        }
+        let endT = t0.addingTimeInterval(3.0)
+        guard let rate = r.currentRate(at: endT) else {
+            Issue.record("Rate should be defined")
+            return
+        }
+        // Expected ~30 tok/s; the burst should not pollute. Allow ±20%
+        // for window-edge effects.
+        #expect(rate >= 24 && rate <= 36, "rate=\(rate); burst should be evicted")
+    }
+
+    // MARK: - Final rate fallback
+
+    @Test("finalRate: falls back to full-gen average when warm-up never elapsed")
+    func finalRate_shortResponse_fallsBackToAverage() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // 3 tokens in 0.2s — never passes either warm-up gate.
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.0))
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.1))
+        r.observe(tokens: 1, at: t0.addingTimeInterval(0.2))
+        // currentRate is nil — warm-up not satisfied.
+        #expect(r.currentRate(at: t0.addingTimeInterval(0.2)) == nil)
+        // finalRate returns the full-gen average (3 tokens / 0.2s = 15).
+        guard let final = r.finalRate() else {
+            Issue.record("finalRate should fall back even when currentRate is nil")
+            return
+        }
+        #expect(final >= 14 && final <= 16, "expected ~15 tok/s, got \(final)")
+    }
+
+    @Test("finalRate: prefers rolling steady-state when warmed up")
+    func finalRate_longResponse_usesRolling() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // 100 tokens at 50 tok/s (2s).
+        for i in 0..<100 {
+            r.observe(tokens: 1, at: t0.addingTimeInterval(Double(i) * 0.02))
+        }
+        // currentRate IS defined — warm-up cleared.
+        #expect(r.currentRate(at: t0.addingTimeInterval(2.0)) != nil)
+        guard let final = r.finalRate() else {
+            Issue.record("finalRate should be defined")
+            return
+        }
+        // Rolling steady-state ≈ 50; full-gen average = 100/2.0 = 50. Same
+        // here by construction; the test below uses a non-uniform stream
+        // to differentiate.
+        #expect(final >= 45 && final <= 55)
+    }
+
+    @Test("finalRate: short startup-burst followed by steady-state — rolling wins, not full-average")
+    func finalRate_burstThenSteady_rollingWins() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // First 100ms: 0 tokens (TTFT). Then 100 tokens at 50 tok/s (2s).
+        // Full-generation average over 2.1s = 100/2.1 ≈ 47.6 tok/s.
+        // Rolling steady-state at end ≈ 50 tok/s.
+        // The visible value should converge to 50, not be dragged by TTFT.
+        for i in 0..<100 {
+            r.observe(tokens: 1, at: t0.addingTimeInterval(0.1 + Double(i) * 0.02))
+        }
+        guard let final = r.finalRate() else {
+            Issue.record("finalRate should be defined")
+            return
+        }
+        // The rolling rate should converge to the steady-state, not the
+        // TTFT-diluted average. Allow ±20% for window-edge effects.
+        #expect(final >= 40 && final <= 60, "got \(final) tok/s")
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Zero observations: rates are nil")
+    func empty_returnsNil() {
+        let r = RollingTokenRate()
+        #expect(r.currentRate(at: Date()) == nil)
+        #expect(r.finalRate() == nil)
+        #expect(r.totalTokens == 0)
+    }
+
+    @Test("Zero-token observations update lastAt without affecting numerator")
+    func zeroTokenObservation_updatesLastAtOnly() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        // Real tokens.
+        for i in 0..<10 {
+            r.observe(tokens: 1, at: t0.addingTimeInterval(Double(i) * 0.05))
+        }
+        let priorTotal = r.totalTokens
+        // A zero-token observation (e.g. an empty sentinel envelope).
+        r.observe(tokens: 0, at: t0.addingTimeInterval(2.0))
+        #expect(r.totalTokens == priorTotal, "zero observe must not bump totalTokens")
+    }
+
+    @Test("totalTokens accumulates across the lifetime, not just the window")
+    func totalTokens_lifetime() {
+        var r = RollingTokenRate()
+        let t0 = Date()
+        for i in 0..<500 {
+            r.observe(tokens: 1, at: t0.addingTimeInterval(Double(i) * 0.01))
+        }
+        // At t=5s, only the last 1.5s of tokens are in the window — but
+        // totalTokens reflects all 500 observed.
+        #expect(r.totalTokens == 500)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ValidateJANGTQUnsupportedFamilyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ValidateJANGTQUnsupportedFamilyTests.swift
@@ -251,4 +251,57 @@ struct ValidateJANGTQUnsupportedFamilyTests {
             name: "Mistral-Medium-3.5-128B-mxfp4"
         )
     }
+
+    // MARK: - Laguna mxfp4 (vmlx LagunaMoE.experts hardcoded to TurboQuant)
+
+    /// Repro: `OsaurusAI/Laguna-XS.2-mxfp4` ships standard mxfp4 affine
+    /// experts (`weight` / `scales` / `biases`) but vmlx's `LagunaMoE.experts`
+    /// is `TurboQuantSwitchGLU` (Laguna.swift:425) which only knows the
+    /// codebook keys (`tq_packed` / `tq_norms` / `tq_bits`). Result:
+    /// "Unhandled keys" error during parameter load, with no actionable
+    /// message for the user. The preflight catches this before vmlx tries.
+    /// Once vmlx ships a polymorphic `LagunaMoE.experts` (production
+    /// reference §13 item #2), drop this test.
+    @Test("Laguna mxfp4 → throws code 5 with remediation pointing to JANGTQ alternative")
+    func laguna_mxfp4_blocked() throws {
+        let dir = try makeBundle(
+            weightFormat: "mxfp4",
+            modelType: "laguna",
+            sidecarPresent: false
+        )
+        defer { cleanup(dir) }
+        do {
+            try ModelRuntime.validateJANGTQSidecarIfRequired(
+                at: dir,
+                name: "Laguna-XS.2-mxfp4"
+            )
+            Issue.record(
+                "Laguna mxfp4 bundle should have been rejected by preflight"
+            )
+        } catch let error as NSError {
+            #expect(error.domain == "ModelRuntime")
+            #expect(error.code == 5)
+            let msg = (error.userInfo[NSLocalizedDescriptionKey] as? String) ?? ""
+            #expect(msg.contains("Laguna mxfp4"))
+            #expect(msg.contains("JANGTQ"))
+            #expect(msg.contains("TurboQuantSwitchGLU"))
+        }
+    }
+
+    /// Boundary: Laguna JANGTQ (the working path) must pass through cleanly.
+    /// The `mxfp4` block above checks `weight_format == "mxfp4"` — `mxtq`
+    /// must not trip it.
+    @Test("Laguna JANGTQ (mxtq) passes preflight — codebook path is supported")
+    func laguna_jangtq_passes() throws {
+        let dir = try makeBundle(
+            weightFormat: "mxtq",
+            modelType: "laguna",
+            sidecarPresent: true
+        )
+        defer { cleanup(dir) }
+        try ModelRuntime.validateJANGTQSidecarIfRequired(
+            at: dir,
+            name: "Laguna-XS.2-JANGTQ"
+        )
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/ValidateJANGTQUnsupportedFamilyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ValidateJANGTQUnsupportedFamilyTests.swift
@@ -252,56 +252,10 @@ struct ValidateJANGTQUnsupportedFamilyTests {
         )
     }
 
-    // MARK: - Laguna mxfp4 (vmlx LagunaMoE.experts hardcoded to TurboQuant)
-
-    /// Repro: `OsaurusAI/Laguna-XS.2-mxfp4` ships standard mxfp4 affine
-    /// experts (`weight` / `scales` / `biases`) but vmlx's `LagunaMoE.experts`
-    /// is `TurboQuantSwitchGLU` (Laguna.swift:425) which only knows the
-    /// codebook keys (`tq_packed` / `tq_norms` / `tq_bits`). Result:
-    /// "Unhandled keys" error during parameter load, with no actionable
-    /// message for the user. The preflight catches this before vmlx tries.
-    /// Once vmlx ships a polymorphic `LagunaMoE.experts` (production
-    /// reference §13 item #2), drop this test.
-    @Test("Laguna mxfp4 → throws code 5 with remediation pointing to JANGTQ alternative")
-    func laguna_mxfp4_blocked() throws {
-        let dir = try makeBundle(
-            weightFormat: "mxfp4",
-            modelType: "laguna",
-            sidecarPresent: false
-        )
-        defer { cleanup(dir) }
-        do {
-            try ModelRuntime.validateJANGTQSidecarIfRequired(
-                at: dir,
-                name: "Laguna-XS.2-mxfp4"
-            )
-            Issue.record(
-                "Laguna mxfp4 bundle should have been rejected by preflight"
-            )
-        } catch let error as NSError {
-            #expect(error.domain == "ModelRuntime")
-            #expect(error.code == 5)
-            let msg = (error.userInfo[NSLocalizedDescriptionKey] as? String) ?? ""
-            #expect(msg.contains("Laguna mxfp4"))
-            #expect(msg.contains("JANGTQ"))
-            #expect(msg.contains("TurboQuantSwitchGLU"))
-        }
-    }
-
-    /// Boundary: Laguna JANGTQ (the working path) must pass through cleanly.
-    /// The `mxfp4` block above checks `weight_format == "mxfp4"` — `mxtq`
-    /// must not trip it.
-    @Test("Laguna JANGTQ (mxtq) passes preflight — codebook path is supported")
-    func laguna_jangtq_passes() throws {
-        let dir = try makeBundle(
-            weightFormat: "mxtq",
-            modelType: "laguna",
-            sidecarPresent: true
-        )
-        defer { cleanup(dir) }
-        try ModelRuntime.validateJANGTQSidecarIfRequired(
-            at: dir,
-            name: "Laguna-XS.2-JANGTQ"
-        )
-    }
+    // Note: the prior `laguna_mxfp4_blocked` + `laguna_jangtq_passes` tests
+    // were removed when vmlx-swift-lm `4699d3a` made `LagunaMoE.experts`
+    // polymorphic — it now dispatches to `SwitchGLU` (affine, mxfp4) or
+    // `TurboQuantSwitchGLU` (codebook, mxtq) at construction time. The
+    // preflight code-5 gate they covered is gone; both Laguna variants
+    // load natively.
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -933,6 +933,33 @@ final class ChatSession: ObservableObject {
         activeRunId == runId && !Task.isCancelled
     }
 
+    /// Push the rolling-rate's current value onto the live `ChatTurn` field
+    /// at ~5Hz so the UI tok/s display ramps smoothly during streaming.
+    /// Throttled because text streams can produce 100+ deltas/sec — every
+    /// SwiftUI re-render of the stats cell costs an animation tick, and at
+    /// full rate that swamps the MainActor on smaller responses. The
+    /// chosen 0.18s cadence (~5.5Hz) matches the existing tool-arg rebuild
+    /// throttle (line ~1199) for visual consistency. Skips the update when
+    /// the rolling rate is still in warm-up (`currentRate` returns nil) so
+    /// the cell shows nothing until the steady-state read is meaningful —
+    /// avoids the prior "shows 12 tok/s for the first half-second then
+    /// jumps to 60 tok/s" jitter users complained about.
+    private func refreshLiveRate(
+        rolling: inout RollingTokenRate,
+        lastRefreshAt: inout Date,
+        now: Date,
+        turn: ChatTurn
+    ) {
+        guard now.timeIntervalSince(lastRefreshAt) >= 0.18 else { return }
+        guard let rate = rolling.currentRate(at: now) else { return }
+        lastRefreshAt = now
+        turn.generationTokensPerSecond = rate
+        // Don't bump generationTokenCount here — vmlx's authoritative count
+        // arrives in the StreamingStatsHint sentinel and would be overwritten
+        // by an estimate. Final stamp uses rolling.totalTokens only as a
+        // last-resort fallback when the sentinel never fires.
+    }
+
     private func trimTrailingEmptyAssistantTurn() {
         if let lastTurn = turns.last,
             lastTurn.role == .assistant,
@@ -1125,17 +1152,34 @@ final class ChatSession: ObservableObject {
         var currentTurn = assistantTurn
         var uiDeltaCount = 0
         var firstDeltaTime: Date?
-        // Track the wall-clock time of the last non-empty delta so
-        // the fallback tok/s calculation uses the actual last-token
-        // moment as the denominator, not the stream's close time
-        // (which is after cancellation / teardown).
-        var lastDeltaTime: Date?
         // Throttle key for streaming tool-call argument rebuilds.
         var lastToolArgRebuildAt: Date = .distantPast
         // Throttle key to ensure the MainActor runloop gets a turn
         // to render SwiftUI updates even if the AsyncStream buffer
         // is saturated by a fast producer.
         var lastRunloopYieldAt: Date = .distantPast
+
+        // Rolling tok/s estimator. Replaces the previous "single-final-
+        // average" pattern that produced two visible artefacts:
+        //
+        //   1. Short responses appeared slow because the average included
+        //      first-token latency + reasoning-parser stamp resolution
+        //      (model warmup costs amortised over only ~100 tokens).
+        //   2. Reasoning ON vs reasoning OFF on the same model showed
+        //      noticeably different numbers — same decode rate, but the
+        //      reasoning preamble's higher token count diluted setup costs
+        //      so the AVERAGE looked higher with thinking on.
+        //
+        // The rolling rate skips a brief warm-up window then reports the
+        // sliding-window decode rate (steady-state). It counts content,
+        // reasoning, and tool-arg tokens uniformly so the visible value is
+        // invariant across {thinking on/off, tools yes/no, local/remote}.
+        // See `RollingTokenRate` doc for the window-choice rationale.
+        var rollingRate = RollingTokenRate()
+        // Throttle UI updates of the live rolling rate. The stream may
+        // produce 100+ deltas/sec; clamping rate refreshes to ~5Hz keeps
+        // SwiftUI repaints cheap without losing visible smoothness.
+        var lastRateRefreshAt: Date = .distantPast
 
         // Reasoning text arrives as `StreamingReasoningHint` sentinel deltas
         // emitted by `GenerationEventMapper` (local MLX) or
@@ -1201,14 +1245,36 @@ final class ChatSession: ObservableObject {
                         rebuildVisibleBlocks()
                     }
                 } else if let stats = StreamingStatsHint.decode(delta) {
+                    // Final stats from vmlx — captured for the post-loop
+                    // stamp. We DELIBERATELY do NOT overwrite the rolling
+                    // rate here: vmlx's `tokensPerSecond` is the full-
+                    // generation average, which has the same first-token-
+                    // amortisation problem the rolling rate was added to
+                    // fix. The rolling rate's steady-state value is used
+                    // for the visible bubble after the stream ends; vmlx's
+                    // tokenCount is preserved as the authoritative count.
                     currentTurn.generationTokenCount = stats.tokenCount
-                    currentTurn.generationTokensPerSecond = stats.tokensPerSecond
                     // Vmlx tells us the model never closed `</think>` before
                     // EOS / max_tokens. Persist on the turn so the bubble
                     // renderer can surface a one-line banner suggesting
                     // the user toggle Disable Thinking for this prompt class.
                     currentTurn.unclosedReasoning = stats.unclosedReasoning
                 } else if let reasoning = StreamingReasoningHint.decode(delta) {
+                    let now = Date()
+                    if firstDeltaTime == nil {
+                        firstDeltaTime = now
+                        ttftTrace?.mark("first_text_delta")
+                        ttftTrace?.set("model", selectedModel ?? "unknown")
+                        ttftTrace?.emit()
+                    }
+                    // Reasoning tokens count toward the rolling rate so
+                    // thinking-ON and thinking-OFF show the same decode
+                    // rate at steady state. See RollingTokenRate doc.
+                    let tokens = ContextBudgetManager.estimateTokens(for: reasoning)
+                    rollingRate.observe(tokens: tokens, at: now)
+                    refreshLiveRate(
+                        rolling: &rollingRate, lastRefreshAt: &lastRateRefreshAt,
+                        now: now, turn: currentTurn)
                     processor.receiveReasoning(reasoning)
                 } else if !delta.isEmpty {
                     let now = Date()
@@ -1218,8 +1284,13 @@ final class ChatSession: ObservableObject {
                         ttftTrace?.set("model", selectedModel ?? "unknown")
                         ttftTrace?.emit()
                     }
-                    lastDeltaTime = now
                     uiDeltaCount += 1
+                    // Content delta — counted uniformly with reasoning.
+                    let tokens = ContextBudgetManager.estimateTokens(for: delta)
+                    rollingRate.observe(tokens: tokens, at: now)
+                    refreshLiveRate(
+                        rolling: &rollingRate, lastRefreshAt: &lastRateRefreshAt,
+                        now: now, turn: currentTurn)
                     processor.receiveDelta(delta)
                 }
 
@@ -1247,28 +1318,19 @@ final class ChatSession: ObservableObject {
 
         if let first = firstDeltaTime {
             currentTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
-            // Fall back to estimated tok/s when MLX stats weren't propagated (remote APIs).
-            // Use the codebase's chars/4 heuristic to approximate tokens from generated text
-            // rather than raw delta count, which doesn't map 1:1 to tokens for most providers.
-            if currentTurn.generationTokensPerSecond == nil,
-                !currentTurn.contentIsEmpty || !currentTurn.thinkingIsEmpty
-            {
-                let endTime = lastDeltaTime ?? Date()
-                let genTime = endTime.timeIntervalSince(first)
-                // Reasoning tokens are generated on the same clock as the
-                // answer; leaving them out of the numerator while keeping
-                // them in the denominator under-reports throughput on
-                // thinking models. Count both.
-                let answerTokens = ContextBudgetManager.estimateTokens(for: currentTurn.content)
-                let reasoningTokens =
-                    currentTurn.thinkingIsEmpty
-                    ? 0
-                    : ContextBudgetManager.estimateTokens(for: currentTurn.thinking)
-                let estimatedTokens = answerTokens + reasoningTokens
-                if genTime > 0 && estimatedTokens > 0 {
-                    currentTurn.generationTokenCount = estimatedTokens
-                    currentTurn.generationTokensPerSecond = Double(estimatedTokens) / genTime
-                }
+            // Stamp the steady-state tok/s. Single source of truth across
+            // local-MLX, remote-API, with-tools, and thinking-on/off paths
+            // — the rolling rate observed every text-bearing delta during
+            // the loop above. Falls back to full-generation average if the
+            // response was too short for the warm-up to elapse (see
+            // `RollingTokenRate.finalRate`).
+            currentTurn.generationTokensPerSecond = rollingRate.finalRate()
+            // Token count: prefer vmlx's authoritative count (already
+            // assigned in the stats sentinel branch above) — only fall back
+            // to our chars/4 estimate if the stats sentinel never fired
+            // (remote provider paths that don't surface vmlx stats).
+            if currentTurn.generationTokenCount == nil, rollingRate.totalTokens > 0 {
+                currentTurn.generationTokenCount = rollingRate.totalTokens
             }
         }
 


### PR DESCRIPTION
## Symptom

Real-bundle testing of #993's merged build reproduces the same degenerate-repetition failure mode that 3-bit KV produced before e202cbbe:

- **Gemma-4 31B JANG_4M with thinking=ON** emitted `idea idea idea idea idea ...` after a few hundred tokens of reasoning preamble.
- Multiple other family bundles drifted into looping after a few multi-turn rounds even though turn 1 was coherent (the **"first turn fine, later turns garbage"** symptom that we thought we'd closed).
- **Thinking=OFF** on the same bundles produced coherent output — confirming the failure scales with reasoning preamble length.

## Root cause

Vmlx commit `1173822` closed the cross-turn paged-cache re-encoding bug (state was transitioning back to `.fill` phase with already-decoded lossy float, then re-quantizing on the next compression pass). But the underlying **codebook quantization error still compounds** across long thinking-mode preambles:

- Longer prefix → more compression rounds → more accumulated error
- Eventually attention can't differentiate "produce next varied token" from "produce same token again"
- Model latches onto a high-probability low-information token (`idea`, `!`, etc.) and loops

The vmlx team's BENCH harness verified 4-bit KV across 6+ bundles but **didn't toggle thinking on every family it covered**. The integration guide's 4-bit recommendation under-tested the failure mode for thinking-capable models.

## Fix

Single-line revert: `defaultKVMode: .turboQuant(keyBits: 4, valueBits: 4)` → `defaultKVMode: .none`.

fp16 KV is the conservative default that matches user expectation of "responses look right out of the box" across every family + every turn count + thinking-on or off. **Per-request `kvMode` still overrides** — clients that want memory savings can submit `.turboQuant(...)` explicitly per request. The `longPromptMultiplier: 2.0` knob (cap kicks in at >16K tokens) is unchanged.

## Why this matters now

#993 just shipped (`8fab9f4d`) with the 4-bit default. This regression is in production. End users will hit it on any thinking-capable model with non-trivial reasoning preamble. Reverting before more downstream rebases / 0.18.4 releases pin the regression in distros.

## Test evidence

- Build: `** BUILD SUCCEEDED **` Release at HEAD
- `swift test`: 1361/1361 pass on CI's macos-26 runner (the 2 local-only `ContextBudgetPreviewTests` failures are environmental, not regression — same source passed CI on #993)
- Comment in `ModelRuntime.swift:343-381` documents the full failure trail (3-bit `!!!!!!!` → revert e202cbbe → 4-bit `idea idea idea` → revert here)