### PR TITLE
[codex] Add global proxy foundation

### DIFF
--- a/Packages/OsaurusCore/Networking/GlobalProxyConfiguration.swift
+++ b/Packages/OsaurusCore/Networking/GlobalProxyConfiguration.swift
@@ -1,0 +1,227 @@
+//
+//  GlobalProxyConfiguration.swift
+//  osaurus
+//
+
+import CFNetwork
+import Foundation
+import Network
+
+/// A validated global proxy endpoint that can be safely translated into
+/// Foundation's `connectionProxyDictionary` without accepting arbitrary
+/// URL-shaped input from settings or import paths.
+public struct GlobalProxyConfiguration: Equatable, Sendable {
+    /// The supported proxy families are intentionally limited to transports
+    /// URLSession can express through `connectionProxyDictionary`.
+    public enum Scheme: String, Sendable {
+        case http
+        case https
+        case socks
+    }
+
+    /// Human-entered proxy URLs are often pasted from provider docs, so parsing
+    /// keeps a typed reason for rejection instead of falling back silently.
+    public enum ValidationError: Error, Equatable, LocalizedError, Sendable {
+        case empty
+        case invalidURL
+        case unsupportedScheme(String?)
+        case missingHost
+        case unsafeHost(String)
+        case missingPort
+        case unsupportedURLComponents
+        case credentialsInURL
+
+        public var errorDescription: String? {
+            switch self {
+            case .empty:
+                "Proxy URL is empty."
+            case .invalidURL:
+                "Proxy URL could not be parsed."
+            case .unsupportedScheme(let scheme):
+                if let scheme {
+                    "Proxy URL scheme '\(scheme)' is not supported."
+                } else {
+                    "Proxy URL must include a scheme."
+                }
+            case .missingHost:
+                "Proxy URL must include a host."
+            case .unsafeHost(let host):
+                "Proxy host '\(host)' is reserved for local networking."
+            case .missingPort:
+                "Proxy URL must include an explicit port."
+            case .unsupportedURLComponents:
+                "Proxy URL must only contain scheme, host, and port."
+            case .credentialsInURL:
+                "Proxy credentials must not be embedded in the URL."
+            }
+        }
+    }
+
+    public let scheme: Scheme
+    public let host: String
+    public let port: Int
+
+    public init(urlString: String) throws {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw ValidationError.empty }
+        guard let components = URLComponents(string: trimmed) else {
+            throw ValidationError.invalidURL
+        }
+
+        guard let scheme = Self.parseScheme(components.scheme) else {
+            throw ValidationError.unsupportedScheme(components.scheme)
+        }
+
+        // Proxy credentials need a separate encrypted storage story. Accepting
+        // URL userinfo here would make later redaction and Keychain boundaries
+        // much harder to audit.
+        if components.percentEncodedUser != nil || components.percentEncodedPassword != nil {
+            throw ValidationError.credentialsInURL
+        }
+
+        // The global proxy setting is an endpoint, not a PAC file, Unix socket,
+        // or endpoint-specific override list. Rejecting extra URL components
+        // keeps secrets out of query strings and avoids path-based surprises.
+        let path = components.percentEncodedPath
+        let hasUnsupportedPath = !path.isEmpty && path != "/"
+        let hasURLDecorators =
+            components.percentEncodedQuery != nil
+            || components.percentEncodedFragment != nil
+        if hasUnsupportedPath || hasURLDecorators {
+            throw ValidationError.unsupportedURLComponents
+        }
+
+        guard let rawHost = components.host, !rawHost.isEmpty else {
+            throw ValidationError.missingHost
+        }
+        let host = Self.normalizeHost(rawHost)
+        guard !host.isEmpty else { throw ValidationError.missingHost }
+        guard !Self.isLocalOnlyHost(host) else { throw ValidationError.unsafeHost(host) }
+        guard let port = components.port else { throw ValidationError.missingPort }
+
+        self.scheme = scheme
+        self.host = host
+        self.port = port
+    }
+
+    /// Foundation consumes proxy settings as CFNetwork key/value pairs; this
+    /// computed dictionary is the single place that shapes those keys.
+    public var connectionProxyDictionary: [AnyHashable: Any] {
+        switch scheme {
+        case .http, .https:
+            [
+                key(kCFNetworkProxiesHTTPEnable): 1,
+                key(kCFNetworkProxiesHTTPProxy): host,
+                key(kCFNetworkProxiesHTTPPort): port,
+                key(kCFNetworkProxiesHTTPSEnable): 1,
+                key(kCFNetworkProxiesHTTPSProxy): host,
+                key(kCFNetworkProxiesHTTPSPort): port,
+            ]
+        case .socks:
+            [
+                key(kCFNetworkProxiesSOCKSEnable): 1,
+                key(kCFNetworkProxiesSOCKSProxy): host,
+                key(kCFNetworkProxiesSOCKSPort): port,
+            ]
+        }
+    }
+
+    /// Logs and PR evidence should be able to identify which endpoint was used
+    /// without ever echoing rejected credential-bearing input.
+    public var redactedDescription: String {
+        "\(scheme.rawValue)://\(host):\(port)"
+    }
+
+    private static func parseScheme(_ scheme: String?) -> Scheme? {
+        guard let scheme = scheme?.lowercased() else { return nil }
+        switch scheme {
+        case "http":
+            return .http
+        case "https":
+            return .https
+        case "socks", "socks5":
+            return .socks
+        default:
+            return nil
+        }
+    }
+
+    private static func normalizeHost(_ host: String) -> String {
+        let normalized =
+            host
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        if normalized.hasPrefix("[") && normalized.hasSuffix("]") {
+            return String(normalized.dropFirst().dropLast())
+        }
+        return normalized
+    }
+
+    private static func isLocalOnlyHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        let isLocalDomain =
+            normalized == "localhost"
+            || normalized.hasSuffix(".localhost")
+            || normalized.hasSuffix(".local")
+        if isLocalDomain {
+            return true
+        }
+
+        if let address = IPv4Address(normalized) {
+            let octets = Array(address.rawValue)
+            return octets[0] == 0
+                || octets[0] == 127
+                || (octets[0] == 169 && octets[1] == 254)
+        }
+
+        if let address = IPv6Address(normalized) {
+            let octets = Array(address.rawValue)
+            let isUnspecified = octets.allSatisfy { $0 == 0 }
+            let isLoopback = octets.dropLast().allSatisfy { $0 == 0 } && octets.last == 1
+            let isLinkLocal = octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80
+            return isUnspecified || isLoopback || isLinkLocal
+        }
+
+        return false
+    }
+
+    private func key(_ value: CFString) -> AnyHashable {
+        AnyHashable(value as String)
+    }
+}
+
+/// Factory helpers centralize proxy injection so later call-site migrations can
+/// opt into the same validation and rollback behavior one session at a time.
+public enum GlobalProxyURLSessionFactory {
+    /// Return a copied configuration so the proxy dictionary never mutates a
+    /// caller-owned `URLSessionConfiguration` that may be reused elsewhere.
+    public static func makeConfiguration(
+        base: URLSessionConfiguration = .default,
+        proxy: GlobalProxyConfiguration?
+    ) -> URLSessionConfiguration {
+        let configuration =
+            base.copy() as? URLSessionConfiguration
+            ?? URLSessionConfiguration.default
+        if let proxy {
+            configuration.connectionProxyDictionary = proxy.connectionProxyDictionary
+        }
+        return configuration
+    }
+
+    /// Build the session from the shaped configuration without touching TLS or
+    /// delegate policy; certificate validation remains Foundation's default.
+    public static func makeSession(
+        base: URLSessionConfiguration = .default,
+        proxy: GlobalProxyConfiguration?,
+        delegate: URLSessionDelegate? = nil,
+        delegateQueue: OperationQueue? = nil
+    ) -> URLSession {
+        let configuration = makeConfiguration(base: base, proxy: proxy)
+        return URLSession(
+            configuration: configuration,
+            delegate: delegate,
+            delegateQueue: delegateQueue
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
@@ -1,0 +1,126 @@
+//
+//  GlobalProxyConfigurationTests.swift
+//  osaurusTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct GlobalProxyConfigurationTests {
+
+    @Test func acceptsHTTPProxyURL() throws {
+        let proxy = try GlobalProxyConfiguration(
+            urlString: " http://proxy.example.com:8080/ "
+        )
+
+        #expect(proxy.scheme == .http)
+        #expect(proxy.host == "proxy.example.com")
+        #expect(proxy.port == 8080)
+        #expect(proxy.redactedDescription == "http://proxy.example.com:8080")
+    }
+
+    @Test func acceptsHTTPSProxyURL() throws {
+        let proxy = try GlobalProxyConfiguration(
+            urlString: "https://secure-proxy.example.com:8443"
+        )
+
+        #expect(proxy.scheme == .https)
+        #expect(proxy.host == "secure-proxy.example.com")
+        #expect(proxy.port == 8443)
+    }
+
+    @Test func acceptsSOCKSProxyURLAliases() throws {
+        let socks = try GlobalProxyConfiguration(urlString: "socks://proxy.example.com:1080")
+        let socks5 = try GlobalProxyConfiguration(urlString: "socks5://proxy.example.com:1080")
+
+        #expect(socks.scheme == .socks)
+        #expect(socks5.scheme == .socks)
+    }
+
+    @Test func shapesHTTPProxyDictionaryForWebTraffic() throws {
+        let proxy = try GlobalProxyConfiguration(urlString: "http://proxy.example.com:8080")
+        let dictionary = proxy.connectionProxyDictionary
+
+        #expect(dictionary[key(kCFNetworkProxiesHTTPEnable)] as? Int == 1)
+        #expect(dictionary[key(kCFNetworkProxiesHTTPProxy)] as? String == "proxy.example.com")
+        #expect(dictionary[key(kCFNetworkProxiesHTTPPort)] as? Int == 8080)
+        #expect(dictionary[key(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+        #expect(dictionary[key(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+        #expect(dictionary[key(kCFNetworkProxiesHTTPSPort)] as? Int == 8080)
+        #expect(dictionary[key(kCFNetworkProxiesSOCKSEnable)] == nil)
+    }
+
+    @Test func shapesSOCKSProxyDictionary() throws {
+        let proxy = try GlobalProxyConfiguration(urlString: "socks5://proxy.example.com:1080")
+        let dictionary = proxy.connectionProxyDictionary
+
+        #expect(dictionary[key(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+        #expect(dictionary[key(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+        #expect(dictionary[key(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        #expect(dictionary[key(kCFNetworkProxiesHTTPEnable)] == nil)
+        #expect(dictionary[key(kCFNetworkProxiesHTTPSEnable)] == nil)
+    }
+
+    @Test func appliesProxyDictionaryToCopiedConfiguration() throws {
+        let base = URLSessionConfiguration.ephemeral
+        base.timeoutIntervalForRequest = 12
+        let proxy = try GlobalProxyConfiguration(urlString: "http://proxy.example.com:8080")
+
+        let configuration = GlobalProxyURLSessionFactory.makeConfiguration(
+            base: base,
+            proxy: proxy
+        )
+
+        #expect(configuration !== base)
+        #expect(configuration.timeoutIntervalForRequest == 12)
+        #expect(base.connectionProxyDictionary == nil)
+        #expect(
+            configuration.connectionProxyDictionary?[key(kCFNetworkProxiesHTTPProxy)] as? String == "proxy.example.com"
+        )
+    }
+
+    @Test func buildsURLSessionWithProxyDictionary() throws {
+        let proxy = try GlobalProxyConfiguration(urlString: "socks5://proxy.example.com:1080")
+
+        let session = GlobalProxyURLSessionFactory.makeSession(
+            base: .ephemeral,
+            proxy: proxy
+        )
+
+        #expect(
+            session.configuration.connectionProxyDictionary?[key(kCFNetworkProxiesSOCKSProxy)] as? String
+                == "proxy.example.com"
+        )
+    }
+
+    @Test func rejectsUnsafeProxyURLInput() {
+        let cases: [(String, GlobalProxyConfiguration.ValidationError)] = [
+            ("", .empty),
+            ("/tmp/proxy.sock", .unsupportedScheme(nil)),
+            ("file:///tmp/proxy", .unsupportedScheme("file")),
+            ("ftp://proxy.example.com:21", .unsupportedScheme("ftp")),
+            ("http://proxy.example.com", .missingPort),
+            ("http://proxy.example.com:8080/path", .unsupportedURLComponents),
+            ("http://proxy.example.com:8080?token=secret", .unsupportedURLComponents),
+            ("http://proxy.example.com:8080#fragment", .unsupportedURLComponents),
+            ("http://user:pass@proxy.example.com:8080", .credentialsInURL),
+            ("http://localhost:8080", .unsafeHost("localhost")),
+            ("http://127.0.0.1:8080", .unsafeHost("127.0.0.1")),
+            ("socks5://[::1]:1080", .unsafeHost("::1")),
+        ]
+
+        for (rawURL, expectedError) in cases {
+            #expect(throws: expectedError) {
+                try GlobalProxyConfiguration(urlString: rawURL)
+            }
+        }
+    }
+
+    private func key(_ value: CFString) -> AnyHashable {
+        AnyHashable(value as String)
+    }
+}

--- a/docs/GLOBAL_PROXY.md
+++ b/docs/GLOBAL_PROXY.md
@@ -1,0 +1,84 @@
+# Global Proxy
+
+This note defines the first foundation for global proxy support tracked by
+[#1091](https://github.com/osaurus-ai/osaurus/issues/1091) and the older
+[#232](https://github.com/osaurus-ai/osaurus/issues/232). The goal is a single
+validated proxy endpoint that later call-site migrations can apply to all
+outbound network traffic without weakening TLS, persistence, or plugin
+boundaries.
+
+## Status
+
+This PR only adds the design note, URL validation, and a URLSession factory
+reference implementation. It does not add settings UI, persistence, provider
+rewiring, model-download rewiring, plugin rewiring, or per-provider overrides.
+Those are rollout steps so the shared network policy can be reviewed before it
+touches every network path.
+
+## Proxy Policy
+
+The global setting is a single URL with one of these forms:
+
+- `http://proxy.example.com:8080`
+- `https://proxy.example.com:8443`
+- `socks://proxy.example.com:1080`
+- `socks5://proxy.example.com:1080`
+
+The validator requires an explicit scheme, host, and port. It rejects unsupported
+schemes, `file:` URLs, path-based input, query strings, fragments, embedded
+userinfo credentials, missing ports, localhost names, `.local` names, loopback
+addresses, unspecified addresses, and link-local addresses.
+
+Credentials are deliberately out of scope for the URL format. If authenticated
+proxies are added later, usernames and secrets should be stored in the encrypted
+settings/Keychain path and injected through a redacted credential API rather
+than through URL userinfo or query strings.
+
+## URLSession Factory
+
+`GlobalProxyConfiguration` parses and validates the user-facing proxy URL.
+`GlobalProxyURLSessionFactory` copies a caller's `URLSessionConfiguration`,
+applies the shaped `connectionProxyDictionary`, and builds a `URLSession`
+without installing any custom TLS delegate. Certificate validation remains the
+Foundation default.
+
+HTTP and HTTPS proxy URLs populate the HTTP and HTTPS CFNetwork proxy keys so a
+single global web proxy covers both web request families. SOCKS and SOCKS5 URLs
+populate only the SOCKS keys. The foundation does not install PAC files, bypass
+lists, environment variables, or destination rewrites.
+
+## Rollout Plan
+
+1. Add encrypted settings storage for an optional global proxy URL. Invalid
+   values should fail closed at save time with the validator's error reason.
+2. Add settings UI that displays only the redacted endpoint. Proxy credentials,
+   if supported later, must be edited as separate secret fields.
+3. Migrate URLSession call sites in small PRs. Known affected paths include
+   remote provider requests, model downloads and catalog refreshes, plugin
+   fetch/search traffic, MCP HTTP/SSE traffic, GitHub skill requests, and remote
+   agent HTTP traffic.
+4. Add smoke coverage with a stub proxy that records CONNECT/HTTP/SOCKS attempts
+   for provider and model-download flows. Include a DNS-leak check before
+   marking #1091 complete.
+5. Keep per-provider proxy selection and model mirror selection as separate
+   designs. The global endpoint is intentionally simpler and should apply before
+   more granular routing is considered.
+
+## Rollback
+
+The rollback hook is the optional proxy configuration itself. Clearing the saved
+proxy URL, or passing `nil` to `GlobalProxyURLSessionFactory`, leaves
+`URLSessionConfiguration` on its normal system behavior with no global proxy
+dictionary applied. A risky call-site migration can also be reverted by changing
+that call site back to its previous `URLSessionConfiguration.default` or
+`.ephemeral` construction while keeping the validator in place.
+
+## Security Notes
+
+The proxy configuration does not bypass certificate validation, does not accept
+credentials in URL query strings, and does not downgrade HTTPS failures to plain
+HTTP retries. A malicious proxy URL is constrained to a host/port endpoint:
+local file paths, PAC scripts, URL paths, localhost/link-local destinations, and
+embedded credentials are rejected before any session is created. The factory only
+creates outbound client sessions, so a proxy setting cannot redirect privileged
+ports, grant host-Keychain access, or mutate plugin/provider identity.


### PR DESCRIPTION
## Business rationale
This PR establishes the safe foundation for global proxy support requested in #1091 and the older #232 without turning on proxy routing everywhere at once. The user-visible problem is that Osaurus has several outbound network paths but no shared, reviewable proxy contract; the evidence is the new design note plus tests proving accepted proxy endpoints are converted into Foundation proxy dictionaries and unsafe URL-shaped inputs are rejected. The observable resolution is a documented rollout path and a reusable `GlobalProxyURLSessionFactory` that later provider, model-download, plugin, MCP, and remote-agent call sites can adopt consistently.

## Coding rationale
The implementation keeps the first step deliberately small: a validated `GlobalProxyConfiguration`, a URLSession factory that copies caller-owned configurations, and coverage for the CFNetwork dictionary shape. I considered wiring provider/model/plugin call sites immediately, but that would cross too many network trust boundaries in one PR; this version only introduces the shared contract and leaves UI, encrypted settings persistence, credentials, and per-call-site migrations out of scope. The trust boundary is outbound network routing: the validator rejects credential-bearing URLs, path/query/fragment input, localhost names, `.local`, loopback, unspecified, and link-local addresses, while the factory preserves Foundation TLS validation and does not install custom delegates.

## Acceptance criteria
- [x] Add a design note for global proxy support and rollout boundaries.
- [x] Add a validated URLSession proxy configuration/factory foundation.
- [x] Cover HTTP, HTTPS, SOCKS/SOCKS5, rejected unsafe input, dictionary shaping, and copied URLSession configuration behavior.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
```
Initial focused regression:
✘ Test rejectsUnsafeProxyURLInput() recorded an issue at GlobalProxyConfigurationTests.swift:117:13:
Expectation failed: an error was expected but none was thrown and
"GlobalProxyConfiguration(scheme: OsaurusCore.GlobalProxyConfiguration.Scheme.socks, host: \"[::1]\", port: 1080)" was returned

After bracketed IPv6 host normalization:
✔ Test rejectsUnsafeProxyURLInput() passed after 0.001 seconds.
✔ Suite GlobalProxyConfigurationTests passed after 0.007 seconds.
✔ Test run with 8 tests in 1 suite passed after 0.007 seconds.

Final full gate completed: 2026-05-16T23:13:50Z
```

## Rollback
`git revert 785b2120`
