### PR TITLE
[codex] Fix theme editor save behavior

### DIFF
--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -179,6 +179,10 @@ struct ThemeEditorView: View {
                 }
                 .pickerStyle(.segmented)
 
+                if editingTheme.background.type == .image {
+                    imageBackgroundControls
+                }
+
                 glassBackgroundToggle
             }
         }
@@ -370,6 +374,76 @@ struct ThemeEditorView: View {
         }
     }
 
+    private var imageBackgroundControls: some View {
+        VStack(spacing: 12) {
+            Text("Background Image", bundle: .module).font(.system(size: 11, weight: .semibold))
+                .foregroundColor(
+                    currentTheme.tertiaryText
+                ).textCase(.uppercase)
+
+            if let imageData = editingTheme.background.imageData,
+                let data = Data(base64Encoded: imageData),
+                let nsImage = NSImage(data: data)
+            {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 100)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(currentTheme.primaryBorder, lineWidth: 1)
+                    )
+
+                Button {
+                    editingTheme.background.imageData = nil
+                } label: {
+                    Text("Remove Image", bundle: .module)
+                }
+                .buttonStyle(.bordered)
+            } else {
+                Button(action: { showImagePicker = true }) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "photo.badge.plus").font(.system(size: 24))
+                        Text("Choose Image", bundle: .module).font(.system(size: 13, weight: .medium))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 80)
+                    .foregroundColor(currentTheme.secondaryText)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(currentTheme.primaryBorder, style: StrokeStyle(lineWidth: 1, dash: [5]))
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+
+            sliderRow(
+                "Image Opacity",
+                value: Binding(
+                    get: { editingTheme.background.imageOpacity ?? 1.0 },
+                    set: { editingTheme.background.imageOpacity = $0 }
+                ),
+                range: 0 ... 1
+            )
+
+            Picker(
+                selection: Binding(
+                    get: { editingTheme.background.imageFit ?? .fill },
+                    set: { editingTheme.background.imageFit = $0 }
+                )
+            ) {
+                Text("Fill", bundle: .module).tag(ThemeBackground.ImageFit.fill)
+                Text("Fit", bundle: .module).tag(ThemeBackground.ImageFit.fit)
+                Text("Stretch", bundle: .module).tag(ThemeBackground.ImageFit.stretch)
+                Text("Tile", bundle: .module).tag(ThemeBackground.ImageFit.tile)
+            } label: {
+                Text("Fit", bundle: .module)
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
     // MARK: - Section 6: Advanced (collapsed by default)
 
     private var advancedSection: some View {
@@ -491,77 +565,6 @@ struct ThemeEditorView: View {
                             ),
                             range: 0 ... 360
                         )
-                    }
-                }
-
-                if editingTheme.background.type == .image {
-                    Divider().opacity(0.3)
-
-                    Text("Background Image", bundle: .module).font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(
-                            currentTheme.tertiaryText
-                        ).textCase(.uppercase)
-                    VStack(spacing: 12) {
-                        if let imageData = editingTheme.background.imageData,
-                            let data = Data(base64Encoded: imageData),
-                            let nsImage = NSImage(data: data)
-                        {
-                            Image(nsImage: nsImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(height: 100)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(currentTheme.primaryBorder, lineWidth: 1)
-                                )
-
-                            Button {
-                                editingTheme.background.imageData = nil
-                            } label: {
-                                Text("Remove Image", bundle: .module)
-                            }
-                            .buttonStyle(.bordered)
-                        } else {
-                            Button(action: { showImagePicker = true }) {
-                                VStack(spacing: 8) {
-                                    Image(systemName: "photo.badge.plus").font(.system(size: 24))
-                                    Text("Choose Image", bundle: .module).font(.system(size: 13, weight: .medium))
-                                }
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 80)
-                                .foregroundColor(currentTheme.secondaryText)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(currentTheme.primaryBorder, style: StrokeStyle(lineWidth: 1, dash: [5]))
-                                )
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                        }
-
-                        sliderRow(
-                            "Image Opacity",
-                            value: Binding(
-                                get: { editingTheme.background.imageOpacity ?? 1.0 },
-                                set: { editingTheme.background.imageOpacity = $0 }
-                            ),
-                            range: 0 ... 1
-                        )
-
-                        Picker(
-                            selection: Binding(
-                                get: { editingTheme.background.imageFit ?? .fill },
-                                set: { editingTheme.background.imageFit = $0 }
-                            )
-                        ) {
-                            Text("Fill", bundle: .module).tag(ThemeBackground.ImageFit.fill)
-                            Text("Fit", bundle: .module).tag(ThemeBackground.ImageFit.fit)
-                            Text("Stretch", bundle: .module).tag(ThemeBackground.ImageFit.stretch)
-                            Text("Tile", bundle: .module).tag(ThemeBackground.ImageFit.tile)
-                        } label: {
-                            Text("Fit", bundle: .module)
-                        }
-                        .pickerStyle(.segmented)
                     }
                 }
 
@@ -881,9 +884,7 @@ struct ThemeEditorView: View {
 
         print("[Osaurus] ThemeEditor: Saving theme '\(themeToSave.metadata.name)' (id: \(themeToSave.metadata.id))")
         themeManager.saveTheme(themeToSave)
-        themeManager.applyCustomTheme(themeToSave)
-        themeManager.refreshInstalledThemes()
-        print("[Osaurus] ThemeEditor: Theme saved and applied successfully")
+        print("[Osaurus] ThemeEditor: Theme saved successfully")
 
         withAnimation { showSaveConfirmation = true }
 


### PR DESCRIPTION
## Summary
- Move background image picker, preview, opacity, and fit controls into the Appearance section directly under Background: Image.
- Stop ThemeEditorView from applying every saved theme; saving now delegates to ThemeManager.saveTheme(), which only updates the active theme when the saved theme is already active.

Fixes #1093.
Fixes #1094.

## Validation
- xcrun swift-format lint --strict Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
- swift build --package-path Packages/OsaurusCore -c release