### PR TITLE
Enforce agent-scoped capability tools

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -672,11 +672,12 @@ public struct SystemPromptComposer: Sendable {
         }
 
         // Capability-discovery nudge: explain how to recover when the
-        // current tool kit is incomplete. Gated to auto mode + presence of
-        // `capabilities_search` so manual-mode agents and tools-disabled
-        // sessions don't see irrelevant guidance.
-        if snapshot.toolMode == .auto,
-            !effectiveToolsOff,
+        // current tool kit is incomplete. The gate follows the actual
+        // schema, not the mode label: manual-mode agents still carry
+        // `capabilities_search` / `capabilities_load` as pragmatic
+        // always-loaded tools, so hiding the instructions made the
+        // discovery path invisible even though it was callable.
+        if !effectiveToolsOff,
             tools.contains(where: { $0.function.name == "capabilities_search" })
         {
             composer.append(

--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -265,7 +265,8 @@ enum CapabilitySearch {
 
     static func search(
         query: String,
-        topK: (methods: Int, tools: Int, skills: Int)
+        topK: (methods: Int, tools: Int, skills: Int),
+        allowedToolNames: Set<String>? = nil
     ) async -> CapabilitySearchResults {
         let methodsThreshold = minimumRelevanceScoreMethods
         let skillsThreshold = minimumRelevanceScoreSkills
@@ -281,6 +282,7 @@ enum CapabilitySearch {
             return await searchWithVerboseTrace(
                 query: query,
                 topK: topK,
+                allowedToolNames: allowedToolNames,
                 methodsThreshold: methodsThreshold,
                 skillsThreshold: skillsThreshold,
                 fusedCutoff: fusedCutoff
@@ -295,7 +297,8 @@ enum CapabilitySearch {
         async let toolHits = ToolSearchService.shared.searchHybrid(
             query: query,
             topK: topK.tools,
-            minFusedScore: fusedCutoff
+            minFusedScore: fusedCutoff,
+            allowedNames: allowedToolNames
         )
         async let skillHits = SkillSearchService.shared.search(
             query: query,
@@ -324,6 +327,7 @@ enum CapabilitySearch {
     private static func searchWithVerboseTrace(
         query: String,
         topK: (methods: Int, tools: Int, skills: Int),
+        allowedToolNames: Set<String>?,
         methodsThreshold: Float,
         skillsThreshold: Float,
         fusedCutoff: Float
@@ -336,7 +340,8 @@ enum CapabilitySearch {
         async let toolPair = ToolSearchService.shared.searchHybridWithDiagnostic(
             query: query,
             topK: topK.tools,
-            minFusedScore: fusedCutoff
+            minFusedScore: fusedCutoff,
+            allowedNames: allowedToolNames
         )
         async let skillPair = SkillSearchService.shared.searchWithDiagnostic(
             query: query,
@@ -360,6 +365,7 @@ enum CapabilitySearch {
             methods accepted=\(formatHits(methodDiag.acceptedHits), privacy: .public)
             tools bm25Available=\(toolDiag.bm25Available, privacy: .public) all=\(formatHybridHits(toolDiag.allHits), privacy: .public)
             tools accepted=\(formatHybridHits(toolDiag.acceptedHits), privacy: .public)
+            tools filteredByAllowlist=\(formatNames(toolDiag.filteredByAllowlist), privacy: .public)
             skills raw=\(formatHits(skillDiag.rawHits), privacy: .public)
             skills accepted=\(formatHits(skillDiag.acceptedHits), privacy: .public)
             """
@@ -416,6 +422,10 @@ fileprivate func formatHybridHits(_ hits: [ToolSearchHybridDiagnostic.Hit]) -> S
             return "\(hit.name)(bm25=\(bm25),embed=\(embed),fused=\(fused))"
         }
         .joined(separator: ",")
+}
+
+fileprivate func formatNames(_ names: [String]) -> String {
+    names.isEmpty ? "[]" : "[\(names.joined(separator: ","))]"
 }
 
 // MARK: - Preflight Tool Selection

--- a/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
@@ -81,6 +81,10 @@ public struct ToolSearchHybridDiagnostic: Sendable {
     public let acceptedHits: [Hit]
     public let requestedMinFusedScore: Float
     public let minFusedScore: Float
+    /// Names that passed score/enabled checks but were suppressed by
+    /// the active agent's enabled-tool allowlist. This separates "not
+    /// indexed" from "not granted" during #823/#789-style triage.
+    public let filteredByAllowlist: [String]
 
     public init(
         indexedToolCount: Int,
@@ -88,7 +92,8 @@ public struct ToolSearchHybridDiagnostic: Sendable {
         allHits: [Hit],
         acceptedHits: [Hit],
         minFusedScore: Float,
-        requestedMinFusedScore: Float? = nil
+        requestedMinFusedScore: Float? = nil,
+        filteredByAllowlist: [String] = []
     ) {
         self.indexedToolCount = indexedToolCount
         self.bm25Available = bm25Available
@@ -96,6 +101,7 @@ public struct ToolSearchHybridDiagnostic: Sendable {
         self.acceptedHits = acceptedHits
         self.requestedMinFusedScore = requestedMinFusedScore ?? minFusedScore
         self.minFusedScore = minFusedScore
+        self.filteredByAllowlist = filteredByAllowlist
     }
 }
 
@@ -330,12 +336,14 @@ public actor ToolSearchService {
     public func searchHybrid(
         query: String,
         topK: Int = 10,
-        minFusedScore: Float = 0.01
+        minFusedScore: Float = 0.01,
+        allowedNames: Set<String>? = nil
     ) async -> [ToolSearchResult] {
         let (results, _) = await searchHybridWithDiagnostic(
             query: query,
             topK: topK,
-            minFusedScore: minFusedScore
+            minFusedScore: minFusedScore,
+            allowedNames: allowedNames
         )
         return results
     }
@@ -355,7 +363,8 @@ public actor ToolSearchService {
     public func searchHybridWithDiagnostic(
         query: String,
         topK: Int,
-        minFusedScore: Float
+        minFusedScore: Float,
+        allowedNames: Set<String>? = nil
     ) async -> (results: [ToolSearchResult], diagnostic: ToolSearchHybridDiagnostic) {
         let indexedCount = (try? ToolDatabase.shared.entryCount()) ?? 0
         let bm25Available = ToolDatabase.sanitizeFTS5Query(query) != nil
@@ -446,10 +455,15 @@ public actor ToolSearchService {
         // checker on first attempt).
         var acceptedResults: [ToolSearchResult] = []
         var acceptedHits: [ToolSearchHybridDiagnostic.Hit] = []
+        var filteredByAllowlist: [String] = []
         for (name, score) in fused {
             if acceptedResults.count >= topK { break }
             guard score >= effectiveMinFusedScore else { continue }
             guard let entry = entriesByName[name], enabledNames.contains(name) else { continue }
+            if let allowedNames, !allowedNames.contains(name) {
+                filteredByAllowlist.append(name)
+                continue
+            }
             acceptedResults.append(ToolSearchResult(entry: entry, searchScore: score))
             acceptedHits.append(makeHit(name: name, score: score))
         }
@@ -460,7 +474,8 @@ public actor ToolSearchService {
             allHits: allHits,
             acceptedHits: acceptedHits,
             minFusedScore: effectiveMinFusedScore,
-            requestedMinFusedScore: minFusedScore
+            requestedMinFusedScore: minFusedScore,
+            filteredByAllowlist: filteredByAllowlist
         )
         return (acceptedResults, diagnostic)
     }

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -145,13 +145,13 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// Manual mode opts out of preflight, which also opts out of the
-    /// capability-discovery nudge (the nudge is gated on auto mode so
-    /// manual agents don't see "go grow your tool list" guidance they
-    /// can't act on). Loop guidance still fires because `todo`/etc.
-    /// are always-loaded built-ins regardless of mode.
-    @Test("preview: manual mode keeps agent loop, drops capability nudge")
-    func toolsOn_manual_dropsCapabilityNudge() async {
+    /// Manual mode opts out of the LLM preflight call, but it still
+    /// includes the capability discovery tools in the schema. The prompt
+    /// must explain those tools whenever they are callable; otherwise the
+    /// model sees an opaque `capabilities_search` function and #789-style
+    /// "search is enabled but never found" failures are hard to diagnose.
+    @Test("preview: manual mode keeps agent loop and capability nudge")
+    func toolsOn_manual_keepsCapabilityNudge() async {
         await withAgent(
             toolSelectionMode: .manual,
             manualToolNames: ["render_chart"]
@@ -162,7 +162,7 @@ struct ContextBudgetPreviewTests {
             )
             let ids = sectionIds(preview)
             #expect(ids.contains("agentLoopGuidance"))
-            #expect(ids.contains("capabilityNudge") == false)
+            #expect(ids.contains("capabilityNudge"))
             #expect(preview.tools.contains { $0.function.name == "render_chart" })
         }
     }

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -46,6 +46,7 @@ struct CapabilityLoadBufferTests {
 
 // MARK: - CapabilitiesSearchTool
 
+@Suite(.serialized)
 struct CapabilitiesSearchToolTests {
 
     @Test func rejectsEmptyQueries() async throws {
@@ -69,10 +70,115 @@ struct CapabilitiesSearchToolTests {
         )
         #expect(result.contains("No capabilities found") || result.contains("capability"))
     }
+
+    @Test @MainActor
+    func searchFiltersDynamicToolsOutsideAgentGrant() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-search-root-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                AgentManager.shared.refresh()
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    AgentManager.shared.refresh()
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-search-grant-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                let previousOverride = ToolConfigurationStore.overrideDirectory
+                ToolConfigurationStore.overrideDirectory = tempDir
+                try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                defer { ToolConfigurationStore.overrideDirectory = previousOverride }
+
+                let dbWasOpen = ToolDatabase.shared.isOpen
+                if !dbWasOpen {
+                    try ToolDatabase.shared.openInMemory()
+                }
+                defer {
+                    try? ToolDatabase.shared.deleteEntry(id: CapabilityPolicyFixtureTool.allowedName)
+                    try? ToolDatabase.shared.deleteEntry(id: CapabilityPolicyFixtureTool.deniedName)
+                    if !dbWasOpen {
+                        ToolDatabase.shared.close()
+                    }
+                }
+
+                let allowed = CapabilityPolicyFixtureTool(
+                    name: CapabilityPolicyFixtureTool.allowedName,
+                    description: "Search the web for current headlines and online results"
+                )
+                let denied = CapabilityPolicyFixtureTool(
+                    name: CapabilityPolicyFixtureTool.deniedName,
+                    description: "Search the web for current headlines and online results"
+                )
+                ToolRegistry.shared.registerPluginTool(allowed)
+                ToolRegistry.shared.registerPluginTool(denied)
+                ToolRegistry.shared.setEnabled(true, for: allowed.name)
+                ToolRegistry.shared.setEnabled(true, for: denied.name)
+                defer { ToolRegistry.shared.unregister(names: [allowed.name, denied.name]) }
+
+                await ToolIndexService.shared.onToolRegistered(
+                    name: allowed.name,
+                    description: allowed.description,
+                    runtime: .native,
+                    tokenCount: 12,
+                    parameters: allowed.parameters
+                )
+                await ToolIndexService.shared.onToolRegistered(
+                    name: denied.name,
+                    description: denied.description,
+                    runtime: .native,
+                    tokenCount: 12,
+                    parameters: denied.parameters
+                )
+                // Seed AgentManager's async known-tool snapshot before the fixture
+                // agent exists, so unrelated parallel tests cannot auto-grow its
+                // explicit allowlist with the denied fixture tool.
+                NotificationCenter.default.post(name: .toolsListChanged, object: nil)
+                await Task.yield()
+
+                let agent = Agent(
+                    name: "CapabilitySearchGrant-\(UUID().uuidString.prefix(6))",
+                    agentAddress: "capability-search-grant-\(UUID().uuidString)",
+                    manualToolNames: [allowed.name]
+                )
+                AgentManager.shared.add(agent)
+                AgentManager.shared.updateEnabledToolNames([allowed.name], for: agent.id)
+                #expect(AgentManager.shared.effectiveEnabledToolNames(for: agent.id) == [allowed.name])
+
+                let (rawResults, diagnostic) = await ToolSearchService.shared.searchHybridWithDiagnostic(
+                    query: "current headline web search",
+                    topK: 5,
+                    minFusedScore: CapabilitySearch.minimumFusedScore,
+                    allowedNames: [allowed.name]
+                )
+                #expect(rawResults.contains { $0.entry.name == allowed.name })
+                #expect(!rawResults.contains { $0.entry.name == denied.name })
+                #expect(diagnostic.filteredByAllowlist.contains(denied.name))
+
+                let tool = CapabilitiesSearchTool(agentId: agent.id)
+                let result = try await tool.execute(
+                    argumentsJSON: "{\"queries\": [\"current headline web search\"]}"
+                )
+                #expect(result.contains(allowed.name))
+                #expect(!result.contains(denied.name))
+
+                _ = await AgentManager.shared.delete(id: agent.id)
+            }
+        }
+    }
 }
 
 // MARK: - CapabilitiesLoadTool
 
+@Suite(.serialized)
 struct CapabilitiesLoadToolTests {
 
     @Test func rejectsEmptyIds() async throws {
@@ -153,5 +259,85 @@ struct CapabilitiesLoadToolTests {
 
         let buffered = await CapabilityLoadBuffer.shared.drain()
         #expect(buffered.contains(where: { $0.function.name == "capabilities_search" }))
+    }
+
+    @Test @MainActor
+    func toolLoadRejectsDynamicToolOutsideAgentGrant() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await DynamicCatalogTestLock.shared.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-load-root-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                AgentManager.shared.refresh()
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    AgentManager.shared.refresh()
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-capability-load-grant-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                let previousOverride = ToolConfigurationStore.overrideDirectory
+                ToolConfigurationStore.overrideDirectory = tempDir
+                try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                defer { ToolConfigurationStore.overrideDirectory = previousOverride }
+
+                let denied = CapabilityPolicyFixtureTool(
+                    name: CapabilityPolicyFixtureTool.deniedName,
+                    description: "Search the web for current headlines and online results"
+                )
+                ToolRegistry.shared.registerPluginTool(denied)
+                ToolRegistry.shared.setEnabled(true, for: denied.name)
+                defer { ToolRegistry.shared.unregister(names: [denied.name]) }
+
+                let agent = Agent(
+                    name: "CapabilityLoadGrant-\(UUID().uuidString.prefix(6))",
+                    agentAddress: "capability-load-grant-\(UUID().uuidString)",
+                    manualToolNames: []
+                )
+                AgentManager.shared.add(agent)
+                _ = await CapabilityLoadBuffer.shared.drain()
+
+                let tool = CapabilitiesLoadTool()
+                let result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+                    try await tool.execute(
+                        argumentsJSON: "{\"ids\": [\"tool/\(denied.name)\"]}"
+                    )
+                }
+                #expect(result.contains("not enabled for this agent"))
+                let buffered = await CapabilityLoadBuffer.shared.drain()
+                #expect(!buffered.contains(where: { $0.function.name == denied.name }))
+
+                _ = await AgentManager.shared.delete(id: agent.id)
+            }
+        }
+    }
+}
+
+private struct CapabilityPolicyFixtureTool: OsaurusTool {
+    static let allowedName = "lane_b_allowed_search_tool"
+    static let deniedName = "lane_b_denied_search_tool"
+
+    let name: String
+    let description: String
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("Search query for current web results"),
+            ])
+        ]),
+        "required": .array([.string("query")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        argumentsJSON
     }
 }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -108,6 +108,9 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
+        let activeAgentId = await Self.resolveAgentId(explicit: agentId)
+        let allowedToolNames = await Self.allowedToolNames(for: activeAgentId)
+
         // Run each query independently and merge by best score per item.
         // The previous implementation joined every query into one string
         // and ran a single search — `["weather API", "get current weather
@@ -120,7 +123,11 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         ) { group in
             for q in queries {
                 group.addTask {
-                    await CapabilitySearch.search(query: q, topK: Self.perQueryTopK)
+                    await CapabilitySearch.search(
+                        query: q,
+                        topK: Self.perQueryTopK,
+                        allowedToolNames: allowedToolNames
+                    )
                 }
             }
             var collected: [CapabilitySearchResults] = []
@@ -132,16 +139,9 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         let hits = Self.mergeHits(perQueryResults)
 
         if hits.isEmpty {
-            let id: UUID
-            if let existingId = agentId ?? ChatExecutionContext.currentAgentId {
-                id = existingId
-            } else {
-                id = await MainActor.run { AgentManager.shared.activeAgent.id }
-            }
-
             let queryList = queries.map { "'\($0)'" }.joined(separator: ", ")
             let text: String
-            if await CapabilitySearch.canCreatePlugins(agentId: id) {
+            if await CapabilitySearch.canCreatePlugins(agentId: activeAgentId) {
                 text = """
                     No capabilities found matching \(queryList).
 
@@ -202,6 +202,27 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         }
         output += "Use `capabilities_load` with the IDs to load them into this session."
         return ToolEnvelope.success(tool: name, text: output)
+    }
+
+    /// Resolve the agent whose capability picker scopes runtime search.
+    /// Tool calls usually carry `ChatExecutionContext.currentAgentId`;
+    /// tests and direct host-API invocations can pass `agentId`
+    /// explicitly. Falling back to the active agent preserves legacy
+    /// behavior for older paths that do not yet bind task-local context.
+    private static func resolveAgentId(explicit: UUID?) async -> UUID {
+        if let explicit { return explicit }
+        if let contextId = ChatExecutionContext.currentAgentId { return contextId }
+        return await MainActor.run { AgentManager.shared.activeAgent.id }
+    }
+
+    /// The enabled-tool allowlist is nil for legacy/unseeded agents,
+    /// which deliberately means "use the global enabled registry." A
+    /// non-nil set is authoritative: `capabilities_search` must not
+    /// return a dynamic tool the current agent has not been granted.
+    private static func allowedToolNames(for agentId: UUID) async -> Set<String>? {
+        await MainActor.run {
+            AgentManager.shared.effectiveEnabledToolNames(for: agentId).map(Set.init)
+        }
     }
 
     // MARK: - Merge
@@ -347,13 +368,33 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             output += "\n\n"
 
             if !method.toolsUsed.isEmpty {
-                let toolSpecs = await MainActor.run {
-                    ToolRegistry.shared.specs(forTools: method.toolsUsed)
+                let allowedNames = await grantedToolNamesForCurrentAgent()
+                let (loadableToolNames, blockedToolNames, toolSpecs) = await MainActor.run {
+                    var allowed: [String] = []
+                    var blocked: [String] = []
+                    for name in method.toolsUsed {
+                        let isBuiltIn = ToolRegistry.shared.builtInToolNames.contains(name)
+                        if isBuiltIn || (allowedNames?.contains(name) ?? true) {
+                            allowed.append(name)
+                        } else {
+                            blocked.append(name)
+                        }
+                    }
+                    return (
+                        allowed,
+                        blocked,
+                        ToolRegistry.shared.specs(forTools: allowed)
+                    )
                 }
                 for spec in toolSpecs {
                     await CapabilityLoadBuffer.shared.add(spec)
                 }
-                output += "Auto-loaded tools: \(method.toolsUsed.joined(separator: ", "))\n"
+                if !loadableToolNames.isEmpty {
+                    output += "Auto-loaded tools: \(loadableToolNames.joined(separator: ", "))\n"
+                }
+                if !blockedToolNames.isEmpty {
+                    output += "Skipped tools not enabled for this agent: \(blockedToolNames.joined(separator: ", "))\n"
+                }
             }
 
             if !method.skillsUsed.isEmpty {
@@ -376,12 +417,16 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     }
 
     private func loadTool(_ toolId: String) async -> String {
+        let allowedNames = await grantedToolNamesForCurrentAgent()
         let (isEnabled, isBuiltIn, toolSpec) = await MainActor.run {
             (
                 ToolRegistry.shared.isGlobalEnabled(toolId),
                 ToolRegistry.shared.builtInToolNames.contains(toolId),
                 ToolRegistry.shared.specs(forTools: [toolId])
             )
+        }
+        guard isBuiltIn || (allowedNames?.contains(toolId) ?? true) else {
+            return "Error: Tool '\(toolId)' is not enabled for this agent.\n"
         }
         // Built-in tools are always loaded via alwaysLoadedSpecs, so skip the
         // enabled check — rejecting them here is misleading since they're callable.
@@ -393,6 +438,23 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         }
         await CapabilityLoadBuffer.shared.add(spec)
         return "Tool '\(toolId)' loaded and available.\n"
+    }
+
+    /// Nil means this agent has not been seeded by the capability picker
+    /// yet, so the historical global-enabled behavior remains in force.
+    /// A concrete set is the user's grant boundary and is enforced even
+    /// if the model invents a `tool/<name>` ID instead of receiving it
+    /// from `capabilities_search`.
+    private func grantedToolNamesForCurrentAgent() async -> Set<String>? {
+        let id: UUID
+        if let contextId = ChatExecutionContext.currentAgentId {
+            id = contextId
+        } else {
+            id = await MainActor.run { AgentManager.shared.activeAgent.id }
+        }
+        return await MainActor.run {
+            AgentManager.shared.effectiveEnabledToolNames(for: id).map(Set.init)
+        }
     }
 
     private func loadSkill(_ skillName: String) async -> String {


### PR DESCRIPTION
## Business rationale
Agents can expose `capabilities_search`/`capabilities_load` even when the initial tool schema is intentionally small, but the runtime search path was still reading from the globally enabled dynamic catalog. That meant a tool could be globally indexed and visible even when the active agent had not been granted it. This PR closes that gap so users see capability discovery results that match the agent picker and so hidden-but-granted tools are discoverable without leaking tools outside the agent grant boundary.

## Coding rationale
The fix keeps the existing BM25/embedding search pipeline and adds the agent allowlist as a narrow filter at the dynamic-tool boundary instead of duplicating search indexes or changing global registry semantics. `capabilities_search` resolves the active agent, passes the effective enabled tool names into `CapabilitySearch`, and diagnostics now report allowlist-filtered names. `capabilities_load` also enforces the same boundary before buffering dynamically loaded tools, while built-in tools remain always-loadable through the existing always-loaded path. Out of scope: changing AgentManager auto-grow behavior, altering provider compatibility, or reworking the capability picker UI. The trust boundary is the model/tool-calling surface: a model must not be able to discover or load a dynamic tool the current agent has not been granted.

## Acceptance criteria
- [x] `capabilities_search` returns indexed and enabled tools from BM25 when embedding is unavailable.
- [x] Diagnostics report requested vs effective fused cutoffs and allowlist-filtered tools.
- [x] Granted tools surface in capability search and prompt assembly.
- [x] Regression tests demonstrate granted-but-hidden tools are caught.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
Failing trace before the final test isolation fix:
`CapabilityToolsTests.swift:149: Expectation failed: !result.contains(denied.name)` with `tool/lane_b_denied_search_tool` returned by `capabilities_search`.

Passing evidence on the PR head:
- `swift test --package-path Packages/OsaurusCore --filter CapabilitiesSearchToolTests` passed 4 tests.
- `swift test --package-path Packages/OsaurusCore --filter CapabilitiesLoadToolTests` passed 10 tests.
- `swift test --package-path Packages/OsaurusCore --filter Capability` passed 103 tests.
- `swift test --package-path Packages/OsaurusCore --filter Context` passed 66 tests.
- `make ci-test` completed successfully; xcbeautify reported the new `CapabilitiesSearchToolTests.searchFiltersDynamicToolsOutsideAgentGrant` and `CapabilitiesLoadToolTests.toolLoadRejectsDynamicToolOutsideAgentGrant` as passing under the Xcode runner.
- `swift test --package-path Packages/OsaurusCLI --parallel`, `swift build --package-path Packages/OsaurusCore -c release`, `swift build --package-path Packages/OsaurusEvals`, and `swift test --package-path Packages/OsaurusEvals` all exited 0.

## Rollback
Revert this PR to restore the previous global-catalog behavior for capability search/load.
