### PR TITLE
[codex] Scope capability search to agent grants

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -161,6 +161,7 @@ struct CapabilitiesSearchToolTests {
                 )
                 #expect(rawResults.contains { $0.entry.name == allowed.name })
                 #expect(!rawResults.contains { $0.entry.name == denied.name })
+                #expect(diagnostic.filteredByAllowlist.count == 1)
                 #expect(diagnostic.filteredByAllowlist.contains(denied.name))
 
                 let tool = CapabilitiesSearchTool(agentId: agent.id)
@@ -169,6 +170,18 @@ struct CapabilitiesSearchToolTests {
                 )
                 #expect(result.contains(allowed.name))
                 #expect(!result.contains(denied.name))
+
+                AgentManager.shared.setActiveAgent(agent.id)
+                defer { AgentManager.shared.setActiveAgent(Agent.defaultId) }
+                let unscopedTool = CapabilitiesSearchTool()
+                let unscopedResult = try await unscopedTool.execute(
+                    argumentsJSON: "{\"queries\": [\"current headline web search\"]}"
+                )
+                #expect(unscopedResult.contains(allowed.name))
+                #expect(
+                    unscopedResult.contains(denied.name),
+                    "Direct capabilities_search calls without explicit/task-local agent context must keep global-enabled results"
+                )
 
                 _ = await AgentManager.shared.delete(id: agent.id)
             }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -108,8 +108,8 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
-        let activeAgentId = await Self.resolveAgentId(explicit: agentId)
-        let allowedToolNames = await Self.allowedToolNames(for: activeAgentId)
+        let agentContextId = Self.resolveAgentContextId(explicit: agentId)
+        let allowedToolNames = await Self.allowedToolNames(for: agentContextId)
 
         // Run each query independently and merge by best score per item.
         // The previous implementation joined every query into one string
@@ -141,7 +141,8 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         if hits.isEmpty {
             let queryList = queries.map { "'\($0)'" }.joined(separator: ", ")
             let text: String
-            if await CapabilitySearch.canCreatePlugins(agentId: activeAgentId) {
+            let pluginCreationAgentId = await Self.resolvePluginCreationAgentId(explicit: agentId)
+            if await CapabilitySearch.canCreatePlugins(agentId: pluginCreationAgentId) {
                 text = """
                     No capabilities found matching \(queryList).
 
@@ -204,14 +205,20 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         return ToolEnvelope.success(tool: name, text: output)
     }
 
-    /// Resolve the agent whose capability picker scopes runtime search.
-    /// Tool calls usually carry `ChatExecutionContext.currentAgentId`;
-    /// tests and direct host-API invocations can pass `agentId`
-    /// explicitly. Falling back to the active agent preserves legacy
-    /// behavior for older paths that do not yet bind task-local context.
-    private static func resolveAgentId(explicit: UUID?) async -> UUID {
-        if let explicit { return explicit }
-        if let contextId = ChatExecutionContext.currentAgentId { return contextId }
+    /// Resolve the agent context whose capability picker scopes runtime
+    /// search. Only explicit tool instances and task-local chat execution
+    /// contexts carry the user's current grant boundary; direct utility
+    /// calls with neither value keep the historical global-enabled search.
+    private static func resolveAgentContextId(explicit: UUID?) -> UUID? {
+        explicit ?? ChatExecutionContext.currentAgentId
+    }
+
+    /// The no-match plugin-creator hint predates runtime allowlist
+    /// scoping and was based on the active agent when no task-local
+    /// context existed. Keep that behavior separate from search
+    /// filtering so direct/no-context search results stay unscoped.
+    private static func resolvePluginCreationAgentId(explicit: UUID?) async -> UUID {
+        if let id = resolveAgentContextId(explicit: explicit) { return id }
         return await MainActor.run { AgentManager.shared.activeAgent.id }
     }
 
@@ -219,8 +226,9 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
     /// which deliberately means "use the global enabled registry." A
     /// non-nil set is authoritative: `capabilities_search` must not
     /// return a dynamic tool the current agent has not been granted.
-    private static func allowedToolNames(for agentId: UUID) async -> Set<String>? {
-        await MainActor.run {
+    private static func allowedToolNames(for agentId: UUID?) async -> Set<String>? {
+        guard let agentId else { return nil }
+        return await MainActor.run {
             AgentManager.shared.effectiveEnabledToolNames(for: agentId).map(Set.init)
         }
     }


### PR DESCRIPTION
## Business rationale

Users can grant tools to a specific agent and still ask that agent to search capabilities at runtime. Before this change, runtime `capabilities_search` could return globally enabled tools outside the agent's granted/manual scope, which weakens the promise behind agent-scoped capability tools and makes issue #823-style reports harder to diagnose. This PR closes that gap: when an agent context is present, capability search results are scoped to that agent's effective allowlist while preserving existing search behavior when no agent context exists.

## Coding rationale

I kept this follow-up narrow to the runtime capability-search tool rather than changing preflight selection, prompt tuning, or the tool index. The implementation derives an allowlist from the current agent context and filters `capabilities_search` results before returning them; callers without agent scope keep the previous global behavior. The trust boundary is tool exposure: models should not be offered tools outside the active agent's grant just because the global registry knows about them.

## Acceptance criteria

- [x] `capabilities_search` filters outside-grant tools when an agent scope is available.
- [x] Allowed tools still appear in runtime search results.
- [x] Existing no-agent behavior is preserved.
- [x] Focused tests cover the allowlist behavior and existing tool-search service behavior.
- [x] Full local quality gate passed after rebasing on current main.

## Quality gate

- [x] `xcrun swift-format lint --strict --recursive Packages App` — clean
- [x] `swiftlint lint --reporter github-actions-logging` — clean
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — clean
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed: `git fetch --all --prune` completed at 2026-05-17T13:52:27Z and `git rebase origin/main` was a no-op on head `271242cab981d931d341dfea72b46daa27da03fb`

## Debug evidence

Focused worker checks passed before the full gate: `swift test --package-path Packages/OsaurusCore --filter CapabilitiesSearchToolTests` passed 4 tests and `swift test --package-path Packages/OsaurusCore --filter ToolSearchServiceTests` passed 8 tests. Full gate evidence is retained locally under `/tmp/osaurus-coord/evidence/T-B2/20260517T134506Z`; its status log shows `PASS swift-format 2026-05-17T13:45:10Z`, `PASS cli-tests 2026-05-17T13:45:13Z`, `PASS ci-test 2026-05-17T13:46:59Z`, and `PASS core-release 2026-05-17T13:51:39Z`.

## Rollback

Revert this PR; runtime capability search returns to the prior global-registry result filtering behavior.
