### PR TITLE
auto speak in agent level

### DIFF
--- a/Packages/OsaurusCore/Managers/TTSService.swift
+++ b/Packages/OsaurusCore/Managers/TTSService.swift
@@ -91,7 +91,7 @@ public final class TTSService: ObservableObject {
     /// Toggle speech for a given message. Tapping the currently-playing
     /// message stops playback; tapping a different message switches to it.
     /// If the model isn't downloaded yet, posts `.openTTSSettingsRequested`.
-    public func toggleSpeak(text: String, messageId: UUID) {
+    public func toggleSpeak(text: String, messageId: UUID, voiceOverride: String? = nil) {
         if playingMessageId == messageId {
             stop()
             return
@@ -112,12 +112,12 @@ public final class TTSService: ObservableObject {
 
         stop()
         playingMessageId = messageId
-        startPlayback(text: plain, messageId: messageId)
+        startPlayback(text: plain, messageId: messageId, voiceOverride: voiceOverride)
     }
 
     /// Fire-and-forget playback for the `speak` tool. Sets
     /// `activeSpeakCallId` so the row spinner runs until audio drains
-    public func startToolPlayback(text: String, messageId: UUID, callId: String) throws {
+    public func startToolPlayback(text: String, messageId: UUID, callId: String, voiceOverride: String? = nil) throws {
         guard isModelReady else {
             if Self.pocketTtsModelsExistOnDisk() {
                 ensureModelLoaded()
@@ -132,7 +132,7 @@ public final class TTSService: ObservableObject {
         stop()
         playingMessageId = messageId
         activeSpeakCallId = callId
-        startPlayback(text: plain, messageId: messageId)
+        startPlayback(text: plain, messageId: messageId, voiceOverride: voiceOverride)
     }
 
     /// Stop any in-flight synthesis and clear playback state.
@@ -223,7 +223,7 @@ public final class TTSService: ObservableObject {
 
     // MARK: - Playback
 
-    private func startPlayback(text: String, messageId: UUID) {
+    private func startPlayback(text: String, messageId: UUID, voiceOverride: String? = nil) {
         do {
             try configureEngineIfNeeded()
         } catch {
@@ -242,7 +242,8 @@ public final class TTSService: ObservableObject {
         playerNode.play()
 
         let config = TTSConfigurationStore.load()
-        let voice = config.voice
+        let trimmedOverride = voiceOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let voice = (trimmedOverride?.isEmpty == false ? trimmedOverride! : config.voice)
         let temperature = Float(config.temperature)
 
         playbackTask = Task { [weak self] in
@@ -328,6 +329,23 @@ public final class TTSService: ObservableObject {
         if !audioEngine.isRunning {
             try audioEngine.start()
         }
+    }
+}
+
+/// built-in PocketTTS voices (kyutai/pocket-tts on HuggingFace). shared by
+/// the TTS settings tab and the per-agent voice picker.
+public enum PocketTTSVoiceCatalog {
+    public static let availableVoices: [String] = [
+        "alba", "anna", "azelma", "bill_boerst", "caro_davy", "charles",
+        "cosette", "eponine", "eve", "fantine", "george", "jane",
+        "javert", "jean", "marius", "mary", "michael", "paul",
+        "peter_yearsley", "stuart_bell", "vera",
+    ]
+
+    public static func displayName(for voice: String) -> String {
+        voice.split(separator: "_")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
     }
 }
 

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -111,6 +111,10 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
     /// `OsaurusPaths.agents()/avatars/`. When set, takes precedence over
     /// `avatar` in the avatar UI. nil = no custom image.
     public var customAvatarFilename: String?
+    /// auto-speak assistant turns after streaming. overrides per-chat toggle.
+    public var autoSpeak: Bool?
+    /// per-agent PocketTTS voice override. nil = use global voice.
+    public var ttsVoice: String?
 
     public init(
         id: UUID = UUID(),
@@ -137,7 +141,9 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
         disableTools: Bool? = nil,
         disableMemory: Bool? = nil,
         avatar: String? = nil,
-        customAvatarFilename: String? = nil
+        customAvatarFilename: String? = nil,
+        autoSpeak: Bool? = nil,
+        ttsVoice: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -164,6 +170,8 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
         self.disableMemory = disableMemory
         self.avatar = avatar
         self.customAvatarFilename = customAvatarFilename
+        self.autoSpeak = autoSpeak
+        self.ttsVoice = ttsVoice
     }
 
     // MARK: - Custom avatar resolution
@@ -261,6 +269,8 @@ extension Agent {
         disableMemory = try c.decodeIfPresent(Bool.self, forKey: .disableMemory)
         avatar = try c.decodeIfPresent(String.self, forKey: .avatar)
         customAvatarFilename = try c.decodeIfPresent(String.self, forKey: .customAvatarFilename)
+        autoSpeak = try c.decodeIfPresent(Bool.self, forKey: .autoSpeak)
+        ttsVoice = try c.decodeIfPresent(String.self, forKey: .ttsVoice)
     }
 }
 

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -445,13 +445,16 @@ public final class SpeakTool: OsaurusTool, @unchecked Sendable {
         // still works, just without the bubble/row UI binding.
         let messageId = ChatExecutionContext.currentAssistantTurnId ?? UUID()
         let callId = ChatExecutionContext.currentToolCallId ?? UUID().uuidString
+        let agentId = ChatExecutionContext.currentAgentId
 
         do {
             try await MainActor.run {
+                let agentVoice = agentId.flatMap { AgentManager.shared.agent(for: $0)?.ttsVoice }
                 try TTSService.shared.startToolPlayback(
                     text: trimmed,
                     messageId: messageId,
-                    callId: callId
+                    callId: callId,
+                    voiceOverride: agentVoice
                 )
             }
         } catch TTSPlaybackError.modelNotReady {

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1583,9 +1583,9 @@ struct AgentDetailView: View {
     private var configureTabContent: some View {
         tabHelperText(DetailTab.configure.helperText)
         identitySection
+        voiceSection
         systemPromptSection
         defaultModelSection
-        voiceSection
         advancedSettingsDisclosure
     }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -796,6 +796,9 @@ struct AgentDetailView: View {
     @State private var pluginInstructionsMap: [String: String] = [:]
     @State private var disableTools: Bool = false
     @State private var disableMemory: Bool = false
+    @State private var autoSpeak: Bool = false
+    @State private var ttsVoice: String = ""
+    @ObservedObject private var ttsService = TTSService.shared
     @State private var avatar: String? = nil
     /// Drives the title-bar agent picker popover. Tapping the avatar / name in the
     /// header bar reveals the list of other custom agents so the user can jump
@@ -1582,6 +1585,7 @@ struct AgentDetailView: View {
         identitySection
         systemPromptSection
         defaultModelSection
+        voiceSection
         advancedSettingsDisclosure
     }
 
@@ -2056,6 +2060,103 @@ struct AgentDetailView: View {
             .onChange(of: temperature) { debouncedSave() }
             .onChange(of: maxTokens) { debouncedSave() }
         }
+    }
+
+    // MARK: - Voice
+
+    /// auto-speak toggle + voice override. toggle is gated on the PocketTTS
+    /// model being downloaded.
+    private var voiceSection: some View {
+        AgentDetailSection(title: "Voice", icon: "speaker.wave.2") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Auto Speak Responses", bundle: .module)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(theme.primaryText)
+                        Text(
+                            ttsService.isModelReady
+                                ? "Read replies aloud after streaming completes."
+                                : "Download the PocketTTS model in Voice settings to enable.",
+                            bundle: .module
+                        )
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $autoSpeak)
+                        .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+                        .labelsHidden()
+                        .disabled(!ttsService.isModelReady)
+                        .onChange(of: autoSpeak) { debouncedSave() }
+                }
+                .padding(10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+
+                if !ttsService.isModelReady {
+                    Button {
+                        NotificationCenter.default.post(
+                            name: .openTTSSettingsRequested, object: nil)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.down.circle")
+                                .font(.system(size: 11, weight: .semibold))
+                            Text("Open Voice Settings", bundle: .module)
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .foregroundColor(theme.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if autoSpeak && ttsService.isModelReady {
+                    HStack {
+                        Text("Voice", bundle: .module)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.secondaryText)
+                        Spacer()
+                        Picker("", selection: $ttsVoice) {
+                            Text("Default (global)", bundle: .module).tag("")
+                            ForEach(agentVoiceOptions, id: \.self) { voice in
+                                Text(PocketTTSVoiceCatalog.displayName(for: voice))
+                                    .tag(voice)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(MenuPickerStyle())
+                        .frame(maxWidth: 200)
+                        .onChange(of: ttsVoice) { debouncedSave() }
+                    }
+                    .padding(10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.inputBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+                }
+            }
+        }
+        .onAppear { ttsService.refreshModelState() }
+    }
+
+    /// built-in catalog plus any stored custom voice (preserves legacy values).
+    private var agentVoiceOptions: [String] {
+        let builtIn = PocketTTSVoiceCatalog.availableVoices
+        let current = ttsVoice.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty && !builtIn.contains(current) {
+            return [current] + builtIn
+        }
+        return builtIn
     }
 
     // MARK: - Tool Selection
@@ -3693,6 +3794,8 @@ struct AgentDetailView: View {
         workQuickActions = agent.workQuickActions
         disableTools = agent.disableTools ?? false
         disableMemory = agent.disableMemory ?? false
+        autoSpeak = agent.autoSpeak ?? false
+        ttsVoice = agent.ttsVoice ?? ""
         avatar = agent.avatar
         var instrMap: [String: String] = [:]
         let overrides = agent.pluginInstructions ?? [:]
@@ -3830,7 +3933,10 @@ struct AgentDetailView: View {
             disableTools: disableTools ? true : nil,
             disableMemory: disableMemory ? true : nil,
             avatar: avatar,
-            customAvatarFilename: current.customAvatarFilename
+            customAvatarFilename: current.customAvatarFilename,
+            autoSpeak: autoSpeak ? true : nil,
+            ttsVoice: ttsVoice.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil : ttsVoice
         )
 
         agentManager.update(updated)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -167,6 +167,7 @@ final class ChatSession: ObservableObject {
     // nonisolated(unsafe) allows deinit to access these for cleanup
     nonisolated(unsafe) private var remoteModelsObserver: NSObjectProtocol?
     nonisolated(unsafe) private var modelSelectionCancellable: AnyCancellable?
+    nonisolated(unsafe) private var agentAutoSpeakCancellable: AnyCancellable?
     /// Flag to prevent auto-persist during initial load or programmatic resets
     private var isLoadingModel: Bool = false
 
@@ -221,6 +222,21 @@ final class ChatSession: ObservableObject {
                 self.currentTodo = await AgentTodoStore.shared.todo(for: sid)
             }
         }
+
+        // when the active agent opts into auto-speak, force the per-session
+        // toggle on and suppress the first-tap prompt. agents that haven't
+        // opted in leave the per-chat toggle alone.
+        agentAutoSpeakCancellable =
+            $agentId
+            .sink { [weak self] newAgentId in
+                guard let self else { return }
+                let id = newAgentId ?? Agent.defaultId
+                let agent = AgentManager.shared.agent(for: id)
+                if agent?.autoSpeak == true {
+                    self.autoSpeakAssistant = true
+                    self.hasAskedAutoSpeak = true
+                }
+            }
 
         // Auto-persist model selection and unload unused models on switch
         modelSelectionCancellable =
@@ -279,6 +295,7 @@ final class ChatSession: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
         modelSelectionCancellable = nil
+        agentAutoSpeakCancellable = nil
         promptQueueCancellable = nil
     }
 
@@ -3042,7 +3059,11 @@ extension ChatView {
             session.hasAskedAutoSpeak = true
             showAutoSpeakPrompt = true
         }
-        TTSService.shared.toggleSpeak(text: turn.visibleContent, messageId: turnId)
+        TTSService.shared.toggleSpeak(
+            text: turn.visibleContent,
+            messageId: turnId,
+            voiceOverride: agentTTSVoiceOverride()
+        )
     }
 
     /// Auto-speak the just-finished assistant turn when the per-session
@@ -3057,7 +3078,17 @@ extension ChatView {
         guard let turn = session.turns.first(where: { $0.id == turnId }),
             !turn.contentIsBlank
         else { return }
-        TTSService.shared.toggleSpeak(text: turn.visibleContent, messageId: turnId)
+        TTSService.shared.toggleSpeak(
+            text: turn.visibleContent,
+            messageId: turnId,
+            voiceOverride: agentTTSVoiceOverride()
+        )
+    }
+
+    /// active agent's voice override, or nil to use the global voice.
+    private func agentTTSVoiceOverride() -> String? {
+        let id = session.agentId ?? Agent.defaultId
+        return AgentManager.shared.agent(for: id)?.ttsVoice
     }
 
     /// Stop any active generation and remove the turn (plus all subsequent turns)

--- a/Packages/OsaurusCore/Views/Voice/TTSModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TTSModeSettingsTab.swift
@@ -17,23 +17,12 @@ struct TTSModeSettingsTab: View {
     @State private var previewText: String = "Hello from Osaurus. Text to speech is now ready."
     @State private var previewMessageId = UUID()
 
-    /// Built-in PocketTTS voices hosted on HuggingFace (kyutai/pocket-tts).
-    /// Each is downloaded on first use.
-    private static let availableVoices: [String] = [
-        "alba", "anna", "azelma", "bill_boerst", "caro_davy", "charles",
-        "cosette", "eponine", "eve", "fantine", "george", "jane",
-        "javert", "jean", "marius", "mary", "michael", "paul",
-        "peter_yearsley", "stuart_bell", "vera",
-    ]
-
     private func displayName(for voice: String) -> String {
-        voice.split(separator: "_")
-            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-            .joined(separator: " ")
+        PocketTTSVoiceCatalog.displayName(for: voice)
     }
 
     private var voiceMenuOptions: [String] {
-        let builtIn = Self.availableVoices
+        let builtIn = PocketTTSVoiceCatalog.availableVoices
         let current = config.voice.trimmingCharacters(in: .whitespacesAndNewlines)
         if !current.isEmpty && !builtIn.contains(current) {
             return [current] + builtIn


### PR DESCRIPTION
## Summary

agents can now opt into auto speak which reads out every assistant reply aloud after streaming finishes for any chat using that agent. when enabled, the agent can also pick its own PocketTTS voice that overrides the global voice for both manual speaker taps and auto playback

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
