### PR TITLE
Fix local release Containerization pin

### DIFF
--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -9,7 +9,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.88.0"),
-        .package(url: "https://github.com/apple/containerization.git", from: "0.26.0"),
+        // Keep package-local SwiftPM builds aligned with the workspace
+        // lockfiles. Containerization 0.32.x changed Process.kill's signal
+        // parameter type while the app CI graph is still pinned to 0.31.x.
+        .package(url: "https://github.com/apple/containerization.git", .upToNextMinor(from: "0.31.0")),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         .package(url: "https://github.com/orlandos-nl/IkigaJSON", from: "2.3.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),


### PR DESCRIPTION
## Summary

Fixes the current-main local release build by keeping package-local SwiftPM resolution aligned with the workspace Containerization pin.

## Problem

Current `origin/main` is green in GitHub CI, but `swift build --package-path Packages/OsaurusCore -c release` failed locally on Apple Swift 6.3.1 / Xcode 26.4.1:

```text
Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift:1009:44: error: cannot convert value of type 'Int32' to expected argument type 'Signal'
```

The package-local build was resolving `apple/containerization` to `0.32.1`, while both workspace `Package.resolved` files pin `0.31.0`. Containerization `0.32.x` changed `Process.kill`'s signal parameter type, so the local package build saw a different API shape than the app CI graph.

## Change

- Restrict `Packages/OsaurusCore/Package.swift` to Containerization `0.31.x` via `.upToNextMinor(from: "0.31.0")`.
- Add a short comment explaining why the package-local manifest must stay aligned with the workspace lockfiles.

## Verification

- `swift package --package-path Packages/OsaurusCore resolve`: PASS; Containerization resolves to `0.31.0`.
- Before fix: `swift build --package-path Packages/OsaurusCore -c release`: FAIL with `Int32` vs `Signal` at `SandboxManager.swift:1009`.
- After fix: `swift build --package-path Packages/OsaurusCore -c release`: PASS (`Build complete!`, 169.41s).

Evidence:
- `/tmp/osaurus-coord/verifier-evidence/main-release-build-a61d661c-confirm.log`
- `/tmp/osaurus-coord/verifier-evidence/containerization-pin-resolve-a61d661c.log`
- `/tmp/osaurus-coord/verifier-evidence/main-release-build-a61d661c-pin-fix.log`
