### PR TITLE
[codex] Tolerate provider model size metadata

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -78,7 +78,11 @@ struct OpenAIModel: Codable, Sendable {
         name = try container.decodeIfPresent(String.self, forKey: .name)
         model = try container.decodeIfPresent(String.self, forKey: .model)
         modified_at = try container.decodeIfPresent(String.self, forKey: .modified_at)
-        size = try container.decodeIfPresent(Int.self, forKey: .size)
+        // Some OpenAI-compatible servers expose provider-local metadata in
+        // `size` as a fractional value. That field is informational for
+        // Osaurus model discovery, so preserve the model row instead of
+        // rejecting the whole `/models` response.
+        size = try? container.decodeIfPresent(Int.self, forKey: .size)
         digest = try container.decodeIfPresent(String.self, forKey: .digest)
         details = try container.decodeIfPresent(ModelDetails.self, forKey: .details)
     }

--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -434,7 +434,7 @@ public struct GitHubTreeEntry: Decodable, Sendable {
 /// `relativePath` from the skill's own root so the installer can stash it
 /// under `references/` or `assets/` with a predictable name.
 public struct GitHubSkillAsset: Sendable {
-    public let path: String          // full path within the repo
+    public let path: String  // full path within the repo
     public let relativePath: String  // path relative to the skill dir
     public let size: Int
 
@@ -1042,7 +1042,7 @@ public final class GitHubSkillService: ObservableObject {
     /// `scripts/`, supporting docs under `references/`, binary templates
     /// under `assets/` or `templates/`.
     nonisolated private static let conventionalAssetSubdirs: Set<String> = [
-        "scripts", "references", "assets", "templates"
+        "scripts", "references", "assets", "templates",
     ]
 
     /// Build the full manifest of importable artifacts for one plugin.

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -831,7 +831,7 @@ public final class ClaudePluginInstaller {
         // inside a much later code block.
         var description = ""
         let scanEnd = min(firstContentLineIndex + 10, lines.count)
-        for idx in firstContentLineIndex..<scanEnd {
+        for idx in firstContentLineIndex ..< scanEnd {
             let stripped = lines[idx].trimmingCharacters(in: .whitespaces)
             if stripped.isEmpty { continue }
             if stripped.lowercased().hasPrefix("description:") {
@@ -895,7 +895,7 @@ public final class ClaudePluginInstaller {
     ) -> (rewritten: String, additionalReferences: [(name: String, data: Data)]) {
         // Build a lookup of fetched assets by basename so a rewrite can
         // map "scripts/recalc.py" → "references/recalc.py".
-        var assetByBasename: [String: String] = [:]   // basename → "references|assets/<name>"
+        var assetByBasename: [String: String] = [:]  // basename → "references|assets/<name>"
         for asset in fetchedAssets {
             let basename = (asset.relativePath as NSString).lastPathComponent
             let bucket = shouldStoreAsReference(basename) ? "references" : "assets"

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -123,6 +123,44 @@ struct RemoteProviderModelDiscoveryTests {
         #expect(models == ["lemonade-chat"])
     }
 
+    @Test func lemonadeModelsResponse_ignoresFractionalSizeMetadata() throws {
+        let provider = makeProvider(basePath: "/api/v1")
+        let body = Data(
+            """
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "Cogito-v2-llama-109B-MoE-GGUF",
+                  "object": "model",
+                  "created": 1234567890,
+                  "owned_by": "lemonade",
+                  "size": 65.3,
+                  "labels": ["vision"],
+                  "checkpoint": "unsloth/cogito-v2-preview-llama-109B-MoE-GGUF:Q4_K_M"
+                },
+                {
+                  "id": "Devstral-Small-2507-GGUF",
+                  "object": "model",
+                  "created": 1234567890,
+                  "owned_by": "lemonade",
+                  "size": 14.3,
+                  "suggested": true
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let models = try RemoteProviderService.decodeOpenAICompatibleModelsResponse(
+            data: body,
+            statusCode: 200,
+            provider: provider
+        )
+
+        #expect(models == ["Cogito-v2-llama-109B-MoE-GGUF", "Devstral-Small-2507-GGUF"])
+    }
+
     private func makeProvider(
         providerProtocol: RemoteProviderProtocol = .https,
         port: Int? = nil,

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
@@ -1029,7 +1029,7 @@ struct ClaudePluginInstallerTests {
         }
         let counter = Counter()
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<20 {
+            for _ in 0 ..< 20 {
                 group.addTask {
                     _ = try? await limiter.run {
                         await counter.enter()


### PR DESCRIPTION
## Business rationale
OpenAI-compatible providers sometimes return useful `/models` payloads with provider-local metadata that does not match OpenAI's exact integer schema. Lemonade-style responses can report `size` as `65.3`; before this patch Osaurus could reject the whole model list even though the model IDs were valid. This keeps users on the direct provider path by treating `size` as optional metadata and preserving the discovered model IDs.

## Coding rationale
The narrowest fix is in `OpenAIModel` decoding: `size` is informational and unused for routing, so a non-integer value should not fail model discovery. This keeps auth/server failures strict and leaves the existing manual-model fallback policy in `RemoteProviderService.decodeOpenAICompatibleModelsResponse` unchanged. No provider URL construction, credential handling, UI state, or fallback trust boundary changed; a malicious provider config still cannot gain a new `file://` or credential exfiltration path from this metadata-only decode tolerance. A separate style commit normalizes current-main skill formatting because the canonical `swift-format --strict` gate fails on those files otherwise.

## Acceptance criteria
- [x] OpenAI-compatible `/models` parsing accepts Lemonade fractional `size` metadata.
- [x] Existing manual fallback tests still cover missing/schema-incompatible `/models` responses.
- [x] Auth and server errors still fail unless existing fallback criteria apply.
- [x] Supersedes the stale provider compatibility draft path from #1059 with a current-main branch.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean (`swiftlint` exits 0 with existing warnings)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (`git fetch --all --prune` completed before gate and again before push/open; `origin/main` 2cfef2de161747604a8ff80c3a06e1e4d98f54ef)

## Debug evidence
Focused regression before the full gate: `swift test --package-path Packages/OsaurusCore --filter RemoteProviderModelDiscoveryTests` ended with `Test run with 8 tests in 1 suite passed after 0.002 seconds.` The new case feeds a Lemonade-style `/models` payload with fractional `size` values and verifies both model IDs survive discovery. Full-gate evidence is archived under `/tmp/osaurus-coord/evidence/T-C/20260517T094029Z/`; `make ci-test` ended with `Done. Inspect failures with: open build/Tests.xcresult`, and the release build ended with `Build complete! (339.97s)`.

## Rollback
Revert this PR's merge commit.

Supersedes #1059. Refs #615, #828.
