### PR TITLE
[codex] Bound eval CLI startup bootstrap

### DIFF
--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -51,13 +51,24 @@ Or call the CLI directly if you need flags the Makefile doesn't expose:
 cd Packages/OsaurusEvals
 swift run osaurus-evals run --suite Suites/Preflight --model foundation
 swift run osaurus-evals run --suite Suites/Preflight --filter browser --out report.json
+swift run osaurus-evals run --suite Suites/CapabilitySearch --bootstrap-plugins
 ```
+
+Startup bootstrap is domain-aware. `preflight` suites load installed native plugins
+and rebuild search indices so they mirror the host app. `capability_search`
+suites initialize only the selected tool / method / skill index lanes without
+loading native plugins; those index-only runs use isolated temporary storage so
+fixtures never touch the user's real encrypted databases or Keychain.
+Plugin-required cases are skipped unless you pass `--bootstrap-plugins`. A
+filtered run that only selects plugin-required cases skips without index
+bootstrap.
 
 Exit codes:
 
 - `0` — every non-skipped case passed
 - `1` — at least one case failed or errored
 - `2` — bad arguments / suite path
+- `124` — startup bootstrap exceeded `--startup-timeout`
 
 ## Case schema
 
@@ -115,7 +126,7 @@ Field notes:
 
 ### `capability_search` domain
 
-Index-only recall measurements over the tools / methods / skills lanes. No LLM, fast (~10 ms/case), deterministic. Drives `CapabilitySearchEvaluator.evaluate` and pins recall + abstain behaviour against `expect.capabilitySearch`.
+Index-only recall measurements over the tools / methods / skills lanes. No LLM, fast (~10 ms/case), deterministic. Drives `CapabilitySearchEvaluator.evaluate` and pins recall + abstain behaviour against `expect.capabilitySearch`. The CLI initializes only the selected index lanes for this domain and does not load installed native plugins by default; pass `--bootstrap-plugins` when you intentionally want local plugin tools included.
 
 ```json
 {

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -54,8 +54,17 @@ struct OsaurusEvalsCLI {
             exit(2)
         }
 
-        let startupWatchdog = makeStartupWatchdog(options: opts, suite: suite)
-        await PreflightEvaluator.loadInstalledPlugins()
+        let bootstrapPlan = EvalBootstrapPlan.make(
+            suite: suite,
+            filter: opts.filter,
+            preference: opts.pluginBootstrapPreference
+        )
+        _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
+        let startupWatchdog =
+            bootstrapPlan.requiresWork
+            ? makeStartupWatchdog(options: opts, suite: suite)
+            : nil
+        await EvalBootstrap.run(bootstrapPlan)
         startupWatchdog?.cancel()
 
         let report = await EvalRunner.run(
@@ -428,6 +437,10 @@ struct OsaurusEvalsCLI {
         /// Wall-clock guard for the Core/plugin/index bootstrap that
         /// happens before the first case can run. `nil` disables it.
         let startupTimeoutSeconds: Double?
+        /// Controls native installed-plugin bootstrap. Automatic mode
+        /// loads plugins only for preflight suites; capability-search
+        /// suites initialize indices without dlopen-ing local plugins.
+        let pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference
 
         static func parse(_ args: [String]) throws -> Options {
             var suite: URL?
@@ -440,6 +453,7 @@ struct OsaurusEvalsCLI {
             var floorsPath: String?
             var failOnFloor = false
             var startupTimeoutSeconds = EvalTimeoutReport.configuredStartupTimeoutSeconds()
+            var pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference = .automatic
 
             var i = 0
             while i < args.count {
@@ -481,6 +495,12 @@ struct OsaurusEvalsCLI {
                     }
                     startupTimeoutSeconds = value > 0 ? value : nil
                     i += 2
+                case "--bootstrap-plugins":
+                    pluginBootstrapPreference = .force
+                    i += 1
+                case "--no-plugin-bootstrap":
+                    pluginBootstrapPreference = .disabled
+                    i += 1
                 case "--help", "-h":
                     printUsage()
                     exit(0)
@@ -500,7 +520,8 @@ struct OsaurusEvalsCLI {
                 reportForensics: reportForensics,
                 floorsPath: floorsPath,
                 failOnFloor: failOnFloor,
-                startupTimeoutSeconds: startupTimeoutSeconds
+                startupTimeoutSeconds: startupTimeoutSeconds,
+                pluginBootstrapPreference: pluginBootstrapPreference
             )
         }
     }
@@ -580,6 +601,15 @@ struct OsaurusEvalsCLI {
                                       disable. Defaults: 120s locally, 30s
                                       when CI=true. Env override:
                                       OSAURUS_EVALS_STARTUP_TIMEOUT_SECONDS.
+                --bootstrap-plugins  Force installed native plugin loading
+                                      before the suite. Automatic mode loads
+                                      plugins for preflight suites only.
+                --no-plugin-bootstrap
+                                      Disable installed native plugin loading.
+                                      Capability-search suites initialize only
+                                      selected search-index lanes in isolated
+                                      eval storage and skip plugin-required
+                                      cases when no plugin is loaded.
 
             EXAMPLES:
                 osaurus-evals run --suite Suites/Preflight --model foundation

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
@@ -1,0 +1,263 @@
+//
+//  EvalBootstrap.swift
+//  OsaurusEvalsKit
+//
+//  Startup bootstrapping for the out-of-process eval CLI.
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+import OsaurusCore
+
+/// Caller preference for loading installed native plugins before an eval run.
+/// This is separate from index bootstrapping because index-only suites should
+/// not pay the `dlopen` cost or inherit a bad local plugin's startup hang.
+public enum EvalInstalledPluginBootstrapPreference: Sendable, Equatable {
+    case automatic
+    case force
+    case disabled
+}
+
+/// Search-index lanes needed by the selected capability-search cases.
+/// Keeping this scoped avoids making a method-only eval wait on tool
+/// registry sync or SKILL.md rebuilds that cannot affect its verdict.
+public struct EvalSearchIndexBootstrapScope: Sendable, Equatable {
+    public let tools: Bool
+    public let methods: Bool
+    public let skills: Bool
+
+    public init(tools: Bool = false, methods: Bool = false, skills: Bool = false) {
+        self.tools = tools
+        self.methods = methods
+        self.skills = skills
+    }
+
+    public var isEmpty: Bool {
+        !tools && !methods && !skills
+    }
+
+    public static let empty = EvalSearchIndexBootstrapScope()
+}
+
+/// Minimal bootstrap work needed before the first eval case can run.
+/// The CLI uses this to bound expensive host-app setup without making pure
+/// data suites depend on local plugin state.
+public struct EvalBootstrapPlan: Sendable, Equatable {
+    public let loadInstalledPlugins: Bool
+    public let searchIndexScope: EvalSearchIndexBootstrapScope
+
+    public init(
+        loadInstalledPlugins: Bool,
+        searchIndexScope: EvalSearchIndexBootstrapScope
+    ) {
+        self.loadInstalledPlugins = loadInstalledPlugins
+        self.searchIndexScope = searchIndexScope
+    }
+
+    public init(loadInstalledPlugins: Bool, initializeSearchIndices: Bool) {
+        self.init(
+            loadInstalledPlugins: loadInstalledPlugins,
+            searchIndexScope: initializeSearchIndices
+                ? EvalSearchIndexBootstrapScope(tools: true, methods: true, skills: true)
+                : .empty
+        )
+    }
+
+    public var initializeSearchIndices: Bool {
+        !searchIndexScope.isEmpty
+    }
+
+    public var requiresWork: Bool {
+        loadInstalledPlugins || !searchIndexScope.isEmpty
+    }
+
+    /// True when the selected cases only need derived search indices.
+    /// Those runs should stay hermetic so fixture writes cannot touch
+    /// the developer's real method database or block on Keychain.
+    public var usesIsolatedSearchStorage: Bool {
+        !loadInstalledPlugins && !searchIndexScope.isEmpty
+    }
+
+    public static func make(
+        suite: EvalSuite,
+        filter: String?,
+        preference: EvalInstalledPluginBootstrapPreference
+    ) -> EvalBootstrapPlan {
+        switch preference {
+        case .force:
+            return EvalBootstrapPlan(loadInstalledPlugins: true, searchIndexScope: .empty)
+        case .disabled:
+            return EvalBootstrapPlan(
+                loadInstalledPlugins: false,
+                searchIndexScope: suite.searchIndexBootstrapScopeWithoutPluginBootstrap(filter: filter)
+            )
+        case .automatic:
+            let needsPreflight = suite.containsCase(domain: "preflight", filter: filter)
+            return EvalBootstrapPlan(
+                loadInstalledPlugins: needsPreflight,
+                searchIndexScope: needsPreflight
+                    ? .empty
+                    : suite.searchIndexBootstrapScopeWithoutPluginBootstrap(filter: filter)
+            )
+        }
+    }
+}
+
+/// Runs the selected bootstrap plan. Full plugin bootstrap delegates to
+/// `PreflightEvaluator` so the eval CLI mirrors the host app for preflight
+/// suites; index-only bootstrap deliberately avoids native plugin loading.
+@MainActor
+public enum EvalBootstrap {
+    /// Capability-search is an index-only eval lane, so automatic
+    /// no-plugin runs should not touch the developer's real encrypted
+    /// databases or wait on Keychain. The CLI calls this before startup
+    /// bootstrap and keeps the override alive for the whole process.
+    @discardableResult
+    public static func configureIsolatedSearchStorageIfNeeded(
+        for plan: EvalBootstrapPlan
+    ) -> URL? {
+        guard plan.usesIsolatedSearchStorage else { return nil }
+
+        #if DEBUG
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-evals-\(UUID().uuidString)", isDirectory: true)
+            try? FileManager.default.createDirectory(
+                at: root,
+                withIntermediateDirectories: true
+            )
+            OsaurusPaths.overrideRoot = root
+            StorageMigrationCoordinator.shared._setReadyForTesting()
+            StorageKeyManager.shared._setKeyForTesting(
+                SymmetricKey(data: Data(repeating: 0xA5, count: 32))
+            )
+            return root
+        #else
+            return nil
+        #endif
+    }
+
+    public static func run(_ plan: EvalBootstrapPlan) async {
+        if plan.loadInstalledPlugins {
+            await withHeadlessStorageMigrationGate {
+                await PreflightEvaluator.loadInstalledPlugins()
+            }
+            return
+        }
+
+        if !plan.searchIndexScope.isEmpty {
+            await initializeSearchIndices(plan.searchIndexScope)
+        }
+    }
+
+    /// Bring up the search indices used by `CapabilitySearchEvaluator`
+    /// without scanning or dlopen-ing installed native plugins.
+    private static func initializeSearchIndices(_ scope: EvalSearchIndexBootstrapScope) async {
+        await withHeadlessStorageMigrationGate {
+            await StorageMigrationCoordinator.shared.awaitReady()
+        }
+
+        if scope.tools {
+            try? ToolDatabase.shared.open()
+            await ToolSearchService.shared.initialize()
+            await ToolIndexService.shared.syncFromRegistry()
+        }
+
+        if scope.methods {
+            try? MethodDatabase.shared.open()
+            await MethodSearchService.shared.initialize()
+        }
+
+        if scope.skills {
+            await SkillManager.shared.refresh()
+            await SkillSearchService.shared.initialize()
+            await SkillSearchService.shared.rebuildIndex()
+        }
+    }
+
+    /// The eval executable is a headless CLI, but `awaitReady()` is shared with
+    /// the app and normally creates a SwiftUI migration panel when work is
+    /// needed. Temporarily marking the process as CI reuses the existing
+    /// Core-side no-panel branch while still running the real migrator and
+    /// preserving the storage gate's fail-closed behaviour.
+    private static func withHeadlessStorageMigrationGate(
+        _ operation: @escaping @MainActor () async -> Void
+    ) async {
+        let previousCI = getenv("CI").map { String(cString: $0) }
+        setenv("CI", "true", 1)
+        defer {
+            if let previousCI {
+                setenv("CI", previousCI, 1)
+            } else {
+                unsetenv("CI")
+            }
+        }
+        await operation()
+    }
+}
+
+public extension EvalSuite {
+    /// Domain presence after applying the same substring filter the CLI applies
+    /// to case execution. Bootstrap should match the cases that will actually run.
+    func containsCase(domain: String, filter: String?) -> Bool {
+        if let filter {
+            return cases.contains { $0.domain == domain && $0.id.contains(filter) }
+        }
+        return cases.contains { testCase in
+            testCase.domain == domain
+        }
+    }
+
+    /// Search indices are only useful for cases that will reach the search
+    /// evaluator. Without plugin bootstrap, plugin-required cases skip before
+    /// searching, so a filtered run of those cases should not block on index IO.
+    func needsSearchIndicesWithoutPluginBootstrap(filter: String?) -> Bool {
+        !searchIndexBootstrapScopeWithoutPluginBootstrap(filter: filter).isEmpty
+    }
+
+    /// Returns the minimum search-index lanes needed by selected cases.
+    /// Plugin-required cases are ignored here because they skip before
+    /// `CapabilitySearchEvaluator.evaluate` when installed plugins were not
+    /// loaded, so their expected lanes cannot affect the report.
+    func searchIndexBootstrapScopeWithoutPluginBootstrap(
+        filter: String?
+    ) -> EvalSearchIndexBootstrapScope {
+        var needsTools = false
+        var needsMethods = false
+        var needsSkills = false
+
+        for testCase in selectedCases(filter: filter) {
+            if testCase.domain == "preflight" {
+                needsTools = true
+                needsMethods = true
+                needsSkills = true
+                continue
+            }
+
+            guard testCase.domain == "capability_search" else { continue }
+            guard testCase.fixtures.requirePlugins?.isEmpty ?? true else { continue }
+
+            let expect = testCase.expect.capabilitySearch
+            needsTools = needsTools || expect?.expectedTools != nil
+            needsMethods =
+                needsMethods
+                || expect?.expectedMethods != nil
+                || !(testCase.fixtures.seedMethods?.isEmpty ?? true)
+            needsSkills =
+                needsSkills
+                || expect?.expectedSkills != nil
+                || !(testCase.fixtures.enableSkills?.isEmpty ?? true)
+        }
+
+        return EvalSearchIndexBootstrapScope(
+            tools: needsTools,
+            methods: needsMethods,
+            skills: needsSkills
+        )
+    }
+
+    private func selectedCases(filter: String?) -> [EvalCase] {
+        guard let filter else { return cases }
+        return cases.filter { $0.id.contains(filter) }
+    }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct EvalBootstrapPlanTests {
+    @Test func pluginRequiredCapabilitySearchSkipsBootstrapByDefault() {
+        let suite = makeSuite(
+            cases: [
+                makeCase(
+                    id: "capability_search.browser-prefix",
+                    domain: "capability_search",
+                    requirePlugins: ["osaurus.browser"]
+                )
+            ]
+        )
+
+        let plan = EvalBootstrapPlan.make(
+            suite: suite,
+            filter: "browser-prefix",
+            preference: .automatic
+        )
+
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+    }
+
+    @Test func capabilitySearchInitializesIndicesWithoutPluginLoadingByDefault() {
+        let suite = makeSuite(
+            cases: [
+                makeCase(
+                    id: "capability_search.method-paraphrase",
+                    domain: "capability_search",
+                    expectedMethods: true
+                )
+            ]
+        )
+
+        let plan = EvalBootstrapPlan.make(
+            suite: suite,
+            filter: "method-paraphrase",
+            preference: .automatic
+        )
+
+        #expect(
+            plan
+                == EvalBootstrapPlan(
+                    loadInstalledPlugins: false,
+                    searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
+                )
+        )
+        #expect(plan.usesIsolatedSearchStorage)
+    }
+
+    @Test func capabilitySearchScopesIndexBootstrapToSelectedLanes() {
+        let suite = makeSuite(
+            cases: [
+                makeCase(
+                    id: "capability_search.skill-direct-name",
+                    domain: "capability_search",
+                    expectedSkills: true,
+                    enableSkills: ["Research Analyst"]
+                )
+            ]
+        )
+
+        let plan = EvalBootstrapPlan.make(
+            suite: suite,
+            filter: "skill-direct-name",
+            preference: .automatic
+        )
+
+        #expect(
+            plan
+                == EvalBootstrapPlan(
+                    loadInstalledPlugins: false,
+                    searchIndexScope: EvalSearchIndexBootstrapScope(skills: true)
+                )
+        )
+    }
+
+    @Test func preflightLoadsPluginsInAutomaticMode() {
+        let suite = makeSuite(
+            cases: [
+                makeCase(
+                    id: "preflight.browser.amazon-orders",
+                    domain: "preflight",
+                    requirePlugins: ["osaurus.browser"]
+                )
+            ]
+        )
+
+        let plan = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .automatic)
+
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
+        #expect(!plan.usesIsolatedSearchStorage)
+    }
+
+    @Test func pureDataSuitesSkipStartupBootstrap() {
+        let suite = makeSuite(cases: [makeCase(id: "schema.minimum-bound", domain: "schema")])
+
+        let plan = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .automatic)
+
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+        #expect(!plan.requiresWork)
+    }
+
+    @Test func filterControlsAutomaticBootstrapPlan() {
+        let suite = makeSuite(
+            cases: [
+                makeCase(id: "preflight.browser", domain: "preflight"),
+                makeCase(id: "schema.minimum-bound", domain: "schema"),
+            ]
+        )
+
+        let plan = EvalBootstrapPlan.make(
+            suite: suite,
+            filter: "minimum-bound",
+            preference: .automatic
+        )
+
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+    }
+
+    @Test func explicitPluginPreferencesOverrideDomainDefault() {
+        let suite = makeSuite(cases: [makeCase(id: "capability_search.browser-prefix", domain: "capability_search")])
+
+        let forced = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .force)
+        let disabled = EvalBootstrapPlan.make(
+            suite: makeSuite(
+                cases: [
+                    makeCase(
+                        id: "capability_search.method-paraphrase",
+                        domain: "capability_search",
+                        expectedMethods: true
+                    )
+                ]
+            ),
+            filter: nil,
+            preference: .disabled
+        )
+
+        #expect(forced == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
+        #expect(
+            disabled
+                == EvalBootstrapPlan(
+                    loadInstalledPlugins: false,
+                    searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
+                )
+        )
+    }
+
+    private func makeSuite(cases: [EvalCase]) -> EvalSuite {
+        EvalSuite(
+            directory: URL(fileURLWithPath: "/tmp/Evals", isDirectory: true),
+            cases: cases,
+            decodeFailures: []
+        )
+    }
+
+    private func makeCase(
+        id: String,
+        domain: String,
+        requirePlugins: [String]? = nil,
+        expectedTools: Bool = false,
+        expectedMethods: Bool = false,
+        expectedSkills: Bool = false,
+        seedMethods: [EvalCase.SeedMethod]? = nil,
+        enableSkills: [String]? = nil
+    ) -> EvalCase {
+        let anyOf = EvalCase.CapabilitySearchExpectations.AnyOfMatcher(
+            anyOf: [],
+            minMatches: 0
+        )
+        let capabilitySearch =
+            expectedTools || expectedMethods || expectedSkills
+            ? EvalCase.CapabilitySearchExpectations(
+                expectedTools: expectedTools ? anyOf : nil,
+                expectedMethods: expectedMethods ? anyOf : nil,
+                expectedSkills: expectedSkills ? anyOf : nil
+            )
+            : nil
+
+        return EvalCase(
+            id: id,
+            domain: domain,
+            query: "query",
+            fixtures: .init(
+                requirePlugins: requirePlugins,
+                seedMethods: seedMethods,
+                enableSkills: enableSkills
+            ),
+            expect: .init(capabilitySearch: capabilitySearch)
+        )
+    }
+}


### PR DESCRIPTION
## Business rationale

Issue #1050 leaves the eval CLI able to hang during startup when a filtered CapabilitySearch run only needs one lane. The concrete repro was `capability_search.browser-prefix` with a 5 second startup watchdog: before this change the CLI exited with `eval timeout: startup bootstrap exceeded 5s; exiting 124` after trying to perform broad installed-plugin startup work. This PR makes filtered eval runs bounded and observable: plugin-required cases skip cleanly when native plugins are unavailable, non-plugin cases initialize only their selected search lane, and both paths write JSON reports instead of stalling.

## Coding rationale

The implementation adds an explicit eval bootstrap plan that separates installed-plugin loading from scoped search-index initialization. The chosen design keeps preflight/plugin runs faithful to production by loading installed plugins when that domain requires it, while pure `capability_search` fixtures use isolated temporary eval storage and initialize only the needed tool, method, or skill index. Alternatives considered were continuing unconditional plugin bootstrap, bootstrapping every index for every suite, or bypassing the storage migration gate globally; those were rejected because they either preserve the hang, add unrelated startup cost, or weaken the storage trust boundary. The change is deliberately scoped to `Packages/OsaurusEvals` and does not change production plugin loading or user data storage semantics.

## Acceptance criteria

- [x] Filtered plugin-required CapabilitySearch run exits without startup timeout and writes a JSON report.
- [x] Non-plugin CapabilitySearch method case initializes only the method index and passes under the startup watchdog.
- [x] Pure data suites skip startup bootstrap work.
- [x] CLI flags document explicit plugin bootstrap override behavior.
- [x] Eval bootstrap plan behavior is covered by tests.

## Quality gate

- [x] swift-format / swiftlint / shellcheck - clean (`swiftlint` reports existing warnings only, 0 serious)
- [x] swift test --package-path Packages/OsaurusCLI --parallel - green
- [x] make ci-test - green
- [x] swift build --package-path Packages/OsaurusCore -c release - green
- [x] swift build --package-path Packages/OsaurusEvals - green
- [x] swift test --package-path Packages/OsaurusEvals - green
- [x] Archive freshness - confirmed with `git fetch --all --prune` immediately before push; `origin/main` remained `353f595d75f0f2732e0efe7d8fbec4fe3aca2aa6`

## Debug evidence

Failing trace before the fix:

```text
swift run --package-path Packages/OsaurusEvals osaurus-evals run --suite Packages/OsaurusEvals/Suites/CapabilitySearch --filter browser-prefix --out /tmp/osaurus-t-d-browser-prefix.json --startup-timeout 5
eval timeout: startup bootstrap exceeded 5s; exiting 124
```

Startup samples showed the hang inside startup bootstrap work, first rendering the storage migration overlay path and then blocking in Keychain-backed storage initialization via `StorageMigrator.runIfNeeded` -> `StorageKeyManager.currentKey()` -> `SecItemCopyMatching`.

Passing traces after the fix:

```text
swift run --package-path Packages/OsaurusEvals osaurus-evals run --suite Packages/OsaurusEvals/Suites/CapabilitySearch --filter browser-prefix --out /tmp/osaurus-t-d-browser-prefix-final.json --startup-timeout 5
[SKIP] capability_search.browser-prefix  score=-        -
       . missing plugins: osaurus.browser
wrote 1 cases to /tmp/osaurus-t-d-browser-prefix-final.json
```

```text
swift run --package-path Packages/OsaurusEvals osaurus-evals run --suite Packages/OsaurusEvals/Suites/CapabilitySearch --filter method-lexical-name --out /tmp/osaurus-t-d-method-final.json --startup-timeout 30
[PASS] capability_search.method-lexical-name  score=-      2ms
       . methods matched 1/1: [summarize_pdf]
wrote 1 cases to /tmp/osaurus-t-d-method-final.json
```

## Rollback

`git revert 6a07f49e85b50a8d0333bdf7186c24b694d85e38`
