### PR TITLE
[codex] Harden MCP accessibility plugin calls

### DIFF
--- a/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/ExternalPlugin.swift
@@ -534,6 +534,11 @@ public struct PluginManifest: Decodable, Sendable {
 }
 
 final class ExternalPlugin: @unchecked Sendable {
+    enum InvocationIsolation: Sendable, Equatable {
+        case pluginQueue
+        case mainActor
+    }
+
     let id: String
     let manifest: PluginManifest
     let bundlePath: String
@@ -724,8 +729,18 @@ final class ExternalPlugin: @unchecked Sendable {
         agentId: UUID? = nil,
         errorCode: Int,
         errorMessage: String,
+        isolation: InvocationIsolation = .pluginQueue,
         _ call: @Sendable @escaping (osr_plugin_ctx_t) -> UnsafePointer<CChar>?
     ) async throws -> String {
+        if isolation == .mainActor {
+            return try await dispatchPluginCallOnMainActor(
+                agentId: agentId,
+                errorCode: errorCode,
+                errorMessage: errorMessage,
+                call
+            )
+        }
+
         let freeString = api.free_string
         nonisolated(unsafe) let ctx = self.ctx
         let pluginId = self.id
@@ -764,7 +779,48 @@ final class ExternalPlugin: @unchecked Sendable {
         }
     }
 
-    func invoke(type: String, id: String, payload: String, agentId: UUID? = nil) async throws -> String {
+    @MainActor
+    private func dispatchPluginCallOnMainActor(
+        agentId: UUID? = nil,
+        errorCode: Int,
+        errorMessage: String,
+        _ call: @Sendable (osr_plugin_ctx_t) -> UnsafePointer<CChar>?
+    ) throws -> String {
+        guard !isShutDown.withLock({ $0 }) else {
+            throw NSError(
+                domain: "ExternalPlugin",
+                code: errorCode,
+                userInfo: [NSLocalizedDescriptionKey: "Plugin has been shut down"]
+            )
+        }
+
+        let freeString = api.free_string
+        let ctx = self.ctx
+        let pluginId = self.id
+        let resPtr = PluginHostContext.withTLSScope(pluginId: pluginId, agentId: agentId) {
+            call(ctx)
+        }
+        guard let resPtr else {
+            throw NSError(
+                domain: "ExternalPlugin",
+                code: errorCode,
+                userInfo: [NSLocalizedDescriptionKey: errorMessage]
+            )
+        }
+
+        let result = String(cString: resPtr)
+        freeString?(resPtr)
+        withExtendedLifetime(self) {}
+        return result
+    }
+
+    func invoke(
+        type: String,
+        id: String,
+        payload: String,
+        agentId: UUID? = nil,
+        isolation: InvocationIsolation = .pluginQueue
+    ) async throws -> String {
         guard let invokeFn = api.invoke else {
             throw NSError(
                 domain: "ExternalPlugin",
@@ -776,7 +832,8 @@ final class ExternalPlugin: @unchecked Sendable {
         return try await dispatchPluginCall(
             agentId: agentId,
             errorCode: 2,
-            errorMessage: "Plugin returned NULL response"
+            errorMessage: "Plugin returned NULL response",
+            isolation: isolation
         ) { ctx in
             type.withCString { typePtr in
                 id.withCString { idPtr in

--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -434,7 +434,7 @@ public struct GitHubTreeEntry: Decodable, Sendable {
 /// `relativePath` from the skill's own root so the installer can stash it
 /// under `references/` or `assets/` with a predictable name.
 public struct GitHubSkillAsset: Sendable {
-    public let path: String          // full path within the repo
+    public let path: String  // full path within the repo
     public let relativePath: String  // path relative to the skill dir
     public let size: Int
 
@@ -1042,7 +1042,7 @@ public final class GitHubSkillService: ObservableObject {
     /// `scripts/`, supporting docs under `references/`, binary templates
     /// under `assets/` or `templates/`.
     nonisolated private static let conventionalAssetSubdirs: Set<String> = [
-        "scripts", "references", "assets", "templates"
+        "scripts", "references", "assets", "templates",
     ]
 
     /// Build the full manifest of importable artifacts for one plugin.

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -831,7 +831,7 @@ public final class ClaudePluginInstaller {
         // inside a much later code block.
         var description = ""
         let scanEnd = min(firstContentLineIndex + 10, lines.count)
-        for idx in firstContentLineIndex..<scanEnd {
+        for idx in firstContentLineIndex ..< scanEnd {
             let stripped = lines[idx].trimmingCharacters(in: .whitespaces)
             if stripped.isEmpty { continue }
             if stripped.lowercased().hasPrefix("description:") {
@@ -895,7 +895,7 @@ public final class ClaudePluginInstaller {
     ) -> (rewritten: String, additionalReferences: [(name: String, data: Data)]) {
         // Build a lookup of fetched assets by basename so a rewrite can
         // map "scripts/recalc.py" → "references/recalc.py".
-        var assetByBasename: [String: String] = [:]   // basename → "references|assets/<name>"
+        var assetByBasename: [String: String] = [:]  // basename → "references|assets/<name>"
         for asset in fetchedAssets {
             let basename = (asset.relativePath as NSString).lastPathComponent
             let bucket = shouldStoreAsReference(basename) ? "references" : "assets"

--- a/Packages/OsaurusCore/Tests/Plugin/PluginAccessibilityInvocationTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginAccessibilityInvocationTests.swift
@@ -1,0 +1,136 @@
+//
+//  PluginAccessibilityInvocationTests.swift
+//  OsaurusCoreTests
+//
+//  Regresses the MCP stdio crash class where native macOS UI tools
+//  (`click_element`, `type_text`, `press_key`) crossed `/mcp/call` and
+//  dereferenced Accessibility/AppKit objects from a plugin queue.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct PluginAccessibilityInvocationTests {
+    final class InvokeRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var calls: [(id: String, payload: String, mainThread: Bool)] = []
+
+        var snapshots: [(id: String, payload: String, mainThread: Bool)] {
+            lock.withLock { calls }
+        }
+
+        func record(id: String, payload: String, mainThread: Bool) {
+            lock.withLock { calls.append((id, payload, mainThread)) }
+        }
+    }
+
+    @Test
+    func accessibilityPluginToolsInvokeOnMainThread() async throws {
+        let recorder = InvokeRecorder()
+        let (plugin, retain) = makePlugin(recorder: recorder)
+        defer {
+            Task { await plugin.shutdown() }
+            retain.release()
+        }
+        let tool = ExternalTool(
+            plugin: plugin,
+            spec: PluginManifest.ToolSpec(
+                id: "type_text",
+                description: "Type text into the focused UI element",
+                parameters: nil,
+                requirements: ["accessibility"],
+                permission_policy: "auto"
+            )
+        )
+
+        let result = try await tool.execute(argumentsJSON: #"{"text":"hello"}"#)
+
+        #expect(result == #"{"ok":true}"#)
+        let call = try #require(recorder.snapshots.first)
+        #expect(call.id == "type_text")
+        #expect(call.payload == #"{"text":"hello"}"#)
+        #expect(call.mainThread)
+    }
+
+    @Test
+    func regularPluginToolsStayOnPluginQueue() async throws {
+        let recorder = InvokeRecorder()
+        let (plugin, retain) = makePlugin(recorder: recorder)
+        defer {
+            Task { await plugin.shutdown() }
+            retain.release()
+        }
+        let tool = ExternalTool(
+            plugin: plugin,
+            spec: PluginManifest.ToolSpec(
+                id: "fetch_status",
+                description: "Fetch status from a remote API",
+                parameters: nil,
+                requirements: [],
+                permission_policy: "auto"
+            )
+        )
+
+        _ = try await tool.execute(argumentsJSON: #"{"project":"osaurus"}"#)
+
+        let call = try #require(recorder.snapshots.first)
+        #expect(call.id == "fetch_status")
+        #expect(!call.mainThread)
+    }
+
+    private func makePlugin(
+        recorder: InvokeRecorder
+    ) -> (plugin: ExternalPlugin, retain: Unmanaged<InvokeRecorder>) {
+        let retain = Unmanaged.passRetained(recorder)
+        let ctx = retain.toOpaque()
+        let api = osr_plugin_api(
+            free_string: nil,
+            init: nil,
+            destroy: nil,
+            get_manifest: nil,
+            invoke: { ctxPtr, _, idPtr, payloadPtr in
+                guard let ctxPtr, let idPtr, let payloadPtr else { return nil }
+                let recorder = Unmanaged<InvokeRecorder>.fromOpaque(ctxPtr).takeUnretainedValue()
+                recorder.record(
+                    id: String(cString: idPtr),
+                    payload: String(cString: payloadPtr),
+                    mainThread: Thread.isMainThread
+                )
+                return UnsafePointer(strdup(#"{"ok":true}"#))
+            },
+            version: 6,
+            handle_route: nil,
+            on_config_changed: nil,
+            on_task_event: nil
+        )
+        let pluginId = "com.test.accessibility-invoke.\(UUID().uuidString)"
+        let manifest = PluginManifest(
+            plugin_id: pluginId,
+            description: nil,
+            capabilities: .init(tools: nil, routes: nil, config: nil, web: nil, artifact_handler: nil),
+            instructions: nil,
+            name: nil,
+            version: nil,
+            license: nil,
+            authors: nil,
+            min_macos: nil,
+            min_osaurus: nil,
+            secrets: nil,
+            docs: nil
+        )
+        return (
+            ExternalPlugin(
+                handle: ctx,
+                api: api,
+                ctx: ctx,
+                manifest: manifest,
+                path: "/tmp/accessibility-invoke-\(pluginId)",
+                abiVersion: 6
+            ),
+            retain
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
@@ -1029,7 +1029,7 @@ struct ClaudePluginInstallerTests {
         }
         let counter = Counter()
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<20 {
+            for _ in 0 ..< 20 {
                 group.addTask {
                     _ = try? await limiter.run {
                         await counter.enter()

--- a/Packages/OsaurusCore/Tools/ExternalTool.swift
+++ b/Packages/OsaurusCore/Tools/ExternalTool.swift
@@ -19,6 +19,7 @@ final class ExternalTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
 
     private let plugin: ExternalPlugin
     private let toolId: String
+    private let invocationIsolation: ExternalPlugin.InvocationIsolation
 
     init(plugin: ExternalPlugin, spec: PluginManifest.ToolSpec) {
         self.plugin = plugin
@@ -29,6 +30,7 @@ final class ExternalTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
         self.description = spec.description
         self.parameters = spec.parameters
         self.requirements = spec.requirements ?? []
+        self.invocationIsolation = Self.invocationIsolation(for: self.requirements)
 
         if let polStr = spec.permission_policy?.lowercased() {
             switch polStr {
@@ -45,7 +47,26 @@ final class ExternalTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
         let agentId = ChatExecutionContext.currentAgentId
         let payloadWithSecrets = injectSecrets(into: argumentsJSON, agentId: agentId)
         let payloadWithContext = injectFolderContext(into: payloadWithSecrets)
-        return try await plugin.invoke(type: "tool", id: toolId, payload: payloadWithContext, agentId: agentId)
+        return try await plugin.invoke(
+            type: "tool",
+            id: toolId,
+            payload: payloadWithContext,
+            agentId: agentId,
+            isolation: invocationIsolation
+        )
+    }
+
+    /// Native plugins that touch macOS automation APIs often hold
+    /// AppKit/Accessibility objects whose lifetime is tied to the main
+    /// thread. Dispatching those C ABI calls on the plugin's concurrent
+    /// queue can turn a valid UI element reference into a dangling ObjC
+    /// pointer during write actions such as click/type/press-key.
+    private static func invocationIsolation(for requirements: [String]) -> ExternalPlugin.InvocationIsolation {
+        let normalized = Set(requirements.map { $0.lowercased() })
+        if normalized.contains("accessibility") || normalized.contains("automation") {
+            return .mainActor
+        }
+        return .pluginQueue
     }
 
     /// Injects plugin secrets into the tool payload under the `_secrets` key


### PR DESCRIPTION
## Business rationale

Native accessibility and automation plugins cross into AppKit and AX APIs that require main-thread affinity. The MCP stdio `/mcp/call` path could invoke those native plugin entry points from the plugin work queue, which matches the crash pattern reported in issue #1129 and creates a user-visible failure whenever an accessibility tool is called through the stdio bridge. This PR makes the execution lane explicit so accessibility/automation plugins run on the main actor while ordinary native plugins keep their existing background isolation; the observable resolution is that the accessibility invocation regression test executes the C ABI call on the main thread and the regular plugin path remains off-main.

## Coding rationale

I considered moving every native plugin call to the main actor, but that would unnecessarily serialize non-UI plugins and increase latency for CPU or IO-bound tools. Instead, `ExternalPlugin` now exposes a small `InvocationIsolation` policy and `ExternalTool` selects `.mainActor` only for plugins whose manifest requirements include `accessibility` or `automation`; all other plugins retain the plugin queue behavior. The trust boundary crossed here is native plugin execution: the change deliberately avoids changing HTTP/MCP request parsing, tool authorization, or plugin loading semantics, and only adjusts the thread/actor used for the already-authorized C ABI call.

## Acceptance criteria

- [x] Accessibility/automation native plugins invoked through `ExternalTool` run their C ABI call on the main actor.
- [x] Regular native plugin tools keep the existing plugin-queue execution path.
- [x] Regression coverage proves both isolation paths.
- [x] Local pre-push formatting baseline is normalized without changing behavior.

## Quality gate

- [x] `xcrun swift-format lint --strict --recursive Packages App` — clean
- [x] `swiftlint lint --reporter github-actions-logging` — clean
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — clean
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed: `git fetch --all --prune` completed at 2026-05-17T12:32:43Z, followed by `git rebase origin/main` with no-op result on head `20522f6b44a391bb58a46d66728f287d6e5b9969`

## Debug evidence

Focused regression before the full gate: `swift test --package-path Packages/OsaurusCore --filter PluginAccessibilityInvocationTests` passed two tests covering main-thread accessibility invocation and non-main regular invocation. Full gate evidence is retained locally under `/tmp/osaurus-coord/evidence/T-E2/20260517T121706Z`; its status log shows `PASS swift-format 2026-05-17T12:17:10Z`, `PASS cli-tests 2026-05-17T12:17:55Z`, `PASS ci-test 2026-05-17T12:23:50Z`, and `PASS core-release 2026-05-17T12:31:57Z`. The first gate attempt also caught the shared local format failure (`Packages/OsaurusCore/Services/GitHubSkillService.swift:1045:55: error: [TrailingComma] add trailing comma...`), and the second commit fixes that so the pre-push-style gate passes without bypassing hooks.

## Rollback

Revert this PR; plugin invocation then returns to the prior single plugin-queue behavior.
