### PR TITLE
[codex] Sync refreshed provider service models

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
@@ -27,6 +27,7 @@ final class ModelPickerItemCache: ObservableObject {
     /// rather than each spawning their own concurrent build that could race to
     /// assign `items` last.
     private var rebuildTask: Task<[ModelPickerItem], Never>?
+    private var remoteRefreshTask: Task<Void, Never>?
 
     /// Set to `true` while a rebuild is in flight to indicate that another
     /// rebuild should run as soon as the current one completes. This coalesces
@@ -104,6 +105,16 @@ final class ModelPickerItemCache: ObservableObject {
         await buildModelPickerItems()
     }
 
+    /// Refresh connected remote-provider model lists, then rebuild the picker
+    /// items from the updated provider state. Concurrent picker opens join the
+    /// same provider refresh so custom endpoints are not hammered by parallel
+    /// `/models` requests.
+    @discardableResult
+    func refreshRemoteProvidersAndBuildModelPickerItems() async -> [ModelPickerItem] {
+        await refreshRemoteProviderModels()
+        return await buildModelPickerItems()
+    }
+
     /// Hard reset of the cache. This DOES blank `items` and is intended only
     /// for explicit invalidation paths (e.g. completing onboarding) where the
     /// caller will immediately trigger a rebuild.
@@ -113,6 +124,20 @@ final class ModelPickerItemCache: ObservableObject {
     }
 
     // MARK: - Private
+
+    private func refreshRemoteProviderModels() async {
+        if let existing = remoteRefreshTask {
+            await existing.value
+            return
+        }
+
+        let task = Task<Void, Never> { @MainActor in
+            await RemoteProviderManager.shared.refreshConnectedProviderModels(notifyOnChange: false)
+        }
+        remoteRefreshTask = task
+        await task.value
+        remoteRefreshTask = nil
+    }
 
     /// Computes a fresh list of picker items by combining the foundation model
     /// (if available), discovered local MLX models, and currently connected

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -57,6 +57,10 @@ public final class RemoteProviderManager: ObservableObject {
     /// Provider IDs created from Bonjour discovery — not persisted to disk
     private var ephemeralProviderIds: Set<UUID> = []
 
+    #if DEBUG
+        private var modelFetchOverride: (@MainActor (RemoteProvider) async throws -> [String])?
+    #endif
+
     private static let openaiNativeMigratedKey = "remoteProvider.openaiNativeMigrated"
 
     private init() {
@@ -238,17 +242,7 @@ public final class RemoteProviderManager: ObservableObject {
             }
 
             // Fetch models from the provider and merge any manually configured deployment IDs.
-            let discoveredModels: [String]
-            do {
-                discoveredModels = try await RemoteProviderService.fetchModels(from: provider)
-            } catch {
-                if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
-                    discoveredModels = []
-                } else {
-                    throw error
-                }
-            }
-            let models = provider.mergedModelIds(discovered: discoveredModels)
+            let models = try await fetchMergedModels(for: provider)
 
             // Create service instance – resolve headers eagerly on @MainActor
             // so the service actor never reads from Keychain off the main thread.
@@ -319,6 +313,57 @@ public final class RemoteProviderManager: ObservableObject {
     public func reconnect(providerId: UUID) async throws {
         disconnect(providerId: providerId)
         try await connect(providerId: providerId)
+    }
+
+    /// Refresh model lists for providers that are already connected without
+    /// tearing down their service instances. Used by the model picker so
+    /// custom OpenAI-compatible endpoints that add/remove models after launch
+    /// are reflected without requiring an app restart or a manual Settings
+    /// test.
+    public func refreshConnectedProviderModels(notifyOnChange: Bool = true) async {
+        var didChangeModels = false
+        var didChangeStatus = false
+
+        for provider in configuration.providers {
+            guard provider.enabled else { continue }
+            guard var state = providerStates[provider.id], state.isConnected else { continue }
+
+            do {
+                let models = try await fetchMergedModels(for: provider)
+
+                if state.discoveredModels != models {
+                    didChangeModels = true
+                }
+                if state.lastError != nil {
+                    didChangeStatus = true
+                }
+
+                state.discoveredModels = models
+                state.lastConnectedAt = Date()
+                state.lastError = nil
+                providerStates[provider.id] = state
+
+                if let service = services[provider.id] {
+                    await service.updateModels(models)
+                }
+            } catch {
+                let message = error.localizedDescription
+                if state.lastError != message {
+                    didChangeStatus = true
+                }
+                state.lastError = message
+                providerStates[provider.id] = state
+
+                print("[Osaurus] Remote Provider '\(provider.name)': Model refresh failed - \(error)")
+            }
+        }
+
+        if notifyOnChange, didChangeStatus {
+            notifyStatusChanged()
+        }
+        if notifyOnChange, didChangeModels {
+            notifyModelsChanged()
+        }
     }
 
     /// Connect to all enabled providers on app launch
@@ -582,6 +627,30 @@ public final class RemoteProviderManager: ObservableObject {
 
     // MARK: - Private Helpers
 
+    private func fetchMergedModels(for provider: RemoteProvider) async throws -> [String] {
+        let discoveredModels: [String]
+        do {
+            discoveredModels = try await fetchModels(for: provider)
+        } catch {
+            if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
+                discoveredModels = []
+            } else {
+                throw error
+            }
+        }
+        return provider.mergedModelIds(discovered: discoveredModels)
+    }
+
+    private func fetchModels(for provider: RemoteProvider) async throws -> [String] {
+        #if DEBUG
+            if let modelFetchOverride {
+                return try await modelFetchOverride(provider)
+            }
+        #endif
+
+        return try await RemoteProviderService.fetchModels(from: provider)
+    }
+
     private func notifyStatusChanged() {
         NotificationCenter.default.post(name: .remoteProviderStatusChanged, object: nil)
     }
@@ -590,6 +659,51 @@ public final class RemoteProviderManager: ObservableObject {
         NotificationCenter.default.post(name: .remoteProviderModelsChanged, object: nil)
     }
 }
+
+#if DEBUG
+    extension RemoteProviderManager {
+        func _setModelFetchOverrideForTesting(
+            _ override: (@MainActor (RemoteProvider) async throws -> [String])?
+        ) {
+            modelFetchOverride = override
+        }
+
+        func _resetForTesting(configuration: RemoteProviderConfiguration = RemoteProviderConfiguration()) async {
+            for service in services.values {
+                await service.invalidateSession()
+            }
+            services = [:]
+            ephemeralProviderIds = []
+            self.configuration = configuration
+            providerStates = Dictionary(
+                uniqueKeysWithValues: configuration.providers.map {
+                    ($0.id, RemoteProviderState(providerId: $0.id))
+                }
+            )
+            modelFetchOverride = nil
+        }
+
+        @discardableResult
+        func _seedConnectedProviderForTesting(_ provider: RemoteProvider, models: [String]) -> RemoteProviderService {
+            let service = RemoteProviderService(
+                provider: provider,
+                models: models,
+                resolvedHeaders: provider.resolvedHeaders()
+            )
+            services[provider.id] = service
+
+            var state = providerStates[provider.id] ?? RemoteProviderState(providerId: provider.id)
+            state.isConnected = true
+            state.isConnecting = false
+            state.discoveredModels = models
+            state.lastConnectedAt = Date()
+            state.lastError = nil
+            providerStates[provider.id] = state
+
+            return service
+        }
+    }
+#endif
 
 // MARK: - OpenAI Models Integration
 

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -33,6 +33,12 @@ struct ModelPickerItemCacheTests {
     /// order, so callers could disagree about whether remote models were
     /// present.
     @Test func concurrentCallers_returnIdenticalResults() async throws {
+        try await SandboxTestLock.shared.run {
+            try await concurrentCallers_returnIdenticalResultsLocked()
+        }
+    }
+
+    private func concurrentCallers_returnIdenticalResultsLocked() async throws {
         // Establish a baseline so we know what to compare against, and so
         // any work needed to populate the cache (e.g. local model
         // discovery) doesn't perturb the concurrent run below.
@@ -70,6 +76,12 @@ struct ModelPickerItemCacheTests {
     /// asserts the invariant that, once populated, `items` never goes
     /// empty across rebuilds.
     @Test func notificationBurst_doesNotTransientlyEmptyItems() async throws {
+        try await SandboxTestLock.shared.run {
+            try await notificationBurst_doesNotTransientlyEmptyItemsLocked()
+        }
+    }
+
+    private func notificationBurst_doesNotTransientlyEmptyItemsLocked() async throws {
         let cache = ModelPickerItemCache.shared
 
         // Make sure we start populated. If this machine has no foundation

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelRefreshTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelRefreshTests.swift
@@ -1,0 +1,122 @@
+//
+//  RemoteProviderModelRefreshTests.swift
+//  osaurusTests
+//
+//  Covers issue #1010: custom OpenAI-compatible providers can change their
+//  `/models` response while Osaurus is already running. The picker refresh path
+//  must re-fetch connected providers instead of relying on the launch-time
+//  connection snapshot.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct RemoteProviderModelRefreshTests {
+
+    @Test("connected custom provider refresh updates manager state and service")
+    func connectedCustomProviderRefresh_updatesStateAndService() async throws {
+        try await runWithCleanProviderManager { manager in
+            let provider = makeCustomProvider()
+            let fetchScript = ModelFetchScript([
+                ["llama-3.2", "qwen3-coder"]
+            ])
+
+            await manager._resetForTesting(configuration: RemoteProviderConfiguration(providers: [provider]))
+            manager._setModelFetchOverrideForTesting { _ in fetchScript.next() }
+            let serviceBefore = manager._seedConnectedProviderForTesting(provider, models: ["llama-3.2"])
+
+            #expect(
+                manager.cachedAvailableModels().first?.models == ["omlx/llama-3.2"]
+            )
+
+            await manager.refreshConnectedProviderModels(notifyOnChange: false)
+
+            #expect(
+                manager.cachedAvailableModels().first?.models == [
+                    "omlx/llama-3.2",
+                    "omlx/qwen3-coder",
+                ]
+            )
+            let serviceAfter = try #require(manager.service(for: provider.id))
+            #expect(serviceBefore === serviceAfter)
+            #expect(await serviceAfter.getRawModels() == ["llama-3.2", "qwen3-coder"])
+        }
+    }
+
+    @Test("picker cache refresh fetches new custom provider models without restart")
+    func pickerCacheRefresh_fetchesNewCustomProviderModelsWithoutRestart() async throws {
+        try await runWithCleanProviderManager { manager in
+            let provider = makeCustomProvider()
+            let fetchScript = ModelFetchScript([
+                ["llama-3.2", "qwen3-coder"]
+            ])
+
+            await manager._resetForTesting(configuration: RemoteProviderConfiguration(providers: [provider]))
+            manager._setModelFetchOverrideForTesting { _ in fetchScript.next() }
+            manager._seedConnectedProviderForTesting(provider, models: ["llama-3.2"])
+
+            let initialItems = await ModelPickerItemCache.shared.buildModelPickerItems()
+            #expect(initialItems.contains { $0.id == "omlx/llama-3.2" })
+            #expect(!initialItems.contains { $0.id == "omlx/qwen3-coder" })
+
+            let refreshedItems = await ModelPickerItemCache.shared.refreshRemoteProvidersAndBuildModelPickerItems()
+
+            #expect(refreshedItems.contains { $0.id == "omlx/llama-3.2" })
+            #expect(refreshedItems.contains { $0.id == "omlx/qwen3-coder" })
+        }
+    }
+
+    private func runWithCleanProviderManager(
+        _ body: @MainActor @Sendable (RemoteProviderManager) async throws -> Void
+    ) async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let manager = RemoteProviderManager.shared
+            await manager._resetForTesting()
+
+            do {
+                try await body(manager)
+            } catch {
+                await manager._resetForTesting()
+                _ = await ModelPickerItemCache.shared.buildModelPickerItems()
+                throw error
+            }
+
+            await manager._resetForTesting()
+            _ = await ModelPickerItemCache.shared.buildModelPickerItems()
+        }
+    }
+
+    private func makeCustomProvider() -> RemoteProvider {
+        RemoteProvider(
+            id: UUID(),
+            name: "oMLX",
+            host: "localhost",
+            providerProtocol: .http,
+            port: 11434,
+            basePath: "/v1",
+            authType: .none,
+            providerType: .openaiLegacy,
+            enabled: true,
+            autoConnect: true
+        )
+    }
+
+    private final class ModelFetchScript {
+        private var responses: [[String]]
+
+        init(_ responses: [[String]]) {
+            self.responses = responses
+        }
+
+        func next() -> [String] {
+            if responses.isEmpty {
+                return []
+            }
+            return responses.removeFirst()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1264,7 +1264,8 @@ extension FloatingInputCard {
                 options: cachedPickerItems,
                 selectedModel: $selectedModel,
                 agentId: agentId,
-                onDismiss: dismissModelPicker
+                onDismiss: dismissModelPicker,
+                refreshRemoteProvidersOnAppear: !isStreaming
             )
         }
         .onChange(of: showModelPicker) { _, isShowing in

--- a/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
@@ -12,13 +12,17 @@ struct ModelPickerView: View {
     @Binding var selectedModel: String?
     let agentId: UUID?
     let onDismiss: () -> Void
+    var refreshRemoteProvidersOnAppear: Bool = true
 
     @State private var searchText = ""
     @State private var searchDebounceTask: Task<Void, Never>?
+    @State private var remoteRefreshTask: Task<Void, Never>?
+    @State private var liveOptions: [ModelPickerItem] = []
     @State private var collapsedGroups: Set<String> = []
     @State private var cachedGroupedOptions: [(source: ModelPickerItem.Source, models: [ModelPickerItem])] = []
     @State private var cachedFlattenedRows: [ModelPickerRow] = []
     @State private var cachedGroupRows: [String: [ModelPickerRow]] = [:]
+    @ObservedObject private var modelCache = ModelPickerItemCache.shared
     @Environment(\.theme) private var theme
 
     // MARK: - Test Mode
@@ -30,13 +34,31 @@ struct ModelPickerView: View {
         }
 
         private var displayOptions: [ModelPickerItem] {
-            useMockData ? ModelPickerItem.generateMockModels(count: 500) : options
+            useMockData ? ModelPickerItem.generateMockModels(count: 500) : liveOptions
         }
     #else
-        private var displayOptions: [ModelPickerItem] { options }
+        private var displayOptions: [ModelPickerItem] { liveOptions }
     #endif
 
     // MARK: - Data
+
+    private var displayOptionIDs: [String] {
+        displayOptions.map(\.id)
+    }
+
+    private var sourceOptionIDs: [String] {
+        options.map(\.id)
+    }
+
+    private var cacheOptionIDs: [String] {
+        modelCache.items.map(\.id)
+    }
+
+    private func applyDisplayedOptions() {
+        cachedGroupedOptions = displayOptions.groupedBySource()
+        cachedGroupRows = [:]
+        recomputeRows()
+    }
 
     private func recomputeRows() {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -110,6 +132,21 @@ struct ModelPickerView: View {
         cachedFlattenedRows = rows
     }
 
+    private func refreshRemoteProvidersOnOpen() {
+        guard refreshRemoteProvidersOnAppear else { return }
+        #if DEBUG
+            guard !useMockData else { return }
+        #endif
+
+        remoteRefreshTask?.cancel()
+        remoteRefreshTask = Task { @MainActor in
+            let refreshed = await modelCache.refreshRemoteProvidersAndBuildModelPickerItems()
+            guard !Task.isCancelled else { return }
+            liveOptions = refreshed
+            applyDisplayedOptions()
+        }
+    }
+
     private func toggleGroup(_ source: ModelPickerItem.Source) {
         let key = source.uniqueKey
         if collapsedGroups.contains(key) {
@@ -149,15 +186,25 @@ struct ModelPickerView: View {
         .overlay(popoverBorder)
         .shadow(color: theme.shadowColor.opacity(0.15), radius: 12, x: 0, y: 6)
         .onAppear {
-            cachedGroupedOptions = displayOptions.groupedBySource()
-            recomputeRows()
+            liveOptions = options
+            applyDisplayedOptions()
+            refreshRemoteProvidersOnOpen()
         }
         .onDisappear {
             searchDebounceTask?.cancel()
+            remoteRefreshTask?.cancel()
         }
-        .onChange(of: displayOptions.count) { _, _ in
-            cachedGroupedOptions = displayOptions.groupedBySource()
-            recomputeRows()
+        .onChange(of: sourceOptionIDs) { _, _ in
+            liveOptions = options
+            applyDisplayedOptions()
+        }
+        .onChange(of: cacheOptionIDs) { _, _ in
+            guard modelCache.isLoaded else { return }
+            liveOptions = modelCache.items
+            applyDisplayedOptions()
+        }
+        .onChange(of: displayOptionIDs) { _, _ in
+            applyDisplayedOptions()
         }
         .onChange(of: searchText) { _, newValue in
             searchDebounceTask?.cancel()


### PR DESCRIPTION
## Business rationale
Custom OpenAI-compatible providers can add models while Osaurus is running. After #1020, the picker refreshes visible model lists on open; this follow-up keeps the backing provider service in sync too, so a model shown as available is also reflected by the service that handles requests. That protects trust in the local multi-provider harness.

## Coding rationale
- Build on #1020’s refreshConnectedProviders/refetchModels path rather than keeping a second refresh API.
- Update the existing RemoteProviderService actor only after the merged model list actually changes, preserving throttling/coalescing behavior and avoiding reconnects.
- Add a process-wide remote-provider test lock because Swift Testing .serialized only serializes tests within one suite; cross-suite singleton/notification races made ModelPickerItemCacheTests fail in full-suite runs while passing in isolation.
- Keep UI behavior unchanged; this PR is service state plus test isolation.

## What changed
- refetchModels(providerId:) now updates the connected service’s model snapshot when provider state changes.
- Added RemoteProviderTestLock.
- Wrapped remote-provider refresh and model-picker cache tests that share provider/cache singletons.

## Validation
- swift build --package-path Packages/OsaurusCore
- swift build -c release --package-path Packages/OsaurusCore
- swift test --package-path Packages/OsaurusCore
- swift test --package-path Packages/OsaurusCore --filter RemoteProviderManagerRefreshTests
- swift test --package-path Packages/OsaurusCore --filter "RemoteProviderManagerRefreshTests|ModelPickerItemCacheTests"
- xcrun swift-format lint --strict Packages/OsaurusCore/Managers/RemoteProviderManager.swift Packages/OsaurusCore/Tests/Helpers/RemoteProviderTestLock.swift Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRefreshTests.swift
- swiftlint lint --strict Packages/OsaurusCore/Managers/RemoteProviderManager.swift Packages/OsaurusCore/Tests/Helpers/RemoteProviderTestLock.swift Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRefreshTests.swift
- git diff --check

## Non-scope
- Does not change picker UI refresh behavior from #1020.
- Does not add a second provider refresh API.
- Does not change provider discovery or connection policy.

## Residual risks
- The service snapshot is still only as fresh as the throttled picker-open refresh path.