### PR TITLE
Fix /api/chat tool call NDJSON

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
+++ b/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
@@ -391,6 +391,44 @@ final class NDJSONResponseWriter: ResponseWriter {
         writeNDJSONMessage("", model: model, done: true, context: context)
     }
 
+    func writeToolCalls(
+        _ invocations: [ServiceToolInvocation],
+        model: String,
+        context: ChannelHandlerContext
+    ) {
+        guard !invocations.isEmpty else {
+            writeFinish(model, responseId: "", created: Int(Date().timeIntervalSince1970), context: context)
+            return
+        }
+
+        let toolCalls = invocations.map { inv in
+            [
+                "function": [
+                    "name": inv.toolName,
+                    "arguments": Self.ollamaArguments(from: inv.jsonArguments),
+                ]
+            ]
+        }
+        let response: [String: Any] = [
+            "model": model,
+            "created_at": Date().ISO8601Format(),
+            "message": [
+                "role": "assistant",
+                "content": "",
+                "tool_calls": toolCalls,
+            ],
+            "done": true,
+        ]
+        writeJSONObject(response, context: context)
+    }
+
+    private static func ollamaArguments(from json: String) -> Any {
+        guard let data = json.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data)
+        else { return json }
+        return object
+    }
+
     @inline(__always)
     private func writeNDJSONMessage(
         _ content: String,
@@ -407,6 +445,10 @@ final class NDJSONResponseWriter: ResponseWriter {
             ],
             "done": done,
         ]
+        writeJSONObject(response, context: context)
+    }
+
+    private func writeJSONObject(_ response: [String: Any], context: ChannelHandlerContext) {
         if let jsonData = try? JSONSerialization.data(withJSONObject: response) {
             var buffer = context.channel.allocator.buffer(capacity: 256)
             buffer.writeBytes(jsonData)

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3965,6 +3965,46 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     maxTokens: logMaxTokens,
                     finishReason: .stop
                 )
+            } catch let invs as ServiceToolInvocations {
+                hop {
+                    writerBound.value.writeToolCalls(invs.invocations, model: req.model, context: ctx.value)
+                    writerBound.value.writeEnd(ctx.value)
+                }
+                let toolLogs = invs.invocations.map {
+                    ToolCallLog(name: $0.toolName, arguments: $0.jsonArguments)
+                }
+                logSelf.logRequest(
+                    method: "POST",
+                    path: "/chat",
+                    userAgent: logUserAgent,
+                    requestBody: logRequestBody,
+                    responseStatus: 200,
+                    startTime: logStartTime,
+                    model: logModel,
+                    toolCalls: toolLogs,
+                    temperature: logTemperature,
+                    maxTokens: logMaxTokens,
+                    finishReason: .toolCalls
+                )
+            } catch let inv as ServiceToolInvocation {
+                hop {
+                    writerBound.value.writeToolCalls([inv], model: req.model, context: ctx.value)
+                    writerBound.value.writeEnd(ctx.value)
+                }
+                let toolLog = ToolCallLog(name: inv.toolName, arguments: inv.jsonArguments)
+                logSelf.logRequest(
+                    method: "POST",
+                    path: "/chat",
+                    userAgent: logUserAgent,
+                    requestBody: logRequestBody,
+                    responseStatus: 200,
+                    startTime: logStartTime,
+                    model: logModel,
+                    toolCalls: [toolLog],
+                    temperature: logTemperature,
+                    maxTokens: logMaxTokens,
+                    finishReason: .toolCalls
+                )
             } catch {
                 // NDJSON response head was already 200 — surface as in-band
                 // NDJSON error chunk and log actual on-wire status.

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -96,6 +96,69 @@ struct HTTPHandlerChatStreamingTests {
         #expect(body.contains("\"done\":true") || body.contains("\"done\": true"))
     }
 
+    @Test func ndjson_api_chat_emits_ollama_tool_calls() async throws {
+        struct ToolCallEngine: ChatEngineProtocol {
+            func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { continuation in
+                    continuation.finish(
+                        throwing: ServiceToolInvocation(
+                            toolName: "get_weather",
+                            jsonArguments: "{\"city\":\"SF\"}"
+                        )
+                    )
+                }
+            }
+            func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+                fatalError("not used")
+            }
+        }
+
+        let server = try await startTestServer(with: ToolCallEngine())
+        defer { Task { await server.shutdown() } }
+
+        var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)/api/chat")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.authenticate()
+        request.disablePersistenceForTests()
+        let reqBody = ChatCompletionRequest(
+            model: "fake",
+            messages: [ChatMessage(role: "user", content: "weather?")],
+            temperature: 0.2,
+            max_tokens: 8,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: [
+                Tool(
+                    type: "function",
+                    function: ToolFunction(
+                        name: "get_weather",
+                        description: nil,
+                        parameters: .object(["city": .string("")])
+                    )
+                )
+            ],
+            tool_choice: .auto,
+            session_id: nil
+        )
+        request.httpBody = try JSONEncoder().encode(reqBody)
+
+        let (data, resp) = try await URLSession.shared.data(for: request)
+        let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        let body = String(decoding: data, as: UTF8.self)
+        #expect(status == 200)
+        #expect(!body.contains("internal_error"))
+        #expect(!body.contains("ServiceToolInvocation"))
+        #expect(body.contains("\"tool_calls\""))
+        #expect(body.contains("\"name\":\"get_weather\""))
+        #expect(body.contains("\"city\":\"SF\""))
+        #expect(body.contains("\"done\":true") || body.contains("\"done\": true"))
+    }
+
     @Test func sse_path_emits_tool_calls_deltas() async throws {
         // Engine that immediately requests a tool call via throwing stream
         struct MockToolCallEngine: ChatEngineProtocol {


### PR DESCRIPTION
## Summary

- Fix `/api/chat` and normalized `/chat` NDJSON streaming when a model chooses tools.
- Serialize `ServiceToolInvocation` and `ServiceToolInvocations` as Ollama-style `message.tool_calls` chunks instead of falling through to the generic internal-error handler.
- Parse JSON tool arguments into an object when possible, preserving the original string when parsing fails.
- Add a focused regression test for `/api/chat` with tools.

Fixes #1085.

## Verification

- `xcrun swift-format lint --strict Packages/OsaurusCore/Models/Chat/ResponseWriters.swift Packages/OsaurusCore/Networking/HTTPHandler.swift Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift`
- `swift test --package-path Packages/OsaurusCore --filter HTTPHandlerChatStreamingTests/ndjson_api_chat_emits_ollama_tool_calls`
- `swift build --package-path Packages/OsaurusCore -c release`

## Notes

- `swiftlint lint --strict` against the touched large files still reports existing file-wide violations outside the changed hunks; this patch did not add new SwiftLint issues in the modified hunks.
