### PR TITLE
[codex] Fix scheduled state leaking into new chats

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/SessionSourcePersistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionSourcePersistenceTests.swift
@@ -87,6 +87,50 @@ struct SessionSourcePersistenceTests {
     }
 
     @Test
+    func chatSession_resetClearsScheduledOriginForNextManualChat() {
+        let scheduleId = UUID()
+        let dispatchId = UUID()
+        let session = ChatSession()
+        session.source = .schedule
+        session.externalSessionKey = scheduleId.uuidString
+        session.dispatchTaskId = dispatchId
+        session.sessionId = dispatchId
+        session.title = "Scheduled report"
+
+        session.reset()
+
+        #expect(session.source == .chat)
+        #expect(session.sourcePluginId == nil)
+        #expect(session.externalSessionKey == nil)
+        #expect(session.dispatchTaskId == nil)
+        #expect(session.sessionId == nil)
+        #expect(session.turns.isEmpty)
+    }
+
+    @Test
+    func chatSession_firstSaveAfterResetPersistsManualChatOrigin() async throws {
+        try await ChatHistoryTestStorage.run {
+            let scheduleId = UUID()
+            let dispatchId = UUID()
+            let session = ChatSession()
+            session.source = .schedule
+            session.externalSessionKey = scheduleId.uuidString
+            session.dispatchTaskId = dispatchId
+            session.sessionId = dispatchId
+
+            session.reset()
+            session.turns = [ChatTurn(role: .user, content: "manual follow-up")]
+            session.save()
+
+            let data = session.toSessionData()
+            #expect(data.source == .chat)
+            #expect(data.sourcePluginId == nil)
+            #expect(data.externalSessionKey == nil)
+            #expect(data.dispatchTaskId == nil)
+        }
+    }
+
+    @Test
     func executionContext_reattach_restoresIdAndOriginAndTurns() async {
         let originalId = UUID()
         let agentId = UUID()

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -572,6 +572,10 @@ final class ChatSession: ObservableObject {
         title = "New Chat"
         createdAt = Date()
         updatedAt = Date()
+        source = .chat
+        sourcePluginId = nil
+        externalSessionKey = nil
+        dispatchTaskId = nil
         isDirty = false
 
         // Reset agent-loop UI state.


### PR DESCRIPTION
## Business rationale

New chats created from the chat UI must be classified as manual chats. When schedule metadata leaks into those chats, users lose trust in sidebar filters and cannot reliably distinguish scheduled automation from manually started work.

## Coding rationale

`ChatWindowState.startNewChat()` reuses the current `ChatSession` instance and calls `reset(for:)`. `ChatSession.reset()` cleared content and identity but left source metadata intact, so the first save of the next manual chat reused `.schedule`, `externalSessionKey`, and dispatch metadata from the previously selected session. Resetting these fields beside `sessionId` keeps the session origin contract local to the session reset boundary.

## What changed

- Reset `source`, `sourcePluginId`, `externalSessionKey`, and `dispatchTaskId` to manual-chat defaults in `ChatSession.reset()`.
- Added regression tests covering reset from a scheduled session and the first saved manual turn after reset.

## Validation

- `git fetch origin main && git rebase origin/main`
- `swift build --package-path Packages/OsaurusCore`
- `swift build -c release --package-path Packages/OsaurusCore`
- `swift test --package-path Packages/OsaurusCore`
- `xcrun swift-format lint --configuration .swift-format Packages/OsaurusCore/Views/Chat/ChatView.swift Packages/OsaurusCore/Tests/Chat/SessionSourcePersistenceTests.swift`
- `swiftlint lint Packages/OsaurusCore/Views/Chat/ChatView.swift Packages/OsaurusCore/Tests/Chat/SessionSourcePersistenceTests.swift`
- `git diff --check`

## Non-scope

- Did not change schedule execution, dispatch reattachment, sidebar filtering, or persisted data migrations.
- Did not address pre-existing SwiftLint warnings in `ChatView.swift` outside the touched hunk.

## Residual risks

The fix relies on all UI-created manual chats flowing through `ChatSession.reset()`. Programmatic dispatch paths still explicitly set their own source metadata through `ExecutionContext`.
