### PR TITLE
[codex] Refresh stale doc references

### DIFF
--- a/docs/CLAUDE_PLUGINS.md
+++ b/docs/CLAUDE_PLUGINS.md
@@ -206,5 +206,5 @@ The installer keeps going if any single file fails to download or parse. Failure
 
 - [Skills](SKILLS.md) — Skill format, RAG selection, and built-in skills
 - [Remote MCP Providers](REMOTE_MCP_PROVIDERS.md) — Manual MCP setup and HTTP/SSE transport details
-- [Schedules](../README.md#schedules) — Recurring agent runs
+- [Schedules](FEATURES.md#schedules) — Recurring agent runs
 - [Features Inventory](FEATURES.md#claude-plugin-import) — Canonical feature record

--- a/docs/DEVELOPER_TOOLS.md
+++ b/docs/DEVELOPER_TOOLS.md
@@ -299,7 +299,7 @@ Currently env-gated:
 The `test-core` job caches `~/Library/Developer/Xcode/DerivedData` keyed on Swift sources, manifests, resources, the pinned Xcode version, and a manual `CACHE_SALT`. Two recovery levers when you suspect a bad cache:
 
 1. **One-shot cold build**: trigger CI manually via the **Run workflow** button on the [CI workflow](../.github/workflows/ci.yml) page and check `clear_cache`. Skips the restore for that one run.
-2. **Permanent bust**: bump `CACHE_SALT` (currently `v1`) at the top of `.github/workflows/ci.yml` to `v2` and merge. Every cache key invalidates immediately.
+2. **Permanent bust**: change `CACHE_SALT` (currently `v2-vmlx-5b84387`) at the top of `.github/workflows/ci.yml` and merge. Every cache key invalidates immediately.
 
 The cache only **saves** on `main` pushes — PRs read from it but never overwrite, so a half-baked branch can't poison everyone.
 
@@ -310,7 +310,7 @@ The full xcodebuild output is collapsed into expandable groups by `xcbeautify`. 
 - A short failure summary (failed tests + assertion messages) at the top of the GitHub Actions run page.
 - The raw `Tests.xcresult` bundle as a downloadable artifact (`test-core-xcresult-N`, 7 days retention).
 
-A passing run produces ~1–2k log lines instead of the historical ~30k, and individual tests that hang are killed in ~2 min by `-test-timeouts-enabled YES` (default 60s, max 120s per test). The whole `test-core` job is also capped at 15 minutes via `timeout-minutes`.
+A passing run produces ~1–2k log lines instead of the historical ~30k, and individual tests that hang are killed in ~2 min by `-test-timeouts-enabled YES` (default 60s, max 120s per test). The whole `test-core` job is capped at 45 minutes via `timeout-minutes`.
 
 ### Deferred follow-up
 

--- a/docs/WATCHERS.md
+++ b/docs/WATCHERS.md
@@ -268,7 +268,7 @@ Each file contains the watcher configuration encoded as JSON with ISO 8601 dates
 
 ## Related Documentation
 
-- [Schedules](../README.md#schedules) — Time-based automation (complements Watchers)
+- [Schedules](FEATURES.md#schedules) — Time-based automation (complements Watchers)
 - [Agent Loop Guide](AGENT_LOOP.md) — Autonomous task execution and folder context
 - [Skills Guide](SKILLS.md) — Reusable AI capabilities
 - [Features Overview](FEATURES.md) — Complete feature inventory


### PR DESCRIPTION
## Business rationale
This PR removes stale documentation that sends users to a README schedules anchor that no longer contains the detailed schedules material, and it updates the developer-tools cache guidance to match the current CI workflow. The evidence is the doc diff plus `rg` checks showing no remaining `../README.md#schedules` links in the affected docs and matching `CACHE_SALT` / `timeout-minutes` values between `docs/DEVELOPER_TOOLS.md` and `.github/workflows/ci.yml`; the observable resolution is that readers land on `docs/FEATURES.md#schedules` and see the current `v2-vmlx-5b84387` cache salt and 45-minute `test-core` timeout.

## Coding rationale
The change is intentionally docs-only because the stale behavior is caused by outdated links and prose, not runtime code. I considered adding a new README schedules anchor, but `docs/FEATURES.md#schedules` is already the canonical inventory entry and keeping duplicate schedule copy in README would create another drift point. The trust boundary here is the CI/release guidance developers use when deciding whether to invalidate caches; the PR keeps that guidance descriptive and does not modify `.github/workflows/ci.yml` or any planning files.

## Acceptance criteria
- [x] Broken Schedules links in docs point to `docs/FEATURES.md#schedules`.
- [x] `docs/DEVELOPER_TOOLS.md` reflects the current CI `CACHE_SALT`.
- [x] `docs/DEVELOPER_TOOLS.md` reflects the current `test-core` timeout.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
```
$ rg -n "\.\./README\.md#schedules" docs/CLAUDE_PLUGINS.md docs/WATCHERS.md

$ rg -n "CACHE_SALT|timeout-minutes" .github/workflows/ci.yml docs/DEVELOPER_TOOLS.md
docs/DEVELOPER_TOOLS.md:302:2. **Permanent bust**: change `CACHE_SALT` (currently `v2-vmlx-5b84387`) at the top of `.github/workflows/ci.yml` and merge. Every cache key invalidates immediately.
docs/DEVELOPER_TOOLS.md:313:A passing run produces ~1–2k log lines instead of the historical ~30k, and individual tests that hang are killed in ~2 min by `-test-timeouts-enabled YES` (default 60s, max 120s per test). The whole `test-core` job is capped at 45 minutes via `timeout-minutes`.
.github/workflows/ci.yml:29:  CACHE_SALT: v2-vmlx-5b84387
.github/workflows/ci.yml:58:    timeout-minutes: 45

Gate completed: 2026-05-16T23:07:51Z
```

## Rollback
`git revert 9d5e1338`
