### PR TITLE
hide folder tool guidance in auto selection mode

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -986,11 +986,12 @@ public struct SystemPromptComposer: Sendable {
             // model gets folder tools in its schema but no prose anchor for
             // WHERE it is, which leads to generic exploration + "I'll do X"
             // stalls. Static so it joins the cached prefix.
+            let toolMode = AgentManager.shared.effectiveToolSelectionMode(for: agentId)
             composer.append(
                 .static(
                     id: "folderContext",
                     label: "Working Directory",
-                    content: SystemPromptTemplates.folderContext(from: folder)
+                    content: SystemPromptTemplates.folderContext(from: folder, toolMode: toolMode)
                 )
             )
         }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -229,7 +229,10 @@ public enum SystemPromptTemplates {
     /// (AGENTS.md / CLAUDE.md / .hermes.md / .cursorrules) loaded at
     /// folder-mount time. Returns `""` when no folder is mounted so the
     /// composer can append unconditionally.
-    public static func folderContext(from folderContext: FolderContext?) -> String {
+    public static func folderContext(
+        from folderContext: FolderContext?,
+        toolMode: ToolSelectionMode = .manual
+    ) -> String {
         guard let folder = folderContext else { return "" }
 
         let topLevel = buildTopLevelSummary(from: folder.tree)
@@ -240,6 +243,32 @@ public enum SystemPromptTemplates {
                 return "\n**Git status (uncommitted changes):**\n```\n\(trimmed)\n```\n"
             } ?? ""
 
+        // Tool recipe names concrete tool ids (`file_read`, `shell_run`, …).
+        // In auto-selection mode those tools aren't in the schema until the
+        // model loads them via `capabilities_load`, so naming them here makes
+        // the model try (and fail) to call them directly. In auto mode we
+        // emit a brief pointer at the capability flow instead.
+        let toolGuidance: String
+        switch toolMode {
+        case .manual:
+            toolGuidance = """
+                Tool recipe — prefer dedicated tools over their shell equivalents:
+                - Layout: `file_tree` for the directory structure (skips hidden + truncates at 300 entries) — **not** `ls`/`tree` in `shell_run`.
+                - Discovery: `file_search` for content (ripgrep) — **not** `grep`/`rg`/`find`. Read individual files with `file_read` — **not** `cat`/`head`/`tail`.
+                - Edits: `file_edit` for targeted (old_string -> new_string) changes — **not** `sed`/`awk`. `file_write` for new files or full rewrites — **not** `echo`/`cat` heredoc. Always read a file before editing it.
+                - Mutations: use `shell_run` for `mv` / `cp` / `rm` / `mkdir` (write/exec ops are logged and undoable).
+                - Multi-step work: take the next concrete action each turn — read, write, run. Don't narrate intent; just do the thing.
+
+                **Files land in the working folder, not in chat.** When you create or edit a file, the user can see it on disk and in the operations log. If the user needs the deliverable to appear in the chat thread (an image, chart, generated text, report, code blob), additionally call `share_artifact` — it's the only thing that surfaces an artifact card.
+                """
+        case .auto:
+            toolGuidance = """
+                To inspect, edit, or run things in this folder, discover the right tool with `capabilities_search` and load it with `capabilities_load` before calling it. Take the next concrete action each turn — don't narrate intent.
+
+                **Files land in the working folder, not in chat.** Edits show up on disk and in the operations log. If the user needs the deliverable to appear in the chat thread (image, chart, text, report, code), additionally call `share_artifact` — it's the only thing that surfaces an artifact card.
+                """
+        }
+
         var section = """
 
             ## Working Directory
@@ -249,14 +278,7 @@ public enum SystemPromptTemplates {
             \(gitBlock)
             **Path arguments are relative to the Working Directory** — pass `README.md`, `src/app.py`, `docs/intro.md`. Absolute paths are rejected as a security boundary, even ones that point inside the directory. The path above is for orientation when you describe the project to the user, not for tool calls.
 
-            Tool recipe — prefer dedicated tools over their shell equivalents:
-            - Layout: `file_tree` for the directory structure (skips hidden + truncates at 300 entries) — **not** `ls`/`tree` in `shell_run`.
-            - Discovery: `file_search` for content (ripgrep) — **not** `grep`/`rg`/`find`. Read individual files with `file_read` — **not** `cat`/`head`/`tail`.
-            - Edits: `file_edit` for targeted (old_string -> new_string) changes — **not** `sed`/`awk`. `file_write` for new files or full rewrites — **not** `echo`/`cat` heredoc. Always read a file before editing it.
-            - Mutations: use `shell_run` for `mv` / `cp` / `rm` / `mkdir` (write/exec ops are logged and undoable).
-            - Multi-step work: take the next concrete action each turn — read, write, run. Don't narrate intent; just do the thing.
-
-            **Files land in the working folder, not in chat.** When you create or edit a file with `file_write` / `file_edit`, the user can see it on disk and in the operations log. If the user needs the deliverable to appear in the chat thread (an image, chart, generated text, report, code blob), additionally call `share_artifact` — it's the only thing that surfaces an artifact card.
+            \(toolGuidance)
 
             """
 

--- a/Packages/OsaurusCore/Tests/Chat/FolderContextToolModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/FolderContextToolModeTests.swift
@@ -1,0 +1,81 @@
+//
+//  FolderContextToolModeTests.swift
+//
+//
+//  Mirrors the gating pattern already used by `capabilityDiscoveryNudge`
+//  in SystemPromptComposer.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("folderContext gates folder-tool guidance on toolMode")
+struct FolderContextToolModeTests {
+
+    private static let folderToolNames: [String] = [
+        "file_tree",
+        "file_search",
+        "file_read",
+        "file_edit",
+        "file_write",
+        "shell_run",
+    ]
+
+    private func sampleFolder() -> FolderContext {
+        FolderContext(
+            rootPath: URL(fileURLWithPath: "/tmp/demo-project"),
+            projectType: .swift,
+            tree: "demo-project/\n  README.md\n  Sources/\n",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false,
+            contextFiles: nil
+        )
+    }
+
+    @Test("manual mode names concrete folder tools")
+    func manualModeIncludesGuidance() {
+        let out = SystemPromptTemplates.folderContext(
+            from: sampleFolder(),
+            toolMode: .manual
+        )
+        for name in Self.folderToolNames {
+            #expect(
+                out.contains(name),
+                "manual-mode folderContext is missing `\(name)` — the tool guidance should be present when all folder tools are pre-loaded"
+            )
+        }
+    }
+
+    @Test("auto mode hides concrete folder-tool names")
+    func autoModeHidesGuidance() {
+        let out = SystemPromptTemplates.folderContext(
+            from: sampleFolder(),
+            toolMode: .auto
+        )
+        for name in Self.folderToolNames {
+            #expect(
+                !out.contains(name),
+                "auto-mode folderContext leaked `\(name)` — these tools aren't in the schema until `capabilities_load` runs, so naming them makes the model call tools it doesn't have"
+            )
+        }
+    }
+
+    @Test("auto mode points at the capability discovery flow")
+    func autoModeMentionsCapabilities() {
+        let out = SystemPromptTemplates.folderContext(
+            from: sampleFolder(),
+            toolMode: .auto
+        )
+        #expect(out.contains("capabilities_search"))
+        #expect(out.contains("capabilities_load"))
+    }
+
+    @Test("nil folder returns empty regardless of tool mode")
+    func nilFolderReturnsEmpty() {
+        #expect(SystemPromptTemplates.folderContext(from: nil, toolMode: .auto).isEmpty)
+        #expect(SystemPromptTemplates.folderContext(from: nil, toolMode: .manual).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

addresses #1027 

when the agent is set to auto-discover capabilities and a folder is mounted, the system prompt was telling the model about specific file and shell tools it didn't actually have yet. it had to load them on demand first. this mismatch wasted turns and sometimes made the model give up. 

now the prompt only mentions tools that are actually available and points the model at the discovery flow when it needs                         
more. manual capability mode is unchanged.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
