### PR TITLE
Fix theme editor save behavior

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/Theme.swift
+++ b/Packages/OsaurusCore/Models/Theme/Theme.swift
@@ -724,6 +724,8 @@ public class ThemeManager: ObservableObject {
         // If this is the active theme, update it
         if activeCustomTheme?.metadata.id == theme.metadata.id {
             applyCustomTheme(theme)
+        } else {
+            NotificationCenter.default.post(name: .globalThemeChanged, object: nil)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateAgentSyncTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateAgentSyncTests.swift
@@ -157,6 +157,38 @@ struct ChatWindowStateAgentSyncTests {
         }
     }
 
+    @Test("saving a non-active agent theme with the same id refreshes the open window theme")
+    func savedAgentTheme_refreshesOpenWindowTheme() async throws {
+        try await ChatHistoryTestStorage.run {
+            var theme = CustomTheme.darkDefault
+            theme.metadata = ThemeMetadata(
+                id: UUID(),
+                name: "Window Theme \(UUID().uuidString.prefix(6))",
+                author: "Test"
+            )
+            theme.isBuiltIn = false
+            ThemeConfigurationStore.saveTheme(theme)
+
+            let custom = makeCustomAgent(name: "ThemeRefresh", themeId: theme.metadata.id)
+            AgentManager.shared.add(custom)
+            let window = makeWindow(for: custom.id)
+
+            #expect(window.theme.customThemeConfig?.colors.accentColor == theme.colors.accentColor)
+
+            var updatedTheme = theme
+            updatedTheme.colors.accentColor = "#FF3366"
+            updatedTheme.metadata.updatedAt = Date()
+            ThemeManager.shared.saveTheme(updatedTheme)
+
+            await flushMainQueue()
+
+            #expect(window.theme.customThemeConfig?.colors.accentColor == "#FF3366")
+
+            _ = await AgentManager.shared.delete(id: custom.id)
+            _ = ThemeConfigurationStore.deleteTheme(id: theme.metadata.id)
+        }
+    }
+
     /// Pins that the existing `.appConfigurationChanged` observer was
     /// preserved across the issue-1004 fix. Without this, a future
     /// contributor could remove that observer thinking the new Combine

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -179,6 +179,10 @@ struct ThemeEditorView: View {
                 }
                 .pickerStyle(.segmented)
 
+                if editingTheme.background.type == .image {
+                    imageBackgroundControls
+                }
+
                 glassBackgroundToggle
             }
         }
@@ -370,6 +374,76 @@ struct ThemeEditorView: View {
         }
     }
 
+    private var imageBackgroundControls: some View {
+        VStack(spacing: 12) {
+            Text("Background Image", bundle: .module).font(.system(size: 11, weight: .semibold))
+                .foregroundColor(
+                    currentTheme.tertiaryText
+                ).textCase(.uppercase)
+
+            if let imageData = editingTheme.background.imageData,
+                let data = Data(base64Encoded: imageData),
+                let nsImage = NSImage(data: data)
+            {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 100)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(currentTheme.primaryBorder, lineWidth: 1)
+                    )
+
+                Button {
+                    editingTheme.background.imageData = nil
+                } label: {
+                    Text("Remove Image", bundle: .module)
+                }
+                .buttonStyle(.bordered)
+            } else {
+                Button(action: { showImagePicker = true }) {
+                    VStack(spacing: 8) {
+                        Image(systemName: "photo.badge.plus").font(.system(size: 24))
+                        Text("Choose Image", bundle: .module).font(.system(size: 13, weight: .medium))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 80)
+                    .foregroundColor(currentTheme.secondaryText)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(currentTheme.primaryBorder, style: StrokeStyle(lineWidth: 1, dash: [5]))
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+
+            sliderRow(
+                "Image Opacity",
+                value: Binding(
+                    get: { editingTheme.background.imageOpacity ?? 1.0 },
+                    set: { editingTheme.background.imageOpacity = $0 }
+                ),
+                range: 0 ... 1
+            )
+
+            Picker(
+                selection: Binding(
+                    get: { editingTheme.background.imageFit ?? .fill },
+                    set: { editingTheme.background.imageFit = $0 }
+                )
+            ) {
+                Text("Fill", bundle: .module).tag(ThemeBackground.ImageFit.fill)
+                Text("Fit", bundle: .module).tag(ThemeBackground.ImageFit.fit)
+                Text("Stretch", bundle: .module).tag(ThemeBackground.ImageFit.stretch)
+                Text("Tile", bundle: .module).tag(ThemeBackground.ImageFit.tile)
+            } label: {
+                Text("Fit", bundle: .module)
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
     // MARK: - Section 6: Advanced (collapsed by default)
 
     private var advancedSection: some View {
@@ -491,77 +565,6 @@ struct ThemeEditorView: View {
                             ),
                             range: 0 ... 360
                         )
-                    }
-                }
-
-                if editingTheme.background.type == .image {
-                    Divider().opacity(0.3)
-
-                    Text("Background Image", bundle: .module).font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(
-                            currentTheme.tertiaryText
-                        ).textCase(.uppercase)
-                    VStack(spacing: 12) {
-                        if let imageData = editingTheme.background.imageData,
-                            let data = Data(base64Encoded: imageData),
-                            let nsImage = NSImage(data: data)
-                        {
-                            Image(nsImage: nsImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(height: 100)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(currentTheme.primaryBorder, lineWidth: 1)
-                                )
-
-                            Button {
-                                editingTheme.background.imageData = nil
-                            } label: {
-                                Text("Remove Image", bundle: .module)
-                            }
-                            .buttonStyle(.bordered)
-                        } else {
-                            Button(action: { showImagePicker = true }) {
-                                VStack(spacing: 8) {
-                                    Image(systemName: "photo.badge.plus").font(.system(size: 24))
-                                    Text("Choose Image", bundle: .module).font(.system(size: 13, weight: .medium))
-                                }
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 80)
-                                .foregroundColor(currentTheme.secondaryText)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(currentTheme.primaryBorder, style: StrokeStyle(lineWidth: 1, dash: [5]))
-                                )
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                        }
-
-                        sliderRow(
-                            "Image Opacity",
-                            value: Binding(
-                                get: { editingTheme.background.imageOpacity ?? 1.0 },
-                                set: { editingTheme.background.imageOpacity = $0 }
-                            ),
-                            range: 0 ... 1
-                        )
-
-                        Picker(
-                            selection: Binding(
-                                get: { editingTheme.background.imageFit ?? .fill },
-                                set: { editingTheme.background.imageFit = $0 }
-                            )
-                        ) {
-                            Text("Fill", bundle: .module).tag(ThemeBackground.ImageFit.fill)
-                            Text("Fit", bundle: .module).tag(ThemeBackground.ImageFit.fit)
-                            Text("Stretch", bundle: .module).tag(ThemeBackground.ImageFit.stretch)
-                            Text("Tile", bundle: .module).tag(ThemeBackground.ImageFit.tile)
-                        } label: {
-                            Text("Fit", bundle: .module)
-                        }
-                        .pickerStyle(.segmented)
                     }
                 }
 
@@ -881,9 +884,7 @@ struct ThemeEditorView: View {
 
         print("[Osaurus] ThemeEditor: Saving theme '\(themeToSave.metadata.name)' (id: \(themeToSave.metadata.id))")
         themeManager.saveTheme(themeToSave)
-        themeManager.applyCustomTheme(themeToSave)
-        themeManager.refreshInstalledThemes()
-        print("[Osaurus] ThemeEditor: Theme saved and applied successfully")
+        print("[Osaurus] ThemeEditor: Theme saved successfully")
 
         withAnimation { showSaveConfirmation = true }
 


### PR DESCRIPTION
Fixes #1093.
Fixes #1094.

## Summary
- move the image background picker controls next to the background mode selector
- stop saving a theme from implicitly applying it as the global default
- refresh open chat windows when a saved custom theme changes, with a regression test

## Validation
- `swift test --package-path Packages/OsaurusCore --filter ChatWindowStateAgentSyncTests`
