### PR TITLE
Add ExternalOfficeRuntime detection

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntime.swift
+++ b/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntime.swift
@@ -1,0 +1,387 @@
+//
+//  ExternalOfficeRuntime.swift
+//  osaurus
+//
+//  Lazy detector for external office suites that expose a `soffice`
+//  executable. Construction is intentionally cheap: filesystem and process
+//  probes happen only when `snapshot()` is awaited.
+//
+
+import Foundation
+
+public final class ExternalOfficeRuntime: @unchecked Sendable {
+    public static let shared = ExternalOfficeRuntime()
+
+    public enum Kind: String, Hashable, Sendable {
+        case libreOffice = "LibreOffice"
+        case openOffice = "OpenOffice"
+    }
+
+    public struct Conversion: Hashable, Sendable {
+        public let sourceExtension: String
+        public let targetExtension: String
+
+        public init(sourceExtension: String, targetExtension: String) {
+            self.sourceExtension = Self.normalizedExtension(sourceExtension)
+            self.targetExtension = Self.normalizedExtension(targetExtension)
+        }
+
+        public static let docToPDF = Conversion(sourceExtension: "doc", targetExtension: "pdf")
+        public static let docxToPDF = Conversion(sourceExtension: "docx", targetExtension: "pdf")
+        public static let odtToPDF = Conversion(sourceExtension: "odt", targetExtension: "pdf")
+        public static let rtfToPDF = Conversion(sourceExtension: "rtf", targetExtension: "pdf")
+        public static let xlsToPDF = Conversion(sourceExtension: "xls", targetExtension: "pdf")
+        public static let xlsxToPDF = Conversion(sourceExtension: "xlsx", targetExtension: "pdf")
+        public static let odsToPDF = Conversion(sourceExtension: "ods", targetExtension: "pdf")
+        public static let pptToPDF = Conversion(sourceExtension: "ppt", targetExtension: "pdf")
+        public static let pptxToPDF = Conversion(sourceExtension: "pptx", targetExtension: "pdf")
+        public static let pptxToPNG = Conversion(sourceExtension: "pptx", targetExtension: "png")
+        public static let pptxRepair = Conversion(sourceExtension: "pptx", targetExtension: "pptx")
+        public static let odpToPDF = Conversion(sourceExtension: "odp", targetExtension: "pdf")
+
+        private static func normalizedExtension(_ value: String) -> String {
+            value
+                .trimmingCharacters(in: CharacterSet(charactersIn: ".").union(.whitespacesAndNewlines))
+                .lowercased()
+        }
+    }
+
+    public struct Snapshot: Equatable, Sendable {
+        public let available: Bool
+        public let kind: Kind?
+        public let version: String?
+        public let executablePath: URL?
+        public let supportedConversions: Set<Conversion>
+
+        public init(
+            available: Bool,
+            kind: Kind?,
+            version: String?,
+            executablePath: URL?,
+            supportedConversions: Set<Conversion>
+        ) {
+            self.available = available
+            self.kind = kind
+            self.version = version
+            self.executablePath = executablePath
+            self.supportedConversions = supportedConversions
+        }
+
+        public static let unavailable = Snapshot(
+            available: false,
+            kind: nil,
+            version: nil,
+            executablePath: nil,
+            supportedConversions: []
+        )
+    }
+
+    struct ProbeCandidate: Equatable, Sendable {
+        let kind: Kind?
+        let executableURL: URL
+    }
+
+    struct ParsedVersion: Equatable, Sendable {
+        let kind: Kind?
+        let version: String?
+    }
+
+    struct ProcessResult: Sendable {
+        let exitStatus: Int32
+        let output: String
+    }
+
+    typealias ProcessRunner = @Sendable (URL, [String]) async -> ProcessResult?
+
+    private struct Configuration: Sendable {
+        let applicationCandidates: [ProbeCandidate]
+        let whichExecutableURL: URL
+        let processRunner: ProcessRunner
+
+        static let production = Configuration(
+            applicationCandidates: [
+                ProbeCandidate(
+                    kind: .libreOffice,
+                    executableURL: URL(
+                        fileURLWithPath: "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+                    )
+                ),
+                ProbeCandidate(
+                    kind: .openOffice,
+                    executableURL: URL(
+                        fileURLWithPath: "/Applications/OpenOffice.app/Contents/MacOS/soffice"
+                    )
+                ),
+            ],
+            whichExecutableURL: URL(fileURLWithPath: "/usr/bin/which"),
+            processRunner: { executableURL, arguments in
+                await ExternalOfficeRuntime.runProcess(
+                    executableURL: executableURL,
+                    arguments: arguments
+                )
+            }
+        )
+    }
+
+    private struct InFlightDetection {
+        let id: Int
+        let task: Task<Snapshot, Never>
+    }
+
+    private enum SnapshotLookup {
+        case cached(Snapshot)
+        case inFlight(Task<Snapshot, Never>)
+        case started(id: Int, task: Task<Snapshot, Never>)
+    }
+
+    private static let standardSupportedConversions: Set<Conversion> = [
+        .docToPDF,
+        .docxToPDF,
+        .odtToPDF,
+        .rtfToPDF,
+        .xlsToPDF,
+        .xlsxToPDF,
+        .odsToPDF,
+        .pptToPDF,
+        .pptxToPDF,
+        .pptxToPNG,
+        .pptxRepair,
+        .odpToPDF,
+    ]
+
+    private let configuration: Configuration
+    private let lock = NSLock()
+    private var cachedSnapshot: Snapshot?
+    private var inFlightDetection: InFlightDetection?
+    private var nextDetectionID = 0
+
+    private init() {
+        self.configuration = .production
+    }
+
+    init(
+        applicationCandidates: [ProbeCandidate],
+        whichExecutableURL: URL
+    ) {
+        self.configuration = Configuration(
+            applicationCandidates: applicationCandidates,
+            whichExecutableURL: whichExecutableURL,
+            processRunner: { executableURL, arguments in
+                await ExternalOfficeRuntime.runProcess(
+                    executableURL: executableURL,
+                    arguments: arguments
+                )
+            }
+        )
+    }
+
+    public func snapshot() async -> Snapshot {
+        switch prepareSnapshotLookup() {
+        case .cached(let snapshot):
+            return snapshot
+
+        case .inFlight(let task):
+            return await task.value
+
+        case .started(let id, let task):
+            let snapshot = await task.value
+            completeDetection(id: id, snapshot: snapshot)
+            return snapshot
+        }
+    }
+
+    func invalidate() {
+        lock.lock()
+        cachedSnapshot = nil
+        inFlightDetection = nil
+        nextDetectionID += 1
+        lock.unlock()
+    }
+
+    private func prepareSnapshotLookup() -> SnapshotLookup {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let cachedSnapshot {
+            return .cached(cachedSnapshot)
+        }
+
+        if let inFlightDetection {
+            return .inFlight(inFlightDetection.task)
+        }
+
+        let id = nextDetectionID
+        nextDetectionID += 1
+
+        let configuration = configuration
+        let task = Task.detached(priority: .utility) {
+            await Self.detect(configuration: configuration)
+        }
+        inFlightDetection = InFlightDetection(id: id, task: task)
+        return .started(id: id, task: task)
+    }
+
+    private func completeDetection(id: Int, snapshot: Snapshot) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard inFlightDetection?.id == id else {
+            return
+        }
+
+        cachedSnapshot = snapshot
+        inFlightDetection = nil
+    }
+
+    private static func detect(configuration: Configuration) async -> Snapshot {
+        for candidate in configuration.applicationCandidates {
+            if let snapshot = await probe(candidate, processRunner: configuration.processRunner) {
+                return snapshot
+            }
+        }
+
+        guard
+            let pathCandidate = await resolvePathCandidate(configuration: configuration),
+            let snapshot = await probe(
+                pathCandidate,
+                processRunner: configuration.processRunner
+            )
+        else {
+            return .unavailable
+        }
+
+        return snapshot
+    }
+
+    private static func resolvePathCandidate(configuration: Configuration) async -> ProbeCandidate? {
+        guard
+            let result = await configuration.processRunner(configuration.whichExecutableURL, ["soffice"]),
+            result.exitStatus == 0,
+            let path = firstPathLine(in: result.output)
+        else {
+            return nil
+        }
+
+        let executableURL = URL(fileURLWithPath: path).standardizedFileURL
+        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+            return nil
+        }
+
+        return ProbeCandidate(kind: nil, executableURL: executableURL)
+    }
+
+    private static func firstPathLine(in output: String) -> String? {
+        for line in output.split(whereSeparator: \.isNewline) {
+            let trimmed = String(line).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
+    private static func probe(
+        _ candidate: ProbeCandidate,
+        processRunner: ProcessRunner
+    ) async -> Snapshot? {
+        let executableURL = candidate.executableURL.standardizedFileURL
+        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+            return nil
+        }
+
+        let versionResult = await processRunner(executableURL, ["--version"])
+        let parsedVersion: ParsedVersion?
+        if let versionResult, versionResult.exitStatus == 0 {
+            parsedVersion = parseVersionOutput(versionResult.output)
+        } else {
+            parsedVersion = nil
+        }
+
+        return Snapshot(
+            available: true,
+            kind: parsedVersion?.kind ?? candidate.kind,
+            version: parsedVersion?.version,
+            executablePath: executableURL,
+            supportedConversions: standardSupportedConversions
+        )
+    }
+
+    static func parseVersionOutput(_ output: String) -> ParsedVersion {
+        let normalizedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercasedOutput = normalizedOutput.lowercased()
+
+        let kind: Kind?
+        if lowercasedOutput.contains("libreoffice") {
+            kind = .libreOffice
+        } else if lowercasedOutput.contains("openoffice") {
+            kind = .openOffice
+        } else {
+            kind = nil
+        }
+
+        let version =
+            normalizedOutput
+            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .compactMap { versionPrefix(in: String($0)) }
+            .first
+
+        return ParsedVersion(kind: kind, version: version)
+    }
+
+    private static func versionPrefix(in token: String) -> String? {
+        guard
+            let first = token.unicodeScalars.first,
+            CharacterSet.decimalDigits.contains(first)
+        else {
+            return nil
+        }
+
+        var result = String.UnicodeScalarView()
+        var sawDot = false
+        for scalar in token.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) || scalar == "." || scalar == "-" {
+                if scalar == "." {
+                    sawDot = true
+                }
+                result.append(scalar)
+            } else {
+                break
+            }
+        }
+
+        let version = String(result).trimmingCharacters(in: CharacterSet(charactersIn: ".-"))
+        return sawDot && !version.isEmpty ? version : nil
+    }
+
+    private static func runProcess(
+        executableURL: URL,
+        arguments: [String]
+    ) async -> ProcessResult? {
+        await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = executableURL
+            process.arguments = arguments
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            do {
+                try process.run()
+            } catch {
+                return nil
+            }
+
+            process.waitUntilExit()
+
+            var outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+            outputData.append(stderr.fileHandleForReading.readDataToEndOfFile())
+
+            return ProcessResult(
+                exitStatus: process.terminationStatus,
+                output: String(data: outputData, encoding: .utf8) ?? ""
+            )
+        }.value
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeTests.swift
@@ -1,0 +1,248 @@
+//
+//  ExternalOfficeRuntimeTests.swift
+//  osaurusTests
+//
+//  Contract tests for the lazy external office detector. The tests use
+//  temporary fake `soffice` and `which` scripts so the host machine's
+//  installed applications and PATH never influence the result.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ExternalOfficeRuntime")
+struct ExternalOfficeRuntimeTests {
+    @Test func libreOfficeApplicationPathFound() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 7.6.4.1 60(Build:2)")
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [
+                .init(kind: .libreOffice, executableURL: soffice)
+            ],
+            whichExecutableURL: try Self.writeWhichNotFound(in: root)
+        )
+
+        let snapshot = await runtime.snapshot()
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == "7.6.4.1")
+        #expect(snapshot.executablePath == soffice.standardizedFileURL)
+        #expect(snapshot.supportedConversions.contains(.docxToPDF))
+        #expect(snapshot.supportedConversions.contains(.pptxToPNG))
+        #expect(snapshot.supportedConversions.contains(.pptxRepair))
+    }
+
+    @Test func openOfficeApplicationPathFoundAfterLibreOfficeMiss() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let missingLibreOffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        let openOffice = root.appendingPathComponent("OpenOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: openOffice, output: "Apache OpenOffice 4.1.15 AOO4115m1(Build:9813)")
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [
+                .init(kind: .libreOffice, executableURL: missingLibreOffice),
+                .init(kind: .openOffice, executableURL: openOffice),
+            ],
+            whichExecutableURL: try Self.writeWhichNotFound(in: root)
+        )
+
+        let snapshot = await runtime.snapshot()
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .openOffice)
+        #expect(snapshot.version == "4.1.15")
+        #expect(snapshot.executablePath == openOffice.standardizedFileURL)
+    }
+
+    @Test func pathExecutableResolvedThroughWhich() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("bin/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 24.2.0.3 420(Build:3)")
+        let which = try Self.writeWhich(in: root, resolvingTo: soffice)
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [],
+            whichExecutableURL: which
+        )
+
+        let snapshot = await runtime.snapshot()
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == "24.2.0.3")
+        #expect(snapshot.executablePath == soffice.standardizedFileURL)
+    }
+
+    @Test func nothingFoundReturnsUnavailableSnapshot() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [],
+            whichExecutableURL: try Self.writeWhichNotFound(in: root)
+        )
+
+        let snapshot = await runtime.snapshot()
+        #expect(snapshot == .unavailable)
+    }
+
+    @Test func unparseableVersionStillMarksRuntimeAvailable() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("bin/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "office runtime ready")
+        let which = try Self.writeWhich(in: root, resolvingTo: soffice)
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [],
+            whichExecutableURL: which
+        )
+
+        let snapshot = await runtime.snapshot()
+        #expect(snapshot.available)
+        #expect(snapshot.kind == nil)
+        #expect(snapshot.version == nil)
+        #expect(snapshot.executablePath == soffice.standardizedFileURL)
+        #expect(snapshot.supportedConversions.contains(.pptxToPDF))
+    }
+
+    @Test func representativeVersionParsing() {
+        let libreOffice = ExternalOfficeRuntime.parseVersionOutput(
+            "LibreOffice 7.5.9.2 50(Build:2)"
+        )
+        #expect(libreOffice.kind == .libreOffice)
+        #expect(libreOffice.version == "7.5.9.2")
+
+        let libreOfficeDev = ExternalOfficeRuntime.parseVersionOutput(
+            "LibreOfficeDev 25.2.0.0.alpha0+ Build:abcd"
+        )
+        #expect(libreOfficeDev.kind == .libreOffice)
+        #expect(libreOfficeDev.version == "25.2.0.0.alpha0")
+
+        let openOffice = ExternalOfficeRuntime.parseVersionOutput(
+            "Apache OpenOffice 4.1.15 AOO4115m1(Build:9813)"
+        )
+        #expect(openOffice.kind == .openOffice)
+        #expect(openOffice.version == "4.1.15")
+    }
+
+    @Test func detectionCachesFirstSnapshot() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 7.6.4.1 60(Build:2)")
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [
+                .init(kind: .libreOffice, executableURL: soffice)
+            ],
+            whichExecutableURL: try Self.writeWhichNotFound(in: root)
+        )
+
+        let first = await runtime.snapshot()
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 7.6.5.2 60(Build:2)")
+        let second = await runtime.snapshot()
+
+        #expect(first.version == "7.6.4.1")
+        #expect(second.version == "7.6.4.1")
+    }
+
+    @Test func explicitInvalidationReprobes() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 7.6.4.1 60(Build:2)")
+
+        let runtime = ExternalOfficeRuntime(
+            applicationCandidates: [
+                .init(kind: .libreOffice, executableURL: soffice)
+            ],
+            whichExecutableURL: try Self.writeWhichNotFound(in: root)
+        )
+
+        let first = await runtime.snapshot()
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 7.6.5.2 60(Build:2)")
+        runtime.invalidate()
+        let second = await runtime.snapshot()
+
+        #expect(first.version == "7.6.4.1")
+        #expect(second.version == "7.6.5.2")
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExternalOfficeRuntimeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func writeFakeSoffice(
+        at url: URL,
+        output: String,
+        exitStatus: Int32 = 0
+    ) throws {
+        let script =
+            [
+                "#!/bin/sh",
+                #"if [ "$1" != "--version" ]; then"#,
+                "  exit 64",
+                "fi",
+                "cat <<'OSAURUS_SOFFICE_VERSION'",
+                output,
+                "OSAURUS_SOFFICE_VERSION",
+                "exit \(exitStatus)",
+            ].joined(separator: "\n") + "\n"
+        try Self.writeExecutableScript(at: url, content: script)
+    }
+
+    private static func writeWhich(in root: URL, resolvingTo soffice: URL) throws -> URL {
+        let which = root.appendingPathComponent("usr/bin/which")
+        let script =
+            [
+                "#!/bin/sh",
+                #"if [ "$1" = "soffice" ]; then"#,
+                "  cat <<'OSAURUS_WHICH_RESULT'",
+                soffice.path,
+                "OSAURUS_WHICH_RESULT",
+                "  exit 0",
+                "fi",
+                "exit 1",
+            ].joined(separator: "\n") + "\n"
+        try Self.writeExecutableScript(at: which, content: script)
+        return which
+    }
+
+    private static func writeWhichNotFound(in root: URL) throws -> URL {
+        let which = root.appendingPathComponent("usr/bin/which")
+        let script =
+            [
+                "#!/bin/sh",
+                "exit 1",
+            ].joined(separator: "\n") + "\n"
+        try Self.writeExecutableScript(at: which, content: script)
+        return which
+    }
+
+    private static func writeExecutableScript(at url: URL, content: String) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: url.path
+        )
+    }
+}


### PR DESCRIPTION
## Applicability review (2026-06-06)

Status: superseded/reference only; do not merge as-is.

External Office runtime detection predates the current `StructuredDocument` and `DocumentFormatRegistry` stack. Use it only as reference if future document creation/runtime detection needs a current-main implementation.

## Business rationale

Business-file workflows need to know whether a local office suite can perform external document conversions before future slices wire conversion consumers into the app. This adds a lazy, cacheable runtime probe without changing app startup behavior or user-facing flows.

## Coding rationale

The runtime is isolated as a small service with a Sendable snapshot so future consumers can depend on a stable detection contract. Detection is ordered, testable through injected probes, and cached behind NSLock while keeping all probing lazy and outside initialization.

## What changed

- Added `ExternalOfficeRuntime` with `shared`, async `snapshot()`, Sendable snapshots, runtime kind/version/path fields, and supported conversion metadata.
- Detects LibreOffice app bundle, OpenOffice app bundle, then PATH `soffice` via `/usr/bin/which soffice`.
- Parses representative `soffice --version` output while treating unparseable version output as available with `nil` version.
- Added focused tests using temp stub executables for app bundle paths, PATH resolution, unavailable state, parsing, cache reuse, and explicit invalidation.

## Validation

- `swift build --package-path Packages/OsaurusCore`
- `swift build -c release --package-path Packages/OsaurusCore`
- `swift test --package-path Packages/OsaurusCore`
- `xcrun swift-format lint --strict Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntime.swift Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeTests.swift`
- `swiftlint lint --strict Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntime.swift Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeTests.swift`
- `git diff --check`

## Non-scope

No document registry/bootstrap, skills, provider, chat, permissions, chart, scheduled-chat, CI, plugin files, or consumers were changed.

## Residual risks

- Full package validation emits existing warnings unrelated to this slice.
- SwiftLint's repo configuration skips the new test path when linted directly; the strict touched-file command exits successfully.
- The PR uses a fork head branch because the authenticated account has read-only permission on `osaurus-ai/osaurus`.
