### PR TITLE
fix(sandbox): adapt ProcessHandle kill closure to Containerization Signal API

### DIFF
--- a/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
@@ -1006,7 +1006,7 @@
             // separate process registry.
             if let onProcessStarted {
                 let handle = ProcessHandle(pid: process.pid) { signal in
-                    try await process.kill(signal)
+                    try await process.kill(Signal(rawValue: signal) ?? .kill)
                 }
                 onProcessStarted(handle)
             }


### PR DESCRIPTION
Build fix: closure passed to ProcessHandle calls process.kill(signal: Int32), but apple/swift-containerization now ships LinuxProcess.kill(_:) accepting a Signal enum. Build on macOS 26.3 fails with: cannot convert value of type Int32 to expected argument type Signal. Patch maps Int32 through Signal(rawValue:) with .kill fallback for unknown numbers. Caught while building osaurus locally to reproduce #3 (engine instrumentation for the JANG inference path). Standalone fix; unrelated to the engine-side issue there.