### PR TITLE
[codex] Specify multimodal plugin IO lanes

### DIFF
--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -434,7 +434,7 @@ public struct GitHubTreeEntry: Decodable, Sendable {
 /// `relativePath` from the skill's own root so the installer can stash it
 /// under `references/` or `assets/` with a predictable name.
 public struct GitHubSkillAsset: Sendable {
-    public let path: String          // full path within the repo
+    public let path: String  // full path within the repo
     public let relativePath: String  // path relative to the skill dir
     public let size: Int
 
@@ -1042,7 +1042,7 @@ public final class GitHubSkillService: ObservableObject {
     /// `scripts/`, supporting docs under `references/`, binary templates
     /// under `assets/` or `templates/`.
     nonisolated private static let conventionalAssetSubdirs: Set<String> = [
-        "scripts", "references", "assets", "templates"
+        "scripts", "references", "assets", "templates",
     ]
 
     /// Build the full manifest of importable artifacts for one plugin.

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -831,7 +831,7 @@ public final class ClaudePluginInstaller {
         // inside a much later code block.
         var description = ""
         let scanEnd = min(firstContentLineIndex + 10, lines.count)
-        for idx in firstContentLineIndex..<scanEnd {
+        for idx in firstContentLineIndex ..< scanEnd {
             let stripped = lines[idx].trimmingCharacters(in: .whitespaces)
             if stripped.isEmpty { continue }
             if stripped.lowercased().hasPrefix("description:") {
@@ -895,7 +895,7 @@ public final class ClaudePluginInstaller {
     ) -> (rewritten: String, additionalReferences: [(name: String, data: Data)]) {
         // Build a lookup of fetched assets by basename so a rewrite can
         // map "scripts/recalc.py" → "references/recalc.py".
-        var assetByBasename: [String: String] = [:]   // basename → "references|assets/<name>"
+        var assetByBasename: [String: String] = [:]  // basename → "references|assets/<name>"
         for asset in fetchedAssets {
             let basename = (asset.relativePath as NSString).lastPathComponent
             let bucket = shouldStoreAsReference(basename) ? "references" : "assets"

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginInstallerTests.swift
@@ -1029,7 +1029,7 @@ struct ClaudePluginInstallerTests {
         }
         let counter = Counter()
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<20 {
+            for _ in 0 ..< 20 {
                 group.addTask {
                     _ = try? await limiter.run {
                         await counter.enter()

--- a/docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md
+++ b/docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md
@@ -11,6 +11,49 @@ The expected product shape is:
 - The plugin does not invent its own prompt serializer unless the target
   provider requires it.
 
+## T-M lane outcome
+
+This lane turns multimodal plugin input/output from a product idea into a
+reviewable contract. It is intentionally docs/spec only unless a later
+implementation slice identifies a narrow, testable model or host API hole.
+
+In scope:
+
+- A canonical plugin input shape for text, image, audio, video, tools,
+  reasoning preferences, member routing, and per-turn session identity.
+- A canonical plugin output shape for streamed text, reasoning deltas, tool
+  calls, final usage, member failures, and shared artifact references.
+- Acceptance criteria that can be converted into tests before any broad council
+  or plugin-browser feature work.
+- A threat model for media exfiltration, key leakage, resource exhaustion,
+  cross-agent contamination, tool abuse, and reasoning disclosure.
+- Small implementation slices that keep model/runtime, plugin host, UI, and
+  provider work independently reviewable.
+
+Out of scope for this spec revision:
+
+- A new ABI version.
+- First-class generated image/audio/video output from local models.
+- A plugin marketplace or community browser.
+- Replacing the existing OpenAI-compatible request/stream format.
+
+## Acceptance criteria
+
+Any implementation PR claiming T-M multimodal plugin support must satisfy all
+rows that match its slice. A docs-only slice satisfies this table by making the
+future evidence explicit.
+
+| Area | Required behavior | Evidence |
+|---|---|---|
+| Input contract | Plugins call `host->complete`, `host->complete_stream`, or the Osaurus HTTP API with ordered OpenAI-compatible content parts. `text`, `image_url`, `input_audio`, and `video_url` survive decode/re-encode without lossy string prompt flattening. | Codable tests for mixed content parts plus a plugin-host completion test that observes the mapped `ChatMessage` parts. |
+| Local media mapping | Local execution maps images to `Chat.Message.images`, videos to `Chat.Message.videos`, and audio to `Chat.Message.audios`; valid WAV audio maps to samples where supported and mp4 video remains video mp4. | `MultimodalContentPartTests`, `MaterializeMediaDataUrlMCDCTests`, and one plugin-host fixture that exercises the same path through `complete_stream`. |
+| Capability gating | A text-only local model never receives image/audio/video content. Unsupported media fails closed with a structured error or an explicit downgrade record. | Model-capability tests for text-only, image, video, and Nemotron-Omni-style audio cases. |
+| Remote consent | Media bytes, local file contents, memory, folder context, tool output, and reasoning are not sent to remote members unless the user explicitly enabled that member and configured its BYO key. | Unit tests for member routing plus redacted log snapshots for denied and allowed remote routes. |
+| Output contract | Streaming exposes visible text as `delta.content`, reasoning as `delta.reasoning_content`, tool calls as `delta.tool_calls`, and terminal state as `finish_reason` plus usage when available. Binary outputs are returned only as shared artifact references until a dedicated media-output ABI exists. | Stream parser tests and a manual plugin smoke that cancels, finishes, and handles tool-call termination. |
+| Tool isolation | Tool calls are allowlist-checked, user-consented when sensitive, and returned only to the member/session that requested the matching `tool_call_id`. | Tool-call tests covering allowed, denied, cross-member mismatch, and timeout paths. |
+| Session/cache isolation | Each council member has a stable session key, distinct media salt, and no cache sharing across members, agents, or changed media. | Local cache tests or structured logs showing member id, session key, media counts, and media salt. |
+| Observability | Logs include member id, model id, provider kind, media counts, sanitized formats, timing, finish reason, and redacted error codes. Logs never include provider keys, auth headers, base64 media, raw tool output, or hidden reasoning. | Redaction tests plus Insights or structured-log snapshot checks. |
+
 ## Recommended integration paths
 
 There are two supported ways to call multimodal generation.
@@ -45,6 +88,72 @@ Assistant messages may include:
 Tool-role messages should include:
 
 - `tool_call_id`: the id from the assistant tool call being answered.
+
+### Canonical plugin input
+
+For ABI-hosted plugins, the request body for `host->complete` and
+`host->complete_stream` is the same OpenAI-compatible JSON shape described
+above. The plugin must keep multimodal data as structured content parts until
+the host maps it into `ChatMessage` / vmlx types.
+
+Minimum request:
+
+```json
+{
+  "model": "local-vl-model-id",
+  "session_id": "optional-stable-session-key",
+  "stream_id": "optional-plugin-generated-uuid-for-complete_stream",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this media."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+        {"type": "input_audio", "input_audio": {"data": "...", "format": "wav"}},
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}
+      ]
+    }
+  ],
+  "tools": [],
+  "metadata": {
+    "member_id": "local-zaya-vl",
+    "member_kind": "local_osaurus",
+    "remote_media_allowed": false
+  }
+}
+```
+
+Input rules:
+
+- Preserve content-part order. Do not merge media into text placeholders except
+  when a deliberate downgrade step records what happened.
+- Keep `session_id` stable per member and agent. Use a different session when
+  the user switches member identity, provider, or privacy policy.
+- Use `stream_id` only for `complete_stream` cancellation. It must be unique per
+  active stream and generated by the plugin.
+- Treat `metadata` as diagnostic context only. The host's security boundary is
+  still the TLS-bound active agent and plugin context; caller-supplied agent
+  ids or addresses are ignored by host APIs.
+- Base64 media should be a request payload detail, not a logging surface.
+
+### Canonical plugin output
+
+V1 multimodal plugin output is text-first and stream-compatible. The plugin may
+render or aggregate these events, but it should not reinterpret them as a
+provider-specific format:
+
+| Output | Shape | Handling rule |
+|---|---|---|
+| Visible text | `choices[].delta.content` or final `message.content` | Append to the visible member transcript. |
+| Reasoning | `choices[].delta.reasoning_content` or `message.reasoning_content` | Render only when user policy allows it; never merge into visible text. |
+| Tool call | `choices[].delta.tool_calls` or final `message.tool_calls` | Execute only after allowlist and consent checks, then return a matching tool-role message. |
+| Terminal state | `finish_reason`, `usage`, `tool_calls_executed`, `shared_artifacts` | Close the member stream and record final metrics. |
+| Member error | Standard error envelope with `error` and `message` | Fail that member; continue the council run unless every required member failed. |
+| Binary output | `shared_artifacts` references | V1 has no raw image/audio/video generation bytes in `complete_stream`; put files in shared artifacts. |
+
+Cancellation uses the existing `stream_id` plus `complete_cancel` contract. The
+final cancelled response must include the same `stream_id`, partial content if
+available, and redacted usage/tool/artifact metadata.
 
 ### Path B: In-process vmlx Swift
 
@@ -356,6 +465,38 @@ For remote members:
 
 - Provider context caching is provider-specific. Do not assume local vmlx cache
   behavior applies remotely.
+
+## Threat model
+
+The T-M surface crosses local media, remote providers, tools, memory, and
+agent-scoped plugin state. Treat every crossing as an explicit policy decision.
+
+| Threat | Impact | Required mitigation |
+|---|---|---|
+| Media exfiltration to a remote member | Private screenshots, audio, video, pasted files, or folder context leave the machine unexpectedly. | Remote members are disabled by default for local artifacts. Each remote member needs explicit user enablement, a BYO key, and a per-run routing record for which media kinds were sent. |
+| Provider key leakage | BYO keys appear in config files, logs, tool output, crash reports, or model-visible context. | Store only Keychain-backed refs in plugin config. Redact `Authorization`, provider keys, cookies, and signed URLs before logging or returning errors. |
+| Prompt/tool injection through media or metadata | OCR text, audio transcript, EXIF, filenames, captions, or remote member output tricks the plugin into running tools or revealing secrets. | Treat media-derived text as untrusted user content. Require the normal tool allowlist and consent path, and never promote media metadata into system or developer instructions. |
+| SSRF and private-network reachability | A plugin or provider fetches `image_url` / `video_url` content from localhost, link-local, RFC1918, or metadata services. | Prefer data URLs or host-owned artifact reads for local media. For plugin outbound HTTP, use `host->http_request` and its SSRF guard; for provider-sent URLs, validate the URL policy before handing it off. |
+| Resource exhaustion | Large videos/audio, base64 expansion, council fan-out, or repeated retries starve host memory, disk, GPU, or worker threads. | Enforce request size caps, per-member timeout, plugin inference concurrency, temp-file cleanup, and retry budgets. Emit `plugin_busy`, timeout, or structured media-size errors instead of queueing unbounded work. |
+| Cross-agent or cross-member contamination | A plugin sends agent A's memory/media/tool output to agent B, or member A receives member B's tool result. | Rely on host active-agent scoping for `complete`/`dispatch`; ignore caller-supplied agent ids. Key plugin state by `(plugin_id, agent_id, member_id, session_id)` and bind tool replies to the originating `tool_call_id`. |
+| Reasoning disclosure | Hidden reasoning or model-private thinking is displayed, persisted, sent to remote providers, or included in synthesizer prompts without consent. | Keep reasoning deltas on a separate channel. Persist or forward `reasoning_content` only when the user setting and model-family continuity requirement both allow it. |
+| Cache confusion | Re-encoded media or shared session keys produce false cache hits, stale context, or cross-member state reuse. | Preserve media byte identity where possible, include media salt in local cache evidence, and never share local session/cache keys across members or agents. |
+
+## Implementation slices
+
+These slices are intentionally small enough to land independently. Each slice
+should update this spec if the implementation discovers a narrower contract.
+
+| Slice | Scope | Acceptance gate |
+|---|---|---|
+| T-M0 spec baseline | Keep `docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md` and the development plan current. No code. | `git diff --check` over touched docs and a clean worktree before PR publication. |
+| T-M1 host API contract tests | Add plugin-host tests proving `host->complete` / `complete_stream` preserve `image_url`, `input_audio`, `video_url`, `reasoning_content`, and `tool_calls` through the existing OpenAI-compatible request path. | Focused plugin and model mapping tests; no ABI version bump unless a missing field is proven. |
+| T-M2 capability discovery | Expose local model media capabilities to plugins through an existing safe surface, preferably `list_models().models[].capabilities`, before adding any new callback. | Tests for text-only, image, video, and audio capability rows; docs in `HOST_API.md` if the response shape changes. |
+| T-M3 member request model | Introduce an internal `CouncilMemberRequest` or equivalent typed model for member id, provider kind, model id, modalities, session key, consent flags, timeouts, tools, and reasoning policy. | Unit tests for unsupported-media rejection, deliberate downgrade records, redacted errors, and stable per-member session ids. |
+| T-M4 streaming/output adapter | Normalize member stream events into visible text, reasoning, tool calls, terminal usage, cancellation, member errors, and shared artifacts. | Stream parser tests for stop, length, tool_calls, max_iterations, cancelled, timeout, and all-member-failed cases. |
+| T-M5 tool and consent gate | Route member tool calls through allowlist and sensitive-tool consent, then return tool-role replies only to the requesting member. | Tool isolation tests for allowed, denied, timeout, malformed args, and cross-member `tool_call_id` mismatch. |
+| T-M6 observability and redaction | Add structured logs for member id, provider kind, model id, media counts, sanitized formats, durations, finish reason, cache/media-salt hints, and redacted failures. | Redaction tests verifying no auth header, provider key, base64 media, raw tool output, or reasoning text reaches logs. |
+| T-M7 manual smoke plugin | Add or update a small local plugin fixture that sends image, audio, video, reasoning, and tool-call prompts through the public host API. | Manual smoke notes plus focused automated fixture checks; no network provider required for the local-only path. |
 
 ## Plugin validation matrix
 

--- a/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
+++ b/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
@@ -100,6 +100,23 @@ Reasons:
   permission (`RequestReviewsByLogin`), so the evidence comment records the
   reviewer handoff state.
 
+## T-M Spec Lane Addendum - 2026-05-17
+
+- Lane T-M is a docs/spec lane for multimodal plugin input/output. It is not a
+  code lane unless review finds an explicit, small, testable plugin model hole.
+- Ownership is `docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md` plus this tracked plan.
+  Avoid provider, runtime, UI, and ABI churn in the same branch.
+- The acceptance criteria now require ordered OpenAI-compatible media content
+  parts, local capability gating, remote-consent boundaries, output stream
+  semantics, tool isolation, session/cache isolation, and redacted observability.
+- The threat model covers media exfiltration, BYO key leakage, media/prompt
+  injection, SSRF, resource exhaustion, cross-agent/member contamination,
+  reasoning disclosure, and cache confusion.
+- Future implementation work should split into T-M1 through T-M7:
+  host API contract tests, capability discovery, typed member request model,
+  streaming/output adapter, tool and consent gate, observability/redaction, and
+  a local-only manual smoke plugin.
+
 ## Maximum Parallelization Plan - 2026-05-16
 
 These lanes are intentionally disjoint. Each implementation branch must start
@@ -113,10 +130,61 @@ issues, and must acquire a mutation lock before writing to GitHub.
 | D. Eval CLI hang | #1050 | Dispatch first; isolated | `Packages/OsaurusEvals/**` only | `swift test --package-path Packages/OsaurusEvals`; CLI smoke with and without `CI=true` | Make eval CLI noninteractive/timeout-safe on current main and document the behavior in help text if needed. |
 | E. MCP stdio docs | #416, #1058 | Dispatch first; docs-only | `README.md`, `docs/REMOTE_MCP_PROVIDERS.md`, `docs/FEATURES.md`, `docs/DEVELOPER_TOOLS.md` | `git diff --check` | Align docs with command-based MCP provider support and clarify remote transport limits. |
 | F. Global proxy | #1091, #232 | Design next | Shared URLSession/proxy policy, settings UI, model download/provider/plugin call sites | Proxy config unit tests plus model/provider smoke tests | Draft architecture first because it crosses provider, model download, plugin, and remote docs scopes. |
+| T-M. Multimodal plugin I/O spec | Plugin/council roadmap; adjacent to #793, #332, #417, #1002 | Spec lane; docs-only | `docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md`, `docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md` | `git diff --check -- docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md` | Use the new acceptance criteria, threat model, and T-M1-T-M7 slices to scope future implementation PRs; do not add ABI surface without a proven host gap. |
 | H. Voice reliability and TTS | #689, #1002, #417, #445, #605 | Feature/quality follow-up | voice settings, TTS/transcription services, hotkey path | Voice service tests plus manual audio smoke | Pick one small target after D/B/C settle: language selection or function-key hotkey. |
 | I. Model/download compatibility | #443, #358, #1065, #886, #833 | Research/design | model discovery/download/runtime adapters | Compatibility notes and focused model manager tests | Produce design notes before code; avoid overlapping provider fallback work. |
 | J. Document stack | #929/#936/#937/#939/#940/#941/#942/#983/#1022/#1023/#1024 and #974 | Parked | document/plugin stack | Full document-stack sequencing gates | Do not dispatch until stack base is rebuilt from current main. |
 | K. Historical PRs | #873, #913, #958, #963, #976, #985/#986/#987/#988/#992, #1006, #1048 | Observe or conflict proof only | varies | conflict proof first | Skip broad rebases; mine narrow fixes only when they match an active current-main lane. |
+
+## T-J Document I/O Foundation Wave - 2026-05-17
+
+T-J replaces the stale document-stack base with a current-main foundation lane.
+It intentionally avoids format-specific import/export depth while unblocking
+the PDF, DOCX, XLSX, and PPTX follow-up lanes with shared contracts.
+
+Wave breakdown:
+
+1. Foundation model and adapter contract:
+   - Add format-neutral document structure, anchors, text/source ranges, and
+     security/provenance metadata under `Models/Documents/**`.
+   - Keep the existing plain-text attachment path stable by preserving
+     `StructuredDocument.textFallback` and the legacy `DocumentParser` shim.
+   - Current adapters may publish shallow trees; high-fidelity lanes replace
+     leaves with page/table/cell/slide/shape subtrees.
+2. Original-file bridge:
+   - Mine #983 first, but rebuild it on current main and preserve the rule that
+     on-disk artifacts stay inside the encrypted attachment/blob envelope.
+   - Expose original bytes to local tools/plugins only through controlled
+     metadata, path containment, and redacted logs.
+3. Format read lanes:
+   - XLSX read: mine #929 for typed workbook/sheet/cell models.
+   - CSV/TSV: mine #939 for streaming tables and encoding/line-ending tests.
+   - PDF: mine #940 for page/table/image anchors and active-content inspection.
+   - PPTX/POTX: mine #1023 for slide/shape/chart/speaker-note anchors, replacing
+     subprocess unzip with a bounded ZIP reader.
+4. Emit/tool lanes:
+   - Mine #936 for XLSX emit and round trips after the typed workbook lands.
+   - Mine #937 for workbook tools after current tool/capability plumbing is
+     stable.
+   - Revisit #942/#941 only after the typed attachment and plugin extension
+     surfaces can use the same anchor/security contracts.
+5. Skills/runtime/docs lanes:
+   - Mine #974 for on-demand high-fidelity skills after document I/O exists.
+   - Mine #1022 for optional office-runtime detection with timeout/trust review.
+   - Finish with #1024-style docs once code behavior is current-main real.
+
+Acceptance gates for the foundation PR:
+
+- Existing `PlainTextAdapter`, `PDFAdapter`, and `RichDocumentAdapter`
+  behaviours remain compatible with the current attachment flow.
+- Every parsed `StructuredDocument` carries a structure tree, at least one
+  stable anchor, and explicit security metadata.
+- Security metadata distinguishes `inspected`, `partiallyInspected`, and
+  `notInspected`; adapters must not imply a deeper scan than they performed.
+- Tests cover UTF-16 text ranges, paginated source offsets, digest metadata,
+  HTML active/external content signals, and current adapter compatibility.
+- Run focused document tests plus `git diff --check`; run the full core gate
+  before publishing a PR.
 
 ## Open PR Plan - 2026-05-16 07:33 UTC
 


### PR DESCRIPTION
## Business rationale

The multimodal plugin and high-fidelity document work spans text, images, audio, video, tool calls, reasoning traces, sessions, and multiple document formats. Without a written contract, implementers can easily ship incompatible plugin payloads or revive parked document PRs in the wrong order, forcing maintainers to reconstruct the architecture from scattered branches. This PR turns the next wave into reviewable, larger functional chunks by documenting the canonical multimodal plugin I/O contract, acceptance criteria, threat model, and the document-format roadmap needed to bring high-fidelity file input/output forward safely.

## Coding rationale

This is intentionally a spec-and-plan PR rather than a mixed runtime change: the user asked for the development plan to be enhanced and for larger comprehensive chunks, and the current blocker is coordination fidelity rather than a single failing code path. I considered scattering the requirements into the issue tracker, but keeping the engine contract in `docs/MULTIMODAL_PLUGIN_ENGINE_SPEC.md` and adding plan slices in `docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md` makes the follow-up work auditable from the repository. The trust boundaries called out are plugin ABI inputs/outputs, external media/file references, persisted session state, and document ingestion/export; concrete runtime enforcement is deliberately left to T-M0 through T-M7 and the T-J document wave.

## Acceptance criteria

- [x] Multimodal plugin input/output categories are defined for text, image, audio, video, document, tool, reasoning, and session data.
- [x] Acceptance criteria and threat model are explicit enough to drive implementation PRs.
- [x] T-M implementation slices are split into larger functional chunks instead of tiny review fragments.
- [x] T-J high-fidelity document I/O follow-up lanes are mapped from foundation through format readers/writers/tools/plugins/skills/runtime docs.
- [x] Local pre-push formatting baseline is normalized without changing behavior.

## Quality gate

- [x] `xcrun swift-format lint --strict --recursive Packages App` — clean
- [x] `swiftlint lint --reporter github-actions-logging` — clean
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — clean
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed: `git fetch --all --prune` completed at 2026-05-17T12:32:43Z, followed by `git rebase origin/main` with no-op result on head `a0d804930e1ca6c30ec310001aceacb5205acd3c`

## Debug evidence

The docs/spec branch passed the same full local gate as the code branches. Evidence is retained locally under `/tmp/osaurus-coord/evidence/T-M/20260517T121706Z`; its status log shows `PASS swift-format 2026-05-17T12:17:10Z`, `PASS cli-tests 2026-05-17T12:17:54Z`, `PASS ci-test 2026-05-17T12:24:01Z`, and `PASS core-release 2026-05-17T12:32:32Z`. The initial gate attempt exposed the shared local format issue in Swift files, and this branch includes only the mechanical formatter output needed for the full local gate to pass without `--no-verify` or hook bypass.

## Rollback

Revert this PR; the repository returns to the previous plan state and multimodal/document follow-up lanes lose their canonical contract until a replacement spec lands.
