### PR TITLE
[codex] Persist custom agent ordering

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -294,10 +294,29 @@ public final class AgentManager: ObservableObject {
     }
 
     /// Assign sequential `order` values (0...N-1) to custom agents in the
-    /// given sequence and refresh once. Built-ins must not be included.
+    /// given sequence and refresh once. Built-ins and duplicate IDs are ignored;
+    /// any omitted custom agents keep their current relative position after the
+    /// requested IDs so every persisted store ends up with one normalized order.
     public func reorder(orderedIds: [UUID]) {
-        for (index, id) in orderedIds.enumerated() {
-            guard var agent = AgentStore.load(id: id), !agent.isBuiltIn else { continue }
+        let customAgents = AgentStore.loadAll().filter { !$0.isBuiltIn }
+        var customById: [UUID: Agent] = [:]
+        for agent in customAgents where customById[agent.id] == nil {
+            customById[agent.id] = agent
+        }
+        var seen = Set<UUID>()
+        var normalizedAgents: [Agent] = []
+
+        for id in orderedIds {
+            guard let agent = customById[id], seen.insert(id).inserted else { continue }
+            normalizedAgents.append(agent)
+        }
+
+        for agent in customAgents where seen.insert(agent.id).inserted {
+            normalizedAgents.append(agent)
+        }
+
+        for (index, agent) in normalizedAgents.enumerated() {
+            guard var agent = AgentStore.load(id: agent.id), !agent.isBuiltIn else { continue }
             guard agent.order != index else { continue }
             agent.order = index
             AgentStore.save(agent)

--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -434,7 +434,7 @@ public struct GitHubTreeEntry: Decodable, Sendable {
 /// `relativePath` from the skill's own root so the installer can stash it
 /// under `references/` or `assets/` with a predictable name.
 public struct GitHubSkillAsset: Sendable {
-    public let path: String          // full path within the repo
+    public let path: String  // full path within the repo
     public let relativePath: String  // path relative to the skill dir
     public let size: Int
 
@@ -1042,7 +1042,7 @@ public final class GitHubSkillService: ObservableObject {
     /// `scripts/`, supporting docs under `references/`, binary templates
     /// under `assets/` or `templates/`.
     nonisolated private static let conventionalAssetSubdirs: Set<String> = [
-        "scripts", "references", "assets", "templates"
+        "scripts", "references", "assets", "templates",
     ]
 
     /// Build the full manifest of importable artifacts for one plugin.

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -831,7 +831,7 @@ public final class ClaudePluginInstaller {
         // inside a much later code block.
         var description = ""
         let scanEnd = min(firstContentLineIndex + 10, lines.count)
-        for idx in firstContentLineIndex..<scanEnd {
+        for idx in firstContentLineIndex ..< scanEnd {
             let stripped = lines[idx].trimmingCharacters(in: .whitespaces)
             if stripped.isEmpty { continue }
             if stripped.lowercased().hasPrefix("description:") {
@@ -895,7 +895,7 @@ public final class ClaudePluginInstaller {
     ) -> (rewritten: String, additionalReferences: [(name: String, data: Data)]) {
         // Build a lookup of fetched assets by basename so a rewrite can
         // map "scripts/recalc.py" → "references/recalc.py".
-        var assetByBasename: [String: String] = [:]   // basename → "references|assets/<name>"
+        var assetByBasename: [String: String] = [:]  // basename → "references|assets/<name>"
         for asset in fetchedAssets {
             let basename = (asset.relativePath as NSString).lastPathComponent
             let bucket = shouldStoreAsReference(basename) ? "references" : "assets"

--- a/Packages/OsaurusCore/Tests/Agent/AgentReorderPersistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentReorderPersistenceTests.swift
@@ -1,0 +1,124 @@
+//
+//  AgentReorderPersistenceTests.swift
+//  osaurusTests
+//
+//  Focused coverage for the custom-agent display order stored on Agent.order.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct AgentReorderPersistenceTests {
+    private func makeAgent(name: String, order: Int? = nil) -> Agent {
+        Agent(
+            name: name,
+            agentAddress: "test-reorder-\(UUID().uuidString)",
+            order: order
+        )
+    }
+
+    private func customAgentNames(in agents: [Agent]) -> [String] {
+        agents.filter { !$0.isBuiltIn }.map(\.name)
+    }
+
+    private func managerCustomNames() -> [String] {
+        customAgentNames(in: AgentManager.shared.agents)
+    }
+
+    private func writeLegacyAgent(id: UUID, name: String) throws {
+        let directory = OsaurusPaths.agents()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let payload: [String: Any] = [
+            "id": id.uuidString,
+            "name": name,
+            "description": "",
+            "systemPrompt": "",
+            "isBuiltIn": false,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z",
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: OsaurusPaths.agentFile(for: id), options: [.atomic])
+    }
+
+    @Test("agent reorder persists across manager refresh")
+    func reorderPersistsAcrossRefresh() async throws {
+        try await ChatHistoryTestStorage.run {
+            let alpha = makeAgent(name: "Alpha")
+            let beta = makeAgent(name: "Beta")
+            let gamma = makeAgent(name: "Gamma")
+
+            for agent in [alpha, beta, gamma] {
+                AgentStore.save(agent)
+            }
+            AgentManager.shared.refresh()
+
+            #expect(managerCustomNames() == ["Alpha", "Beta", "Gamma"])
+
+            AgentManager.shared.reorder(orderedIds: [gamma.id, alpha.id, beta.id])
+
+            #expect(managerCustomNames() == ["Gamma", "Alpha", "Beta"])
+            #expect(AgentStore.load(id: gamma.id)?.order == 0)
+            #expect(AgentStore.load(id: alpha.id)?.order == 1)
+            #expect(AgentStore.load(id: beta.id)?.order == 2)
+
+            AgentManager.shared.refresh()
+
+            #expect(managerCustomNames() == ["Gamma", "Alpha", "Beta"])
+        }
+    }
+
+    @Test("legacy agents without order decode and can be reordered")
+    func legacyAgentsWithoutOrderCanBeReordered() async throws {
+        try await ChatHistoryTestStorage.run {
+            let alphaId = UUID()
+            let bravoId = UUID()
+            let charlieId = UUID()
+
+            try writeLegacyAgent(id: charlieId, name: "Charlie")
+            try writeLegacyAgent(id: alphaId, name: "Alpha")
+            try writeLegacyAgent(id: bravoId, name: "Bravo")
+
+            let legacyJSON = try String(contentsOf: OsaurusPaths.agentFile(for: alphaId), encoding: .utf8)
+            #expect(!legacyJSON.contains("\"order\""))
+
+            AgentManager.shared.refresh()
+
+            #expect(AgentStore.load(id: alphaId)?.order == nil)
+            #expect(managerCustomNames() == ["Alpha", "Bravo", "Charlie"])
+
+            AgentManager.shared.reorder(orderedIds: [charlieId, alphaId, bravoId])
+
+            #expect(managerCustomNames() == ["Charlie", "Alpha", "Bravo"])
+            #expect(AgentStore.load(id: charlieId)?.order == 0)
+            #expect(AgentStore.load(id: alphaId)?.order == 1)
+            #expect(AgentStore.load(id: bravoId)?.order == 2)
+        }
+    }
+
+    @Test("chat agent picker snapshot follows reordered agents")
+    func chatAgentPickerSnapshotFollowsReorder() async throws {
+        try await ChatHistoryTestStorage.run {
+            let alpha = makeAgent(name: "Alpha")
+            let beta = makeAgent(name: "Beta")
+            let gamma = makeAgent(name: "Gamma")
+
+            for agent in [alpha, beta, gamma] {
+                AgentStore.save(agent)
+            }
+            AgentManager.shared.refresh()
+
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+
+            #expect(customAgentNames(in: window.agents) == ["Alpha", "Beta", "Gamma"])
+
+            AgentManager.shared.reorder(orderedIds: [beta.id, gamma.id, alpha.id])
+
+            #expect(customAgentNames(in: window.agents) == ["Beta", "Gamma", "Alpha"])
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
@@ -1029,7 +1029,7 @@ struct ClaudePluginInstallerTests {
         }
         let counter = Counter()
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<20 {
+            for _ in 0 ..< 20 {
                 group.addTask {
                     _ = try? await limiter.run {
                         await counter.enter()

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1541,7 +1541,6 @@ struct AgentDetailView: View {
     private var agentSwitcherPopover: some View {
         let switchableAgents = agentManager.agents
             .filter { !$0.isBuiltIn }
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
 
         return VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {


### PR DESCRIPTION
## Business rationale
Users who curate several custom agents expect the order they set in the reorder sheet to be the order they see everywhere else. Before this change the switcher path could still alphabetize agents, and partially specified reorder operations could leave older stores with mixed `order` values. This PR makes custom-agent ordering stable across refreshes and launches, and makes the agent switcher reflect that same user order.

## Coding rationale
The implementation stays on the existing `AgentStore` persistence path and the existing `Agent.order` field, so it does not introduce a new on-disk artifact or bypass the current agent storage boundary. `AgentManager.reorder` now normalizes custom agents by ignoring built-ins, unknown IDs, and duplicates, then appending omitted custom agents in their current relative order before saving sequential order values. The switcher consumes `agentManager.agents` directly instead of re-sorting alphabetically. The deliberately out-of-scope work is any multi-agent API behavior, voice/provider/MCP changes, or a new persistence system. A separate style commit normalizes current-main skill formatting because the canonical repo-wide `swift-format --strict` gate fails on those inherited files otherwise.

## Acceptance criteria
- [x] Agent reorder persists across manager refreshes and relaunch-equivalent reloads.
- [x] Picker/switcher dropdown reflects user order instead of alphabetical order.
- [x] Legacy custom agents without an `order` field decode safely and can be normalized.
- [x] No new persistence path was added; existing agent records carry the order.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean (`swiftlint` exits 0 with existing warnings)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (`git fetch --all --prune` completed before gate and again before push/open; `origin/main` 2cfef2de161747604a8ff80c3a06e1e4d98f54ef)

## Debug evidence
Focused regression evidence is archived under `/tmp/osaurus-coord/evidence/T-G/20260517T095849Z/focused-agent-reorder-tests.log`: `swift test --package-path Packages/OsaurusCore --filter AgentReorderPersistenceTests` ended with `Test run with 3 tests in 1 suite passed after 0.030 seconds.` The tests cover persisted custom order, legacy no-order migration, and a chat picker snapshot following reordered agents. Full-gate evidence is archived under `/tmp/osaurus-coord/evidence/T-G/20260517T095849Z/`; `make ci-test` ended with `Done. Inspect failures with: open build/Tests.xcresult`, and the release build ended with `Build complete! (321.64s)`.

## Rollback
Revert this PR's merge commit.

Refs #654.
