### PR TITLE
[codex] Add document IO foundation metadata

### DIFF
--- a/Packages/OsaurusCore/Models/Documents/DocumentAnchor.swift
+++ b/Packages/OsaurusCore/Models/Documents/DocumentAnchor.swift
@@ -1,0 +1,244 @@
+//
+//  DocumentAnchor.swift
+//  osaurus
+//
+//  Format-neutral source anchors for structured document I/O. The same
+//  anchor model is used by PDF pages, DOCX paragraphs, workbook cells, and
+//  presentation shapes so later high-fidelity adapters can reference source
+//  locations without leaking a format-specific object graph upward.
+//
+
+import Foundation
+
+public struct DocumentTextRange: Codable, Equatable, Hashable, Sendable {
+    public let startUTF16Offset: Int
+    public let length: Int
+
+    public var endUTF16Offset: Int { startUTF16Offset + length }
+    public var isEmpty: Bool { length == 0 }
+
+    public init(startUTF16Offset: Int, length: Int) {
+        precondition(startUTF16Offset >= 0, "Document text range start must be non-negative")
+        precondition(length >= 0, "Document text range length must be non-negative")
+        self.startUTF16Offset = startUTF16Offset
+        self.length = length
+    }
+
+    public static func entireText(_ text: String) -> DocumentTextRange {
+        DocumentTextRange(startUTF16Offset: 0, length: text.utf16.count)
+    }
+}
+
+public struct DocumentBoundingBox: Codable, Equatable, Hashable, Sendable {
+    public enum CoordinateSpace: String, Codable, Sendable {
+        case page
+        case slide
+        case image
+        case worksheet
+        case unknown
+    }
+
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+    public let coordinateSpace: CoordinateSpace
+
+    public init(
+        x: Double,
+        y: Double,
+        width: Double,
+        height: Double,
+        coordinateSpace: CoordinateSpace
+    ) {
+        precondition(width >= 0, "Document bounding box width must be non-negative")
+        precondition(height >= 0, "Document bounding box height must be non-negative")
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+        self.coordinateSpace = coordinateSpace
+    }
+}
+
+public struct DocumentSourceLocation: Codable, Equatable, Hashable, Sendable {
+    public let pageIndex: Int?
+    public let slideIndex: Int?
+    public let sheetIndex: Int?
+    public let sheetName: String?
+    public let rowIndex: Int?
+    public let columnIndex: Int?
+    public let paragraphIndex: Int?
+    public let runIndex: Int?
+    public let characterOffset: Int?
+    public let namedRegion: String?
+
+    public init(
+        pageIndex: Int? = nil,
+        slideIndex: Int? = nil,
+        sheetIndex: Int? = nil,
+        sheetName: String? = nil,
+        rowIndex: Int? = nil,
+        columnIndex: Int? = nil,
+        paragraphIndex: Int? = nil,
+        runIndex: Int? = nil,
+        characterOffset: Int? = nil,
+        namedRegion: String? = nil
+    ) {
+        Self.requireNonNegative(pageIndex, "pageIndex")
+        Self.requireNonNegative(slideIndex, "slideIndex")
+        Self.requireNonNegative(sheetIndex, "sheetIndex")
+        Self.requireNonNegative(rowIndex, "rowIndex")
+        Self.requireNonNegative(columnIndex, "columnIndex")
+        Self.requireNonNegative(paragraphIndex, "paragraphIndex")
+        Self.requireNonNegative(runIndex, "runIndex")
+        Self.requireNonNegative(characterOffset, "characterOffset")
+        self.pageIndex = pageIndex
+        self.slideIndex = slideIndex
+        self.sheetIndex = sheetIndex
+        self.sheetName = sheetName
+        self.rowIndex = rowIndex
+        self.columnIndex = columnIndex
+        self.paragraphIndex = paragraphIndex
+        self.runIndex = runIndex
+        self.characterOffset = characterOffset
+        self.namedRegion = namedRegion
+    }
+
+    public static func page(_ index: Int) -> DocumentSourceLocation {
+        DocumentSourceLocation(pageIndex: index)
+    }
+
+    public static func slide(_ index: Int) -> DocumentSourceLocation {
+        DocumentSourceLocation(slideIndex: index)
+    }
+
+    public static func cell(sheetName: String? = nil, rowIndex: Int, columnIndex: Int) -> DocumentSourceLocation {
+        DocumentSourceLocation(sheetName: sheetName, rowIndex: rowIndex, columnIndex: columnIndex)
+    }
+
+    private static func requireNonNegative(_ value: Int?, _ label: String) {
+        guard let value else { return }
+        precondition(value >= 0, "Document source location \(label) must be non-negative")
+    }
+}
+
+public struct DocumentSourceRange: Codable, Equatable, Hashable, Sendable {
+    public let start: DocumentSourceLocation
+    public let end: DocumentSourceLocation?
+    public let boundingBox: DocumentBoundingBox?
+
+    public init(
+        start: DocumentSourceLocation,
+        end: DocumentSourceLocation? = nil,
+        boundingBox: DocumentBoundingBox? = nil
+    ) {
+        self.start = start
+        self.end = end
+        self.boundingBox = boundingBox
+    }
+}
+
+public struct DocumentAnchor: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public enum Kind: String, Codable, Sendable {
+        case document
+        case section
+        case page
+        case slide
+        case sheet
+        case row
+        case column
+        case cell
+        case table
+        case paragraph
+        case heading
+        case list
+        case listItem
+        case run
+        case text
+        case image
+        case chart
+        case shape
+        case speakerNotes
+        case comment
+        case footnote
+        case endnote
+        case header
+        case footer
+        case metadata
+        case unknown
+    }
+
+    public struct PathComponent: Codable, Equatable, Hashable, Sendable {
+        public let kind: Kind
+        public let identifier: String?
+        public let index: Int?
+
+        public init(kind: Kind, identifier: String? = nil, index: Int? = nil) {
+            if let index {
+                precondition(index >= 0, "Document anchor path index must be non-negative")
+            }
+            self.kind = kind
+            self.identifier = identifier
+            self.index = index
+        }
+
+        fileprivate var stableFragment: String {
+            let raw: String
+            if let identifier, !identifier.isEmpty {
+                raw = "\(kind.rawValue)=\(identifier)"
+            } else if let index {
+                raw = "\(kind.rawValue)[\(index)]"
+            } else {
+                raw = kind.rawValue
+            }
+            return raw.addingPercentEncoding(withAllowedCharacters: Self.idAllowedCharacters) ?? raw
+        }
+
+        private static let idAllowedCharacters: CharacterSet = {
+            var allowed = CharacterSet.alphanumerics
+            allowed.insert(charactersIn: "-._~[]=")
+            return allowed
+        }()
+    }
+
+    public let id: String
+    public let kind: Kind
+    public let path: [PathComponent]
+    public let textRange: DocumentTextRange?
+    public let sourceRange: DocumentSourceRange?
+    public let label: String?
+    public let metadata: [String: String]
+
+    public init(
+        id: String? = nil,
+        kind: Kind,
+        path: [PathComponent],
+        textRange: DocumentTextRange? = nil,
+        sourceRange: DocumentSourceRange? = nil,
+        label: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id ?? Self.stableId(kind: kind, path: path)
+        self.kind = kind
+        self.path = path
+        self.textRange = textRange
+        self.sourceRange = sourceRange
+        self.label = label
+        self.metadata = metadata
+    }
+
+    public static func root(label: String? = nil) -> DocumentAnchor {
+        DocumentAnchor(
+            id: "document",
+            kind: .document,
+            path: [.init(kind: .document)],
+            label: label
+        )
+    }
+
+    private static func stableId(kind: Kind, path: [PathComponent]) -> String {
+        let fragments = [kind.rawValue] + path.map(\.stableFragment)
+        return fragments.joined(separator: "/")
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/DocumentSecurityMetadata.swift
+++ b/Packages/OsaurusCore/Models/Documents/DocumentSecurityMetadata.swift
@@ -1,0 +1,194 @@
+//
+//  DocumentSecurityMetadata.swift
+//  osaurus
+//
+//  Security and provenance facts attached to structured document parse
+//  results. This is intentionally descriptive rather than policy-enforcing:
+//  adapters record what they inspected, what they could not inspect, and any
+//  active/external content they found so later tool and artifact layers can
+//  make fail-closed decisions with format-neutral data.
+//
+
+import Foundation
+
+public enum DocumentActiveContentType: String, Codable, CaseIterable, Hashable, Sendable {
+    case macro
+    case script
+    case embeddedFile
+    case externalReference
+    case formula
+    case remoteTemplate
+    case media
+    case unknown
+}
+
+public struct DocumentExternalReference: Codable, Equatable, Hashable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case hyperlink
+        case image
+        case stylesheet
+        case script
+        case media
+        case remoteTemplate
+        case packageRelationship
+        case unknown
+    }
+
+    public let kind: Kind
+    public let urlString: String
+    public let anchorId: String?
+    public let relationshipId: String?
+
+    public init(
+        kind: Kind,
+        urlString: String,
+        anchorId: String? = nil,
+        relationshipId: String? = nil
+    ) {
+        self.kind = kind
+        self.urlString = urlString
+        self.anchorId = anchorId
+        self.relationshipId = relationshipId
+    }
+}
+
+public struct DocumentSecurityFinding: Codable, Equatable, Hashable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case activeContent
+        case encryptedContent
+        case externalReference
+        case embeddedFile
+        case macro
+        case script
+        case formula
+        case malformedContent
+        case truncatedContent
+        case unsupportedFeature
+        case integrityUnavailable
+        case permissionRestriction
+        case redaction
+        case unknown
+    }
+
+    public enum Severity: String, Codable, Comparable, Sendable {
+        case informational
+        case low
+        case medium
+        case high
+        case critical
+
+        private var rank: Int {
+            switch self {
+            case .informational: return 0
+            case .low: return 1
+            case .medium: return 2
+            case .high: return 3
+            case .critical: return 4
+            }
+        }
+
+        public static func < (lhs: Severity, rhs: Severity) -> Bool {
+            lhs.rank < rhs.rank
+        }
+    }
+
+    public let kind: Kind
+    public let severity: Severity
+    public let anchorId: String?
+    public let message: String
+    public let metadata: [String: String]
+
+    public init(
+        kind: Kind,
+        severity: Severity,
+        anchorId: String? = nil,
+        message: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.kind = kind
+        self.severity = severity
+        self.anchorId = anchorId
+        self.message = message
+        self.metadata = metadata
+    }
+}
+
+public struct DocumentSecurityMetadata: Codable, Equatable, Sendable {
+    public enum InspectionStatus: String, Codable, Sendable {
+        case inspected
+        case partiallyInspected
+        case notInspected
+        case failed
+    }
+
+    public enum SourceTrust: String, Codable, Sendable {
+        case userSelectedLocalFile
+        case generatedArtifact
+        case pluginProvided
+        case remoteDownload
+        case pastedContent
+        case unknown
+    }
+
+    public let inspectionStatus: InspectionStatus
+    public let sourceTrust: SourceTrust
+    public let formatId: String
+    public let fileExtension: String?
+    public let uti: String?
+    public let declaredMimeType: String?
+    public let sha256: String?
+    public let isEncrypted: Bool?
+    public let activeContentTypes: Set<DocumentActiveContentType>
+    public let externalReferences: [DocumentExternalReference]
+    public let findings: [DocumentSecurityFinding]
+    public let inspectedAt: Date
+
+    public var hasActiveContent: Bool {
+        !activeContentTypes.isEmpty || !externalReferences.isEmpty
+    }
+
+    public var maximumSeverity: DocumentSecurityFinding.Severity? {
+        findings.map(\.severity).max()
+    }
+
+    public init(
+        inspectionStatus: InspectionStatus,
+        sourceTrust: SourceTrust = .unknown,
+        formatId: String,
+        fileExtension: String? = nil,
+        uti: String? = nil,
+        declaredMimeType: String? = nil,
+        sha256: String? = nil,
+        isEncrypted: Bool? = nil,
+        activeContentTypes: Set<DocumentActiveContentType> = [],
+        externalReferences: [DocumentExternalReference] = [],
+        findings: [DocumentSecurityFinding] = [],
+        inspectedAt: Date = Date()
+    ) {
+        self.inspectionStatus = inspectionStatus
+        self.sourceTrust = sourceTrust
+        self.formatId = formatId
+        self.fileExtension = fileExtension
+        self.uti = uti
+        self.declaredMimeType = declaredMimeType
+        self.sha256 = sha256
+        self.isEncrypted = isEncrypted
+        self.activeContentTypes = activeContentTypes
+        self.externalReferences = externalReferences
+        self.findings = findings
+        self.inspectedAt = inspectedAt
+    }
+
+    public static func notInspected(
+        formatId: String,
+        fileExtension: String? = nil,
+        sourceTrust: SourceTrust = .unknown
+    ) -> DocumentSecurityMetadata {
+        DocumentSecurityMetadata(
+            inspectionStatus: .notInspected,
+            sourceTrust: sourceTrust,
+            formatId: formatId,
+            fileExtension: fileExtension
+        )
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/DocumentStructure.swift
+++ b/Packages/OsaurusCore/Models/Documents/DocumentStructure.swift
@@ -1,0 +1,214 @@
+//
+//  DocumentStructure.swift
+//  osaurus
+//
+//  Format-neutral document structure used by adapters that can preserve
+//  layout and source identity. Existing plain-text adapters can publish a
+//  shallow tree today; PDF/DOCX/XLSX/PPTX lanes can replace those leaves with
+//  richer page, table, cell, slide, and shape subtrees without changing the
+//  registry or attachment boundary.
+//
+
+import Foundation
+
+public struct DocumentElementAttributes: Codable, Equatable, Hashable, Sendable {
+    public let role: String?
+    public let level: Int?
+    public let styleName: String?
+    public let languageCode: String?
+    public let isHidden: Bool
+    public let metadata: [String: String]
+
+    public init(
+        role: String? = nil,
+        level: Int? = nil,
+        styleName: String? = nil,
+        languageCode: String? = nil,
+        isHidden: Bool = false,
+        metadata: [String: String] = [:]
+    ) {
+        if let level {
+            precondition(level >= 0, "Document element level must be non-negative")
+        }
+        self.role = role
+        self.level = level
+        self.styleName = styleName
+        self.languageCode = languageCode
+        self.isHidden = isHidden
+        self.metadata = metadata
+    }
+}
+
+public struct DocumentElement: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public enum Kind: String, Codable, Sendable {
+        case document
+        case section
+        case page
+        case slide
+        case sheet
+        case paragraph
+        case heading
+        case list
+        case listItem
+        case table
+        case tableRow
+        case tableCell
+        case run
+        case image
+        case chart
+        case shape
+        case textBox
+        case speakerNotes
+        case metadata
+        case unknown
+    }
+
+    public let id: String
+    public let kind: Kind
+    public let anchor: DocumentAnchor
+    public let text: String?
+    public let attributes: DocumentElementAttributes
+    public let children: [DocumentElement]
+
+    public init(
+        id: String? = nil,
+        kind: Kind,
+        anchor: DocumentAnchor,
+        text: String? = nil,
+        attributes: DocumentElementAttributes = .init(),
+        children: [DocumentElement] = []
+    ) {
+        self.id = id ?? anchor.id
+        self.kind = kind
+        self.anchor = anchor
+        self.text = text
+        self.attributes = attributes
+        self.children = children
+    }
+}
+
+public struct DocumentPageText: Codable, Equatable, Hashable, Sendable {
+    public let pageIndex: Int
+    public let text: String
+
+    public init(pageIndex: Int, text: String) {
+        precondition(pageIndex >= 0, "Document page index must be non-negative")
+        self.pageIndex = pageIndex
+        self.text = text
+    }
+}
+
+public struct DocumentStructure: Codable, Equatable, Sendable {
+    public let root: DocumentElement
+    public let anchors: [DocumentAnchor]
+    public let textLengthUTF16: Int
+
+    public init(
+        root: DocumentElement,
+        anchors: [DocumentAnchor]? = nil,
+        textLengthUTF16: Int? = nil
+    ) {
+        self.root = root
+        self.anchors = Self.deduplicated(anchors ?? root.collectedAnchors())
+        self.textLengthUTF16 = textLengthUTF16 ?? Self.derivedTextLength(from: self.anchors)
+    }
+
+    public func anchor(id: String) -> DocumentAnchor? {
+        anchors.first { $0.id == id }
+    }
+
+    public func elements(kind: DocumentElement.Kind) -> [DocumentElement] {
+        root.descendants(matching: kind)
+    }
+
+    public static func plainText(filename: String, text: String) -> DocumentStructure {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let textAnchor = DocumentAnchor(
+            id: "document/body",
+            kind: .text,
+            path: [
+                .init(kind: .document),
+                .init(kind: .text, identifier: "body"),
+            ],
+            textRange: .entireText(text),
+            label: filename
+        )
+        let textElement = DocumentElement(
+            kind: .paragraph,
+            anchor: textAnchor,
+            text: text
+        )
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: [textElement]
+        )
+        return DocumentStructure(root: root, textLengthUTF16: text.utf16.count)
+    }
+
+    public static func paginatedText(filename: String, pages: [DocumentPageText]) -> DocumentStructure {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        var offset = 0
+        var elements: [DocumentElement] = []
+
+        for page in pages {
+            if !elements.isEmpty {
+                offset += 2  // Matches the "\n\n" separator in the text fallback.
+            }
+            let range = DocumentTextRange(startUTF16Offset: offset, length: page.text.utf16.count)
+            let anchor = DocumentAnchor(
+                kind: .page,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .page, index: page.pageIndex),
+                ],
+                textRange: range,
+                sourceRange: .init(start: .page(page.pageIndex)),
+                label: "Page \(page.pageIndex + 1)"
+            )
+            elements.append(
+                DocumentElement(
+                    kind: .page,
+                    anchor: anchor,
+                    text: page.text,
+                    attributes: .init(metadata: ["pageIndex": "\(page.pageIndex)"])
+                )
+            )
+            offset += page.text.utf16.count
+        }
+
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: elements
+        )
+        return DocumentStructure(root: root, textLengthUTF16: offset)
+    }
+
+    private static func deduplicated(_ anchors: [DocumentAnchor]) -> [DocumentAnchor] {
+        var seen: Set<String> = []
+        var result: [DocumentAnchor] = []
+        for anchor in anchors where !seen.contains(anchor.id) {
+            seen.insert(anchor.id)
+            result.append(anchor)
+        }
+        return result
+    }
+
+    private static func derivedTextLength(from anchors: [DocumentAnchor]) -> Int {
+        anchors.compactMap(\.textRange?.endUTF16Offset).max() ?? 0
+    }
+}
+
+private extension DocumentElement {
+    func collectedAnchors() -> [DocumentAnchor] {
+        [anchor] + children.flatMap { $0.collectedAnchors() }
+    }
+
+    func descendants(matching kind: DocumentElement.Kind) -> [DocumentElement] {
+        let current = self.kind == kind ? [self] : []
+        return current + children.flatMap { $0.descendants(matching: kind) }
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/StructuredDocument.swift
+++ b/Packages/OsaurusCore/Models/Documents/StructuredDocument.swift
@@ -35,6 +35,8 @@ public struct StructuredDocument: @unchecked Sendable {
     public let filename: String
     public let fileSize: Int64
     public let representation: AnyStructuredRepresentation
+    public let structure: DocumentStructure
+    public let security: DocumentSecurityMetadata
     public let textFallback: String
     public let createdAt: Date
 
@@ -43,6 +45,8 @@ public struct StructuredDocument: @unchecked Sendable {
         filename: String,
         fileSize: Int64,
         representation: AnyStructuredRepresentation,
+        structure: DocumentStructure? = nil,
+        security: DocumentSecurityMetadata? = nil,
         textFallback: String,
         createdAt: Date = Date()
     ) {
@@ -50,6 +54,13 @@ public struct StructuredDocument: @unchecked Sendable {
         self.filename = filename
         self.fileSize = fileSize
         self.representation = representation
+        self.structure = structure ?? .plainText(filename: filename, text: textFallback)
+        self.security =
+            security
+            ?? .notInspected(
+                formatId: formatId,
+                fileExtension: URL(fileURLWithPath: filename).pathExtension.lowercased()
+            )
         self.textFallback = textFallback
         self.createdAt = createdAt
     }

--- a/Packages/OsaurusCore/Services/Documents/DocumentFileInspector.swift
+++ b/Packages/OsaurusCore/Services/Documents/DocumentFileInspector.swift
@@ -1,0 +1,183 @@
+//
+//  DocumentFileInspector.swift
+//  osaurus
+//
+//  Shared provenance/security helpers for document adapters. The helpers keep
+//  byte-level facts (UTI, digest) and lightweight active-content heuristics in
+//  one place while higher-fidelity format lanes add deeper inspectors.
+//
+
+import CryptoKit
+import Foundation
+import UniformTypeIdentifiers
+
+public enum DocumentFileInspector {
+    public struct HTMLSecuritySignals: Sendable {
+        public let findings: [DocumentSecurityFinding]
+        public let externalReferences: [DocumentExternalReference]
+        public let activeContentTypes: Set<DocumentActiveContentType>
+
+        public init(
+            findings: [DocumentSecurityFinding] = [],
+            externalReferences: [DocumentExternalReference] = [],
+            activeContentTypes: Set<DocumentActiveContentType> = []
+        ) {
+            self.findings = findings
+            self.externalReferences = externalReferences
+            self.activeContentTypes = activeContentTypes
+        }
+    }
+
+    public static func localFileSecurityMetadata(
+        url: URL,
+        formatId: String,
+        inspectionStatus: DocumentSecurityMetadata.InspectionStatus = .inspected,
+        isEncrypted: Bool? = nil,
+        findings initialFindings: [DocumentSecurityFinding] = [],
+        externalReferences: [DocumentExternalReference] = [],
+        activeContentTypes: Set<DocumentActiveContentType> = []
+    ) -> DocumentSecurityMetadata {
+        var findings = initialFindings
+        var status = inspectionStatus
+        let digest = try? sha256Hex(of: url)
+        if digest == nil {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .integrityUnavailable,
+                    severity: .low,
+                    message: "Could not compute SHA-256 digest for the source document."
+                )
+            )
+            if status == .inspected {
+                status = .partiallyInspected
+            }
+        }
+
+        let fileExtension = url.pathExtension.isEmpty ? nil : url.pathExtension.lowercased()
+        let type = fileExtension.flatMap { UTType(filenameExtension: $0) }
+        return DocumentSecurityMetadata(
+            inspectionStatus: status,
+            sourceTrust: .userSelectedLocalFile,
+            formatId: formatId,
+            fileExtension: fileExtension,
+            uti: type?.identifier,
+            declaredMimeType: type?.preferredMIMEType,
+            sha256: digest,
+            isEncrypted: isEncrypted,
+            activeContentTypes: activeContentTypes,
+            externalReferences: externalReferences,
+            findings: findings
+        )
+    }
+
+    public static func sha256Hex(of url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 1024 * 1024)
+            guard let chunk, !chunk.isEmpty else { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func htmlSecuritySignals(rawHTML: String) -> HTMLSecuritySignals {
+        let lowercased = rawHTML.lowercased()
+        var findings: [DocumentSecurityFinding] = []
+        var activeContentTypes: Set<DocumentActiveContentType> = []
+
+        if lowercased.contains("<script") || lowercased.contains("javascript:") {
+            activeContentTypes.insert(.script)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .script,
+                    severity: .medium,
+                    message: "HTML document contains script-bearing content."
+                )
+            )
+        }
+
+        if lowercased.contains("<iframe") || lowercased.contains("<object") || lowercased.contains("<embed") {
+            activeContentTypes.insert(.embeddedFile)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .embeddedFile,
+                    severity: .medium,
+                    message: "HTML document contains embeddable active content."
+                )
+            )
+        }
+
+        let externalReferences = extractHTMLExternalReferences(rawHTML)
+        if !externalReferences.isEmpty {
+            activeContentTypes.insert(.externalReference)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .externalReference,
+                    severity: .low,
+                    message: "HTML document references external resources.",
+                    metadata: ["count": "\(externalReferences.count)"]
+                )
+            )
+        }
+
+        return HTMLSecuritySignals(
+            findings: findings,
+            externalReferences: externalReferences,
+            activeContentTypes: activeContentTypes
+        )
+    }
+
+    private static func extractHTMLExternalReferences(_ rawHTML: String) -> [DocumentExternalReference] {
+        let pattern = #"(?i)\b(href|src|action)\s*=\s*["']([^"']+)["']"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(location: 0, length: rawHTML.utf16.count)
+        return regex.matches(in: rawHTML, range: range).compactMap { match in
+            guard match.numberOfRanges >= 3,
+                let attributeRange = Range(match.range(at: 1), in: rawHTML),
+                let valueRange = Range(match.range(at: 2), in: rawHTML)
+            else { return nil }
+            let attribute = String(rawHTML[attributeRange]).lowercased()
+            let urlString = String(rawHTML[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isExternalURL(urlString) else { return nil }
+            return DocumentExternalReference(
+                kind: htmlReferenceKind(attribute: attribute, urlString: urlString),
+                urlString: urlString
+            )
+        }
+    }
+
+    private static func isExternalURL(_ value: String) -> Bool {
+        let lowercased = value.lowercased()
+        return lowercased.hasPrefix("http://")
+            || lowercased.hasPrefix("https://")
+            || lowercased.hasPrefix("//")
+            || lowercased.hasPrefix("file://")
+    }
+
+    private static func htmlReferenceKind(attribute: String, urlString: String) -> DocumentExternalReference.Kind {
+        let lowercased = urlString.lowercased()
+        switch attribute {
+        case "href" where lowercased.hasSuffix(".css"):
+            return .stylesheet
+        case "href":
+            return .hyperlink
+        case "src" where lowercased.hasSuffix(".js"):
+            return .script
+        case "src" where ["png", "jpg", "jpeg", "gif", "webp", "svg"].contains(lowercased.pathExtension):
+            return .image
+        case "src":
+            return .media
+        default:
+            return .unknown
+        }
+    }
+}
+
+private extension String {
+    var pathExtension: String {
+        (self as NSString).pathExtension
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
@@ -33,7 +33,8 @@ public struct PDFAdapter: DocumentFormatAdapter {
             throw DocumentAdapterError.readFailed(underlying: "PDFKit could not open document")
         }
 
-        let extracted = Self.extractText(from: document)
+        let pages = Self.extractTextPages(from: document)
+        let extracted = pages.map(\.text).joined(separator: "\n\n")
         guard !extracted.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             // No text layer — let the shim fall through to the legacy image-
             // render fallback. Don't claim a result we can't produce.
@@ -41,6 +42,25 @@ public struct PDFAdapter: DocumentFormatAdapter {
         }
 
         let truncated = PlainTextAdapter.applyCharacterCap(extracted)
+        let pageTexts = pages.map { DocumentPageText(pageIndex: $0.pageIndex, text: $0.text) }
+        let structure = Self.structureForTextFallback(
+            filename: url.lastPathComponent,
+            pages: pageTexts,
+            extractedText: extracted,
+            textFallback: truncated
+        )
+        let securitySignals = Self.securitySignals(for: document)
+        let securityFindings =
+            securitySignals.findings
+            + Self.truncationFindings(extractedText: extracted, textFallback: truncated)
+        let security = DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: formatId,
+            inspectionStatus: .partiallyInspected,
+            isEncrypted: document.isEncrypted || document.isLocked,
+            findings: securityFindings,
+            activeContentTypes: securitySignals.activeContentTypes
+        )
 
         return StructuredDocument(
             formatId: formatId,
@@ -50,19 +70,92 @@ public struct PDFAdapter: DocumentFormatAdapter {
                 formatId: formatId,
                 underlying: PlainTextRepresentation(text: truncated)
             ),
+            structure: structure,
+            security: security,
             textFallback: truncated
         )
     }
 
-    private static func extractText(from document: PDFDocument) -> String {
-        var pages: [String] = []
+    private static func extractTextPages(from document: PDFDocument) -> [ExtractedPageText] {
+        var pages: [ExtractedPageText] = []
         for index in 0 ..< document.pageCount {
             guard let page = document.page(at: index),
                 let text = page.string,
                 !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             else { continue }
-            pages.append(text)
+            pages.append(ExtractedPageText(pageIndex: index, text: text))
         }
-        return pages.joined(separator: "\n\n")
+        return pages
+    }
+
+    static func structureForTextFallback(
+        filename: String,
+        pages: [DocumentPageText],
+        extractedText: String,
+        textFallback: String
+    ) -> DocumentStructure {
+        guard extractedText == textFallback else {
+            return DocumentStructure.plainText(filename: filename, text: textFallback)
+        }
+        return DocumentStructure.paginatedText(filename: filename, pages: pages)
+    }
+
+    private static func securitySignals(
+        for document: PDFDocument
+    ) -> (findings: [DocumentSecurityFinding], activeContentTypes: Set<DocumentActiveContentType>) {
+        var findings: [DocumentSecurityFinding] = [
+            DocumentSecurityFinding(
+                kind: .unsupportedFeature,
+                severity: .informational,
+                message:
+                    "PDF active content, embedded files, and annotations are not fully inspected by the text-layer adapter."
+            )
+        ]
+        let activeContentTypes: Set<DocumentActiveContentType> = []
+
+        if document.isEncrypted || document.isLocked {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .encryptedContent,
+                    severity: document.isLocked ? .high : .low,
+                    message: "PDF reports encrypted or locked content."
+                )
+            )
+        }
+
+        if !document.allowsCopying {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .permissionRestriction,
+                    severity: .low,
+                    message: "PDF permissions disallow copying."
+                )
+            )
+        }
+
+        return (findings, activeContentTypes)
+    }
+
+    private static func truncationFindings(
+        extractedText: String,
+        textFallback: String
+    ) -> [DocumentSecurityFinding] {
+        guard extractedText != textFallback else { return [] }
+        return [
+            DocumentSecurityFinding(
+                kind: .truncatedContent,
+                severity: .low,
+                message: "PDF text fallback was character-capped; page-level text ranges were not preserved.",
+                metadata: [
+                    "extractedUTF16Length": "\(extractedText.utf16.count)",
+                    "fallbackUTF16Length": "\(textFallback.utf16.count)",
+                ]
+            )
+        ]
+    }
+
+    private struct ExtractedPageText {
+        let pageIndex: Int
+        let text: String
     }
 }

--- a/Packages/OsaurusCore/Services/Documents/PlainTextAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PlainTextAdapter.swift
@@ -47,6 +47,11 @@ public struct PlainTextAdapter: DocumentFormatAdapter {
         }
 
         let truncated = Self.applyCharacterCap(rawContent)
+        let structure = DocumentStructure.plainText(filename: url.lastPathComponent, text: truncated)
+        let security = DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: formatId
+        )
 
         return StructuredDocument(
             formatId: formatId,
@@ -56,6 +61,8 @@ public struct PlainTextAdapter: DocumentFormatAdapter {
                 formatId: formatId,
                 underlying: PlainTextRepresentation(text: truncated)
             ),
+            structure: structure,
+            security: security,
             textFallback: truncated
         )
     }

--- a/Packages/OsaurusCore/Services/Documents/RichDocumentAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/RichDocumentAdapter.swift
@@ -51,6 +51,16 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
         }
 
         let truncated = PlainTextAdapter.applyCharacterCap(extracted)
+        let structure = DocumentStructure.plainText(filename: url.lastPathComponent, text: truncated)
+        let securitySignals = Self.securitySignals(url: url)
+        let security = DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: formatId,
+            inspectionStatus: securitySignals.inspectionStatus,
+            findings: securitySignals.findings,
+            externalReferences: securitySignals.externalReferences,
+            activeContentTypes: securitySignals.activeContentTypes
+        )
 
         return StructuredDocument(
             formatId: formatId,
@@ -60,6 +70,8 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
                 formatId: formatId,
                 underlying: PlainTextRepresentation(text: truncated)
             ),
+            structure: structure,
+            security: security,
             textFallback: truncated
         )
     }
@@ -80,5 +92,71 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
         case "html", "htm": return .html
         default: return nil
         }
+    }
+
+    private static func securitySignals(url: URL) -> RichSecuritySignals {
+        let ext = url.pathExtension.lowercased()
+        if ext == "html" || ext == "htm" {
+            guard let rawHTML = readTextSource(url: url) else {
+                return RichSecuritySignals(
+                    inspectionStatus: .partiallyInspected,
+                    findings: [
+                        DocumentSecurityFinding(
+                            kind: .integrityUnavailable,
+                            severity: .low,
+                            message: "Could not inspect HTML source for active content."
+                        )
+                    ]
+                )
+            }
+            let signals = DocumentFileInspector.htmlSecuritySignals(rawHTML: rawHTML)
+            return RichSecuritySignals(
+                inspectionStatus: .inspected,
+                findings: signals.findings,
+                externalReferences: signals.externalReferences,
+                activeContentTypes: signals.activeContentTypes
+            )
+        }
+
+        var findings: [DocumentSecurityFinding] = [
+            DocumentSecurityFinding(
+                kind: .unsupportedFeature,
+                severity: .informational,
+                message:
+                    "Rich document package relationships and embedded objects are not fully inspected by the text-only adapter."
+            )
+        ]
+        var activeContentTypes: Set<DocumentActiveContentType> = []
+        if ext == "doc" {
+            activeContentTypes.insert(.unknown)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .activeContent,
+                    severity: .low,
+                    message: "Legacy Word documents may contain macros or embedded active content."
+                )
+            )
+        }
+
+        return RichSecuritySignals(
+            inspectionStatus: .partiallyInspected,
+            findings: findings,
+            activeContentTypes: activeContentTypes
+        )
+    }
+
+    private static func readTextSource(url: URL) -> String? {
+        if let utf8 = try? String(contentsOf: url, encoding: .utf8) {
+            return utf8
+        }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return String(data: data, encoding: .isoLatin1)
+    }
+
+    private struct RichSecuritySignals {
+        let inspectionStatus: DocumentSecurityMetadata.InspectionStatus
+        var findings: [DocumentSecurityFinding] = []
+        var externalReferences: [DocumentExternalReference] = []
+        var activeContentTypes: Set<DocumentActiveContentType> = []
     }
 }

--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -434,7 +434,7 @@ public struct GitHubTreeEntry: Decodable, Sendable {
 /// `relativePath` from the skill's own root so the installer can stash it
 /// under `references/` or `assets/` with a predictable name.
 public struct GitHubSkillAsset: Sendable {
-    public let path: String          // full path within the repo
+    public let path: String  // full path within the repo
     public let relativePath: String  // path relative to the skill dir
     public let size: Int
 
@@ -1042,7 +1042,7 @@ public final class GitHubSkillService: ObservableObject {
     /// `scripts/`, supporting docs under `references/`, binary templates
     /// under `assets/` or `templates/`.
     nonisolated private static let conventionalAssetSubdirs: Set<String> = [
-        "scripts", "references", "assets", "templates"
+        "scripts", "references", "assets", "templates",
     ]
 
     /// Build the full manifest of importable artifacts for one plugin.

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -831,7 +831,7 @@ public final class ClaudePluginInstaller {
         // inside a much later code block.
         var description = ""
         let scanEnd = min(firstContentLineIndex + 10, lines.count)
-        for idx in firstContentLineIndex..<scanEnd {
+        for idx in firstContentLineIndex ..< scanEnd {
             let stripped = lines[idx].trimmingCharacters(in: .whitespaces)
             if stripped.isEmpty { continue }
             if stripped.lowercased().hasPrefix("description:") {
@@ -895,7 +895,7 @@ public final class ClaudePluginInstaller {
     ) -> (rewritten: String, additionalReferences: [(name: String, data: Data)]) {
         // Build a lookup of fetched assets by basename so a rewrite can
         // map "scripts/recalc.py" → "references/recalc.py".
-        var assetByBasename: [String: String] = [:]   // basename → "references|assets/<name>"
+        var assetByBasename: [String: String] = [:]  // basename → "references|assets/<name>"
         for asset in fetchedAssets {
             let basename = (asset.relativePath as NSString).lastPathComponent
             let bucket = shouldStoreAsReference(basename) ? "references" : "assets"

--- a/Packages/OsaurusCore/Tests/Documents/DocumentSecurityMetadataTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentSecurityMetadataTests.swift
@@ -1,0 +1,50 @@
+//
+//  DocumentSecurityMetadataTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("DocumentSecurityMetadata")
+struct DocumentSecurityMetadataTests {
+    @Test func localFileSecurityMetadata_recordsDigestAndType() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("digest-\(UUID().uuidString).txt")
+        try Data("hello".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let metadata = DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: "plaintext"
+        )
+
+        #expect(metadata.inspectionStatus == .inspected)
+        #expect(metadata.sourceTrust == .userSelectedLocalFile)
+        #expect(metadata.fileExtension == "txt")
+        #expect(metadata.sha256 == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        #expect(metadata.findings.isEmpty)
+    }
+
+    @Test func htmlSecuritySignals_detectsScriptsAndExternalResources() {
+        let html = """
+            <html>
+              <head><script src="https://example.com/app.js"></script></head>
+              <body>
+                <img src="https://example.com/image.png">
+                <a href="javascript:alert(1)">bad</a>
+              </body>
+            </html>
+            """
+
+        let signals = DocumentFileInspector.htmlSecuritySignals(rawHTML: html)
+
+        #expect(signals.activeContentTypes.contains(.script))
+        #expect(signals.activeContentTypes.contains(.externalReference))
+        #expect(signals.findings.contains { $0.kind == .script })
+        #expect(signals.externalReferences.contains { $0.kind == .script })
+        #expect(signals.externalReferences.contains { $0.kind == .image })
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/DocumentStructureTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentStructureTests.swift
@@ -1,0 +1,41 @@
+//
+//  DocumentStructureTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("DocumentStructure")
+struct DocumentStructureTests {
+    @Test func plainText_buildsRootAndBodyAnchorWithUTF16Range() {
+        let text = "A😀B"
+        let structure = DocumentStructure.plainText(filename: "note.txt", text: text)
+
+        #expect(structure.root.kind == .document)
+        #expect(structure.anchor(id: "document")?.label == "note.txt")
+        #expect(structure.anchor(id: "document/body")?.textRange == .entireText(text))
+        #expect(structure.textLengthUTF16 == text.utf16.count)
+        #expect(structure.elements(kind: .paragraph).first?.text == text)
+    }
+
+    @Test func paginatedText_preservesPageSourceAndFallbackOffsets() {
+        let structure = DocumentStructure.paginatedText(
+            filename: "fixture.pdf",
+            pages: [
+                DocumentPageText(pageIndex: 0, text: "first"),
+                DocumentPageText(pageIndex: 2, text: "second😀"),
+            ]
+        )
+
+        let pages = structure.elements(kind: .page)
+        #expect(pages.count == 2)
+        #expect(pages[0].anchor.sourceRange?.start.pageIndex == 0)
+        #expect(pages[0].anchor.textRange == DocumentTextRange(startUTF16Offset: 0, length: "first".utf16.count))
+        #expect(pages[1].anchor.sourceRange?.start.pageIndex == 2)
+        #expect(pages[1].anchor.textRange?.startUTF16Offset == "first\n\n".utf16.count)
+        #expect(structure.textLengthUTF16 == "first\n\nsecond😀".utf16.count)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
@@ -33,6 +33,30 @@ struct PDFAdapterTests {
         let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
         #expect(doc.formatId == "pdf")
         #expect(doc.textFallback.contains("Hello PDF body content"))
+        #expect(doc.structure.elements(kind: .page).count == 1)
+        #expect(doc.structure.elements(kind: .page).first?.anchor.sourceRange?.start.pageIndex == 0)
+        #expect(doc.security.inspectionStatus == .partiallyInspected)
+        #expect(doc.security.findings.contains { $0.kind == .unsupportedFeature })
+    }
+
+    @Test func structureForTextFallback_usesPlainTextWhenFallbackIsCapped() {
+        let pages = [
+            DocumentPageText(pageIndex: 0, text: "first page"),
+            DocumentPageText(pageIndex: 1, text: "second page"),
+        ]
+        let extracted = "first page\n\nsecond page"
+        let fallback = "first page\n\nse"
+
+        let structure = PDFAdapter.structureForTextFallback(
+            filename: "long.pdf",
+            pages: pages,
+            extractedText: extracted,
+            textFallback: fallback
+        )
+
+        #expect(structure.elements(kind: .page).isEmpty)
+        #expect(structure.elements(kind: .paragraph).first?.text == fallback)
+        #expect(structure.anchor(id: "document/body")?.textRange == .entireText(fallback))
     }
 
     @Test func parse_throwsEmptyContentForPDFWithNoTextLayer() async throws {

--- a/Packages/OsaurusCore/Tests/Documents/PlainTextAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PlainTextAdapterTests.swift
@@ -33,6 +33,10 @@ struct PlainTextAdapterTests {
         #expect(doc.filename.hasSuffix("hello.txt"))
         #expect(doc.textFallback.contains("hello"))
         #expect(doc.textFallback.contains("utf8"))
+        #expect(doc.structure.root.kind == .document)
+        #expect(doc.structure.anchor(id: "document/body")?.textRange?.length == doc.textFallback.utf16.count)
+        #expect(doc.security.inspectionStatus == .inspected)
+        #expect(doc.security.sha256?.isEmpty == false)
     }
 
     @Test func parse_fallsBackToLatin1ForNonUtf8Bytes() async throws {

--- a/Packages/OsaurusCore/Tests/Documents/RichDocumentAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/RichDocumentAdapterTests.swift
@@ -28,7 +28,12 @@ struct RichDocumentAdapterTests {
 
     @Test func parse_readsHTMLBodyAsPlainText() async throws {
         let url = try Self.write(
-            "<html><body><h1>Title</h1><p>Body text</p></body></html>",
+            """
+            <html>
+              <head><script src="https://example.com/app.js"></script></head>
+              <body><h1>Title</h1><p>Body text</p></body>
+            </html>
+            """,
             filename: "page.html"
         )
         defer { try? FileManager.default.removeItem(at: url) }
@@ -38,6 +43,10 @@ struct RichDocumentAdapterTests {
         #expect(doc.textFallback.contains("Title"))
         #expect(doc.textFallback.contains("Body text"))
         #expect(doc.textFallback.contains("<h1>") == false)
+        #expect(doc.structure.elements(kind: .paragraph).first?.text == doc.textFallback)
+        #expect(doc.security.inspectionStatus == .inspected)
+        #expect(doc.security.activeContentTypes.contains(.script))
+        #expect(doc.security.externalReferences.contains { $0.kind == .script })
     }
 
     @Test func parse_readsRTFAsPlainText() async throws {

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
@@ -1029,7 +1029,7 @@ struct ClaudePluginInstallerTests {
         }
         let counter = Counter()
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<20 {
+            for _ in 0 ..< 20 {
                 group.addTask {
                     _ = try? await limiter.run {
                         await counter.enter()


### PR DESCRIPTION
## Business rationale

High-fidelity document I/O needs a format-neutral internal model before the project can safely revive the parked XLSX, CSV/TSV, PDF, PPTX, typed attachment, plugin-extension, and skills work. Today document parsing mostly collapses files into plain fallback text, which makes it hard for tools and plugins to preserve page/sheet/section provenance, detect active content, or report security-relevant file metadata. This PR lays the production foundation: adapters now return structured anchors, source ranges, SHA-256-backed file metadata, active-content findings, and external-reference findings while preserving existing `textFallback` behavior for current callers.

## Coding rationale

I kept this as a narrow foundation instead of importing a full Office/PDF parser stack in one jump. The new `DocumentAnchor`, `DocumentStructure`, and `DocumentSecurityMetadata` models let existing adapters expose provenance and risk metadata without changing the public parse pipeline shape or bypassing existing size caps. The trust boundary is untrusted document input: the implementation records digests, source locations, active content, and external references, but deliberately leaves full XLSX/PPTX/PDF fidelity, emitters, workbook tools, plugin ABI extensions, and skill runtime integration to follow-up lanes where each format can be reviewed with targeted tests.

## Acceptance criteria

- [x] `StructuredDocument` carries optional structure and security metadata without breaking fallback text consumers.
- [x] Plain text, rich text/HTML, and PDF adapters populate structure/security data using the existing size-limit posture.
- [x] PDF fallback truncation cannot create structure ranges beyond the returned fallback text.
- [x] HTML active content and external resource references are surfaced as security findings.
- [x] Regression tests cover structure ranges, source anchors, digest metadata, rich-document security signals, and PDF capped fallback behavior.
- [x] Local pre-push formatting baseline is normalized without changing behavior.

## Quality gate

- [x] `xcrun swift-format lint --strict --recursive Packages App` — clean
- [x] `swiftlint lint --reporter github-actions-logging` — clean
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — clean
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed: `git fetch --all --prune` completed at 2026-05-17T12:32:43Z, followed by `git rebase origin/main` with no-op result on head `eb02bb3b21076dd63a78b8b6a79cf4495d8849cc`

## Debug evidence

Focused document tests passed before the full gate with `swift test --package-path Packages/OsaurusCore --filter 'Document|PDFAdapter|PlainTextAdapter'`. Full gate evidence is retained locally under `/tmp/osaurus-coord/evidence/T-J/20260517T121706Z`; its status log shows `PASS swift-format 2026-05-17T12:17:10Z`, `PASS cli-tests 2026-05-17T12:17:55Z`, `PASS ci-test 2026-05-17T12:24:01Z`, and `PASS core-release 2026-05-17T12:32:07Z`. The Core gate output includes document-specific passing cases such as `DocumentSecurityMetadataTests`, `DocumentStructureTests`, `PDFAdapterTests.structureForTextFallback_usesPlainTextWhenFallbackIsCapped`, `PlainTextAdapterTests.parse_truncatesLongContentWithMarker`, and `RichDocumentAdapterTests.parse_readsHTMLBodyAsPlainText`.

## Rollback

Revert this PR; adapters return to fallback-text-only metadata and the parked document-format lanes remain blocked on a replacement foundation.
