### PR TITLE
Nemotron Omni live voice input path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ benchmarks/
 
 # Generated benchmark/test output
 results/
+
+# Swift test coverage artifacts
+default.profraw
+*.profraw

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "ad1d23199b056ed502124717e6ca8877f2fb303a"
+        "revision" : "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "4365651d9245ad983094717bb2886a64635a5b38"
+        "revision" : "f72871888e951929a11f7aabe14d9ea9024f1773"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "f72871888e951929a11f7aabe14d9ea9024f1773"
+        "revision" : "6561a72f93d6cd5e0202e8067b53fed5cf21a660"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
+        "revision" : "b57fe98845bd1f678bd8f722dc50dba56f11d029"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "81c8ef7389c031292287801f761957c681d086ea"
+        "revision" : "4365651d9245ad983094717bb2886a64635a5b38"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
+        "revision" : "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "638024bae655b93b1da92385ce9fb4935584fb64"
+        "revision" : "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "b57fe98845bd1f678bd8f722dc50dba56f11d029"
+        "revision" : "81c8ef7389c031292287801f761957c681d086ea"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
+        "revision" : "638024bae655b93b1da92385ce9fb4935584fb64"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/SpeechService.swift
+++ b/Packages/OsaurusCore/Managers/SpeechService.swift
@@ -23,6 +23,68 @@ public struct TranscriptionResult: Sendable {
     }
 }
 
+/// Raw audio captured during a live voice turn, preserved separately from the
+/// short STT chunks that the streaming worker drains.
+public struct LiveVoiceAudioSnapshot: Sendable {
+    public let samples: [Float]
+    public let sampleRate: Int
+
+    public init(samples: [Float], sampleRate: Int) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+    }
+
+    public var durationSeconds: Double {
+        guard sampleRate > 0 else { return 0 }
+        return Double(samples.count) / Double(sampleRate)
+    }
+
+    public func wavData() -> Data {
+        var data = Data()
+        let channelCount: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let bytesPerSample = Int(bitsPerSample / 8)
+        let byteRate = UInt32(sampleRate * Int(channelCount) * bytesPerSample)
+        let blockAlign = UInt16(Int(channelCount) * bytesPerSample)
+        let pcmByteCount = UInt32(samples.count * bytesPerSample)
+
+        data.appendASCII("RIFF")
+        data.appendLittleEndian(UInt32(36) + pcmByteCount)
+        data.appendASCII("WAVE")
+        data.appendASCII("fmt ")
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(channelCount)
+        data.appendLittleEndian(UInt32(sampleRate))
+        data.appendLittleEndian(byteRate)
+        data.appendLittleEndian(blockAlign)
+        data.appendLittleEndian(bitsPerSample)
+        data.appendASCII("data")
+        data.appendLittleEndian(pcmByteCount)
+
+        for sample in samples {
+            let clamped = max(-1.0, min(1.0, sample))
+            let pcm = Int16(clamped * Float(Int16.max))
+            data.appendLittleEndian(pcm)
+        }
+
+        return data
+    }
+}
+
+private extension Data {
+    mutating func appendASCII(_ string: String) {
+        append(contentsOf: string.utf8)
+    }
+
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
+}
+
 /// Error types for speech operations
 public enum SpeechError: Error, LocalizedError {
     case noModelSelected
@@ -777,6 +839,20 @@ public final class SpeechService: ObservableObject {
 
     public var keepAudioEngineAlive: Bool = false
 
+    /// Captures the current live turn's raw PCM for direct Omni audio input.
+    /// Call before `stopStreamingTranscription()` clears the active buffer.
+    public func currentLiveAudioSnapshot() -> LiveVoiceAudioSnapshot? {
+        let samples = audioBuffer.snapshotRetained()
+        guard !samples.isEmpty else { return nil }
+
+        let sampleRate = Int(activeTapFormat?.sampleRate.rounded() ?? 16_000)
+        return LiveVoiceAudioSnapshot(samples: samples, sampleRate: max(1, sampleRate))
+    }
+
+    public func currentLiveAudioWAVData() -> Data? {
+        currentLiveAudioSnapshot()?.wavData()
+    }
+
     /// Start streaming transcription
     public func startStreamingTranscription() async throws {
         if isRecording {
@@ -1522,8 +1598,10 @@ private actor TranscriptionWorker {
 
 private final class ThreadSafeAudioBuffer: @unchecked Sendable {
     private var samples: [Float] = []
+    private var retainedSamples: [Float] = []
     private var _isActive: Bool = false
     private var _level: Float = 0.0
+    private let maxRetainedSamples = 48_000 * 60 * 5
     private let lock = OSAllocatedUnfairLock()
 
     var isActive: Bool {
@@ -1546,6 +1624,10 @@ private final class ThreadSafeAudioBuffer: @unchecked Sendable {
         lock.withLock {
             if _isActive {
                 samples.append(contentsOf: newSamples)
+                retainedSamples.append(contentsOf: newSamples)
+                if retainedSamples.count > maxRetainedSamples {
+                    retainedSamples.removeFirst(retainedSamples.count - maxRetainedSamples)
+                }
             }
         }
     }
@@ -1558,9 +1640,14 @@ private final class ThreadSafeAudioBuffer: @unchecked Sendable {
         }
     }
 
+    func snapshotRetained() -> [Float] {
+        lock.withLock { retainedSamples }
+    }
+
     func clear() {
         lock.withLock {
             samples = []
+            retainedSamples = []
             _isActive = false
             _level = 0.0
         }

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -146,6 +146,17 @@ struct ModelsResponse: Codable, Sendable {
 struct LocalAudioSamples: Sendable, Equatable {
     let samples: [Float]
     let sampleRate: Int
+    let preencodedAttachmentId: UUID?
+
+    init(
+        samples: [Float],
+        sampleRate: Int,
+        preencodedAttachmentId: UUID? = nil
+    ) {
+        self.samples = samples
+        self.sampleRate = sampleRate
+        self.preencodedAttachmentId = preencodedAttachmentId
+    }
 }
 
 // MARK: - Multimodal Content Parts

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -167,11 +167,10 @@ struct LocalAudioSamples: Sendable, Equatable {
 ///   - `text` / `input_text` — plain text
 ///   - `image_url` — `{url, detail?}`. URL may be `data:image/...;base64,...` or `https://...`
 ///   - `input_audio` — `{data: <base64>, format: "wav"|"mp3"|"flac"|...}`. Mirrors the
-///     OpenAI Realtime / GPT-4o audio shape; the audio bytes are written to a temp
-///     file and handed to vmlx as `UserInput.Audio.url(...)` so vmlx's
-///     `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32) handles
-///     all decoding. Format strings are passed through to vmlx unchanged — vmlx
-///     uses the file extension, so the format hint becomes the file extension.
+///     OpenAI Realtime / GPT-4o audio shape; valid WAV bytes decode directly to
+///     `UserInput.Audio.samples(...)` for local MLX, while other containers fall
+///     back to a temp file handed to vmlx as `UserInput.Audio.url(...)` so
+///     `nemotronOmniLoadAudioFile` can use AVAudioConverter.
 ///   - `video_url` — `{url}`. Mirrors the convention adopted by LM Studio / Ollama
 ///     for video inputs since OpenAI hasn't published a canonical chat-completions
 ///     video shape. URL may be `data:video/...;base64,...` or `https://...`.
@@ -299,10 +298,9 @@ struct ChatMessage: Codable, Sendable {
     }
 
     /// Extract `(base64, format)` pairs from `input_audio` content parts.
-    /// `format` is whatever the client sent (e.g. `"wav"`, `"mp3"`); we pass
-    /// it through to the file extension when materializing the temp file
-    /// because vmlx's `nemotronOmniLoadAudioFile` keys decoder selection on
-    /// the URL extension via AVAudioConverter.
+    /// `format` is whatever the client sent (e.g. `"wav"`, `"mp3"`); valid
+    /// WAV data can bypass temp-file materialization, and fallback containers
+    /// pass the format through to the temp-file extension for AVAudioConverter.
     var audioInputs: [(data: String, format: String)] {
         audioInputsWithLocalSamples.map { (data: $0.data, format: $0.format) }
     }
@@ -458,8 +456,7 @@ extension ChatMessage {
     /// modality. Audio bytes encode as `input_audio` with explicit
     /// format hint; video bytes encode as `video_url` with
     /// `data:video/<container>` URL. All three flow into the
-    /// OpenAI-compatible JSON shape that vmlx's
-    /// `mapOpenAIChatToMLX` materializes through
+    /// OpenAI-compatible JSON shape that `mapOpenAIChatToMLX` lowers through
     /// `extractAudioSources` / `extractVideoSources`.
     init(
         role: String,

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -143,6 +143,11 @@ struct ModelsResponse: Codable, Sendable {
     }
 }
 
+struct LocalAudioSamples: Sendable, Equatable {
+    let samples: [Float]
+    let sampleRate: Int
+}
+
 // MARK: - Multimodal Content Parts
 
 /// OpenAI-compatible content part for multimodal messages.
@@ -245,6 +250,11 @@ struct ChatMessage: Codable, Sendable {
     let content: String?
     /// Multimodal content parts (images, text) - populated when content is an array
     let contentParts: [MessageContentPart]?
+    /// In-process live voice samples aligned to audio input parts. This is
+    /// deliberately not Codable: OpenAI-compatible JSON keeps the portable
+    /// `input_audio` payload, while local MLX requests can bypass the
+    /// WAV/base64/temp-file round trip.
+    let localAudioSamples: [LocalAudioSamples?]
     /// Present when assistant requests tool invocations
     let tool_calls: [ToolCall]?
     /// Required for role=="tool" messages to associate with a prior tool call
@@ -283,10 +293,17 @@ struct ChatMessage: Codable, Sendable {
     /// because vmlx's `nemotronOmniLoadAudioFile` keys decoder selection on
     /// the URL extension via AVAudioConverter.
     var audioInputs: [(data: String, format: String)] {
+        audioInputsWithLocalSamples.map { (data: $0.data, format: $0.format) }
+    }
+
+    var audioInputsWithLocalSamples: [(data: String, format: String, localSamples: LocalAudioSamples?)] {
         guard let parts = contentParts else { return [] }
+        var audioIndex = 0
         return parts.compactMap { part in
             if case .audioInput(let data, let format) = part {
-                return (data, format)
+                let local = audioIndex < localAudioSamples.count ? localAudioSamples[audioIndex] : nil
+                audioIndex += 1
+                return (data, format, local)
             }
             return nil
         }
@@ -320,6 +337,7 @@ extension ChatMessage {
         self.tool_calls = try? container.decode([ToolCall].self, forKey: .tool_calls)
         self.tool_call_id = try? container.decode(String.self, forKey: .tool_call_id)
         self.reasoning_content = try? container.decode(String.self, forKey: .reasoning_content)
+        self.localAudioSamples = []
 
         if let stringContent = try? container.decode(String.self, forKey: .content) {
             self.content = stringContent
@@ -374,6 +392,7 @@ extension ChatMessage {
         self.role = role
         self.content = content
         self.contentParts = nil
+        self.localAudioSamples = []
         self.tool_calls = nil
         self.tool_call_id = nil
         self.reasoning_content = nil
@@ -392,6 +411,7 @@ extension ChatMessage {
         self.role = role
         self.content = content
         self.contentParts = nil
+        self.localAudioSamples = []
         self.tool_calls = tool_calls
         self.tool_call_id = tool_call_id
         self.reasoning_content = reasoning_content
@@ -416,6 +436,7 @@ extension ChatMessage {
 
         self.contentParts = parts.isEmpty ? nil : parts
         self.content = text.isEmpty ? nil : text
+        self.localAudioSamples = []
         self.tool_calls = nil
         self.tool_call_id = nil
         self.reasoning_content = nil
@@ -434,6 +455,7 @@ extension ChatMessage {
         text: String,
         imageData: [Data],
         audios: [(data: Data, format: String)],
+        localAudioSamples: [LocalAudioSamples?] = [],
         videos: [(data: Data, mimeSubtype: String)]
     ) {
         self.role = role
@@ -469,6 +491,7 @@ extension ChatMessage {
 
         self.contentParts = parts.isEmpty ? nil : parts
         self.content = text.isEmpty ? nil : text
+        self.localAudioSamples = localAudioSamples
         self.tool_calls = nil
         self.tool_call_id = nil
         self.reasoning_content = nil

--- a/Packages/OsaurusCore/Models/Chat/LiveVoiceAudioInputRegistry.swift
+++ b/Packages/OsaurusCore/Models/Chat/LiveVoiceAudioInputRegistry.swift
@@ -4,12 +4,32 @@
 //
 
 import Foundation
+import MLX
+import MLXLMCommon
 
 final class LiveVoiceAudioInputRegistry: @unchecked Sendable {
     static let shared = LiveVoiceAudioInputRegistry()
 
+    struct PreencodedAudioMetadata: Sendable, Equatable {
+        let sourceSampleCount: Int
+        let sampleRate: Int
+        let encodeMs: Int
+        let encodedAt: Date
+    }
+
+    private final class PreencodedAudioEntry: @unchecked Sendable {
+        let audio: MLXLMCommon.UserInput.Audio
+        let metadata: PreencodedAudioMetadata
+
+        init(audio: MLXLMCommon.UserInput.Audio, metadata: PreencodedAudioMetadata) {
+            self.audio = audio
+            self.metadata = metadata
+        }
+    }
+
     private let lock = NSLock()
     private var samplesByAttachmentId: [UUID: LocalAudioSamples] = [:]
+    private var preencodedByAttachmentId: [UUID: PreencodedAudioEntry] = [:]
     private var insertionOrder: [UUID] = []
     private let maxEntries = 16
 
@@ -27,13 +47,83 @@ final class LiveVoiceAudioInputRegistry: @unchecked Sendable {
             }
             samplesByAttachmentId[attachmentId] = LocalAudioSamples(
                 samples: samples,
-                sampleRate: sampleRate
+                sampleRate: sampleRate,
+                preencodedAttachmentId: attachmentId
             )
 
             while insertionOrder.count > maxEntries, let oldest = insertionOrder.first {
                 insertionOrder.removeFirst()
                 samplesByAttachmentId.removeValue(forKey: oldest)
+                preencodedByAttachmentId.removeValue(forKey: oldest)
             }
+        }
+    }
+
+    func storePreencoded(
+        samples: [Float],
+        sampleRate: Int,
+        sourceSampleCount: Int? = nil,
+        sourceSampleRate: Int? = nil,
+        embedding: MLXArray,
+        encodeMs: Int,
+        for attachmentId: UUID
+    ) {
+        guard !samples.isEmpty, sampleRate > 0 else { return }
+        let metadata = PreencodedAudioMetadata(
+            sourceSampleCount: sourceSampleCount ?? samples.count,
+            sampleRate: sourceSampleRate ?? sampleRate,
+            encodeMs: encodeMs,
+            encodedAt: Date()
+        )
+        let entry = PreencodedAudioEntry(
+            audio: .preEncoded(samples: samples, sampleRate: sampleRate, embedding: embedding),
+            metadata: metadata
+        )
+        lock.withLock {
+            if samplesByAttachmentId[attachmentId] == nil {
+                samplesByAttachmentId[attachmentId] = LocalAudioSamples(
+                    samples: samples,
+                    sampleRate: sampleRate,
+                    preencodedAttachmentId: attachmentId
+                )
+            }
+            if !insertionOrder.contains(attachmentId) {
+                insertionOrder.append(attachmentId)
+            }
+            preencodedByAttachmentId[attachmentId] = entry
+            while insertionOrder.count > maxEntries, let oldest = insertionOrder.first {
+                insertionOrder.removeFirst()
+                samplesByAttachmentId.removeValue(forKey: oldest)
+                preencodedByAttachmentId.removeValue(forKey: oldest)
+            }
+        }
+    }
+
+    func freshPreencodedAudio(
+        for attachmentId: UUID,
+        sourceSampleCount: Int,
+        sampleRate: Int
+    ) -> MLXLMCommon.UserInput.Audio? {
+        lock.withLock {
+            guard let entry = preencodedByAttachmentId[attachmentId],
+                entry.metadata.sourceSampleCount == sourceSampleCount,
+                entry.metadata.sampleRate == sampleRate
+            else {
+                return nil
+            }
+            return entry.audio
+        }
+    }
+
+    func preencodedMetadata(for attachmentId: UUID) -> PreencodedAudioMetadata? {
+        lock.withLock { preencodedByAttachmentId[attachmentId]?.metadata }
+    }
+
+    func remove(for attachmentId: UUID) {
+        lock.withLock {
+            samplesByAttachmentId.removeValue(forKey: attachmentId)
+            preencodedByAttachmentId.removeValue(forKey: attachmentId)
+            insertionOrder.removeAll { $0 == attachmentId }
         }
     }
 
@@ -44,6 +134,7 @@ final class LiveVoiceAudioInputRegistry: @unchecked Sendable {
     func removeAll() {
         lock.withLock {
             samplesByAttachmentId.removeAll()
+            preencodedByAttachmentId.removeAll()
             insertionOrder.removeAll()
         }
     }

--- a/Packages/OsaurusCore/Models/Chat/LiveVoiceAudioInputRegistry.swift
+++ b/Packages/OsaurusCore/Models/Chat/LiveVoiceAudioInputRegistry.swift
@@ -1,0 +1,50 @@
+//
+//  LiveVoiceAudioInputRegistry.swift
+//  osaurus
+//
+
+import Foundation
+
+final class LiveVoiceAudioInputRegistry: @unchecked Sendable {
+    static let shared = LiveVoiceAudioInputRegistry()
+
+    private let lock = NSLock()
+    private var samplesByAttachmentId: [UUID: LocalAudioSamples] = [:]
+    private var insertionOrder: [UUID] = []
+    private let maxEntries = 16
+
+    private init() {}
+
+    func store(snapshot: LiveVoiceAudioSnapshot, for attachmentId: UUID) {
+        store(samples: snapshot.samples, sampleRate: snapshot.sampleRate, for: attachmentId)
+    }
+
+    func store(samples: [Float], sampleRate: Int, for attachmentId: UUID) {
+        guard !samples.isEmpty, sampleRate > 0 else { return }
+        lock.withLock {
+            if samplesByAttachmentId[attachmentId] == nil {
+                insertionOrder.append(attachmentId)
+            }
+            samplesByAttachmentId[attachmentId] = LocalAudioSamples(
+                samples: samples,
+                sampleRate: sampleRate
+            )
+
+            while insertionOrder.count > maxEntries, let oldest = insertionOrder.first {
+                insertionOrder.removeFirst()
+                samplesByAttachmentId.removeValue(forKey: oldest)
+            }
+        }
+    }
+
+    func samples(for attachmentId: UUID) -> LocalAudioSamples? {
+        lock.withLock { samplesByAttachmentId[attachmentId] }
+    }
+
+    func removeAll() {
+        lock.withLock {
+            samplesByAttachmentId.removeAll()
+            insertionOrder.removeAll()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -36,6 +36,20 @@ enum ModelFamilyNames {
         ) != nil
     }
 
+    /// Nemotron Omni bundles. Match both the long public `Nemotron-3-Nano-Omni`
+    /// naming and shorter local picker/API ids like `Nemotron-Omni-Nano`.
+    static func isNemotronOmniFamily(_ modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return lower.range(
+            of: #"(^|/)nemotron[\-_]3[\-_][^/]*omni($|[\-_/\.0-9])"#,
+            options: .regularExpression
+        ) != nil
+            || lower.range(
+                of: #"(^|/)nemotron[\-_]omni($|[\-_/\.0-9])"#,
+                options: .regularExpression
+            ) != nil
+    }
+
     /// Match Zyphra ZAYA bundles (`model_type=zaya`). Matches the bare
     /// repo form (`Zaya1-…`, `Zaya2-…`, `Zaya-S-…`) and any
     /// `<owner>/Zaya…` path. The required digit-or-dash boundary after

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -91,11 +91,15 @@ public enum ModelMediaCapabilities {
     public static func from(modelId: String) -> Capabilities {
         let lower = modelId.lowercased()
 
-        // Nemotron-3-Nano-Omni — only family with native audio today.
+        // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — only family with
+        // native audio today.
         // Matches:
         //   OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4 / -JANGTQ4 / -JANGTQ
         //   nemotron-3-nano-omni-* (case-folded picker form)
-        if regexMatches(lower, pattern: #"nemotron-3-nano-omni|nemotron[_-]h[_-]omni"#) {
+        //   local crack bundles like Nemotron-Omni-Nano-JANGTQ-CRACK
+        if ModelFamilyNames.isNemotronOmniFamily(modelId)
+            || regexMatches(lower, pattern: #"nemotron-3-nano-omni|nemotron[_-]h[_-]omni"#)
+        {
             return .omni
         }
 
@@ -155,6 +159,33 @@ public enum ModelMediaCapabilities {
         }
 
         return .textOnly
+    }
+
+    /// Capabilities for the chat composer. `from(modelId:)` is the
+    /// family-specific source of truth for local models. The
+    /// `fallbackSupportsImages` bit lets externally discovered VLMs
+    /// (notably remote/provider models that do not match local family
+    /// names) keep image paste/drop support without accidentally
+    /// granting audio or video.
+    public static func composerCapabilities(
+        modelId: String?,
+        fallbackSupportsImages: Bool
+    ) -> Capabilities {
+        guard let modelId,
+            !modelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return fallbackSupportsImages ? .imageOnly : .textOnly
+        }
+
+        let detected = from(modelId: modelId)
+        guard fallbackSupportsImages, !detected.supportsImage else {
+            return detected
+        }
+        return Capabilities(
+            supportsImage: true,
+            supportsVideo: detected.supportsVideo,
+            supportsAudio: detected.supportsAudio
+        )
     }
 
     /// Resolve capabilities by inspecting the locally-installed bundle.

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -270,7 +270,7 @@ struct NemotronThinkingProfile: ModelProfile {
 
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
-        return lower.contains("nemotron-3") && !lower.contains("coder")
+        return ModelFamilyNames.isNemotronOmniFamily(modelId) && !lower.contains("coder")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -149,7 +149,8 @@ enum ModelProfileRegistry {
 /// three intentional modes:
 /// - instruct: closed `</think>` assistant tail, answer on content rail
 /// - reasoning: open `<think>` assistant tail, normal reasoning split
-/// - max: open `<think>` tail plus the DSV4 max-reasoning preface
+/// - max: public API/UI compatibility selector; vmlx normalizes it to the
+///   stable high-thinking rail by default unless raw max is explicitly enabled
 struct DSV4ReasoningProfile: ModelProfile {
     static let displayName = "DSV4 Reasoning"
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3477,6 +3477,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     httpTrace.mark("http_stream_chat_ready")
                     var accumulatedContent = ""
                     var authoritativeCompletionTokens: Int?
+                    var streamFinishReason = "stop"
                     for try await delta in stream {
                         if let reasoning = StreamingReasoningHint.decode(delta) {
                             httpTrace.markFirstSemanticDelta("reasoning")
@@ -3493,6 +3494,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         if let stats = StreamingStatsHint.decode(delta) {
                             authoritativeCompletionTokens = stats.tokenCount
+                            if let stopReason = stats.stopReason {
+                                streamFinishReason = stopReason
+                            }
                             continue
                         }
                         if StreamingToolHint.isSentinel(delta) { continue }
@@ -3514,9 +3518,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         authoritativeCompletionTokens ?? TokenEstimator.estimate(accumulatedContent)
                     httpTrace.set("http_prompt_tokens_estimate", promptTokens)
                     httpTrace.set("http_completion_tokens", completionTokens)
+                    let finalStreamFinishReason = streamFinishReason
                     hop {
-                        writerBound.value.writeFinish(
-                            model,
+                        writerBound.value.writeFinishWithReason(
+                            finalStreamFinishReason,
+                            model: model,
                             responseId: responseId,
                             created: created,
                             context: ctx.value
@@ -3534,7 +3540,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         writerBound.value.writeEnd(ctx.value)
                     }
                     httpTrace.mark("http_sse_finish_written")
-                    httpTrace.emit(finishReason: "stop", responseStatus: 200)
+                    httpTrace.emit(finishReason: finalStreamFinishReason, responseStatus: 200)
                     if persistOnSuccess {
                         var finalMessages = priorMessages
                         if !accumulatedContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -3561,7 +3567,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         model: logModel,
                         temperature: logTemperature,
                         maxTokens: logMaxTokens,
-                        finishReason: .stop
+                        finishReason: RequestLog.FinishReason(rawValue: finalStreamFinishReason) ?? .stop
                     )
                 } catch let invs as ServiceToolInvocations {
                     // Multi-tool MLX completion: emit one tool_call delta

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -20,6 +20,56 @@ private final class SendableBool: @unchecked Sendable {
     }
 }
 
+private final class HTTPTraceRecorder: @unchecked Sendable {
+    private let trace: TTFTTrace?
+    private let lock = NSLock()
+    private var emitted = false
+    private var markedFirstSemanticDelta = false
+
+    init(_ trace: TTFTTrace?) {
+        self.trace = trace
+    }
+
+    func mark(_ name: String) {
+        trace?.mark(name)
+    }
+
+    func set(_ key: String, _ value: Any) {
+        trace?.set(key, value)
+    }
+
+    func markFirstSemanticDelta(_ kind: String) {
+        guard trace != nil else { return }
+        lock.lock()
+        let shouldMark = !markedFirstSemanticDelta
+        if shouldMark {
+            markedFirstSemanticDelta = true
+        }
+        lock.unlock()
+        guard shouldMark else { return }
+        trace?.set("http_first_semantic_delta_kind", kind)
+        trace?.mark("http_first_semantic_delta")
+    }
+
+    func emit(finishReason: String, responseStatus: Int, errorMessage: String? = nil) {
+        guard trace != nil else { return }
+        lock.lock()
+        let shouldEmit = !emitted
+        if shouldEmit {
+            emitted = true
+        }
+        lock.unlock()
+        guard shouldEmit else { return }
+        trace?.set("http_finish_reason", finishReason)
+        trace?.set("http_response_status", responseStatus)
+        if let errorMessage {
+            trace?.set("http_error", errorMessage)
+        }
+        trace?.mark("http_trace_emit")
+        trace?.emit()
+    }
+}
+
 /// SwiftNIO HTTP request handler
 final class HTTPHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = HTTPServerRequestPart
@@ -3282,7 +3332,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             requestBodyString = nil
         }
 
-        guard let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
+        guard var req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
             let body = Self.errorBody(.openai(type: "invalid_request_error"), message: "Invalid request format")
             sendResponse(
                 context: context,
@@ -3336,6 +3386,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let created = Int(Date().timeIntervalSince1970)
         let responseId = Self.shortId(prefix: "chatcmpl-", length: 12)
         let model = req.model
+        #if DEBUG
+            let ttftTrace: TTFTTrace? = TTFTTrace()
+        #else
+            let ttftTrace: TTFTTrace? = nil
+        #endif
+        let httpTrace = HTTPTraceRecorder(ttftTrace)
+        req.ttftTrace = ttftTrace
+        httpTrace.mark("http_request_decoded")
+        httpTrace.set("endpoint", "/chat/completions")
+        httpTrace.set("model", model)
+        httpTrace.set("stream", wantsSSE ? 1 : 0)
+        httpTrace.set("request_body_bytes", data.count)
+        httpTrace.set("http_message_count", req.messages.count)
+        httpTrace.set("http_input_image_count", req.messages.reduce(0) { $0 + $1.imageUrls.count })
+        httpTrace.set("http_input_audio_count", req.messages.reduce(0) { $0 + $1.audioInputs.count })
+        httpTrace.set("http_input_video_count", req.messages.reduce(0) { $0 + $1.videoUrls.count })
 
         let memoryAgentId = head.headers.first(name: "X-Osaurus-Agent-Id")
 
@@ -3382,8 +3448,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             Task(priority: .userInitiated) {
                 defer { keepaliveTask.cancel() }
                 do {
+                    httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
                     let enrichedReq = await Self.enrichWithAgentContext(req, agentId: memoryAgentId)
+                    httpTrace.mark("http_enrich_done")
+                    httpTrace.set("http_enriched_message_count", enrichedReq.messages.count)
 
                     // Compute prefix hash after enrichment so it matches the cache key
                     let prefixHash: String = {
@@ -3401,12 +3470,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             context: ctx.value
                         )
                     }
+                    httpTrace.mark("http_sse_role_written")
 
+                    httpTrace.mark("http_stream_chat_start")
                     let stream = try await chatEngine.streamChat(request: enrichedReq)
+                    httpTrace.mark("http_stream_chat_ready")
                     var accumulatedContent = ""
                     var authoritativeCompletionTokens: Int?
                     for try await delta in stream {
                         if let reasoning = StreamingReasoningHint.decode(delta) {
+                            httpTrace.markFirstSemanticDelta("reasoning")
                             hop {
                                 writerBound.value.writeReasoning(
                                     reasoning,
@@ -3423,6 +3496,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             continue
                         }
                         if StreamingToolHint.isSentinel(delta) { continue }
+                        httpTrace.markFirstSemanticDelta("content")
                         accumulatedContent += delta
                         hop {
                             writerBound.value.writeContent(
@@ -3438,6 +3512,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     let promptTokens = Self.estimatePromptTokens(enrichedReq.messages)
                     let completionTokens =
                         authoritativeCompletionTokens ?? TokenEstimator.estimate(accumulatedContent)
+                    httpTrace.set("http_prompt_tokens_estimate", promptTokens)
+                    httpTrace.set("http_completion_tokens", completionTokens)
                     hop {
                         writerBound.value.writeFinish(
                             model,
@@ -3457,6 +3533,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         writerBound.value.writeEnd(ctx.value)
                     }
+                    httpTrace.mark("http_sse_finish_written")
+                    httpTrace.emit(finishReason: "stop", responseStatus: 200)
                     if persistOnSuccess {
                         var finalMessages = priorMessages
                         if !accumulatedContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -3489,6 +3567,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // Multi-tool MLX completion: emit one tool_call delta
                     // per invocation, sharing one finish_reason="tool_calls".
                     // OpenAI clients deduplicate by `index`.
+                    httpTrace.markFirstSemanticDelta("tool_calls")
+                    httpTrace.set("http_tool_call_count", invs.invocations.count)
                     let includeUsage = req.stream_options?.include_usage == true
                     // Use `req.messages` here (not `enrichedReq.messages`)
                     // because the enriched value is scoped to the `do` block
@@ -3526,6 +3606,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         writerBound.value.writeEnd(ctx.value)
                     }
+                    httpTrace.mark("http_sse_tool_calls_written")
+                    httpTrace.emit(finishReason: "tool_calls", responseStatus: 200)
                     let toolLogs = invs.invocations.map {
                         ToolCallLog(name: $0.toolName, arguments: $0.jsonArguments)
                     }
@@ -3544,6 +3626,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     )
                 } catch let inv as ServiceToolInvocation {
                     // Single tool invocation — same emission as above.
+                    httpTrace.markFirstSemanticDelta("tool_calls")
+                    httpTrace.set("http_tool_call_count", 1)
                     let includeUsage = req.stream_options?.include_usage == true
                     let promptTokens = Self.estimatePromptTokens(req.messages)
                     hop {
@@ -3575,6 +3659,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         writerBound.value.writeEnd(ctx.value)
                     }
+                    httpTrace.mark("http_sse_tool_calls_written")
+                    httpTrace.emit(finishReason: "tool_calls", responseStatus: 200)
                     let toolLog = ToolCallLog(name: inv.toolName, arguments: inv.jsonArguments)
                     logSelf.logRequest(
                         method: "POST",
@@ -3598,6 +3684,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                         writerBound.value.writeEnd(ctx.value)
                     }
+                    httpTrace.mark("http_sse_error_written")
+                    httpTrace.emit(
+                        finishReason: "error",
+                        responseStatus: 200,
+                        errorMessage: error.localizedDescription
+                    )
                     logSelf.logRequest(
                         method: "POST",
                         path: "/chat/completions",
@@ -3628,9 +3720,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let logSelf = self
             Task(priority: .userInitiated) {
                 do {
+                    httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
                     let enrichedReq = await Self.enrichWithAgentContext(req, agentId: memoryAgentId)
+                    httpTrace.mark("http_enrich_done")
+                    httpTrace.set("http_enriched_message_count", enrichedReq.messages.count)
+                    httpTrace.mark("http_complete_chat_start")
                     var resp = try await chatEngine.completeChat(request: enrichedReq)
+                    httpTrace.mark("http_complete_chat_done")
                     // Compute prefix hash after enrichment so it matches the cache key
                     let sysContent = enrichedReq.messages.first(where: { $0.role == "system" })?.content ?? ""
                     let toolNames = (enrichedReq.tools ?? []).map { $0.function.name }
@@ -3672,17 +3769,20 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // Extract token counts and finish reason from response
                     let tokensIn = resp.usage.prompt_tokens
                     let tokensOut = resp.usage.completion_tokens
+                    let finishReasonString = resp.choices.first?.finish_reason ?? "stop"
                     let finishReason: RequestLog.FinishReason = {
-                        if let reason = resp.choices.first?.finish_reason {
-                            switch reason {
-                            case "stop": return .stop
-                            case "length": return .length
-                            case "tool_calls": return .toolCalls
-                            default: return .stop
-                            }
+                        switch finishReasonString {
+                        case "stop": return .stop
+                        case "length": return .length
+                        case "tool_calls": return .toolCalls
+                        default: return .stop
                         }
-                        return .stop
                     }()
+                    httpTrace.markFirstSemanticDelta("completion")
+                    httpTrace.set("http_prompt_tokens", tokensIn)
+                    httpTrace.set("http_completion_tokens", tokensOut)
+                    httpTrace.mark("http_json_response_written")
+                    httpTrace.emit(finishReason: finishReasonString, responseStatus: 200)
                     logSelf.logRequest(
                         method: "POST",
                         path: "/chat/completions",
@@ -3738,6 +3838,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             ctx.value.close(promise: nil)
                         }
                     }
+                    httpTrace.mark("http_json_error_written")
+                    httpTrace.emit(
+                        finishReason: "error",
+                        responseStatus: actualStatus,
+                        errorMessage: error.localizedDescription
+                    )
                     logSelf.logRequest(
                         method: "POST",
                         path: "/chat/completions",

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -270,9 +270,11 @@ let package = Package(
         // retained waveform for the final Omni request. `638024b` adds the
         // tracked OmniAudioLatencyBench executable and local call-mode
         // latency evidence for raw PCM vs pre-encoded Parakeet embeddings.
+        // `fb8fb39` makes Omni media cache restore token-aware and records
+        // prompt/media topology in the latency bench output.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "638024bae655b93b1da92385ce9fb4935584fb64"
+            revision: "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -267,10 +267,12 @@ let package = Package(
         // docs for media-aware cache verification. `e497f61` adds the
         // reusable thread-safe live PCM buffer and recorder streaming cursor
         // needed by real VAD/call-mode polling while preserving the full
-        // retained waveform for the final Omni request.
+        // retained waveform for the final Omni request. `638024b` adds the
+        // tracked OmniAudioLatencyBench executable and local call-mode
+        // latency evidence for raw PCM vs pre-encoded Parakeet embeddings.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
+            revision: "638024bae655b93b1da92385ce9fb4935584fb64"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -271,10 +271,12 @@ let package = Package(
         // tracked OmniAudioLatencyBench executable and local call-mode
         // latency evidence for raw PCM vs pre-encoded Parakeet embeddings.
         // `fb8fb39` makes Omni media cache restore token-aware and records
-        // prompt/media topology in the latency bench output.
+        // prompt/media topology in the latency bench output. `b57fe98`
+        // refreshes the live Parakeet/RADIO integration docs consumed by the
+        // Osaurus voice path.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
+            revision: "b57fe98845bd1f678bd8f722dc50dba56f11d029"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -261,10 +261,13 @@ let package = Package(
         // makes the DSV4 tokenizer fallback match the canonical multi-turn
         // chat encoder so generated cache boundaries can be reused. `ad1d231`
         // synchronizes before and after safetensors disk writes so
-        // post-answer cache storage cannot crash after generation.
+        // post-answer cache storage cannot crash after generation. `c0f8b3b`
+        // adds Nemotron Omni live-voice handoff support, including
+        // pre-encoded Parakeet/audio embeddings and updated Osaurus hookup
+        // docs for media-aware cache verification.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "ad1d23199b056ed502124717e6ca8877f2fb303a"
+            revision: "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -273,10 +273,11 @@ let package = Package(
         // `fb8fb39` makes Omni media cache restore token-aware and records
         // prompt/media topology in the latency bench output. `b57fe98`
         // refreshes the live Parakeet/RADIO integration docs consumed by the
-        // Osaurus voice path.
+        // Osaurus voice path. `81c8ef7` adds the OmniAudioChunkStabilityBench
+        // proof that current Parakeet embeddings are not chunk-concat safe.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "b57fe98845bd1f678bd8f722dc50dba56f11d029"
+            revision: "81c8ef7389c031292287801f761957c681d086ea"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -275,9 +275,12 @@ let package = Package(
         // refreshes the live Parakeet/RADIO integration docs consumed by the
         // Osaurus voice path. `81c8ef7` adds the OmniAudioChunkStabilityBench
         // proof that current Parakeet embeddings are not chunk-concat safe.
+        // `4365651` decodes nested ZAYA/JANGTQ-K routed-expert mxtq bit
+        // metadata, including separate fused gate/up and down-projection
+        // widths, without falling back to config parse failure.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "81c8ef7389c031292287801f761957c681d086ea"
+            revision: "4365651d9245ad983094717bb2886a64635a5b38"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -264,10 +264,13 @@ let package = Package(
         // post-answer cache storage cannot crash after generation. `c0f8b3b`
         // adds Nemotron Omni live-voice handoff support, including
         // pre-encoded Parakeet/audio embeddings and updated Osaurus hookup
-        // docs for media-aware cache verification.
+        // docs for media-aware cache verification. `e497f61` adds the
+        // reusable thread-safe live PCM buffer and recorder streaming cursor
+        // needed by real VAD/call-mode polling while preserving the full
+        // retained waveform for the final Omni request.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
+            revision: "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -278,9 +278,13 @@ let package = Package(
         // `4365651` decodes nested ZAYA/JANGTQ-K routed-expert mxtq bit
         // metadata, including separate fused gate/up and down-projection
         // widths, without falling back to config parse failure.
+        // `f728718` fixes DSV4 Flash HSA selection for long prompts by masking
+        // future compressed pool chunks before indexer top-k, preventing the
+        // 3-4K-token degradation caused by selecting rows the later attention
+        // mask would discard.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "4365651d9245ad983094717bb2886a64635a5b38"
+            revision: "f72871888e951929a11f7aabe14d9ea9024f1773"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -279,12 +279,12 @@ let package = Package(
         // metadata, including separate fused gate/up and down-projection
         // widths, without falling back to config parse failure.
         // `f728718` fixes DSV4 Flash HSA selection for long prompts by masking
-        // future compressed pool chunks before indexer top-k, preventing the
-        // 3-4K-token degradation caused by selecting rows the later attention
-        // mask would discard.
+        // future compressed pool chunks before indexer top-k. `6561a72`
+        // preserves ratio-4 overlap-compressor state across decode calls so
+        // long-tail DSV4 generation keeps the previous complete pool window.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift-lm",
-            revision: "f72871888e951929a11f7aabe14d9ea9024f1773"
+            revision: "6561a72f93d6cd5e0202e8067b53fed5cf21a660"
         ),
         // Osaurus-owned transformers/Jinja chain. `swift-transformers`
         // depends on `osaurus-ai/Jinja`, but its semver range can fresh-

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -445,7 +445,13 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
             do {
                 for try await delta in inner {
-                    if StreamingStatsHint.decode(delta) != nil {
+                    if let stats = StreamingStatsHint.decode(delta) {
+                        outputTokenCount = stats.tokenCount
+                        if let stopReason = stats.stopReason,
+                           let loggedReason = InferenceLog.FinishReason(rawValue: stopReason)
+                        {
+                            finishReason = loggedReason
+                        }
                         continuation.yield(delta)
                         continue
                     }

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -196,27 +196,46 @@ enum StreamingReasoningHint: Sendable {
 /// Wire format: `<sentinel>stats:<tokenCount>;<tokensPerSecond>[;<flags>]`.
 /// The optional third field carries comma-separated flags so future
 /// observability signals can be added without breaking older decoders —
-/// today's only flag is `unclosed`, set when vmlx's
+/// current flags are `unclosed`, set when vmlx's
 /// `GenerateCompletionInfo.unclosedReasoning == true` (the model ended
-/// the stream still inside a `<think>` block, i.e. trapped-thinking).
+/// the stream still inside a `<think>` block, i.e. trapped-thinking),
+/// and `stop=<reason>`, which preserves vmlx's terminal stop reason so
+/// HTTP writers can distinguish `length` from a natural `stop`.
 enum StreamingStatsHint: Sendable {
     private static let statsPrefix = "\u{FFFE}stats:"
     private static let posixLocale = Locale(identifier: "en_US_POSIX")
     private static let unclosedFlag = "unclosed"
+    private static let stopFlagPrefix = "stop="
 
     static func encode(
         tokenCount: Int,
         tokensPerSecond: Double,
-        unclosedReasoning: Bool = false
+        unclosedReasoning: Bool = false,
+        stopReason: String? = nil
     ) -> String {
         let tps = String(format: "%.4f", locale: posixLocale, tokensPerSecond)
-        let suffix = unclosedReasoning ? ";\(unclosedFlag)" : ""
+        var flags: [String] = []
+        if unclosedReasoning {
+            flags.append(unclosedFlag)
+        }
+        if let stopReason {
+            let normalized = stopReason.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !normalized.isEmpty {
+                flags.append("\(stopFlagPrefix)\(normalized)")
+            }
+        }
+        let suffix = flags.isEmpty ? "" : ";\(flags.joined(separator: ","))"
         return "\(statsPrefix)\(tokenCount);\(tps)\(suffix)"
     }
 
     static func decode(
         _ delta: String
-    ) -> (tokenCount: Int, tokensPerSecond: Double, unclosedReasoning: Bool)? {
+    ) -> (
+        tokenCount: Int,
+        tokensPerSecond: Double,
+        unclosedReasoning: Bool,
+        stopReason: String?
+    )? {
         guard delta.hasPrefix(statsPrefix) else { return nil }
         let payload = delta.dropFirst(statsPrefix.count)
         // Split into at most 3 parts: count, tps, optional flags. `maxSplits=2`
@@ -229,7 +248,13 @@ enum StreamingStatsHint: Sendable {
         else { return nil }
         let flags = parts.count >= 3 ? parts[2].split(separator: ",") : []
         let unclosed = flags.contains { $0 == Substring(unclosedFlag) }
-        return (count, tps, unclosed)
+        let stopReason = flags.compactMap { flag -> String? in
+            guard flag.hasPrefix(stopFlagPrefix) else { return nil }
+            let value = flag.dropFirst(stopFlagPrefix.count)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? nil : value
+        }.first
+        return (count, tps, unclosed, stopReason)
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1336,6 +1336,7 @@ public actor ModelRuntime {
         if audioMetrics.inputCount > 0 {
             trace?.set("input_audio_count", audioMetrics.inputCount)
             trace?.set("input_audio_materialized_count", audioMetrics.materializedCount)
+            trace?.set("input_audio_local_sample_count", audioMetrics.localSampleCount)
             trace?.set("input_audio_bytes", audioMetrics.byteCount)
             trace?.set("input_audio_materialize_ms", audioMetrics.materializeMs)
             trace?.mark("input_audio_materialize_done")
@@ -1414,15 +1415,15 @@ public actor ModelRuntime {
     }
 
     /// Extract `[UserInput.Audio]` from `input_audio` content parts. The
-    /// OpenAI shape is `{data: <base64>, format: "wav"|"mp3"|...}`; we
-    /// materialize a temp file with that extension and hand the URL to vmlx
-    /// so `nemotronOmniLoadAudioFile` (AVAudioConverter → 16 kHz mono Float32)
-    /// drives the decode end-to-end. Going through a file URL keeps the path
-    /// uniform across formats — there is no in-memory `[Float]` decode here
-    /// because we'd have to duplicate vmlx's AVAudioConverter rig and lose
-    /// resampling fidelity in the process.
+    /// OpenAI wire shape is `{data: <base64>, format: "wav"|"mp3"|...}`; for
+    /// remote/API requests we materialize a temp file with that extension and
+    /// let vmlx run its normal AVAudioConverter decode. Live in-app voice may
+    /// also carry local PCM samples aligned to the same audio part, in which
+    /// case we hand those samples directly to vmlx and keep the encoded bytes
+    /// only as the portable history/fallback representation.
     private struct AudioMaterializationMetrics {
         var inputCount = 0
+        var localSampleCount = 0
         var materializedCount = 0
         var byteCount = 0
         var materializeMs = 0
@@ -1432,13 +1433,19 @@ public actor ModelRuntime {
         from message: ChatMessage,
         metrics: inout AudioMaterializationMetrics
     ) -> [MLXLMCommon.UserInput.Audio] {
-        let inputs = message.audioInputs
+        let inputs = message.audioInputsWithLocalSamples
         guard !inputs.isEmpty else { return [] }
 
         var sources: [MLXLMCommon.UserInput.Audio] = []
         let startedAt = CFAbsoluteTimeGetCurrent()
         metrics.inputCount += inputs.count
-        for (data, format) in inputs {
+        for (data, format, localSamples) in inputs {
+            if let localSamples {
+                metrics.localSampleCount += 1
+                sources.append(.samples(localSamples.samples, sampleRate: localSamples.sampleRate))
+                continue
+            }
+
             let ext = format.lowercased()
             // Synthesize a `data:audio/<format>;base64,<data>` URL so we can
             // reuse the same materializer the video path uses. The audio data

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1194,12 +1194,18 @@ public actor ModelRuntime {
             var scrubber = ThinkTagScrubber()
             do {
                 for try await ev in events {
-                    if case .completionInfo(let tokenCount, let tokensPerSecond, let unclosedReasoning) = ev {
+                    if case .completionInfo(
+                        let tokenCount,
+                        let tokensPerSecond,
+                        let unclosedReasoning,
+                        let stopReason
+                    ) = ev {
                         continuation.yield(
                             StreamingStatsHint.encode(
                                 tokenCount: tokenCount,
                                 tokensPerSecond: tokensPerSecond,
-                                unclosedReasoning: unclosedReasoning
+                                unclosedReasoning: unclosedReasoning,
+                                stopReason: stopReason
                             )
                         )
                         continue

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1554,12 +1554,14 @@ public actor ModelRuntime {
     }
 
     /// Extract `[UserInput.Audio]` from `input_audio` content parts. The
-    /// OpenAI wire shape is `{data: <base64>, format: "wav"|"mp3"|...}`; for
-    /// remote/API requests we materialize a temp file with that extension and
-    /// let vmlx run its normal AVAudioConverter decode. Live in-app voice may
-    /// also carry local PCM samples aligned to the same audio part, in which
-    /// case we hand those samples directly to vmlx and keep the encoded bytes
-    /// only as the portable history/fallback representation.
+    /// OpenAI wire shape is `{data: <base64>, format: "wav"|"mp3"|...}`. Valid
+    /// WAV payloads decode directly to PCM samples so the Nemotron Omni adapter
+    /// can pre-encode without a temp-file re-decode. Other supported containers
+    /// still materialize to a temp file and let vmlx's AVAudioConverter path
+    /// handle codec-specific decoding. Live in-app voice may also carry local
+    /// PCM samples aligned to the same audio part, in which case we hand those
+    /// samples directly to vmlx and keep the encoded bytes only as the portable
+    /// history/fallback representation.
     private struct AudioMaterializationMetrics {
         var inputCount = 0
         var localSampleCount = 0
@@ -1598,14 +1600,26 @@ public actor ModelRuntime {
                 continue
             }
 
-            let ext = format.lowercased()
+            if let bytes = Data(base64Encoded: data),
+                let decoded = decodeWAVAudioSamples(bytes)
+            {
+                metrics.localSampleCount += 1
+                metrics.byteCount += decoded.byteCount
+                sources.append(.samples(decoded.samples, sampleRate: decoded.sampleRate))
+                continue
+            }
+
+            let ext = format.trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+                .lowercased()
+            let fallbackExtension = ext.isEmpty ? "wav" : ext
             // Synthesize a `data:audio/<format>;base64,<data>` URL so we can
             // reuse the same materializer the video path uses. The audio data
             // comes in as a bare base64 string from `input_audio.data`, not a
             // data URL — wrap it before handing off so the helper's data-URL
             // parsing applies uniformly.
-            let dataUrl = "data:audio/\(ext);base64,\(data)"
-            if let file = materializeMediaDataUrlResult(dataUrl, defaultExtension: ext.isEmpty ? "wav" : ext) {
+            let dataUrl = "data:audio/\(fallbackExtension);base64,\(data)"
+            if let file = materializeMediaDataUrlResult(dataUrl, defaultExtension: fallbackExtension) {
                 metrics.materializedCount += 1
                 metrics.byteCount += file.byteCount
                 sources.append(.url(file.url))
@@ -1613,6 +1627,163 @@ public actor ModelRuntime {
         }
         metrics.materializeMs += Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
         return sources
+    }
+
+    private struct DecodedAudioSamples {
+        let samples: [Float]
+        let sampleRate: Int
+        let byteCount: Int
+    }
+
+    nonisolated private static func decodeWAVAudioSamples(_ bytes: Data) -> DecodedAudioSamples? {
+        guard bytes.count >= 44 else { return nil }
+        guard ascii(bytes, offset: 0, count: 4) == "RIFF",
+            ascii(bytes, offset: 8, count: 4) == "WAVE"
+        else { return nil }
+
+        var offset = 12
+        var audioFormat: UInt16?
+        var channelCount: UInt16?
+        var sampleRate: Int?
+        var blockAlign: UInt16?
+        var bitsPerSample: UInt16?
+        var dataRange: Range<Int>?
+
+        while offset + 8 <= bytes.count {
+            guard let chunkId = ascii(bytes, offset: offset, count: 4),
+                let chunkSize = readUInt32LE(bytes, offset: offset + 4)
+            else { return nil }
+
+            let chunkStart = offset + 8
+            let chunkEnd = chunkStart + Int(chunkSize)
+            guard chunkEnd <= bytes.count else { return nil }
+
+            switch chunkId {
+            case "fmt ":
+                guard chunkSize >= 16,
+                    let format = readUInt16LE(bytes, offset: chunkStart),
+                    let channels = readUInt16LE(bytes, offset: chunkStart + 2),
+                    let rate = readUInt32LE(bytes, offset: chunkStart + 4),
+                    let align = readUInt16LE(bytes, offset: chunkStart + 12),
+                    let bits = readUInt16LE(bytes, offset: chunkStart + 14)
+                else { return nil }
+                audioFormat = format
+                if format == 0xFFFE, chunkSize >= 40,
+                    let subformat = readUInt16LE(bytes, offset: chunkStart + 24)
+                {
+                    audioFormat = subformat
+                }
+                channelCount = channels
+                sampleRate = Int(rate)
+                blockAlign = align
+                bitsPerSample = bits
+
+            case "data":
+                dataRange = chunkStart ..< chunkEnd
+
+            default:
+                break
+            }
+
+            offset = chunkEnd + (Int(chunkSize) & 1)
+        }
+
+        guard let format = audioFormat,
+            let channels = channelCount,
+            let rate = sampleRate,
+            let align = blockAlign,
+            let bits = bitsPerSample,
+            let range = dataRange,
+            channels > 0,
+            rate > 0,
+            align > 0
+        else { return nil }
+
+        let channelTotal = Int(channels)
+        let bytesPerSample = Int(bits / 8)
+        guard bytesPerSample > 0, Int(align) >= channelTotal * bytesPerSample else { return nil }
+        guard format == 1 || format == 3 else { return nil }
+        if format == 3 {
+            guard bits == 32 else { return nil }
+        } else {
+            guard bits == 8 || bits == 16 || bits == 24 || bits == 32 else { return nil }
+        }
+
+        let frameStride = Int(align)
+        let frameCount = range.count / frameStride
+        guard frameCount > 0 else { return nil }
+
+        var samples: [Float] = []
+        samples.reserveCapacity(frameCount)
+        for frame in 0 ..< frameCount {
+            let frameOffset = range.lowerBound + frame * frameStride
+            var mixed = Float(0)
+            for channel in 0 ..< channelTotal {
+                let sampleOffset = frameOffset + channel * bytesPerSample
+                guard let sample = decodeWAVSample(bytes, offset: sampleOffset, format: format, bits: bits)
+                else { return nil }
+                mixed += sample
+            }
+            samples.append(mixed / Float(channelTotal))
+        }
+
+        return DecodedAudioSamples(samples: samples, sampleRate: rate, byteCount: bytes.count)
+    }
+
+    nonisolated private static func decodeWAVSample(
+        _ bytes: Data,
+        offset: Int,
+        format: UInt16,
+        bits: UInt16
+    ) -> Float? {
+        switch (format, bits) {
+        case (1, 8):
+            guard offset < bytes.count else { return nil }
+            return max(-1, min(1, (Float(bytes[offset]) - 128.0) / 127.0))
+        case (1, 16):
+            guard let raw = readUInt16LE(bytes, offset: offset) else { return nil }
+            return max(-1, min(1, Float(Int16(bitPattern: raw)) / Float(Int16.max)))
+        case (1, 24):
+            guard let raw = readInt24LE(bytes, offset: offset) else { return nil }
+            return max(-1, min(1, Float(raw) / 8_388_607.0))
+        case (1, 32):
+            guard let raw = readUInt32LE(bytes, offset: offset) else { return nil }
+            return max(-1, min(1, Float(Int32(bitPattern: raw)) / Float(Int32.max)))
+        case (3, 32):
+            guard let raw = readUInt32LE(bytes, offset: offset) else { return nil }
+            return Float(bitPattern: raw)
+        default:
+            return nil
+        }
+    }
+
+    nonisolated private static func ascii(_ bytes: Data, offset: Int, count: Int) -> String? {
+        guard offset >= 0, count >= 0, offset + count <= bytes.count else { return nil }
+        return String(data: bytes[offset ..< offset + count], encoding: .ascii)
+    }
+
+    nonisolated private static func readUInt16LE(_ bytes: Data, offset: Int) -> UInt16? {
+        guard offset >= 0, offset + 2 <= bytes.count else { return nil }
+        return UInt16(bytes[offset]) | (UInt16(bytes[offset + 1]) << 8)
+    }
+
+    nonisolated private static func readUInt32LE(_ bytes: Data, offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= bytes.count else { return nil }
+        return UInt32(bytes[offset])
+            | (UInt32(bytes[offset + 1]) << 8)
+            | (UInt32(bytes[offset + 2]) << 16)
+            | (UInt32(bytes[offset + 3]) << 24)
+    }
+
+    nonisolated private static func readInt24LE(_ bytes: Data, offset: Int) -> Int32? {
+        guard offset >= 0, offset + 3 <= bytes.count else { return nil }
+        var raw = Int32(bytes[offset])
+            | (Int32(bytes[offset + 1]) << 8)
+            | (Int32(bytes[offset + 2]) << 16)
+        if (raw & 0x0080_0000) != 0 {
+            raw |= ~0x00FF_FFFF
+        }
+        return raw
     }
 
     /// Decode a `data:<mediatype>;base64,<bytes>` URL into a temp file URL with

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -953,7 +953,7 @@ public actor ModelRuntime {
         }
         activeGenerationTask = ActiveGenerationRecord(modelName: modelName, task: activeTask)
 
-        return GenerationEventMapper.map(events: prepared.stream, modelName: modelName)
+        return GenerationEventMapper.map(events: prepared.stream, modelName: modelName, trace: trace)
     }
 
     // MARK: - New message-based (OpenAI ChatMessage) APIs
@@ -984,7 +984,7 @@ public actor ModelRuntime {
         var pendingTools: [ServiceToolInvocation] = []
         let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented) },
+            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented, trace: parameters.ttftTrace) },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -1028,7 +1028,7 @@ public actor ModelRuntime {
     ) async throws -> AsyncThrowingStream<String, Error> {
         let augmented = ModelRuntime.applyJSONMode(messages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented) },
+            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented, trace: parameters.ttftTrace) },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -1251,14 +1251,16 @@ public actor ModelRuntime {
     /// `TemplateException: "Message has tool role, but there was no
     /// previous assistant message with a tool call!"` on MiniMax).
     nonisolated static func mapOpenAIChatToMLX(
-        _ msgs: [ChatMessage]
+        _ msgs: [ChatMessage],
+        trace: TTFTTrace? = nil
     ) -> [MLXLMCommon.Chat.Message] {
         var out: [MLXLMCommon.Chat.Message] = []
         out.reserveCapacity(max(6, msgs.count))
+        var audioMetrics = AudioMaterializationMetrics()
         for m in msgs {
             let images = extractImageSources(from: m)
             let videos = extractVideoSources(from: m)
-            let audios = extractAudioSources(from: m)
+            let audios = extractAudioSources(from: m, metrics: &audioMetrics)
             switch m.role {
             case "system":
                 out.append(
@@ -1330,6 +1332,13 @@ public actor ModelRuntime {
                     )
                 )
             }
+        }
+        if audioMetrics.inputCount > 0 {
+            trace?.set("input_audio_count", audioMetrics.inputCount)
+            trace?.set("input_audio_materialized_count", audioMetrics.materializedCount)
+            trace?.set("input_audio_bytes", audioMetrics.byteCount)
+            trace?.set("input_audio_materialize_ms", audioMetrics.materializeMs)
+            trace?.mark("input_audio_materialize_done")
         }
         return out
     }
@@ -1412,13 +1421,23 @@ public actor ModelRuntime {
     /// uniform across formats — there is no in-memory `[Float]` decode here
     /// because we'd have to duplicate vmlx's AVAudioConverter rig and lose
     /// resampling fidelity in the process.
+    private struct AudioMaterializationMetrics {
+        var inputCount = 0
+        var materializedCount = 0
+        var byteCount = 0
+        var materializeMs = 0
+    }
+
     nonisolated private static func extractAudioSources(
-        from message: ChatMessage
+        from message: ChatMessage,
+        metrics: inout AudioMaterializationMetrics
     ) -> [MLXLMCommon.UserInput.Audio] {
         let inputs = message.audioInputs
         guard !inputs.isEmpty else { return [] }
 
         var sources: [MLXLMCommon.UserInput.Audio] = []
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        metrics.inputCount += inputs.count
         for (data, format) in inputs {
             let ext = format.lowercased()
             // Synthesize a `data:audio/<format>;base64,<data>` URL so we can
@@ -1427,10 +1446,13 @@ public actor ModelRuntime {
             // data URL — wrap it before handing off so the helper's data-URL
             // parsing applies uniformly.
             let dataUrl = "data:audio/\(ext);base64,\(data)"
-            if let url = materializeMediaDataUrl(dataUrl, defaultExtension: ext.isEmpty ? "wav" : ext) {
-                sources.append(.url(url))
+            if let file = materializeMediaDataUrlResult(dataUrl, defaultExtension: ext.isEmpty ? "wav" : ext) {
+                metrics.materializedCount += 1
+                metrics.byteCount += file.byteCount
+                sources.append(.url(file.url))
             }
         }
+        metrics.materializeMs += Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
         return sources
     }
 
@@ -1448,6 +1470,18 @@ public actor ModelRuntime {
         _ urlString: String,
         defaultExtension: String
     ) -> URL? {
+        materializeMediaDataUrlResult(urlString, defaultExtension: defaultExtension)?.url
+    }
+
+    private struct MaterializedMediaFile {
+        let url: URL
+        let byteCount: Int
+    }
+
+    nonisolated private static func materializeMediaDataUrlResult(
+        _ urlString: String,
+        defaultExtension: String
+    ) -> MaterializedMediaFile? {
         // Expect `data:<mediatype>[;base64],<payload>`. Pull the mediatype
         // subtype as the file extension when available so AVFoundation /
         // AVAudioConverter's extension-keyed dispatch picks the right decoder.
@@ -1488,7 +1522,7 @@ public actor ModelRuntime {
             .appendingPathExtension(ext)
         do {
             try bytes.write(to: tmp, options: .atomic)
-            return tmp
+            return MaterializedMediaFile(url: tmp, byteCount: bytes.count)
         } catch {
             return nil
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -37,6 +37,23 @@ public actor ModelRuntime {
         let isCurrent: Bool
     }
 
+    struct LiveVoiceAudioPreencodeResult: Sendable, Equatable {
+        enum Status: String, Sendable {
+            case stored
+            case skippedNoSamples
+            case skippedUnsupportedModel
+            case skippedModelNotResident
+            case skippedModelUnavailable
+            case failed
+        }
+
+        let status: Status
+        let sampleCount: Int
+        let sampleRate: Int
+        let encodeMs: Int
+        let message: String?
+    }
+
     private final class SessionHolder: NSObject, @unchecked Sendable {
         let name: String
         let container: ModelContainer
@@ -117,6 +134,127 @@ public actor ModelRuntime {
             if lhs.isCurrent != rhs.isCurrent { return lhs.isCurrent }
             return lhs.name < rhs.name
         }
+    }
+
+    func preencodeLiveVoiceAudioIfResident(
+        modelName: String,
+        attachmentId: UUID,
+        samples: [Float],
+        sampleRate: Int
+    ) async -> LiveVoiceAudioPreencodeResult {
+        guard !samples.isEmpty, sampleRate > 0 else {
+            return LiveVoiceAudioPreencodeResult(
+                status: .skippedNoSamples,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: nil
+            )
+        }
+
+        guard ModelFamilyNames.isNemotronOmniFamily(modelName) else {
+            return LiveVoiceAudioPreencodeResult(
+                status: .skippedUnsupportedModel,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: nil
+            )
+        }
+
+        guard let holder = modelCache[modelName]
+            ?? modelCache.values.first(where: {
+                $0.name.caseInsensitiveCompare(modelName) == .orderedSame
+            })
+        else {
+            return LiveVoiceAudioPreencodeResult(
+                status: .skippedModelNotResident,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: nil
+            )
+        }
+
+        await ModelLease.shared.acquire(holder.name)
+        let soloLease = await MLXBatchAdapter.Registry.shared.acquireSoloLease(for: holder.name)
+
+        final class OutBox: @unchecked Sendable {
+            var result: LiveVoiceAudioPreencodeResult?
+        }
+        let box = OutBox()
+
+        do {
+            try await holder.container.perform { context in
+                guard let omni = context.model as? NemotronHOmni else {
+                    box.result = LiveVoiceAudioPreencodeResult(
+                        status: .skippedModelUnavailable,
+                        sampleCount: samples.count,
+                        sampleRate: sampleRate,
+                        encodeMs: 0,
+                        message: "Resident model is not NemotronHOmni"
+                    )
+                    return
+                }
+
+                let startedAt = CFAbsoluteTimeGetCurrent()
+                guard case .preEncoded(let encodedSamples, let encodedSampleRate, let embedding) =
+                    try MLXBatchAdapter.preencodedAudio(
+                        .samples(samples, sampleRate: sampleRate),
+                        using: omni
+                    )
+                else {
+                    box.result = LiveVoiceAudioPreencodeResult(
+                        status: .skippedModelUnavailable,
+                        sampleCount: samples.count,
+                        sampleRate: sampleRate,
+                        encodeMs: 0,
+                        message: "Nemotron audio encoder returned no embedding"
+                    )
+                    return
+                }
+
+                let encodeMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+                LiveVoiceAudioInputRegistry.shared.storePreencoded(
+                    samples: encodedSamples,
+                    sampleRate: encodedSampleRate,
+                    sourceSampleCount: samples.count,
+                    sourceSampleRate: sampleRate,
+                    embedding: embedding,
+                    encodeMs: encodeMs,
+                    for: attachmentId
+                )
+                box.result = LiveVoiceAudioPreencodeResult(
+                    status: .stored,
+                    sampleCount: samples.count,
+                    sampleRate: sampleRate,
+                    encodeMs: encodeMs,
+                    message: nil
+                )
+            }
+        } catch {
+            await soloLease.release()
+            await ModelLease.shared.release(holder.name)
+            return LiveVoiceAudioPreencodeResult(
+                status: .failed,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: String(describing: error)
+            )
+        }
+
+        await soloLease.release()
+        await ModelLease.shared.release(holder.name)
+
+        return box.result
+            ?? LiveVoiceAudioPreencodeResult(
+                status: .skippedModelUnavailable,
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                encodeMs: 0,
+                message: nil
+            )
     }
 
     // MARK: - Model lifecycle
@@ -1337,6 +1475,7 @@ public actor ModelRuntime {
             trace?.set("input_audio_count", audioMetrics.inputCount)
             trace?.set("input_audio_materialized_count", audioMetrics.materializedCount)
             trace?.set("input_audio_local_sample_count", audioMetrics.localSampleCount)
+            trace?.set("input_audio_local_preencoded_count", audioMetrics.localPreencodedCount)
             trace?.set("input_audio_bytes", audioMetrics.byteCount)
             trace?.set("input_audio_materialize_ms", audioMetrics.materializeMs)
             trace?.mark("input_audio_materialize_done")
@@ -1424,6 +1563,7 @@ public actor ModelRuntime {
     private struct AudioMaterializationMetrics {
         var inputCount = 0
         var localSampleCount = 0
+        var localPreencodedCount = 0
         var materializedCount = 0
         var byteCount = 0
         var materializeMs = 0
@@ -1441,6 +1581,18 @@ public actor ModelRuntime {
         metrics.inputCount += inputs.count
         for (data, format, localSamples) in inputs {
             if let localSamples {
+                if let attachmentId = localSamples.preencodedAttachmentId,
+                    let preencoded = LiveVoiceAudioInputRegistry.shared.freshPreencodedAudio(
+                        for: attachmentId,
+                        sourceSampleCount: localSamples.samples.count,
+                        sampleRate: localSamples.sampleRate
+                    )
+                {
+                    metrics.localPreencodedCount += 1
+                    sources.append(preencoded)
+                    continue
+                }
+
                 metrics.localSampleCount += 1
                 sources.append(.samples(localSamples.samples, sampleRate: localSamples.sampleRate))
                 continue

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -839,7 +839,8 @@ public actor ModelRuntime {
     /// Installs the cache coordinator on a freshly-loaded holder.
     ///
     /// `enableCaching(config:)` constructs the coordinator with our
-    /// recommended knobs (paged + L2 disk + TurboQuant default + 8K window).
+    /// recommended knobs (paged + L2 disk, fp16 KV by default, 64K rotating
+    /// cap for callers that do not provide `maxKVSize`).
     /// vmlx's `BatchEngine.admitPendingRequests` auto-flips
     /// `coordinator.isHybrid` on first slot admission for any model whose
     /// per-layer cache list contains a `MambaCache` or `ArraysCache` — that

--- a/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
@@ -29,5 +29,10 @@ enum ModelRuntimeEvent: Sendable {
     /// number") because their training data extends thought through
     /// arbitrary self-verification. `false` for non-reasoning models or
     /// for streams that emitted `</think>` cleanly.
-    case completionInfo(tokenCount: Int, tokensPerSecond: Double, unclosedReasoning: Bool)
+    case completionInfo(
+        tokenCount: Int,
+        tokensPerSecond: Double,
+        unclosedReasoning: Bool,
+        stopReason: String?
+    )
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -50,7 +50,8 @@ enum GenerationEventMapper {
     ///   stream behaves identically to the historical pass-through.
     static func map(
         events: AsyncStream<Generation>,
-        modelName: String = ""
+        modelName: String = "",
+        trace: TTFTTrace? = nil
     ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
         let mergeReasoning = treatReasoningAsContent(modelName: modelName)
         let suppressUnclosedReasoning = ModelFamilyNames.isLingFamily(modelName)
@@ -66,6 +67,15 @@ enum GenerationEventMapper {
                 var sawCompletionInfo = false
                 var sawReasoning = false
                 var estimatedTextTokens = 0
+                var markedFirstModelOutput = false
+
+                func markFirstModelOutput() {
+                    guard !markedFirstModelOutput else { return }
+                    markedFirstModelOutput = true
+                    let ms = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+                    trace?.set("first_token_ms", ms)
+                    trace?.mark("first_model_output")
+                }
 
                 for await event in events {
                     if case .info(let info) = event {
@@ -87,16 +97,18 @@ enum GenerationEventMapper {
                     if Task.isCancelled { break }
                     switch event {
                     case .chunk(let text):
+                        guard !text.isEmpty else { continue }
+                        markFirstModelOutput()
                         if firstChunk {
                             firstChunk = false
                             InferenceProgressManager.shared.prefillDidFinishAsync()
                         }
-                        guard !text.isEmpty else { continue }
                         estimatedTextTokens += max(1, text.count / 4)
                         continuation.yield(.tokens(text))
 
                     case .reasoning(let text):
                         guard !text.isEmpty else { continue }
+                        markFirstModelOutput()
                         sawReasoning = true
                         estimatedTextTokens += max(1, text.count / 4)
                         // Reasoning-capable families (DSV4-Flash thinking,
@@ -121,6 +133,7 @@ enum GenerationEventMapper {
                         }
 
                     case .toolCall(let call):
+                        markFirstModelOutput()
                         let argsJSON = serializeArguments(
                             call.function.arguments,
                             toolName: call.function.name

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -88,7 +88,8 @@ enum GenerationEventMapper {
                                 tokensPerSecond: info.tokensPerSecond,
                                 unclosedReasoning: suppressUnclosedReasoning
                                     ? false
-                                    : info.unclosedReasoning
+                                    : info.unclosedReasoning,
+                                stopReason: Self.openAIStopReason(from: info.stopReason)
                             )
                         )
                         continue
@@ -161,7 +162,8 @@ enum GenerationEventMapper {
                         .completionInfo(
                             tokenCount: estimatedTextTokens,
                             tokensPerSecond: 0,
-                            unclosedReasoning: sawReasoning && !suppressUnclosedReasoning
+                            unclosedReasoning: sawReasoning && !suppressUnclosedReasoning,
+                            stopReason: nil
                         )
                     )
                 }
@@ -198,6 +200,17 @@ enum GenerationEventMapper {
             id: .exclusive,
             "prompt: \(info.promptTokenCount, privacy: .public) tok \(info.promptTokensPerSecond, privacy: .public) tok/s | gen: \(info.generationTokenCount, privacy: .public) tok \(info.tokensPerSecond, privacy: .public) tok/s"
         )
+    }
+
+    private static func openAIStopReason(from stopReason: GenerateStopReason) -> String {
+        switch stopReason {
+        case .stop:
+            return "stop"
+        case .length:
+            return "length"
+        case .cancelled:
+            return "cancelled"
+        }
     }
 
     /// Convert vmlx's `[String: JSONValue]` argument map to a compact JSON

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -403,7 +403,7 @@ struct MLXBatchAdapter {
         return result.chat
     }
 
-    private static func preencodedAudio(
+    static func preencodedAudio(
         _ audio: MLXLMCommon.UserInput.Audio,
         using omni: NemotronHOmni
     ) throws -> MLXLMCommon.UserInput.Audio? {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -578,6 +578,8 @@ struct MLXBatchAdapter {
             var chatCount = 0
             var toolCount = 0
             var imageCount = 0
+            var videoCount = 0
+            var audioCount = 0
             var contextKeys: [String] = []
             var contextSummary = ""
             var promptTokenCount = 0
@@ -592,6 +594,8 @@ struct MLXBatchAdapter {
             box.chatBuiltAt = CFAbsoluteTimeGetCurrent()
             box.chatCount = chat.count
             box.imageCount = chat.reduce(0) { $0 + $1.images.count }
+            box.videoCount = chat.reduce(0) { $0 + $1.videos.count }
+            box.audioCount = chat.reduce(0) { $0 + $1.audios.count }
             let toolsSpec = buildToolsSpec()
             box.toolsBuiltAt = CFAbsoluteTimeGetCurrent()
             box.toolCount = toolsSpec?.count ?? 0
@@ -649,8 +653,16 @@ struct MLXBatchAdapter {
             return Int((end - start) * 1000)
         }
         let contextKeyString = box.contextKeys.joined(separator: ",")
+        let totalPrepareMs = Int((doneAt - prepareStartedAt) * 1000)
+        trace?.set("prompt_prepare_ms", totalPrepareMs)
+        trace?.set("processor_prepare_ms", ms(box.contextBuiltAt, box.processorDoneAt))
+        trace?.set("token_array_ms", ms(box.processorDoneAt, box.tokenArrayDoneAt))
+        trace?.set("chat_message_count", box.chatCount)
+        trace?.set("chat_image_count", box.imageCount)
+        trace?.set("chat_video_count", box.videoCount)
+        trace?.set("chat_audio_count", box.audioCount)
         batchAdapterLog.info(
-            "prepareInput: model=\(modelName, privacy: .public) totalMs=\(Int((doneAt - prepareStartedAt) * 1000), privacy: .public) waitForContainerMs=\(ms(prepareStartedAt, box.performEnteredAt), privacy: .public) chatBuildMs=\(ms(box.performEnteredAt, box.chatBuiltAt), privacy: .public) toolsBuildMs=\(ms(box.chatBuiltAt, box.toolsBuiltAt), privacy: .public) contextMs=\(ms(box.toolsBuiltAt, box.contextBuiltAt), privacy: .public) processorPrepareMs=\(ms(box.contextBuiltAt, box.processorDoneAt), privacy: .public) tokenArrayMs=\(ms(box.processorDoneAt, box.tokenArrayDoneAt), privacy: .public) chat=\(box.chatCount, privacy: .public) tools=\(box.toolCount, privacy: .public) images=\(box.imageCount, privacy: .public) promptTokens=\(box.promptTokenCount, privacy: .public) contextKeys=\(contextKeyString, privacy: .public) context=\(box.contextSummary, privacy: .public)"
+            "prepareInput: model=\(modelName, privacy: .public) totalMs=\(totalPrepareMs, privacy: .public) waitForContainerMs=\(ms(prepareStartedAt, box.performEnteredAt), privacy: .public) chatBuildMs=\(ms(box.performEnteredAt, box.chatBuiltAt), privacy: .public) toolsBuildMs=\(ms(box.chatBuiltAt, box.toolsBuiltAt), privacy: .public) contextMs=\(ms(box.toolsBuiltAt, box.contextBuiltAt), privacy: .public) processorPrepareMs=\(ms(box.contextBuiltAt, box.processorDoneAt), privacy: .public) tokenArrayMs=\(ms(box.processorDoneAt, box.tokenArrayDoneAt), privacy: .public) chat=\(box.chatCount, privacy: .public) tools=\(box.toolCount, privacy: .public) images=\(box.imageCount, privacy: .public) videos=\(box.videoCount, privacy: .public) audios=\(box.audioCount, privacy: .public) promptTokens=\(box.promptTokenCount, privacy: .public) contextKeys=\(contextKeyString, privacy: .public) context=\(box.contextSummary, privacy: .public)"
         )
 
         guard let prepared = box.result else {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -476,7 +476,7 @@ struct MLXBatchAdapter {
             switch effort {
             case "max":
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = "max"
+                context["reasoning_effort"] = Self.dsv4RawMaxEnabled ? "max" : "high"
             case "high":
                 context["enable_thinking"] = true
                 context["reasoning_effort"] = "high"
@@ -537,6 +537,21 @@ struct MLXBatchAdapter {
         }
         context["enable_thinking"] = true
         return context
+    }
+
+    /// DSV4's raw `max` effort prepends an extreme "absolute maximum" thinking
+    /// preface. Keep the UI's Max segment on the stable high-thinking rail by
+    /// default; enable raw max only for explicit diagnostic runs.
+    private static var dsv4RawMaxEnabled: Bool {
+        switch ProcessInfo.processInfo.environment["OSAURUS_DSV4_RAW_MAX"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
     }
 
     private static func isDirectRailReasoningEffort(_ value: String?) -> Bool {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -397,6 +397,10 @@ struct MLXBatchAdapter {
             context["enable_thinking"] = !disableThinking
             return context
         }
+        if ModelFamilyNames.isNemotronOmniFamily(modelName) {
+            context["enable_thinking"] = false
+            return context
+        }
         if ModelFamilyNames.isZayaFamily(modelName) {
             context["enable_thinking"] = false
             return context

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -43,6 +43,13 @@ struct MLXBatchAdapter {
         let genTask: Task<Void, Never>
     }
 
+    struct AudioPreencodeResult {
+        let chat: [MLXLMCommon.Chat.Message]
+        let inputCount: Int
+        let convertedCount: Int
+        let alreadyPreencodedCount: Int
+    }
+
     struct EffectiveGenerationSettings: Equatable, Sendable {
         let temperature: Float
         let maxTokens: Int
@@ -332,6 +339,111 @@ struct MLXBatchAdapter {
         }
     }
 
+    static func preencodeAudioSources(
+        in chat: [MLXLMCommon.Chat.Message],
+        encode: (MLXLMCommon.UserInput.Audio) throws -> MLXLMCommon.UserInput.Audio?
+    ) rethrows -> AudioPreencodeResult {
+        var inputCount = 0
+        var convertedCount = 0
+        var alreadyPreencodedCount = 0
+
+        let mapped = try chat.map { message in
+            guard !message.audios.isEmpty else { return message }
+            var updated = message
+            updated.audios = try message.audios.map { audio in
+                inputCount += 1
+                if case .preEncoded = audio {
+                    alreadyPreencodedCount += 1
+                    return audio
+                }
+                if let encoded = try encode(audio) {
+                    convertedCount += 1
+                    return encoded
+                }
+                return audio
+            }
+            return updated
+        }
+
+        return AudioPreencodeResult(
+            chat: mapped,
+            inputCount: inputCount,
+            convertedCount: convertedCount,
+            alreadyPreencodedCount: alreadyPreencodedCount
+        )
+    }
+
+    private static func preencodeNemotronOmniAudioIfPossible(
+        in chat: [MLXLMCommon.Chat.Message],
+        modelName: String,
+        model: any LanguageModel,
+        trace: TTFTTrace?
+    ) throws -> [MLXLMCommon.Chat.Message] {
+        guard ModelFamilyNames.isNemotronOmniFamily(modelName),
+            let omni = model as? NemotronHOmni
+        else {
+            return chat
+        }
+
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        let result = try preencodeAudioSources(in: chat) { audio in
+            try preencodedAudio(audio, using: omni)
+        }
+        guard result.inputCount > 0 else { return result.chat }
+
+        let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+        trace?.set("omni_audio_preencode_input_count", result.inputCount)
+        trace?.set("omni_audio_preencode_converted_count", result.convertedCount)
+        trace?.set("omni_audio_preencode_existing_count", result.alreadyPreencodedCount)
+        trace?.set("omni_audio_preencode_ms", elapsedMs)
+        trace?.mark("omni_audio_preencode_done")
+        batchAdapterLog.info(
+            "preencodeAudio: model=\(modelName, privacy: .public) input=\(result.inputCount, privacy: .public) converted=\(result.convertedCount, privacy: .public) existing=\(result.alreadyPreencodedCount, privacy: .public) ms=\(elapsedMs, privacy: .public)"
+        )
+        return result.chat
+    }
+
+    private static func preencodedAudio(
+        _ audio: MLXLMCommon.UserInput.Audio,
+        using omni: NemotronHOmni
+    ) throws -> MLXLMCommon.UserInput.Audio? {
+        let samples16k: [Float]
+        switch audio {
+        case .url(let url):
+            samples16k = try nemotronOmniLoadAudioFile(
+                url,
+                targetSampleRate: Double(omni.config.soundSampleRate)
+            )
+        case .samples(let samples, let sampleRate):
+            samples16k = sampleRate == omni.config.soundSampleRate
+                ? samples
+                : linearResamplePCM(
+                    samples,
+                    fromRate: sampleRate,
+                    toRate: omni.config.soundSampleRate
+                )
+        case .array(let array, let sampleRate):
+            let samples = array.reshaped([-1]).asType(.float32).asArray(Float.self)
+            samples16k = sampleRate == omni.config.soundSampleRate
+                ? samples
+                : linearResamplePCM(
+                    samples,
+                    fromRate: sampleRate,
+                    toRate: omni.config.soundSampleRate
+                )
+        case .preEncoded:
+            return nil
+        }
+
+        let embedding = omni.extractAudioEmbeds(waveform: samples16k)
+        MLX.eval(embedding)
+        return .preEncoded(
+            samples: samples16k,
+            sampleRate: omni.config.soundSampleRate,
+            embedding: embedding
+        )
+    }
+
     // MARK: - Thinking template context
 
     static func additionalContext(
@@ -594,7 +706,13 @@ struct MLXBatchAdapter {
         try await container.perform { (context: MLXLMCommon.ModelContext) in
             box.performEnteredAt = CFAbsoluteTimeGetCurrent()
             trace?.mark("batch_container_perform_entered")
-            let chat = preprocessImages(in: buildChat())
+            var chat = preprocessImages(in: buildChat())
+            chat = try preencodeNemotronOmniAudioIfPossible(
+                in: chat,
+                modelName: modelName,
+                model: context.model,
+                trace: trace
+            )
             box.chatBuiltAt = CFAbsoluteTimeGetCurrent()
             box.chatCount = chat.count
             box.imageCount = chat.reduce(0) { $0 + $1.images.count }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -459,6 +459,9 @@ struct MLXBatchAdapter {
             return normalized.isEmpty ? nil : normalized
         }()
         let disableThinking = generation.modelOptions["disableThinking"]?.boolValue
+        let directRailReasoningEffort = Self.isDirectRailReasoningEffort(normalizedReasoningEffort)
+        let hasPositiveReasoningEffort =
+            normalizedReasoningEffort != nil && !directRailReasoningEffort
 
         if DSV4ReasoningProfile.matches(modelId: modelName) {
             let effort: String
@@ -494,31 +497,56 @@ struct MLXBatchAdapter {
             return context
         }
 
-        if ModelFamilyNames.isZayaVLFamily(modelName) {
-            return context
-        }
-
-        if let normalizedReasoningEffort {
-            context["reasoning_effort"] = normalizedReasoningEffort
-        }
         if ModelFamilyNames.isLingFamily(modelName) {
             context["enable_thinking"] = false
             return context
         }
+
+        if ModelFamilyNames.isZayaVLFamily(modelName) {
+            return context
+        }
+
         if let disableThinking {
             context["enable_thinking"] = !disableThinking
+            if !disableThinking, let normalizedReasoningEffort {
+                context["reasoning_effort"] = normalizedReasoningEffort
+            }
             return context
         }
         if ModelFamilyNames.isNemotronOmniFamily(modelName) {
-            context["enable_thinking"] = false
+            context["enable_thinking"] = hasPositiveReasoningEffort
+            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+                context["reasoning_effort"] = normalizedReasoningEffort
+            }
             return context
         }
         if ModelFamilyNames.isZayaFamily(modelName) {
+            context["enable_thinking"] = hasPositiveReasoningEffort
+            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+                context["reasoning_effort"] = normalizedReasoningEffort
+            }
+            return context
+        }
+
+        if let normalizedReasoningEffort, !directRailReasoningEffort {
+            context["reasoning_effort"] = normalizedReasoningEffort
+        }
+        if directRailReasoningEffort {
             context["enable_thinking"] = false
             return context
         }
         context["enable_thinking"] = true
         return context
+    }
+
+    private static func isDirectRailReasoningEffort(_ value: String?) -> Bool {
+        guard let value else { return false }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "instruct", "chat", "none", "no_think", "nothink", "off", "disabled", "false":
+            return true
+        default:
+            return false
+        }
     }
 
     static func shouldEnableCompiledBatchDecode(modelName: String, maxBatchSize: Int) -> Bool {

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1452,6 +1452,7 @@ final class PluginHostContext: @unchecked Sendable {
                 do {
                     let stream = try await prep.engine.streamChat(request: iterReq)
                     var iterContent = ""
+                    var iterFinishReason = "stop"
 
                     for try await delta in stream {
                         // Cancellation check: plugin called `complete_cancel`
@@ -1493,6 +1494,9 @@ final class PluginHostContext: @unchecked Sendable {
                             // usage delta and remember it for the aggregated
                             // return so non-stream and stream paths surface
                             // the same metering shape.
+                            if let stopReason = stats.stopReason {
+                                iterFinishReason = stopReason
+                            }
                             let usage: [String: Any] = [
                                 "completion_tokens": stats.tokenCount,
                                 "tokens_per_second": stats.tokensPerSecond,
@@ -1511,7 +1515,7 @@ final class PluginHostContext: @unchecked Sendable {
                     if !iterContent.isEmpty {
                         messages.append(ChatMessage(role: "assistant", content: iterContent))
                     }
-                    emit(Self.chunkPayload(id: cid, delta: [:], finishReason: "stop"))
+                    emit(Self.chunkPayload(id: cid, delta: [:], finishReason: iterFinishReason))
                     Self.persistStreamingInference(
                         pluginId: pid,
                         agentId: prep.agentId,
@@ -1527,7 +1531,7 @@ final class PluginHostContext: @unchecked Sendable {
                         toolCallsExecuted: toolCallsExecuted,
                         sharedArtifacts: sharedArtifacts,
                         usage: lastUsage,
-                        finishReason: "stop"
+                        finishReason: iterFinishReason
                     )
 
                 } catch let invs as ServiceToolInvocations {

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -177,9 +177,13 @@ public actor RemoteProviderService: ToolCapableService {
         model: String,
         effort: String?
     ) -> (effort: String?, thinking: ThinkingConfig?) {
-        let normalized = effort?
+        guard let normalized = effort?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
+            .lowercased(), !normalized.isEmpty
+        else {
+            return (nil, nil)
+        }
+
         let isDirectRailEffort: Bool
         switch normalized {
         case "instruct", "chat", "none", "no_think", "nothink", "off", "disabled", "false":
@@ -187,12 +191,27 @@ public actor RemoteProviderService: ToolCapableService {
         default:
             isDirectRailEffort = false
         }
-        guard isDirectRailEffort else { return (effort, nil) }
+        guard isDirectRailEffort else { return (normalized, nil) }
         let thinking =
             host.lowercased().contains("deepseek")
             && DSV4ReasoningProfile.matches(modelId: model)
             ? ThinkingConfig(type: "disabled") : nil
         return (nil, thinking)
+    }
+
+    static func remoteChatReasoningControls(
+        providerType: RemoteProviderType,
+        host: String,
+        model: String,
+        effort: String?
+    ) -> (effort: String?, thinking: ThinkingConfig?) {
+        let translated = Self.dsv4RemoteEffort(host: host, model: model, effort: effort)
+        let providerAcceptedEffort = Self.chatCompletionsReasoningEffort(
+            providerType: providerType,
+            host: host,
+            effort: translated.effort
+        )
+        return (providerAcceptedEffort, translated.thinking)
     }
 
     static func effectiveRequestProviderType(
@@ -1697,7 +1716,8 @@ public actor RemoteProviderService: ToolCapableService {
         tools: [Tool]?,
         toolChoice: ToolChoiceOption?
     ) -> RemoteChatRequest {
-        let (effortValue, thinking) = Self.dsv4RemoteEffort(
+        let (effortValue, thinking) = Self.remoteChatReasoningControls(
+            providerType: provider.providerType,
             host: provider.host,
             model: model,
             effort: parameters.modelOptions["reasoningEffort"]?.stringValue

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -168,8 +168,10 @@ public actor RemoteProviderService: ToolCapableService {
     /// field is DeepSeek-specific and only injected for DeepSeek hosts to avoid
     /// 422s on strict schemas.
     ///
-    /// Non-DSV4 models pass through unchanged so this is safe to call
-    /// unconditionally from `buildChatRequest`.
+    /// Direct/off aliases (`instruct`, `no_think`, `none`, etc.) are internal
+    /// local-runtime controls, not portable OpenAI-compatible wire values. They
+    /// are stripped for every remote model; DSV4 on DeepSeek additionally gets
+    /// the provider-specific `thinking.disabled` object.
     static func dsv4RemoteEffort(
         host: String,
         model: String,
@@ -178,14 +180,17 @@ public actor RemoteProviderService: ToolCapableService {
         let normalized = effort?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        guard
-            normalized == "instruct",
-            DSV4ReasoningProfile.matches(modelId: model)
-        else {
-            return (effort, nil)
+        let isDirectRailEffort: Bool
+        switch normalized {
+        case "instruct", "chat", "none", "no_think", "nothink", "off", "disabled", "false":
+            isDirectRailEffort = true
+        default:
+            isDirectRailEffort = false
         }
+        guard isDirectRailEffort else { return (effort, nil) }
         let thinking =
             host.lowercased().contains("deepseek")
+            && DSV4ReasoningProfile.matches(modelId: model)
             ? ThinkingConfig(type: "disabled") : nil
         return (nil, thinking)
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -116,6 +116,30 @@ public actor RemoteProviderService: ToolCapableService {
         }
     }
 
+    static func chatCompletionsReasoningEffort(
+        providerType: RemoteProviderType,
+        host: String,
+        effort: String?
+    ) -> String? {
+        guard
+            let effort = effort?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+            !effort.isEmpty
+        else {
+            return nil
+        }
+
+        switch providerType {
+        case .openaiLegacy, .azureOpenAI:
+            if host.lowercased().contains("deepseek") {
+                let acceptedDeepSeekEfforts: Set<String> = ["low", "medium", "high", "max", "xhigh"]
+                return acceptedDeepSeekEfforts.contains(effort) ? effort : nil
+            }
+            return effort
+        case .anthropic, .openResponses, .openAICodex, .gemini, .osaurus:
+            return effort
+        }
+    }
+
     /// Whether the target provider requires `reasoning_content` to be echoed
     /// back on assistant messages in multi-round conversations. DeepSeek's
     /// thinking mode 400s otherwise (issue #959). Other OpenAI-compat hosts

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -113,5 +113,6 @@ struct ChatAttachmentSecurityTests {
         #expect(inputs[0].localSamples == nil)
         #expect(inputs[1].localSamples?.samples == [0.25, -0.5])
         #expect(inputs[1].localSamples?.sampleRate == 16_000)
+        #expect(inputs[1].localSamples?.preencodedAttachmentId == liveAudio.id)
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -51,4 +51,42 @@ struct ChatAttachmentSecurityTests {
         let message = ChatSession.buildUserMessageText(content: "", attachments: [attachment])
         #expect(message.contains(#"<attached_document name="attachment">"#))
     }
+
+    @Test func buildUserChatMessage_forwardsAudioAndVideoWhenSupported() {
+        let audio = Attachment.audio(Data([0x01, 0x02, 0x03]), format: "wav", filename: "voice.wav")
+        let video = Attachment.video(Data([0x10, 0x11]), filename: "clip.mov")
+
+        let message = ChatSession.buildUserChatMessage(
+            content: "describe",
+            attachments: [audio, video],
+            supportsImages: false,
+            supportsAudio: true,
+            supportsVideo: true
+        )
+
+        #expect(message.content == "describe")
+        #expect(message.audioInputs.count == 1)
+        #expect(message.audioInputs[0].data == Data([0x01, 0x02, 0x03]).base64EncodedString())
+        #expect(message.audioInputs[0].format == "wav")
+        #expect(message.videoUrls.count == 1)
+        #expect(message.videoUrls[0] == "data:video/quicktime;base64,\(Data([0x10, 0x11]).base64EncodedString())")
+    }
+
+    @Test func buildUserChatMessage_dropsAudioAndVideoWhenUnsupported() {
+        let audio = Attachment.audio(Data([0x01]), format: "wav", filename: "voice.wav")
+        let video = Attachment.video(Data([0x02]), filename: "clip.mp4")
+
+        let message = ChatSession.buildUserChatMessage(
+            content: "plain",
+            attachments: [audio, video],
+            supportsImages: false,
+            supportsAudio: false,
+            supportsVideo: false
+        )
+
+        #expect(message.content == "plain")
+        #expect(message.contentParts == nil)
+        #expect(message.audioInputs.isEmpty)
+        #expect(message.videoUrls.isEmpty)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -90,6 +90,31 @@ struct ChatAttachmentSecurityTests {
         #expect(message.videoUrls.isEmpty)
     }
 
+    @Test func buildUserChatMessage_gatesImagesByModelSupport() {
+        let image = Attachment.image(Data([0x89, 0x50, 0x4E, 0x47]))
+
+        let dropped = ChatSession.buildUserChatMessage(
+            content: "plain",
+            attachments: [image],
+            supportsImages: false,
+            supportsAudio: false,
+            supportsVideo: false
+        )
+        #expect(dropped.content == "plain")
+        #expect(dropped.contentParts == nil)
+        #expect(dropped.imageUrls.isEmpty)
+
+        let forwarded = ChatSession.buildUserChatMessage(
+            content: "look",
+            attachments: [image],
+            supportsImages: true,
+            supportsAudio: false,
+            supportsVideo: false
+        )
+        #expect(forwarded.imageUrls.count == 1)
+        #expect(forwarded.imageUrls[0].hasPrefix("data:image/png;base64,"))
+    }
+
     @Test func buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs() {
         let droppedAudio = Attachment.audio(Data([0x01]), format: "wav", filename: "dropped.wav")
         let liveAudio = Attachment.audio(Data([0x02, 0x03]), format: "wav", filename: "voice.wav")

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -89,4 +89,29 @@ struct ChatAttachmentSecurityTests {
         #expect(message.audioInputs.isEmpty)
         #expect(message.videoUrls.isEmpty)
     }
+
+    @Test func buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs() {
+        let droppedAudio = Attachment.audio(Data([0x01]), format: "wav", filename: "dropped.wav")
+        let liveAudio = Attachment.audio(Data([0x02, 0x03]), format: "wav", filename: "voice.wav")
+        LiveVoiceAudioInputRegistry.shared.store(
+            samples: [0.25, -0.5],
+            sampleRate: 16_000,
+            for: liveAudio.id
+        )
+        defer { LiveVoiceAudioInputRegistry.shared.removeAll() }
+
+        let message = ChatSession.buildUserChatMessage(
+            content: "hear these",
+            attachments: [droppedAudio, liveAudio],
+            supportsImages: false,
+            supportsAudio: true,
+            supportsVideo: false
+        )
+
+        let inputs = message.audioInputsWithLocalSamples
+        #expect(inputs.count == 2)
+        #expect(inputs[0].localSamples == nil)
+        #expect(inputs[1].localSamples?.samples == [0.25, -0.5])
+        #expect(inputs[1].localSamples?.sampleRate == 16_000)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -42,6 +42,12 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.from(modelId: "nemotron-3-nano-omni-30b-a3b-mxfp4") == .omni)
     }
 
+    @Test("D1: short local Nemotron-Omni-Nano form → .omni")
+    func d1_nemotronOmniShortLocal() {
+        #expect(ModelMediaCapabilities.from(modelId: "Nemotron-Omni-Nano-JANGTQ-CRACK") == .omni)
+        #expect(ModelMediaCapabilities.from(modelId: "nemotron-omni-nano-jangtq-crack") == .omni)
+    }
+
     @Test("D1: nemotron_h_omni alternate naming → .omni")
     func d1_nemotronHOmniUnderscore() {
         #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Nemotron_H_Omni-Future") == .omni)
@@ -235,5 +241,33 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.Capabilities.imageOnly.anyMedia)
         #expect(ModelMediaCapabilities.Capabilities.imageVideo.anyMedia)
         #expect(ModelMediaCapabilities.Capabilities.omni.anyMedia)
+    }
+
+    @Test("Composer capabilities merge image fallback only")
+    func composerCapabilities_mergeImageFallbackOnly() {
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "unknown-remote-vlm",
+                fallbackSupportsImages: true
+            ) == .imageOnly
+        )
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "JANGQ-AI/Laguna-XS.2-JANGTQ",
+                fallbackSupportsImages: false
+            ) == .textOnly
+        )
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "Qwen/Qwen3-VL-8B",
+                fallbackSupportsImages: false
+            ) == .imageVideo
+        )
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
+                fallbackSupportsImages: false
+            ) == .omni
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -106,6 +106,8 @@ struct ModelProfileRegistryTests {
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ",
+            "dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK",
+            "nemotron-omni-nano-jangtq-crack",
             "nemotron-3-nano-omni-30b-a3b-mxfp4",  // case-folded picker form
         ] {
             let profile = ModelProfileRegistry.profile(for: id)

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import MLX
 import MLXLMCommon
 import Testing
 
@@ -219,6 +220,92 @@ struct MultimodalContentPartTests {
             return
         }
         #expect(samples == [0.1, -0.2, 0.3])
+        #expect(sampleRate == 16_000)
+    }
+
+    @Test(
+        "mapOpenAIChatToMLX prefers fresh preencoded live audio",
+        .disabled("Requires an MLXArray fixture; local SwiftPM tests cannot load default.metallib.")
+    )
+    func mapping_prefersFreshPreencodedLiveAudio() throws {
+        let attachmentId = UUID()
+        let samples: [Float] = [0.1, -0.2, 0.3]
+        let embedding = MLXArray.zeros([2, 4])
+        LiveVoiceAudioInputRegistry.shared.store(samples: samples, sampleRate: 16_000, for: attachmentId)
+        LiveVoiceAudioInputRegistry.shared.storePreencoded(
+            samples: samples,
+            sampleRate: 16_000,
+            embedding: embedding,
+            encodeMs: 12,
+            for: attachmentId
+        )
+        defer { LiveVoiceAudioInputRegistry.shared.removeAll() }
+
+        let message = ChatMessage(
+            role: "user",
+            text: "hear preencoded",
+            imageData: [],
+            audios: [(data: Data([0x52, 0x49, 0x46, 0x46]), format: "wav")],
+            localAudioSamples: [
+                LocalAudioSamples(
+                    samples: samples,
+                    sampleRate: 16_000,
+                    preencodedAttachmentId: attachmentId
+                )
+            ],
+            videos: []
+        )
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([message])
+
+        guard case .preEncoded(let mappedSamples, let sampleRate, let mappedEmbedding) = mapped[0].audios[0] else {
+            Issue.record("fresh live audio embedding should be forwarded as preEncoded")
+            return
+        }
+        #expect(mappedSamples == samples)
+        #expect(sampleRate == 16_000)
+        #expect(mappedEmbedding.shape == embedding.shape)
+    }
+
+    @Test(
+        "mapOpenAIChatToMLX ignores stale preencoded live audio",
+        .disabled("Requires an MLXArray fixture; local SwiftPM tests cannot load default.metallib.")
+    )
+    func mapping_ignoresStalePreencodedLiveAudio() throws {
+        let attachmentId = UUID()
+        LiveVoiceAudioInputRegistry.shared.store(samples: [0.1], sampleRate: 16_000, for: attachmentId)
+        LiveVoiceAudioInputRegistry.shared.storePreencoded(
+            samples: [0.1],
+            sampleRate: 16_000,
+            embedding: MLXArray.zeros([1, 4]),
+            encodeMs: 12,
+            for: attachmentId
+        )
+        defer { LiveVoiceAudioInputRegistry.shared.removeAll() }
+
+        let freshSamples: [Float] = [0.1, -0.2]
+        let message = ChatMessage(
+            role: "user",
+            text: "hear fresh",
+            imageData: [],
+            audios: [(data: Data([0x52, 0x49, 0x46, 0x46]), format: "wav")],
+            localAudioSamples: [
+                LocalAudioSamples(
+                    samples: freshSamples,
+                    sampleRate: 16_000,
+                    preencodedAttachmentId: attachmentId
+                )
+            ],
+            videos: []
+        )
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([message])
+
+        guard case .samples(let mappedSamples, let sampleRate) = mapped[0].audios[0] else {
+            Issue.record("stale live audio embedding should fall back to samples")
+            return
+        }
+        #expect(mappedSamples == freshSamples)
         #expect(sampleRate == 16_000)
     }
 

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -193,6 +193,35 @@ struct MultimodalContentPartTests {
         try? FileManager.default.removeItem(at: u)
     }
 
+    @Test("mapOpenAIChatToMLX uses local live audio samples when present")
+    func mapping_usesLocalLiveAudioSamples() throws {
+        let fallbackBytes = Data([0x52, 0x49, 0x46, 0x46])
+        let message = ChatMessage(
+            role: "user",
+            text: "hear both",
+            imageData: [],
+            audios: [
+                (data: fallbackBytes, format: "wav"),
+                (data: fallbackBytes, format: "wav"),
+            ],
+            localAudioSamples: [
+                nil,
+                LocalAudioSamples(samples: [0.1, -0.2, 0.3], sampleRate: 16_000),
+            ],
+            videos: []
+        )
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([message])
+
+        #expect(mapped[0].audios.count == 2)
+        guard case .samples(let samples, let sampleRate) = mapped[0].audios[1] else {
+            Issue.record("second audio input should use local live samples")
+            return
+        }
+        #expect(samples == [0.1, -0.2, 0.3])
+        #expect(sampleRate == 16_000)
+    }
+
     /// Locks in the fix for a shared-helper bug where the audio mediatype
     /// canonicalization table (`mp4 → m4a`) ran unconditionally in
     /// `materializeMediaDataUrl` — meaning a `data:video/mp4;base64,...`

--- a/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MultimodalContentPartTests.swift
@@ -194,6 +194,37 @@ struct MultimodalContentPartTests {
         try? FileManager.default.removeItem(at: u)
     }
 
+    @Test("mapOpenAIChatToMLX decodes valid WAV input_audio into samples")
+    func mapping_audioWavDecodesToSamples() throws {
+        let snapshot = LiveVoiceAudioSnapshot(
+            samples: [-1.0, 0.0, 1.0],
+            sampleRate: 16_000)
+        let b64 = snapshot.wavData().base64EncodedString()
+        let json = """
+            [{
+              "role": "user",
+              "content": [
+                {"type": "input_audio", "input_audio": {"data": "\(b64)", "format": "wav"}}
+              ]
+            }]
+            """.data(using: .utf8)!
+
+        let msgs = try JSONDecoder().decode([ChatMessage].self, from: json)
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(msgs)
+
+        #expect(mapped.count == 1)
+        #expect(mapped[0].audios.count == 1)
+        guard case .samples(let samples, let sampleRate) = mapped[0].audios[0] else {
+            Issue.record("valid WAV input_audio should decode directly to .samples")
+            return
+        }
+        #expect(sampleRate == 16_000)
+        #expect(samples.count == 3)
+        #expect(abs(samples[0] - -1.0) < 0.0001)
+        #expect(abs(samples[1]) < 0.0001)
+        #expect(abs(samples[2] - 1.0) < 0.0001)
+    }
+
     @Test("mapOpenAIChatToMLX uses local live audio samples when present")
     func mapping_usesLocalLiveAudioSamples() throws {
         let fallbackBytes = Data([0x52, 0x49, 0x46, 0x46])

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -229,7 +229,13 @@ struct HTTPHandlerChatStreamingTests {
             > {
                 AsyncThrowingStream { continuation in
                     continuation.yield("hello")
-                    continuation.yield(StreamingStatsHint.encode(tokenCount: 77, tokensPerSecond: 12.5))
+                    continuation.yield(
+                        StreamingStatsHint.encode(
+                            tokenCount: 77,
+                            tokensPerSecond: 12.5,
+                            stopReason: "length"
+                        )
+                    )
                     continuation.finish()
                 }
             }
@@ -259,6 +265,7 @@ struct HTTPHandlerChatStreamingTests {
         #expect(status == 200)
         #expect(body.contains("\"content\":\"hello\""))
         #expect(body.contains("\"completion_tokens\":77"))
+        #expect(body.contains("\"finish_reason\":\"length\""))
         #expect(!body.contains("\u{FFFE}"))
     }
 

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -252,6 +252,35 @@ struct RemoteChatRequestEncodingTests {
         }
     }
 
+    @Test func remoteChatReasoningControls_deepSeekNormalizesAndFiltersEfforts() throws {
+        let accepted = RemoteProviderService.remoteChatReasoningControls(
+            providerType: .openaiLegacy,
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro",
+            effort: "  MAX  "
+        )
+        #expect(accepted.effort == "max")
+        #expect(accepted.thinking == nil)
+
+        let direct = RemoteProviderService.remoteChatReasoningControls(
+            providerType: .openaiLegacy,
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro",
+            effort: "instruct"
+        )
+        #expect(direct.effort == nil)
+        #expect(direct.thinking == ThinkingConfig(type: "disabled"))
+
+        let unknown = RemoteProviderService.remoteChatReasoningControls(
+            providerType: .openaiLegacy,
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro",
+            effort: "reasoning"
+        )
+        #expect(unknown.effort == nil)
+        #expect(unknown.thinking == nil)
+    }
+
     // MARK: - `reasoning_content` echo (issue #959)
 
     @Test func chatMessage_encode_includesReasoningContentWhenPresent() throws {
@@ -395,6 +424,17 @@ struct RemoteChatRequestEncodingTests {
             #expect(translated.effort == effort)
             #expect(translated.thinking == nil)
         }
+    }
+
+    @Test func dsv4RemoteEffort_normalizesAcceptedEffortCasing() throws {
+        let translated = RemoteProviderService.dsv4RemoteEffort(
+            host: "api.deepseek.com",
+            model: "deepseek-v4-pro",
+            effort: "  HIGH  "
+        )
+
+        #expect(translated.effort == "high")
+        #expect(translated.thinking == nil)
     }
 
     @Test func dsv4RemoteEffort_nonDeepSeekHost_stripsInstructWithoutThinkingField() throws {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -411,15 +411,19 @@ struct RemoteChatRequestEncodingTests {
         #expect(translated.thinking == nil)
     }
 
-    @Test func dsv4RemoteEffort_passesThroughWhenTranslationDoesNotApply() throws {
-        // Non-DSV4 model: effort flows through verbatim regardless of host.
-        let nonDSV4 = RemoteProviderService.dsv4RemoteEffort(
-            host: "api.deepseek.com",
-            model: "gpt-5.5",
-            effort: "instruct"
-        )
-        #expect(nonDSV4.effort == "instruct")
-        #expect(nonDSV4.thinking == nil)
+    @Test func dsv4RemoteEffort_stripsDirectRailAliasesForAllRemoteModels() throws {
+        // Direct/off aliases are local runtime controls. Public remote schemas
+        // reject them as `reasoning_effort` values, even when the model is not
+        // a local DSV4 bundle.
+        for effort in ["instruct", "none", "no_think", "off", "disabled", "false"] {
+            let nonDSV4 = RemoteProviderService.dsv4RemoteEffort(
+                host: "api.openai.com",
+                model: "gpt-5.5",
+                effort: effort
+            )
+            #expect(nonDSV4.effort == nil)
+            #expect(nonDSV4.thinking == nil)
+        }
 
         // Nil effort: nothing to translate, nothing to inject.
         let nilEffort = RemoteProviderService.dsv4RemoteEffort(

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -230,6 +230,28 @@ struct RemoteChatRequestEncodingTests {
         #expect(provider.mergedModelIds(discovered: ["gpt-4.1", "gpt-5.5"]) == ["prod-chat", "gpt-5.5"])
     }
 
+    @Test func deepSeekProvider_dropsLocalInstructReasoningEffort() throws {
+        #expect(
+            RemoteProviderService.chatCompletionsReasoningEffort(
+                providerType: .openaiLegacy,
+                host: "api.deepseek.com",
+                effort: "instruct"
+            ) == nil
+        )
+    }
+
+    @Test func deepSeekProvider_preservesAcceptedReasoningEfforts() throws {
+        for effort in ["low", "medium", "high", "max", "xhigh"] {
+            #expect(
+                RemoteProviderService.chatCompletionsReasoningEffort(
+                    providerType: .openaiLegacy,
+                    host: "api.deepseek.com",
+                    effort: effort
+                ) == effort
+            )
+        }
+    }
+
     // MARK: - `reasoning_content` echo (issue #959)
 
     @Test func chatMessage_encode_includesReasoningContentWhenPresent() throws {

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -86,7 +86,7 @@ struct GenerationEventMapperTests {
         )
         let events: [Generation] = [.chunk("ok"), .info(info)]
         let out = try await collect(events: events)
-        guard case .completionInfo(let count, let tps, let unclosed) = out.last else {
+        guard case .completionInfo(let count, let tps, let unclosed, let stopReason) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -95,6 +95,7 @@ struct GenerationEventMapperTests {
         // Default-constructed GenerateCompletionInfo carries unclosedReasoning=false;
         // a healthy stream that emitted </think> properly should mirror that here.
         #expect(unclosed == false)
+        #expect(stopReason == "stop")
     }
 
     @Test func info_propagates_unclosedReasoning_when_trapped() async throws {
@@ -108,7 +109,7 @@ struct GenerationEventMapperTests {
         )
         let events: [Generation] = [.reasoning("Self-Correction…"), .info(info)]
         let out = try await collect(events: events)
-        guard case .completionInfo(_, _, let unclosed) = out.last else {
+        guard case .completionInfo(_, _, let unclosed, let stopReason) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -116,6 +117,7 @@ struct GenerationEventMapperTests {
             unclosed == true,
             "vmlx flagged trapped-thinking; mapper must surface it on the runtime event."
         )
+        #expect(stopReason == "length")
     }
 
     @Test func info_propagates_unclosedReasoning_for_minimax_thinkingRail() async throws {
@@ -131,7 +133,7 @@ struct GenerationEventMapperTests {
             events: [.reasoning("The user is straightforward greeting"), .info(info)],
             modelName: "JANGQ-AI/MiniMax-M2.7-JANGTQ"
         )
-        guard case .completionInfo(_, _, let unclosed) = out.last else {
+        guard case .completionInfo(_, _, let unclosed, _) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -262,12 +264,13 @@ struct GenerationEventMapperTests {
             ],
             modelName: "JANGQ-AI/MiniMax-M2.7-JANGTQ"
         )
-        guard case .completionInfo(let count, _, let unclosed) = out.last else {
+        guard case .completionInfo(let count, _, let unclosed, let stopReason) = out.last else {
             Issue.record("expected synthesized completionInfo at end, got \(String(describing: out.last))")
             return
         }
         #expect(count > 0)
         #expect(unclosed == true)
+        #expect(stopReason == nil)
     }
 
     /// ZAYA1 (Zyphra; `model_type=zaya`) is reasoning-capable. Unlike Ling,

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -475,7 +475,10 @@ struct MLXBatchAdapterTests {
             modelName: modelName
         )
         #expect(maxReasoning["enable_thinking"] as? Bool == true)
-        #expect(maxReasoning["reasoning_effort"] as? String == "max")
+        #expect(
+            maxReasoning["reasoning_effort"] as? String == "high",
+            "Osaurus UI Max stays on DSV4's stable high-thinking rail unless raw max diagnostics are explicitly enabled"
+        )
 
         let legacyToggle = MLXBatchAdapter.additionalContext(
             for: GenerationParameters(

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -336,6 +336,34 @@ struct MLXBatchAdapterTests {
             MLXBatchAdapter.additionalContext(for: unspecified, modelName: modelName)["enable_thinking"] as? Bool
                 == true
         )
+
+        let staleOffEffort = MLXBatchAdapter.additionalContext(
+            for: GenerationParameters(
+                temperature: nil,
+                maxTokens: 16,
+                modelOptions: [
+                    "reasoningEffort": .string("no_think"),
+                    "disableThinking": .bool(true),
+                ]
+            ),
+            modelName: modelName
+        )
+        #expect(staleOffEffort["enable_thinking"] as? Bool == false)
+        #expect(
+            staleOffEffort["reasoning_effort"] == nil,
+            "direct/off aliases should not add a second cache-scope signal when generic thinking is disabled"
+        )
+
+        let apiReasoningEffort = MLXBatchAdapter.additionalContext(
+            for: GenerationParameters(
+                temperature: nil,
+                maxTokens: 16,
+                modelOptions: ["reasoningEffort": .string("high")]
+            ),
+            modelName: modelName
+        )
+        #expect(apiReasoningEffort["enable_thinking"] as? Bool == true)
+        #expect(apiReasoningEffort["reasoning_effort"] as? String == "high")
     }
 
     @Test func additionalContext_mapsReasoningEffortToTemplateKwarg() {
@@ -487,6 +515,17 @@ struct MLXBatchAdapterTests {
                     modelName: modelName
                 )["enable_thinking"] as? Bool == false
             )
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: GenerationParameters(
+                        temperature: nil,
+                        maxTokens: 16,
+                        modelOptions: ["reasoningEffort": .string("high")]
+                    ),
+                    modelName: modelName
+                )["reasoning_effort"] == nil,
+                "Ling is a non-reasoning Osaurus profile; stale effort values must not fragment cache or reach the Bailing directive bridge"
+            )
         }
 
         for modelName in ["linguistics-model-7b", "darling-llm"] {
@@ -534,6 +573,28 @@ struct MLXBatchAdapterTests {
                 )["enable_thinking"] as? Bool == true,
                 "ZAYA must honor explicit thinking opt-in: \(modelName)"
             )
+
+            let directOff = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("instruct")]
+                ),
+                modelName: modelName
+            )
+            #expect(directOff["enable_thinking"] as? Bool == false)
+            #expect(directOff["reasoning_effort"] == nil)
+
+            let apiReasoning = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("high")]
+                ),
+                modelName: modelName
+            )
+            #expect(apiReasoning["enable_thinking"] as? Bool == true)
+            #expect(apiReasoning["reasoning_effort"] as? String == "high")
         }
 
         // Boundary regression guards: names that contain `zaya` as a
@@ -584,6 +645,28 @@ struct MLXBatchAdapterTests {
                 )["enable_thinking"] as? Bool == true,
                 "Nemotron Omni must honor explicit thinking opt-in: \(modelName)"
             )
+
+            let directOff = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("no_think")]
+                ),
+                modelName: modelName
+            )
+            #expect(directOff["enable_thinking"] as? Bool == false)
+            #expect(directOff["reasoning_effort"] == nil)
+
+            let apiReasoning = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("high")]
+                ),
+                modelName: modelName
+            )
+            #expect(apiReasoning["enable_thinking"] as? Bool == true)
+            #expect(apiReasoning["reasoning_effort"] as? String == "high")
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -513,6 +513,39 @@ struct MLXBatchAdapterTests {
         }
     }
 
+    /// Nemotron Omni call/audio workloads should default to visible assistant
+    /// content instead of spending the first streamed chunks in the hidden
+    /// reasoning rail. Explicit user/API opt-in still enables thinking.
+    @Test func additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn() {
+        let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
+        let userEnabled = GenerationParameters(
+            temperature: nil,
+            maxTokens: 16,
+            modelOptions: ["disableThinking": .bool(false)]
+        )
+
+        for modelName in [
+            "dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK",
+            "nemotron-omni-nano-jangtq-crack",
+            "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+        ] {
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: unspecified,
+                    modelName: modelName
+                )["enable_thinking"] as? Bool == false,
+                "Nemotron Omni should default to no-thinking chat mode: \(modelName)"
+            )
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: userEnabled,
+                    modelName: modelName
+                )["enable_thinking"] as? Bool == true,
+                "Nemotron Omni must honor explicit thinking opt-in: \(modelName)"
+            )
+        }
+    }
+
     @Test func additionalContext_doesNotSendThinkingKwargForZayaVLTemplateSidecar() {
         let userEnabled = GenerationParameters(
             temperature: nil,

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import MLXLMCommon
 import Testing
 
 @testable import OsaurusCore
@@ -52,6 +53,46 @@ struct MLXBatchAdapterTests {
         // Zero is treated as "unset" — falls back to the compile-friendly
         // default of 1 (was 4 prior to fa694e9e).
         #expect(InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(in: defaults) == 1)
+    }
+
+    @Test func preencodeAudioSources_replacesRawAudioAndCountsInputs() {
+        let rawSamples: [Float] = [0.1, -0.2, 0.3]
+        let chat = [
+            MLXLMCommon.Chat.Message.user(
+                "hear this",
+                audios: [
+                    .samples(rawSamples, sampleRate: 16_000),
+                    .samples([0.4], sampleRate: 8_000),
+                ]
+            )
+        ]
+
+        let result = MLXBatchAdapter.preencodeAudioSources(in: chat) { audio in
+            guard case .samples(let samples, let sampleRate) = audio else {
+                Issue.record("only raw samples should be passed to the encoder")
+                return nil
+            }
+            return .samples(samples.map { $0 + 1 }, sampleRate: sampleRate == 16_000 ? 16_000 : 8_000)
+        }
+
+        #expect(result.inputCount == 2)
+        #expect(result.convertedCount == 2)
+        #expect(result.alreadyPreencodedCount == 0)
+        #expect(result.chat.count == 1)
+        #expect(result.chat[0].audios.count == 2)
+        guard case .samples(let convertedSamples, let convertedRate) = result.chat[0].audios[0] else {
+            Issue.record("raw samples should be replaced by the encoder output")
+            return
+        }
+        #expect(convertedSamples == [1.1, 0.8, 1.3])
+        #expect(convertedRate == 16_000)
+
+        guard case .samples(let secondSamples, let secondRate) = result.chat[0].audios[1] else {
+            Issue.record("second raw sample clip should also be replaced")
+            return
+        }
+        #expect(secondSamples == [1.4])
+        #expect(secondRate == 8_000)
     }
 
     @Test func generateParameters_enableCompiledBatchDecodeForSoloDefault() {

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -95,10 +95,14 @@ struct RuntimePolicySourceTests {
         // `c0f8b3b` adds Nemotron Omni live-voice handoff support and preserves
         // pre-encoded Parakeet/audio embeddings. `e497f61` adds the reusable
         // retained live PCM buffer plus a streaming cursor for VAD/call-mode
-        // polling without losing the final full-turn waveform.
-        #expect(manifest.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
-        #expect(workspaceResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
-        #expect(appResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
+        // polling without losing the final full-turn waveform. `638024b`
+        // adds a tracked OmniAudioLatencyBench for raw PCM vs pre-encoded
+        // Parakeet call-mode measurements.
+        #expect(manifest.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
+        #expect(workspaceResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
+        #expect(appResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
+        #expect(!workspaceResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
+        #expect(!appResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
         #expect(!workspaceResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
         #expect(!appResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
         #expect(!workspaceResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -93,10 +93,14 @@ struct RuntimePolicySourceTests {
         // be reused on growing chat prompts. `ad1d231` synchronizes before and
         // after safetensors disk writes against the GPU stream after generation.
         // `c0f8b3b` adds Nemotron Omni live-voice handoff support and preserves
-        // pre-encoded Parakeet/audio embeddings.
-        #expect(manifest.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
-        #expect(workspaceResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
-        #expect(appResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
+        // pre-encoded Parakeet/audio embeddings. `e497f61` adds the reusable
+        // retained live PCM buffer plus a streaming cursor for VAD/call-mode
+        // polling without losing the final full-turn waveform.
+        #expect(manifest.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
+        #expect(workspaceResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
+        #expect(appResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
+        #expect(!workspaceResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
+        #expect(!appResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
         #expect(!workspaceResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
         #expect(!appResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
         #expect(!workspaceResolved.contains("6de602c6d18daf2c1a07cef16b79b507a25feafd"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -99,11 +99,14 @@ struct RuntimePolicySourceTests {
         // adds a tracked OmniAudioLatencyBench for raw PCM vs pre-encoded
         // Parakeet call-mode measurements. `fb8fb39` makes Omni media cache
         // restore token-aware and records prompt/media topology in the bench
-        // output.
-        let currentVmlxRevision = "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
+        // output. `b57fe98` refreshes the Parakeet/RADIO integration docs
+        // consumed by Osaurus live-voice work.
+        let currentVmlxRevision = "b57fe98845bd1f678bd8f722dc50dba56f11d029"
         #expect(manifest.contains(currentVmlxRevision))
         #expect(workspaceResolved.contains(currentVmlxRevision))
         #expect(appResolved.contains(currentVmlxRevision))
+        #expect(!workspaceResolved.contains("fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"))
+        #expect(!appResolved.contains("fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"))
         #expect(!workspaceResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
         #expect(!appResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
         #expect(!workspaceResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -92,9 +92,13 @@ struct RuntimePolicySourceTests {
         // canonical multi-turn encoder so UI-generated cache boundaries can
         // be reused on growing chat prompts. `ad1d231` synchronizes before and
         // after safetensors disk writes against the GPU stream after generation.
-        #expect(manifest.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
-        #expect(workspaceResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
-        #expect(appResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
+        // `c0f8b3b` adds Nemotron Omni live-voice handoff support and preserves
+        // pre-encoded Parakeet/audio embeddings.
+        #expect(manifest.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
+        #expect(workspaceResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
+        #expect(appResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))
+        #expect(!workspaceResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
+        #expect(!appResolved.contains("ad1d23199b056ed502124717e6ca8877f2fb303a"))
         #expect(!workspaceResolved.contains("6de602c6d18daf2c1a07cef16b79b507a25feafd"))
         #expect(!appResolved.contains("6de602c6d18daf2c1a07cef16b79b507a25feafd"))
         #expect(!workspaceResolved.contains("b350af6daad0d25c39335356f56de2ae8d70226c"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -100,12 +100,15 @@ struct RuntimePolicySourceTests {
         // Parakeet call-mode measurements. `fb8fb39` makes Omni media cache
         // restore token-aware and records prompt/media topology in the bench
         // output. `b57fe98` refreshes the Parakeet/RADIO integration docs
-        // consumed by Osaurus live-voice work.
-        let currentVmlxRevision = "b57fe98845bd1f678bd8f722dc50dba56f11d029"
+        // consumed by Osaurus live-voice work. `81c8ef7` adds the
+        // OmniAudioChunkStabilityBench proof that current Parakeet embeddings
+        // cannot be concatenated safely across independently encoded chunks.
+        let currentVmlxRevision = "81c8ef7389c031292287801f761957c681d086ea"
         #expect(manifest.contains(currentVmlxRevision))
         #expect(workspaceResolved.contains(currentVmlxRevision))
         #expect(appResolved.contains(currentVmlxRevision))
-        #expect(!workspaceResolved.contains("fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"))
+        #expect(!workspaceResolved.contains("b57fe98845bd1f678bd8f722dc50dba56f11d029"))
+        #expect(!appResolved.contains("b57fe98845bd1f678bd8f722dc50dba56f11d029"))
         #expect(!appResolved.contains("fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"))
         #expect(!workspaceResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
         #expect(!appResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -97,10 +97,15 @@ struct RuntimePolicySourceTests {
         // retained live PCM buffer plus a streaming cursor for VAD/call-mode
         // polling without losing the final full-turn waveform. `638024b`
         // adds a tracked OmniAudioLatencyBench for raw PCM vs pre-encoded
-        // Parakeet call-mode measurements.
-        #expect(manifest.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
-        #expect(workspaceResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
-        #expect(appResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
+        // Parakeet call-mode measurements. `fb8fb39` makes Omni media cache
+        // restore token-aware and records prompt/media topology in the bench
+        // output.
+        let currentVmlxRevision = "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
+        #expect(manifest.contains(currentVmlxRevision))
+        #expect(workspaceResolved.contains(currentVmlxRevision))
+        #expect(appResolved.contains(currentVmlxRevision))
+        #expect(!workspaceResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
+        #expect(!appResolved.contains("638024bae655b93b1da92385ce9fb4935584fb64"))
         #expect(!workspaceResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
         #expect(!appResolved.contains("e497f61c3a68c6d70334d8a14a7ad0a58864af9b"))
         #expect(!workspaceResolved.contains("c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -104,8 +104,11 @@ struct RuntimePolicySourceTests {
         // OmniAudioChunkStabilityBench proof that current Parakeet embeddings
         // cannot be concatenated safely across independently encoded chunks.
         // `f728718` fixes DSV4 Flash long-prompt HSA selection by masking
-        // future compressed-pool chunks before indexer top-k.
-        let currentVmlxRevision = "f72871888e951929a11f7aabe14d9ea9024f1773"
+        // future compressed-pool chunks before indexer top-k. `6561a72`
+        // preserves DSV4's ratio-4 overlap-compressor state across decode
+        // calls, preventing the previous complete pool window from being
+        // zeroed after a single-token generation boundary.
+        let currentVmlxRevision = "6561a72f93d6cd5e0202e8067b53fed5cf21a660"
         #expect(manifest.contains(currentVmlxRevision))
         #expect(workspaceResolved.contains(currentVmlxRevision))
         #expect(appResolved.contains(currentVmlxRevision))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -103,7 +103,9 @@ struct RuntimePolicySourceTests {
         // consumed by Osaurus live-voice work. `81c8ef7` adds the
         // OmniAudioChunkStabilityBench proof that current Parakeet embeddings
         // cannot be concatenated safely across independently encoded chunks.
-        let currentVmlxRevision = "81c8ef7389c031292287801f761957c681d086ea"
+        // `f728718` fixes DSV4 Flash long-prompt HSA selection by masking
+        // future compressed-pool chunks before indexer top-k.
+        let currentVmlxRevision = "f72871888e951929a11f7aabe14d9ea9024f1773"
         #expect(manifest.contains(currentVmlxRevision))
         #expect(workspaceResolved.contains(currentVmlxRevision))
         #expect(appResolved.contains(currentVmlxRevision))

--- a/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
@@ -122,6 +122,22 @@ struct StreamingHintTests {
         #expect(decoded?.unclosedReasoning == true)
     }
 
+    @Test func statsHint_encode_includesStopReasonWhenPresent() {
+        let encoded = StreamingStatsHint.encode(
+            tokenCount: 300,
+            tokensPerSecond: 5.25,
+            stopReason: "length"
+        )
+        #expect(encoded.hasSuffix(";stop=length"))
+    }
+
+    @Test func statsHint_decode_recoversStopReasonAlongsideUnclosedFlag() {
+        let payload = "\u{FFFE}stats:10;5.0;futureflag,unclosed,stop=length"
+        let decoded = StreamingStatsHint.decode(payload)
+        #expect(decoded?.unclosedReasoning == true)
+        #expect(decoded?.stopReason == "length")
+    }
+
     // Issue #856 regression: the sentinel must NEVER appear in the
     // visible text of an assistant message. ChatView filters it out
     // before render. Here we lock in the contract that the decoder

--- a/Packages/OsaurusCore/Tests/Voice/LiveVoiceAudioSnapshotTests.swift
+++ b/Packages/OsaurusCore/Tests/Voice/LiveVoiceAudioSnapshotTests.swift
@@ -1,0 +1,27 @@
+//
+//  LiveVoiceAudioSnapshotTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Live voice audio snapshot")
+struct LiveVoiceAudioSnapshotTests {
+    @Test("snapshot encodes mono Float PCM as 16-bit WAV")
+    func snapshotEncodesWAV() throws {
+        let snapshot = LiveVoiceAudioSnapshot(
+            samples: [-1.0, 0.0, 1.0],
+            sampleRate: 16_000)
+
+        let wav = snapshot.wavData()
+
+        #expect(String(data: wav[0 ..< 4], encoding: .ascii) == "RIFF")
+        #expect(String(data: wav[8 ..< 12], encoding: .ascii) == "WAVE")
+        #expect(String(data: wav[12 ..< 16], encoding: .ascii) == "fmt ")
+        #expect(String(data: wav[36 ..< 40], encoding: .ascii) == "data")
+        #expect(wav.count == 44 + 6)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Voice/LiveVoiceResidentPreencodeIntegrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Voice/LiveVoiceResidentPreencodeIntegrationTests.swift
@@ -1,0 +1,225 @@
+//
+//  LiveVoiceResidentPreencodeIntegrationTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@testable import OsaurusCore
+
+private let isResidentOmniPreencodeEnabled =
+    ProcessInfo.processInfo.environment["OSAURUS_RUN_REAL_OMNI_PREENCODE"] == "1"
+
+@Suite(
+    "Resident Nemotron Omni live voice preencode integration",
+    .serialized,
+    .disabled(
+        if: !isResidentOmniPreencodeEnabled,
+        "Set OSAURUS_RUN_REAL_OMNI_PREENCODE=1, OSU_MODELS_DIR, OSAURUS_OMNI_MODEL, and OSAURUS_OMNI_AUDIO to run."
+    )
+)
+struct LiveVoiceResidentPreencodeIntegrationTests {
+    @Test("resident model stores fresh preencoded live audio")
+    func residentModelStoresFreshPreencodedLiveAudio() async throws {
+        try Self.prepareMLXMetallibForSwiftPMTest()
+
+        let env = ProcessInfo.processInfo.environment
+        let modelName = env["OSAURUS_OMNI_MODEL"] ?? "nemotron-omni-nano-jangtq-crack"
+        let audioPath = try #require(
+            env["OSAURUS_OMNI_AUDIO"],
+            "OSAURUS_OMNI_AUDIO must point to a real audio file."
+        )
+        let audioURL = URL(fileURLWithPath: audioPath)
+        #expect(FileManager.default.fileExists(atPath: audioURL.path))
+
+        LiveVoiceAudioInputRegistry.shared.removeAll()
+        defer { LiveVoiceAudioInputRegistry.shared.removeAll() }
+
+        let warmStart = CFAbsoluteTimeGetCurrent()
+        _ = try await MLXService.shared.generateOneShot(
+            messages: [ChatMessage(role: "user", content: "Reply with: ready")],
+            parameters: GenerationParameters(
+                temperature: 0,
+                maxTokens: 4,
+                modelOptions: ["reasoningEffort": .string("no_think")]
+            ),
+            requestedModel: modelName
+        )
+        let warmMs = Int((CFAbsoluteTimeGetCurrent() - warmStart) * 1000)
+
+        let resident = try #require(
+            await ModelRuntime.shared.cachedModelSummaries()
+                .first { ModelFamilyNames.isNemotronOmniFamily($0.name) },
+            "Expected a resident Nemotron Omni model after warmup."
+        )
+
+        let samples = try nemotronOmniLoadAudioFile(audioURL, targetSampleRate: 16_000)
+        #expect(!samples.isEmpty)
+
+        let attachmentId = UUID()
+        let result = await ModelRuntime.shared.preencodeLiveVoiceAudioIfResident(
+            modelName: resident.name,
+            attachmentId: attachmentId,
+            samples: samples,
+            sampleRate: 16_000
+        )
+
+        #expect(result.status == .stored)
+        #expect(result.sampleCount == samples.count)
+        #expect(result.sampleRate == 16_000)
+        #expect(result.encodeMs > 0)
+
+        let metadata = try #require(LiveVoiceAudioInputRegistry.shared.preencodedMetadata(for: attachmentId))
+        #expect(metadata.sourceSampleCount == samples.count)
+        #expect(metadata.sampleRate == 16_000)
+        #expect(metadata.encodeMs == result.encodeMs)
+
+        let preencoded = try #require(
+            LiveVoiceAudioInputRegistry.shared.freshPreencodedAudio(
+                for: attachmentId,
+                sourceSampleCount: samples.count,
+                sampleRate: 16_000
+            )
+        )
+        guard case .preEncoded(let encodedSamples, let encodedSampleRate, let embedding) = preencoded else {
+            Issue.record("Expected fresh registry lookup to return preEncoded audio.")
+            return
+        }
+
+        #expect(!encodedSamples.isEmpty)
+        #expect(encodedSampleRate == 16_000)
+        #expect(!embedding.shape.isEmpty)
+
+        #expect(
+            LiveVoiceAudioInputRegistry.shared.freshPreencodedAudio(
+                for: attachmentId,
+                sourceSampleCount: samples.count + 1,
+                sampleRate: 16_000
+            ) == nil
+        )
+
+        print(
+            "[Osaurus][LiveVoiceIntegration] model=\(resident.name) warm_ms=\(warmMs) samples=\(samples.count) encode_ms=\(result.encodeMs) embedding_shape=\(embedding.shape)"
+        )
+    }
+
+    private static func prepareMLXMetallibForSwiftPMTest() throws {
+        let fileManager = FileManager.default
+        guard let sourceURL = try findMLXMetallib(fileManager: fileManager) else {
+            throw NSError(
+                domain: "LiveVoiceResidentPreencodeIntegrationTests",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Unable to find MLX default.metallib. Build the osaurus app first or set OSAURUS_MLX_METALLIB to the metallib path."
+                ]
+            )
+        }
+
+        for directory in metallibDestinationDirectories(fileManager: fileManager) {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            for filename in ["default.metallib", "mlx.metallib"] {
+                let destination = directory.appendingPathComponent(filename)
+                if !fileManager.fileExists(atPath: destination.path) {
+                    try fileManager.copyItem(at: sourceURL, to: destination)
+                }
+            }
+        }
+    }
+
+    private static func findMLXMetallib(fileManager: FileManager) throws -> URL? {
+        let env = ProcessInfo.processInfo.environment
+        var candidates: [URL] = []
+
+        if let envPath = env["OSAURUS_MLX_METALLIB"], !envPath.isEmpty {
+            candidates.append(URL(fileURLWithPath: envPath))
+        }
+        for directory in metallibDestinationDirectories(fileManager: fileManager) {
+            candidates.append(directory.appendingPathComponent("default.metallib"))
+            candidates.append(directory.appendingPathComponent("mlx.metallib"))
+        }
+
+        let root = repoRoot
+        candidates.append(
+            root.appendingPathComponent(
+                "build/XcodeDerivedData-livevoice/Build/Products/Debug/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+            )
+        )
+        candidates.append(
+            root.appendingPathComponent(
+                "build/XcodeDerivedData-livevoice/Build/Products/Debug/osaurus.app/Contents/Resources/default.metallib"
+            )
+        )
+        candidates.append(
+            root.appendingPathComponent(
+                "build/XcodeDerivedData-livevoice/Build/Products/Debug/default.metallib"
+            )
+        )
+
+        for candidate in candidates {
+            if fileManager.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func metallibDestinationDirectories(fileManager: FileManager) -> [URL] {
+        var candidates: [URL] = []
+
+        if let executableURL = Bundle.main.executableURL {
+            candidates.append(executableURL.deletingLastPathComponent())
+        }
+        if let resourceURL = Bundle.main.resourceURL {
+            candidates.append(resourceURL)
+        }
+        if let firstArgument = CommandLine.arguments.first, !firstArgument.isEmpty {
+            candidates.append(URL(fileURLWithPath: firstArgument).deletingLastPathComponent())
+        }
+
+        let packageRoot = packageRoot
+        candidates.append(packageRoot.appendingPathComponent(".build/arm64-apple-macosx/debug"))
+        candidates.append(
+            packageRoot.appendingPathComponent(
+                ".build/arm64-apple-macosx/debug/OsaurusCorePackageTests.xctest/Contents/MacOS"
+            )
+        )
+        candidates.append(
+            packageRoot.appendingPathComponent(
+                ".build/arm64-apple-macosx/debug/OsaurusCorePackageTests.xctest/Contents/Resources"
+            )
+        )
+        candidates.append(packageRoot.appendingPathComponent(".build/debug"))
+        candidates.append(
+            packageRoot.appendingPathComponent(
+                ".build/debug/OsaurusCorePackageTests.xctest/Contents/MacOS"
+            )
+        )
+        candidates.append(
+            packageRoot.appendingPathComponent(
+                ".build/debug/OsaurusCorePackageTests.xctest/Contents/Resources"
+            )
+        )
+
+        var seen: Set<String> = []
+        return candidates.compactMap { url in
+            let standardized = url.standardizedFileURL
+            guard standardized.path.hasPrefix(packageRoot.path + "/") else {
+                return nil
+            }
+            return seen.insert(standardized.path).inserted ? standardized : nil
+        }
+    }
+
+    private static let packageRoot: URL = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    private static let repoRoot: URL = packageRoot
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}

--- a/Packages/OsaurusCore/Tests/Voice/LiveVoiceResidentPreencodeIntegrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Voice/LiveVoiceResidentPreencodeIntegrationTests.swift
@@ -101,8 +101,39 @@ struct LiveVoiceResidentPreencodeIntegrationTests {
             ) == nil
         )
 
+        let snapshot = LiveVoiceAudioSnapshot(samples: samples, sampleRate: 16_000)
+        LiveVoiceAudioInputRegistry.shared.store(snapshot: snapshot, for: attachmentId)
+        let audioAttachment = Attachment(
+            id: attachmentId,
+            kind: .audio(snapshot.wavData(), format: "wav", filename: "voice-input.wav")
+        )
+        let chatMessage = await MainActor.run {
+            ChatSession.buildUserChatMessage(
+                content: "What is in this audio?",
+                attachments: [audioAttachment],
+                supportsImages: false,
+                supportsAudio: true,
+                supportsVideo: false
+            )
+        }
+        #expect(chatMessage.audioInputsWithLocalSamples.count == 1)
+        #expect(chatMessage.audioInputsWithLocalSamples[0].localSamples?.preencodedAttachmentId == attachmentId)
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([chatMessage])
+        #expect(mapped.count == 1)
+        #expect(mapped[0].audios.count == 1)
+        guard case .preEncoded(let submittedSamples, let submittedSampleRate, let submittedEmbedding) =
+            mapped[0].audios[0]
+        else {
+            Issue.record("Composer-style audio submit should consume fresh preencoded audio.")
+            return
+        }
+        #expect(submittedSamples.count == samples.count)
+        #expect(submittedSampleRate == 16_000)
+        #expect(submittedEmbedding.shape == embedding.shape)
+
         print(
-            "[Osaurus][LiveVoiceIntegration] model=\(resident.name) warm_ms=\(warmMs) samples=\(samples.count) encode_ms=\(result.encodeMs) embedding_shape=\(embedding.shape)"
+            "[Osaurus][LiveVoiceIntegration] model=\(resident.name) warm_ms=\(warmMs) samples=\(samples.count) encode_ms=\(result.encodeMs) embedding_shape=\(embedding.shape) composer_submit=preencoded"
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -399,6 +399,7 @@ final class ChatSession: ObservableObject {
     var selectedModelSupportsImages: Bool {
         guard let model = selectedModel else { return false }
         if model.lowercased() == "foundation" { return false }
+        if ModelMediaCapabilities.from(modelId: model).supportsImage { return true }
         guard let option = pickerItems.first(where: { $0.id == model }) else { return false }
         if case .remote = option.source { return true }
         return option.isVLM

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -588,9 +588,11 @@ final class ChatSession: ObservableObject {
     ) -> ChatMessage {
         let messageText = buildUserMessageText(content: content, attachments: attachments)
         let imageData = supportsImages ? attachments.images : []
-        let audios: [(data: Data, format: String)] = supportsAudio
+        let audioPayloads = supportsAudio
             ? attachments.compactMap(audioPayload)
             : []
+        let audios = audioPayloads.map { (data: $0.data, format: $0.format) }
+        let localAudioSamples = audioPayloads.map(\.localSamples)
         let videos: [(data: Data, mimeSubtype: String)] = supportsVideo
             ? attachments.compactMap(videoPayload)
             : []
@@ -601,6 +603,7 @@ final class ChatSession: ObservableObject {
                 text: messageText,
                 imageData: imageData,
                 audios: audios,
+                localAudioSamples: localAudioSamples,
                 videos: videos
             )
         }
@@ -608,12 +611,20 @@ final class ChatSession: ObservableObject {
         return ChatMessage(role: "user", content: messageText)
     }
 
-    private static func audioPayload(from attachment: Attachment) -> (data: Data, format: String)? {
+    private static func audioPayload(from attachment: Attachment) -> (
+        data: Data,
+        format: String,
+        localSamples: LocalAudioSamples?
+    )? {
         guard attachment.isAudio, let data = attachment.loadAudioData() else { return nil }
         let format = attachment.audioFormat?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        return (data, (format?.isEmpty == false) ? format! : "wav")
+        return (
+            data,
+            (format?.isEmpty == false) ? format! : "wav",
+            LiveVoiceAudioInputRegistry.shared.samples(for: attachment.id)
+        )
     }
 
     private static func videoPayload(from attachment: Attachment) -> (data: Data, mimeSubtype: String)? {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -404,6 +404,16 @@ final class ChatSession: ObservableObject {
         return option.isVLM
     }
 
+    var selectedModelSupportsAudio: Bool {
+        guard let model = selectedModel else { return false }
+        return ModelMediaCapabilities.from(modelId: model).supportsAudio
+    }
+
+    var selectedModelSupportsVideo: Bool {
+        guard let model = selectedModel else { return false }
+        return ModelMediaCapabilities.from(modelId: model).supportsVideo
+    }
+
     /// Get the currently selected ModelPickerItem
     var selectedPickerItem: ModelPickerItem? {
         guard let model = selectedModel else { return nil }
@@ -567,6 +577,64 @@ final class ChatSession: ObservableObject {
         }
 
         return parts.joined(separator: "\n\n")
+    }
+
+    static func buildUserChatMessage(
+        content: String,
+        attachments: [Attachment],
+        supportsImages: Bool,
+        supportsAudio: Bool,
+        supportsVideo: Bool
+    ) -> ChatMessage {
+        let messageText = buildUserMessageText(content: content, attachments: attachments)
+        let imageData = supportsImages ? attachments.images : []
+        let audios: [(data: Data, format: String)] = supportsAudio
+            ? attachments.compactMap(audioPayload)
+            : []
+        let videos: [(data: Data, mimeSubtype: String)] = supportsVideo
+            ? attachments.compactMap(videoPayload)
+            : []
+
+        if !imageData.isEmpty || !audios.isEmpty || !videos.isEmpty {
+            return ChatMessage(
+                role: "user",
+                text: messageText,
+                imageData: imageData,
+                audios: audios,
+                videos: videos
+            )
+        }
+
+        return ChatMessage(role: "user", content: messageText)
+    }
+
+    private static func audioPayload(from attachment: Attachment) -> (data: Data, format: String)? {
+        guard attachment.isAudio, let data = attachment.loadAudioData() else { return nil }
+        let format = attachment.audioFormat?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return (data, (format?.isEmpty == false) ? format! : "wav")
+    }
+
+    private static func videoPayload(from attachment: Attachment) -> (data: Data, mimeSubtype: String)? {
+        guard attachment.isVideo, let data = attachment.loadVideoData() else { return nil }
+        return (data, videoMimeSubtype(for: attachment.filename))
+    }
+
+    private static func videoMimeSubtype(for filename: String?) -> String {
+        let ext = ((filename ?? "") as NSString).pathExtension
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        switch ext {
+        case "mov", "qt", "quicktime":
+            return "quicktime"
+        case "m4v":
+            return "mp4"
+        case "":
+            return "mp4"
+        default:
+            return ext
+        }
     }
 
     private static func escapeAttachmentName(_ raw: String) -> String {
@@ -1671,13 +1739,13 @@ final class ChatSession: ObservableObject {
                             tool_call_id: t.toolCallId
                         )
                     case .user:
-                        let messageText = Self.buildUserMessageText(content: t.content, attachments: t.attachments)
-                        let imageData = selectedModelSupportsImages ? t.attachments.images : []
-                        if !imageData.isEmpty {
-                            return ChatMessage(role: "user", text: messageText, imageData: imageData)
-                        } else {
-                            return ChatMessage(role: t.role.rawValue, content: messageText)
-                        }
+                        return Self.buildUserChatMessage(
+                            content: t.content,
+                            attachments: t.attachments,
+                            supportsImages: selectedModelSupportsImages,
+                            supportsAudio: selectedModelSupportsAudio,
+                            supportsVideo: selectedModelSupportsVideo
+                        )
                     default:
                         return ChatMessage(role: t.role.rawValue, content: t.content)
                     }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1351,6 +1351,7 @@ final class ChatSession: ObservableObject {
                     let now = Date()
                     if firstDeltaTime == nil {
                         firstDeltaTime = now
+                        ttftTrace?.set("first_chunk_ms", Int(now.timeIntervalSince(streamStartTime) * 1000))
                         ttftTrace?.mark("first_text_delta")
                         ttftTrace?.set("model", selectedModel ?? "unknown")
                         ttftTrace?.emit()
@@ -1371,6 +1372,7 @@ final class ChatSession: ObservableObject {
                     let now = Date()
                     if firstDeltaTime == nil {
                         firstDeltaTime = now
+                        ttftTrace?.set("first_chunk_ms", Int(now.timeIntervalSince(streamStartTime) * 1000))
                         ttftTrace?.mark("first_text_delta")
                         ttftTrace?.set("model", selectedModel ?? "unknown")
                         ttftTrace?.emit()

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -841,6 +841,7 @@ extension FloatingInputCard {
     private func sendVoiceMessage(_ message: String) {
         print("[FloatingInputCard] Sending voice message. Continuous mode: \(isContinuousVoiceMode)")
         logVoiceState(trigger: "sendVoiceMessage-start")
+        let voiceAudioData = mediaCapabilities.supportsAudio ? speechService.currentLiveAudioWAVData() : nil
 
         // show sending state first
         voiceInputState = .sending
@@ -861,6 +862,14 @@ extension FloatingInputCard {
 
                 let existing = localText.trimmingCharacters(in: .whitespacesAndNewlines)
                 let fullMessage = existing.isEmpty ? cleanedMessage : "\(existing) \(cleanedMessage)"
+
+                if let voiceAudioData {
+                    pendingAttachments.append(.audio(
+                        voiceAudioData,
+                        format: "wav",
+                        filename: "voice-input.wav"
+                    ))
+                }
 
                 // try to paste. if it fails (permissions), we fall back to direct text setting
                 if KeyboardSimulationService.shared.pasteText(cleanedMessage) {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -841,7 +841,17 @@ extension FloatingInputCard {
     private func sendVoiceMessage(_ message: String) {
         print("[FloatingInputCard] Sending voice message. Continuous mode: \(isContinuousVoiceMode)")
         logVoiceState(trigger: "sendVoiceMessage-start")
-        let voiceAudioData = mediaCapabilities.supportsAudio ? speechService.currentLiveAudioWAVData() : nil
+        let voiceCaptureStart = CFAbsoluteTimeGetCurrent()
+        let voiceSnapshot = mediaCapabilities.supportsAudio ? speechService.currentLiveAudioSnapshot() : nil
+        let snapshotMs = Int((CFAbsoluteTimeGetCurrent() - voiceCaptureStart) * 1000)
+        let wavEncodeStart = CFAbsoluteTimeGetCurrent()
+        let voiceAudioData = voiceSnapshot?.wavData()
+        let wavEncodeMs = Int((CFAbsoluteTimeGetCurrent() - wavEncodeStart) * 1000)
+        if mediaCapabilities.supportsAudio {
+            let wavBytes = voiceAudioData?.count ?? 0
+            let durationMs = Int((voiceSnapshot?.durationSeconds ?? 0) * 1000)
+            print("[Osaurus][LiveVoice] snapshot_ms=\(snapshotMs) wav_encode_ms=\(wavEncodeMs) wav_bytes=\(wavBytes) sample_rate=\(voiceSnapshot?.sampleRate ?? 0) duration_ms=\(durationMs)")
+        }
 
         // show sending state first
         voiceInputState = .sending

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -874,11 +874,18 @@ extension FloatingInputCard {
                 let fullMessage = existing.isEmpty ? cleanedMessage : "\(existing) \(cleanedMessage)"
 
                 if let voiceAudioData {
-                    pendingAttachments.append(.audio(
+                    let voiceAttachment = Attachment.audio(
                         voiceAudioData,
                         format: "wav",
                         filename: "voice-input.wav"
-                    ))
+                    )
+                    if let voiceSnapshot {
+                        LiveVoiceAudioInputRegistry.shared.store(
+                            snapshot: voiceSnapshot,
+                            for: voiceAttachment.id
+                        )
+                    }
+                    pendingAttachments.append(voiceAttachment)
                 }
 
                 // try to paste. if it fails (permissions), we fall back to direct text setting

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -174,6 +174,10 @@ struct FloatingInputCard: View {
     @State private var lastConfirmedLength: Int = 0
 
     @State private var pauseTimerCancellable: AnyCancellable? = nil
+    @State private var liveVoiceAttachmentId: UUID?
+    @State private var liveVoicePreencodeTask: Task<Void, Never>?
+    @State private var lastLiveVoicePreencodeAt: Date = .distantPast
+    @State private var lastLiveVoicePreencodeSampleCount: Int = 0
 
     // TextEditor should grow up to ~6 lines before scrolling
     private var inputFontSize: CGFloat { CGFloat(theme.bodySize) }
@@ -428,6 +432,7 @@ struct FloatingInputCard: View {
                     print("[FloatingInputCard] onDisappear: Stopping active voice recording")
                     // Don't use cancelVoiceInput() here as it forces continuous mode off.
                     // Instead, just stop recording but preserve the mode.
+                    cancelLiveVoicePreencodeSession(removeRegistryEntry: true)
                     Task {
                         _ = await speechService.stopStreamingTranscription()
                         speechService.clearTranscription()
@@ -521,6 +526,7 @@ struct FloatingInputCard: View {
                             checkForPause()
                             checkForSilenceTimeout()
                             handlePauseCountdown()
+                            scheduleLiveVoicePreencodeIfNeeded()
                         }
                 } else {
                     pauseTimerCancellable = nil
@@ -660,6 +666,9 @@ extension FloatingInputCard {
         if speechService.isRecording {
             print("[FloatingInputCard] startVoiceInput: Recording already active, ensuring UI is visible")
             showVoiceOverlay = true
+            if liveVoiceAttachmentId == nil {
+                beginLiveVoicePreencodeSession()
+            }
             if voiceInputState == .idle {
                 voiceInputState = .recording
                 lastVoiceActivityTime = Date()
@@ -674,6 +683,7 @@ extension FloatingInputCard {
         // Show overlay immediately for visual feedback, but don't set recording state yet.
         // Recording state will be set when speechService.isRecording becomes true.
         showVoiceOverlay = true
+        beginLiveVoicePreencodeSession()
 
         Task {
             do {
@@ -704,11 +714,90 @@ extension FloatingInputCard {
         }
     }
 
+    private func beginLiveVoicePreencodeSession() {
+        if let oldId = liveVoiceAttachmentId {
+            LiveVoiceAudioInputRegistry.shared.remove(for: oldId)
+        }
+        liveVoicePreencodeTask?.cancel()
+        liveVoicePreencodeTask = nil
+        liveVoiceAttachmentId = UUID()
+        lastLiveVoicePreencodeAt = .distantPast
+        lastLiveVoicePreencodeSampleCount = 0
+    }
+
+    private func cancelLiveVoicePreencodeSession(removeRegistryEntry: Bool) {
+        liveVoicePreencodeTask?.cancel()
+        liveVoicePreencodeTask = nil
+        if removeRegistryEntry, let id = liveVoiceAttachmentId {
+            LiveVoiceAudioInputRegistry.shared.remove(for: id)
+        }
+        liveVoiceAttachmentId = nil
+        lastLiveVoicePreencodeAt = .distantPast
+        lastLiveVoicePreencodeSampleCount = 0
+    }
+
+    @discardableResult
+    private func scheduleLiveVoicePreencodeIfNeeded(
+        force: Bool = false,
+        snapshot providedSnapshot: LiveVoiceAudioSnapshot? = nil,
+        attachmentId providedAttachmentId: UUID? = nil
+    ) -> Task<Void, Never>? {
+        guard mediaCapabilities.supportsAudio,
+            let modelName = selectedModel,
+            ModelFamilyNames.isNemotronOmniFamily(modelName)
+        else {
+            return nil
+        }
+
+        guard let snapshot = providedSnapshot ?? speechService.currentLiveAudioSnapshot(),
+            !snapshot.samples.isEmpty
+        else {
+            return nil
+        }
+
+        let attachmentId: UUID
+        if let providedAttachmentId {
+            attachmentId = providedAttachmentId
+        } else if let existing = liveVoiceAttachmentId {
+            attachmentId = existing
+        } else {
+            let newId = UUID()
+            liveVoiceAttachmentId = newId
+            attachmentId = newId
+        }
+
+        let sampleCount = snapshot.samples.count
+        let minSampleDelta = max(4_000, snapshot.sampleRate / 2)
+        if !force {
+            guard sampleCount >= minSampleDelta else { return nil }
+            guard Date().timeIntervalSince(lastLiveVoicePreencodeAt) >= 0.75 else { return nil }
+            guard sampleCount - lastLiveVoicePreencodeSampleCount >= minSampleDelta else { return nil }
+        }
+
+        lastLiveVoicePreencodeAt = Date()
+        lastLiveVoicePreencodeSampleCount = sampleCount
+
+        let samples = snapshot.samples
+        let sampleRate = snapshot.sampleRate
+        let task = Task.detached(priority: .utility) {
+            let result = await ModelRuntime.shared.preencodeLiveVoiceAudioIfResident(
+                modelName: modelName,
+                attachmentId: attachmentId,
+                samples: samples,
+                sampleRate: sampleRate
+            )
+            print("[Osaurus][LiveVoice] preencode_status=\(result.status.rawValue) samples=\(result.sampleCount) sample_rate=\(result.sampleRate) encode_ms=\(result.encodeMs) message=\(result.message ?? "")")
+        }
+        liveVoicePreencodeTask = task
+        return task
+    }
+
     private func cancelVoiceInput() {
         print("[FloatingInputCard] User cancelled voice input - disabling continuous mode")
         hasDetectedSpeechThisTurn = false
         lastConfirmedLength = 0
         isContinuousVoiceMode = false
+        cancelLiveVoicePreencodeSession(removeRegistryEntry: true)
         Task {
             _ = await speechService.stopStreamingTranscription()
             speechService.clearTranscription()
@@ -830,6 +919,7 @@ extension FloatingInputCard {
     }
 
     private func stopVoiceInputFromTimeout() {
+        cancelLiveVoicePreencodeSession(removeRegistryEntry: true)
         Task {
             _ = await speechService.stopStreamingTranscription(force: false)
             speechService.clearTranscription()
@@ -847,6 +937,15 @@ extension FloatingInputCard {
         let wavEncodeStart = CFAbsoluteTimeGetCurrent()
         let voiceAudioData = voiceSnapshot?.wavData()
         let wavEncodeMs = Int((CFAbsoluteTimeGetCurrent() - wavEncodeStart) * 1000)
+        let voiceAttachmentId = liveVoiceAttachmentId ?? UUID()
+        liveVoiceAttachmentId = voiceAttachmentId
+        let finalPreencodeTask = voiceSnapshot.flatMap {
+            scheduleLiveVoicePreencodeIfNeeded(
+                force: true,
+                snapshot: $0,
+                attachmentId: voiceAttachmentId
+            )
+        }
         if mediaCapabilities.supportsAudio {
             let wavBytes = voiceAudioData?.count ?? 0
             let durationMs = Int((voiceSnapshot?.durationSeconds ?? 0) * 1000)
@@ -865,6 +964,7 @@ extension FloatingInputCard {
             print("[FloatingInputCard] Invoking cleanup for voice message (\(message.count) chars)")
             let cleanedMessage = await TranscriptionCleanupService.shared.clean(message)
             print("[FloatingInputCard] Cleanup done. Original: \(message) | Cleaned: \(cleanedMessage)")
+            await finalPreencodeTask?.value
 
             await MainActor.run {
                 voiceInputState = .idle
@@ -874,10 +974,13 @@ extension FloatingInputCard {
                 let fullMessage = existing.isEmpty ? cleanedMessage : "\(existing) \(cleanedMessage)"
 
                 if let voiceAudioData {
-                    let voiceAttachment = Attachment.audio(
-                        voiceAudioData,
-                        format: "wav",
-                        filename: "voice-input.wav"
+                    let voiceAttachment = Attachment(
+                        id: voiceAttachmentId,
+                        kind: .audio(
+                            voiceAudioData,
+                            format: "wav",
+                            filename: "voice-input.wav"
+                        )
                     )
                     if let voiceSnapshot {
                         LiveVoiceAudioInputRegistry.shared.store(
@@ -905,6 +1008,7 @@ extension FloatingInputCard {
                     text = ""
                     onSend(fullMessage)
                 }
+                cancelLiveVoicePreencodeSession(removeRegistryEntry: voiceAudioData == nil)
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2266,27 +2266,29 @@ extension FloatingInputCard {
     }
 
     /// Capability-gated UTType allowlist for both the file picker and
-    /// the drop zone. Resolves from `selectedModel`; non-multimodal
-    /// models stay at images + documents only. Audio appears only for
-    /// Nemotron-3-Nano-Omni; video appears for Qwen-VL family +
-    /// SmolVLM 2 + Nemotron-Omni.
+    /// the drop zone. Resolves from `selectedModel` plus the session's
+    /// already-known image support bit. Text-only models keep document
+    /// attach support but reject image/audio/video media.
     ///
     /// See `Models/Configuration/ModelMediaCapabilities.swift` for the
     /// substring/regex matcher; tests pin the boundary at
     /// `ModelMediaCapabilitiesMCDCTests`.
     private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
-        guard let modelId = selectedModel else { return .imageOnly }
-        return ModelMediaCapabilities.from(modelId: modelId)
+        ModelMediaCapabilities.composerCapabilities(
+            modelId: selectedModel,
+            fallbackSupportsImages: supportsImages
+        )
     }
 
-    /// UTTypes the drop zone advertises. Image + fileURL always — image
-    /// is universally supported across multimodal models, fileURL covers
-    /// document parsing. Audio + movie/video are conditional on the
-    /// loaded model's capabilities so users can't drop a wav onto a
-    /// dense LLM and have it silently ignored.
+    /// UTTypes the drop zone advertises. `fileURL` stays enabled for
+    /// documents, while image/audio/video are advertised only when the
+    /// selected model can consume them.
     private var dropAcceptedTypes: [UTType] {
-        var types: [UTType] = [UTType.image, UTType.fileURL]
+        var types: [UTType] = [UTType.fileURL]
         let cap = mediaCapabilities
+        if cap.supportsImage {
+            types.append(.image)
+        }
         if cap.supportsAudio {
             types.append(.audio)
             // explicit common audio formats so HEIF-style "any audio"
@@ -2309,9 +2311,12 @@ extension FloatingInputCard {
     /// only). Picker shows audio/video formats only when the loaded
     /// model can actually consume them.
     private var pickerAllowedTypes: [UTType] {
-        var types: [UTType] = [UTType.image]
-        types.append(contentsOf: DocumentParser.supportedDocumentTypes)
+        var types: [UTType] = []
         let cap = mediaCapabilities
+        if cap.supportsImage {
+            types.append(.image)
+        }
+        types.append(contentsOf: DocumentParser.supportedDocumentTypes)
         if cap.supportsAudio {
             types.append(.audio)
             types.append(.mp3)
@@ -2353,8 +2358,18 @@ extension FloatingInputCard {
         let ext = url.pathExtension.lowercased()
         let cap = mediaCapabilities
 
-        // Image fast path — universally supported among VLMs.
+        // Image fast path — only for image-capable models.
         if DocumentParser.isImageFile(url: url) {
+            guard cap.supportsImage else {
+                ToastManager.shared.error(
+                    "Cannot attach \(url.lastPathComponent)",
+                    message:
+                        cap.anyMedia
+                        ? "The current model supports \(cap.summary) only."
+                        : "The current model is text-only."
+                )
+                return
+            }
             if let data = try? Data(contentsOf: url), data.count <= maxImageSize,
                 let nsImage = NSImage(data: data),
                 let pngData = nsImage.pngData()
@@ -2455,7 +2470,9 @@ extension FloatingInputCard {
         let cap = mediaCapabilities
 
         for provider in providers {
-            if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+            if cap.supportsImage,
+                provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+            {
                 handled = true
                 provider.loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
                     guard let data = data, error == nil, data.count <= maxImageSize else { return }
@@ -2567,7 +2584,7 @@ extension FloatingInputCard {
         }
         .background(
             PasteboardImageMonitor(
-                supportsImages: supportsImages,
+                supportsImages: mediaCapabilities.supportsImage,
                 onImagePaste: { imageData in
                     withAnimation(theme.springAnimation()) {
                         pendingAttachments.append(.image(imageData))

--- a/docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md
+++ b/docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md
@@ -1,0 +1,392 @@
+# Multimodal plugin and engine integration spec
+
+This is the working spec for an Osaurus council or multimodal chat plugin.
+The expected product shape is:
+
+- Users bring their own provider keys.
+- The plugin can call local Osaurus/vmlx models and remote OpenAI-compatible
+  providers.
+- Image, video, audio, reasoning, and tool calls use the same structured chat
+  contracts that the main app uses.
+- The plugin does not invent its own prompt serializer unless the target
+  provider requires it.
+
+## Recommended integration paths
+
+There are two supported ways to call multimodal generation.
+
+### Path A: Osaurus OpenAI-compatible HTTP API
+
+Use this for most plugins. It is stable, provider-like, and naturally works
+with BYO keys and remote/local routing.
+
+Endpoints:
+
+```text
+POST /v1/chat/completions
+POST /chat/completions
+```
+
+Message content parts supported by Osaurus:
+
+| Part type | Shape | Local mapping |
+|---|---|---|
+| `text` | `{ "type": "text", "text": "..." }` | message text |
+| `image_url` | `{ "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }` | `UserInput.Image.url` after materialization |
+| `input_audio` | `{ "type": "input_audio", "input_audio": { "data": "<base64>", "format": "wav" } }` | valid WAV to `UserInput.Audio.samples`; fallback file URL for converter-backed formats |
+| `video_url` | `{ "type": "video_url", "video_url": { "url": "data:video/mp4;base64,..." } }` | temp file, then `UserInput.Video.url` |
+
+Assistant messages may include:
+
+- `reasoning_content`: prior hidden/visible thinking text that local thinking
+  templates may need on follow-up turns.
+- `tool_calls`: OpenAI-style structured tool calls.
+
+Tool-role messages should include:
+
+- `tool_call_id`: the id from the assistant tool call being answered.
+
+### Path B: In-process vmlx Swift
+
+Use this only for core Osaurus code or a trusted local plugin host that links
+against vmlx. This path gives direct access to `ModelContainer`, but it also
+means the plugin owns load policy, memory policy, cancellation, and event
+routing.
+
+Current vmlx primitives:
+
+| API | Purpose |
+|---|---|
+| `MLXLMCommon.Chat.Message` | Structured role/content/media/tool/reasoning turn |
+| `MLXLMCommon.UserInput` | Prompt plus images, videos, audios, tools, and template context |
+| `ModelContainer.prepare(input:)` | Runs tokenizer, chat template, and media processor |
+| `ModelContainer.generate(input:parameters:)` | Streams generation events |
+| `GenerateParameters` | max tokens, sampling, prefill step, KV quant, compile flags, stop strings |
+| `Generation.chunk` | Visible assistant text |
+| `Generation.reasoning` | Reasoning pane delta |
+| `Generation.toolCall` | Structured tool call |
+| `Generation.info` | Terminal counts, timing, stop reason |
+
+## Local vmlx Swift example
+
+This example intentionally focuses on current request/stream shapes. The host
+still chooses the exact downloader/tokenizer loader and local model path.
+
+```swift
+import Foundation
+import MLXLMCommon
+
+let modelURL = URL(fileURLWithPath: "/path/to/local/model")
+
+let container = try await loadModelContainer(
+    from: modelURL,
+    using: tokenizerLoader,
+    loadConfiguration: .default
+)
+
+let imageURL = URL(fileURLWithPath: "/tmp/input.png")
+let audioURL = URL(fileURLWithPath: "/tmp/question.wav")
+let videoURL = URL(fileURLWithPath: "/tmp/clip.mp4")
+
+let chat: [Chat.Message] = [
+    .system("Answer briefly. Use tools only when needed."),
+    .user(
+        "Describe the image, summarize the clip, and note anything audible.",
+        images: [.url(imageURL)],
+        videos: [.url(videoURL)],
+        audios: [.url(audioURL)]
+    ),
+]
+
+let input = UserInput(
+    chat: chat,
+    processing: .init(),
+    tools: nil,
+    additionalContext: [
+        "enable_thinking": false
+    ]
+)
+
+let prepared = try await container.prepare(input: input)
+
+var params = await container.defaultGenerateParameters(
+    fallback: GenerateParameters(maxTokens: 512)
+)
+
+let stream = try await container.generate(input: prepared, parameters: params)
+
+for await event in stream {
+    switch event {
+    case .chunk(let text):
+        print(text, terminator: "")
+    case .reasoning(let text):
+        // Route to a thinking pane, or ignore if the plugin does not expose it.
+        print("[thinking] \(text)")
+    case .toolCall(let call):
+        // Execute only allowlisted tools, then send a tool-role follow-up.
+        print("tool call: \(call.function.name)")
+    case .info(let info):
+        print("\nstop=\(info.stopReason) generated=\(info.generationTokenCount)")
+    }
+}
+```
+
+Important rules for in-process use:
+
+- Prefer `UserInput(chat:)` over raw string prompts for multimodal chat.
+- Put media on the `Chat.Message` that owns it. `UserInput(chat:)` copies those
+  media arrays into top-level `images`, `videos`, and `audios` for processors.
+- Preserve `reasoningContent` on assistant history when replaying a local
+  thinking-model conversation.
+- Preserve `toolCalls` on assistant messages and `toolCallId` on tool messages.
+- Use `container.defaultGenerateParameters(fallback:)` if the plugin wants the
+  bundle's `generation_config.json` defaults.
+- Keep `additionalContext` model-aware. Common keys are `enable_thinking` and
+  `reasoning_effort`, but not every family uses both.
+- For trusted local live voice, prefer retained PCM snapshots or fresh
+  `UserInput.Audio.preEncoded` embeddings. Do not concatenate independently
+  encoded Parakeet chunks; current bench evidence shows they are not
+  prefix-stable.
+
+## HTTP examples
+
+Image:
+
+```sh
+IMAGE_B64="$(base64 -i /tmp/input.png | tr -d '\n')"
+
+curl http://127.0.0.1:4242/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"model\": \"local-vl-model-id\",
+    \"stream\": true,
+    \"messages\": [{
+      \"role\": \"user\",
+      \"content\": [
+        {\"type\": \"text\", \"text\": \"Describe this image.\"},
+        {\"type\": \"image_url\", \"image_url\": {\"url\": \"data:image/png;base64,$IMAGE_B64\"}}
+      ]
+    }]
+  }"
+```
+
+Audio:
+
+```sh
+AUDIO_B64="$(base64 -i /tmp/question.wav | tr -d '\n')"
+
+curl http://127.0.0.1:4242/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"model\": \"nemotron-omni-model-id\",
+    \"stream\": true,
+    \"messages\": [{
+      \"role\": \"user\",
+      \"content\": [
+        {\"type\": \"text\", \"text\": \"Transcribe this audio and answer the question.\"},
+        {\"type\": \"input_audio\", \"input_audio\": {\"data\": \"$AUDIO_B64\", \"format\": \"wav\"}}
+      ]
+    }]
+  }"
+```
+
+Video:
+
+```sh
+VIDEO_B64="$(base64 -i /tmp/clip.mp4 | tr -d '\n')"
+
+curl http://127.0.0.1:4242/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"model\": \"local-video-vl-model-id\",
+    \"stream\": true,
+    \"messages\": [{
+      \"role\": \"user\",
+      \"content\": [
+        {\"type\": \"text\", \"text\": \"Summarize this clip.\"},
+        {\"type\": \"video_url\", \"video_url\": {\"url\": \"data:video/mp4;base64,$VIDEO_B64\"}}
+      ]
+    }]
+  }"
+```
+
+Tool follow-up:
+
+```json
+[
+  {
+    "role": "assistant",
+    "content": "",
+    "tool_calls": [
+      {
+        "id": "call_weather",
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"location\":\"San Francisco\"}"
+        }
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "tool_call_id": "call_weather",
+    "content": "{\"temperature_f\": 62}"
+  }
+]
+```
+
+## Council plugin design
+
+A council plugin should not be a single prompt string passed to N providers.
+It should be a coordinator with explicit member capabilities.
+
+Suggested member config:
+
+```json
+{
+  "id": "local-zaya-vl",
+  "display_name": "Local ZAYA VL",
+  "kind": "local_osaurus|openai_compatible|custom_http",
+  "base_url": "http://127.0.0.1:4242/v1",
+  "model": "ZAYA1-VL-8B-JANGTQ4",
+  "api_key_ref": "keychain://osaurus/plugins/council/local-zaya-vl",
+  "modalities": ["text", "image", "video"],
+  "supports_tools": true,
+  "supports_reasoning": true,
+  "timeout_seconds": 90
+}
+```
+
+Execution flow:
+
+1. Normalize the user turn into one internal content-part list: text, images,
+   audio, video, and optional tool specs.
+2. Resolve each council member's modality support. Reject unsupported media or
+   downgrade intentionally, for example image caption by a local VLM before
+   sending text to a text-only remote member.
+3. Build per-member OpenAI-compatible messages.
+4. Fan out with per-member timeouts and cancellation.
+5. Stream member deltas to the UI under member ids.
+6. Execute only allowlisted tool calls, then send tool-role follow-ups to the
+   same member session.
+7. Feed member final answers into a synthesizer member or local model.
+8. Persist `reasoning_content` only when the user setting permits it and the
+   target model requires it for multi-turn continuity.
+
+## BYO key rules
+
+- Store provider keys in Keychain or the approved Osaurus secret store. Config
+  files should contain only `api_key_ref`, never raw key bytes.
+- Do not send local files, media bytes, memory entries, folder context, or tool
+  outputs to a remote provider unless the user explicitly enabled that member.
+- Redact `Authorization`, provider keys, base64 media, and tool outputs in logs.
+- The plugin should support a "local only" mode where every remote member is
+  disabled.
+- Failed/missing BYO keys should fail that member cleanly, not the full council
+  run, unless all members fail.
+
+## Capability and model checks
+
+Before submitting to a local Osaurus model:
+
+- Use `ModelMediaCapabilities.from(modelId:)` or
+  `ModelMediaCapabilities.from(directory:modelId:)` to validate media support.
+- Keep text-only models from receiving image/audio/video content parts.
+- Treat audio support as Nemotron-Omni-only until another local model advertises
+  a proven audio processor.
+- ZAYA1-VL must be detected as `zaya1_vl` / VLM, not routed through text-only
+  ZAYA. A config parse failure here usually means the model-family or quant
+  metadata detector is wrong, not that the user media should be dropped.
+- For local thinking models, set the same model options the app uses. Do not
+  invent a plugin-only thinking policy.
+- If the model is local and cached, keep the same member/session stable across
+  turns so prefix cache can hit.
+- Keep media byte identity stable. Re-encoding the same file differently can
+  produce a different media salt and defeat cache reuse.
+
+## Reasoning policy
+
+The plugin should expose three modes:
+
+| Mode | Behavior |
+|---|---|
+| Off | Ask local models to disable thinking when supported; do not render reasoning |
+| On | Pass model-specific thinking context and render `.reasoning` separately |
+| Auto | Follow Osaurus model defaults and family policy |
+
+Rules:
+
+- Do not display raw `<think>` tags. The engine should emit `Generation.reasoning`
+  for reasoning bytes and `Generation.chunk` for visible bytes.
+- Do not force fake close tags in plugin code.
+- Preserve `reasoning_content` only for model families that need it on
+  follow-up turns and only if the user setting allows it.
+- Ling-family models are non-reasoning in current Osaurus policy.
+
+## Tool policy
+
+Remote and local models can emit tool calls, but the plugin is responsible for
+execution policy.
+
+- Only execute tools from an allowlist.
+- Require user consent for tools that touch filesystem, network, shell, memory,
+  or secrets.
+- Bind each tool result to the originating `tool_call_id`.
+- Feed tool-role replies back to the same member that requested the tool.
+- Prevent cross-member tool-call contamination. Member A's tool result should
+  not be sent as a tool-role reply to member B unless the synthesizer explicitly
+  includes it as plain text evidence.
+
+## Cache/session policy
+
+For local Osaurus members:
+
+- One council member should map to one stable chat session key.
+- Do not rebuild the system prefix differently on every turn unless the member
+  intentionally needs new context.
+- Keep memory/tool sections deterministic so prompt hashes remain useful.
+- Different media should produce distinct media salt and avoid false cache hits.
+- Switching members must not share cache state.
+- Keep cache claims topology-specific. ZAYA/ZAYA1-VL CCA, hybrid SSM, DSV4
+  compressor state, and dense KV do not have interchangeable prefix-cache
+  semantics.
+
+For remote members:
+
+- Provider context caching is provider-specific. Do not assume local vmlx cache
+  behavior applies remotely.
+
+## Plugin validation matrix
+
+Before shipping a council/multimodal plugin, run:
+
+| Scenario | Expected result |
+|---|---|
+| Text-only local member | text streams, no media accepted |
+| Local image VLM | image content reaches `Chat.Message.images` and answer references image |
+| Local video VLM | video content reaches `Chat.Message.videos`; mp4 stays video mp4 |
+| Local omni | audio reaches `Chat.Message.audios`; valid WAV maps to samples and resident live voice can use fresh pre-encoded Parakeet |
+| Mixed council, image prompt | image-capable members receive image; text-only members are skipped or get caption downgrade |
+| BYO key missing | only that member fails with a redacted error |
+| Remote timeout | council continues with other members and reports timeout |
+| Tool call | tool is allowlist-checked, executed, and fed back with matching `tool_call_id` |
+| Reasoning on/off/on | UI state and engine context stay consistent across turns |
+| Same media, turn 2 | local member cache can hit where topology supports it |
+| Changed media, turn 2 | local member cache does not false-hit across media |
+
+## Osaurus-side gaps worth adding before large plugin work
+
+These are not required to start a plugin, but they will make future debugging
+much cleaner:
+
+- Add `videos`, `audios`, and media salt to `MLXBatchAdapter.prepareInput`
+  structured logs.
+- Add a first-class internal `CouncilMemberRequest` type rather than passing
+  loosely-shaped dictionaries between plugin layers.
+- Add a plugin-facing media-capability endpoint so a plugin can ask the app
+  what the currently loaded local model accepts.
+- Add a plugin-facing runtime-smoke command that returns the same JSON fields
+  described in `RUNTIME_VALIDATION_STANDARD.md`.
+- Add a redaction helper shared by remote providers and plugins so BYO key logs
+  cannot drift.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -40,9 +40,10 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
 - `ModelRuntime.extractAudioSources(from:)` maps aligned local PCM to
   `UserInput.Audio.samples` so current in-app voice turns avoid the
   WAV/base64/temp-file re-decode path, and maps fresh live pre-encoded audio to
-  `UserInput.Audio.preEncoded` so vMLX skips request-time Parakeet. API/remote
-  requests without local PCM still materialize `input_audio` into a temp audio
-  file and hand `UserInput.Audio.url` to vMLX.
+  `UserInput.Audio.preEncoded` so vMLX skips request-time Parakeet. Valid API
+  `input_audio` WAV payloads now decode directly to `UserInput.Audio.samples`;
+  non-WAV and malformed audio still falls back to temp-file
+  `UserInput.Audio.url` materialization for AVAudioConverter coverage.
 - `ModelRuntime.preencodeLiveVoiceAudioIfResident(...)` pre-encodes against the
   already-resident model only. It does not cold-load a multi-GB Omni model from
   the voice UI; call-mode setups should keep the target model resident.
@@ -55,6 +56,11 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   tracked `OmniAudioLatencyBench` and `OmniAudioChunkStabilityBench`
   harnesses, and media-placeholder-aware cache restore guard, plus current
   Parakeet/RADIO integration documentation.
+- Parakeet/RADIO source, function, and documentation verification is an
+  explicit release guard: the source repo must contain the encoder functions
+  and bench/docs, the live remote must contain the pinned commit, Osaurus must
+  resolve the same revision, and this check must be repeated after any final
+  Osaurus commit/push before calling the PR ready.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -95,6 +101,14 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --package-path Packages/OsaurusCore
   --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests/deepSeekProvider_dropsLocalInstructReasoningEffort|RemoteChatRequestEncodingTests/deepSeekProvider_preservesAcceptedReasoningEfforts|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
+- Parakeet/RADIO source/push/doc check passed for the live library pin:
+  `vmlx-swift-lm` contains `NemotronHParakeetEncoder`,
+  `remapParakeetWeights`, `NemotronHRADIOVisionModel`,
+  `remapRadioWeights`, `OmniAudioChunkStabilityBench`,
+  `PARAKEET-RADIO-INTEGRATION.md`, and
+  `docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md`; Osaurus
+  resolves `https://github.com/osaurus-ai/vmlx-swift-lm` at
+  `81c8ef7389c031292287801f761957c681d086ea`.
 - Focused UI/API attachment regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
@@ -102,6 +116,36 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   attachments when capabilities allow them, dropping audio/video when
   unsupported, and the existing `input_audio`/`video_url` mapping into vMLX
   `Chat.Message.audios` / `.videos`.
+- Focused API WAV side-channel regression test passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --package-path Packages/OsaurusCore --filter
+  MultimodalContentPartTests/mapping_audioWavDecodesToSamples`.
+  This covers OpenAI-compatible `input_audio` WAV payloads mapping directly to
+  `UserInput.Audio.samples` instead of a temp-file `UserInput.Audio.url`.
+- API WAV side-channel regression set passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --package-path Packages/OsaurusCore --filter
+  'MultimodalContentPartTests|MaterializeMediaDataUrlMCDCTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs'`.
+  This passed with `25` tests in `3` suites, preserving video/audio temp-file
+  fallback coverage while adding the valid-WAV direct PCM path. The two
+  `.preEncoded` mapping tests remain skipped for the existing standalone
+  `MLXArray`/`default.metallib` fixture limitation.
+- Xcode debug app build passed after the API WAV side-channel change:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
+  -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
+  -destination 'platform=macOS,arch=arm64' ... build`. The build resolved
+  `vmlx-swift-lm @ 81c8ef7`.
+- Rebuilt debug app `/chat/completions` smoke passed for an
+  OpenAI-compatible streaming `input_audio` WAV request. The cold-load request
+  returned HTTP `200` and TTFT trace metrics
+  `input_audio_materialized_count=0`, `input_audio_local_sample_count=1`,
+  `omni_audio_preencode_converted_count=1`, `load_container_done=2388.6 ms`,
+  `prompt_prepare_ms=1447`, and `first_token_ms=75`. A resident repeat also
+  returned HTTP `200` with `load_container_done=0.1 ms`,
+  `input_audio_materialized_count=0`, `input_audio_local_sample_count=1`,
+  `omni_audio_preencode_converted_count=1`, `prompt_prepare_ms=1415`, and
+  `first_token_ms=71`. This proves valid API WAV now reaches the same local
+  PCM side channel as in-app voice before the Parakeet pre-encode adapter.
 - Focused adapter pre-encode regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs`.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -46,7 +46,15 @@ cache restore token-aware. Omni audio support is gated by
   TTFT/live-voice timing instrumentation. It also passed after the API-level
   `/chat/completions` trace recorder was added. Re-run after the `fb8fb39`
   media-cache pin bump passed with SwiftPM resolving `vmlx-swift-lm` at
-  `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`.
+  `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. Re-run after the Nemotron Omni
+  no-thinking default/profile fix also passed under Xcode's Swift toolchain.
+- Focused Xcode-toolchain regression tests passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --filter 'ModelProfileRegistryTests/nemotron3_matchesNemotronProfile|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
+  This covers the shorter live model ids
+  `dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK` and
+  `nemotron-omni-nano-jangtq-crack`, and the runtime default
+  `enable_thinking=false` with explicit opt-in still honored.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
@@ -62,7 +70,8 @@ cache restore token-aware. Omni audio support is gated by
   -derivedDataPath build/XcodeDerivedData-livevoice
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Re-run after the `fb8fb39` pin bump passed with the workspace resolver
-  checking out `vmlx-swift-lm @ fb8fb39`.
+  checking out `vmlx-swift-lm @ fb8fb39`. Re-run after the Nemotron Omni
+  no-thinking default/profile fix passed.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
 - No-model-load API trace smoke passed against the same built app on port 4242:
@@ -80,6 +89,31 @@ cache restore token-aware. Omni audio support is gated by
   `/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK`.
   The health endpoint reported the model loaded, and OpenAI-compatible
   `/chat/completions` accepted `input_audio` WAV content.
+- A pre-fix default API smoke exposed the live-call visible-output bug: the
+  model streamed only `reasoning_content` for text/audio turns unless the
+  request explicitly set `enable_thinking=false` / `reasoning_effort=no_think`.
+  Root cause was model-id matching: the live id
+  `nemotron-omni-nano-jangtq-crack` did not match `NemotronThinkingProfile`,
+  so `MLXBatchAdapter` fell through to generic `enable_thinking=true`.
+- Rebuilt-app default API smoke after the fix passed with no request-level
+  thinking overrides:
+  - text cold load: first visible `content` delta `2588.8 ms`, total
+    `2697.9 ms`, no `reasoning_content`; trace shows `load_container_done`
+    `2377.1 ms`, `first_token_ms=62`, and
+    `http_first_semantic_delta_kind=content`.
+  - warm raw WAV audio: first visible `content` delta `3218.8 ms`, total
+    `3574.7 ms`, text `A single electronic beep`, no `reasoning_content`;
+    trace shows `input_audio_materialize_ms=1`, `prompt_prepare_ms=21`,
+    `first_token_ms=109`, and a `3079.8 ms` wait inside
+    `chatengine_streamDeltas_done` before HTTP receives the stream.
+  - warm follow-up retaining the audio turn: first visible `content` delta
+    `3264.6 ms`, total `3409.8 ms`, text `yes`, no `reasoning_content`;
+    trace shows `input_audio_materialize_ms=1`, `prompt_prepare_ms=48`,
+    `first_token_ms=111`, and `http_first_semantic_delta_kind=content`.
+  - process RSS after the three-turn smoke was about `12.4 GiB`
+    (`12723.6 MB` reported by `ps`), with `77128.4 MB` free+speculative VM.
+  Evidence files are under `/tmp/osaurus-live-smoke-evidence/` with the prefix
+  `default_after_patch_`.
 - Warm latency control from the built app:
   - text-only streaming request: first semantic SSE delta at `358.3 ms`, total
     `777.4 ms`.
@@ -91,9 +125,11 @@ cache restore token-aware. Omni audio support is gated by
     `prepareInput` was `38 ms` on the first audio request and `16 ms` on the
     repeated request, while the vMLX `engine.generate(...)` await dominated the
     first semantic delta.
-- `swift test --filter LiveVoiceAudioSnapshotTests` is blocked by the existing
-  local toolchain issue: the package test target imports Swift `Testing`, which
-  is unavailable in this environment.
+- `swift test --filter LiveVoiceAudioSnapshotTests` without `DEVELOPER_DIR`
+  remains blocked by the local Command Line Tools selection: the package test
+  target imports Swift `Testing`, which is unavailable from that path. Use
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` for Swift Testing
+  checks on this machine.
 - vMLX real-model bench passed on the local JANGTQ2 Omni-Nano bundle:
   `build/evidence-20260512/nemotron_omni_live_voice_jangtq2_clean_20260512_155446.log`
   in `vmlx-swift-lm`.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,11 +3,12 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `fb8fb39`, which can consume
+models. This branch pins `vmlx-swift-lm` to `b57fe98`, which can consume
 `UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, exposes a
 reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
 polling, adds a tracked Omni audio latency bench, and keeps media-placeholder
-cache restore token-aware. Omni audio support is gated by
+cache restore token-aware. The pin also carries the refreshed Parakeet/RADIO
+host-integration docs. Omni audio support is gated by
 `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
@@ -48,10 +49,10 @@ cache restore token-aware. Omni audio support is gated by
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
   is the handoff point for a future live Parakeet/sound-projection component.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `fb8fb39` so
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `b57fe98` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
   tracked `OmniAudioLatencyBench` harness, and media-placeholder-aware cache
-  restore guard.
+  restore guard, plus current Parakeet/RADIO integration documentation.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -76,7 +77,8 @@ cache restore token-aware. Omni audio support is gated by
   TTFT/live-voice timing instrumentation. It also passed after the API-level
   `/chat/completions` trace recorder was added. Re-run after the `fb8fb39`
   media-cache pin bump passed with SwiftPM resolving `vmlx-swift-lm` at
-  `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. Re-run after the Nemotron Omni
+  `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. The follow-up `b57fe98` pin
+  adds the refreshed Parakeet/RADIO integration docs. Re-run after the Nemotron Omni
   no-thinking default/profile fix also passed under Xcode's Swift toolchain.
 - Focused Xcode-toolchain regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
@@ -146,7 +148,8 @@ cache restore token-aware. Omni audio support is gated by
   -derivedDataPath build/XcodeDerivedData-livevoice
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Re-run after the `fb8fb39` pin bump passed with the workspace resolver
-  checking out `vmlx-swift-lm @ fb8fb39`. Re-run after the Nemotron Omni
+  checking out `vmlx-swift-lm @ fb8fb39`; the current dependency pin is
+  `vmlx-swift-lm @ b57fe98`. Re-run after the Nemotron Omni
   no-thinking default/profile fix passed.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -15,15 +15,23 @@ cache restore token-aware. Omni audio support is gated by
 - `SpeechService` exposes `LiveVoiceAudioSnapshot` and `currentLiveAudioWAVData()`.
 - `ThreadSafeAudioBuffer` retains a bounded copy of the active live voice PCM
   separately from the short chunks drained by the streaming STT worker.
-- `FloatingInputCard.sendVoiceMessage(_:)` captures the WAV before stopping
-  transcription and appends it as `Attachment.audio(..., format: "wav")` when
-  the selected model supports audio.
+- `FloatingInputCard.sendVoiceMessage(_:)` captures the live PCM snapshot and
+  WAV fallback before stopping transcription, stores the PCM against the
+  generated audio attachment id in `LiveVoiceAudioInputRegistry`, and appends
+  the WAV as `Attachment.audio(..., format: "wav")` when the selected model
+  supports audio.
 - `ChatSession.buildUserChatMessage(...)` converts supported image/audio/video
   attachments into multimodal `ChatMessage` content parts. This closes the UI
   bridge gap where live voice appended `Attachment.audio` but the in-app
   send path could still serialize the turn as plain text only.
-- `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
-  temp audio file and hands `UserInput.Audio.url` to vMLX.
+- `ChatMessage` carries optional in-process `LocalAudioSamples` aligned to each
+  OpenAI `input_audio` content part. The JSON-visible message still retains
+  the portable base64 audio fallback for persistence and remote providers.
+- `ModelRuntime.extractAudioSources(from:)` maps aligned local PCM to
+  `UserInput.Audio.samples` so current in-app voice turns avoid the
+  WAV/base64/temp-file re-decode path. API/remote requests without local PCM
+  still materialize `input_audio` into a temp audio file and hand
+  `UserInput.Audio.url` to vMLX.
 - `MLXBatchAdapter` now detects Nemotron Omni models and converts raw
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
@@ -36,7 +44,8 @@ cache restore token-aware. Omni audio support is gated by
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
   - `TTFTTrace` records `input_audio_count`, `input_audio_materialized_count`,
-    `input_audio_bytes`, `input_audio_materialize_ms`, `prompt_prepare_ms`,
+    `input_audio_bytes`, `input_audio_local_sample_count`,
+    `input_audio_materialize_ms`, `prompt_prepare_ms`,
     `processor_prepare_ms`, `omni_audio_preencode_input_count`,
     `omni_audio_preencode_converted_count`,
     `omni_audio_preencode_existing_count`, `omni_audio_preencode_ms`,
@@ -75,6 +84,18 @@ cache restore token-aware. Omni audio support is gated by
   --filter MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs`.
   The helper replaces raw audio sources with encoder output and reports input,
   converted, and already-preencoded counts without requiring a model load.
+- Focused local live-PCM bridge regression tests passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --filter 'ChatAttachmentSecurityTests/buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs|MultimodalContentPartTests/mapping_usesLocalLiveAudioSamples'`.
+  These cover attachment-id alignment from the live voice registry into
+  `ChatMessage.audioInputsWithLocalSamples`, and `ModelRuntime` mapping the
+  aligned input to `UserInput.Audio.samples`.
+- Broader focused regression tests passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs|RemoteChatRequestEncodingTests'`.
+  This rechecked the local PCM bridge together with multimodal
+  audio/video mapping, the Nemotron Omni pre-encode adapter helper, and the
+  DeepSeek remote `reasoning_effort` guard.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
@@ -188,8 +209,8 @@ cache restore token-aware. Omni audio support is gated by
      attachment.
   4. Confirm the vMLX request includes `input_audio`.
   5. Confirm response stream starts and `/tmp/osaurus_ttft_trace.log` includes
-     `input_audio_materialize_ms`, `prompt_prepare_ms`, `first_token_ms`, and
-     `first_chunk_ms`.
+     `input_audio_local_sample_count`, `input_audio_materialize_ms`,
+     `prompt_prepare_ms`, `first_token_ms`, and `first_chunk_ms`.
 - Negative smoke:
   1. Select a text-only model.
   2. Send a voice message.
@@ -198,10 +219,11 @@ cache restore token-aware. Omni audio support is gated by
 
 ## Remaining Work
 
-- Add direct live pre-encoded audio emission from the Osaurus voice component.
-  The adapter now preserves `.preEncoded` audio, but the current HTTP/UI WAV
-  path still pays request-prep Nemotron audio encoding before the stream is
-  returned.
+- Add true live-during-speech pre-encoded audio emission from the Osaurus voice
+  component. Current in-app voice turns can now bypass WAV/temp-file re-decode
+  by carrying local PCM to `UserInput.Audio.samples`, and the adapter preserves
+  `.preEncoded` audio, but the request still pays Nemotron audio encoding
+  before the stream is returned.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -101,14 +101,18 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --package-path Packages/OsaurusCore
   --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests/deepSeekProvider_dropsLocalInstructReasoningEffort|RemoteChatRequestEncodingTests/deepSeekProvider_preservesAcceptedReasoningEfforts|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
-- Parakeet/RADIO source/push/doc check passed for the live library pin:
-  `vmlx-swift-lm` contains `NemotronHParakeetEncoder`,
+- Parakeet/RADIO source/push/doc checks have passed repeatedly for the live
+  library pin, including after the rebased Osaurus head `54330b43` was pushed:
+  `git ls-remote origin refs/heads/main` for `vmlx-swift-lm` returns
+  `81c8ef7389c031292287801f761957c681d086ea`; `git grep` against the committed
+  `vmlx-swift-lm` tree confirms `NemotronHParakeetEncoder`,
   `remapParakeetWeights`, `NemotronHRADIOVisionModel`,
   `remapRadioWeights`, `OmniAudioChunkStabilityBench`,
   `PARAKEET-RADIO-INTEGRATION.md`, and
-  `docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md`; Osaurus
-  resolves `https://github.com/osaurus-ai/vmlx-swift-lm` at
-  `81c8ef7389c031292287801f761957c681d086ea`.
+  `docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md`; Osaurus pins the
+  same revision in `Packages/OsaurusCore/Package.swift` and
+  `Packages/OsaurusCore/Package.resolved`; the Osaurus-resolved checkout also
+  contains the same encoder functions and docs.
 - Focused UI/API attachment regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
@@ -163,6 +167,12 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   This rechecked the local PCM bridge together with multimodal
   audio/video mapping, the Nemotron Omni pre-encode adapter helper, and the
   DeepSeek remote `reasoning_effort` guard.
+- After rebase onto `osaurus/main` `acbf75cc`, the post-rebase focused package
+  suite passed with `48` tests in `6` suites:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --package-path Packages/OsaurusCore --filter
+  'RemoteChatRequestEncodingTests|RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|MultimodalContentPartTests/mapping_audioWavDecodesToSamples|MaterializeMediaDataUrlMCDCTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs|LiveVoiceResidentPreencodeIntegrationTests'`.
+  The gated real-model test skipped in this default run, as intended.
 - After the resident live-preencode scheduler landed, the same broader focused
   suite passed again with `46` tests in `4` suites. The two direct `.preEncoded`
   mapping tests are present but disabled because constructing a standalone
@@ -185,10 +195,13 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   submit path by storing the final PCM snapshot under the same attachment id,
   building `ChatSession.buildUserChatMessage(...)`, and requiring
   `ModelRuntime.mapOpenAIChatToMLX(...)` to consume `.preEncoded` audio.
-  Local run with `OSAURUS_MLX_METALLIB` passed after the composer-submit
-  assertion with `warm_ms=2807`, `samples=80620`, `encode_ms=1312`,
-  `embedding_shape=[63, 2688]`, and `composer_submit=preencoded`. Earlier run
-  before the composer-submit assertion recorded max RSS about `13.1 GB`.
+  Local run with `OSAURUS_MLX_METALLIB` passed again after the rebase at
+  `54330b43` with `warm_ms=2780`, `samples=80620`, `encode_ms=1310`,
+  `embedding_shape=[63, 2688]`, and `composer_submit=preencoded`. The prior
+  post-composer assertion run also passed with `warm_ms=2807`,
+  `samples=80620`, `encode_ms=1312`, `embedding_shape=[63, 2688]`, and
+  `composer_submit=preencoded`; earlier run before the composer-submit
+  assertion recorded max RSS about `13.1 GB`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,8 +3,9 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. It assumes vMLX can consume `UserInput.Audio` and that Omni audio
-support is gated by `ModelMediaCapabilities.supportsAudio`.
+models. This branch pins `vmlx-swift-lm` to `c0f8b3b`, which can consume
+`UserInput.Audio` and preserves pre-encoded Parakeet/audio embeddings. Omni
+audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
 
@@ -18,11 +19,13 @@ support is gated by `ModelMediaCapabilities.supportsAudio`.
   `input_audio` content parts.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `c0f8b3b` so
+  the app consumes the Swift live-voice handoff support.
 
 ## Verified Evidence
 
 - `swift build --target OsaurusCore` passed after the live voice snapshot
-  changes.
+  changes and after the `vmlx-swift-lm` pin bump to `c0f8b3b`.
 - `swift test --filter LiveVoiceAudioSnapshotTests` is blocked by the existing
   local toolchain issue: the package test target imports Swift `Testing`, which
   is unavailable in this environment.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,11 +3,12 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `638024b`, which can consume
-`UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, and exposes
-a reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
-polling, plus a tracked Omni audio latency bench. Omni audio support is gated
-by `ModelMediaCapabilities.supportsAudio`.
+models. This branch pins `vmlx-swift-lm` to `fb8fb39`, which can consume
+`UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, exposes a
+reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
+polling, adds a tracked Omni audio latency bench, and keeps media-placeholder
+cache restore token-aware. Omni audio support is gated by
+`ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
 
@@ -21,9 +22,10 @@ by `ModelMediaCapabilities.supportsAudio`.
   `input_audio` content parts.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `638024b` so
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `fb8fb39` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
-  and tracked `OmniAudioLatencyBench` harness.
+  tracked `OmniAudioLatencyBench` harness, and media-placeholder-aware cache
+  restore guard.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -42,18 +44,25 @@ by `ModelMediaCapabilities.supportsAudio`.
 - `swift build --target OsaurusCore` passed after the live voice snapshot
   changes, after the `vmlx-swift-lm` pin bump to `638024b`, and after the
   TTFT/live-voice timing instrumentation. It also passed after the API-level
-  `/chat/completions` trace recorder was added.
+  `/chat/completions` trace recorder was added. Re-run after the `fb8fb39`
+  media-cache pin bump passed with SwiftPM resolving `vmlx-swift-lm` at
+  `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
-  Osaurus BatchEngine path at `2180.7 ms` raw PCM first semantic delta on
-  turn 1, `1473.8 ms` raw PCM on turn 2, `200.0 ms` pre-encoded Parakeet on
-  turn 1, and `211.9 ms` pre-encoded Parakeet on turn 2. This is not output
-  TTS TTFAB; it measures first text delta before a separate TTS model.
+  Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
+  turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
+  turn 1, and `201.8 ms` pre-encoded Parakeet on turn 2. The bench recorded
+  `63` media-placeholder tokens, known media token IDs `[18, 27]`, media
+  placeholders spanning prompt indices `12...74`, and a 64-token cache suffix
+  that still contains media tokens. This is not output TTS TTFAB; it measures
+  first text delta before a separate TTS model.
 - Xcode app build passed from the workspace:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
   -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
   -destination 'platform=macOS,arch=arm64'
   -derivedDataPath build/XcodeDerivedData-livevoice
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
+  Re-run after the `fb8fb39` pin bump passed with the workspace resolver
+  checking out `vmlx-swift-lm @ fb8fb39`.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
 - No-model-load API trace smoke passed against the same built app on port 4242:

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -20,6 +20,10 @@ cache restore token-aware. Omni audio support is gated by
   generated audio attachment id in `LiveVoiceAudioInputRegistry`, and appends
   the WAV as `Attachment.audio(..., format: "wav")` when the selected model
   supports audio.
+- `FloatingInputCard` now creates a stable live voice attachment id at recording
+  start, periodically asks the resident Nemotron Omni runtime to pre-encode
+  retained PCM snapshots while capture is active, and force-runs one final
+  pre-encode during transcript cleanup before the chat message is submitted.
 - `ChatSession.buildUserChatMessage(...)` converts supported image/audio/video
   attachments into multimodal `ChatMessage` content parts. This closes the UI
   bridge gap where live voice appended `Attachment.audio` but the in-app
@@ -27,11 +31,19 @@ cache restore token-aware. Omni audio support is gated by
 - `ChatMessage` carries optional in-process `LocalAudioSamples` aligned to each
   OpenAI `input_audio` content part. The JSON-visible message still retains
   the portable base64 audio fallback for persistence and remote providers.
+- `LiveVoiceAudioInputRegistry` can retain a fresh `.preEncoded` audio embedding
+  for the same attachment id. `ModelRuntime` only consumes it when the stored
+  source sample count and sample rate exactly match the final local PCM, so a
+  stale periodic pre-encode cannot silently drop the tail of the user's speech.
 - `ModelRuntime.extractAudioSources(from:)` maps aligned local PCM to
   `UserInput.Audio.samples` so current in-app voice turns avoid the
-  WAV/base64/temp-file re-decode path. API/remote requests without local PCM
-  still materialize `input_audio` into a temp audio file and hand
-  `UserInput.Audio.url` to vMLX.
+  WAV/base64/temp-file re-decode path, and maps fresh live pre-encoded audio to
+  `UserInput.Audio.preEncoded` so vMLX skips request-time Parakeet. API/remote
+  requests without local PCM still materialize `input_audio` into a temp audio
+  file and hand `UserInput.Audio.url` to vMLX.
+- `ModelRuntime.preencodeLiveVoiceAudioIfResident(...)` pre-encodes against the
+  already-resident model only. It does not cold-load a multi-GB Omni model from
+  the voice UI; call-mode setups should keep the target model resident.
 - `MLXBatchAdapter` now detects Nemotron Omni models and converts raw
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
@@ -45,7 +57,8 @@ cache restore token-aware. Omni audio support is gated by
     `sample_rate`, and `duration_ms` when a voice turn is captured.
   - `TTFTTrace` records `input_audio_count`, `input_audio_materialized_count`,
     `input_audio_bytes`, `input_audio_local_sample_count`,
-    `input_audio_materialize_ms`, `prompt_prepare_ms`,
+    `input_audio_local_preencoded_count`, `input_audio_materialize_ms`,
+    `prompt_prepare_ms`,
     `processor_prepare_ms`, `omni_audio_preencode_input_count`,
     `omni_audio_preencode_converted_count`,
     `omni_audio_preencode_existing_count`, `omni_audio_preencode_ms`,
@@ -96,6 +109,12 @@ cache restore token-aware. Omni audio support is gated by
   This rechecked the local PCM bridge together with multimodal
   audio/video mapping, the Nemotron Omni pre-encode adapter helper, and the
   DeepSeek remote `reasoning_effort` guard.
+- After the resident live-preencode scheduler landed, the same broader focused
+  suite passed again with `46` tests in `4` suites. The two direct `.preEncoded`
+  mapping tests are present but disabled because constructing a standalone
+  `MLXArray` fixture in the SwiftPM test process currently fails to load
+  `default.metallib`; production embeddings are produced inside
+  `ModelContainer.perform`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
@@ -209,8 +228,9 @@ cache restore token-aware. Omni audio support is gated by
      attachment.
   4. Confirm the vMLX request includes `input_audio`.
   5. Confirm response stream starts and `/tmp/osaurus_ttft_trace.log` includes
-     `input_audio_local_sample_count`, `input_audio_materialize_ms`,
-     `prompt_prepare_ms`, `first_token_ms`, and `first_chunk_ms`.
+     `input_audio_local_sample_count`, `input_audio_local_preencoded_count`,
+     `input_audio_materialize_ms`, `prompt_prepare_ms`, `first_token_ms`, and
+     `first_chunk_ms`.
 - Negative smoke:
   1. Select a text-only model.
   2. Send a voice message.
@@ -219,11 +239,12 @@ cache restore token-aware. Omni audio support is gated by
 
 ## Remaining Work
 
-- Add true live-during-speech pre-encoded audio emission from the Osaurus voice
-  component. Current in-app voice turns can now bypass WAV/temp-file re-decode
-  by carrying local PCM to `UserInput.Audio.samples`, and the adapter preserves
-  `.preEncoded` audio, but the request still pays Nemotron audio encoding
-  before the stream is returned.
+- Replace periodic full-snapshot pre-encoding with true causal/incremental
+  Parakeet embedding accumulation if the encoder can be made chunk-safe.
+  Current in-app voice turns can pre-encode against the resident model while
+  capture/cleanup is active and submit fresh `.preEncoded` audio at endpoint,
+  but the implementation intentionally rejects stale embeddings instead of
+  concatenating chunk outputs that may not match full-context Conformer output.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,10 +3,11 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `e497f61`, which can consume
+models. This branch pins `vmlx-swift-lm` to `638024b`, which can consume
 `UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, and exposes
 a reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
-polling. Omni audio support is gated by `ModelMediaCapabilities.supportsAudio`.
+polling, plus a tracked Omni audio latency bench. Omni audio support is gated
+by `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
 
@@ -20,8 +21,9 @@ polling. Omni audio support is gated by `ModelMediaCapabilities.supportsAudio`.
   `input_audio` content parts.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `e497f61` so
-  the app consumes the Swift live-voice handoff and live PCM streaming cursor.
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `638024b` so
+  the app consumes the Swift live-voice handoff, live PCM streaming cursor,
+  and tracked `OmniAudioLatencyBench` harness.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -38,9 +40,14 @@ polling. Omni audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 ## Verified Evidence
 
 - `swift build --target OsaurusCore` passed after the live voice snapshot
-  changes, after the `vmlx-swift-lm` pin bump to `e497f61`, and after the
+  changes, after the `vmlx-swift-lm` pin bump to `638024b`, and after the
   TTFT/live-voice timing instrumentation. It also passed after the API-level
   `/chat/completions` trace recorder was added.
+- `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
+  Osaurus BatchEngine path at `2180.7 ms` raw PCM first semantic delta on
+  turn 1, `1473.8 ms` raw PCM on turn 2, `200.0 ms` pre-encoded Parakeet on
+  turn 1, and `211.9 ms` pre-encoded Parakeet on turn 2. This is not output
+  TTS TTFAB; it measures first text delta before a separate TTS model.
 - Xcode app build passed from the workspace:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
   -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,12 +3,13 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `b57fe98`, which can consume
+models. This branch pins `vmlx-swift-lm` to `81c8ef7`, which can consume
 `UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, exposes a
 reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
-polling, adds a tracked Omni audio latency bench, and keeps media-placeholder
-cache restore token-aware. The pin also carries the refreshed Parakeet/RADIO
-host-integration docs. Omni audio support is gated by
+polling, adds tracked Omni audio latency and chunk-stability benches, and keeps
+media-placeholder cache restore token-aware. The pin also carries the refreshed
+Parakeet/RADIO host-integration docs and the current proof that independently
+encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated by
 `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
@@ -49,10 +50,11 @@ host-integration docs. Omni audio support is gated by
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
   is the handoff point for a future live Parakeet/sound-projection component.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `b57fe98` so
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `81c8ef7` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
-  tracked `OmniAudioLatencyBench` harness, and media-placeholder-aware cache
-  restore guard, plus current Parakeet/RADIO integration documentation.
+  tracked `OmniAudioLatencyBench` and `OmniAudioChunkStabilityBench`
+  harnesses, and media-placeholder-aware cache restore guard, plus current
+  Parakeet/RADIO integration documentation.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -78,7 +80,8 @@ host-integration docs. Omni audio support is gated by
   `/chat/completions` trace recorder was added. Re-run after the `fb8fb39`
   media-cache pin bump passed with SwiftPM resolving `vmlx-swift-lm` at
   `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. The follow-up `b57fe98` pin
-  adds the refreshed Parakeet/RADIO integration docs. Re-run after the Nemotron Omni
+  adds the refreshed Parakeet/RADIO integration docs, and the `81c8ef7` pin
+  adds the Parakeet chunk-stability bench. Re-run after the Nemotron Omni
   no-thinking default/profile fix also passed under Xcode's Swift toolchain.
 - Focused Xcode-toolchain regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
@@ -87,6 +90,11 @@ host-integration docs. Omni audio support is gated by
   `dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK` and
   `nemotron-omni-nano-jangtq-crack`, and the runtime default
   `enable_thinking=false` with explicit opt-in still honored.
+- After the `81c8ef7` vMLX pin bump, the focused pin/provider/profile suite
+  passed again with `4` tests in `3` suites:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --package-path Packages/OsaurusCore
+  --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests/deepSeekProvider_dropsLocalInstructReasoningEffort|RemoteChatRequestEncodingTests/deepSeekProvider_preservesAcceptedReasoningEfforts|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
 - Focused UI/API attachment regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
@@ -141,6 +149,11 @@ host-integration docs. Omni audio support is gated by
   placeholders spanning prompt indices `12...74`, and a 64-token cache suffix
   that still contains media tokens. This is not output TTS TTFAB; it measures
   first text delta before a separate TTS model.
+- `OmniAudioChunkStabilityBench` on the same model and 5.0388 s audio fixture
+  measured `10` prefix-vs-next/final comparisons, `10` unstable comparisons,
+  and `stable_tokens_default=0` for every comparison at tolerance `0.01`.
+  This confirms current Parakeet outputs are not prefix-stable and should not
+  be concatenated from independently encoded live chunks.
 - Xcode app build passed from the workspace:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
   -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
@@ -149,7 +162,7 @@ host-integration docs. Omni audio support is gated by
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Re-run after the `fb8fb39` pin bump passed with the workspace resolver
   checking out `vmlx-swift-lm @ fb8fb39`; the current dependency pin is
-  `vmlx-swift-lm @ b57fe98`. Re-run after the Nemotron Omni
+  `vmlx-swift-lm @ 81c8ef7`. Re-run after the Nemotron Omni
   no-thinking default/profile fix passed.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
@@ -255,15 +268,22 @@ host-integration docs. Omni audio support is gated by
   2. Send a voice message.
   3. Confirm no audio attachment is appended; only cleaned transcript text is
      sent.
+- Repeated Parakeet/RADIO source verification before merge:
+  1. Confirm `vmlx-swift-lm` live remote `main` contains commit `81c8ef7`.
+  2. Confirm source contains `NemotronHParakeetEncoder`,
+     `NemotronHRADIOVisionModel`, `extractAudioEmbeds`, `extractImageEmbeds`,
+     and `OmniAudioChunkStabilityBench`.
+  3. Confirm Osaurus `Package.swift` and both `Package.resolved` files pin
+     full revision `81c8ef7389c031292287801f761957c681d086ea`.
+  4. Confirm the Osaurus-resolved checkout contains the same Parakeet/RADIO
+     functions and docs after dependency resolution.
 
 ## Remaining Work
 
-- Replace periodic full-snapshot pre-encoding with true causal/incremental
-  Parakeet embedding accumulation if the encoder can be made chunk-safe.
-  Current in-app voice turns can pre-encode against the resident model while
-  capture/cleanup is active and submit fresh `.preEncoded` audio at endpoint,
-  but the implementation intentionally rejects stale embeddings instead of
-  concatenating chunk outputs that may not match full-context Conformer output.
+- Do not replace periodic full-snapshot pre-encoding with chunk-concatenated
+  Parakeet outputs on the current encoder. The chunk-stability bench shows the
+  outputs are not prefix-stable. Any future causal/incremental path needs a
+  stateful encoder proof with explicit lookahead and rollback semantics.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -24,6 +24,10 @@ cache restore token-aware. Omni audio support is gated by
   send path could still serialize the turn as plain text only.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
+- `MLXBatchAdapter` now detects Nemotron Omni models and converts raw
+  `UserInput.Audio` sources to `.preEncoded` audio embeddings before
+  `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
+  is the handoff point for a future live Parakeet/sound-projection component.
 - `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `fb8fb39` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
   tracked `OmniAudioLatencyBench` harness, and media-placeholder-aware cache
@@ -33,8 +37,10 @@ cache restore token-aware. Omni audio support is gated by
     `sample_rate`, and `duration_ms` when a voice turn is captured.
   - `TTFTTrace` records `input_audio_count`, `input_audio_materialized_count`,
     `input_audio_bytes`, `input_audio_materialize_ms`, `prompt_prepare_ms`,
-    `processor_prepare_ms`, `chat_audio_count`, `first_token_ms`, and
-    `first_chunk_ms`.
+    `processor_prepare_ms`, `omni_audio_preencode_input_count`,
+    `omni_audio_preencode_converted_count`,
+    `omni_audio_preencode_existing_count`, `omni_audio_preencode_ms`,
+    `chat_audio_count`, `first_token_ms`, and `first_chunk_ms`.
   - OpenAI-compatible `/chat/completions` debug builds attach the same
     `TTFTTrace` to API requests and emit `/tmp/osaurus_ttft_trace.log` on SSE
     finish, tool-call finish, JSON finish, and handled API errors. This records
@@ -64,6 +70,11 @@ cache restore token-aware. Omni audio support is gated by
   attachments when capabilities allow them, dropping audio/video when
   unsupported, and the existing `input_audio`/`video_url` mapping into vMLX
   `Chat.Message.audios` / `.videos`.
+- Focused adapter pre-encode regression tests passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --filter MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs`.
+  The helper replaces raw audio sources with encoder output and reports input,
+  converted, and already-preencoded counts without requiring a model load.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
@@ -123,6 +134,25 @@ cache restore token-aware. Omni audio support is gated by
     (`12723.6 MB` reported by `ps`), with `77128.4 MB` free+speculative VM.
   Evidence files are under `/tmp/osaurus-live-smoke-evidence/` with the prefix
   `default_after_patch_`.
+- Rebuilt-app API smoke after the adapter pre-encode hook passed with no
+  request-level thinking overrides:
+  - cold text warmup: first visible `content` delta `2967.3 ms`, total
+    `3077.8 ms`, visible text `Ready.`, no `reasoning_content`.
+  - warm WAV audio: first visible `content` delta `1634.8 ms`, total
+    `1893.5 ms`, visible text `A guitar is played in this audio.`, no
+    `reasoning_content`; trace shows `input_audio_materialize_ms=0`,
+    `omni_audio_preencode_input_count=1`,
+    `omni_audio_preencode_converted_count=1`,
+    `omni_audio_preencode_existing_count=0`,
+    `omni_audio_preencode_ms=1368`, `processor_prepare_ms=14`, and
+    `first_token_ms=50`.
+  - repeated warm WAV audio: first visible `content` delta `1553.0 ms`, total
+    `1667.1 ms`, visible text `Tick`, no `reasoning_content`; trace shows
+    `omni_audio_preencode_ms=1327`, `processor_prepare_ms=15`, and
+    `first_token_ms=47`.
+  - process RSS after the smoke was about `12.4 GiB` (`12972.5 MB` reported by
+    `ps`). Evidence files are under `/tmp/osaurus-live-smoke-evidence/` with
+    the prefix `preencode_after_patch_`.
 - Warm latency control from the built app:
   - text-only streaming request: first semantic SSE delta at `358.3 ms`, total
     `777.4 ms`.
@@ -168,9 +198,10 @@ cache restore token-aware. Omni audio support is gated by
 
 ## Remaining Work
 
-- Add a direct pre-encoded audio path only after an Osaurus voice component can
-  emit stable Parakeet/sound-projection embeddings. The current WAV path is
-  correct but pays model-side encoding.
+- Add direct live pre-encoded audio emission from the Osaurus voice component.
+  The adapter now preserves `.preEncoded` audio, but the current HTTP/UI WAV
+  path still pays request-prep Nemotron audio encoding before the stream is
+  returned.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -28,12 +28,18 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
     `input_audio_bytes`, `input_audio_materialize_ms`, `prompt_prepare_ms`,
     `processor_prepare_ms`, `chat_audio_count`, `first_token_ms`, and
     `first_chunk_ms`.
+  - OpenAI-compatible `/chat/completions` debug builds attach the same
+    `TTFTTrace` to API requests and emit `/tmp/osaurus_ttft_trace.log` on SSE
+    finish, tool-call finish, JSON finish, and handled API errors. This records
+    endpoint/model/media counts plus the HTTP stream phases needed for
+    headless audio latency benches.
 
 ## Verified Evidence
 
 - `swift build --target OsaurusCore` passed after the live voice snapshot
   changes, after the `vmlx-swift-lm` pin bump to `c0f8b3b`, and after the
-  TTFT/live-voice timing instrumentation.
+  TTFT/live-voice timing instrumentation. It also passed after the API-level
+  `/chat/completions` trace recorder was added.
 - Xcode app build passed from the workspace:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
   -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
@@ -42,6 +48,14 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
+- No-model-load API trace smoke passed against the same built app on port 4242:
+  - JSON `/chat/completions` with an unknown model returned HTTP 404 in
+    `5.3 ms` total and wrote a trace block containing `http_json_error_written`,
+    endpoint/model/media counts, and `http_response_status=404`.
+  - SSE `/chat/completions` with an unknown model returned an in-band SSE error
+    with HTTP 200 in `4.2 ms` total and wrote a trace block containing
+    `http_sse_error_written`, endpoint/model/media counts, and
+    `http_response_status=200`.
 - Built-app API smoke passed against
   `build/XcodeDerivedData-livevoice/Build/Products/Debug/osaurus.app` with
   `OSU_MODELS_DIR=/Users/eric/models` and
@@ -95,9 +109,6 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 - Add a direct pre-encoded audio path only after an Osaurus voice component can
   emit stable Parakeet/sound-projection embeddings. The current WAV path is
   correct but pays model-side encoding.
-- Add API-level TTFT trace emission for `/chat/completions`; the current
-  `/tmp/osaurus_ttft_trace.log` emission is attached to the chat UI path, while
-  API smoke uses client-side SSE timing plus unified logs.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -21,11 +21,19 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
   temp audio file and hands `UserInput.Audio.url` to vMLX.
 - `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `c0f8b3b` so
   the app consumes the Swift live-voice handoff support.
+- Live voice timing is now visible in the normal debug path:
+  - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
+    `sample_rate`, and `duration_ms` when a voice turn is captured.
+  - `TTFTTrace` records `input_audio_count`, `input_audio_materialized_count`,
+    `input_audio_bytes`, `input_audio_materialize_ms`, `prompt_prepare_ms`,
+    `processor_prepare_ms`, `chat_audio_count`, `first_token_ms`, and
+    `first_chunk_ms`.
 
 ## Verified Evidence
 
 - `swift build --target OsaurusCore` passed after the live voice snapshot
-  changes and after the `vmlx-swift-lm` pin bump to `c0f8b3b`.
+  changes, after the `vmlx-swift-lm` pin bump to `c0f8b3b`, and after the
+  TTFT/live-voice timing instrumentation.
 - `swift test --filter LiveVoiceAudioSnapshotTests` is blocked by the existing
   local toolchain issue: the package test target imports Swift `Testing`, which
   is unavailable in this environment.
@@ -47,7 +55,9 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
   3. Confirm the sent chat turn contains cleaned transcript text plus an audio
      attachment.
   4. Confirm the vMLX request includes `input_audio`.
-  5. Confirm response stream starts and TTFT trace includes preprocessing time.
+  5. Confirm response stream starts and `/tmp/osaurus_ttft_trace.log` includes
+     `input_audio_materialize_ms`, `prompt_prepare_ms`, `first_token_ms`, and
+     `first_chunk_ms`.
 - Negative smoke:
   1. Select a text-only model.
   2. Send a voice message.
@@ -56,9 +66,6 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 
 ## Remaining Work
 
-- Add app-level timing logs around live voice handoff:
-  `snapshot_ms`, `wav_bytes`, `input_audio_materialize_ms`,
-  `prepare_ms`, `first_token_ms`, `first_chunk_ms`.
 - Add a direct pre-encoded audio path only after an Osaurus voice component can
   emit stable Parakeet/sound-projection embeddings. The current WAV path is
   correct but pays model-side encoding.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -1,0 +1,65 @@
+# Nemotron Omni Live Voice PR Checklist - 2026-05-12
+
+## Scope
+
+This checklist tracks the Osaurus side of live voice input for Nemotron Omni
+models. It assumes vMLX can consume `UserInput.Audio` and that Omni audio
+support is gated by `ModelMediaCapabilities.supportsAudio`.
+
+## Current Hookups
+
+- `SpeechService` exposes `LiveVoiceAudioSnapshot` and `currentLiveAudioWAVData()`.
+- `ThreadSafeAudioBuffer` retains a bounded copy of the active live voice PCM
+  separately from the short chunks drained by the streaming STT worker.
+- `FloatingInputCard.sendVoiceMessage(_:)` captures the WAV before stopping
+  transcription and appends it as `Attachment.audio(..., format: "wav")` when
+  the selected model supports audio.
+- Existing chat attachment flow converts `Attachment.audio` into
+  `input_audio` content parts.
+- `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
+  temp audio file and hands `UserInput.Audio.url` to vMLX.
+
+## Verified Evidence
+
+- `swift build --target OsaurusCore` passed after the live voice snapshot
+  changes.
+- `swift test --filter LiveVoiceAudioSnapshotTests` is blocked by the existing
+  local toolchain issue: the package test target imports Swift `Testing`, which
+  is unavailable in this environment.
+- vMLX real-model bench passed on the local JANGTQ2 Omni-Nano bundle:
+  `build/evidence-20260512/nemotron_omni_live_voice_jangtq2_clean_20260512_155446.log`
+  in `vmlx-swift-lm`.
+- That bench exercised text multi-turn, audio encoder smoke, full audio
+  `LMInput`, mixed image + audio, media-salt isolation, reasoning toggle, and
+  hybrid SSM warm-pass parity: `13 passed, 0 failed`, `bench_exit=0`.
+
+## PR Gates
+
+- Build: `swift build --target OsaurusCore` from `Packages/OsaurusCore`.
+- Unit test when the toolchain supports it:
+  `swift test --filter LiveVoiceAudioSnapshotTests`.
+- Manual app smoke:
+  1. Select a Nemotron Omni model that reports `supportsAudio=true`.
+  2. Start voice input and speak a short utterance.
+  3. Confirm the sent chat turn contains cleaned transcript text plus an audio
+     attachment.
+  4. Confirm the vMLX request includes `input_audio`.
+  5. Confirm response stream starts and TTFT trace includes preprocessing time.
+- Negative smoke:
+  1. Select a text-only model.
+  2. Send a voice message.
+  3. Confirm no audio attachment is appended; only cleaned transcript text is
+     sent.
+
+## Remaining Work
+
+- Add app-level timing logs around live voice handoff:
+  `snapshot_ms`, `wav_bytes`, `input_audio_materialize_ms`,
+  `prepare_ms`, `first_token_ms`, `first_chunk_ms`.
+- Add a direct pre-encoded audio path only after an Osaurus voice component can
+  emit stable Parakeet/sound-projection embeddings. The current WAV path is
+  correct but pays model-side encoding.
+- Add TTFAB coverage once a TTS backend is selected. Current evidence covers
+  speech input into model output text, not first output audio byte.
+- Keep audio attachment spillover and temp-file cleanup under review for longer
+  call clips.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,9 +3,10 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `c0f8b3b`, which can consume
-`UserInput.Audio` and preserves pre-encoded Parakeet/audio embeddings. Omni
-audio support is gated by `ModelMediaCapabilities.supportsAudio`.
+models. This branch pins `vmlx-swift-lm` to `e497f61`, which can consume
+`UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, and exposes
+a reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
+polling. Omni audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
 
@@ -19,8 +20,8 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
   `input_audio` content parts.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `c0f8b3b` so
-  the app consumes the Swift live-voice handoff support.
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `e497f61` so
+  the app consumes the Swift live-voice handoff and live PCM streaming cursor.
 - Live voice timing is now visible in the normal debug path:
   - `FloatingInputCard` logs `snapshot_ms`, `wav_encode_ms`, `wav_bytes`,
     `sample_rate`, and `duration_ms` when a voice turn is captured.
@@ -37,7 +38,7 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 ## Verified Evidence
 
 - `swift build --target OsaurusCore` passed after the live voice snapshot
-  changes, after the `vmlx-swift-lm` pin bump to `c0f8b3b`, and after the
+  changes, after the `vmlx-swift-lm` pin bump to `e497f61`, and after the
   TTFT/live-voice timing instrumentation. It also passed after the API-level
   `/chat/completions` trace recorder was added.
 - Xcode app build passed from the workspace:

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -115,6 +115,22 @@ cache restore token-aware. Omni audio support is gated by
   `MLXArray` fixture in the SwiftPM test process currently fails to load
   `default.metallib`; production embeddings are produced inside
   `ModelContainer.perform`.
+- A gated real-model integration test now exists for the resident live voice
+  pre-encode path. It requires a local Nemotron Omni bundle, an audio fixture,
+  and an MLX metallib from the app build:
+  `OSAURUS_RUN_REAL_OMNI_PREENCODE=1 OSU_MODELS_DIR=<models-root>
+  OSAURUS_OMNI_MODEL=<local-omni-id> OSAURUS_OMNI_AUDIO=<audio-file>
+  OSAURUS_MLX_METALLIB=<default.metallib>
+  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --package-path Packages/OsaurusCore --filter
+  LiveVoiceResidentPreencodeIntegrationTests`. The test warms a resident
+  Nemotron Omni model, runs `preencodeLiveVoiceAudioIfResident(...)` on a real
+  audio file, checks `status=stored`, checks exact source sample count/rate
+  metadata, verifies a fresh `.preEncoded` registry lookup, and verifies the
+  stale-count guard rejects mismatched samples. Local run with
+  `OSAURUS_MLX_METALLIB` passed with `warm_ms=2838`, `samples=80620`,
+  `encode_ms=1289`, `embedding_shape=[63, 2688]`, and max RSS about
+  `13.1 GB`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -34,6 +34,32 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 - `swift build --target OsaurusCore` passed after the live voice snapshot
   changes, after the `vmlx-swift-lm` pin bump to `c0f8b3b`, and after the
   TTFT/live-voice timing instrumentation.
+- Xcode app build passed from the workspace:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
+  -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
+  -destination 'platform=macOS,arch=arm64'
+  -derivedDataPath build/XcodeDerivedData-livevoice
+  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
+  Xcode still reports the local CoreSimulator framework mismatch, but the macOS
+  app build succeeds.
+- Built-app API smoke passed against
+  `build/XcodeDerivedData-livevoice/Build/Products/Debug/osaurus.app` with
+  `OSU_MODELS_DIR=/Users/eric/models` and
+  `nemotron-omni-nano-jangtq-crack` loaded from
+  `/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK`.
+  The health endpoint reported the model loaded, and OpenAI-compatible
+  `/chat/completions` accepted `input_audio` WAV content.
+- Warm latency control from the built app:
+  - text-only streaming request: first semantic SSE delta at `358.3 ms`, total
+    `777.4 ms`.
+  - first audio streaming request after warm text load: first semantic SSE delta
+    at `5304.7 ms`, total `5513.7 ms`.
+  - repeated audio streaming request: first semantic SSE delta at `1601.1 ms`,
+    total `1815.3 ms`.
+  - Osaurus logs showed model cache hits for the audio requests; audio
+    `prepareInput` was `38 ms` on the first audio request and `16 ms` on the
+    repeated request, while the vMLX `engine.generate(...)` await dominated the
+    first semantic delta.
 - `swift test --filter LiveVoiceAudioSnapshotTests` is blocked by the existing
   local toolchain issue: the package test target imports Swift `Testing`, which
   is unavailable in this environment.
@@ -69,6 +95,9 @@ audio support is gated by `ModelMediaCapabilities.supportsAudio`.
 - Add a direct pre-encoded audio path only after an Osaurus voice component can
   emit stable Parakeet/sound-projection embeddings. The current WAV path is
   correct but pays model-side encoding.
+- Add API-level TTFT trace emission for `/chat/completions`; the current
+  `/tmp/osaurus_ttft_trace.log` emission is attached to the chat UI path, while
+  API smoke uses client-side SSE timing plus unified logs.
 - Add TTFAB coverage once a TTS backend is selected. Current evidence covers
   speech input into model output text, not first output audio byte.
 - Keep audio attachment spillover and temp-file cleanup under review for longer

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,13 +3,14 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `81c8ef7`, which can consume
+models. This branch pins `vmlx-swift-lm` to `f728718`, which can consume
 `UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, exposes a
 reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
 polling, adds tracked Omni audio latency and chunk-stability benches, and keeps
 media-placeholder cache restore token-aware. The pin also carries the refreshed
-Parakeet/RADIO host-integration docs and the current proof that independently
-encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated by
+Parakeet/RADIO host-integration docs, the current proof that independently
+encoded Parakeet chunks are not safe to concatenate, and the DSV4 Flash
+long-prompt HSA top-k fix. Omni audio support is gated by
 `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
@@ -51,11 +52,12 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
   is the handoff point for a future live Parakeet/sound-projection component.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `81c8ef7` so
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `f728718` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
   tracked `OmniAudioLatencyBench` and `OmniAudioChunkStabilityBench`
   harnesses, and media-placeholder-aware cache restore guard, plus current
-  Parakeet/RADIO integration documentation.
+  Parakeet/RADIO integration documentation and the DSV4 Flash causal HSA
+  indexer fix.
 - Parakeet/RADIO source, function, and documentation verification is an
   explicit release guard: the source repo must contain the encoder functions
   and bench/docs, the live remote must contain the pinned commit, Osaurus must
@@ -86,9 +88,12 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `/chat/completions` trace recorder was added. Re-run after the `fb8fb39`
   media-cache pin bump passed with SwiftPM resolving `vmlx-swift-lm` at
   `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. The follow-up `b57fe98` pin
-  adds the refreshed Parakeet/RADIO integration docs, and the `81c8ef7` pin
-  adds the Parakeet chunk-stability bench. Re-run after the Nemotron Omni
-  no-thinking default/profile fix also passed under Xcode's Swift toolchain.
+  adds the refreshed Parakeet/RADIO integration docs, the `81c8ef7` pin adds
+  the Parakeet chunk-stability bench, and the `f728718` pin adds the DSV4
+  Flash causal HSA top-k fix. Re-run after the Nemotron Omni no-thinking
+  default/profile fix also passed under Xcode's Swift toolchain. The current
+  `f728718` pin was source-built in this CLT shell with
+  `swift build --package-path Packages/OsaurusCore`.
 - Focused Xcode-toolchain regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ModelProfileRegistryTests/nemotron3_matchesNemotronProfile|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
@@ -96,15 +101,15 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK` and
   `nemotron-omni-nano-jangtq-crack`, and the runtime default
   `enable_thinking=false` with explicit opt-in still honored.
-- After the `81c8ef7` vMLX pin bump, the focused pin/provider/profile suite
-  passed again with `4` tests in `3` suites:
-  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
-  --package-path Packages/OsaurusCore
-  --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests/deepSeekProvider_dropsLocalInstructReasoningEffort|RemoteChatRequestEncodingTests/deepSeekProvider_preservesAcceptedReasoningEfforts|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
+- After the `f728718` vMLX pin bump, the same focused pin/provider/profile
+  suite should be rerun under Xcode's Swift toolchain. In this CLT shell,
+  `swift test --package-path Packages/OsaurusCore --filter 'RemoteChatRequestEncodingTests|RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening'`
+  is blocked before execution by `no such module 'Testing'` while compiling
+  the shared test target.
 - Parakeet/RADIO source/push/doc checks have passed repeatedly for the live
   library pin, including after the rebased Osaurus head `54330b43` was pushed:
   `git ls-remote origin refs/heads/main` for `vmlx-swift-lm` returns
-  `81c8ef7389c031292287801f761957c681d086ea`; `git grep` against the committed
+  `f72871888e951929a11f7aabe14d9ea9024f1773`; `git grep` against the committed
   `vmlx-swift-lm` tree confirms `NemotronHParakeetEncoder`,
   `remapParakeetWeights`, `NemotronHRADIOVisionModel`,
   `remapRadioWeights`, `OmniAudioChunkStabilityBench`,
@@ -112,7 +117,7 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md`; Osaurus pins the
   same revision in `Packages/OsaurusCore/Package.swift` and
   `Packages/OsaurusCore/Package.resolved`; the Osaurus-resolved checkout also
-  contains the same encoder functions and docs.
+  contains the same encoder functions, docs, and DSV4 causal top-k helper.
 - Focused UI/API attachment regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
@@ -138,7 +143,7 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild
   -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug
   -destination 'platform=macOS,arch=arm64' ... build`. The build resolved
-  `vmlx-swift-lm @ 81c8ef7`.
+  `vmlx-swift-lm @ f728718`.
 - Rebuilt debug app `/chat/completions` smoke passed for an
   OpenAI-compatible streaming `input_audio` WAV request. The cold-load request
   returned HTTP `200` and TTFT trace metrics
@@ -223,7 +228,7 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Re-run after the `fb8fb39` pin bump passed with the workspace resolver
   checking out `vmlx-swift-lm @ fb8fb39`; the current dependency pin is
-  `vmlx-swift-lm @ 81c8ef7`. Re-run after the Nemotron Omni
+  `vmlx-swift-lm @ f728718`. Re-run after the Nemotron Omni
   no-thinking default/profile fix passed.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
@@ -333,12 +338,12 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   3. Confirm no audio attachment is appended; only cleaned transcript text is
      sent.
 - Repeated Parakeet/RADIO source verification before merge:
-  1. Confirm `vmlx-swift-lm` live remote `main` contains commit `81c8ef7`.
+  1. Confirm `vmlx-swift-lm` live remote `main` contains commit `f728718`.
   2. Confirm source contains `NemotronHParakeetEncoder`,
      `NemotronHRADIOVisionModel`, `extractAudioEmbeds`, `extractImageEmbeds`,
      and `OmniAudioChunkStabilityBench`.
   3. Confirm Osaurus `Package.swift` and both `Package.resolved` files pin
-     full revision `81c8ef7389c031292287801f761957c681d086ea`.
+     full revision `f72871888e951929a11f7aabe14d9ea9024f1773`.
   4. Confirm the Osaurus-resolved checkout contains the same Parakeet/RADIO
      functions and docs after dependency resolution.
 

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -18,8 +18,10 @@ cache restore token-aware. Omni audio support is gated by
 - `FloatingInputCard.sendVoiceMessage(_:)` captures the WAV before stopping
   transcription and appends it as `Attachment.audio(..., format: "wav")` when
   the selected model supports audio.
-- Existing chat attachment flow converts `Attachment.audio` into
-  `input_audio` content parts.
+- `ChatSession.buildUserChatMessage(...)` converts supported image/audio/video
+  attachments into multimodal `ChatMessage` content parts. This closes the UI
+  bridge gap where live voice appended `Attachment.audio` but the in-app
+  send path could still serialize the turn as plain text only.
 - `ModelRuntime.extractAudioSources(from:)` materializes `input_audio` into a
   temp audio file and hands `UserInput.Audio.url` to vMLX.
 - `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `fb8fb39` so
@@ -55,6 +57,13 @@ cache restore token-aware. Omni audio support is gated by
   `dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK` and
   `nemotron-omni-nano-jangtq-crack`, and the runtime default
   `enable_thinking=false` with explicit opt-in still honored.
+- Focused UI/API attachment regression tests passed:
+  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+  --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
+  The tests cover the new user-message builder forwarding audio/video
+  attachments when capabilities allow them, dropping audio/video when
+  unsupported, and the existing `input_audio`/`video_url` mapping into vMLX
+  `Chat.Message.audios` / `.videos`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -180,11 +180,15 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
   LiveVoiceResidentPreencodeIntegrationTests`. The test warms a resident
   Nemotron Omni model, runs `preencodeLiveVoiceAudioIfResident(...)` on a real
   audio file, checks `status=stored`, checks exact source sample count/rate
-  metadata, verifies a fresh `.preEncoded` registry lookup, and verifies the
-  stale-count guard rejects mismatched samples. Local run with
-  `OSAURUS_MLX_METALLIB` passed with `warm_ms=2838`, `samples=80620`,
-  `encode_ms=1289`, `embedding_shape=[63, 2688]`, and max RSS about
-  `13.1 GB`.
+  metadata, verifies a fresh `.preEncoded` registry lookup, verifies the
+  stale-count guard rejects mismatched samples, and simulates the composer
+  submit path by storing the final PCM snapshot under the same attachment id,
+  building `ChatSession.buildUserChatMessage(...)`, and requiring
+  `ModelRuntime.mapOpenAIChatToMLX(...)` to consume `.preEncoded` audio.
+  Local run with `OSAURUS_MLX_METALLIB` passed after the composer-submit
+  assertion with `warm_ms=2807`, `samples=80620`, `encode_ms=1312`,
+  `embedding_shape=[63, 2688]`, and `composer_submit=preencoded`. Earlier run
+  before the composer-submit assertion recorded max RSS about `13.1 GB`.
 - `OmniAudioLatencyBench` on `Nemotron-Omni-Nano-JANGTQ-CRACK` measured the
   Osaurus BatchEngine path at `1514.1 ms` raw PCM first semantic delta on
   turn 1, `1498.6 ms` raw PCM on turn 2, `208.9 ms` pre-encoded Parakeet on
@@ -307,6 +311,9 @@ encoded Parakeet chunks are not safe to concatenate. Omni audio support is gated
      `input_audio_local_sample_count`, `input_audio_local_preencoded_count`,
      `input_audio_materialize_ms`, `prompt_prepare_ms`, `first_token_ms`, and
      `first_chunk_ms`.
+  6. The gated real-model test covers the same attachment-id handoff into
+     `ChatSession.buildUserChatMessage(...)`; this manual smoke still covers
+     the actual microphone/paste/overlay UI loop.
 - Negative smoke:
   1. Select a text-only model.
   2. Send a voice message.

--- a/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
+++ b/docs/NEMOTRON_OMNI_LIVE_VOICE_PR_CHECKLIST_2026_05_12.md
@@ -3,15 +3,15 @@
 ## Scope
 
 This checklist tracks the Osaurus side of live voice input for Nemotron Omni
-models. This branch pins `vmlx-swift-lm` to `f728718`, which can consume
+models. This branch pins `vmlx-swift-lm` to `6561a72`, which can consume
 `UserInput.Audio`, preserves pre-encoded Parakeet/audio embeddings, exposes a
 reusable retained live PCM buffer with a streaming cursor for VAD/call-mode
 polling, adds tracked Omni audio latency and chunk-stability benches, and keeps
 media-placeholder cache restore token-aware. The pin also carries the refreshed
 Parakeet/RADIO host-integration docs, the current proof that independently
 encoded Parakeet chunks are not safe to concatenate, and the DSV4 Flash
-long-prompt HSA top-k fix. Omni audio support is gated by
-`ModelMediaCapabilities.supportsAudio`.
+long-prompt HSA top-k plus overlap-compressor state fixes. Omni audio support
+is gated by `ModelMediaCapabilities.supportsAudio`.
 
 ## Current Hookups
 
@@ -52,12 +52,12 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   `UserInput.Audio` sources to `.preEncoded` audio embeddings before
   `processor.prepare(input:)`. Existing `.preEncoded` audio is preserved, which
   is the handoff point for a future live Parakeet/sound-projection component.
-- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `f728718` so
+- `Packages/OsaurusCore/Package.swift` pins `vmlx-swift-lm` to `6561a72` so
   the app consumes the Swift live-voice handoff, live PCM streaming cursor,
   tracked `OmniAudioLatencyBench` and `OmniAudioChunkStabilityBench`
   harnesses, and media-placeholder-aware cache restore guard, plus current
   Parakeet/RADIO integration documentation and the DSV4 Flash causal HSA
-  indexer fix.
+  indexer plus ratio-4 overlap-compressor state fixes.
 - Parakeet/RADIO source, function, and documentation verification is an
   explicit release guard: the source repo must contain the encoder functions
   and bench/docs, the live remote must contain the pinned commit, Osaurus must
@@ -90,10 +90,10 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   `fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e`. The follow-up `b57fe98` pin
   adds the refreshed Parakeet/RADIO integration docs, the `81c8ef7` pin adds
   the Parakeet chunk-stability bench, and the `f728718` pin adds the DSV4
-  Flash causal HSA top-k fix. Re-run after the Nemotron Omni no-thinking
-  default/profile fix also passed under Xcode's Swift toolchain. The current
-  `f728718` pin was source-built in this CLT shell with
-  `swift build --package-path Packages/OsaurusCore`.
+  Flash causal HSA top-k fix. The current `6561a72` pin also preserves DSV4
+  ratio-4 overlap-compressor state across single-token decode calls. Re-run
+  after the Nemotron Omni no-thinking default/profile fix also passed under
+  Xcode's Swift toolchain.
 - Focused Xcode-toolchain regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ModelProfileRegistryTests/nemotron3_matchesNemotronProfile|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'`.
@@ -101,23 +101,21 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   `dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK` and
   `nemotron-omni-nano-jangtq-crack`, and the runtime default
   `enable_thinking=false` with explicit opt-in still honored.
-- After the `f728718` vMLX pin bump, the same focused pin/provider/profile
-  suite should be rerun under Xcode's Swift toolchain. In this CLT shell,
-  `swift test --package-path Packages/OsaurusCore --filter 'RemoteChatRequestEncodingTests|RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening'`
-  is blocked before execution by `no such module 'Testing'` while compiling
-  the shared test target.
+- After current vMLX pin bumps, focused pin/provider/profile suites must run
+  under Xcode's Swift toolchain on this machine; the Command Line Tools Swift
+  path does not provide the Swift `Testing` module used by the shared tests.
 - Parakeet/RADIO source/push/doc checks have passed repeatedly for the live
-  library pin, including after the rebased Osaurus head `54330b43` was pushed:
+  library pin:
   `git ls-remote origin refs/heads/main` for `vmlx-swift-lm` returns
-  `f72871888e951929a11f7aabe14d9ea9024f1773`; `git grep` against the committed
+  `6561a72f93d6cd5e0202e8067b53fed5cf21a660`; `git grep` against the committed
   `vmlx-swift-lm` tree confirms `NemotronHParakeetEncoder`,
   `remapParakeetWeights`, `NemotronHRADIOVisionModel`,
   `remapRadioWeights`, `OmniAudioChunkStabilityBench`,
   `PARAKEET-RADIO-INTEGRATION.md`, and
   `docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md`; Osaurus pins the
-  same revision in `Packages/OsaurusCore/Package.swift` and
-  `Packages/OsaurusCore/Package.resolved`; the Osaurus-resolved checkout also
-  contains the same encoder functions, docs, and DSV4 causal top-k helper.
+  same revision in `Packages/OsaurusCore/Package.swift` and the tracked
+  resolved files; the Osaurus-resolved checkout also contains the same encoder
+  functions, docs, and DSV4 causal top-k/overlap-compressor helpers.
 - Focused UI/API attachment regression tests passed:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'`.
@@ -172,7 +170,7 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   This rechecked the local PCM bridge together with multimodal
   audio/video mapping, the Nemotron Omni pre-encode adapter helper, and the
   DeepSeek remote `reasoning_effort` guard.
-- After rebase onto `osaurus/main` `acbf75cc`, the post-rebase focused package
+- After rebase onto `osaurus/main`, the post-rebase focused package
   suite passed with `48` tests in `6` suites:
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
   --package-path Packages/OsaurusCore --filter
@@ -200,8 +198,8 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   submit path by storing the final PCM snapshot under the same attachment id,
   building `ChatSession.buildUserChatMessage(...)`, and requiring
   `ModelRuntime.mapOpenAIChatToMLX(...)` to consume `.preEncoded` audio.
-  Local run with `OSAURUS_MLX_METALLIB` passed again after the rebase at
-  `54330b43` with `warm_ms=2780`, `samples=80620`, `encode_ms=1310`,
+  Local run with `OSAURUS_MLX_METALLIB` passed again after rebase with
+  `warm_ms=2780`, `samples=80620`, `encode_ms=1310`,
   `embedding_shape=[63, 2688]`, and `composer_submit=preencoded`. The prior
   post-composer assertion run also passed with `warm_ms=2807`,
   `samples=80620`, `encode_ms=1312`, `embedding_shape=[63, 2688]`, and
@@ -228,7 +226,7 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`.
   Re-run after the `fb8fb39` pin bump passed with the workspace resolver
   checking out `vmlx-swift-lm @ fb8fb39`; the current dependency pin is
-  `vmlx-swift-lm @ f728718`. Re-run after the Nemotron Omni
+  `vmlx-swift-lm @ 6561a72`. Re-run after the Nemotron Omni
   no-thinking default/profile fix passed.
   Xcode still reports the local CoreSimulator framework mismatch, but the macOS
   app build succeeds.
@@ -240,11 +238,8 @@ long-prompt HSA top-k fix. Omni audio support is gated by
     with HTTP 200 in `4.2 ms` total and wrote a trace block containing
     `http_sse_error_written`, endpoint/model/media counts, and
     `http_response_status=200`.
-- Built-app API smoke passed against
-  `build/XcodeDerivedData-livevoice/Build/Products/Debug/osaurus.app` with
-  `OSU_MODELS_DIR=/Users/eric/models` and
-  `nemotron-omni-nano-jangtq-crack` loaded from
-  `/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK`.
+- Built-app API smoke passed against the debug app with
+  `nemotron-omni-nano-jangtq-crack` loaded from a local model bundle.
   The health endpoint reported the model loaded, and OpenAI-compatible
   `/chat/completions` accepted `input_audio` WAV content.
 - A pre-fix default API smoke exposed the live-call visible-output bug: the
@@ -270,8 +265,6 @@ long-prompt HSA top-k fix. Omni audio support is gated by
     `first_token_ms=111`, and `http_first_semantic_delta_kind=content`.
   - process RSS after the three-turn smoke was about `12.4 GiB`
     (`12723.6 MB` reported by `ps`), with `77128.4 MB` free+speculative VM.
-  Evidence files are under `/tmp/osaurus-live-smoke-evidence/` with the prefix
-  `default_after_patch_`.
 - Rebuilt-app API smoke after the adapter pre-encode hook passed with no
   request-level thinking overrides:
   - cold text warmup: first visible `content` delta `2967.3 ms`, total
@@ -289,8 +282,7 @@ long-prompt HSA top-k fix. Omni audio support is gated by
     `omni_audio_preencode_ms=1327`, `processor_prepare_ms=15`, and
     `first_token_ms=47`.
   - process RSS after the smoke was about `12.4 GiB` (`12972.5 MB` reported by
-    `ps`). Evidence files are under `/tmp/osaurus-live-smoke-evidence/` with
-    the prefix `preencode_after_patch_`.
+    `ps`).
 - Warm latency control from the built app:
   - text-only streaming request: first semantic SSE delta at `358.3 ms`, total
     `777.4 ms`.
@@ -307,9 +299,7 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   target imports Swift `Testing`, which is unavailable from that path. Use
   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer` for Swift Testing
   checks on this machine.
-- vMLX real-model bench passed on the local JANGTQ2 Omni-Nano bundle:
-  `build/evidence-20260512/nemotron_omni_live_voice_jangtq2_clean_20260512_155446.log`
-  in `vmlx-swift-lm`.
+- vMLX real-model bench passed on a local JANGTQ2 Omni-Nano bundle.
 - That bench exercised text multi-turn, audio encoder smoke, full audio
   `LMInput`, mixed image + audio, media-salt isolation, reasoning toggle, and
   hybrid SSM warm-pass parity: `13 passed, 0 failed`, `bench_exit=0`.
@@ -338,12 +328,13 @@ long-prompt HSA top-k fix. Omni audio support is gated by
   3. Confirm no audio attachment is appended; only cleaned transcript text is
      sent.
 - Repeated Parakeet/RADIO source verification before merge:
-  1. Confirm `vmlx-swift-lm` live remote `main` contains commit `f728718`.
+  1. Confirm `vmlx-swift-lm` live remote `main` contains commit `6561a72`.
   2. Confirm source contains `NemotronHParakeetEncoder`,
      `NemotronHRADIOVisionModel`, `extractAudioEmbeds`, `extractImageEmbeds`,
      and `OmniAudioChunkStabilityBench`.
-  3. Confirm Osaurus `Package.swift` and both `Package.resolved` files pin
-     full revision `f72871888e951929a11f7aabe14d9ea9024f1773`.
+  3. Confirm Osaurus `Package.swift` plus workspace, app project, and
+     `OsaurusCore` `Package.resolved` files pin full revision
+     `6561a72f93d6cd5e0202e8067b53fed5cf21a660`.
   4. Confirm the Osaurus-resolved checkout contains the same Parakeet/RADIO
      functions and docs after dependency resolution.
 

--- a/docs/RUNTIME_VALIDATION_STANDARD.md
+++ b/docs/RUNTIME_VALIDATION_STANDARD.md
@@ -1,0 +1,327 @@
+# Runtime validation standard
+
+This is the standard checklist for Osaurus + vmlx runtime changes that touch
+model loading, generation, cache residency, reasoning, Jinja templates, media
+inputs, tool calls, or sampling defaults.
+
+The goal is not "one smoke passed." The goal is enough evidence to know which
+topologies are covered, which are intentionally gated, and which still need a
+real-model run.
+
+## Ground rules
+
+- Record the exact Osaurus SHA, vmlx-swift-lm SHA, mlx-swift SHA, swift-jinja
+  SHA, model bundle path, model revision, and Package.resolved entries.
+- Do not claim speed, cache, or coherence from source reading alone. Source
+  tests are contract guards. Runtime claims need logs or benchmark artifacts.
+- Keep cache claims topology-specific. "Cache works" is not a valid result.
+  Say which cache tier was used and which model cache family was exercised.
+- Test both the direct engine path and the Osaurus app/API path when the change
+  affects user-visible behavior.
+- Preserve bundle generation_config defaults unless a model-specific reason is
+  proven from a failing run.
+- Never use fake parser transitions, forced tool calls, or hidden sampling
+  shims as a substitute for fixing prompt, template, parser, or config wiring.
+- Treat workspace, app-project, and package-level `Package.resolved` files as
+  part of the runtime contract. They must agree on the vmlx, mlx-swift, Jinja,
+  and swift-transformers revisions and org fork URLs.
+
+## Required artifacts
+
+Every manual or nightly run should write a folder such as:
+
+```text
+build/runtime-validation/YYYYMMDD-HHMM/
+  summary.json
+  runs.jsonl
+  osaurus.log
+  vmlx.log
+  package-pins.txt
+  ui-notes.md
+```
+
+Each `runs.jsonl` row should include:
+
+```json
+{
+  "osaurus_sha": "...",
+  "vmlx_sha": "...",
+  "model_id": "...",
+  "model_path": "...",
+  "model_type": "...",
+  "quant": "mxfp4|jangtq4|jangtk|fp16|...",
+  "architecture_bucket": "dense|moe|swa|ssm|linear|cca|mla|vl|omni",
+  "turn": 2,
+  "prompt_tokens": 3472,
+  "media": {"images": 0, "videos": 0, "audios": 0, "salt": "..."},
+  "cache": {
+    "tier": "paged|disk|none",
+    "hit": true,
+    "boundary_tokens": 3430,
+    "path_dependent": false
+  },
+  "timing": {
+    "submit_ms": 20,
+    "processor_prepare_ms": 45,
+    "prompt_ms": 146,
+    "ttft_ms": 320,
+    "tokens_per_second": 32.5
+  },
+  "generation": {
+    "stop_reason": "stop|length|cancelled|error",
+    "generated_tokens": 96,
+    "reasoning_tokens": 25,
+    "unclosed_reasoning": false,
+    "tool_calls": 0
+  },
+  "memory": {
+    "rss_peak_bytes": 0,
+    "mlx_cache_bytes_peak": 0
+  },
+  "verdict": "pass|fail|blocked"
+}
+```
+
+## GitHub checks
+
+These checks should run on every PR that changes runtime code, package pins, or
+model-family detection.
+
+### Pin integrity
+
+Fail if any of these are true:
+
+- `Package.swift` or any tracked `Package.resolved` references a local path
+  such as `/Users/...`.
+- The workspace and app resolved files disagree on vmlx-swift-lm, mlx-swift,
+  swift-jinja, or swift-transformers.
+- A required org fork resolves to an upstream URL when Osaurus expects the
+  osaurus-ai fork.
+- vmlx, mlx-swift, or Jinja code needed by Osaurus is uncommitted while
+  Osaurus pins an older SHA.
+
+Suggested job:
+
+```sh
+swift package resolve --package-path Packages/OsaurusCore
+swift package resolve
+mkdir -p build/runtime-pin-check
+runtime_pins() {
+  jq -r '.pins[]
+    | select(.identity=="vmlx-swift-lm"
+      or .identity=="mlx-swift"
+      or .identity=="jinja"
+      or .identity=="swift-transformers")
+    | [.identity, .location, .state.revision] | @tsv' "$1"
+}
+runtime_pins Packages/OsaurusCore/Package.resolved > build/runtime-pin-check/core.tsv
+runtime_pins App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved > build/runtime-pin-check/app.tsv
+runtime_pins osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved > build/runtime-pin-check/workspace.tsv
+diff -u build/runtime-pin-check/core.tsv build/runtime-pin-check/app.tsv
+diff -u build/runtime-pin-check/core.tsv build/runtime-pin-check/workspace.tsv
+rg -n '/Users/|huggingface/swift-jinja|huggingface/swift-transformers' \
+  Packages/OsaurusCore/Package.swift \
+  Packages/OsaurusCore/Package.resolved \
+  App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved \
+  osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved && exit 1 || true
+```
+
+### Osaurus no-load contract tests
+
+These are fast CI checks for wiring and policy. They do not prove model quality.
+
+Run at least:
+
+```sh
+swift test --package-path Packages/OsaurusCore \
+  --filter 'ModelRuntimeMappingTests|MultimodalContentPartTests|MaterializeMediaDataUrlMCDCTests|ModelMediaCapabilitiesMCDCTests|VLMDetectionTests|MultiTurnFamilyMatrixTests|LocalReasoningCapabilityTests|LocalGenerationDefaultsTests|GenerationEventMapperTests|MLXBatchAdapterTests|RuntimePolicySourceTests|ThinkTagScrubberTests'
+```
+
+Coverage expected from these tests:
+
+- OpenAI content parts decode for text, image_url, input_audio, and video_url.
+- `mapOpenAIChatToMLX` forwards images, videos, audios, assistant
+  `reasoning_content`, assistant tool calls, and tool-role `tool_call_id`.
+- Local reasoning policy is family-aware: Ling is non-reasoning, ZAYA defaults
+  off unless explicitly opted in, Hy3 uses `reasoning_effort`, MiniMax and
+  Qwen-family stamps resolve through vmlx.
+- Media capability detection rejects bare text models that only look similar to
+  VLM or omni names.
+- Generation defaults from bundle/config and Osaurus overrides are merged
+  without silently dropping top_k, top_p, temperature, min_p, stop strings, or
+  KV settings.
+
+### vmlx contract tests
+
+Run on the vmlx repo before repinning Osaurus:
+
+```sh
+swift build --target MLXLMCommon
+swift test --filter 'ReasoningParser|ReasoningStamp|GenerationConfig|Gemma4PLE|BatchEngineGrowingChatCache|Zaya|Cache|ToolCall|MultiTurnFamilyMatrix'
+```
+
+Required contract areas:
+
+- `Chat.Message.reasoningContent` remains in the generated Jinja dict.
+- `Chat.Message` media arrays copy into `UserInput.images`, `videos`, and
+  `audios`.
+- `Generation.reasoning` and `Generation.chunk` are mutually exclusive for the
+  same bytes.
+- Tool-call routing works on both content and reasoning rails when the family
+  can emit calls there.
+- JANG capability stamps for reasoning/tool parsers resolve by stamp first and
+  by model_type only as fallback.
+- Gemma 4 PLE config tolerance handles known non-PLE A4B configs without
+  disabling real PLE when both PLE fields are present.
+
+### Nightly real-model matrix
+
+Run this on self-hosted hardware with local model bundles. It is too large for
+normal hosted CI, but it should be required before runtime-heavy releases.
+
+For each row, do at least three turns: cold turn, same-chat follow-up, and
+follow-up after assistant reasoning/tool state. Record `runs.jsonl`.
+
+| Bucket | Example families | Required checks |
+|---|---|---|
+| Dense KV | Qwen dense, Mistral dense | cold/warm TTFT, generation_config, stop/EOS, compiled decode on/off if enabled |
+| Dense MoE | Qwen3.5/3.6 MoE, Laguna, Gemma MoE | top-k override honored, compiled router active where supported, no router fallback speed cliff |
+| Sliding/rotating KV | Gemma 4 | PLE load, rotating cache behavior, image token path for VLM variants |
+| Hybrid SSM/Mamba | MiniMax, Nemotron-H, Jamba, FalconH1 | SSM companion disk cache, no unsafe full-hit double count, reasoning/tool parser stamps, no cross-model cache poisoning |
+| Linear attention | Ling/Bailing hybrid, LFM-style models | ArraysCache disk round-trip, non-reasoning policy where expected, no false paged-cache claim |
+| CCA | ZAYA text/VL | ZayaCCACache state restore, reasoning toggle on/off, no CCA state corruption across turns |
+| MLA/compressor | DSV4, Nemotron variants | compressor/cache restore, reasoning tags, EOS/stop tokens |
+| Image VL | Qwen VL, ZAYA1-VL, Gemma VLM, Pixtral/Mistral VL | image token IDs, media salt isolation, repeated same image cache hit |
+| Video VL | Qwen VL, SmolVLM, omni | data:video mp4 extension preservation, frame extraction, changed video cache miss |
+| Audio/omni | Nemotron-Omni | input_audio temp-file materialization, audio sample prep, changed audio cache miss |
+| Tool calling | MiniMax, Qwen, Mistral, Laguna, Gemma | structured tool_calls, tool result turn, no XML-in-content fallback |
+
+## Known Regression Classes
+
+Use these as explicit release blockers when they touch the current branch:
+
+- Stale resolver URLs: the app project, workspace, and package resolver records
+  must not disagree on `osaurus-ai/Jinja`, `osaurus-ai/swift-transformers`,
+  `osaurus-ai/vmlx-swift-lm`, or `osaurus-ai/mlx-swift`.
+- Parakeet live streaming: independently encoded chunks are not safe to
+  concatenate. Use retained PCM snapshots or fresh `.preEncoded` embeddings until
+  a stateful/incremental Parakeet path has its own proof.
+- Nemotron Omni default reasoning: call-mode/audio defaults should produce
+  visible answer deltas unless the user explicitly opts into thinking.
+- DSV4 long context: HSA top-k must mask future compressed chunks, and the
+  overlap compressor must preserve previous complete ratio windows across
+  decode calls. Raw `reasoning_effort=max` needs separate diagnostics before it
+  is treated as a stable UI default.
+- ZAYA1-VL detection: `zaya1_vl` and bundles with `vision_config` must route
+  through VLM detection, not text-only ZAYA. Nested MXTQ/routed-expert bit
+  metadata parse failures are runtime detection bugs, not user-facing media
+  errors.
+- Cache topology: CCA state, SSM companion state, DSV4 compressor state, dense
+  KV, rotating KV, and media-salted VLM prompts require separate cache evidence.
+
+## Manual UI checklist
+
+Run after a fresh Release build from the same pins that will ship.
+
+For each selected model:
+
+1. Confirm the UI chip and debug log show the correct model.
+2. Send `hi`. Record TTFT, stop reason, visible answer, and whether stop button
+   returns to send.
+3. Send a follow-up in the same chat. Confirm prefix-cache behavior by log, not
+   by perception.
+4. Toggle reasoning OFF, send a short prompt, confirm no reasoning pane and no
+   leaked think tags.
+5. Toggle reasoning ON, send a short prompt, confirm the expected family
+   behavior:
+   - non-reasoning families ignore or hide the control by policy;
+   - reasoning families emit `.reasoning` when the template/model supports it;
+   - final visible answer is separate from reasoning unless the family is
+     explicitly configured otherwise.
+6. Stop a generation mid-stream. Confirm cancellation yields terminal stats or
+   a clear cancelled state and the input control unlocks.
+7. For VLM/omni models, attach one supported media file and one unsupported
+   media file. Confirm the unsupported file is rejected before submit.
+
+Do not call a run "good" if only the first turn passed. Many regressions only
+show on turn 2 or after prior assistant reasoning/tool state is serialized.
+
+## Cache-specific probes
+
+Every cache fix must answer these questions with logs or a test:
+
+- Which cache family is active: `KVCacheSimple`, `RotatingKVCache`,
+  `TurboQuantKVCache`, `MambaCache`, `ArraysCache`, `ZayaCCACache`,
+  `CacheList`, or a batch wrapper?
+- Which coordinator tier hit: paged memory, disk, or none?
+- If the cache is path-dependent, was the stored boundary restored and then
+  correctly advanced for the remaining prompt?
+- Was the restored cache materialized before decode so TTFT does not hide
+  deferred Metal work?
+- Did media salt participate in the key when image/audio/video was present?
+- Was a full hit treated differently from a growing-chat partial hit when SSM
+  state would be double-counted by re-feeding the last token?
+- Did stop reason `.stop`, `.length`, and `.cancelled` each do the intended
+  post-answer storage behavior?
+
+Minimum sequence:
+
+```text
+T1: new chat, no cache expected.
+T2: same chat, same model, growing prompt, cache hit expected where supported.
+T3: same chat after assistant reasoning_content or tool_calls, cache still valid.
+T4: same chat with different media, cache miss or different media salt expected.
+T5: switch model, then switch back, no cross-model cache poisoning.
+```
+
+## Reasoning and parser probes
+
+Every reasoning-family change must test:
+
+- Template context sent by Osaurus (`enable_thinking`, `reasoning_effort`, or
+  family-specific field) in `MLXBatchAdapter.prepareInput`.
+- vmlx parser stamp source: JANG stamp, model_type heuristic, or none.
+- ON/OFF/ON toggle across three turns in the same chat.
+- Prior assistant `reasoning_content` on the next prompt.
+- Stream split: reasoning pane receives `.reasoning`; visible answer receives
+  `.chunk`; no byte appears in both.
+- Terminal `.info` arrives and `unclosedReasoning` is shown only when it is a
+  real diagnostic.
+
+For MiniMax, Qwen, ZAYA, Hy3, Nemotron, DSV4, and Gemma 4, do not assume a
+shared tag contract. Check the bundle template, JANG stamps, and current vmlx
+`ReasoningParser.fromCapabilityName` behavior.
+
+## Performance probes
+
+Separate these timings:
+
+- App submit-to-engine time.
+- Chat/tool/context build time.
+- Jinja/template processor prepare time.
+- Prompt prefill time.
+- Restore/materialization time.
+- First decode token time.
+- Sustained decode tok/s.
+- Model load time and peak resident memory.
+
+If a user-visible TTFT is slow but `promptMs` is fast, inspect template render,
+cache materialization, media preprocessing, and first-token decode before
+calling it a cache miss.
+
+## Recommended next tooling
+
+Add these scripts as follow-up work:
+
+- `scripts/runtime-matrix/run_osaurus_matrix.sh`: runs the live app/API matrix
+  and writes `runs.jsonl`.
+- `scripts/runtime-matrix/collect_logs.sh`: extracts structured Osaurus and
+  vmlx logs for one run window.
+- `scripts/runtime-matrix/compare_runs.py`: compares two validation folders and
+  flags speed, stop-reason, parser, or cache regressions.
+- `scripts/ci/check-package-pins.sh`: enforces remote pins and org fork URLs.
+- `scripts/ci/check-runtime-policy-tests.sh`: runs the no-load tests above.
+
+Also extend `MLXBatchAdapter.prepareInput` logs to include `videos`, `audios`,
+and media salt. Existing logs include images, tool count, prompt tokens, and
+context keys; audio/video need equal visibility for future omni/VL debugging.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -94,7 +94,7 @@
     {
       "identity" : "jinja",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-jinja",
+      "location" : "https://github.com/osaurus-ai/Jinja.git",
       "state" : {
         "revision" : "58d21aa5b69fdd9eb7e23ce2c3730f47db8e0c9d"
       }
@@ -389,7 +389,7 @@
     {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "location" : "https://github.com/osaurus-ai/swift-transformers",
       "state" : {
         "revision" : "087a66b17e482220b94909c5cf98688383ae481a"
       }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "4365651d9245ad983094717bb2886a64635a5b38"
+        "revision" : "f72871888e951929a11f7aabe14d9ea9024f1773"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "f72871888e951929a11f7aabe14d9ea9024f1773"
+        "revision" : "6561a72f93d6cd5e0202e8067b53fed5cf21a660"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
+        "revision" : "b57fe98845bd1f678bd8f722dc50dba56f11d029"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "81c8ef7389c031292287801f761957c681d086ea"
+        "revision" : "4365651d9245ad983094717bb2886a64635a5b38"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
+        "revision" : "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "638024bae655b93b1da92385ce9fb4935584fb64"
+        "revision" : "fb8fb3959ac97598c6b4ddeba0516f01d84ddf0e"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e7e9990e6a036126ec6792bd01789a6f4d2d4bb6fd7c5617a2e495a8a9158a1e",
+  "originHash" : "9b1e6f4f7c73c68b7f1508fe2f891cf110763b0f523aaca6823051d868ddbfcd",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -94,7 +94,7 @@
     {
       "identity" : "jinja",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/osaurus-ai/Jinja.git",
+      "location" : "https://github.com/huggingface/swift-jinja",
       "state" : {
         "revision" : "58d21aa5b69fdd9eb7e23ce2c3730f47db8e0c9d"
       }
@@ -389,7 +389,7 @@
     {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/osaurus-ai/swift-transformers",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
         "revision" : "087a66b17e482220b94909c5cf98688383ae481a"
       }
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "ad1d23199b056ed502124717e6ca8877f2fb303a"
+        "revision" : "c0f8b3b1e87f92983bb82f8ace2ec6fd3779c471"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "b57fe98845bd1f678bd8f722dc50dba56f11d029"
+        "revision" : "81c8ef7389c031292287801f761957c681d086ea"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -416,7 +416,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift-lm",
       "state" : {
-        "revision" : "e497f61c3a68c6d70334d8a14a7ad0a58864af9b"
+        "revision" : "638024bae655b93b1da92385ce9fb4935584fb64"
       }
     },
     {


### PR DESCRIPTION
## Summary
- retain live voice PCM and attach WAV input audio for audio-capable voice sends
- forward supported in-app chat media attachments, including live voice `Attachment.audio`, into multimodal `ChatMessage` content parts instead of serializing the user turn as plain text only
- carry current in-app live voice PCM through an in-process `LocalAudioSamples` side channel aligned with `input_audio`, so local MLX turns reach vMLX as `UserInput.Audio.samples` while the WAV/base64 payload remains available for history and fallback
- create a stable live voice attachment id at recording start and periodically pre-encode retained PCM snapshots against the already-resident Nemotron Omni model while capture/cleanup is active
- force one final resident-model pre-encode during transcription cleanup, then only consume the stored `.preEncoded` audio when the final PCM sample count and sample rate exactly match so stale periodic embeddings cannot drop the end of an utterance
- pre-encode Nemotron Omni `UserInput.Audio` in `MLXBatchAdapter` before `processor.prepare(input:)`, while preserving existing `.preEncoded` audio from the live voice path
- decode valid OpenAI-compatible API `input_audio` WAV payloads directly to `UserInput.Audio.samples` before the adapter pre-encodes them, while preserving temp-file fallback for non-WAV or malformed audio
- pin vmlx-swift-lm to 81c8ef7 for Nemotron Omni audio/pre-encoded handoff support, retained live PCM streaming cursor, the tracked OmniAudioLatencyBench and OmniAudioChunkStabilityBench harnesses, media-placeholder-aware cache restore, refreshed Parakeet/RADIO integration docs, and the proof that current Parakeet chunks are not safe to concatenate
- require repeated Parakeet/RADIO release verification: committed source functions, docs/bench docs, live vmlx remote, Osaurus manifest pin, and Osaurus resolved checkout must all match before calling the PR ready
- default Nemotron Omni local/API ids, including nemotron-omni-nano-jangtq-crack, to no-think streaming while preserving explicit opt-in for reasoning
- keep Osaurus-local DeepSeek reasoning mode `instruct` out of remote DeepSeek API requests; only `low`, `medium`, `high`, `max`, and `xhigh` are forwarded as `reasoning_effort`
- add live-voice latency trace fields for snapshot, audio materialization/local-sample counts, live pre-encoded count, Omni audio pre-encoding, prompt prepare, first model output, and first visible chunk

## Latest validation after 3920c878
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'ModelMediaCapabilitiesMCDCTests|MultiTurnFamilyMatrixTests|ChatAttachmentSecurityTests|MultimodalContentPartTests|MaterializeMediaDataUrlMCDCTests|LiveVoiceAudioSnapshotTests|MLXBatchAdapterTests'
  - 102 tests in 11 suites passed; covers short local `Nemotron-Omni-Nano-JANGTQ-CRACK` capability detection, text-only image rejection, remote-image fallback, audio/video lowering, and adapter preencode helper
- OSAURUS_RUN_REAL_OMNI_PREENCODE=1 OSU_MODELS_DIR=/Users/eric/models/dealign.ai OSAURUS_OMNI_MODEL=Nemotron-Omni-Nano-JANGTQ-CRACK OSAURUS_OMNI_AUDIO=/Users/eric/vmlx-swift-lm/Tests/MLXLMTests/Resources/audio_only.mov OSAURUS_MLX_METALLIB=/Users/eric/osaurus-staging/Packages/OsaurusCore/.build/arm64-apple-macosx/debug/default.metallib DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter LiveVoiceResidentPreencodeIntegrationTests
  - real local model run passed: warm_ms=2791, samples=80620, encode_ms=1409, embedding_shape=[63, 2688], composer_submit=preencoded
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore
  - 2038 tests in 266 suites passed
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath build/XcodeDerivedData-media-wiring-nosign CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
  - unsigned macOS app build succeeded; signed local build is blocked only by the missing Mac Development certificate for team 4W8QF9VR2F
- GitHub PR #1073 at 3920c878: shellcheck, swiftlint, test-cli, test-core, and update_release_draft all passed; mergeStateStatus CLEAN

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --target OsaurusCore
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ChatAttachmentSecurityTests/buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs|MultimodalContentPartTests/mapping_usesLocalLiveAudioSamples'
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests'
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ModelProfileRegistryTests/nemotron3_matchesNemotronProfile|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs|ChatAttachmentSecurityTests|MultimodalContentPartTests'
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter RemoteChatRequestEncodingTests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs|RemoteChatRequestEncodingTests'
  - latest run after 051a05ef: 46 tests in 4 suites passed; 2 direct `.preEncoded` mapping tests are present but skipped because standalone `MLXArray` fixtures cannot load `default.metallib` in this SwiftPM test process
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests|LiveVoiceResidentPreencodeIntegrationTests'
  - latest run after 82f734a9: 29 tests in 3 suites passed; gated resident pre-encode test skipped by default
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'ChatAttachmentSecurityTests|MultimodalContentPartTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs|RemoteChatRequestEncodingTests|RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|LiveVoiceResidentPreencodeIntegrationTests'
  - latest run after 82f734a9: 48 tests in 6 suites passed; 3 gated/MLXArray-fixture tests skipped
- OSAURUS_RUN_REAL_OMNI_PREENCODE=1 OSU_MODELS_DIR=<models-root> OSAURUS_OMNI_MODEL=<local-omni-id> OSAURUS_OMNI_AUDIO=<audio-file> OSAURUS_MLX_METALLIB=<default.metallib> DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter LiveVoiceResidentPreencodeIntegrationTests
  - post-rebase local real-model run after 54330b43 passed: warm_ms=2780, samples=80620, encode_ms=1310, embedding_shape=[63, 2688], composer_submit=preencoded
  - prior local real-model run after 9b080e45 passed: warm_ms=2807, samples=80620, encode_ms=1312, embedding_shape=[63, 2688], composer_submit=preencoded; earlier run recorded max RSS about 13.1 GB
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path Packages/OsaurusCore --target OsaurusCore
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RemoteChatRequestEncodingTests/deepSeekProvider_dropsLocalInstructReasoningEffort|RemoteChatRequestEncodingTests/deepSeekProvider_preservesAcceptedReasoningEfforts|MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn'
  - latest run after 6fdc2717: 4 tests in 3 suites passed; SwiftPM resolved vmlx-swift-lm at 81c8ef7389c031292287801f761957c681d086ea
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter MultimodalContentPartTests/mapping_audioWavDecodesToSamples
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'MultimodalContentPartTests|MaterializeMediaDataUrlMCDCTests|MLXBatchAdapterTests/preencodeAudioSources_replacesRawAudioAndCountsInputs'
  - latest run after 888c866a: 25 tests in 3 suites passed; 2 direct `.preEncoded` mapping tests are still skipped for the existing standalone `MLXArray`/`default.metallib` fixture limitation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter LiveVoiceResidentPreencodeIntegrationTests
  - latest non-gated run after 9b080e45 compiled and skipped cleanly when `OSAURUS_RUN_REAL_OMNI_PREENCODE` was unset
- stale CI source-policy expectation from the prior 638024b vmlx pin reproduced from the test-core xcresult and fixed in 82f734a9; the corrected focused policy test passes locally
- xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath build/XcodeDerivedData-livevoice CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
- app-level OpenAI-compatible streaming smoke on local nemotron-omni-nano-jangtq-crack after the default no-think fix:
  - text turn: first visible content 2588.8ms cold load, text `ready`, no reasoning_content
  - WAV input_audio turn: first visible content 3218.8ms, text `A single electronic beep`, no reasoning_content
  - follow-up turn after audio prefix: first visible content 3264.6ms, text `yes`, no reasoning_content
- app-level OpenAI-compatible streaming smoke after the adapter pre-encode hook:
  - cold text warmup: first visible content 2967.3ms, text `Ready.`, no reasoning_content
  - warm WAV input_audio: first visible content 1634.8ms, total 1893.5ms, text `A guitar is played in this audio.`, no reasoning_content
  - repeat warm WAV input_audio: first visible content 1553.0ms, total 1667.1ms, text `Tick`, no reasoning_content
  - /tmp/osaurus_ttft_trace.log confirmed input_audio_materialize_ms=0, omni_audio_preencode_converted_count=1, omni_audio_preencode_ms=1368/1327, processor_prepare_ms=14/15, first_token_ms=50/47, and http_first_semantic_delta_kind=content
- app-level OpenAI-compatible streaming smoke after the API WAV PCM side-channel fix:
  - cold WAV `input_audio` request: HTTP 200, input_audio_materialized_count=0, input_audio_local_sample_count=1, omni_audio_preencode_converted_count=1, load_container_done=2388.6ms, prompt_prepare_ms=1447, first_token_ms=75
  - resident repeat: HTTP 200, load_container_done=0.1ms, input_audio_materialized_count=0, input_audio_local_sample_count=1, omni_audio_preencode_converted_count=1, prompt_prepare_ms=1415, first_token_ms=71
- upstream vmlx-swift-lm OmniAudioLatencyBench on local Nemotron-Omni-Nano-JANGTQ-CRACK: BatchEngine raw PCM first semantic delta 1514.1ms turn 1 / 1498.6ms turn 2; pre-encoded Parakeet 208.9ms turn 1 / 201.8ms turn 2; swaps 0
- OmniAudioLatencyBench cache diagnostics at fb8fb39: prompt_tokens 94, media_placeholder_tokens 63, known media token IDs [18, 27], media span indices 12...74, 64-token suffix still contains media tokens
- upstream vmlx-swift-lm OmniAudioChunkStabilityBench at 81c8ef7: 10 prefix comparisons, 10 unstable at tolerance 0.01, stable_tokens_default=0 for every comparison; current Parakeet chunk concatenation is unsafe
- repeated Parakeet/RADIO source check after final pushed PR head 7c8f76be: live Osaurus branch is 7c8f76be09b8cabefccb19acb2f6524cde2d0602; live vmlx main is 81c8ef7389c031292287801f761957c681d086ea; committed vmlx HEAD contains NemotronHParakeetEncoder, remapParakeetWeights, NemotronHRADIOVisionModel, remapRadioWeights, OmniAudioChunkStabilityBench, PARAKEET-RADIO-INTEGRATION.md, and docs/benchmarks/omni-audio-chunk-stability-2026-05-13.md; Osaurus Package.swift and Package.resolved pin that full hash; the Osaurus-resolved checkout contains the same encoder functions and docs
- upstream vmlx-swift-lm OmniBench on local Nemotron-Omni-Nano-JANGTQ-CRACK: 13 passed, 0 failed; audio encoder 0.29s; audio LMInput e2e 1.56s; swaps 0
- git diff --check
- post-rebase focused suite after 54330b43: 48 tests in 6 suites passed for RemoteChatRequestEncodingTests, RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening, API WAV mapping, media materialization MCDC tests, MLXBatchAdapter preencode helper, and LiveVoiceResidentPreencodeIntegrationTests skipped-by-default path
- rebase onto osaurus/main acbf75cc kept the newer dsv4RemoteEffort/ThinkingConfig DeepSeek remote reasoning translation while preserving the Osaurus-local instruct-stripping guard
- GitHub PR #1073 at 888c866a: shellcheck, swiftlint, test-cli, test-core, and update_release_draft all passed; mergeStateStatus CLEAN
- GitHub PR #1073 at 7c8f76be: checks started after the post-rebase documentation/evidence push

## Known Local Test Runner Issue
- swift test without DEVELOPER_DIR on this machine uses /Library/Developer/CommandLineTools and fails before assertions with `no such module 'Testing'`; the focused tests pass with DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
- Xcode prints the existing out-of-date CoreSimulator warning, but the macOS build succeeds
- the gated real-model resident pre-encode SwiftPM test needs `OSAURUS_MLX_METALLIB` or a prior app build so MLX `default.metallib` can be copied beside the test binary

## Remaining Manual Gates
- do not replace periodic full-snapshot pre-encoding with chunk-concatenated Parakeet outputs on the current encoder; a future causal/incremental path needs a stateful encoder proof with explicit lookahead and rollback semantics
- true output TTS TTFAB once the output TTS backend is selected








