### PR TITLE
align tools tab badge with rendered rows

### DIFF
--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -28,7 +28,6 @@ struct ToolsManagerView: View {
     @State private var policyInfoCache: [String: ToolRegistry.ToolPolicyInfo] = [:]
 
     // Cached filtered results
-    @State private var filteredEntries: [ToolRegistry.ToolEntry] = []
     @State private var installedPluginsWithTools: [(plugin: PluginState, tools: [ToolRegistry.ToolEntry])] = []
     @State private var remoteProviderTools: [(provider: MCPProvider, tools: [ToolRegistry.ToolEntry])] = []
     @State private var pluginsWithMissingPermissionsCount: Int = 0
@@ -99,10 +98,19 @@ struct ToolsManagerView: View {
                 }
             }
         } tabsRow: {
+            // count only what the Available tab actually renders plugin Tools +
+            // remote tools). using `filteredEntries.count` (the full registry)
+            // leaks builtin / sandbox / folder conflicting tools into the
+            // badge — none of which have a visible row — so the badge drifts
+            // from the per-section sum and varies across machines depending on
+            // whether the sandbox container has provisioned its builtin tools
+            let availableShown =
+                installedPluginsWithTools.reduce(0) { $0 + $1.tools.count }
+                + remoteProviderTools.reduce(0) { $0 + $1.tools.count }
             HeaderTabsRow(
                 selection: $selectedTab,
                 counts: [
-                    .available: filteredEntries.count,
+                    .available: availableShown,
                     .remote: remoteProviderCount,
                     .sandbox: SandboxPluginLibrary.shared.plugins.count,
                 ],
@@ -209,21 +217,10 @@ struct ToolsManagerView: View {
         let currentProviders = providerManager.configuration.providers
         let currentProviderStates = providerManager.providerStates
 
-        let (filteredEntriesResult, installedPluginsResult, remoteToolsResult) =
+        let (installedPluginsResult, remoteToolsResult) =
             await Task.detached(priority: .userInitiated) {
 
-                // 1. Filtered Entries (for counts)
-                let filteredEntries: [ToolRegistry.ToolEntry]
-                if query.isEmpty {
-                    filteredEntries = currentToolEntries
-                } else {
-                    filteredEntries = currentToolEntries.filter { e in
-                        let candidates = [e.name.lowercased(), e.description.lowercased()]
-                        return candidates.contains { SearchService.fuzzyMatch(query: queryLower, in: $0) }
-                    }
-                }
-
-                // 2. Installed Plugins with Tools (for Available tab)
+                // 1. Installed Plugins with Tools (for Available tab)
                 let installedPlugins =
                     currentPlugins
                     .filter { $0.isInstalled }
@@ -257,7 +254,7 @@ struct ToolsManagerView: View {
                         $0.plugin.displayName < $1.plugin.displayName
                     }
 
-                // 3. Remote Provider Tools (for Available tab)
+                // 2. Remote Provider Tools (for Available tab)
                 let remoteTools =
                     currentProviders
                     .filter { provider in
@@ -293,12 +290,11 @@ struct ToolsManagerView: View {
                     }
                     .sorted { $0.provider.name < $1.provider.name }
 
-                return (filteredEntries, installedPlugins, remoteTools)
+                return (installedPlugins, remoteTools)
             }.value
 
         guard !Task.isCancelled else { return }
 
-        filteredEntries = filteredEntriesResult
         installedPluginsWithTools = installedPluginsResult
         remoteProviderTools = remoteToolsResult
 


### PR DESCRIPTION
## Summary

The Available tab's badge counted the full tool registry, including builtins, sandbox and folder conflicting tools that never render as rows and the sandbox subset registers asynchronously so the number drifted across windows. The badge is now derived from the plugin and remote sections actually shown so it matches the per-section sum and is stable across launches

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
