### PR TITLE
prevent switching active theme when saving a theme edit

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -721,9 +721,14 @@ public class ThemeManager: ObservableObject {
         ThemeConfigurationStore.saveTheme(theme)
         refreshInstalledThemes()
 
-        // If this is the active theme, update it
+        // If this is the active theme, re-apply it (which also posts the
+        // notification). Otherwise still post `.globalThemeChanged` so any
+        // open chat window using this theme via a per-agent `themeId` picks
+        // up the edit without us having to switch the user's active theme.
         if activeCustomTheme?.metadata.id == theme.metadata.id {
             applyCustomTheme(theme)
+        } else {
+            NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
         }
     }
 

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -881,9 +881,7 @@ struct ThemeEditorView: View {
 
         print("[Osaurus] ThemeEditor: Saving theme '\(themeToSave.metadata.name)' (id: \(themeToSave.metadata.id))")
         themeManager.saveTheme(themeToSave)
-        themeManager.applyCustomTheme(themeToSave)
-        themeManager.refreshInstalledThemes()
-        print("[Osaurus] ThemeEditor: Theme saved and applied successfully")
+        print("[Osaurus] ThemeEditor: Theme saved successfully")
 
         withAnimation { showSaveConfirmation = true }
 


### PR DESCRIPTION
## Summary

addresses #1094 

Editing a theme no longer hijacks the user's active theme on save. Switching themes stays a deliberate action through the tile or the "Apply Theme" menu. The open chat windows still pick up edits live including ones using the theme through a per-agent assignment

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
