### PR TITLE
Improved DX: Support installing development plugins to release Osaurus

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift
@@ -269,19 +269,25 @@ public struct ToolsInstall {
         let digest = SHA256.hash(data: dylibData)
         let dylibSha = Data(digest).map { String(format: "%02x", $0) }.joined()
 
-        // Create receipt structure matching PluginReceipt
-        let receipt: [String: Any] = [
-            "plugin_id": pluginId,
-            "version": version.description,
-            "installed_at": ISO8601DateFormatter().string(from: Date()),
-            "dylib_filename": dylibURL.lastPathComponent,
-            "dylib_sha256": dylibSha,
-            "platform": "macos",
-            "arch": "arm64",
-        ]
+        let receipt = PluginReceipt(
+            plugin_id: pluginId,
+            version: version,
+            installed_at: Date(),
+            dylib_filename: dylibURL.lastPathComponent,
+            dylib_sha256: dylibSha,
+            platform: "macos",
+            arch: "arm64",
+            public_keys: nil,
+            artifact: .init(
+                url: "file://" + dylibURL.path,
+                sha256: dylibSha,
+                minisign: nil,
+                size: dylibData.count
+            )
+        )
 
         let receiptURL = installDir.appendingPathComponent("receipt.json")
-        let receiptData = try JSONSerialization.data(withJSONObject: receipt, options: [.prettyPrinted, .sortedKeys])
+        let receiptData = try JSONEncoder().encode(receipt)
         try receiptData.write(to: receiptURL)
     }
 

--- a/Packages/OsaurusRepository/InstalledPluginsStore.swift
+++ b/Packages/OsaurusRepository/InstalledPluginsStore.swift
@@ -13,6 +13,13 @@ public struct PluginReceipt: Codable, Equatable, Sendable {
         public let sha256: String
         public let minisign: MinisignInfo?
         public let size: Int?
+
+        public init(url: String, sha256: String, minisign: MinisignInfo? = nil, size: Int? = nil) {
+            self.url = url
+            self.sha256 = sha256
+            self.minisign = minisign
+            self.size = size
+        }
     }
 
     public let plugin_id: String
@@ -24,6 +31,18 @@ public struct PluginReceipt: Codable, Equatable, Sendable {
     public let arch: String
     public let public_keys: [String: String]?
     public let artifact: ArtifactInfo
+
+    public init(plugin_id: String, version: SemanticVersion, installed_at: Date, dylib_filename: String, dylib_sha256: String, platform: String, arch: String, public_keys: [String: String]? = nil, artifact: ArtifactInfo) {
+        self.plugin_id = plugin_id
+        self.version = version
+        self.installed_at = installed_at
+        self.dylib_filename = dylib_filename
+        self.dylib_sha256 = dylib_sha256
+        self.platform = platform
+        self.arch = arch
+        self.public_keys = public_keys
+        self.artifact = artifact
+    }
 }
 
 /// Derives installed plugin state from the file system.


### PR DESCRIPTION
# Problem & benefit from fixing it

Currently, developing Swift (or Rust) plugins locally and then installing such plugins to released version Osaurus for trying out the plugin fails. It would be desirable to be able to develop plugins without checking out whole Osaurus, learning the ropes on XCode etc.

This will make it easier for plugin developers to contribute to Osaurus, and paves the way for more automated and streamlined plugin development overall.

# Details

`osaurus tools install` currently writes a effectively broken receipt.json because the runtime cannot decode it, preventing manually installed plugins from loading in release builds.

`ToolsInstall.createManualInstallReceipt` constructs the receipt as a `[String: Any]` dictionary and serializes it with JSONSerialization:

```
let receipt: [String: Any] = [
    "plugin_id": pluginId,
    "version": ...,
    "installed_at": ISO8601DateFormatter().string(from: Date()),
    "dylib_filename": ...,
    "dylib_sha256": ...,
    "platform": "macos",
    "arch": "arm64",
    // ❌ artifact missing
]
```

Two issues there:

1. Missing artifact field — PluginReceipt.artifact is non-optional. At load time `verifyDylibBeforeLoadWithError` calls `JSONDecoder().decode(PluginReceipt.self, from: data)` which throws `DecodingError.keyNotFound `for artifact. The plugin silently fails to load.

2. `installed_at` format mismatch — encoded as ISO8601 string, but decoded as `TimeInterval` (Double) via the default `.deferredToDate `strategy.

Note: The registry install path (PluginInstallManager) has no such issue — it uses PluginReceipt directly with `JSONEncoder().encode()`.

An additional contributing factor: PluginReceipt and ArtifactInfo had no public memberwise initializers, so the auto-synthesized internal inits were inaccessible from the OsaurusCLICore module. This is why the CLI fell back to the raw dictionary approach.

# Changes:

Packages/OsaurusRepository/InstalledPluginsStore.swift — Added public init to ArtifactInfo and PluginReceipt so they can be constructed across module boundaries.

Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsInstall.swift — Replaced the [String: Any] dictionary + JSONSerialization with PluginReceipt(...) + JSONEncoder().encode(), mirroring the registry install path. This correctly populates:

artifact → file:// URL, SHA256, and size of the installed dylib
installed_at → TimeInterval (seconds since reference date), matching the decoder's expectation 

## Checklist

- [x] verified build on macOS with latest Xcode on macOS Tahoe
- [x] verified the fix works for locally developed plugins