### PR TITLE
reorder agents

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -293,6 +293,18 @@ public final class AgentManager: ObservableObject {
         update(agent)
     }
 
+    /// Assign sequential `order` values (0...N-1) to custom agents in the
+    /// given sequence and refresh once. Built-ins must not be included.
+    public func reorder(orderedIds: [UUID]) {
+        for (index, id) in orderedIds.enumerated() {
+            guard var agent = AgentStore.load(id: id), !agent.isBuiltIn else { continue }
+            guard agent.order != index else { continue }
+            agent.order = index
+            AgentStore.save(agent)
+        }
+        refresh()
+    }
+
     /// Update an existing agent
     public func update(_ agent: Agent) {
         guard !agent.isBuiltIn else {

--- a/Packages/OsaurusCore/Managers/WindowManager.swift
+++ b/Packages/OsaurusCore/Managers/WindowManager.swift
@@ -61,7 +61,7 @@ public struct WindowConfiguration: Sendable {
         usePanel: false,
         titlebarAppearsTransparent: true,
         titleVisibility: .hidden,
-        isMovableByWindowBackground: true,
+        isMovableByWindowBackground: false,
         hideStandardButtons: [],
         autosaveKey: .management
     )

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -118,6 +118,8 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
     /// Opt-in feature settings (Agent DB + self-scheduling). Agents created before
     /// the feature shipped decode with `.defaultDisabled`, leaving the surface dormant.
     public var settings: AgentSettings
+    /// User-defined position. `nil` falls to the end, sorted alphabetically.
+    public var order: Int?
 
     public init(
         id: UUID = UUID(),
@@ -147,7 +149,8 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
         customAvatarFilename: String? = nil,
         autoSpeak: Bool? = nil,
         ttsVoice: String? = nil,
-        settings: AgentSettings = .defaultDisabled
+        settings: AgentSettings = .defaultDisabled,
+        order: Int? = nil
     ) {
         self.id = id
         self.name = name
@@ -177,6 +180,7 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
         self.autoSpeak = autoSpeak
         self.ttsVoice = ttsVoice
         self.settings = settings
+        self.order = order
     }
 
     // MARK: - Custom avatar resolution
@@ -277,6 +281,7 @@ extension Agent {
         autoSpeak = try c.decodeIfPresent(Bool.self, forKey: .autoSpeak)
         ttsVoice = try c.decodeIfPresent(String.self, forKey: .ttsVoice)
         settings = try c.decodeIfPresent(AgentSettings.self, forKey: .settings) ?? .defaultDisabled
+        order = try c.decodeIfPresent(Int.self, forKey: .order)
     }
 }
 

--- a/Packages/OsaurusCore/Models/Agent/AgentStore.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentStore.swift
@@ -43,7 +43,17 @@ public enum AgentStore {
                 if a.id == Agent.defaultId { return true }
                 if b.id == Agent.defaultId { return false }
             }
-            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+            // Ordered agents first; unordered fall through to alphabetical.
+            switch (a.order, b.order) {
+            case let (lhs?, rhs?) where lhs != rhs:
+                return lhs < rhs
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentReorderSheet.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentReorderSheet.swift
@@ -1,0 +1,152 @@
+//
+//  AgentReorderSheet.swift
+//  osaurus
+//
+//  Drag-to-reorder custom agents. Commits once on dismiss.
+//
+
+import SwiftUI
+
+struct AgentReorderSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
+    @ObservedObject private var agentManager = AgentManager.shared
+
+    @State private var orderedAgents: [Agent] = []
+    @State private var hasPendingReorder = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider().foregroundColor(theme.primaryBorder)
+
+            if orderedAgents.isEmpty {
+                emptyState
+            } else {
+                // EditMode is iOS-only; macOS List supports drag-reorder natively.
+                List {
+                    ForEach(orderedAgents) { agent in
+                        row(for: agent)
+                            .listRowBackground(theme.cardBackground)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: 4, leading: 20, bottom: 4, trailing: 20))
+                    }
+                    .onMove(perform: moveAgents)
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .frame(minWidth: 420, minHeight: 480)
+        .background(theme.secondaryBackground)
+        .onAppear { syncFromManager() }
+        .onReceive(agentManager.$agents) { _ in syncFromManager() }
+        .onDisappear { commitIfNeeded() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Reorder Agents", bundle: .module)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text("Drag to set the order shown across the app.", bundle: .module)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+            }
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Done", bundle: .module)
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - Row
+
+    private func row(for agent: Agent) -> some View {
+        HStack(spacing: 12) {
+            AgentAvatarView(
+                mascotId: agent.avatar,
+                name: agent.name,
+                tint: theme.accentColor,
+                diameter: 28,
+                customImageURL: agent.customAvatarURL,
+                monogramFontSize: 13,
+                borderWidth: 1
+            )
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(agent.name)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+
+                if !agent.description.isEmpty {
+                    Text(agent.description)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Spacer()
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 32, weight: .light))
+                .foregroundColor(theme.tertiaryText)
+            Text("No custom agents to reorder.", bundle: .module)
+                .font(.system(size: 13))
+                .foregroundColor(theme.secondaryText)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Actions
+
+    /// Preserve working order on external change so an in-progress drag stays stable.
+    private func syncFromManager() {
+        let custom = agentManager.agents.filter { !$0.isBuiltIn }
+        let existingIds = Set(orderedAgents.map(\.id))
+        let incomingIds = Set(custom.map(\.id))
+        let kept = orderedAgents.filter { incomingIds.contains($0.id) }
+        let added = custom.filter { !existingIds.contains($0.id) }
+        orderedAgents = kept + added
+    }
+
+    private func moveAgents(from source: IndexSet, to destination: Int) {
+        orderedAgents.move(fromOffsets: source, toOffset: destination)
+        hasPendingReorder = true
+    }
+
+    private func commitIfNeeded() {
+        guard hasPendingReorder else { return }
+        agentManager.reorder(orderedIds: orderedAgents.map(\.id))
+        hasPendingReorder = false
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -41,6 +41,7 @@ struct AgentsView: View {
     @State private var selectedAgent: Agent?
     @State private var selectedRemoteAgentId: UUID?
     @State private var isCreating = false
+    @State private var isReordering = false
     @State private var hasAppeared = false
     @State private var successMessage: String?
     @State private var sandboxCleanupNotice: SandboxCleanupNotice?
@@ -130,6 +131,10 @@ struct AgentsView: View {
                     isCreating = false
                 }
             )
+        }
+        .sheet(isPresented: $isReordering) {
+            AgentReorderSheet()
+                .environment(\.theme, themeManager.currentTheme)
         }
         .themedAlert(
             sandboxCleanupNotice?.title ?? "Sandbox Cleanup",
@@ -295,6 +300,11 @@ struct AgentsView: View {
         ) {
             HeaderIconButton("arrow.clockwise", help: "Refresh agents") {
                 agentManager.refresh()
+            }
+            if !customAgents.isEmpty {
+                HeaderIconButton("list.bullet.indent", help: "Reorder agents") {
+                    isReordering = true
+                }
             }
             HeaderPrimaryButton("Create Agent", icon: "plus") {
                 isCreating = true


### PR DESCRIPTION
## Summary

addresses #1092

- added drag-to-reorder for custom agents via a new sheet (entry point in the Agents
  toolbar). The order persists on each agent and reflects in the grid and the chat window's agent dropdown
- the settings window now only drags from the titlebar instead of being draggable from anywhere

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
