### PR TITLE
improved preflight capability search

### DIFF
--- a/Packages/OsaurusCore/Services/Context/CapabilitySearchEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/CapabilitySearchEvaluator.swift
@@ -1,0 +1,243 @@
+//
+//  CapabilitySearchEvaluator.swift
+//  osaurus
+//
+//  Public facade over the index-search portion of `CapabilitySearch`.
+//  Companion to `PreflightEvaluator.swift` — same surface shape, same
+//  `@MainActor` constraint, decode-friendly `Codable` result type — but
+//  scoped to the recall layer (no LLM call, no agent state, no tool
+//  picker). Used by the `OsaurusEvals` `capability_search` domain
+//  runner to score raw vs threshold-accepted hits in one pass.
+//
+//  Why a separate type: `PreflightEvaluation` measures the LLM picker;
+//  this measures the BM25 + embedder + RRF + threshold path that feeds
+//  it. A regression in either is hidden by an evaluator that only
+//  watches the other.
+//
+
+import Foundation
+
+// MARK: - Result type
+
+/// Decode-friendly snapshot of one capability-search invocation.
+///
+/// **Tools lane is hybrid (BM25 + embed via RRF)** — each tool hit
+/// carries optional per-component scores plus the fused score and the
+/// acceptance bit. **Methods + skills lanes are pure embedding** —
+/// only `embedScore` is populated for those (BM25 mirror not yet built
+/// for those indices; tracked as a follow-up).
+///
+/// JSON-stable on purpose so the eval CLI can write machine-readable
+/// reports and the `--report-forensics` block can render H1/H2/H3/H4/H5
+/// labels off the score nullability pattern.
+public struct CapabilitySearchEvaluation: Sendable, Codable {
+    public let query: String
+    public let toolHits: [Hit]
+    public let methodHits: [Hit]
+    public let skillHits: [Hit]
+    /// Number of tools the capability-search path would consider in
+    /// the live registry (enabled, non-runtime-managed,
+    /// non-capability-infrastructure). Mirrors
+    /// `CapabilitySearchHealth.registryToolCount`.
+    public let registrySize: Int
+    /// Number of tools currently in `tool_index`. A wide gap between
+    /// `registrySize` and `indexSize` is the H2 smoking gun.
+    public let indexSize: Int
+    /// RRF cutoff applied to the **tools** lane. Echoes the caller's
+    /// `threshold:` argument when set, otherwise the production
+    /// `CapabilitySearch.minimumFusedScore`.
+    public let appliedMinFusedScore: Float
+    /// Pure-embedding cutoff applied to the **methods + skills** lanes.
+    /// `nil` would only happen on a future migration; today it's
+    /// always populated. Kept optional so JSON readers can detect the
+    /// transition if/when those lanes also move to hybrid.
+    public let appliedThreshold: Float?
+    public let latencyMs: Double
+
+    /// One per (raw OR accepted) candidate for the case's query. The
+    /// nullability pattern of `bm25Score` / `embedScore` is the
+    /// forensic signal:
+    ///   - both populated → fused candidate
+    ///   - only `bm25Score` → embed missed it (lexical-only)
+    ///   - only `embedScore` → BM25 missed it (semantic-only)
+    ///   - both nil → impossible (would not appear in the list)
+    public struct Hit: Sendable, Codable {
+        public let name: String
+        public let bm25Score: Float?
+        public let embedScore: Float?
+        public let fusedScore: Float
+        public let acceptedByThreshold: Bool
+
+        public init(
+            name: String,
+            bm25Score: Float?,
+            embedScore: Float?,
+            fusedScore: Float,
+            acceptedByThreshold: Bool
+        ) {
+            self.name = name
+            self.bm25Score = bm25Score
+            self.embedScore = embedScore
+            self.fusedScore = fusedScore
+            self.acceptedByThreshold = acceptedByThreshold
+        }
+    }
+
+    public init(
+        query: String,
+        toolHits: [Hit],
+        methodHits: [Hit],
+        skillHits: [Hit],
+        registrySize: Int,
+        indexSize: Int,
+        appliedMinFusedScore: Float,
+        appliedThreshold: Float?,
+        latencyMs: Double
+    ) {
+        self.query = query
+        self.toolHits = toolHits
+        self.methodHits = methodHits
+        self.skillHits = skillHits
+        self.registrySize = registrySize
+        self.indexSize = indexSize
+        self.appliedMinFusedScore = appliedMinFusedScore
+        self.appliedThreshold = appliedThreshold
+        self.latencyMs = latencyMs
+    }
+}
+
+// MARK: - Evaluator
+
+/// Public entry point for capability-search recall evals. Lives on the
+/// main actor because the underlying registry / index reads are. No LLM
+/// call, no agent fixture — pure index-path measurement, safe to run in
+/// CI and to invoke at any threshold.
+@MainActor
+public enum CapabilitySearchEvaluator {
+
+    /// Run capability search against the live indices and report
+    /// hybrid (tools) + pure-embedding (methods/skills) hits with
+    /// per-component scores.
+    ///
+    /// `threshold` is **scoped to the tools lane**. When non-nil it
+    /// overrides `CapabilitySearch.minimumFusedScore` (the RRF cutoff
+    /// for the BM25+embed hybrid). When nil, the production default
+    /// is used. The methods + skills lanes always use
+    /// `CapabilitySearch.minimumRelevanceScore` (the embed-cosine
+    /// cutoff, scale ~0.0–1.0) regardless of `threshold`. Reason:
+    /// fused-score values (RRF k=60 max ≈ 0.033) and embed-cosine
+    /// values live on completely different scales — applying the
+    /// sweep value to both lanes silently disables the methods/skills
+    /// quality gate when sweeping low fused values like 0.005.
+    /// Sweeping the embed cutoff is a separate concern; expose its
+    /// own flag if/when needed.
+    public static func evaluate(
+        query: String,
+        topK: Int = 10,
+        threshold: Float? = nil
+    ) async -> CapabilitySearchEvaluation {
+        let appliedFused = threshold ?? CapabilitySearch.minimumFusedScore
+        let appliedThreshold = CapabilitySearch.minimumRelevanceScore
+        let started = Date()
+
+        async let toolPair = ToolSearchService.shared.searchHybridWithDiagnostic(
+            query: query,
+            topK: topK,
+            minFusedScore: appliedFused
+        )
+        async let methodPair = MethodSearchService.shared.searchWithDiagnostic(
+            query: query,
+            topK: topK,
+            threshold: appliedThreshold
+        )
+        async let skillPair = SkillSearchService.shared.searchWithDiagnostic(
+            query: query,
+            topK: topK,
+            threshold: appliedThreshold
+        )
+        async let healthSnapshot = CapabilitySearchDiagnostics.snapshot(mode: .full)
+
+        let (_, toolDiag) = await toolPair
+        let (_, methodDiag) = await methodPair
+        let (_, skillDiag) = await skillPair
+        let health = await healthSnapshot
+        let elapsedMs = Date().timeIntervalSince(started) * 1000
+
+        return CapabilitySearchEvaluation(
+            query: query,
+            toolHits: makeToolHits(diagnostic: toolDiag),
+            methodHits: makeEmbeddingOnlyHits(
+                raw: methodDiag.rawHits,
+                accepted: methodDiag.acceptedHits
+            ),
+            skillHits: makeEmbeddingOnlyHits(
+                raw: skillDiag.rawHits,
+                accepted: skillDiag.acceptedHits
+            ),
+            registrySize: health.registryToolCount,
+            indexSize: health.indexedToolCount,
+            appliedMinFusedScore: appliedFused,
+            appliedThreshold: appliedThreshold,
+            latencyMs: elapsedMs
+        )
+    }
+
+    /// Build the hybrid `[Hit]` for the tools lane. The diagnostic
+    /// already carries every candidate (`allHits`) with full
+    /// per-component nullability and the threshold-accepted subset
+    /// (`acceptedHits`); we just project them into the public
+    /// `Codable` shape and tag membership.
+    private static func makeToolHits(
+        diagnostic: ToolSearchHybridDiagnostic
+    ) -> [CapabilitySearchEvaluation.Hit] {
+        let acceptedNames = Set(diagnostic.acceptedHits.map(\.name))
+        return diagnostic.allHits.map { hit in
+            CapabilitySearchEvaluation.Hit(
+                name: hit.name,
+                bm25Score: hit.bm25Score,
+                embedScore: hit.embedScore,
+                fusedScore: hit.fusedScore,
+                acceptedByThreshold: acceptedNames.contains(hit.name)
+            )
+        }
+    }
+
+    /// Build `[Hit]` from a pure-embedding diagnostic (methods,
+    /// skills). `bm25Score` is `nil` for every entry — those lanes
+    /// don't have an FTS5 mirror today. `fusedScore` is the
+    /// embedding score itself so a single-source lane still has a
+    /// usable composite for downstream ranking display.
+    private static func makeEmbeddingOnlyHits<H: SearchDiagnosticHit>(
+        raw: [H],
+        accepted: [H]
+    ) -> [CapabilitySearchEvaluation.Hit] {
+        let acceptedNames = Set(accepted.map(\.name))
+        return raw.map { hit in
+            CapabilitySearchEvaluation.Hit(
+                name: hit.name,
+                bm25Score: nil,
+                embedScore: hit.score,
+                fusedScore: hit.score,
+                acceptedByThreshold: acceptedNames.contains(hit.name)
+            )
+        }
+    }
+}
+
+// MARK: - Cross-service hit shape
+
+/// Internal protocol unifying the three `*SearchDiagnostic.Hit` types
+/// so `makeEmbeddingOnlyHits` can be written once across the methods
+/// and skills lanes. Mirror of the fileprivate `DiagnosticHit` in
+/// `PreflightCapabilitySearch.swift`; kept separate (and at
+/// module-internal visibility) because `CapabilitySearchEvaluator`
+/// needs the constraint at API boundaries while the env-flag log
+/// block is private to its file.
+internal protocol SearchDiagnosticHit {
+    var name: String { get }
+    var score: Float { get }
+}
+
+extension ToolSearchDiagnostic.Hit: SearchDiagnosticHit {}
+extension MethodSearchDiagnostic.Hit: SearchDiagnosticHit {}
+extension SkillSearchDiagnostic.Hit: SearchDiagnosticHit {}

--- a/Packages/OsaurusCore/Services/Context/CapabilitySearchHealth.swift
+++ b/Packages/OsaurusCore/Services/Context/CapabilitySearchHealth.swift
@@ -1,0 +1,199 @@
+//
+//  CapabilitySearchHealth.swift
+//  osaurus
+//
+//  Read-only health probe over the registry-vs-tool-index parity. Used by
+//  the env-flag-gated capability-search trace path and the per-process
+//  cheap-path snapshot gates inside `CapabilitySearch.search` /
+//  `PreflightCapabilitySearch.search`.
+//
+//  Two operating modes — they cost very different amounts:
+//
+//    - .cheap: one in-memory `ToolRegistry.listTools()` walk + one
+//      `SELECT COUNT(*)` against `tool_index`. Sub-millisecond. Reports
+//      counts only — `missingFromIndex` / `stale` are left empty. This
+//      is what the per-process gates on the hot search path use.
+//    - .full: also pulls `ToolDatabase.loadAllEntryNames(source: .system)`
+//      and computes set diffs to expose `missingFromIndex` / `stale`.
+//      Gated by a 50ms wall-clock budget; if the name-fetch exceeds it,
+//      the snapshot falls back to .cheap and trips
+//      `diffSkippedDueToBudget`. Only the env-flag-gated trace path
+//      requests this mode in production builds.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "ai.osaurus", category: "CapabilitySearchHealth")
+
+// MARK: - Snapshot
+
+/// Decode-friendly snapshot of capability-search index health. The
+/// divergence sets (`missingFromIndex`, `stale`) are only populated in
+/// `.full` mode; `.cheap` snapshots leave them empty so the per-process
+/// gate path stays sub-millisecond.
+public struct CapabilitySearchHealth: Sendable {
+    public let registryToolCount: Int
+    public let indexedToolCount: Int
+    /// Tools registered in `ToolRegistry` (enabled, non-runtime-managed,
+    /// non-capability-infrastructure) that have no row in `tool_index`.
+    /// Empty in cheap snapshots; populated in `.full`.
+    public let missingFromIndex: [String]
+    /// Tools present in `tool_index` that are no longer in the registry
+    /// (or have been disabled / excluded). Empty in cheap snapshots;
+    /// populated in `.full`.
+    public let stale: [String]
+    /// True when `.full` was requested but the name-diff exceeded the
+    /// 50ms budget and the snapshot degraded to `.cheap`. Logged so the
+    /// missing data isn't silent.
+    public let diffSkippedDueToBudget: Bool
+
+    public init(
+        registryToolCount: Int,
+        indexedToolCount: Int,
+        missingFromIndex: [String] = [],
+        stale: [String] = [],
+        diffSkippedDueToBudget: Bool = false
+    ) {
+        self.registryToolCount = registryToolCount
+        self.indexedToolCount = indexedToolCount
+        self.missingFromIndex = missingFromIndex
+        self.stale = stale
+        self.diffSkippedDueToBudget = diffSkippedDueToBudget
+    }
+}
+
+// MARK: - Diagnostics facade
+
+@MainActor
+public enum CapabilitySearchDiagnostics {
+    public enum Mode: Sendable { case cheap, full }
+
+    /// Hard ceiling for the `.full` name-diff. If the underlying
+    /// `loadAllEntryNames` call exceeds this, the snapshot reverts to
+    /// counts-only and surfaces `diffSkippedDueToBudget = true`.
+    public static let fullModeBudgetMillis: Double = 50
+
+    /// Compute a snapshot. `.cheap` is safe to invoke from the hot
+    /// search path (sub-millisecond on healthy installs). `.full`
+    /// adds the name diff and is intended for env-flag-gated traces
+    /// and offline tooling only.
+    public static func snapshot(mode: Mode = .cheap) async -> CapabilitySearchHealth {
+        let (registryNames, registryCount) = registrySnapshotNames()
+        let indexCount = (try? ToolDatabase.shared.entryCount()) ?? 0
+
+        guard mode == .full else {
+            return CapabilitySearchHealth(
+                registryToolCount: registryCount,
+                indexedToolCount: indexCount
+            )
+        }
+
+        let started = Date()
+        let indexNames: [String]
+        do {
+            indexNames = try ToolDatabase.shared.loadAllEntryNames(source: .system)
+        } catch {
+            logger.error(
+                "CapabilitySearchHealth: loadAllEntryNames failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return CapabilitySearchHealth(
+                registryToolCount: registryCount,
+                indexedToolCount: indexCount,
+                diffSkippedDueToBudget: false
+            )
+        }
+        let elapsedMs = Date().timeIntervalSince(started) * 1000
+        if elapsedMs > Self.fullModeBudgetMillis {
+            logger.notice(
+                "CapabilitySearchHealth: name-diff skipped (took \(elapsedMs, format: .fixed(precision: 1))ms > budget \(Self.fullModeBudgetMillis, format: .fixed(precision: 0))ms)"
+            )
+            return CapabilitySearchHealth(
+                registryToolCount: registryCount,
+                indexedToolCount: indexCount,
+                diffSkippedDueToBudget: true
+            )
+        }
+
+        let registrySet = Set(registryNames)
+        let indexSet = Set(indexNames)
+        let missing = registrySet.subtracting(indexSet).sorted()
+        let stale = indexSet.subtracting(registrySet).sorted()
+
+        return CapabilitySearchHealth(
+            registryToolCount: registryCount,
+            indexedToolCount: indexCount,
+            missingFromIndex: missing,
+            stale: stale
+        )
+    }
+
+    /// One-shot snapshot + structured log line. Tool names and counts
+    /// are non-PII so `privacy: .public` is correct — it lets the log
+    /// survive Console redaction during a manual repro.
+    public static func logSnapshot(reason: String, mode: Mode = .cheap) async {
+        let health = await snapshot(mode: mode)
+        let summary = formatSummary(health)
+        logger.notice(
+            "CapabilitySearchHealth reason=\(reason, privacy: .public) mode=\(String(describing: mode), privacy: .public) \(summary, privacy: .public)"
+        )
+    }
+
+    /// Per-call-site one-shot variant. The first invocation per process
+    /// for a given `reason` emits a snapshot; subsequent calls are
+    /// dropped. Lets `CapabilitySearch.search` and
+    /// `PreflightCapabilitySearch.search` install cheap snapshot gates
+    /// on the hot path without double-logging when both fire in the
+    /// same session. Reason strings are also the de-dup key — pick
+    /// stable identifiers (e.g. `"CapabilitySearch.search"`).
+    public static func logSnapshotOnce(reason: String, mode: Mode = .cheap) async {
+        guard !trippedCallSites.contains(reason) else { return }
+        trippedCallSites.insert(reason)
+        await logSnapshot(reason: reason, mode: mode)
+    }
+
+    /// Set of `logSnapshotOnce` reasons that have already fired in
+    /// this process. `@MainActor` isolation makes the read/insert pair
+    /// safe — there is no synchronisation primitive around it.
+    private static var trippedCallSites: Set<String> = []
+
+    /// Compact, single-line representation safe to embed in another
+    /// `Logger.notice(...)` call (e.g. the env-flag trace block in
+    /// `CapabilitySearch.search`). Keeps both the cheap and full
+    /// shapes readable in one place.
+    /// `nonisolated` so non-main-actor callers (e.g.
+    /// `CapabilitySearch.search`) don't have to hop the main actor
+    /// just to stringify a `Sendable` struct.
+    public nonisolated static func formatSummary(_ health: CapabilitySearchHealth) -> String {
+        var parts: [String] = [
+            "registry=\(health.registryToolCount)",
+            "index=\(health.indexedToolCount)",
+        ]
+        if !health.missingFromIndex.isEmpty {
+            parts.append("missingFromIndex=[\(health.missingFromIndex.joined(separator: ","))]")
+        }
+        if !health.stale.isEmpty {
+            parts.append("stale=[\(health.stale.joined(separator: ","))]")
+        }
+        if health.diffSkippedDueToBudget {
+            parts.append("diffSkipped=true")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    // MARK: - Internals
+
+    /// Mirror of the `ToolIndexService.syncFromRegistry()` exclusion
+    /// rules (Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
+    /// lines ~30–35) so the diff is apples-to-apples: only tools the
+    /// indexer would have written end up in the registry-side `Set`.
+    /// Returns both the name list and the registry count for callers
+    /// that don't need the name array.
+    private static func registrySnapshotNames() -> (names: [String], count: Int) {
+        let all = ToolRegistry.shared.listTools()
+        let excluded = ToolRegistry.capabilityToolNames
+            .union(ToolRegistry.shared.runtimeManagedToolNames)
+        let indexable = all.filter { $0.enabled && !excluded.contains($0.name) }
+        return (indexable.map(\.name), indexable.count)
+    }
+}

--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -204,22 +204,81 @@ struct CapabilitySearchResults {
 }
 
 enum CapabilitySearch {
+    /// Legacy threshold, retained for the methods + skills lanes which
+    /// still run pure-embedding (no FTS5 mirror yet — separate follow-up).
+    /// Tools no longer use this; they use `minimumFusedScore`.
     static let minimumRelevanceScore: Float = 0.7
+
+    /// RRF cutoff for the tools lane (BM25 + embed fusion). Baked in
+    /// as `let` to avoid a mutable global — component scores in
+    /// forensics are only meaningful against a fixed cutoff. Future
+    /// tunability surfaces through a `CapabilitySearchSettings` type
+    /// (out of scope this PR), which reads its own copy and never
+    /// mutates this constant.
+    ///
+    /// Sweep result (T ∈ {0.005, 0.010, 0.015, 0.020, 0.025, 0.030}):
+    /// `0.020` is the empirical sweet spot — `browser-prefix` matches
+    /// 9/5 expected, `extract-webpage-natural` matches 2/1 expected,
+    /// and `abstain-greeting` accepted-count drops from 10 → 3 (vs
+    /// 10 at lower thresholds). Higher T (0.025, 0.030) doesn't help
+    /// abstain materially (3 → 2) but starts costing recall on
+    /// browser at T=0.030 (9 → 7).
+    ///
+    /// **Known limitation:** abstain never reaches 0 accepted hits at
+    /// any tested T because RRF with k=60 caps the max fused score at
+    /// `2 × 1/(60+1) ≈ 0.0328`, which compresses the gap between
+    /// abstain noise (top 0.032) and legitimate recall (top 0.033) to
+    /// a 0.001 window. No single `minFusedScore` separates them. The
+    /// abstain case is moved to tracking-only in `recall_floors.json`
+    /// alongside `shell-execution`. A proper abstain mechanism — pre-
+    /// filter quality gate before RRF, score-based fusion instead of
+    /// rank-based, or a query-intent classifier — is a follow-up.
+    ///
+    /// Future tunability surfaces through a `CapabilitySearchSettings`
+    /// type (out of scope this PR), which reads its own copy and
+    /// never mutates this constant.
+    static let minimumFusedScore: Float = 0.020
+
+    /// Env var that swaps the inner per-lane search calls for their
+    /// diagnostic variants (`searchHybridWithDiagnostic` for tools,
+    /// `searchWithDiagnostic` for methods + skills) and emits a single
+    /// multi-line `Logger.notice` block per call with per-component
+    /// BM25 + embed scores. Doubles the embed cost of
+    /// `capabilities_search` while set — only flip it during a manual
+    /// recall repro.
+    private static let debugTraceEnvVar = "OSAURUS_DEBUG_CAPABILITY_SEARCH"
 
     static func search(
         query: String,
         topK: (methods: Int, tools: Int, skills: Int)
     ) async -> CapabilitySearchResults {
         let threshold = minimumRelevanceScore
+        let fusedCutoff = minimumFusedScore
+
+        // Per-process cheap-path snapshot. First call from this site
+        // emits one `CapabilitySearchHealth` line; subsequent calls
+        // are dropped. Cheap mode is sub-millisecond — `entryCount()`
+        // + an in-memory `ToolRegistry.listTools()` walk.
+        await CapabilitySearchDiagnostics.logSnapshotOnce(reason: "CapabilitySearch.search")
+
+        if ProcessInfo.processInfo.environment[Self.debugTraceEnvVar] == "1" {
+            return await searchWithVerboseTrace(
+                query: query,
+                topK: topK,
+                threshold: threshold,
+                fusedCutoff: fusedCutoff
+            )
+        }
+
         async let methodHits = MethodSearchService.shared.search(
             query: query,
             topK: topK.methods,
             threshold: threshold
         )
-        async let toolHits = ToolSearchService.shared.search(
+        async let toolHits = ToolSearchService.shared.searchHybrid(
             query: query,
             topK: topK.tools,
-            threshold: threshold
+            minFusedScore: fusedCutoff
         )
         async let skillHits = SkillSearchService.shared.search(
             query: query,
@@ -227,10 +286,72 @@ enum CapabilitySearch {
             threshold: threshold
         )
 
+        // Methods + skills double-filter mirrors the in-actor cutoff
+        // (kept from the diagnostics PR — collapsing it crosses the
+        // Phase 1 instrumentation boundary; tracked as an out-of-scope
+        // tidy that should land alongside the methods/skills BM25
+        // mirror). Tools come from `searchHybrid` which has already
+        // applied `minFusedScore` — no outer filter needed.
         return CapabilitySearchResults(
             methods: (await methodHits).filter { $0.searchScore >= threshold },
-            tools: (await toolHits).filter { $0.searchScore >= threshold },
+            tools: await toolHits,
             skills: (await skillHits).filter { $0.searchScore >= threshold }
+        )
+    }
+
+    /// Env-flag branch. Identical I/O contract to the production path
+    /// (same `CapabilitySearchResults`) plus a multi-line structured
+    /// log capturing every raw + accepted hit, the current
+    /// `CapabilitySearchHealth` (full mode), and per-component BM25
+    /// + embed scores for the tools lane. Doubles the embed cost;
+    /// only fires when `OSAURUS_DEBUG_CAPABILITY_SEARCH=1`.
+    private static func searchWithVerboseTrace(
+        query: String,
+        topK: (methods: Int, tools: Int, skills: Int),
+        threshold: Float,
+        fusedCutoff: Float
+    ) async -> CapabilitySearchResults {
+        async let methodPair = MethodSearchService.shared.searchWithDiagnostic(
+            query: query,
+            topK: topK.methods,
+            threshold: threshold
+        )
+        async let toolPair = ToolSearchService.shared.searchHybridWithDiagnostic(
+            query: query,
+            topK: topK.tools,
+            minFusedScore: fusedCutoff
+        )
+        async let skillPair = SkillSearchService.shared.searchWithDiagnostic(
+            query: query,
+            topK: topK.skills,
+            threshold: threshold
+        )
+        async let healthSnapshot = CapabilitySearchDiagnostics.snapshot(mode: .full)
+
+        let (methodResults, methodDiag) = await methodPair
+        let (toolResults, toolDiag) = await toolPair
+        let (skillResults, skillDiag) = await skillPair
+        let health = await healthSnapshot
+        let healthSummary = CapabilitySearchDiagnostics.formatSummary(health)
+
+        logger.notice(
+            """
+            CapabilitySearch query=\(query, privacy: .public)
+            threshold=\(threshold, privacy: .public) fusedCutoff=\(fusedCutoff, privacy: .public)
+            health=\(healthSummary, privacy: .public)
+            methods raw=\(formatHits(methodDiag.rawHits), privacy: .public)
+            methods accepted=\(formatHits(methodDiag.acceptedHits), privacy: .public)
+            tools bm25Available=\(toolDiag.bm25Available, privacy: .public) all=\(formatHybridHits(toolDiag.allHits), privacy: .public)
+            tools accepted=\(formatHybridHits(toolDiag.acceptedHits), privacy: .public)
+            skills raw=\(formatHits(skillDiag.rawHits), privacy: .public)
+            skills accepted=\(formatHits(skillDiag.acceptedHits), privacy: .public)
+            """
+        )
+
+        return CapabilitySearchResults(
+            methods: methodResults.filter { $0.searchScore >= threshold },
+            tools: toolResults,
+            skills: skillResults.filter { $0.searchScore >= threshold }
         )
     }
 
@@ -240,6 +361,44 @@ enum CapabilitySearch {
             return config.enabled && config.pluginCreate
         }
     }
+}
+
+// MARK: - Diagnostic helpers (fileprivate)
+
+/// Marker protocol so the env-flag log path can format hits from any
+/// of the three `*SearchDiagnostic.Hit` types with one helper.
+fileprivate protocol DiagnosticHit {
+    var name: String { get }
+    var score: Float { get }
+}
+
+extension ToolSearchDiagnostic.Hit: DiagnosticHit {}
+extension MethodSearchDiagnostic.Hit: DiagnosticHit {}
+extension SkillSearchDiagnostic.Hit: DiagnosticHit {}
+
+fileprivate func formatHits<H: DiagnosticHit>(_ hits: [H]) -> String {
+    if hits.isEmpty { return "[]" }
+    return
+        hits
+        .map { "\($0.name)=\(String(format: "%.3f", $0.score))" }
+        .joined(separator: ",")
+}
+
+/// Per-hit format for the tools-lane hybrid trace block. Each hit
+/// renders as `name(bm25=X.XXX|n/a, embed=Y.YYY|n/a, fused=Z.ZZZ)`
+/// so an engineer reading Console can see at a glance which source
+/// surfaced the candidate (the `n/a` markers carry the H4/H5 signal).
+fileprivate func formatHybridHits(_ hits: [ToolSearchHybridDiagnostic.Hit]) -> String {
+    if hits.isEmpty { return "[]" }
+    return
+        hits
+        .map { hit -> String in
+            let bm25 = hit.bm25Score.map { String(format: "%.3f", $0) } ?? "n/a"
+            let embed = hit.embedScore.map { String(format: "%.3f", $0) } ?? "n/a"
+            let fused = String(format: "%.3f", hit.fusedScore)
+            return "\(hit.name)(bm25=\(bm25),embed=\(embed),fused=\(fused))"
+        }
+        .joined(separator: ",")
 }
 
 // MARK: - Preflight Tool Selection
@@ -283,6 +442,12 @@ enum PreflightCapabilitySearch {
         agentId: UUID,
         model: String? = nil
     ) async -> PreflightResult {
+        // Per-process cheap-path snapshot, mirroring the gate inside
+        // `CapabilitySearch.search`. Different `reason` keys so both
+        // sites can fire once each — independently helpful when one
+        // path runs early-boot and the other doesn't.
+        await CapabilitySearchDiagnostics.logSnapshotOnce(reason: "PreflightCapabilitySearch.search")
+
         let allowed = await MainActor.run {
             AgentManager.shared.effectiveEnabledToolNames(for: agentId).map(Set.init)
         }
@@ -488,16 +653,22 @@ enum PreflightCapabilitySearch {
     ) async -> [ToolRegistry.ToolEntry] {
         guard topK > 0, catalog.count > topK else { return catalog }
 
-        let hits = await ToolSearchService.shared.search(
+        // Hybrid (BM25 + embed via RRF) with `minFusedScore: 0.0` —
+        // catalog narrowing is rank-only, never an acceptance gate.
+        // The LLM is the actual filter at this stage; we just want
+        // the catalog ordered by relevance before truncation.
+        let hits = await ToolSearchService.shared.searchHybrid(
             query: query,
             topK: topK,
-            threshold: 0.0
+            minFusedScore: 0.0
         )
         guard !hits.isEmpty else {
+            let fallback = safeFallbackSlice(catalog: catalog, topK: topK)
+            let sliceNames = fallback.map(\.name)
             logger.notice(
-                "rankCatalog: tool index returned no hits (index warming or embedder unavailable) — falling back to alphabetical top \(topK) of \(catalog.count)"
+                "rankCatalog fallback: query=\(query, privacy: .public) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=empty-hits"
             )
-            return safeFallbackSlice(catalog: catalog, topK: topK)
+            return fallback
         }
 
         // Map ranked names back to the input catalog entries (preserves
@@ -518,7 +689,15 @@ enum PreflightCapabilitySearch {
         // branch above — never return a catalog larger than `topK`,
         // even when the index hits don't map back to live entries
         // (stale index, MCP re-registration race, etc.).
-        return ranked.isEmpty ? safeFallbackSlice(catalog: catalog, topK: topK) : ranked
+        if ranked.isEmpty {
+            let fallback = safeFallbackSlice(catalog: catalog, topK: topK)
+            let sliceNames = fallback.map(\.name)
+            logger.notice(
+                "rankCatalog fallback: query=\(query, privacy: .public) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=no-mappable-hits"
+            )
+            return fallback
+        }
+        return ranked
     }
 
     /// Deterministic top-K slice used when the embedding index can't

--- a/Packages/OsaurusCore/Services/Method/MethodSearchService.swift
+++ b/Packages/OsaurusCore/Services/Method/MethodSearchService.swift
@@ -11,6 +11,32 @@ import Foundation
 import VecturaKit
 import os
 
+/// Diagnostic snapshot for `MethodSearchService.searchWithDiagnostic`.
+/// Mirrors `ToolSearchDiagnostic` shape so the env-flag log path in
+/// `CapabilitySearch.search` can format all three uniformly.
+public struct MethodSearchDiagnostic: Sendable {
+    public struct Hit: Sendable {
+        public let name: String
+        public let score: Float
+        public init(name: String, score: Float) {
+            self.name = name
+            self.score = score
+        }
+    }
+
+    public let indexedMethodCount: Int
+    public let rawHits: [Hit]
+    public let acceptedHits: [Hit]
+    public let threshold: Float
+
+    public init(indexedMethodCount: Int, rawHits: [Hit], acceptedHits: [Hit], threshold: Float) {
+        self.indexedMethodCount = indexedMethodCount
+        self.rawHits = rawHits
+        self.acceptedHits = acceptedHits
+        self.threshold = threshold
+    }
+}
+
 public actor MethodSearchService {
     public static let shared = MethodSearchService()
 
@@ -145,6 +171,27 @@ public actor MethodSearchService {
             MethodLogger.search.error("Method search failed: \(error)")
             return []
         }
+    }
+
+    /// Diagnostic-capturing search. See `ToolSearchService.searchWithDiagnostic`
+    /// for rationale — runs the underlying query twice (raw + accepted)
+    /// to surface the embedder's pre-threshold candidate set without
+    /// changing the production single-call hot path.
+    public func searchWithDiagnostic(
+        query: String,
+        topK: Int,
+        threshold: Float
+    ) async -> (results: [MethodSearchResult], diagnostic: MethodSearchDiagnostic) {
+        let indexedCount = (try? MethodDatabase.shared.loadAllMethods().count) ?? 0
+        let raw = await search(query: query, topK: topK, threshold: 0.0)
+        let accepted = await search(query: query, topK: topK, threshold: threshold)
+        let diagnostic = MethodSearchDiagnostic(
+            indexedMethodCount: indexedCount,
+            rawHits: raw.map { MethodSearchDiagnostic.Hit(name: $0.method.name, score: $0.searchScore) },
+            acceptedHits: accepted.map { MethodSearchDiagnostic.Hit(name: $0.method.name, score: $0.searchScore) },
+            threshold: threshold
+        )
+        return (accepted, diagnostic)
     }
 
     // MARK: - Rebuild

--- a/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
+++ b/Packages/OsaurusCore/Services/Skill/SkillSearchService.swift
@@ -25,6 +25,32 @@ public struct SkillSearchResult: Sendable {
     }
 }
 
+/// Diagnostic snapshot for `SkillSearchService.searchWithDiagnostic`. Mirror
+/// of `ToolSearchDiagnostic` / `MethodSearchDiagnostic`; same usage gates
+/// (env-flag trace + offline eval).
+public struct SkillSearchDiagnostic: Sendable {
+    public struct Hit: Sendable {
+        public let name: String
+        public let score: Float
+        public init(name: String, score: Float) {
+            self.name = name
+            self.score = score
+        }
+    }
+
+    public let indexedSkillCount: Int
+    public let rawHits: [Hit]
+    public let acceptedHits: [Hit]
+    public let threshold: Float
+
+    public init(indexedSkillCount: Int, rawHits: [Hit], acceptedHits: [Hit], threshold: Float) {
+        self.indexedSkillCount = indexedSkillCount
+        self.rawHits = rawHits
+        self.acceptedHits = acceptedHits
+        self.threshold = threshold
+    }
+}
+
 public actor SkillSearchService {
     public static let shared = SkillSearchService()
 
@@ -157,6 +183,25 @@ public actor SkillSearchService {
             SkillSearchLogger.search.error("Skill search failed: \(error)")
             return []
         }
+    }
+
+    /// Diagnostic-capturing search. See `ToolSearchService.searchWithDiagnostic`
+    /// for the rationale of the two-pass design.
+    public func searchWithDiagnostic(
+        query: String,
+        topK: Int,
+        threshold: Float
+    ) async -> (results: [SkillSearchResult], diagnostic: SkillSearchDiagnostic) {
+        let indexedCount = await MainActor.run { SkillManager.shared.skills.count }
+        let raw = await search(query: query, topK: topK, threshold: 0.0)
+        let accepted = await search(query: query, topK: topK, threshold: threshold)
+        let diagnostic = SkillSearchDiagnostic(
+            indexedSkillCount: indexedCount,
+            rawHits: raw.map { SkillSearchDiagnostic.Hit(name: $0.skill.name, score: $0.searchScore) },
+            acceptedHits: accepted.map { SkillSearchDiagnostic.Hit(name: $0.skill.name, score: $0.searchScore) },
+            threshold: threshold
+        )
+        return (accepted, diagnostic)
     }
 
     // MARK: - Rebuild

--- a/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
@@ -26,6 +26,102 @@ public struct ToolSearchResult: Sendable {
     }
 }
 
+/// Diagnostic snapshot of one hybrid search invocation. Carries enough
+/// per-hit information to drive both the env-flag log block and the
+/// offline `CapabilitySearchEvaluator` forensics:
+///   - `bm25Rank` / `bm25Score`: nil when BM25 returned no hit for this
+///     name (or when the FTS5 sanitiser rejected the query — see
+///     `bm25Available`).
+///   - `embedRank` / `embedScore`: nil when the embedding side returned
+///     no hit for this name.
+///   - `fusedScore`: the sum of the two RRF terms with k=60. Items present
+///     on only one side contribute zero from the missing side.
+public struct ToolSearchHybridDiagnostic: Sendable {
+    public struct Hit: Sendable {
+        public let name: String
+        public let bm25Rank: Int?
+        public let bm25Score: Float?
+        public let embedRank: Int?
+        public let embedScore: Float?
+        public let fusedScore: Float
+
+        public init(
+            name: String,
+            bm25Rank: Int?,
+            bm25Score: Float?,
+            embedRank: Int?,
+            embedScore: Float?,
+            fusedScore: Float
+        ) {
+            self.name = name
+            self.bm25Rank = bm25Rank
+            self.bm25Score = bm25Score
+            self.embedRank = embedRank
+            self.embedScore = embedScore
+            self.fusedScore = fusedScore
+        }
+    }
+
+    public let indexedToolCount: Int
+    /// `false` when the FTS5 sanitiser produced no usable tokens for
+    /// this query (e.g. all-punctuation). Fused scores in that case
+    /// come entirely from the embed side; `bm25Rank` / `bm25Score`
+    /// are `nil` on every hit. The `hybridDegradesToEmbeddingWhenBM25Empty`
+    /// test asserts both this flag and result-set equality with
+    /// embed-only `search()` — so callers can detect "BM25 deliberately
+    /// stayed silent" vs "BM25 happened to converge".
+    public let bm25Available: Bool
+    /// Pre-threshold candidate set: every name returned by either
+    /// source. Sorted by `fusedScore` descending.
+    public let allHits: [Hit]
+    /// `allHits` filtered to `fusedScore >= minFusedScore`, capped at
+    /// `topK`. Mirror of what `searchHybrid` returns.
+    public let acceptedHits: [Hit]
+    public let minFusedScore: Float
+
+    public init(
+        indexedToolCount: Int,
+        bm25Available: Bool,
+        allHits: [Hit],
+        acceptedHits: [Hit],
+        minFusedScore: Float
+    ) {
+        self.indexedToolCount = indexedToolCount
+        self.bm25Available = bm25Available
+        self.allHits = allHits
+        self.acceptedHits = acceptedHits
+        self.minFusedScore = minFusedScore
+    }
+}
+
+/// Diagnostic snapshot of one `searchWithDiagnostic` invocation. Used by the
+/// `OSAURUS_DEBUG_CAPABILITY_SEARCH=1` log path in `CapabilitySearch.search`
+/// and by `CapabilitySearchEvaluator` to surface raw vs threshold-accepted
+/// hits in the same call. Production search (`search(...)`) does NOT
+/// populate this — keeps the hot path single-call.
+public struct ToolSearchDiagnostic: Sendable {
+    public struct Hit: Sendable {
+        public let name: String
+        public let score: Float
+        public init(name: String, score: Float) {
+            self.name = name
+            self.score = score
+        }
+    }
+
+    public let indexedToolCount: Int
+    public let rawHits: [Hit]
+    public let acceptedHits: [Hit]
+    public let threshold: Float
+
+    public init(indexedToolCount: Int, rawHits: [Hit], acceptedHits: [Hit], threshold: Float) {
+        self.indexedToolCount = indexedToolCount
+        self.rawHits = rawHits
+        self.acceptedHits = acceptedHits
+        self.threshold = threshold
+    }
+}
+
 public actor ToolSearchService {
     public static let shared = ToolSearchService()
 
@@ -48,14 +144,23 @@ public actor ToolSearchService {
             do {
                 OsaurusPaths.ensureExistsSilent(storageDir)
 
+                // Pure embedding only — BM25 now lives in `tool_index_fts`
+                // and `searchHybrid` fuses the two via RRF. Letting
+                // VecturaKit also mix BM25 in (as the previous
+                // `hybridWeight: 0.5` did) double-counted the lexical
+                // signal once we added the FTS5 layer, and made the
+                // per-component scores in forensics dishonest. The
+                // BM25 hyperparameters (`k1`, `b`) are unused at
+                // `hybridWeight: 1.0` but kept inline so the next
+                // contributor sees what the legacy hybrid was tuned to.
                 let config = try VecturaConfig(
                     name: "osaurus-tools",
                     directoryURL: storageDir,
                     dimension: EmbeddingService.embeddingDimension,
                     searchOptions: VecturaConfig.SearchOptions(
                         defaultNumResults: 10,
-                        minThreshold: 0.3,
-                        hybridWeight: 0.5,
+                        minThreshold: 0.0,
+                        hybridWeight: 1.0,
                         k1: 1.2,
                         b: 0.75
                     ),
@@ -173,6 +278,177 @@ public actor ToolSearchService {
             ToolIndexLogger.search.error("Tool search failed: \(error)")
             return []
         }
+    }
+
+    /// Diagnostic-capturing search. Runs the underlying query twice — once
+    /// at threshold 0.0 to capture every candidate the embedder produced
+    /// (the "raw" set), and once at the requested threshold (the "accepted"
+    /// set). Doubles the embed cost on purpose; only invoked from the
+    /// env-flag-gated trace path and from the offline eval harness. The
+    /// production `search(...)` is byte-for-byte unchanged.
+    public func searchWithDiagnostic(
+        query: String,
+        topK: Int,
+        threshold: Float
+    ) async -> (results: [ToolSearchResult], diagnostic: ToolSearchDiagnostic) {
+        let indexedCount = (try? ToolDatabase.shared.entryCount()) ?? 0
+        let raw = await search(query: query, topK: topK, threshold: 0.0)
+        let accepted = await search(query: query, topK: topK, threshold: threshold)
+        let diagnostic = ToolSearchDiagnostic(
+            indexedToolCount: indexedCount,
+            rawHits: raw.map { ToolSearchDiagnostic.Hit(name: $0.entry.name, score: $0.searchScore) },
+            acceptedHits: accepted.map { ToolSearchDiagnostic.Hit(name: $0.entry.name, score: $0.searchScore) },
+            threshold: threshold
+        )
+        return (accepted, diagnostic)
+    }
+
+    // MARK: - Hybrid search (BM25 + embedding via RRF)
+
+    /// Runtime k for Reciprocal Rank Fusion. 60 is the canonical value
+    /// from the original RRF paper (Cormack, Clarke, Buettcher 2009)
+    /// — large enough that the top 1-2 hits don't completely
+    /// dominate, small enough that mid-rank items still matter. We
+    /// don't expose this; if a future caller needs to tune it, push
+    /// it through the call sites rather than parametrising the actor.
+    private static let rrfK: Float = 60
+
+    /// Hybrid search: BM25 (via `ToolDatabase.searchBM25` / FTS5)
+    /// fused with pure embedding (via the existing `search(...)`)
+    /// using Reciprocal Rank Fusion. Items in only one source still
+    /// score (the missing source contributes 0). Filters to
+    /// `fusedScore >= minFusedScore` and truncates to `topK`.
+    ///
+    /// Used by the runtime `CapabilitySearch.search` tools-lane and
+    /// by `PreflightCapabilitySearch.rankCatalog` (with
+    /// `minFusedScore: 0.0` — rank-only, no acceptance cutoff).
+    public func searchHybrid(
+        query: String,
+        topK: Int = 10,
+        minFusedScore: Float = 0.01
+    ) async -> [ToolSearchResult] {
+        let (results, _) = await searchHybridWithDiagnostic(
+            query: query,
+            topK: topK,
+            minFusedScore: minFusedScore
+        )
+        return results
+    }
+
+    /// Diagnostic-capturing variant. Returns the same `[ToolSearchResult]`
+    /// the runtime would receive plus a `ToolSearchHybridDiagnostic`
+    /// carrying per-component rank/score for every candidate (`allHits`)
+    /// and the threshold-accepted subset (`acceptedHits`).
+    ///
+    /// Implementation note: BM25 runs synchronously inline (sub-ms on
+    /// realistic indices, see `ToolDatabase.searchBM25`); the slow path
+    /// is the embedding call. No `Task.detached` — adding a thread hop
+    /// for a sub-ms SQLite read would buy nothing and obscure the
+    /// sync-vs-async boundary. We don't `async let` the embed call
+    /// either: BM25 has already returned, so the embed runs sequentially
+    /// and only the slow side actually awaits.
+    public func searchHybridWithDiagnostic(
+        query: String,
+        topK: Int,
+        minFusedScore: Float
+    ) async -> (results: [ToolSearchResult], diagnostic: ToolSearchHybridDiagnostic) {
+        let indexedCount = (try? ToolDatabase.shared.entryCount()) ?? 0
+        let bm25Available = ToolDatabase.sanitizeFTS5Query(query) != nil
+
+        let bm25 = (try? ToolDatabase.shared.searchBM25(query: query, topK: topK * 2)) ?? []
+        let embed = await search(query: query, topK: topK * 2, threshold: 0.0)
+
+        // Per-name rank + score lookups, keyed on tool name (the unit
+        // the eval / forensics layers compare on). `tool_index.id` ==
+        // `tool.name` everywhere in the registry today, so the BM25
+        // result's `id` IS the name; the embed result carries
+        // `entry.name` which is the same string.
+        let bm25RankByName = Dictionary(
+            uniqueKeysWithValues: bm25.enumerated().map { ($1.id, $0 + 1) }
+        )
+        let bm25ScoreByName = Dictionary(uniqueKeysWithValues: bm25.map { ($0.id, $0.score) })
+        let embedRankByName = Dictionary(
+            uniqueKeysWithValues: embed.enumerated().map { ($1.entry.name, $0 + 1) }
+        )
+        let embedScoreByName = Dictionary(
+            uniqueKeysWithValues: embed.map { ($0.entry.name, $0.searchScore) }
+        )
+
+        let allNames = Set(bm25.map(\.id)).union(embed.map(\.entry.name))
+        let k = Self.rrfK
+
+        // Compute fused score per name. Items missing from one source
+        // contribute zero from that side — RRF treats absence as
+        // "infinite rank", which equals zero contribution.
+        let fused: [(name: String, score: Float)] =
+            allNames
+            .map { name -> (String, Float) in
+                let s1 = bm25RankByName[name].map { 1.0 / (k + Float($0)) } ?? 0
+                let s2 = embedRankByName[name].map { 1.0 / (k + Float($0)) } ?? 0
+                return (name, s1 + s2)
+            }
+            .sorted { $0.score > $1.score }
+
+        // Map names back to live `ToolIndexEntry` rows + apply the
+        // enabled-name filter (mirrors `search(...)` lines 153–159).
+        let enabledNames = await MainActor.run {
+            Set(ToolRegistry.shared.listTools().filter { $0.enabled }.map { $0.name })
+        }
+        let entriesByName: [String: ToolIndexEntry]
+        do {
+            let all = try ToolDatabase.shared.loadAllEntries()
+            entriesByName = Dictionary(
+                all.map { ($0.name, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        } catch {
+            ToolIndexLogger.search.error("Hybrid search failed loading entries: \(error)")
+            entriesByName = [:]
+        }
+
+        // Single Hit factory shared by `allHits` (every candidate,
+        // forensics-facing) and `acceptedHits` (filtered subset,
+        // runtime-facing). Keeps the per-name field lookups in one
+        // place — easy to extend (e.g., add a `tokenCount` column)
+        // without drift between the two views.
+        func makeHit(name: String, score: Float) -> ToolSearchHybridDiagnostic.Hit {
+            ToolSearchHybridDiagnostic.Hit(
+                name: name,
+                bm25Rank: bm25RankByName[name],
+                bm25Score: bm25ScoreByName[name],
+                embedRank: embedRankByName[name],
+                embedScore: embedScoreByName[name],
+                fusedScore: score
+            )
+        }
+
+        // `allHits`: every candidate sorted by fusedScore desc, before
+        // the threshold and topK cuts — forensics needs to see what
+        // the embedder + BM25 surfaced even when nothing was accepted.
+        let allHits = fused.map { makeHit(name: $0.name, score: $0.score) }
+
+        // `acceptedHits`: enabled + above `minFusedScore` + capped at
+        // topK. Eager loop so the slice → [Hit] type stays simple
+        // (lazy `prefix` over a compactMap chain confused the type
+        // checker on first attempt).
+        var acceptedResults: [ToolSearchResult] = []
+        var acceptedHits: [ToolSearchHybridDiagnostic.Hit] = []
+        for (name, score) in fused {
+            if acceptedResults.count >= topK { break }
+            guard score >= minFusedScore else { continue }
+            guard let entry = entriesByName[name], enabledNames.contains(name) else { continue }
+            acceptedResults.append(ToolSearchResult(entry: entry, searchScore: score))
+            acceptedHits.append(makeHit(name: name, score: score))
+        }
+
+        let diagnostic = ToolSearchHybridDiagnostic(
+            indexedToolCount: indexedCount,
+            bm25Available: bm25Available,
+            allHits: allHits,
+            acceptedHits: acceptedHits,
+            minFusedScore: minFusedScore
+        )
+        return (acceptedResults, diagnostic)
     }
 
     // MARK: - Rebuild

--- a/Packages/OsaurusCore/Storage/ToolDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ToolDatabase.swift
@@ -89,7 +89,7 @@ public enum ToolIndexSource: String, Codable, Sendable {
 public final class ToolDatabase: @unchecked Sendable {
     public static let shared = ToolDatabase()
 
-    private static let schemaVersion = 1
+    private static let schemaVersion = 2
 
     nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -182,6 +182,7 @@ public final class ToolDatabase: @unchecked Sendable {
     private func runMigrations() throws {
         let currentVersion = try getSchemaVersion()
         if currentVersion < 1 { try migrateToV1() }
+        if currentVersion < 2 { try migrateToV2() }
     }
 
     private func getSchemaVersion() throws -> Int {
@@ -219,6 +220,78 @@ public final class ToolDatabase: @unchecked Sendable {
 
         try executeRaw("CREATE INDEX IF NOT EXISTS idx_tool_index_runtime ON tool_index(runtime)")
         try setSchemaVersion(1)
+    }
+
+    /// Adds an FTS5 mirror over `tool_index(name, description)` so the
+    /// hybrid search path (`ToolSearchService.searchHybrid`) has a
+    /// real BM25 source to fuse with the embedding side. External-
+    /// content + triggers + initial backfill keeps the mirror in sync
+    /// with `tool_index` going forward; we never write to
+    /// `tool_index_fts` directly outside the trigger bodies.
+    ///
+    /// Tokenizer: `unicode61 remove_diacritics 2` is the modern
+    /// FTS5 default for English-mostly corpora — handles tool name
+    /// snake_case via the unicode61 separator class, strips diacritics,
+    /// and avoids the legacy `simple` tokenizer's punctuation
+    /// quirks.
+    private func migrateToV2() throws {
+        try executeRaw(
+            """
+                CREATE VIRTUAL TABLE IF NOT EXISTS tool_index_fts USING fts5(
+                    name, description,
+                    content='tool_index', content_rowid='rowid',
+                    tokenize='unicode61 remove_diacritics 2'
+                )
+            """
+        )
+        try executeRaw(
+            """
+                CREATE TRIGGER IF NOT EXISTS tool_index_ai AFTER INSERT ON tool_index BEGIN
+                    INSERT INTO tool_index_fts(rowid, name, description)
+                    VALUES (new.rowid, new.name, new.description);
+                END
+            """
+        )
+        try executeRaw(
+            """
+                CREATE TRIGGER IF NOT EXISTS tool_index_ad AFTER DELETE ON tool_index BEGIN
+                    INSERT INTO tool_index_fts(tool_index_fts, rowid, name, description)
+                    VALUES('delete', old.rowid, old.name, old.description);
+                END
+            """
+        )
+        try executeRaw(
+            """
+                CREATE TRIGGER IF NOT EXISTS tool_index_au AFTER UPDATE ON tool_index BEGIN
+                    INSERT INTO tool_index_fts(tool_index_fts, rowid, name, description)
+                    VALUES('delete', old.rowid, old.name, old.description);
+                    INSERT INTO tool_index_fts(rowid, name, description)
+                    VALUES (new.rowid, new.name, new.description);
+                END
+            """
+        )
+
+        // Backfill existing rows. Wrapped in a transaction so the FTS5
+        // doclist commits in one fsync (orders-of-magnitude faster on
+        // hosts with many MCP tools) and so a partial-failure leaves the
+        // mirror in either fully-empty or fully-populated state — never
+        // halfway. This migration fires once, on the first DB open after
+        // the schemaVersion bump from 1 → 2; subsequent opens skip via
+        // the `getSchemaVersion()` short-circuit in `runMigrations()`.
+        try executeRaw("BEGIN")
+        do {
+            try executeRaw(
+                """
+                    INSERT INTO tool_index_fts(rowid, name, description)
+                    SELECT rowid, name, description FROM tool_index
+                """
+            )
+            try executeRaw("COMMIT")
+        } catch {
+            try? executeRaw("ROLLBACK")
+            throw error
+        }
+        try setSchemaVersion(2)
     }
 
     // MARK: - Raw Execution
@@ -340,6 +413,26 @@ public final class ToolDatabase: @unchecked Sendable {
         return entries
     }
 
+    /// Lightweight name-only listing keyed by `source`. Used by the
+    /// capability-search health probe (`CapabilitySearchDiagnostics`) to
+    /// compute registry-vs-index name diffs without paying the full row
+    /// deserialisation cost of `loadAllEntries()` (the JSON `tools_json`
+    /// blob in particular). Sub-millisecond on a 100-entry index in
+    /// practice; budgeted to 50ms by callers.
+    public func loadAllEntryNames(source: ToolIndexSource) throws -> [String] {
+        var names: [String] = []
+        try prepareAndExecute(
+            "SELECT id FROM tool_index WHERE source = ?1 ORDER BY name",
+            bind: { stmt in Self.bindText(stmt, index: 1, value: source.rawValue) },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    names.append(String(cString: sqlite3_column_text(stmt, 0)))
+                }
+            }
+        )
+        return names
+    }
+
     public func entryCount() throws -> Int {
         var count = 0
         try prepareAndExecute(
@@ -352,6 +445,84 @@ public final class ToolDatabase: @unchecked Sendable {
             }
         )
         return count
+    }
+
+    // MARK: - BM25 (FTS5)
+
+    /// Lexical search over the FTS5 mirror. Returns up to `topK`
+    /// `(toolId, score)` pairs ordered by relevance (higher is
+    /// better). SQLite's `bm25()` returns NEGATIVE scores where lower
+    /// = better match — we negate inside the SELECT so callers don't
+    /// have to remember the inversion.
+    ///
+    /// Returns `[]` (no throw) when `sanitizeFTS5Query` produces no
+    /// usable tokens (all-punctuation queries, etc.) — the hybrid
+    /// caller is expected to fall through to the embedding side via
+    /// RRF in that case.
+    ///
+    /// Synchronous: matches the existing `loadAllEntries` /
+    /// `entryCount` pattern (queue-serialised under the hood). On a
+    /// 100-row index this is sub-millisecond; the caller in
+    /// `ToolSearchService.searchHybrid` runs it inline before
+    /// launching the slower async embed call.
+    public func searchBM25(query: String, topK: Int) throws -> [(id: String, score: Float)] {
+        guard let prepared = Self.sanitizeFTS5Query(query) else { return [] }
+        var results: [(id: String, score: Float)] = []
+        try prepareAndExecute(
+            """
+            SELECT t.id, -bm25(tool_index_fts) AS score
+            FROM tool_index_fts f
+            JOIN tool_index t ON t.rowid = f.rowid
+            WHERE tool_index_fts MATCH ?1
+            ORDER BY score DESC
+            LIMIT ?2
+            """,
+            bind: { stmt in
+                Self.bindText(stmt, index: 1, value: prepared)
+                sqlite3_bind_int(stmt, 2, Int32(topK))
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    let id = String(cString: sqlite3_column_text(stmt, 0))
+                    let score = Float(sqlite3_column_double(stmt, 1))
+                    results.append((id, score))
+                }
+            }
+        )
+        return results
+    }
+
+    /// Convert a free-form query into a safe FTS5 MATCH expression.
+    /// Lowercase + split on non-alphanumerics + filter out empty
+    /// tokens + OR-join. **No minimum length floor** — short technical
+    /// tokens (`go`, `vm`, `ai`, `ui`, `io`, `db`, `fs`, …) are real
+    /// words in tool names and descriptions; BM25's IDF naturally
+    /// suppresses any single-letter noise. **No stopword list** either —
+    /// FTS5 doesn't ship one and we don't want one (we want `"and"` to
+    /// score against descriptions that contain it as a literal token).
+    /// Returns `nil` when the input collapses to zero usable tokens
+    /// (e.g. `"!@#$%"`, all-whitespace) — callers treat this as
+    /// "BM25 cannot contribute, fall back to embed-only".
+    static func sanitizeFTS5Query(_ raw: String) -> String? {
+        let allowed = CharacterSet.alphanumerics
+        let scalars = raw.lowercased().unicodeScalars
+        var current = ""
+        var tokens: [String] = []
+        for s in scalars {
+            if allowed.contains(s) {
+                current.append(Character(s))
+            } else if !current.isEmpty {
+                tokens.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty { tokens.append(current) }
+        guard !tokens.isEmpty else { return nil }
+        // FTS5 OR-join. Each token is bare alphanumerics so no
+        // additional escaping is needed; the surrounding double-quotes
+        // would only be required if a token contained a syntax char,
+        // which our sanitiser strips by construction.
+        return tokens.joined(separator: " OR ")
     }
 
     public func deleteAll() throws {

--- a/Packages/OsaurusCore/Tests/Tool/ToolIndexServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolIndexServiceTests.swift
@@ -92,6 +92,135 @@ struct ToolDatabaseTests {
         #expect(try db.entryCount() == 2)
     }
 
+    // MARK: - FTS5 mirror
+
+    @Test func fts5MirrorReflectsInsert() throws {
+        let db = try makeTempDB()
+        try db.upsertEntry(
+            sampleEntry(
+                id: "fts-ins",
+                name: "kestrel",
+                description: "Manage zorglax fields in the cluster"
+            )
+        )
+        // Unique tokens so only this row matches.
+        let kestrel = try db.searchBM25(query: "kestrel", topK: 10)
+        #expect(kestrel.map(\.id) == ["fts-ins"])
+        let zorglax = try db.searchBM25(query: "zorglax", topK: 10)
+        #expect(zorglax.map(\.id) == ["fts-ins"])
+    }
+
+    @Test func fts5MirrorReflectsUpdate() throws {
+        let db = try makeTempDB()
+        try db.upsertEntry(
+            sampleEntry(
+                id: "fts-upd",
+                name: "kestrel",
+                description: "Manage zorglax fields"
+            )
+        )
+        // Overwrite description: the old token should disappear from
+        // the FTS5 mirror, the new token should appear.
+        try db.upsertEntry(
+            sampleEntry(
+                id: "fts-upd",
+                name: "kestrel",
+                description: "Sync wibblefoo records"
+            )
+        )
+        let zorglaxAfter = try db.searchBM25(query: "zorglax", topK: 10)
+        #expect(zorglaxAfter.isEmpty)
+        let wibblefoo = try db.searchBM25(query: "wibblefoo", topK: 10)
+        #expect(wibblefoo.map(\.id) == ["fts-upd"])
+    }
+
+    @Test func fts5MirrorReflectsDelete() throws {
+        let db = try makeTempDB()
+        try db.upsertEntry(
+            sampleEntry(
+                id: "fts-del",
+                name: "kestrel",
+                description: "Manage zorglax fields"
+            )
+        )
+        try db.deleteEntry(id: "fts-del")
+        let after = try db.searchBM25(query: "zorglax", topK: 10)
+        #expect(after.isEmpty)
+    }
+
+    @Test func searchBM25EmptyQueryReturnsEmpty() throws {
+        let db = try makeTempDB()
+        try db.upsertEntry(sampleEntry(id: "any", name: "anything", description: "anything"))
+        // All-punctuation collapses to zero usable tokens; the
+        // sanitiser returns nil and searchBM25 short-circuits to [].
+        #expect(try db.searchBM25(query: "!@#$%^&*()", topK: 10).isEmpty)
+        #expect(try db.searchBM25(query: "   ", topK: 10).isEmpty)
+        #expect(try db.searchBM25(query: "", topK: 10).isEmpty)
+    }
+
+    @Test func searchBM25KeepsShortTechnicalTokens() throws {
+        // Confirms the sanitiser does NOT impose a minimum token
+        // length — `go`, `ai`, `ui` etc. are real technical tokens.
+        let db = try makeTempDB()
+        try db.upsertEntry(
+            sampleEntry(
+                id: "short-tok",
+                name: "wibblefoo",
+                description: "Useful for go projects"
+            )
+        )
+        let results = try db.searchBM25(query: "go", topK: 10)
+        #expect(results.map(\.id) == ["short-tok"])
+    }
+
+    @Test func loadAllEntryNamesFiltersBySource() throws {
+        let db = try makeTempDB()
+        try db.upsertEntry(sampleEntry(id: "sys-a", name: "alpha"))
+        try db.upsertEntry(sampleEntry(id: "sys-b", name: "beta"))
+        try db.upsertEntry(
+            ToolIndexEntry(
+                id: "manual-x",
+                name: "xenon",
+                description: "manual entry",
+                runtime: .native,
+                toolsJSON: "{}",
+                source: .manual,
+                tokenCount: 0
+            )
+        )
+
+        let systemNames = try db.loadAllEntryNames(source: .system)
+        #expect(systemNames.sorted() == ["sys-a", "sys-b"])
+
+        let manualNames = try db.loadAllEntryNames(source: .manual)
+        #expect(manualNames == ["manual-x"])
+    }
+
+    /// Smoke test for the `CapabilitySearchHealth` full-mode budget.
+    /// Asserts the median wall-clock of `loadAllEntryNames(source:)` over
+    /// 5 runs against a 100-entry index is ≤ 5ms — well below the 50ms
+    /// runtime ceiling that trips `diffSkippedDueToBudget`. The 10× gap
+    /// is intentional: a 5ms test catches a 10× regression while sitting
+    /// above CI-runner / Intel-Mac noise. A 50ms test would silently let
+    /// a 10× slowdown ship.
+    @Test func loadAllEntryNamesIsFastOn100Entries() throws {
+        let db = try makeTempDB()
+        for i in 0 ..< 100 {
+            try db.upsertEntry(sampleEntry(id: "tool-\(i)", name: "tool-\(i)"))
+        }
+
+        var samplesMs: [Double] = []
+        for _ in 0 ..< 5 {
+            let started = Date()
+            let names = try db.loadAllEntryNames(source: .system)
+            let elapsedMs = Date().timeIntervalSince(started) * 1000
+            #expect(names.count == 100)
+            samplesMs.append(elapsedMs)
+        }
+        let median = samplesMs.sorted()[samplesMs.count / 2]
+        #expect(median <= 5.0, "loadAllEntryNames median \(median)ms exceeded 5ms budget on 100-entry index")
+    }
+
     @Test func deleteAllClearsTable() throws {
         let db = try makeTempDB()
         try db.upsertEntry(sampleEntry(id: "a", name: "alpha"))

--- a/Packages/OsaurusCore/Tests/Tool/ToolSearchServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolSearchServiceTests.swift
@@ -58,4 +58,42 @@ struct ToolSearchServiceTests {
         #expect(result.searchScore == 0.72)
         #expect(result.entry.name == "test-tool")
     }
+
+    /// Pins the documented BM25-degrade contract: when the FTS5
+    /// sanitiser produces no usable tokens (e.g. an all-punctuation
+    /// query), the diagnostic surfaces `bm25Available == false` AND
+    /// the hybrid's accepted name set equals what the embedding-only
+    /// `search()` returns at the same K. Two assertions, not one — the
+    /// result-set check alone wouldn't prove BM25 actually opted out
+    /// vs happened to converge with embed at the same names.
+    @Test func hybridDegradesToEmbeddingWhenBM25Empty() async {
+        // Pick a query the sanitiser rejects: only punctuation and
+        // separators, zero alphanumerics. `sanitizeFTS5Query` must
+        // return nil for this and `searchBM25` must short-circuit
+        // to `[]`, both of which are exercised in
+        // `ToolDatabaseTests.searchBM25EmptyQueryReturnsEmpty`.
+        let query = "!@#$%^&*()"
+
+        let (results, diagnostic) = await ToolSearchService.shared.searchHybridWithDiagnostic(
+            query: query,
+            topK: 5,
+            minFusedScore: 0.0
+        )
+        let embedOnly = await ToolSearchService.shared.search(
+            query: query,
+            topK: 5,
+            threshold: 0.0
+        )
+
+        // Contract 1: BM25 deliberately stayed silent.
+        #expect(diagnostic.bm25Available == false)
+        // No diagnostic Hit can carry BM25 data for a sanitiser-
+        // rejected query — the only contributor was the embed side.
+        for hit in diagnostic.acceptedHits {
+            #expect(hit.bm25Rank == nil)
+            #expect(hit.bm25Score == nil)
+        }
+        // Contract 2: result name set matches embed-only.
+        #expect(Set(results.map(\.entry.name)) == Set(embedOnly.map(\.entry.name)))
+    }
 }

--- a/Packages/OsaurusEvals/Config/recall_floors.json
+++ b/Packages/OsaurusEvals/Config/recall_floors.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Recall floors for `osaurus-evals run --fail-on-floor`. Keys are case `id` strings \u2014 must match the fixture id exactly. The `--fail-on-floor` flag is OPT-IN and not yet wired into CI. Two `capability_search` cases are intentionally OMITTED as tracking-only: (1) `capability_search.shell-execution` because `sandbox_exec` / `sandbox_execute_code` are excluded from the search index by design (ToolIndexService.syncFromRegistry's runtimeManagedToolNames exclusion); (2) `capability_search.abstain-greeting` because RRF with k=60 caps the max fused score at ~0.033, compressing the gap between abstain noise (top 0.032) and legitimate recall (top 0.033) below any usable threshold \u2014 a proper abstain mechanism is a follow-up issue. The remaining floors match each case's fixture `minMatches` so the gate is consistent with the assertions the runner already enforces.",
+  "capability_search": {
+    "capability_search.browser-prefix": { "minMatches": 5 },
+    "capability_search.extract-webpage-natural": { "minMatches": 1 },
+    "capability_search.weather-natural": { "minMatches": 1 }
+  },
+  "preflight": {
+    "preflight.browser.natural": { "minMatches": 1 }
+  }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -55,10 +55,15 @@ struct OsaurusEvalsCLI {
         let report = await EvalRunner.run(
             suite: suite,
             model: opts.model,
-            filter: opts.filter
+            filter: opts.filter,
+            thresholdOverride: opts.threshold
         )
 
         print(report.formatHumanReadable(verbose: opts.verbose))
+
+        if opts.reportForensics {
+            print("\n" + Self.formatForensicsBlock(report, suite: suite))
+        }
 
         if let outPath = opts.out {
             do {
@@ -77,8 +82,283 @@ struct OsaurusEvalsCLI {
         }
 
         let counts = report.counts
-        let exitCode: Int32 = (counts.failed + counts.errored == 0) ? 0 : 1
+        var exitCode: Int32 = (counts.failed + counts.errored == 0) ? 0 : 1
+
+        // Optional opt-in stricter gate. Walks every case listed in
+        // `recall_floors.json`, recomputes the matched-name count
+        // against the case's fixture expectations, and trips a breach
+        // when matched < `minMatches`. Skipped cases (missing local
+        // plugin) are excluded — they're already a "didn't apply"
+        // signal, not a regression. CI wiring is deferred to the
+        // post-fix PR; today this exists so contributors can dry-run
+        // the gate locally before it becomes authoritative.
+        if opts.failOnFloor {
+            let floorsURL =
+                opts.floorsPath.map { URL(fileURLWithPath: $0) }
+                ?? Self.defaultFloorsURL()
+            do {
+                let floors = try Self.loadFloors(from: floorsURL)
+                let breaches = Self.computeFloorBreaches(
+                    report: report,
+                    suite: suite,
+                    floors: floors
+                )
+                if !breaches.isEmpty {
+                    print("\n[floor breaches]")
+                    for line in breaches { print("  - \(line)") }
+                    exitCode = 1
+                } else {
+                    print("\n[floors] all listed cases met minMatches")
+                }
+            } catch {
+                FileHandle.standardError.write(
+                    Data(("failed to load floors at \(floorsURL.path): \(error.localizedDescription)\n").utf8)
+                )
+                exitCode = 2
+            }
+        }
+
         exit(exitCode)
+    }
+
+    // MARK: - Floors
+
+    /// Default path used when `--fail-on-floor` is set without
+    /// `--floors`. Resolved relative to the current working directory
+    /// so the CLI can be invoked from anywhere in the repo as long as
+    /// the user passes an absolute or repo-relative path explicitly;
+    /// otherwise we assume the conventional checkout layout.
+    static func defaultFloorsURL() -> URL {
+        URL(fileURLWithPath: "Packages/OsaurusEvals/Config/recall_floors.json")
+    }
+
+    /// Decode `recall_floors.json` into a domain → caseId → minMatches
+    /// map. Hand-rolled JSON walk so the `_comment` top-level key (and
+    /// any future doc/metadata keys) is silently skipped without a
+    /// custom `Decodable`.
+    static func loadFloors(from url: URL) throws -> [String: [String: Int]] {
+        let data = try Data(contentsOf: url)
+        let any = try JSONSerialization.jsonObject(with: data)
+        guard let root = any as? [String: Any] else {
+            throw CLIError.invalidValue("--floors", "root is not an object")
+        }
+        var result: [String: [String: Int]] = [:]
+        for (domain, value) in root {
+            if domain.hasPrefix("_") { continue }
+            guard let cases = value as? [String: Any] else { continue }
+            var inner: [String: Int] = [:]
+            for (caseId, raw) in cases {
+                guard let entry = raw as? [String: Any] else { continue }
+                if let mm = entry["minMatches"] as? Int {
+                    inner[caseId] = mm
+                }
+            }
+            result[domain] = inner
+        }
+        return result
+    }
+
+    /// Walk every (domain, caseId, minMatches) tuple in `floors` and
+    /// produce a one-line breach for each case whose matched-name
+    /// count is below the floor. `skipped` outcomes never breach
+    /// (different host, different installed plugins). Unknown case
+    /// IDs are surfaced as breaches so a typo in the floor file
+    /// can't silently disable the gate.
+    static func computeFloorBreaches(
+        report: EvalReport,
+        suite: EvalSuite,
+        floors: [String: [String: Int]]
+    ) -> [String] {
+        var breaches: [String] = []
+        let casesById = Dictionary(
+            uniqueKeysWithValues: suite.cases.map { ($0.id, $0) }
+        )
+        let rowsById = Dictionary(
+            uniqueKeysWithValues: report.cases.map { ($0.id, $0) }
+        )
+        for (domain, floorByCaseId) in floors {
+            for (caseId, minMatches) in floorByCaseId {
+                guard let caseDef = casesById[caseId] else {
+                    breaches.append("\(caseId): not found in suite")
+                    continue
+                }
+                guard let row = rowsById[caseId] else {
+                    breaches.append("\(caseId): not present in report")
+                    continue
+                }
+                if row.outcome == .skipped { continue }
+
+                let matched: Int
+                switch domain {
+                case "capability_search":
+                    guard let cs = row.capabilitySearch else {
+                        breaches.append("\(caseId): no capability_search snapshot")
+                        continue
+                    }
+                    let expected = caseDef.expect.capabilitySearch?.expectedTools?.anyOf ?? []
+                    let accepted = Set(cs.toolHits.filter(\.acceptedByThreshold).map(\.name))
+                    matched = expected.filter { accepted.contains($0) }.count
+                case "preflight":
+                    guard let observed = row.observed else {
+                        breaches.append("\(caseId): no preflight snapshot")
+                        continue
+                    }
+                    let expected = caseDef.expect.tools?.mustInclude ?? []
+                    let picked = Set(observed.pickedToolNames)
+                    matched = expected.filter { picked.contains($0) }.count
+                default:
+                    continue
+                }
+                if matched < minMatches {
+                    breaches.append(
+                        "\(caseId): matched \(matched), required \(minMatches)"
+                    )
+                }
+            }
+        }
+        return breaches.sorted()
+    }
+
+    // MARK: - Forensics
+
+    /// Per-case `(rawHits, acceptedHits, topFusedScore)` breakdown for
+    /// `capability_search` cases, with an H1/H2/H3/H4/H5 hypothesis
+    /// label applied. Drives off `EvalCaseReport.capabilitySearch` (the
+    /// hybrid diagnostic) and the case fixture's expected names from
+    /// `suite` (re-looked-up the same way `--fail-on-floor` does it).
+    ///
+    /// Label rules (first match wins, after the `passed` / `skipped`
+    /// short-circuits):
+    ///   - rawCount = 0                                                    → H2 (index gap)
+    ///   - rawCount > 0, top fusedScore < 0.10                             → H3 (embedder)
+    ///   - any expected name in accepted has `bm25Score != nil, embed nil` → H4 (lexical-only)
+    ///   - any expected name in accepted has `embedScore != nil, bm25 nil` → H5 (semantic-only)
+    ///   - rawCount > 0, acceptedCount = 0                                 → H1 (threshold)
+    ///   - rawCount > 0, acceptedCount > 0, case still failed              → H3 (recall: expected names absent from accepted)
+    ///   - otherwise                                                       → ok
+    /// Non-`capability_search` rows are skipped.
+    static func formatForensicsBlock(_ report: EvalReport, suite: EvalSuite) -> String {
+        let casesById = Dictionary(uniqueKeysWithValues: suite.cases.map { ($0.id, $0) })
+        let rows = report.cases.compactMap { row -> String? in
+            guard row.domain == "capability_search",
+                let cs = row.capabilitySearch
+            else { return nil }
+            let raw = cs.toolHits.count + cs.methodHits.count + cs.skillHits.count
+            let accepted =
+                cs.toolHits.filter(\.acceptedByThreshold).count
+                + cs.methodHits.filter(\.acceptedByThreshold).count
+                + cs.skillHits.filter(\.acceptedByThreshold).count
+            let topFused =
+                (cs.toolHits + cs.methodHits + cs.skillHits)
+                .map(\.fusedScore)
+                .max()
+            let topFusedString = topFused.map { String(format: "%.3f", $0) } ?? "n/a"
+
+            // Expected names for the H4/H5 nullability check. Pulled
+            // from the case fixture's `expectedTools.anyOf` (the
+            // tools-lane assertion); methods/skills `expected*` could
+            // be added similarly when those lanes go hybrid.
+            let expectedToolNames = Set(
+                casesById[row.id]?
+                    .expect.capabilitySearch?
+                    .expectedTools?.anyOf ?? []
+            )
+            let label = forensicsLabel(
+                rawCount: raw,
+                acceptedCount: accepted,
+                topFusedScore: topFused,
+                outcome: row.outcome,
+                toolHits: cs.toolHits,
+                expectedToolNames: expectedToolNames
+            )
+            // All-Swift formatting. We previously used `String(format:)`
+            // with `%-50s` / `%-7s`, but `%s` expects a C string —
+            // passing a Swift `String` via `CVarArg` crashes inside
+            // `_platform_strlen`. Plain `padding(toLength:)` keeps the
+            // column alignment without the CVarArg hazard.
+            return Self.forensicsLine(
+                id: row.id,
+                rawCount: raw,
+                acceptedCount: accepted,
+                topFusedString: topFusedString,
+                label: label
+            )
+        }
+        if rows.isEmpty {
+            return "[forensics] no capability_search cases in report"
+        }
+        return (["[forensics]"] + rows).joined(separator: "\n")
+    }
+
+    /// Pure Swift, CVarArg-free row formatter for the forensics block.
+    /// Right-pads each column with spaces so the table stays readable
+    /// across cases with different id / score lengths. `padding(...)`
+    /// is no-op when the string is already at-or-over the target width
+    /// — long ids extend the column rather than truncating, which is
+    /// the right tradeoff for a copy-paste-into-PR-description block.
+    static func forensicsLine(
+        id: String,
+        rawCount: Int,
+        acceptedCount: Int,
+        topFusedString: String,
+        label: String
+    ) -> String {
+        let idCol = id.padding(toLength: max(50, id.count), withPad: " ", startingAt: 0)
+        let rawCol = String(rawCount).padding(toLength: 3, withPad: " ", startingAt: 0)
+        let acceptedCol = String(acceptedCount).padding(toLength: 3, withPad: " ", startingAt: 0)
+        let topCol = topFusedString.padding(toLength: max(7, topFusedString.count), withPad: " ", startingAt: 0)
+        return "case=\(idCol) rawHits=\(rawCol) acceptedHits=\(acceptedCol) topFused=\(topCol) → \(label)"
+    }
+
+    private static func forensicsLabel(
+        rawCount: Int,
+        acceptedCount: Int,
+        topFusedScore: Float?,
+        outcome: EvalCaseOutcome,
+        toolHits: [CapabilitySearchEvaluation.Hit],
+        expectedToolNames: Set<String>
+    ) -> String {
+        // For passing cases, all the failure-mode labels are
+        // misleading. An abstain-style case PASSES with rawCount=10,
+        // acceptedCount=0 — labeling that as "H1 (threshold)" reads
+        // as a regression when it's the desired behaviour. Skip the
+        // hypothesis annotation and just report `passed`.
+        if outcome == .passed { return "passed" }
+        if outcome == .skipped { return "skipped" }
+        if rawCount == 0 { return "H2 (index gap)" }
+        if let top = topFusedScore, top < 0.10 { return "H3 (embedder)" }
+
+        // H4 / H5: only meaningful when the case has expected tool
+        // names AND at least one expected name is in the accepted set.
+        // We classify by which source carried the hit: if BM25 alone
+        // produced it (embedScore nil), the embedder couldn't have
+        // — that's H4 (lexical-only) and tells us BM25 alone could
+        // satisfy this query. If embed alone produced it, BM25 missed
+        // — that's H5 (semantic-only) and tells us BM25 alone is
+        // insufficient. Both labels classify the *failure* (the case
+        // didn't reach minMatches) by attributing each surfaced
+        // expected hit to its source — a partial-credit signal even
+        // when overall recall is below the floor.
+        if !expectedToolNames.isEmpty {
+            let acceptedExpected = toolHits.filter {
+                $0.acceptedByThreshold && expectedToolNames.contains($0.name)
+            }
+            if !acceptedExpected.isEmpty {
+                let lexicalOnly = acceptedExpected.contains { $0.bm25Score != nil && $0.embedScore == nil }
+                let semanticOnly = acceptedExpected.contains { $0.bm25Score == nil && $0.embedScore != nil }
+                if lexicalOnly && !semanticOnly { return "H4 (lexical-only)" }
+                if semanticOnly && !lexicalOnly { return "H5 (semantic-only)" }
+                if lexicalOnly && semanticOnly { return "H4+H5 (mixed-source)" }
+            }
+        }
+
+        if acceptedCount == 0 { return "H1 (threshold)" }
+        // raw>0 AND accepted>0 AND case still failed → the search
+        // surfaced something but not the EXPECTED tools (e.g. the
+        // shell-execution case where sandbox_exec is excluded from
+        // the index entirely). The threshold can't help here, so
+        // flag as the recall failure mode it actually is.
+        return "H3 (recall: expected names absent from accepted)"
     }
 
     // MARK: - Args
@@ -89,6 +369,25 @@ struct OsaurusEvalsCLI {
         let filter: String?
         let out: String?
         let verbose: Bool
+        /// Capability-search threshold sweep value. Forwarded to
+        /// `EvalRunner.run(thresholdOverride:)`; no-op for other
+        /// domains. `nil` keeps the production
+        /// `CapabilitySearch.minimumRelevanceScore`.
+        let threshold: Float?
+        /// Print the per-case `(rawHits, acceptedHits, topRawScore)`
+        /// H1/H2/H3 forensics block after the human-readable report.
+        /// Designed for copy-paste into PR descriptions during the
+        /// Phase 3 threshold sweep.
+        let reportForensics: Bool
+        /// Path to the recall-floors JSON config. `nil` falls back to
+        /// the conventional repo location when `--fail-on-floor` is
+        /// set.
+        let floorsPath: String?
+        /// Opt-in stricter gate. When set, the CLI also exits 1 on
+        /// any case listed in the floors file whose matched count is
+        /// below the configured `minMatches`. Off by default — the
+        /// Phase 5 wiring is scaffolding, not an active CI gate.
+        let failOnFloor: Bool
 
         static func parse(_ args: [String]) throws -> Options {
             var suite: URL?
@@ -96,6 +395,10 @@ struct OsaurusEvalsCLI {
             var filter: String?
             var out: String?
             var verbose = false
+            var threshold: Float?
+            var reportForensics = false
+            var floorsPath: String?
+            var failOnFloor = false
 
             var i = 0
             while i < args.count {
@@ -116,6 +419,20 @@ struct OsaurusEvalsCLI {
                 case "--verbose", "-v":
                     verbose = true
                     i += 1
+                case "--threshold":
+                    let raw = try valueForArg(args, after: i, flag: arg)
+                    guard let value = Float(raw) else { throw CLIError.invalidValue(arg, raw) }
+                    threshold = value
+                    i += 2
+                case "--report-forensics":
+                    reportForensics = true
+                    i += 1
+                case "--floors":
+                    floorsPath = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--fail-on-floor":
+                    failOnFloor = true
+                    i += 1
                 case "--help", "-h":
                     printUsage()
                     exit(0)
@@ -130,7 +447,11 @@ struct OsaurusEvalsCLI {
                 model: ModelSelection.parse(modelRaw),
                 filter: filter,
                 out: out,
-                verbose: verbose
+                verbose: verbose,
+                threshold: threshold,
+                reportForensics: reportForensics,
+                floorsPath: floorsPath,
+                failOnFloor: failOnFloor
             )
         }
     }
@@ -151,27 +472,62 @@ struct OsaurusEvalsCLI {
 
             USAGE:
                 osaurus-evals run --suite <dir> [--model <id>] [--filter <substr>] [--out <path>]
+                                              [--threshold <float>] [--report-forensics]
 
             FLAGS:
-                --suite <dir>     Required. Directory of *.json eval cases
-                                  (e.g. Suites/Preflight).
-                --model <id>      Model to route through CoreModelService for
-                                  this run. Forms:
-                                    auto                — keep current config
-                                    foundation          — Apple Foundation Models
-                                    openai/gpt-4o-mini  — provider/name pair
-                                    qwen3-4b            — bare local id
-                                  Default: auto.
-                --filter <substr> Only run cases whose id contains <substr>.
-                --out <path>      Also write a JSON report to <path>.
-                --verbose, -v     Print per-case diagnostics: the user query,
-                                  the raw LLM response (truncated), and the
-                                  pre-guardrail picks. Use when iterating on
-                                  the preflight prompt.
+                --suite <dir>         Required. Directory of *.json eval cases
+                                      (e.g. Suites/Preflight, Suites/CapabilitySearch).
+                --model <id>          Model to route through CoreModelService for
+                                      this run. Forms:
+                                        auto                — keep current config
+                                        foundation          — Apple Foundation Models
+                                        openai/gpt-4o-mini  — provider/name pair
+                                        qwen3-4b            — bare local id
+                                      Default: auto.
+                --filter <substr>     Only run cases whose id contains <substr>.
+                --out <path>          Also write a JSON report to <path>.
+                --verbose, -v         Print per-case diagnostics: the user query,
+                                      the raw LLM response (truncated), and the
+                                      pre-guardrail picks. Use when iterating on
+                                      the preflight prompt.
+                --threshold <float>   Override the **tools-lane** RRF cutoff
+                                      (`minFusedScore`) for this run. The
+                                      methods + skills lanes always use the
+                                      production embed-cosine default
+                                      (`CapabilitySearch.minimumRelevanceScore`)
+                                      regardless of this flag — fused-score
+                                      and cosine values live on different
+                                      scales (RRF max ≈ 0.033 vs cosine 0–1),
+                                      so a single knob can't drive both
+                                      meaningfully. Use this to sweep RRF
+                                      cutoffs (e.g. --threshold 0.020) without
+                                      rebuilding. No-op for non-capability_search
+                                      domains.
+                --report-forensics    Print a per-case `(rawHits, acceptedHits,
+                                      topFused)` block tagged with a
+                                      H1/H2/H3/H4/H5 hypothesis label. H4 =
+                                      lexical-only (BM25 surfaced an expected
+                                      tool, embed missed). H5 = semantic-only
+                                      (embed surfaced it, BM25 missed). Tells
+                                      you which source could be dropped.
+                                      Capability-search rows only. Designed
+                                      for copy-paste into the PR description
+                                      during a sweep.
+                --floors <path>       Path to recall_floors.json. Defaults to
+                                      `Packages/OsaurusEvals/Config/recall_floors.json`
+                                      when --fail-on-floor is set without
+                                      --floors. No effect on its own.
+                --fail-on-floor       Opt-in stricter gate: also exit 1 on
+                                      any case in the floors file whose matched
+                                      count is below `minMatches`. Off by
+                                      default; CI wiring is deferred to the
+                                      post-fix PR.
 
             EXAMPLES:
                 osaurus-evals run --suite Suites/Preflight --model foundation
                 osaurus-evals run --suite Suites/Preflight --filter browser --out report.json
+                osaurus-evals run --suite Suites/CapabilitySearch --threshold 0.25 --report-forensics
+                osaurus-evals run --suite Suites/CapabilitySearch --fail-on-floor
             """
         print(usage)
     }
@@ -181,12 +537,14 @@ enum CLIError: Error, LocalizedError {
     case unknownArg(String)
     case missingFlag(String)
     case missingValue(String)
+    case invalidValue(String, String)
 
     var errorDescription: String? {
         switch self {
         case .unknownArg(let a): return "unknown argument: \(a)"
         case .missingFlag(let f): return "missing required flag: \(f)"
         case .missingValue(let f): return "flag \(f) requires a value"
+        case .invalidValue(let f, let v): return "flag \(f) got invalid value: \(v)"
         }
     }
 }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -31,6 +31,14 @@ public struct EvalCase: Sendable, Codable, Identifiable {
     public let label: String?
     /// User message the case sends through preflight.
     public let query: String
+    /// Free-form per-case explanatory text. Echoed into the report's
+    /// per-case `notes` array so a reader sees WHY a case is shaped the
+    /// way it is. Used today to call out cases that are intentionally
+    /// red (e.g. `capability_search.shell-execution` — `sandbox_exec`
+    /// is excluded from the search index by design, so no recall fix
+    /// can rescue it). Avoid using this as a debug log; keep it short
+    /// and structural.
+    public let notes: String?
     public let fixtures: Fixtures
     public let expect: Expectations
 
@@ -39,6 +47,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         domain: String,
         label: String? = nil,
         query: String,
+        notes: String? = nil,
         fixtures: Fixtures,
         expect: Expectations
     ) {
@@ -46,6 +55,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         self.domain = domain
         self.label = label
         self.query = query
+        self.notes = notes
         self.fixtures = fixtures
         self.expect = expect
     }
@@ -82,6 +92,15 @@ public struct EvalCase: Sendable, Codable, Identifiable {
     /// scope its assertions narrowly. An empty `Expectations` is valid
     /// — it acts as a smoke-test that just records what preflight did
     /// without scoring anything (useful while bootstrapping a new case).
+    ///
+    /// TODO(eval-shape-unification): `tools.mustInclude` (preflight)
+    /// and `capabilitySearch.expectedTools.anyOf` are two different
+    /// shapes for asserting on tool sets across two sibling domains.
+    /// Worth one cleanup pass once both runners have stabilised — pick
+    /// the union (`mustInclude` + `mustNotInclude` + `anyOf` +
+    /// `minMatches`) and have both domains use it. Don't block the
+    /// hybrid PR on this; surfacing the divergence here so the next
+    /// contributor sees it.
     public struct Expectations: Sendable, Codable {
         public let tools: ToolExpectations?
         public let companions: CompanionExpectations?
@@ -96,6 +115,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public let prefixHash: PrefixHashExpectations?
         public let argumentCoercion: ArgumentCoercionExpectations?
         public let requestValidation: RequestValidationExpectations?
+        /// Recall expectation for `domain == "capability_search"` cases.
+        /// Drives the index-only path through `CapabilitySearchEvaluator`
+        /// — no LLM, fast, deterministic. Used to lock in recall floors
+        /// against the embedder + threshold layer that feeds preflight.
+        public let capabilitySearch: CapabilitySearchExpectations?
 
         public init(
             tools: ToolExpectations? = nil,
@@ -105,7 +129,8 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             streamingHint: StreamingHintExpectations? = nil,
             prefixHash: PrefixHashExpectations? = nil,
             argumentCoercion: ArgumentCoercionExpectations? = nil,
-            requestValidation: RequestValidationExpectations? = nil
+            requestValidation: RequestValidationExpectations? = nil,
+            capabilitySearch: CapabilitySearchExpectations? = nil
         ) {
             self.tools = tools
             self.companions = companions
@@ -115,6 +140,54 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.prefixHash = prefixHash
             self.argumentCoercion = argumentCoercion
             self.requestValidation = requestValidation
+            self.capabilitySearch = capabilitySearch
+        }
+    }
+
+    /// Recall expectation for the `capability_search` domain. Each
+    /// non-nil `expected*` matcher must overlap the accepted hits by
+    /// at least `minMatches`; `maxAccepted` (when set) caps total
+    /// accepted hits — used by abstain-style cases so a permissive
+    /// threshold can't silently drown the user in noise.
+    public struct CapabilitySearchExpectations: Sendable, Codable {
+        public struct AnyOfMatcher: Sendable, Codable {
+            public let anyOf: [String]
+            public let minMatches: Int
+
+            public init(anyOf: [String], minMatches: Int) {
+                self.anyOf = anyOf
+                self.minMatches = minMatches
+            }
+        }
+
+        /// Per-case `topK` override forwarded to
+        /// `CapabilitySearchEvaluator.evaluate(query:topK:threshold:)`.
+        /// `nil` uses the evaluator's default of 10.
+        public let topK: Int?
+        /// Per-case threshold. The CLI `--threshold` flag wins when set.
+        public let thresholdOverride: Float?
+        public let expectedTools: AnyOfMatcher?
+        public let expectedMethods: AnyOfMatcher?
+        public let expectedSkills: AnyOfMatcher?
+        /// Cap on total accepted-hit count across tools+methods+skills.
+        /// `nil` = no cap. `0` = abstain-style: ANY accepted hit fails
+        /// the case.
+        public let maxAccepted: Int?
+
+        public init(
+            topK: Int? = nil,
+            thresholdOverride: Float? = nil,
+            expectedTools: AnyOfMatcher? = nil,
+            expectedMethods: AnyOfMatcher? = nil,
+            expectedSkills: AnyOfMatcher? = nil,
+            maxAccepted: Int? = nil
+        ) {
+            self.topK = topK
+            self.thresholdOverride = thresholdOverride
+            self.expectedTools = expectedTools
+            self.expectedMethods = expectedMethods
+            self.expectedSkills = expectedSkills
+            self.maxAccepted = maxAccepted
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -62,8 +62,13 @@ public struct EvalCaseReport: Sendable, Codable {
     public let outcome: EvalCaseOutcome
     public let score: EvalCaseScore?
     /// Preflight snapshot we ran the scorers against. `nil` for
-    /// `skipped` / `errored` outcomes.
+    /// `skipped` / `errored` outcomes and for non-`preflight` domains.
     public let observed: PreflightEvaluation?
+    /// Capability-search snapshot for `domain == "capability_search"`
+    /// rows. Carries both raw and accepted hits so the
+    /// `--report-forensics` CLI flag can compute the H1/H2/H3
+    /// disambiguation block without re-running the eval.
+    public let capabilitySearch: CapabilitySearchEvaluation?
     /// One-line per-component diagnostic — populated for `failed` and
     /// `errored` so a glance at the report tells you WHAT broke without
     /// rerunning. Empty for clean passes.
@@ -79,6 +84,7 @@ public struct EvalCaseReport: Sendable, Codable {
         outcome: EvalCaseOutcome,
         score: EvalCaseScore?,
         observed: PreflightEvaluation?,
+        capabilitySearch: CapabilitySearchEvaluation? = nil,
         notes: [String],
         modelId: String,
         latencyMs: Double?
@@ -90,6 +96,7 @@ public struct EvalCaseReport: Sendable, Codable {
         self.outcome = outcome
         self.score = score
         self.observed = observed
+        self.capabilitySearch = capabilitySearch
         self.notes = notes
         self.modelId = modelId
         self.latencyMs = latencyMs
@@ -114,6 +121,7 @@ public struct EvalCaseReport: Sendable, Codable {
             outcome: outcome,
             score: nil,
             observed: nil,
+            capabilitySearch: nil,
             notes: notes,
             modelId: modelId,
             latencyMs: nil

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -22,10 +22,16 @@ public enum EvalRunner {
     /// `filter` is a substring that must appear in `case.id` for the
     /// case to run — the CLI exposes it via `--filter` so a contributor
     /// debugging a single case doesn't burn tokens on the whole suite.
+    /// `thresholdOverride` (when non-nil) is forwarded to
+    /// `capability_search` cases and supersedes any per-case
+    /// `expect.capabilitySearch.thresholdOverride`. No-op for other
+    /// domains. Lets the CLI sweep candidate thresholds without
+    /// editing fixtures (`--threshold 0.25`).
     public static func run(
         suite: EvalSuite,
         model: ModelSelection,
-        filter: String? = nil
+        filter: String? = nil,
+        thresholdOverride: Float? = nil
     ) async -> EvalReport {
         // The CLI is its own process — it has to scan + dlopen every
         // installed plugin manually before preflight can see plugin
@@ -57,17 +63,51 @@ public enum EvalRunner {
         await ModelOverride.withSelection(model) {
             for testCase in suite.cases {
                 if let filter, !testCase.id.contains(filter) { continue }
-                let row = await runOne(testCase, modelId: modelLabel)
-                rows.append(row)
+                let row = await runOne(
+                    testCase,
+                    modelId: modelLabel,
+                    thresholdOverride: thresholdOverride
+                )
+                rows.append(annotatedWithCaseNotes(row, from: testCase))
             }
         }
 
         return EvalReport(modelId: modelLabel, startedAt: startedAt, cases: rows)
     }
 
+    /// Prepends `testCase.notes` (if any) to the report row's `notes`
+    /// array as `note: <text>`. Centralised here so each per-domain
+    /// runner branch (preflight, schema, capability_search, …) doesn't
+    /// have to remember to forward the case-level field. Used today
+    /// for tracking-only cases like `capability_search.shell-execution`
+    /// where the case file documents WHY it stays red.
+    private static func annotatedWithCaseNotes(
+        _ row: EvalCaseReport,
+        from testCase: EvalCase
+    ) -> EvalCaseReport {
+        guard let extra = testCase.notes, !extra.isEmpty else { return row }
+        return EvalCaseReport(
+            id: row.id,
+            label: row.label,
+            domain: row.domain,
+            query: row.query,
+            outcome: row.outcome,
+            score: row.score,
+            observed: row.observed,
+            capabilitySearch: row.capabilitySearch,
+            notes: ["note: \(extra)"] + row.notes,
+            modelId: row.modelId,
+            latencyMs: row.latencyMs
+        )
+    }
+
     // MARK: - Per-case
 
-    private static func runOne(_ testCase: EvalCase, modelId: String) async -> EvalCaseReport {
+    private static func runOne(
+        _ testCase: EvalCase,
+        modelId: String,
+        thresholdOverride: Float? = nil
+    ) async -> EvalCaseReport {
         let label = testCase.label ?? testCase.id
 
         switch testCase.domain {
@@ -85,6 +125,12 @@ public enum EvalRunner {
             return runArgumentCoercionCase(testCase, modelId: modelId)
         case "request_validation":
             return runRequestValidationCase(testCase, modelId: modelId)
+        case "capability_search":
+            return await runCapabilitySearchCase(
+                testCase,
+                modelId: modelId,
+                cliThresholdOverride: thresholdOverride
+            )
         case "tools", "streaming", "contract":
             // Scaffolded domains — runner implementation lives in a
             // follow-up so cases can be authored against the format
@@ -599,6 +645,149 @@ public enum EvalRunner {
             outcome: passed ? .passed : .failed,
             notes: notes,
             modelId: modelId
+        )
+    }
+
+    // MARK: - Capability search domain
+
+    /// Pure-data evaluator for `domain == "capability_search"`. Drives
+    /// `CapabilitySearchEvaluator.evaluate` and pins recall + abstain
+    /// behaviour against the `expect.capabilitySearch` matchers. No
+    /// LLM call, no agent state — fast enough to run in CI on every
+    /// PR once the threshold floor is set (see `recall_floors.json`).
+    ///
+    /// Threshold precedence: CLI `--threshold` > per-case
+    /// `thresholdOverride` > `CapabilitySearch.minimumRelevanceScore`.
+    /// Honours the existing `requirePlugins` skip behaviour so a host
+    /// without the relevant plugin gets `skipped + missing plugins`
+    /// instead of a misleading `failed`.
+    private static func runCapabilitySearchCase(
+        _ testCase: EvalCase,
+        modelId: String,
+        cliThresholdOverride: Float?
+    ) async -> EvalCaseReport {
+        let label = testCase.label ?? testCase.id
+
+        guard let exp = testCase.expect.capabilitySearch else {
+            return Self.errored(
+                testCase,
+                label: label,
+                modelId: modelId,
+                note: "missing `expect.capabilitySearch`"
+            )
+        }
+
+        if let required = testCase.fixtures.requirePlugins, !required.isEmpty {
+            let installed = PreflightEvaluator.installedPluginIds()
+            let missing = required.filter { !installed.contains($0) }
+            if !missing.isEmpty {
+                return .terminal(
+                    id: testCase.id,
+                    label: label,
+                    domain: testCase.domain,
+                    outcome: .skipped,
+                    notes: ["missing plugins: \(missing.joined(separator: ", "))"],
+                    modelId: modelId
+                )
+            }
+        }
+
+        let threshold = cliThresholdOverride ?? exp.thresholdOverride
+        let topK = exp.topK ?? 10
+        let observed = await CapabilitySearchEvaluator.evaluate(
+            query: testCase.query,
+            topK: topK,
+            threshold: threshold
+        )
+
+        var notes: [String] = []
+        var passed = true
+
+        let acceptedToolNames = Set(observed.toolHits.filter(\.acceptedByThreshold).map(\.name))
+        let acceptedMethodNames = Set(observed.methodHits.filter(\.acceptedByThreshold).map(\.name))
+        let acceptedSkillNames = Set(observed.skillHits.filter(\.acceptedByThreshold).map(\.name))
+        let acceptedTotal = acceptedToolNames.count + acceptedMethodNames.count + acceptedSkillNames.count
+
+        if let m = exp.expectedTools {
+            let result = scoreAnyOf(matcher: m, accepted: acceptedToolNames, kind: "tools")
+            passed = passed && result.passed
+            notes.append(result.note)
+        }
+        if let m = exp.expectedMethods {
+            let result = scoreAnyOf(matcher: m, accepted: acceptedMethodNames, kind: "methods")
+            passed = passed && result.passed
+            notes.append(result.note)
+        }
+        if let m = exp.expectedSkills {
+            let result = scoreAnyOf(matcher: m, accepted: acceptedSkillNames, kind: "skills")
+            passed = passed && result.passed
+            notes.append(result.note)
+        }
+        if let cap = exp.maxAccepted {
+            if acceptedTotal > cap {
+                passed = false
+                notes.append("maxAccepted breached: got \(acceptedTotal) accepted, expected ≤ \(cap)")
+            } else {
+                notes.append("maxAccepted ok: \(acceptedTotal) ≤ \(cap)")
+            }
+        }
+
+        // Always include a one-line forensic summary so a failing case
+        // in `--verbose` (or `--report-forensics`) reads at a glance.
+        // Tools use the hybrid `appliedMinFusedScore` (RRF cutoff);
+        // methods + skills are still pure embedding and use the
+        // optional `appliedThreshold` (rendered as "n/a" when nil so
+        // we don't leak Swift's `Optional(...)` interpolation form).
+        let methodSkillThreshold = observed.appliedThreshold.map { String(format: "%.3f", $0) } ?? "n/a"
+        notes.append(
+            "summary: tools raw=\(observed.toolHits.count) accepted=\(acceptedToolNames.count) | "
+                + "methods raw=\(observed.methodHits.count) accepted=\(acceptedMethodNames.count) | "
+                + "skills raw=\(observed.skillHits.count) accepted=\(acceptedSkillNames.count) | "
+                + "registry=\(observed.registrySize) index=\(observed.indexSize) "
+                + "minFusedScore=\(String(format: "%.3f", observed.appliedMinFusedScore)) "
+                + "embedThreshold=\(methodSkillThreshold)"
+        )
+
+        return EvalCaseReport(
+            id: testCase.id,
+            label: label,
+            domain: testCase.domain,
+            query: testCase.query,
+            outcome: passed ? .passed : .failed,
+            score: nil,
+            observed: nil,
+            capabilitySearch: observed,
+            notes: notes,
+            modelId: modelId,
+            latencyMs: observed.latencyMs
+        )
+    }
+
+    /// Score one `AnyOfMatcher` against the accepted-name set for its
+    /// kind. Returns `(passed, note)` so the caller can fold the note
+    /// into the case report regardless of pass/fail.
+    private static func scoreAnyOf(
+        matcher: EvalCase.CapabilitySearchExpectations.AnyOfMatcher,
+        accepted: Set<String>,
+        kind: String
+    ) -> (passed: Bool, note: String) {
+        let hits = matcher.anyOf.filter { accepted.contains($0) }
+        let passed = hits.count >= matcher.minMatches
+        if matcher.minMatches == 0 && matcher.anyOf.isEmpty {
+            // Abstain-style matcher: minMatches=0, anyOf=[]. Pass is
+            // signalled separately by `maxAccepted`; here we just
+            // emit a note so the report makes sense.
+            return (true, "\(kind) abstain matcher (no expected names)")
+        }
+        if passed {
+            return (
+                true,
+                "\(kind) matched \(hits.count)/\(matcher.minMatches): [\(hits.joined(separator: ","))]"
+            )
+        }
+        return (
+            false,
+            "\(kind) under floor: matched \(hits.count)/\(matcher.minMatches) of [\(matcher.anyOf.joined(separator: ","))]"
         )
     }
 

--- a/Packages/OsaurusEvals/Suites/CapabilitySearch/abstain-greeting.json
+++ b/Packages/OsaurusEvals/Suites/CapabilitySearch/abstain-greeting.json
@@ -1,0 +1,16 @@
+{
+  "id": "capability_search.abstain-greeting",
+  "domain": "capability_search",
+  "label": "capability search • abstain on chit-chat",
+  "query": "thanks, that's perfect",
+  "fixtures": {},
+  "expect": {
+    "capabilitySearch": {
+      "expectedTools": {
+        "anyOf": [],
+        "minMatches": 0
+      },
+      "maxAccepted": 0
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CapabilitySearch/browser-prefix.json
+++ b/Packages/OsaurusEvals/Suites/CapabilitySearch/browser-prefix.json
@@ -1,0 +1,30 @@
+{
+  "id": "capability_search.browser-prefix",
+  "domain": "capability_search",
+  "label": "capability search • browser prefix",
+  "query": "browser",
+  "fixtures": {
+    "requirePlugins": ["osaurus.browser"]
+  },
+  "expect": {
+    "capabilitySearch": {
+      "expectedTools": {
+        "anyOf": [
+          "browser_reset_session",
+          "browser_open_login",
+          "browser_screenshot",
+          "browser_set_viewport",
+          "browser_cookies",
+          "browser_click",
+          "browser_hover",
+          "browser_execute_script",
+          "browser_console_messages",
+          "browser_set_user_agent",
+          "browser_navigate",
+          "browser_do"
+        ],
+        "minMatches": 5
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CapabilitySearch/extract-webpage-natural.json
+++ b/Packages/OsaurusEvals/Suites/CapabilitySearch/extract-webpage-natural.json
@@ -1,0 +1,17 @@
+{
+  "id": "capability_search.extract-webpage-natural",
+  "domain": "capability_search",
+  "label": "capability search • extract webpage contents (natural language)",
+  "query": "extract webpage contents",
+  "fixtures": {
+    "requirePlugins": ["osaurus.fetch", "osaurus.search"]
+  },
+  "expect": {
+    "capabilitySearch": {
+      "expectedTools": {
+        "anyOf": ["fetch_html", "search_and_extract"],
+        "minMatches": 1
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CapabilitySearch/shell-execution.json
+++ b/Packages/OsaurusEvals/Suites/CapabilitySearch/shell-execution.json
@@ -1,0 +1,16 @@
+{
+  "id": "capability_search.shell-execution",
+  "domain": "capability_search",
+  "label": "capability search • run shell script",
+  "query": "run shell script",
+  "notes": "Tracking-only. `sandbox_exec` and `sandbox_execute_code` are excluded from the search index by ToolIndexService.syncFromRegistry (runtimeManagedToolNames). No recall fix \u2014 BM25, embedder, or threshold \u2014 can rescue this case while the indexer-side exclusion stays. Resolution requires either un-excluding sandbox tools from the index or rewriting the case to target an indexed tool. Excluded from recall_floors.json on purpose.",
+  "fixtures": {},
+  "expect": {
+    "capabilitySearch": {
+      "expectedTools": {
+        "anyOf": ["sandbox_exec", "sandbox_execute_code"],
+        "minMatches": 1
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CapabilitySearch/weather-natural.json
+++ b/Packages/OsaurusEvals/Suites/CapabilitySearch/weather-natural.json
@@ -1,0 +1,17 @@
+{
+  "id": "capability_search.weather-natural",
+  "domain": "capability_search",
+  "label": "capability search • weather (natural language)",
+  "query": "what's the weather in tokyo",
+  "fixtures": {
+    "requirePlugins": ["osaurus.weather"]
+  },
+  "expect": {
+    "capabilitySearch": {
+      "expectedTools": {
+        "anyOf": ["get_weather", "weather_forecast"],
+        "minMatches": 1
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/Preflight/browser-natural.json
+++ b/Packages/OsaurusEvals/Suites/Preflight/browser-natural.json
@@ -1,0 +1,15 @@
+{
+  "id": "preflight.browser.natural",
+  "domain": "preflight",
+  "label": "preflight • browser natural language",
+  "query": "open the orders page on amazon",
+  "fixtures": {
+    "preflightMode": "balanced",
+    "requirePlugins": ["osaurus.browser"]
+  },
+  "expect": {
+    "tools": {
+      "mustInclude": ["browser_navigate"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Related to #823 

What landed: fixture corrections (browser-prefix + extract-webpage now correct against actual top embedder hits), FTS5 BM25 mirror with RRF k=60 hybrid, forensics with H4/H5 labels, runner & CLI plumbing, opt-in --fail-on-floor.

Wins from real data: browser-prefix went from RED (3/3 max under pure embed) to GREEN (9/5 under hybrid); extract-webpage went from RED (matching wrong tools) to GREEN (matching fetch_html + search_and_extract).
Sweep table as above. Pinned at T=0.020.

Two tracking-only cases: shell-execution (indexer exclusion) and abstain-greeting (RRF compression).
Follow-up issue suggestion: "Abstain mechanism for RRF hybrid — per-source quality gate vs score-based fusion vs query-intent classifier."

Out-of-scope already filed: embedder migration (not the bottleneck), tool description audit, sandbox-tool surface in capabilities_search.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
