### PR TITLE
[codex] Fix pie chart slice labels

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/NativeChartViewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/NativeChartViewTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct NativeChartViewTests {
+    @Test
+    func pieDataPointsUseCategoriesAsSliceNames() throws {
+        let series = ChartSeries(name: "Revenue", data: [10, 20, nil, 40])
+
+        let points = NativeChartView.chartDataPoints(
+            for: series,
+            chartType: "pie",
+            categories: ["Hardware", "Software"]
+        )
+
+        let dicts = try dictionaries(from: points)
+        #expect(dicts.count == 4)
+        #expect(dicts[0]["name"] as? String == "Hardware")
+        #expect((dicts[0]["y"] as? NSNumber)?.doubleValue == 10)
+        #expect(dicts[1]["name"] as? String == "Software")
+        #expect((dicts[1]["y"] as? NSNumber)?.doubleValue == 20)
+        #expect(dicts[2]["name"] as? String == "Slice 3")
+        #expect(dicts[2]["y"] is NSNull)
+        #expect(dicts[3]["name"] as? String == "Slice 4")
+        #expect((dicts[3]["y"] as? NSNumber)?.doubleValue == 40)
+    }
+
+    @Test
+    func pieDataPointsFallBackWhenCategoriesAreMissingOrBlank() throws {
+        let series = ChartSeries(name: "Mix", data: [1, 2])
+
+        let points = NativeChartView.chartDataPoints(
+            for: series,
+            chartType: "pie",
+            categories: ["", "  "]
+        )
+
+        let dicts = try dictionaries(from: points)
+        #expect(dicts.map { $0["name"] as? String } == ["Slice 1", "Slice 2"])
+    }
+
+    @Test(arguments: ["bar", "line", "area", "scatter"])
+    func nonPieDataPointsRemainScalarArrays(chartType: String) {
+        let series = ChartSeries(name: "Values", data: [1.5, nil, 3.25])
+
+        let points = NativeChartView.chartDataPoints(
+            for: series,
+            chartType: chartType,
+            categories: ["Ignored", "Also ignored", "Still ignored"]
+        )
+
+        #expect(points.count == 3)
+        #expect(points.allSatisfy { !($0 is NSDictionary) })
+        #expect((points[0] as? NSNumber)?.doubleValue == 1.5)
+        #expect(points[1] is NSNull)
+        #expect((points[2] as? NSNumber)?.doubleValue == 3.25)
+    }
+
+    private func dictionaries(from points: [AnyObject]) throws -> [NSDictionary] {
+        try points.map { point in
+            try #require(point as? NSDictionary)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -223,20 +223,10 @@ final class NativeChartView: NSView {
     ) -> (AAOptions, [AASeriesElement]) {
         let gridHex = NSColor(theme.primaryBorder).withAlphaComponent(0.2).hexString
 
-        // Pie charts read each slice's label from a `name` field on the data
-        // point itself — they ignore the model's `categories` array. Bar/line/etc.
-        // use `categories` for x-axis labels so plain numeric data is fine there
-        let isPie = spec.chartType == "pie"
-        let seriesElements: [AASeriesElement] = spec.series.map { s in
-            let element = AASeriesElement().name(s.name)
-            if isPie, let cats = spec.categories {
-                let paired: [Any] = s.data.enumerated().map { idx, v -> Any in
-                    let label = idx < cats.count ? cats[idx] : "Slice \(idx + 1)"
-                    return ["name": label, "y": v as Any? ?? NSNull()] as [String: Any]
-                }
-                return element.data(paired as [AnyObject])
-            }
-            return element.data(s.data.map { v -> Any in v.map { $0 as Any } ?? NSNull() } as [AnyObject])
+        let seriesElements: [AASeriesElement] = spec.series.map { series in
+            AASeriesElement()
+                .name(series.name)
+                .data(Self.chartDataPoints(for: series, chartType: spec.chartType, categories: spec.categories))
         }
 
         let model = AAChartModel()
@@ -253,10 +243,10 @@ final class NativeChartView: NSView {
         if let categories = spec.categories {
             model.categories(categories)
         }
-        if let stacking = spec.stacking,
-            let stackingType = AAChartStackingType(rawValue: stacking)
-        {
-            model.stacking(stackingType)
+        if let stacking = spec.stacking {
+            if let stackingType = AAChartStackingType(rawValue: stacking) {
+                model.stacking(stackingType)
+            }
         }
         if let colors = spec.colorsTheme {
             model.colorsTheme(colors)
@@ -273,6 +263,41 @@ final class NativeChartView: NSView {
         options.legend?.itemStyle(AAStyle().color(textHex).fontSize(12).fontWeight(.regular))
 
         return (options, seriesElements)
+    }
+
+    static func chartDataPoints(
+        for series: ChartSeries,
+        chartType: String,
+        categories: [String]?
+    ) -> [AnyObject] {
+        guard chartType == "pie" else {
+            return series.data.map { value -> AnyObject in
+                (value.map { $0 as Any } ?? NSNull()) as AnyObject
+            }
+        }
+
+        return series.data.enumerated().map { index, value -> AnyObject in
+            let yValue = value.map { $0 as Any } ?? NSNull()
+            return [
+                "name": Self.sliceName(at: index, categories: categories),
+                "y": yValue,
+            ] as NSDictionary
+        }
+    }
+
+    private static func sliceName(at index: Int, categories: [String]?) -> String {
+        guard let category = categories?[safe: index],
+            !category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return "Slice \(index + 1)"
+        }
+        return category
+    }
+}
+
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 


### PR DESCRIPTION
Fixes #1011

## Business rationale
Pie chart legends and tooltips currently collapse every point to a generic “Slice” label, which makes categorized data hard to interpret even though the same data labels correctly in other chart types. This fixes the user-visible chart labeling bug while preserving the existing chart switcher behavior.

## Coding rationale
AAChartKit/Highcharts needs pie points emitted as named point objects, while non-pie series should keep the scalar/null data shape used by bar, line, area, and scatter charts. The change isolates that mapping in a small testable helper rather than adding a broad UI automation seam around the chart view.

## What changed
- Native pie chart series data now emits point dictionaries with `name` from `ChartSpec.categories` and `y` from the slice value.
- Missing or blank category names fall back to `Slice 1`, `Slice 2`, etc.
- Non-pie chart types continue to emit the existing scalar/`NSNull` data array.
- Added focused unit coverage for pie category labels, fallback labels, and unchanged bar/line/area/scatter data shape.

## Validation
- `swift build --package-path Packages/OsaurusCore`
- `swift build --package-path Packages/OsaurusCore -c release`
- `swift test --package-path Packages/OsaurusCore`
- `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-format lint --configuration .swift-format Packages/OsaurusCore/Views/Chat/NativeChartView.swift Packages/OsaurusCore/Tests/Chat/NativeChartViewTests.swift`
- `swiftlint lint --config .swiftlint.yml Packages/OsaurusCore/Views/Chat/NativeChartView.swift`
- `swiftlint lint --config .swiftlint.yml Packages/OsaurusCore/Tests/Chat/NativeChartViewTests.swift`
- `git diff --check`

## Non-scope
- No changes to chart generation, tool schemas, downsampling, color themes, or chart type picker behavior.
- No broad UI/snapshot test framework added.

## Residual risks
- This validates the AAChartKit payload shape in unit tests, not a rendered WebView screenshot.
- Multiple-series pie charts retain the existing series structure; each series now gets named slice points.
