### PR TITLE
[codex] Add high-fidelity document format IO

### DIFF
--- a/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
@@ -28,6 +28,7 @@ public enum DocumentAdaptersBootstrap {
         registry.register(adapter: CSVAdapter(delimiter: .comma))
         registry.register(adapter: CSVAdapter(delimiter: .tab))
         registry.register(adapter: PDFAdapter())
+        registry.register(adapter: PPTXAdapter())
         registry.register(adapter: RichDocumentAdapter())
         registry.register(adapter: XLSXAdapter())
         registry.register(emitter: XLSXEmitter())

--- a/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
@@ -30,6 +30,7 @@ public enum DocumentAdaptersBootstrap {
         registry.register(adapter: PDFAdapter())
         registry.register(adapter: RichDocumentAdapter())
         registry.register(adapter: XLSXAdapter())
+        registry.register(emitter: XLSXEmitter())
         if registry === DocumentFormatRegistry.shared {
             didRegisterShared = true
         }

--- a/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
@@ -29,6 +29,7 @@ public enum DocumentAdaptersBootstrap {
         registry.register(adapter: CSVAdapter(delimiter: .tab))
         registry.register(adapter: PDFAdapter())
         registry.register(adapter: RichDocumentAdapter())
+        registry.register(adapter: XLSXAdapter())
         if registry === DocumentFormatRegistry.shared {
             didRegisterShared = true
         }

--- a/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
@@ -25,6 +25,8 @@ public enum DocumentAdaptersBootstrap {
         defer { lock.unlock() }
         if registry === DocumentFormatRegistry.shared, didRegisterShared { return }
         registry.register(adapter: PlainTextAdapter())
+        registry.register(adapter: CSVAdapter(delimiter: .comma))
+        registry.register(adapter: CSVAdapter(delimiter: .tab))
         registry.register(adapter: PDFAdapter())
         registry.register(adapter: RichDocumentAdapter())
         if registry === DocumentFormatRegistry.shared {

--- a/Packages/OsaurusCore/Models/Documents/CSVDocument.swift
+++ b/Packages/OsaurusCore/Models/Documents/CSVDocument.swift
@@ -1,0 +1,113 @@
+//
+//  CSVDocument.swift
+//  osaurus
+//
+//  Typed CSV/TSV representation for the document adapter stack. The
+//  normalized text fallback is still what chat ingress consumes, but the
+//  row/cell model keeps enough source identity for later table-aware tools
+//  to reason about the original delimited text without reparsing it.
+//
+
+import Foundation
+
+/// Delimited text uses a tiny delimiter enum so a TSV table can share the
+/// same row/cell model as CSV while preserving the user's source format.
+public enum CSVDelimiter: String, Codable, Equatable, Hashable, Sendable {
+    case comma = ","
+    case tab = "\t"
+
+    public var formatId: String {
+        switch self {
+        case .comma: return "csv"
+        case .tab: return "tsv"
+        }
+    }
+
+    public var fileExtension: String {
+        formatId
+    }
+}
+
+/// A parsed cell stores both normalized cell text and source/fallback ranges
+/// because quoting and escaped quotes make byte-equivalent reconstruction
+/// lossy once the user-facing text fallback is generated.
+public struct CSVCell: Codable, Equatable, Hashable, Sendable {
+    public let rowIndex: Int
+    public let columnIndex: Int
+    public let text: String
+    public let wasQuoted: Bool
+    public let sourceRange: DocumentTextRange
+    public let textRange: DocumentTextRange
+    public let anchorId: String
+
+    public init(
+        rowIndex: Int,
+        columnIndex: Int,
+        text: String,
+        wasQuoted: Bool,
+        sourceRange: DocumentTextRange,
+        textRange: DocumentTextRange,
+        anchorId: String
+    ) {
+        precondition(rowIndex >= 0, "CSV row index must be non-negative")
+        precondition(columnIndex >= 0, "CSV column index must be non-negative")
+        self.rowIndex = rowIndex
+        self.columnIndex = columnIndex
+        self.text = text
+        self.wasQuoted = wasQuoted
+        self.sourceRange = sourceRange
+        self.textRange = textRange
+        self.anchorId = anchorId
+    }
+}
+
+/// Rows are first-class because blank lines are meaningful in delimited text
+/// imports and because row anchors let later table tools cite entire records.
+public struct CSVRow: Codable, Equatable, Hashable, Sendable {
+    public let rowIndex: Int
+    public let cells: [CSVCell]
+    public let sourceRange: DocumentTextRange
+    public let textRange: DocumentTextRange
+    public let anchorId: String
+
+    public init(
+        rowIndex: Int,
+        cells: [CSVCell],
+        sourceRange: DocumentTextRange,
+        textRange: DocumentTextRange,
+        anchorId: String
+    ) {
+        precondition(rowIndex >= 0, "CSV row index must be non-negative")
+        self.rowIndex = rowIndex
+        self.cells = cells
+        self.sourceRange = sourceRange
+        self.textRange = textRange
+        self.anchorId = anchorId
+    }
+}
+
+/// The adapter's typed payload keeps the parsed table plus the exact delimiter
+/// and UTF-16 source length so callers can validate anchors against the source
+/// string if they still have access to the file contents.
+public struct CSVDocument: StructuredRepresentation, Codable, Equatable, Sendable {
+    public let delimiter: CSVDelimiter
+    public let rows: [CSVRow]
+    public let sourceTextLengthUTF16: Int
+    public let textFallback: String
+
+    public var rowCount: Int { rows.count }
+    public var columnCount: Int { rows.map(\.cells.count).max() ?? 0 }
+
+    public init(
+        delimiter: CSVDelimiter,
+        rows: [CSVRow],
+        sourceTextLengthUTF16: Int,
+        textFallback: String
+    ) {
+        precondition(sourceTextLengthUTF16 >= 0, "CSV source text length must be non-negative")
+        self.delimiter = delimiter
+        self.rows = rows
+        self.sourceTextLengthUTF16 = sourceTextLengthUTF16
+        self.textFallback = textFallback
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/DocumentLimits.swift
+++ b/Packages/OsaurusCore/Models/Documents/DocumentLimits.swift
@@ -21,6 +21,7 @@ public enum DocumentLimits {
     public static let xlsx: Int64 = 50 * 1024 * 1024
     public static let pdf: Int64 = 100 * 1024 * 1024
     public static let docx: Int64 = 50 * 1024 * 1024
+    public static let presentation: Int64 = 100 * 1024 * 1024
 
     /// Fallback for formats that haven't been assigned a tuned cap.
     public static let defaultLimit: Int64 = 10 * 1024 * 1024
@@ -32,6 +33,7 @@ public enum DocumentLimits {
         case "xlsx", "xls", "ods": return xlsx
         case "pdf": return pdf
         case "docx", "doc", "rtf": return docx
+        case "pptx", "potx": return presentation
         default: return defaultLimit
         }
     }

--- a/Packages/OsaurusCore/Models/Documents/PresentationDocument.swift
+++ b/Packages/OsaurusCore/Models/Documents/PresentationDocument.swift
@@ -1,0 +1,128 @@
+//
+//  PresentationDocument.swift
+//  osaurus
+//
+//  Typed read model for presentation files. It intentionally records only
+//  text-bearing slide content today so PPTX/POTX ingestion can preserve
+//  source identity without pretending to understand the full OOXML layout
+//  graph.
+//
+
+import Foundation
+
+/// Distinguishes decks from templates while keeping both on one typed
+/// representation; OpenXML templates share the same slide package layout.
+public enum PresentationDocumentKind: String, Codable, Equatable, Sendable {
+    case presentation
+    case template
+}
+
+/// Format-native representation for presentation reads that downstream tools
+/// can inspect before higher-fidelity media, layout, and chart support lands.
+public struct PresentationDocument: StructuredRepresentation, Codable, Equatable, Sendable {
+    public let kind: PresentationDocumentKind
+    public let sourceName: String
+    public let slides: [PresentationSlide]
+
+    public init(
+        kind: PresentationDocumentKind,
+        sourceName: String,
+        slides: [PresentationSlide]
+    ) {
+        self.kind = kind
+        self.sourceName = sourceName
+        self.slides = slides
+    }
+}
+
+/// A slide preserves both user-facing order (`index`) and source numbering
+/// (`number`) because OpenXML slide filenames are not guaranteed contiguous.
+public struct PresentationSlide: Codable, Equatable, Sendable {
+    public let index: Int
+    public let number: Int
+    public let sourcePart: String
+    public let label: String
+    public let textRuns: [PresentationTextRun]
+    public let speakerNotes: PresentationSpeakerNotes?
+
+    public var text: String {
+        PresentationTextRun.paragraphText(from: textRuns)
+    }
+
+    public init(
+        index: Int,
+        number: Int,
+        sourcePart: String,
+        label: String,
+        textRuns: [PresentationTextRun],
+        speakerNotes: PresentationSpeakerNotes? = nil
+    ) {
+        precondition(index >= 0, "Presentation slide index must be non-negative")
+        precondition(number > 0, "Presentation slide number must be positive")
+        self.index = index
+        self.number = number
+        self.sourcePart = sourcePart
+        self.label = label
+        self.textRuns = textRuns
+        self.speakerNotes = speakerNotes
+    }
+}
+
+/// Run-level text keeps paragraph/run coordinates available for later rich
+/// conversion while the current fallback still flattens to paragraph text.
+public struct PresentationTextRun: Codable, Equatable, Sendable {
+    public let text: String
+    public let paragraphIndex: Int
+    public let runIndex: Int
+    public let sourcePart: String
+    public let anchorId: String
+
+    public init(
+        text: String,
+        paragraphIndex: Int,
+        runIndex: Int,
+        sourcePart: String,
+        anchorId: String
+    ) {
+        precondition(paragraphIndex >= 0, "Presentation paragraph index must be non-negative")
+        precondition(runIndex >= 0, "Presentation run index must be non-negative")
+        self.text = text
+        self.paragraphIndex = paragraphIndex
+        self.runIndex = runIndex
+        self.sourcePart = sourcePart
+        self.anchorId = anchorId
+    }
+
+    public static func paragraphText(from runs: [PresentationTextRun]) -> String {
+        var paragraphs: [Int: String] = [:]
+        for run in runs.sorted(by: { ($0.paragraphIndex, $0.runIndex) < ($1.paragraphIndex, $1.runIndex) }) {
+            paragraphs[run.paragraphIndex, default: ""].append(run.text)
+        }
+        return paragraphs.keys.sorted()
+            .compactMap { paragraphs[$0]?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}
+
+/// Speaker notes are modelled separately because they are attached to a slide
+/// but live in a distinct OOXML part with a distinct source anchor.
+public struct PresentationSpeakerNotes: Codable, Equatable, Sendable {
+    public let sourcePart: String
+    public let anchorId: String
+    public let textRuns: [PresentationTextRun]
+
+    public var text: String {
+        PresentationTextRun.paragraphText(from: textRuns)
+    }
+
+    public init(
+        sourcePart: String,
+        anchorId: String,
+        textRuns: [PresentationTextRun]
+    ) {
+        self.sourcePart = sourcePart
+        self.anchorId = anchorId
+        self.textRuns = textRuns
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/RichDocumentRepresentation.swift
+++ b/Packages/OsaurusCore/Models/Documents/RichDocumentRepresentation.swift
@@ -1,0 +1,102 @@
+//
+//  RichDocumentRepresentation.swift
+//  osaurus
+//
+
+import Foundation
+
+/// Safe source-format labels for rich text imports that still flow through
+/// AppKit. The enum keeps the migration adapter honest: it can advertise
+/// "DOCX text imported through NSAttributedString" without implying full
+/// OOXML package fidelity.
+public enum RichDocumentSourceFormat: String, Codable, Equatable, Sendable {
+    case docx
+    case doc
+    case rtf
+    case rtfd
+    case html
+    case unknown
+
+    public init(fileExtension: String) {
+        switch fileExtension.lowercased() {
+        case "docx": self = .docx
+        case "doc": self = .doc
+        case "rtf": self = .rtf
+        case "rtfd": self = .rtfd
+        case "html", "htm": self = .html
+        default: self = .unknown
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .docx: return "Word document (DOCX)"
+        case .doc: return "Word document (legacy DOC)"
+        case .rtf: return "Rich Text Format"
+        case .rtfd: return "Rich Text Format Directory"
+        case .html: return "HTML document"
+        case .unknown: return "Rich document"
+        }
+    }
+}
+
+/// A format-neutral block recovered from `NSAttributedString` paragraph
+/// metadata. These blocks intentionally model only what AppKit exposes
+/// safely; package-native tables, comments, tracked changes, and embedded
+/// object graphs belong to the later high-fidelity Office lanes.
+public struct RichDocumentBlock: Codable, Equatable, Hashable, Sendable {
+    public enum Kind: String, Codable, Sendable {
+        case paragraph
+        case heading
+        case listItem
+    }
+
+    public let kind: Kind
+    public let text: String
+    public let textRange: DocumentTextRange
+    public let sourceIndex: Int
+    public let headingLevel: Int?
+    public let listDepth: Int?
+    public let anchorId: String
+
+    public init(
+        kind: Kind,
+        text: String,
+        textRange: DocumentTextRange,
+        sourceIndex: Int,
+        headingLevel: Int? = nil,
+        listDepth: Int? = nil,
+        anchorId: String
+    ) {
+        self.kind = kind
+        self.text = text
+        self.textRange = textRange
+        self.sourceIndex = sourceIndex
+        self.headingLevel = headingLevel
+        self.listDepth = listDepth
+        self.anchorId = anchorId
+    }
+}
+
+/// Typed representation for the migration rich-document reader. The plain
+/// `text` remains the compatibility contract, while `blocks` give callers a
+/// conservative structure view when AppKit exposed one without extra Office
+/// dependencies.
+public struct RichDocumentRepresentation: StructuredRepresentation, Codable, Equatable, Sendable {
+    public let sourceFormat: RichDocumentSourceFormat
+    public let sourceLabel: String
+    public let text: String
+    public let blocks: [RichDocumentBlock]
+
+    public init(
+        sourceFormat: RichDocumentSourceFormat,
+        sourceLabel: String,
+        text: String,
+        blocks: [RichDocumentBlock]
+    ) {
+        self.sourceFormat = sourceFormat
+        self.sourceLabel = sourceLabel
+        self.text = text
+        self.blocks = blocks
+    }
+}

--- a/Packages/OsaurusCore/Models/Documents/Workbook.swift
+++ b/Packages/OsaurusCore/Models/Documents/Workbook.swift
@@ -1,0 +1,133 @@
+//
+//  Workbook.swift
+//  osaurus
+//
+//  Typed workbook representation for spreadsheet readers. The first XLSX
+//  adapter only fills the stable cell surface that can be extracted without
+//  style evaluation: sheet order/names, sparse rows, scalar cell values, and
+//  formula source text. Styling, number formats, charts, and workbook-level
+//  calculation metadata stay outside this model until a later fidelity slice
+//  can preserve them without guessing.
+//
+
+import Foundation
+
+/// Spreadsheet-native representation carried by `StructuredDocument` so XLSX
+/// ingestion can preserve cell identity while the legacy attachment flow keeps
+/// consuming a plain-text fallback.
+public struct Workbook: StructuredRepresentation, Codable, Equatable, Sendable {
+    public let sheets: [Sheet]
+    public let sharedStrings: [String]
+
+    public init(sheets: [Sheet], sharedStrings: [String] = []) {
+        self.sheets = sheets
+        self.sharedStrings = sharedStrings
+    }
+
+    /// A worksheet is anchored separately from its cells so callers can cite a
+    /// whole tab even when a prompt only includes its rendered text fallback.
+    public struct Sheet: Codable, Equatable, Sendable {
+        public let name: String
+        public let index: Int
+        public let rows: [Row]
+        public let mergedRanges: [CellRange]
+        public let anchor: DocumentAnchor
+
+        public init(
+            name: String,
+            index: Int,
+            rows: [Row],
+            mergedRanges: [CellRange] = [],
+            anchor: DocumentAnchor
+        ) {
+            precondition(index >= 0, "Workbook sheet index must be non-negative")
+            self.name = name
+            self.index = index
+            self.rows = rows
+            self.mergedRanges = mergedRanges
+            self.anchor = anchor
+        }
+    }
+
+    /// XLSX rows are sparse; `number` preserves the one-based worksheet row
+    /// reference instead of implying that array position equals source row.
+    public struct Row: Codable, Equatable, Sendable {
+        public let number: Int
+        public let cells: [Cell]
+        public let anchor: DocumentAnchor
+
+        public init(number: Int, cells: [Cell], anchor: DocumentAnchor) {
+            precondition(number >= 1, "Workbook row number must be one-based")
+            self.number = number
+            self.cells = cells
+            self.anchor = anchor
+        }
+    }
+
+    /// A cell keeps both its A1 reference and numeric coordinates because text
+    /// citations prefer A1 while source anchors need stable row/column indexes.
+    public struct Cell: Codable, Equatable, Sendable {
+        public let reference: String
+        public let rowNumber: Int
+        public let columnNumber: Int
+        public let value: CellValue
+        public let formula: String?
+        public let anchor: DocumentAnchor
+
+        public init(
+            reference: String,
+            rowNumber: Int,
+            columnNumber: Int,
+            value: CellValue,
+            formula: String? = nil,
+            anchor: DocumentAnchor
+        ) {
+            precondition(rowNumber >= 1, "Workbook cell row number must be one-based")
+            precondition(columnNumber >= 1, "Workbook cell column number must be one-based")
+            self.reference = reference
+            self.rowNumber = rowNumber
+            self.columnNumber = columnNumber
+            self.value = value
+            self.formula = formula
+            self.anchor = anchor
+        }
+    }
+
+    /// Scalar cell values intentionally avoid date/style inference. Most XLSX
+    /// writers encode dates as numbers plus styles, and guessing at this layer
+    /// would make typed output less trustworthy than the source package.
+    public enum CellValue: Codable, Equatable, Sendable {
+        case empty
+        case number(Double)
+        case string(String)
+        case bool(Bool)
+
+        public var fallbackText: String {
+            switch self {
+            case .empty:
+                return ""
+            case .number(let value):
+                return value.isFinite
+                    && value >= Double(Int64.min)
+                    && value <= Double(Int64.max)
+                    && value.rounded(.towardZero) == value
+                    ? String(Int64(value))
+                    : String(value)
+            case .string(let value):
+                return value
+            case .bool(let value):
+                return value ? "TRUE" : "FALSE"
+            }
+        }
+    }
+
+    /// Merged ranges stay as A1 strings for now because the reader does not yet
+    /// need to split or validate range endpoints to preserve source identity.
+    public struct CellRange: Codable, Equatable, Hashable, Sendable {
+        public let reference: String
+
+        public init(reference: String) {
+            self.reference = reference
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
@@ -1,0 +1,439 @@
+//
+//  CSVAdapter.swift
+//  osaurus
+//
+//  High-fidelity CSV/TSV reader for the document adapter stack. It keeps the
+//  legacy text attachment contract by emitting a normalized fallback while
+//  also preserving rows, cells, source offsets, and structure anchors.
+//
+
+import Foundation
+
+public struct CSVAdapter: DocumentFormatAdapter {
+    public let delimiter: CSVDelimiter
+    public var formatId: String { delimiter.formatId }
+
+    public init(delimiter: CSVDelimiter = .comma) {
+        self.delimiter = delimiter
+    }
+
+    public func canHandle(url: URL, uti: String?) -> Bool {
+        url.pathExtension.lowercased() == delimiter.fileExtension
+    }
+
+    public func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
+        let fileSize = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        if sizeLimit > 0, fileSize > sizeLimit {
+            throw DocumentAdapterError.sizeLimitExceeded(actual: fileSize, limit: sizeLimit)
+        }
+
+        let source = try Self.readTextSource(url: url)
+        guard !source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DocumentAdapterError.emptyContent
+        }
+
+        let parsedRows = Self.parseRows(source: source, delimiter: delimiter)
+        guard !parsedRows.isEmpty else {
+            throw DocumentAdapterError.emptyContent
+        }
+
+        let built = Self.buildDocument(
+            filename: url.lastPathComponent,
+            delimiter: delimiter,
+            parsedRows: parsedRows,
+            sourceTextLengthUTF16: source.utf16.count
+        )
+        let security = DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: formatId
+        )
+
+        return StructuredDocument(
+            formatId: formatId,
+            filename: url.lastPathComponent,
+            fileSize: fileSize,
+            representation: AnyStructuredRepresentation(
+                formatId: formatId,
+                underlying: built.document
+            ),
+            structure: built.structure,
+            security: security,
+            textFallback: built.document.textFallback
+        )
+    }
+
+    // MARK: - Reading
+
+    private static func readTextSource(url: URL) throws -> String {
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            guard let data = try? Data(contentsOf: url),
+                let decoded = String(data: data, encoding: .isoLatin1)
+            else {
+                throw DocumentAdapterError.readFailed(underlying: error.localizedDescription)
+            }
+            return decoded
+        }
+    }
+
+    // MARK: - Parsing
+
+    private static func parseRows(source: String, delimiter: CSVDelimiter) -> [ParsedRow] {
+        let delimiterScalar = scalar(for: delimiter)
+        let quoteScalar = UnicodeScalar("\"")
+        let carriageReturn = UnicodeScalar("\r")
+        let lineFeed = UnicodeScalar("\n")
+        let scalars = source.unicodeScalars
+
+        var rows: [ParsedRow] = []
+        var cells: [ParsedCell] = []
+        var field = ""
+        var fieldStart = 0
+        var rowStart = 0
+        var offset = 0
+        var isQuoted = false
+        var wasQuoted = false
+        var index = scalars.startIndex
+
+        func finishCell(sourceEnd: Int) {
+            let sourceRange = DocumentTextRange(
+                startUTF16Offset: fieldStart,
+                length: sourceEnd - fieldStart
+            )
+            cells.append(
+                ParsedCell(
+                    text: field,
+                    wasQuoted: wasQuoted,
+                    sourceRange: sourceRange
+                )
+            )
+            field = ""
+            wasQuoted = false
+        }
+
+        func finishRow(sourceEnd: Int) {
+            finishCell(sourceEnd: sourceEnd)
+            let rowRange = DocumentTextRange(
+                startUTF16Offset: rowStart,
+                length: sourceEnd - rowStart
+            )
+            rows.append(ParsedRow(cells: cells, sourceRange: rowRange))
+            cells = []
+        }
+
+        while index != scalars.endIndex {
+            let scalar = scalars[index]
+            let scalarLength = utf16Length(of: scalar)
+
+            if isQuoted {
+                if scalar == quoteScalar {
+                    let nextIndex = scalars.index(after: index)
+                    if nextIndex != scalars.endIndex, scalars[nextIndex] == quoteScalar {
+                        field.unicodeScalars.append(quoteScalar)
+                        scalars.formIndex(after: &index)
+                        scalars.formIndex(after: &index)
+                        offset += 2
+                    } else {
+                        isQuoted = false
+                        scalars.formIndex(after: &index)
+                        offset += scalarLength
+                    }
+                } else {
+                    field.unicodeScalars.append(scalar)
+                    scalars.formIndex(after: &index)
+                    offset += scalarLength
+                }
+                continue
+            }
+
+            if scalar == quoteScalar, field.isEmpty, fieldStart == offset {
+                isQuoted = true
+                wasQuoted = true
+                scalars.formIndex(after: &index)
+                offset += scalarLength
+                continue
+            }
+
+            if scalar == delimiterScalar {
+                finishCell(sourceEnd: offset)
+                scalars.formIndex(after: &index)
+                offset += scalarLength
+                fieldStart = offset
+                continue
+            }
+
+            if scalar == carriageReturn || scalar == lineFeed {
+                finishRow(sourceEnd: offset)
+                let nextIndex = scalars.index(after: index)
+                if scalar == carriageReturn, nextIndex != scalars.endIndex, scalars[nextIndex] == lineFeed {
+                    scalars.formIndex(after: &index)
+                    scalars.formIndex(after: &index)
+                    offset += 2
+                } else {
+                    scalars.formIndex(after: &index)
+                    offset += scalarLength
+                }
+                rowStart = offset
+                fieldStart = offset
+                continue
+            }
+
+            field.unicodeScalars.append(scalar)
+            scalars.formIndex(after: &index)
+            offset += scalarLength
+        }
+
+        if !cells.isEmpty || !field.isEmpty || wasQuoted || fieldStart < offset {
+            finishRow(sourceEnd: offset)
+        }
+
+        return rows
+    }
+
+    private static func scalar(for delimiter: CSVDelimiter) -> UnicodeScalar {
+        switch delimiter {
+        case .comma: return UnicodeScalar(",")
+        case .tab: return UnicodeScalar("\t")
+        }
+    }
+
+    private static func utf16Length(of scalar: UnicodeScalar) -> Int {
+        scalar.value <= 0xFFFF ? 1 : 2
+    }
+
+    // MARK: - Structure
+
+    private static func buildDocument(
+        filename: String,
+        delimiter: CSVDelimiter,
+        parsedRows: [ParsedRow],
+        sourceTextLengthUTF16: Int
+    ) -> BuiltCSVDocument {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let tableAnchor = DocumentAnchor(
+            id: "document/table",
+            kind: .table,
+            path: [
+                .init(kind: .document),
+                .init(kind: .table, identifier: delimiter.formatId),
+            ],
+            textRange: DocumentTextRange(startUTF16Offset: 0, length: 0),
+            sourceRange: .init(
+                start: DocumentSourceLocation(characterOffset: 0, namedRegion: "source"),
+                end: DocumentSourceLocation(characterOffset: sourceTextLengthUTF16, namedRegion: "source")
+            ),
+            label: filename,
+            metadata: ["delimiter": delimiter.rawValue, "formatId": delimiter.formatId]
+        )
+
+        var fallback = ""
+        var fallbackOffset = 0
+        var rows: [CSVRow] = []
+        var rowElements: [DocumentElement] = []
+
+        for parsedRowIndex in parsedRows.indices {
+            let parsedRow = parsedRows[parsedRowIndex]
+            let rowStart = fallbackOffset
+            var rowText = ""
+            var cells: [CSVCell] = []
+            var cellElements: [DocumentElement] = []
+
+            for parsedCellIndex in parsedRow.cells.indices {
+                let parsedCell = parsedRow.cells[parsedCellIndex]
+                if parsedCellIndex > 0 {
+                    fallback += "\t"
+                    rowText += "\t"
+                    fallbackOffset += 1
+                }
+
+                let cellStart = fallbackOffset
+                fallback += parsedCell.text
+                rowText += parsedCell.text
+                fallbackOffset += parsedCell.text.utf16.count
+
+                let cellTextRange = DocumentTextRange(
+                    startUTF16Offset: cellStart,
+                    length: parsedCell.text.utf16.count
+                )
+                let cellAnchor = makeCellAnchor(
+                    rowIndex: parsedRowIndex,
+                    columnIndex: parsedCellIndex,
+                    textRange: cellTextRange,
+                    sourceRange: parsedCell.sourceRange,
+                    wasQuoted: parsedCell.wasQuoted
+                )
+                cells.append(
+                    CSVCell(
+                        rowIndex: parsedRowIndex,
+                        columnIndex: parsedCellIndex,
+                        text: parsedCell.text,
+                        wasQuoted: parsedCell.wasQuoted,
+                        sourceRange: parsedCell.sourceRange,
+                        textRange: cellTextRange,
+                        anchorId: cellAnchor.id
+                    )
+                )
+                cellElements.append(
+                    DocumentElement(
+                        kind: .tableCell,
+                        anchor: cellAnchor,
+                        text: parsedCell.text,
+                        attributes: .init(metadata: cellAnchor.metadata)
+                    )
+                )
+            }
+
+            let rowTextRange = DocumentTextRange(
+                startUTF16Offset: rowStart,
+                length: fallbackOffset - rowStart
+            )
+            let rowAnchor = makeRowAnchor(
+                rowIndex: parsedRowIndex,
+                textRange: rowTextRange,
+                sourceRange: parsedRow.sourceRange
+            )
+            rows.append(
+                CSVRow(
+                    rowIndex: parsedRowIndex,
+                    cells: cells,
+                    sourceRange: parsedRow.sourceRange,
+                    textRange: rowTextRange,
+                    anchorId: rowAnchor.id
+                )
+            )
+            rowElements.append(
+                DocumentElement(
+                    kind: .tableRow,
+                    anchor: rowAnchor,
+                    text: rowText,
+                    attributes: .init(metadata: rowAnchor.metadata),
+                    children: cellElements
+                )
+            )
+
+            if parsedRowIndex < parsedRows.count - 1 {
+                fallback += "\n"
+                fallbackOffset += 1
+            }
+        }
+
+        let tableElement = DocumentElement(
+            kind: .table,
+            anchor: DocumentAnchor(
+                id: tableAnchor.id,
+                kind: tableAnchor.kind,
+                path: tableAnchor.path,
+                textRange: DocumentTextRange(startUTF16Offset: 0, length: fallbackOffset),
+                sourceRange: tableAnchor.sourceRange,
+                label: tableAnchor.label,
+                metadata: tableAnchor.metadata
+            ),
+            children: rowElements
+        )
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: [tableElement]
+        )
+        let structure = DocumentStructure(
+            root: root,
+            textLengthUTF16: fallbackOffset
+        )
+        let document = CSVDocument(
+            delimiter: delimiter,
+            rows: rows,
+            sourceTextLengthUTF16: sourceTextLengthUTF16,
+            textFallback: fallback
+        )
+        return BuiltCSVDocument(document: document, structure: structure)
+    }
+
+    private static func makeRowAnchor(
+        rowIndex: Int,
+        textRange: DocumentTextRange,
+        sourceRange: DocumentTextRange
+    ) -> DocumentAnchor {
+        DocumentAnchor(
+            id: "document/table/rows/\(rowIndex)",
+            kind: .row,
+            path: [
+                .init(kind: .document),
+                .init(kind: .table, identifier: "rows"),
+                .init(kind: .row, index: rowIndex),
+            ],
+            textRange: textRange,
+            sourceRange: makeSourceRange(sourceRange, rowIndex: rowIndex, columnIndex: nil),
+            label: "Row \(rowIndex + 1)",
+            metadata: [
+                "rowIndex": "\(rowIndex)",
+                "sourceStartUTF16": "\(sourceRange.startUTF16Offset)",
+                "sourceLengthUTF16": "\(sourceRange.length)",
+            ]
+        )
+    }
+
+    private static func makeCellAnchor(
+        rowIndex: Int,
+        columnIndex: Int,
+        textRange: DocumentTextRange,
+        sourceRange: DocumentTextRange,
+        wasQuoted: Bool
+    ) -> DocumentAnchor {
+        DocumentAnchor(
+            id: "document/table/rows/\(rowIndex)/cells/\(columnIndex)",
+            kind: .cell,
+            path: [
+                .init(kind: .document),
+                .init(kind: .table, identifier: "rows"),
+                .init(kind: .row, index: rowIndex),
+                .init(kind: .cell, index: columnIndex),
+            ],
+            textRange: textRange,
+            sourceRange: makeSourceRange(sourceRange, rowIndex: rowIndex, columnIndex: columnIndex),
+            label: "R\(rowIndex + 1)C\(columnIndex + 1)",
+            metadata: [
+                "rowIndex": "\(rowIndex)",
+                "columnIndex": "\(columnIndex)",
+                "sourceStartUTF16": "\(sourceRange.startUTF16Offset)",
+                "sourceLengthUTF16": "\(sourceRange.length)",
+                "wasQuoted": "\(wasQuoted)",
+            ]
+        )
+    }
+
+    private static func makeSourceRange(
+        _ range: DocumentTextRange,
+        rowIndex: Int,
+        columnIndex: Int?
+    ) -> DocumentSourceRange {
+        let start = DocumentSourceLocation(
+            rowIndex: rowIndex,
+            columnIndex: columnIndex,
+            characterOffset: range.startUTF16Offset
+        )
+        let end = DocumentSourceLocation(
+            rowIndex: rowIndex,
+            columnIndex: columnIndex,
+            characterOffset: range.endUTF16Offset
+        )
+        return DocumentSourceRange(start: start, end: end)
+    }
+
+    private struct ParsedCell {
+        let text: String
+        let wasQuoted: Bool
+        let sourceRange: DocumentTextRange
+    }
+
+    private struct ParsedRow {
+        let cells: [ParsedCell]
+        let sourceRange: DocumentTextRange
+    }
+
+    private struct BuiltCSVDocument {
+        let document: CSVDocument
+        let structure: DocumentStructure
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntimeDetector.swift
+++ b/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntimeDetector.swift
@@ -1,0 +1,510 @@
+//
+//  ExternalOfficeRuntimeDetector.swift
+//  osaurus
+//
+//  Finds optional office-suite runtimes for future high-fidelity document
+//  work. The detector only verifies executable discovery and bounded
+//  `--version` metadata; it never sends document bytes to the runtime.
+//
+
+import Darwin
+import Foundation
+
+/// Identifies the office-suite family so later document code can choose
+/// conservative compatibility paths without making the runtime mandatory.
+public enum ExternalOfficeRuntimeKind: String, Equatable, Sendable {
+    case libreOffice = "LibreOffice"
+    case openOffice = "OpenOffice"
+}
+
+/// Records where a candidate came from because explicit configuration is a
+/// stronger signal than a generic PATH hit when future consumers explain UI
+/// or diagnostics.
+public enum ExternalOfficeRuntimeSource: Equatable, Sendable {
+    case explicitURL
+    case environmentVariable(name: String)
+    case applicationBundle
+    case searchPath
+}
+
+/// Captures the bounded `--version` probe outcome without retaining raw
+/// process output that could grow large or accidentally include host details.
+public struct ExternalOfficeVersionProbe: Equatable, Sendable {
+    /// Distinguishes a real version response from launch and timeout failures
+    /// without exposing the raw process output.
+    public enum Status: Equatable, Sendable {
+        case exited(status: Int32)
+        case launchFailed
+        case timedOut
+    }
+
+    public let status: Status
+    public let capturedOutputBytes: Int
+    public let outputWasTruncated: Bool
+
+    public init(
+        status: Status,
+        capturedOutputBytes: Int,
+        outputWasTruncated: Bool
+    ) {
+        self.status = status
+        self.capturedOutputBytes = capturedOutputBytes
+        self.outputWasTruncated = outputWasTruncated
+    }
+}
+
+/// Describes a discovered runtime while keeping unavailable results cheap and
+/// explicit; absence of this optional dependency must never block parsing.
+public struct ExternalOfficeRuntimeSnapshot: Equatable, Sendable {
+    public let available: Bool
+    public let kind: ExternalOfficeRuntimeKind?
+    public let version: String?
+    public let executableURL: URL?
+    public let source: ExternalOfficeRuntimeSource?
+    public let versionProbe: ExternalOfficeVersionProbe?
+
+    public init(
+        available: Bool,
+        kind: ExternalOfficeRuntimeKind?,
+        version: String?,
+        executableURL: URL?,
+        source: ExternalOfficeRuntimeSource?,
+        versionProbe: ExternalOfficeVersionProbe?
+    ) {
+        self.available = available
+        self.kind = kind
+        self.version = version
+        self.executableURL = executableURL
+        self.source = source
+        self.versionProbe = versionProbe
+    }
+
+    public static let unavailable = ExternalOfficeRuntimeSnapshot(
+        available: false,
+        kind: nil,
+        version: nil,
+        executableURL: nil,
+        source: nil,
+        versionProbe: nil
+    )
+}
+
+/// Performs narrow, side-effect-light runtime discovery for LibreOffice and
+/// OpenOffice style `soffice` executables ahead of future conversion support.
+public struct ExternalOfficeRuntimeDetector: Sendable {
+    /// Keeps each filesystem probe explicit so tests and future callers can
+    /// verify ordering without mutating global process environment.
+    public struct Candidate: Equatable, Sendable {
+        public let executableURL: URL
+        public let kind: ExternalOfficeRuntimeKind?
+        public let source: ExternalOfficeRuntimeSource
+
+        public init(
+            executableURL: URL,
+            kind: ExternalOfficeRuntimeKind?,
+            source: ExternalOfficeRuntimeSource
+        ) {
+            self.executableURL = executableURL
+            self.kind = kind
+            self.source = source
+        }
+    }
+
+    /// Carries all external inputs for detection so production behavior stays
+    /// deterministic and tests can use temporary fake executables.
+    public struct Configuration: Sendable {
+        public var explicitExecutableURL: URL?
+        public var environment: [String: String]
+        public var commonApplicationCandidates: [Candidate]
+        public var versionProbeTimeoutSeconds: TimeInterval
+        public var maxVersionProbeOutputBytes: Int
+
+        public init(
+            explicitExecutableURL: URL? = nil,
+            environment: [String: String] = ProcessInfo.processInfo.environment,
+            commonApplicationCandidates: [Candidate] = Candidate.defaultApplicationCandidates,
+            versionProbeTimeoutSeconds: TimeInterval = 2.0,
+            maxVersionProbeOutputBytes: Int = 4_096
+        ) {
+            self.explicitExecutableURL = explicitExecutableURL
+            self.environment = environment
+            self.commonApplicationCandidates = commonApplicationCandidates
+            self.versionProbeTimeoutSeconds = versionProbeTimeoutSeconds
+            self.maxVersionProbeOutputBytes = maxVersionProbeOutputBytes
+        }
+    }
+
+    /// Preferred environment knobs for a user or integration test that wants
+    /// to point Osaurus at a specific office runtime.
+    public static let environmentExecutableKeys = [
+        "OSAURUS_OFFICE_RUNTIME_URL",
+        "OSAURUS_OFFICE_RUNTIME_PATH",
+    ]
+
+    private let configuration: Configuration
+
+    public init(configuration: Configuration = Configuration()) {
+        self.configuration = configuration
+    }
+
+    public func detect() async -> ExternalOfficeRuntimeSnapshot {
+        for candidate in orderedCandidates() {
+            if let snapshot = await probe(candidate) {
+                return snapshot
+            }
+        }
+        return .unavailable
+    }
+
+    private func orderedCandidates() -> [Candidate] {
+        var candidates: [Candidate] = []
+
+        if let explicitExecutableURL = configuration.explicitExecutableURL {
+            candidates.append(
+                Candidate(
+                    executableURL: explicitExecutableURL,
+                    kind: Self.kindHint(from: explicitExecutableURL),
+                    source: .explicitURL
+                )
+            )
+        }
+
+        for key in Self.environmentExecutableKeys {
+            guard let value = configuration.environment[key],
+                let url = Self.executableURL(fromEnvironmentValue: value)
+            else {
+                continue
+            }
+            candidates.append(
+                Candidate(
+                    executableURL: url,
+                    kind: Self.kindHint(from: url),
+                    source: .environmentVariable(name: key)
+                )
+            )
+        }
+
+        candidates.append(contentsOf: configuration.commonApplicationCandidates)
+        candidates.append(contentsOf: pathCandidates())
+        return candidates
+    }
+
+    private func pathCandidates() -> [Candidate] {
+        guard let path = configuration.environment["PATH"] else {
+            return []
+        }
+
+        return
+            path
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .compactMap { directory in
+                let directoryPath = String(directory)
+                guard directoryPath.hasPrefix("/") else {
+                    return nil
+                }
+
+                let executableURL = URL(fileURLWithPath: directoryPath, isDirectory: true)
+                    .appendingPathComponent("soffice")
+                    .standardizedFileURL
+                return Candidate(
+                    executableURL: executableURL,
+                    kind: Self.kindHint(from: executableURL),
+                    source: .searchPath
+                )
+            }
+    }
+
+    private func probe(
+        _ candidate: Candidate
+    ) async -> ExternalOfficeRuntimeSnapshot? {
+        let executableURL = candidate.executableURL.standardizedFileURL
+        guard Self.isExecutableFile(executableURL) else {
+            return nil
+        }
+
+        let probeResult = await Self.runVersionProbe(
+            executableURL: executableURL,
+            timeoutSeconds: configuration.versionProbeTimeoutSeconds,
+            maxOutputBytes: configuration.maxVersionProbeOutputBytes
+        )
+        let parsed = probeResult.output.flatMap(Self.parseVersionOutput)
+
+        return ExternalOfficeRuntimeSnapshot(
+            available: true,
+            kind: parsed?.kind ?? candidate.kind ?? Self.kindHint(from: executableURL),
+            version: parsed?.version,
+            executableURL: executableURL,
+            source: candidate.source,
+            versionProbe: probeResult.metadata
+        )
+    }
+
+    private static func executableURL(fromEnvironmentValue value: String) -> URL? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: trimmed), url.scheme != nil {
+            guard url.isFileURL else {
+                return nil
+            }
+            return url.standardizedFileURL
+        }
+
+        let expanded = NSString(string: trimmed).expandingTildeInPath
+        guard expanded.hasPrefix("/") else {
+            return nil
+        }
+        return URL(fileURLWithPath: expanded).standardizedFileURL
+    }
+
+    private static func isExecutableFile(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        let path = url.path
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+            !isDirectory.boolValue
+        else {
+            return false
+        }
+        return FileManager.default.isExecutableFile(atPath: path)
+    }
+
+    static func parseVersionOutput(_ output: String) -> ParsedVersion? {
+        let normalizedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedOutput.isEmpty else {
+            return nil
+        }
+
+        let lowercasedOutput = normalizedOutput.lowercased()
+        let kind: ExternalOfficeRuntimeKind?
+        if lowercasedOutput.contains("libreoffice") {
+            kind = .libreOffice
+        } else if lowercasedOutput.contains("openoffice") {
+            kind = .openOffice
+        } else {
+            kind = nil
+        }
+
+        let version =
+            normalizedOutput
+            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .compactMap { versionPrefix(in: String($0)) }
+            .first
+
+        if kind == nil, version == nil {
+            return nil
+        }
+        return ParsedVersion(kind: kind, version: version)
+    }
+
+    private static func versionPrefix(in token: String) -> String? {
+        guard let first = token.unicodeScalars.first,
+            CharacterSet.decimalDigits.contains(first)
+        else {
+            return nil
+        }
+
+        var result = String.UnicodeScalarView()
+        var sawDot = false
+        for scalar in token.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) || scalar == "."
+                || scalar == "-" || scalar == "_"
+            {
+                if scalar == "." {
+                    sawDot = true
+                }
+                result.append(scalar)
+            } else {
+                break
+            }
+        }
+
+        let version = String(result).trimmingCharacters(in: CharacterSet(charactersIn: ".-_"))
+        return sawDot && !version.isEmpty ? version : nil
+    }
+
+    private static func kindHint(from url: URL) -> ExternalOfficeRuntimeKind? {
+        let lowercasedPath = url.path.lowercased()
+        if lowercasedPath.contains("libreoffice") {
+            return .libreOffice
+        }
+        if lowercasedPath.contains("openoffice") {
+            return .openOffice
+        }
+        return nil
+    }
+
+    private static func runVersionProbe(
+        executableURL: URL,
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int
+    ) async -> VersionProbeResult {
+        await Task.detached(priority: .utility) {
+            runVersionProbeSynchronously(
+                executableURL: executableURL,
+                timeoutSeconds: timeoutSeconds,
+                maxOutputBytes: maxOutputBytes
+            )
+        }.value
+    }
+
+    private static func runVersionProbeSynchronously(
+        executableURL: URL,
+        timeoutSeconds: TimeInterval,
+        maxOutputBytes: Int
+    ) -> VersionProbeResult {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExternalOfficeRuntime-\(UUID().uuidString).version")
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let outputHandle: FileHandle
+        do {
+            outputHandle = try FileHandle(forWritingTo: outputURL)
+        } catch {
+            return VersionProbeResult(
+                metadata: ExternalOfficeVersionProbe(
+                    status: .launchFailed,
+                    capturedOutputBytes: 0,
+                    outputWasTruncated: false
+                ),
+                output: nil
+            )
+        }
+        defer { try? outputHandle.close() }
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = ["--version"]
+        process.standardOutput = outputHandle
+        process.standardError = outputHandle
+
+        do {
+            try process.run()
+        } catch {
+            return VersionProbeResult(
+                metadata: ExternalOfficeVersionProbe(
+                    status: .launchFailed,
+                    capturedOutputBytes: 0,
+                    outputWasTruncated: false
+                ),
+                output: nil
+            )
+        }
+
+        if waitForExit(process, timeoutSeconds: timeoutSeconds) == false {
+            stop(process)
+            let captured = capturedOutput(at: outputURL, maxBytes: maxOutputBytes)
+            return VersionProbeResult(
+                metadata: ExternalOfficeVersionProbe(
+                    status: .timedOut,
+                    capturedOutputBytes: captured.bytes,
+                    outputWasTruncated: captured.truncated
+                ),
+                output: nil
+            )
+        }
+
+        let captured = capturedOutput(at: outputURL, maxBytes: maxOutputBytes)
+        return VersionProbeResult(
+            metadata: ExternalOfficeVersionProbe(
+                status: .exited(status: process.terminationStatus),
+                capturedOutputBytes: captured.bytes,
+                outputWasTruncated: captured.truncated
+            ),
+            output: process.terminationStatus == 0 && captured.truncated == false
+                ? captured.text : nil
+        )
+    }
+
+    private static func waitForExit(
+        _ process: Process,
+        timeoutSeconds: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(max(timeoutSeconds, 0))
+        while process.isRunning {
+            if Date() >= deadline {
+                return false
+            }
+            Thread.sleep(forTimeInterval: min(0.01, max(0.001, deadline.timeIntervalSinceNow)))
+        }
+        return true
+    }
+
+    private static func stop(_ process: Process) {
+        guard process.isRunning else {
+            return
+        }
+
+        process.terminate()
+        let deadline = Date().addingTimeInterval(0.2)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+        }
+    }
+
+    private static func capturedOutput(
+        at url: URL,
+        maxBytes: Int
+    ) -> CapturedOutput {
+        let readLimit = max(0, maxBytes)
+        guard readLimit > 0,
+            let handle = try? FileHandle(forReadingFrom: url)
+        else {
+            return CapturedOutput(text: "", bytes: 0, truncated: false)
+        }
+        defer { try? handle.close() }
+
+        let data = (try? handle.read(upToCount: readLimit + 1)) ?? Data()
+        let truncated = data.count > readLimit
+        let limitedData = truncated ? Data(data.prefix(readLimit)) : data
+        return CapturedOutput(
+            text: String(data: limitedData, encoding: .utf8) ?? "",
+            bytes: limitedData.count,
+            truncated: truncated
+        )
+    }
+}
+
+extension ExternalOfficeRuntimeDetector.Candidate {
+    /// Default macOS app bundle probes keep production discovery useful
+    /// without adding a runtime dependency or launching conversions.
+    public static let defaultApplicationCandidates: [Self] = [
+        .init(
+            executableURL: URL(
+                fileURLWithPath: "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+            ),
+            kind: .libreOffice,
+            source: .applicationBundle
+        ),
+        .init(
+            executableURL: URL(
+                fileURLWithPath: "/Applications/OpenOffice.app/Contents/MacOS/soffice"
+            ),
+            kind: .openOffice,
+            source: .applicationBundle
+        ),
+    ]
+}
+
+struct ParsedVersion: Equatable, Sendable {
+    let kind: ExternalOfficeRuntimeKind?
+    let version: String?
+}
+
+private struct VersionProbeResult: Sendable {
+    let metadata: ExternalOfficeVersionProbe
+    let output: String?
+}
+
+private struct CapturedOutput: Sendable {
+    let text: String
+    let bytes: Int
+    let truncated: Bool
+}

--- a/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
@@ -94,10 +94,143 @@ public struct PDFAdapter: DocumentFormatAdapter {
         extractedText: String,
         textFallback: String
     ) -> DocumentStructure {
-        guard extractedText == textFallback else {
+        guard !pages.isEmpty else {
             return DocumentStructure.plainText(filename: filename, text: textFallback)
         }
-        return DocumentStructure.paginatedText(filename: filename, pages: pages)
+        return Self.paginatedTextStructure(
+            filename: filename,
+            pages: pages,
+            extractedText: extractedText,
+            textFallback: textFallback
+        )
+    }
+
+    private static func paginatedTextStructure(
+        filename: String,
+        pages: [DocumentPageText],
+        extractedText: String,
+        textFallback: String
+    ) -> DocumentStructure {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let visiblePrefixLength = Self.visibleExtractedPrefixUTF16Length(
+            extractedText: extractedText,
+            textFallback: textFallback
+        )
+        var extractedOffset = 0
+        var elements: [DocumentElement] = []
+
+        for (order, page) in pages.enumerated() {
+            if order > 0 {
+                extractedOffset += Self.pageSeparatorUTF16Length
+            }
+
+            let sourceLength = page.text.utf16.count
+            let visibleLength = min(sourceLength, max(0, visiblePrefixLength - extractedOffset))
+            let fallbackStart = min(extractedOffset, visiblePrefixLength)
+            let range = DocumentTextRange(startUTF16Offset: fallbackStart, length: visibleLength)
+            let clippedText = Self.prefix(page.text, maxUTF16Length: visibleLength)
+            let wasClipped = visibleLength < sourceLength
+            let metadata = Self.pageMetadata(
+                pageIndex: page.pageIndex,
+                order: order,
+                sourceLength: sourceLength,
+                visibleLength: visibleLength,
+                range: range,
+                wasClipped: wasClipped
+            )
+            let anchor = DocumentAnchor(
+                kind: .page,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .page, index: page.pageIndex),
+                ],
+                textRange: range,
+                sourceRange: .init(
+                    start: .init(pageIndex: page.pageIndex, characterOffset: 0),
+                    end: .init(pageIndex: page.pageIndex, characterOffset: visibleLength)
+                ),
+                label: "Page \(page.pageIndex + 1)",
+                metadata: metadata
+            )
+            elements.append(
+                DocumentElement(
+                    kind: .page,
+                    anchor: anchor,
+                    text: clippedText.isEmpty ? nil : clippedText,
+                    attributes: .init(metadata: metadata)
+                )
+            )
+            extractedOffset += sourceLength
+        }
+
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: elements
+        )
+        return DocumentStructure(root: root, textLengthUTF16: textFallback.utf16.count)
+    }
+
+    private static func visibleExtractedPrefixUTF16Length(
+        extractedText: String,
+        textFallback: String
+    ) -> Int {
+        if extractedText == textFallback {
+            return textFallback.utf16.count
+        }
+
+        // The fallback may contain the truncation marker, which is not source
+        // PDF text. Only the shared prefix can safely receive page anchors.
+        var extractedIndex = extractedText.startIndex
+        var fallbackIndex = textFallback.startIndex
+        var length = 0
+        while extractedIndex < extractedText.endIndex,
+            fallbackIndex < textFallback.endIndex,
+            extractedText[extractedIndex] == textFallback[fallbackIndex]
+        {
+            let nextExtractedIndex = extractedText.index(after: extractedIndex)
+            length += extractedText[extractedIndex ..< nextExtractedIndex].utf16.count
+            extractedIndex = nextExtractedIndex
+            fallbackIndex = textFallback.index(after: fallbackIndex)
+        }
+        return length
+    }
+
+    private static func prefix(_ text: String, maxUTF16Length: Int) -> String {
+        guard maxUTF16Length > 0 else { return "" }
+        guard text.utf16.count > maxUTF16Length else { return text }
+
+        var endIndex = text.startIndex
+        var length = 0
+        while endIndex < text.endIndex {
+            let nextIndex = text.index(after: endIndex)
+            let nextLength = text[endIndex ..< nextIndex].utf16.count
+            guard length + nextLength <= maxUTF16Length else { break }
+            length += nextLength
+            endIndex = nextIndex
+        }
+        return String(text[..<endIndex])
+    }
+
+    private static func pageMetadata(
+        pageIndex: Int,
+        order: Int,
+        sourceLength: Int,
+        visibleLength: Int,
+        range: DocumentTextRange,
+        wasClipped: Bool
+    ) -> [String: String] {
+        [
+            "pageIndex": "\(pageIndex)",
+            "pageNumber": "\(pageIndex + 1)",
+            "pageOrder": "\(order)",
+            "fallbackStartUTF16Offset": "\(range.startUTF16Offset)",
+            "fallbackEndUTF16Offset": "\(range.endUTF16Offset)",
+            "sourceTextUTF16Length": "\(sourceLength)",
+            "visibleTextUTF16Length": "\(visibleLength)",
+            "truncatedByFallbackCap": "\(wasClipped)",
+        ]
     }
 
     private static func securitySignals(
@@ -145,7 +278,7 @@ public struct PDFAdapter: DocumentFormatAdapter {
             DocumentSecurityFinding(
                 kind: .truncatedContent,
                 severity: .low,
-                message: "PDF text fallback was character-capped; page-level text ranges were not preserved.",
+                message: "PDF text fallback was character-capped; page anchors were clipped to visible fallback text.",
                 metadata: [
                     "extractedUTF16Length": "\(extractedText.utf16.count)",
                     "fallbackUTF16Length": "\(textFallback.utf16.count)",
@@ -158,4 +291,6 @@ public struct PDFAdapter: DocumentFormatAdapter {
         let pageIndex: Int
         let text: String
     }
+
+    private static let pageSeparatorUTF16Length = "\n\n".utf16.count
 }

--- a/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
@@ -1,0 +1,1268 @@
+//
+//  PPTXAdapter.swift
+//  osaurus
+//
+//  Read-only PPTX/POTX adapter. It uses a small bounded ZIP reader for the
+//  OpenXML parts needed for slide text and speaker notes, avoiding shell
+//  extraction and failing closed on archive features this lane does not need.
+//
+
+import Compression
+import Foundation
+
+/// Extracts basic text-bearing presentation structure without claiming to
+/// support the full OOXML drawing, media, chart, or layout model.
+public struct PPTXAdapter: DocumentFormatAdapter {
+    public static let id = "pptx"
+
+    public let formatId = PPTXAdapter.id
+
+    public init() {}
+
+    public func canHandle(url: URL, uti: String?) -> Bool {
+        let fileExtension = url.pathExtension.lowercased()
+        if ["pptx", "potx"].contains(fileExtension) {
+            return true
+        }
+
+        guard let uti else { return false }
+        return [
+            "org.openxmlformats.presentationml.presentation",
+            "org.openxmlformats.presentationml.template",
+            "com.microsoft.powerpoint.pptx",
+            "com.microsoft.powerpoint.potx",
+        ].contains(uti)
+    }
+
+    public func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
+        try Task.checkCancellation()
+
+        let fileSize = try Self.fileSize(for: url)
+        let effectiveLimit = sizeLimit > 0 ? sizeLimit : DocumentLimits.presentation
+        if fileSize > effectiveLimit {
+            throw DocumentAdapterError.sizeLimitExceeded(actual: fileSize, limit: effectiveLimit)
+        }
+        guard fileSize <= Int64(Int.max) else {
+            throw DocumentAdapterError.sizeLimitExceeded(actual: fileSize, limit: Int64(Int.max))
+        }
+
+        do {
+            let maxArchiveBytes = Int(min(effectiveLimit, Int64(Int.max)))
+            let archive = try BoundedZipReader(url: url, maxArchiveBytes: maxArchiveBytes)
+            let presentation = try await Self.parsePresentation(from: archive, url: url)
+            let built = Self.buildFallbackAndStructure(for: presentation, filename: url.lastPathComponent)
+            let textFallback = PlainTextAdapter.applyCharacterCap(built.text)
+            guard !textFallback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw DocumentAdapterError.emptyContent
+            }
+
+            let security = try Self.securityMetadata(
+                for: url,
+                archive: archive,
+                extractedText: built.text,
+                textFallback: textFallback
+            )
+            let structure =
+                built.text == textFallback
+                ? built.structure
+                : DocumentStructure.plainText(filename: url.lastPathComponent, text: textFallback)
+
+            return StructuredDocument(
+                formatId: formatId,
+                filename: url.lastPathComponent,
+                fileSize: fileSize,
+                representation: AnyStructuredRepresentation(
+                    formatId: formatId,
+                    underlying: presentation
+                ),
+                structure: structure,
+                security: security,
+                textFallback: textFallback
+            )
+        } catch is CancellationError {
+            throw DocumentAdapterError.cancelled
+        } catch let error as DocumentAdapterError {
+            throw error
+        } catch {
+            throw DocumentAdapterError.readFailed(underlying: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Presentation parse
+
+    private static func parsePresentation(
+        from archive: BoundedZipReader,
+        url: URL
+    ) async throws -> PresentationDocument {
+        let slideParts = try slideParts(in: archive)
+        guard !slideParts.isEmpty else {
+            throw DocumentAdapterError.readFailed(underlying: "PPTX package contains no slide XML parts.")
+        }
+
+        var slides: [PresentationSlide] = []
+        for (index, slidePart) in slideParts.enumerated() {
+            try Task.checkCancellation()
+
+            let slideRuns = try textRuns(
+                in: slidePart.path,
+                from: archive,
+                slideIndex: index,
+                region: .slideText
+            )
+            let notesPart = try notesPart(for: slidePart, in: archive)
+            let speakerNotes = try notesPart.map { part in
+                PresentationSpeakerNotes(
+                    sourcePart: part,
+                    anchorId: notesAnchorId(slideIndex: index),
+                    textRuns: try textRuns(
+                        in: part,
+                        from: archive,
+                        slideIndex: index,
+                        region: .speakerNotes
+                    )
+                )
+            }
+
+            slides.append(
+                PresentationSlide(
+                    index: index,
+                    number: slidePart.number,
+                    sourcePart: slidePart.path,
+                    label: "Slide \(index + 1)",
+                    textRuns: slideRuns,
+                    speakerNotes: speakerNotes?.text.isEmpty == false ? speakerNotes : nil
+                )
+            )
+        }
+
+        let kind: PresentationDocumentKind = url.pathExtension.lowercased() == "potx" ? .template : .presentation
+        return PresentationDocument(
+            kind: kind,
+            sourceName: url.lastPathComponent,
+            slides: slides
+        )
+    }
+
+    private static func slideParts(in archive: BoundedZipReader) throws -> [SlidePart] {
+        let ordered = try slidePartsFromPresentationRelationships(in: archive)
+        if !ordered.isEmpty {
+            return ordered
+        }
+
+        return archive.entryNames.compactMap { path -> SlidePart? in
+            guard path.hasPrefix("ppt/slides/slide"), path.hasSuffix(".xml"),
+                let number = numberedPart(path: path, prefix: "ppt/slides/slide")
+            else {
+                return nil
+            }
+            return SlidePart(number: number, path: path)
+        }
+        .sorted {
+            if $0.number == $1.number {
+                return $0.path < $1.path
+            }
+            return $0.number < $1.number
+        }
+    }
+
+    private static func slidePartsFromPresentationRelationships(
+        in archive: BoundedZipReader
+    ) throws -> [SlidePart] {
+        guard archive.contains("ppt/presentation.xml"),
+            archive.contains("ppt/_rels/presentation.xml.rels")
+        else {
+            return []
+        }
+
+        let slideIds = try slideRelationshipIds(in: "ppt/presentation.xml", from: archive)
+        guard !slideIds.isEmpty else { return [] }
+
+        let relationships = try relationships(in: "ppt/_rels/presentation.xml.rels", from: archive)
+        var byId: [String: OpenXMLRelationship] = [:]
+        for relationship in relationships where byId[relationship.id] == nil {
+            byId[relationship.id] = relationship
+        }
+        return slideIds.compactMap { relationshipId -> SlidePart? in
+            guard let relationship = byId[relationshipId],
+                relationship.targetMode != .external,
+                relationship.type.contains("/slide"),
+                let path = resolveRelationshipTarget(
+                    from: "ppt/presentation.xml",
+                    target: relationship.target
+                ),
+                archive.contains(path)
+            else {
+                return nil
+            }
+            return SlidePart(
+                number: numberedPart(path: path, prefix: "ppt/slides/slide") ?? 1,
+                path: path
+            )
+        }
+    }
+
+    private static func notesPart(
+        for slide: SlidePart,
+        in archive: BoundedZipReader
+    ) throws -> String? {
+        let relationshipsPath = relationshipsPart(for: slide.path)
+        if archive.contains(relationshipsPath) {
+            let relationships = try relationships(in: relationshipsPath, from: archive)
+            for relationship in relationships
+            where relationship.targetMode != .external && relationship.type.contains("/notesSlide") {
+                guard let path = resolveRelationshipTarget(from: slide.path, target: relationship.target) else {
+                    continue
+                }
+                if archive.contains(path) {
+                    return path
+                }
+            }
+        }
+
+        let fallback = "ppt/notesSlides/notesSlide\(slide.number).xml"
+        return archive.contains(fallback) ? fallback : nil
+    }
+
+    private static func textRuns(
+        in part: String,
+        from archive: BoundedZipReader,
+        slideIndex: Int,
+        region: PresentationTextRegion
+    ) throws -> [PresentationTextRun] {
+        let data = try archive.entryData(part, maxUncompressedBytes: Constants.maxXMLPartBytes)
+        let collector = OpenXMLTextRunCollector(maxUTF16Length: Constants.maxTextPartUTF16)
+        let parser = XMLParser(data: data)
+        parser.delegate = collector
+        parser.shouldResolveExternalEntities = false
+
+        guard parser.parse() else {
+            if collector.didOverflow {
+                throw DocumentAdapterError.readFailed(
+                    underlying: "\(part) exceeded the PPTX text extraction limit."
+                )
+            }
+            if collector.didExceedDepth {
+                throw DocumentAdapterError.readFailed(
+                    underlying: "\(part) exceeded the PPTX XML nesting limit."
+                )
+            }
+            let message = parser.parserError?.localizedDescription ?? "Invalid XML in \(part)."
+            throw DocumentAdapterError.readFailed(underlying: message)
+        }
+
+        return collector.runs.map { run in
+            PresentationTextRun(
+                text: run.text,
+                paragraphIndex: run.paragraphIndex,
+                runIndex: run.runIndex,
+                sourcePart: part,
+                anchorId: textRunAnchorId(
+                    slideIndex: slideIndex,
+                    region: region,
+                    paragraphIndex: run.paragraphIndex,
+                    runIndex: run.runIndex
+                )
+            )
+        }
+    }
+
+    private static func slideRelationshipIds(
+        in part: String,
+        from archive: BoundedZipReader
+    ) throws -> [String] {
+        let data = try archive.entryData(part, maxUncompressedBytes: Constants.maxXMLPartBytes)
+        let collector = OpenXMLSlideOrderCollector()
+        let parser = XMLParser(data: data)
+        parser.delegate = collector
+        parser.shouldResolveExternalEntities = false
+
+        guard parser.parse() else {
+            let message = parser.parserError?.localizedDescription ?? "Invalid XML in \(part)."
+            throw DocumentAdapterError.readFailed(underlying: message)
+        }
+        return collector.relationshipIds
+    }
+
+    private static func relationships(
+        in part: String,
+        from archive: BoundedZipReader
+    ) throws -> [OpenXMLRelationship] {
+        let data = try archive.entryData(part, maxUncompressedBytes: Constants.maxXMLPartBytes)
+        let collector = OpenXMLRelationshipCollector()
+        let parser = XMLParser(data: data)
+        parser.delegate = collector
+        parser.shouldResolveExternalEntities = false
+
+        guard parser.parse() else {
+            let message = parser.parserError?.localizedDescription ?? "Invalid XML in \(part)."
+            throw DocumentAdapterError.readFailed(underlying: message)
+        }
+        return collector.relationships
+    }
+
+    // MARK: - Fallback and structure
+
+    private static func buildFallbackAndStructure(
+        for presentation: PresentationDocument,
+        filename: String
+    ) -> (text: String, structure: DocumentStructure) {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        var text = ""
+        var slideElements: [DocumentElement] = []
+
+        for slide in presentation.slides {
+            if !text.isEmpty {
+                text.append("\n\n")
+            }
+            let slideStart = text.utf16.count
+            text.append(slide.label)
+
+            var children = appendParagraphElements(
+                runs: slide.textRuns,
+                slide: slide,
+                region: .slideText,
+                text: &text
+            ).elements
+
+            if let notes = slide.speakerNotes, !notes.text.isEmpty {
+                text.append("\nSpeaker notes:")
+                let appended = appendParagraphElements(
+                    runs: notes.textRuns,
+                    slide: slide,
+                    region: .speakerNotes,
+                    text: &text
+                )
+                let notesAnchor = DocumentAnchor(
+                    id: notes.anchorId,
+                    kind: .speakerNotes,
+                    path: [
+                        .init(kind: .document),
+                        .init(kind: .slide, index: slide.index),
+                        .init(kind: .speakerNotes),
+                    ],
+                    textRange: DocumentTextRange(
+                        startUTF16Offset: appended.textStart,
+                        length: appended.textEnd - appended.textStart
+                    ),
+                    sourceRange: .init(
+                        start: DocumentSourceLocation(
+                            slideIndex: slide.index,
+                            namedRegion: "speakerNotes"
+                        )
+                    ),
+                    label: "\(slide.label) speaker notes",
+                    metadata: ["sourcePart": notes.sourcePart]
+                )
+                children.append(
+                    DocumentElement(
+                        kind: .speakerNotes,
+                        anchor: notesAnchor,
+                        text: notes.text,
+                        attributes: .init(role: "speakerNotes"),
+                        children: appended.elements
+                    )
+                )
+            }
+
+            let slideAnchor = DocumentAnchor(
+                id: slideAnchorId(slideIndex: slide.index),
+                kind: .slide,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .slide, index: slide.index),
+                ],
+                textRange: DocumentTextRange(
+                    startUTF16Offset: slideStart,
+                    length: text.utf16.count - slideStart
+                ),
+                sourceRange: .init(start: .slide(slide.index)),
+                label: slide.label,
+                metadata: [
+                    "sourcePart": slide.sourcePart,
+                    "slideNumber": "\(slide.number)",
+                ]
+            )
+            slideElements.append(
+                DocumentElement(
+                    kind: .slide,
+                    anchor: slideAnchor,
+                    text: slide.text,
+                    attributes: .init(metadata: ["slideNumber": "\(slide.number)"]),
+                    children: children
+                )
+            )
+        }
+
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: slideElements
+        )
+        return (
+            text,
+            DocumentStructure(root: root, textLengthUTF16: text.utf16.count)
+        )
+    }
+
+    private static func appendParagraphElements(
+        runs: [PresentationTextRun],
+        slide: PresentationSlide,
+        region: PresentationTextRegion,
+        text: inout String
+    ) -> ParagraphAppendResult {
+        let paragraphs = groupedParagraphs(runs)
+        var elements: [DocumentElement] = []
+        var firstStart: Int?
+
+        for paragraph in paragraphs {
+            text.append("\n")
+            let paragraphStart = text.utf16.count
+            firstStart = firstStart ?? paragraphStart
+            var runOffset = 0
+            var runElements: [DocumentElement] = []
+            let paragraphText = paragraph.runs.map(\.text).joined()
+
+            for run in paragraph.runs {
+                let range = DocumentTextRange(
+                    startUTF16Offset: paragraphStart + runOffset,
+                    length: run.text.utf16.count
+                )
+                let anchor = DocumentAnchor(
+                    id: run.anchorId,
+                    kind: .run,
+                    path: anchorPath(
+                        slideIndex: slide.index,
+                        region: region,
+                        paragraphIndex: paragraph.index,
+                        runIndex: run.runIndex
+                    ),
+                    textRange: range,
+                    sourceRange: .init(
+                        start: DocumentSourceLocation(
+                            slideIndex: slide.index,
+                            paragraphIndex: paragraph.index,
+                            runIndex: run.runIndex,
+                            namedRegion: region.sourceRegionName
+                        )
+                    ),
+                    label: "\(slide.label) \(region.label) run \(paragraph.index + 1).\(run.runIndex + 1)",
+                    metadata: ["sourcePart": run.sourcePart]
+                )
+                runElements.append(
+                    DocumentElement(
+                        kind: .run,
+                        anchor: anchor,
+                        text: run.text,
+                        attributes: .init(role: region.rawValue)
+                    )
+                )
+                runOffset += run.text.utf16.count
+            }
+
+            text.append(paragraphText)
+            let paragraphAnchor = DocumentAnchor(
+                id: paragraphAnchorId(
+                    slideIndex: slide.index,
+                    region: region,
+                    paragraphIndex: paragraph.index
+                ),
+                kind: .paragraph,
+                path: anchorPath(
+                    slideIndex: slide.index,
+                    region: region,
+                    paragraphIndex: paragraph.index
+                ),
+                textRange: DocumentTextRange(
+                    startUTF16Offset: paragraphStart,
+                    length: paragraphText.utf16.count
+                ),
+                sourceRange: .init(
+                    start: DocumentSourceLocation(
+                        slideIndex: slide.index,
+                        paragraphIndex: paragraph.index,
+                        namedRegion: region.sourceRegionName
+                    )
+                ),
+                label: "\(slide.label) \(region.label) paragraph \(paragraph.index + 1)",
+                metadata: ["sourcePart": paragraph.runs.first?.sourcePart ?? slide.sourcePart]
+            )
+            elements.append(
+                DocumentElement(
+                    kind: region == .slideText && paragraph.index == 0 ? .heading : .paragraph,
+                    anchor: paragraphAnchor,
+                    text: paragraphText,
+                    attributes: .init(role: region.rawValue),
+                    children: runElements
+                )
+            )
+        }
+
+        let textEnd = text.utf16.count
+        return ParagraphAppendResult(
+            elements: elements,
+            textStart: firstStart ?? textEnd,
+            textEnd: textEnd
+        )
+    }
+
+    private static func groupedParagraphs(
+        _ runs: [PresentationTextRun]
+    ) -> [PresentationParagraphRuns] {
+        let grouped = Dictionary(grouping: runs, by: \.paragraphIndex)
+        return grouped.keys.sorted().compactMap { index in
+            guard let runs = grouped[index] else { return nil }
+            let sorted = runs.sorted { $0.runIndex < $1.runIndex }
+            let text = sorted.map(\.text).joined().trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            return PresentationParagraphRuns(index: index, runs: sorted)
+        }
+    }
+
+    // MARK: - Security
+
+    private static func securityMetadata(
+        for url: URL,
+        archive: BoundedZipReader,
+        extractedText: String,
+        textFallback: String
+    ) throws -> DocumentSecurityMetadata {
+        var findings: [DocumentSecurityFinding] = [
+            DocumentSecurityFinding(
+                kind: .unsupportedFeature,
+                severity: .informational,
+                message:
+                    "PPTX/POTX adapter extracts slide text, speaker notes, and package relationships; media, charts, comments, and layout are not fully interpreted."
+            )
+        ]
+        var activeContentTypes: Set<DocumentActiveContentType> = []
+        var externalReferences: [DocumentExternalReference] = []
+
+        if archive.entryNames.contains(where: { $0.lowercased().hasSuffix("vbaproject.bin") }) {
+            activeContentTypes.insert(.macro)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .macro,
+                    severity: .high,
+                    message: "Presentation package contains a VBA project part."
+                )
+            )
+        }
+
+        let embeddedCount = archive.entryNames.filter {
+            $0.hasPrefix("ppt/embeddings/") || $0.hasPrefix("ppt/activeX/")
+        }.count
+        if embeddedCount > 0 {
+            activeContentTypes.insert(.embeddedFile)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .embeddedFile,
+                    severity: .medium,
+                    message: "Presentation package contains embedded or ActiveX parts.",
+                    metadata: ["count": "\(embeddedCount)"]
+                )
+            )
+        }
+
+        for relationshipsPart in archive.entryNames.filter({ $0.hasSuffix(".rels") }).prefix(
+            Constants.maxRelationshipFiles
+        ) {
+            for relationship in try relationships(in: relationshipsPart, from: archive)
+            where relationship.targetMode == .external {
+                activeContentTypes.insert(.externalReference)
+                externalReferences.append(
+                    DocumentExternalReference(
+                        kind: relationship.referenceKind,
+                        urlString: relationship.target,
+                        relationshipId: relationship.id
+                    )
+                )
+            }
+        }
+
+        if !externalReferences.isEmpty {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .externalReference,
+                    severity: .low,
+                    message: "Presentation package contains external relationship targets.",
+                    metadata: ["count": "\(externalReferences.count)"]
+                )
+            )
+        }
+
+        if extractedText != textFallback {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .truncatedContent,
+                    severity: .low,
+                    message: "Presentation text fallback was character-capped; slide-level ranges were not preserved.",
+                    metadata: [
+                        "extractedUTF16Length": "\(extractedText.utf16.count)",
+                        "fallbackUTF16Length": "\(textFallback.utf16.count)",
+                    ]
+                )
+            )
+        }
+
+        return DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: id,
+            inspectionStatus: .partiallyInspected,
+            isEncrypted: false,
+            findings: findings,
+            externalReferences: externalReferences,
+            activeContentTypes: activeContentTypes
+        )
+    }
+
+    // MARK: - Paths and IDs
+
+    private static func numberedPart(path: String, prefix: String) -> Int? {
+        guard path.hasPrefix(prefix), path.hasSuffix(".xml") else { return nil }
+        let start = path.index(path.startIndex, offsetBy: prefix.count)
+        let end = path.index(path.endIndex, offsetBy: -".xml".count)
+        guard start < end else { return nil }
+        return Int(path[start ..< end])
+    }
+
+    private static func relationshipsPart(for sourcePart: String) -> String {
+        var components = sourcePart.split(separator: "/").map(String.init)
+        guard let fileName = components.popLast() else { return "\(sourcePart).rels" }
+        components.append("_rels")
+        components.append("\(fileName).rels")
+        return components.joined(separator: "/")
+    }
+
+    private static func resolveRelationshipTarget(from sourcePart: String, target: String) -> String? {
+        guard !target.contains("\\") else { return nil }
+        let lowercased = target.lowercased()
+        guard !lowercased.hasPrefix("http://"),
+            !lowercased.hasPrefix("https://"),
+            !lowercased.hasPrefix("file://"),
+            !lowercased.hasPrefix("//")
+        else {
+            return nil
+        }
+
+        let sourceDirectory = sourcePart.split(separator: "/").dropLast().map(String.init)
+        let targetComponents = target.split(separator: "/").map(String.init)
+        let rawComponents = target.hasPrefix("/") ? targetComponents : sourceDirectory + targetComponents
+        var normalized: [String] = []
+        for component in rawComponents {
+            switch component {
+            case "", ".":
+                continue
+            case "..":
+                guard !normalized.isEmpty else { return nil }
+                normalized.removeLast()
+            default:
+                normalized.append(component)
+            }
+        }
+        return normalized.joined(separator: "/")
+    }
+
+    private static func slideAnchorId(slideIndex: Int) -> String {
+        "presentation/slide-\(slideIndex + 1)"
+    }
+
+    private static func notesAnchorId(slideIndex: Int) -> String {
+        "\(slideAnchorId(slideIndex: slideIndex))/speaker-notes"
+    }
+
+    private static func paragraphAnchorId(
+        slideIndex: Int,
+        region: PresentationTextRegion,
+        paragraphIndex: Int
+    ) -> String {
+        "\(slideAnchorId(slideIndex: slideIndex))/\(region.idComponent)/p-\(paragraphIndex + 1)"
+    }
+
+    private static func textRunAnchorId(
+        slideIndex: Int,
+        region: PresentationTextRegion,
+        paragraphIndex: Int,
+        runIndex: Int
+    ) -> String {
+        "\(paragraphAnchorId(slideIndex: slideIndex, region: region, paragraphIndex: paragraphIndex))/r-\(runIndex + 1)"
+    }
+
+    private static func anchorPath(
+        slideIndex: Int,
+        region: PresentationTextRegion,
+        paragraphIndex: Int,
+        runIndex: Int? = nil
+    ) -> [DocumentAnchor.PathComponent] {
+        var path: [DocumentAnchor.PathComponent] = [
+            .init(kind: .document),
+            .init(kind: .slide, index: slideIndex),
+            .init(kind: region.anchorKind),
+            .init(kind: .paragraph, index: paragraphIndex),
+        ]
+        if let runIndex {
+            path.append(.init(kind: .run, index: runIndex))
+        }
+        return path
+    }
+
+    private static func fileSize(for url: URL) throws -> Int64 {
+        do {
+            let values = try url.resourceValues(forKeys: [.fileSizeKey])
+            if let size = values.fileSize {
+                return Int64(size)
+            }
+
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            if let size = attributes[.size] as? NSNumber {
+                return size.int64Value
+            }
+            return 0
+        } catch {
+            throw DocumentAdapterError.readFailed(underlying: error.localizedDescription)
+        }
+    }
+}
+
+private struct SlidePart: Sendable {
+    let number: Int
+    let path: String
+}
+
+private struct PresentationParagraphRuns {
+    let index: Int
+    let runs: [PresentationTextRun]
+}
+
+private struct ParagraphAppendResult {
+    let elements: [DocumentElement]
+    let textStart: Int
+    let textEnd: Int
+}
+
+private enum PresentationTextRegion: String {
+    case slideText
+    case speakerNotes
+
+    var idComponent: String {
+        switch self {
+        case .slideText: return "text"
+        case .speakerNotes: return "speaker-notes"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .slideText: return "text"
+        case .speakerNotes: return "speaker notes"
+        }
+    }
+
+    var sourceRegionName: String {
+        switch self {
+        case .slideText: return "slideText"
+        case .speakerNotes: return "speakerNotes"
+        }
+    }
+
+    var anchorKind: DocumentAnchor.Kind {
+        switch self {
+        case .slideText: return .text
+        case .speakerNotes: return .speakerNotes
+        }
+    }
+}
+
+private enum Constants {
+    static let maxEntries = 4_096
+    static let maxXMLPartBytes = 5 * 1024 * 1024
+    static let maxTextPartUTF16 = 1_000_000
+    static let maxXMLDepth = 512
+    static let maxRelationshipFiles = 512
+}
+
+private struct OpenXMLRelationship: Sendable {
+    enum TargetMode: Sendable {
+        case internalPackage
+        case external
+    }
+
+    let id: String
+    let type: String
+    let target: String
+    let targetMode: TargetMode
+
+    var referenceKind: DocumentExternalReference.Kind {
+        let lowercased = type.lowercased()
+        if lowercased.contains("hyperlink") {
+            return .hyperlink
+        }
+        if lowercased.contains("image") {
+            return .image
+        }
+        if lowercased.contains("stylesheet") {
+            return .stylesheet
+        }
+        if lowercased.contains("script") {
+            return .script
+        }
+        if lowercased.contains("media") || lowercased.contains("audio") || lowercased.contains("video") {
+            return .media
+        }
+        if lowercased.contains("attachedtemplate") || lowercased.contains("remotetemplate") {
+            return .remoteTemplate
+        }
+        return .packageRelationship
+    }
+}
+
+private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
+    private let maxUTF16Length: Int
+    private var depth = 0
+    private var inParagraph = false
+    private var inText = false
+    private var currentRun = ""
+    private var currentParagraphRuns: [String] = []
+    private var totalUTF16Length = 0
+
+    private(set) var runs: [CollectedRun] = []
+    private(set) var didOverflow = false
+    private(set) var didExceedDepth = false
+
+    init(maxUTF16Length: Int) {
+        self.maxUTF16Length = maxUTF16Length
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        depth += 1
+        if depth > Constants.maxXMLDepth {
+            didExceedDepth = true
+            parser.abortParsing()
+            return
+        }
+
+        switch OpenXMLName.localName(elementName, qualifiedName: qName) {
+        case "p":
+            inParagraph = true
+            currentParagraphRuns = []
+        case "t":
+            inText = true
+            currentRun = ""
+        default:
+            break
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        defer { depth = max(0, depth - 1) }
+
+        switch OpenXMLName.localName(elementName, qualifiedName: qName) {
+        case "t":
+            if !currentRun.isEmpty {
+                if inParagraph {
+                    currentParagraphRuns.append(currentRun)
+                } else {
+                    appendParagraphRuns([currentRun], parser: parser)
+                }
+            }
+            currentRun = ""
+            inText = false
+        case "p":
+            appendParagraphRuns(currentParagraphRuns, parser: parser)
+            currentParagraphRuns = []
+            inParagraph = false
+        default:
+            break
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        guard inText else { return }
+        currentRun.append(string)
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        resolveExternalEntityName name: String,
+        systemID: String?
+    ) -> Data? {
+        nil
+    }
+
+    private func appendParagraphRuns(_ rawRuns: [String], parser: XMLParser) {
+        let paragraphText = rawRuns.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !paragraphText.isEmpty else { return }
+
+        let paragraphIndex = Set(runs.map(\.paragraphIndex)).count
+        var runIndex = 0
+        for rawRun in rawRuns {
+            guard !rawRun.isEmpty else { continue }
+            totalUTF16Length += rawRun.utf16.count
+            if totalUTF16Length > maxUTF16Length {
+                didOverflow = true
+                parser.abortParsing()
+                return
+            }
+            runs.append(
+                CollectedRun(
+                    text: rawRun,
+                    paragraphIndex: paragraphIndex,
+                    runIndex: runIndex
+                )
+            )
+            runIndex += 1
+        }
+    }
+
+    struct CollectedRun {
+        let text: String
+        let paragraphIndex: Int
+        let runIndex: Int
+    }
+}
+
+private final class OpenXMLSlideOrderCollector: NSObject, XMLParserDelegate {
+    private(set) var relationshipIds: [String] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        guard OpenXMLName.localName(elementName, qualifiedName: qName) == "sldId",
+            let relationshipId = OpenXMLName.attribute("r:id", in: attributeDict)
+        else {
+            return
+        }
+        relationshipIds.append(relationshipId)
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        resolveExternalEntityName name: String,
+        systemID: String?
+    ) -> Data? {
+        nil
+    }
+}
+
+private final class OpenXMLRelationshipCollector: NSObject, XMLParserDelegate {
+    private(set) var relationships: [OpenXMLRelationship] = []
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        guard OpenXMLName.localName(elementName, qualifiedName: qName) == "Relationship",
+            let id = OpenXMLName.attribute("Id", in: attributeDict),
+            let type = OpenXMLName.attribute("Type", in: attributeDict),
+            let target = OpenXMLName.attribute("Target", in: attributeDict)
+        else {
+            return
+        }
+
+        let mode =
+            OpenXMLName.attribute("TargetMode", in: attributeDict)?.lowercased() == "external"
+            ? OpenXMLRelationship.TargetMode.external
+            : .internalPackage
+        relationships.append(
+            OpenXMLRelationship(
+                id: id,
+                type: type,
+                target: target,
+                targetMode: mode
+            )
+        )
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        resolveExternalEntityName name: String,
+        systemID: String?
+    ) -> Data? {
+        nil
+    }
+}
+
+private enum OpenXMLName {
+    static func localName(_ elementName: String, qualifiedName qName: String?) -> String {
+        let name = qName ?? elementName
+        return name.split(separator: ":").last.map(String.init) ?? name
+    }
+
+    static func attribute(_ name: String, in attributes: [String: String]) -> String? {
+        if let value = attributes[name] {
+            return value
+        }
+        let lowercasedName = name.lowercased()
+        return attributes.first { key, _ in
+            key.split(separator: ":").last.map { $0.lowercased() } == lowercasedName
+        }?.value
+    }
+}
+
+private struct BoundedZipReader: Sendable {
+    private let data: Data
+    private let entriesByName: [String: ZipEntry]
+
+    var entryNames: [String] {
+        entriesByName.keys.sorted()
+    }
+
+    init(url: URL, maxArchiveBytes: Int) throws {
+        let data = try Data(contentsOf: url)
+        guard data.count <= maxArchiveBytes else {
+            throw DocumentAdapterError.sizeLimitExceeded(
+                actual: Int64(data.count),
+                limit: Int64(maxArchiveBytes)
+            )
+        }
+        self.data = data
+        self.entriesByName = try Self.parseEntries(data: data)
+    }
+
+    func contains(_ path: String) -> Bool {
+        entriesByName[path] != nil
+    }
+
+    func entryData(_ path: String, maxUncompressedBytes: Int) throws -> Data {
+        guard let entry = entriesByName[path] else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) was not found.")
+        }
+        guard entry.uncompressedSize <= maxUncompressedBytes else {
+            throw DocumentAdapterError.readFailed(
+                underlying: "ZIP entry \(path) exceeds the PPTX XML size limit."
+            )
+        }
+        guard entry.compressedSize <= data.count else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) has invalid compressed size.")
+        }
+
+        let localHeaderOffset = entry.localHeaderOffset
+        guard localHeaderOffset + 30 <= data.count,
+            Self.uint32(data, localHeaderOffset) == Signatures.localFileHeader
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) has an invalid local header.")
+        }
+
+        let nameLength = Int(Self.uint16(data, localHeaderOffset + 26))
+        let extraLength = Int(Self.uint16(data, localHeaderOffset + 28))
+        let dataStart = localHeaderOffset + 30 + nameLength + extraLength
+        let dataEnd = dataStart + entry.compressedSize
+        guard dataStart <= data.count, dataEnd <= data.count else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) points outside the archive.")
+        }
+
+        let localNameStart = localHeaderOffset + 30
+        let localNameEnd = localNameStart + nameLength
+        guard localNameEnd <= data.count,
+            String(data: data[localNameStart ..< localNameEnd], encoding: .utf8) == path
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) local header name mismatch.")
+        }
+
+        let compressed = data[dataStart ..< dataEnd]
+        switch entry.compressionMethod {
+        case 0:
+            guard compressed.count == entry.uncompressedSize else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) stored size mismatch.")
+            }
+            return Data(compressed)
+        case 8:
+            return try Self.inflate(compressed, outputSize: entry.uncompressedSize, path: path)
+        default:
+            throw DocumentAdapterError.readFailed(
+                underlying: "ZIP entry \(path) uses unsupported compression method \(entry.compressionMethod)."
+            )
+        }
+    }
+
+    private static func parseEntries(data: Data) throws -> [String: ZipEntry] {
+        guard data.count >= 22 else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP archive is too small.")
+        }
+
+        let eocdOffset = try endOfCentralDirectoryOffset(in: data)
+        let diskNumber = uint16(data, eocdOffset + 4)
+        let centralDirectoryDisk = uint16(data, eocdOffset + 6)
+        let entriesOnDisk = uint16(data, eocdOffset + 8)
+        let totalEntries = uint16(data, eocdOffset + 10)
+        let centralDirectorySize = uint32(data, eocdOffset + 12)
+        let centralDirectoryOffset = uint32(data, eocdOffset + 16)
+        guard diskNumber == 0, centralDirectoryDisk == 0, entriesOnDisk == totalEntries else {
+            throw DocumentAdapterError.readFailed(underlying: "Multi-disk ZIP archives are not supported.")
+        }
+        guard totalEntries != UInt16.max,
+            centralDirectorySize != UInt32.max,
+            centralDirectoryOffset != UInt32.max
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP64 PPTX packages are not supported.")
+        }
+        guard Int(totalEntries) <= Constants.maxEntries else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP archive contains too many entries.")
+        }
+
+        let directoryOffset = Int(centralDirectoryOffset)
+        let directorySize = Int(centralDirectorySize)
+        guard directoryOffset >= 0,
+            directorySize >= 0,
+            directoryOffset + directorySize <= eocdOffset
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP central directory is outside the archive.")
+        }
+
+        var offset = directoryOffset
+        var entries: [String: ZipEntry] = [:]
+        for _ in 0 ..< Int(totalEntries) {
+            guard offset + 46 <= data.count,
+                uint32(data, offset) == Signatures.centralDirectoryHeader
+            else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP central directory entry is invalid.")
+            }
+
+            let flags = uint16(data, offset + 8)
+            let compressionMethod = uint16(data, offset + 10)
+            let compressedSize = uint32(data, offset + 20)
+            let uncompressedSize = uint32(data, offset + 24)
+            let fileNameLength = Int(uint16(data, offset + 28))
+            let extraLength = Int(uint16(data, offset + 30))
+            let commentLength = Int(uint16(data, offset + 32))
+            let localHeaderOffset = uint32(data, offset + 42)
+            guard localHeaderOffset != UInt32.max,
+                compressedSize != UInt32.max,
+                uncompressedSize != UInt32.max
+            else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP64 PPTX entries are not supported.")
+            }
+
+            let nameStart = offset + 46
+            let nameEnd = nameStart + fileNameLength
+            let nextOffset = nameEnd + extraLength + commentLength
+            guard nameEnd <= data.count, nextOffset <= data.count else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP central directory entry is truncated.")
+            }
+            guard let path = String(data: data[nameStart ..< nameEnd], encoding: .utf8),
+                isSafeEntryPath(path)
+            else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP archive contains an unsafe entry path.")
+            }
+            guard flags & 0x0001 == 0 else {
+                throw DocumentAdapterError.readFailed(underlying: "Encrypted ZIP entries are not supported.")
+            }
+            guard compressionMethod == 0 || compressionMethod == 8 else {
+                throw DocumentAdapterError.readFailed(
+                    underlying: "ZIP entry \(path) uses unsupported compression method \(compressionMethod)."
+                )
+            }
+            guard entries[path] == nil else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP archive contains duplicate entry \(path).")
+            }
+
+            entries[path] = ZipEntry(
+                path: path,
+                compressionMethod: compressionMethod,
+                compressedSize: Int(compressedSize),
+                uncompressedSize: Int(uncompressedSize),
+                localHeaderOffset: Int(localHeaderOffset)
+            )
+            offset = nextOffset
+        }
+
+        return entries
+    }
+
+    private static func endOfCentralDirectoryOffset(in data: Data) throws -> Int {
+        let minimumOffset = max(0, data.count - 22 - UInt16.maxValueAsInt)
+        var offset = data.count - 22
+        while offset >= minimumOffset {
+            if uint32(data, offset) == Signatures.endOfCentralDirectory {
+                let commentLength = Int(uint16(data, offset + 20))
+                if offset + 22 + commentLength == data.count {
+                    return offset
+                }
+            }
+            offset -= 1
+        }
+        throw DocumentAdapterError.readFailed(underlying: "ZIP end-of-central-directory record was not found.")
+    }
+
+    private static func inflate(_ compressed: Data, outputSize: Int, path: String) throws -> Data {
+        if outputSize == 0 {
+            return Data()
+        }
+        var output = [UInt8](repeating: 0, count: outputSize)
+        let written = compressed.withUnsafeBytes { sourceBuffer in
+            guard let source = sourceBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                return 0
+            }
+            return compression_decode_buffer(
+                &output,
+                output.count,
+                source,
+                compressed.count,
+                nil,
+                COMPRESSION_ZLIB
+            )
+        }
+        guard written == outputSize else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP entry \(path) could not be inflated.")
+        }
+        return Data(output)
+    }
+
+    private static func isSafeEntryPath(_ path: String) -> Bool {
+        guard !path.isEmpty,
+            !path.hasPrefix("/"),
+            !path.contains("\\"),
+            !path.contains("\0")
+        else {
+            return false
+        }
+        return !path.split(separator: "/").contains("..")
+    }
+
+    private static func uint16(_ data: Data, _ offset: Int) -> UInt16 {
+        UInt16(data[offset]) | UInt16(data[offset + 1]) << 8
+    }
+
+    private static func uint32(_ data: Data, _ offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | UInt32(data[offset + 1]) << 8
+            | UInt32(data[offset + 2]) << 16
+            | UInt32(data[offset + 3]) << 24
+    }
+}
+
+private struct ZipEntry: Sendable {
+    let path: String
+    let compressionMethod: UInt16
+    let compressedSize: Int
+    let uncompressedSize: Int
+    let localHeaderOffset: Int
+}
+
+private enum Signatures {
+    static let localFileHeader: UInt32 = 0x0403_4B50
+    static let centralDirectoryHeader: UInt32 = 0x0201_4B50
+    static let endOfCentralDirectory: UInt32 = 0x0605_4B50
+}
+
+private extension UInt16 {
+    static let maxValueAsInt = Int(UInt16.max)
+}

--- a/Packages/OsaurusCore/Services/Documents/RichDocumentAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/RichDocumentAdapter.swift
@@ -29,35 +29,52 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
             throw DocumentAdapterError.sizeLimitExceeded(actual: fileSize, limit: sizeLimit)
         }
 
-        let documentType = Self.documentType(forExtension: url.pathExtension.lowercased())
-        let extracted: String
+        let ext = url.pathExtension.lowercased()
+        let sourceFormat = RichDocumentSourceFormat(fileExtension: ext)
+        let documentType = Self.documentType(forExtension: ext)
+        let attributed: NSAttributedString
         do {
             var options: [NSAttributedString.DocumentReadingOptionKey: Any] = [:]
             if let documentType {
                 options[.documentType] = documentType
             }
-            let attributed = try NSAttributedString(
+            attributed = try NSAttributedString(
                 url: url,
                 options: options,
                 documentAttributes: nil
             )
-            extracted = attributed.string
         } catch {
             throw DocumentAdapterError.readFailed(underlying: error.localizedDescription)
         }
 
+        let extracted = attributed.string
         guard !extracted.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw DocumentAdapterError.emptyContent
         }
 
         let truncated = PlainTextAdapter.applyCharacterCap(extracted)
-        let structure = DocumentStructure.plainText(filename: url.lastPathComponent, text: truncated)
+        let sourceLabel = sourceFormat.label
+        let blocks = Self.richBlocks(
+            from: attributed,
+            textFallback: truncated,
+            sourceWasTruncated: extracted != truncated
+        )
+        let structure = Self.structure(
+            filename: url.lastPathComponent,
+            textFallback: truncated,
+            blocks: blocks,
+            sourceFormat: sourceFormat,
+            sourceLabel: sourceLabel
+        )
         let securitySignals = Self.securitySignals(url: url)
+        let findings =
+            securitySignals.findings
+            + Self.truncationFindings(extractedText: extracted, textFallback: truncated)
         let security = DocumentFileInspector.localFileSecurityMetadata(
             url: url,
             formatId: formatId,
             inspectionStatus: securitySignals.inspectionStatus,
-            findings: securitySignals.findings,
+            findings: findings,
             externalReferences: securitySignals.externalReferences,
             activeContentTypes: securitySignals.activeContentTypes
         )
@@ -68,7 +85,12 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
             fileSize: fileSize,
             representation: AnyStructuredRepresentation(
                 formatId: formatId,
-                underlying: PlainTextRepresentation(text: truncated)
+                underlying: RichDocumentRepresentation(
+                    sourceFormat: sourceFormat,
+                    sourceLabel: sourceLabel,
+                    text: truncated,
+                    blocks: blocks
+                )
             ),
             structure: structure,
             security: security,
@@ -151,6 +173,232 @@ public struct RichDocumentAdapter: DocumentFormatAdapter {
         }
         guard let data = try? Data(contentsOf: url) else { return nil }
         return String(data: data, encoding: .isoLatin1)
+    }
+
+    private static func richBlocks(
+        from attributed: NSAttributedString,
+        textFallback: String,
+        sourceWasTruncated: Bool
+    ) -> [RichDocumentBlock] {
+        guard !sourceWasTruncated else {
+            return [
+                RichDocumentBlock(
+                    kind: .paragraph,
+                    text: textFallback,
+                    textRange: .entireText(textFallback),
+                    sourceIndex: 0,
+                    anchorId: "document/body"
+                )
+            ]
+        }
+
+        let nsText = attributed.string as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var blocks: [RichDocumentBlock] = []
+        var paragraphIndex = 0
+
+        nsText.enumerateSubstrings(
+            in: fullRange,
+            options: [.byParagraphs, .substringNotRequired]
+        ) { _, paragraphRange, _, _ in
+            defer { paragraphIndex += 1 }
+            guard paragraphRange.length > 0 else { return }
+
+            let text = nsText.substring(with: paragraphRange)
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+            let style = Self.paragraphStyle(
+                in: attributed,
+                at: paragraphRange.location
+            )
+            let headingLevel = style.flatMap { $0.headerLevel > 0 ? $0.headerLevel : nil }
+            let listDepth = style.flatMap { $0.textLists.isEmpty ? nil : $0.textLists.count }
+            let kind: RichDocumentBlock.Kind =
+                if headingLevel != nil {
+                    .heading
+                } else if listDepth != nil {
+                    .listItem
+                } else {
+                    .paragraph
+                }
+            let anchorId = "document/block/\(blocks.count)"
+
+            blocks.append(
+                RichDocumentBlock(
+                    kind: kind,
+                    text: text,
+                    textRange: DocumentTextRange(
+                        startUTF16Offset: paragraphRange.location,
+                        length: paragraphRange.length
+                    ),
+                    sourceIndex: paragraphIndex,
+                    headingLevel: headingLevel,
+                    listDepth: listDepth,
+                    anchorId: anchorId
+                )
+            )
+        }
+
+        guard !blocks.isEmpty else {
+            return [
+                RichDocumentBlock(
+                    kind: .paragraph,
+                    text: textFallback,
+                    textRange: .entireText(textFallback),
+                    sourceIndex: 0,
+                    anchorId: "document/body"
+                )
+            ]
+        }
+        return blocks
+    }
+
+    private static func paragraphStyle(
+        in attributed: NSAttributedString,
+        at location: Int
+    ) -> NSParagraphStyle? {
+        guard attributed.length > 0 else { return nil }
+        let safeLocation = min(location, attributed.length - 1)
+        return attributed.attribute(
+            .paragraphStyle,
+            at: safeLocation,
+            effectiveRange: nil
+        ) as? NSParagraphStyle
+    }
+
+    private static func structure(
+        filename: String,
+        textFallback: String,
+        blocks: [RichDocumentBlock],
+        sourceFormat: RichDocumentSourceFormat,
+        sourceLabel: String
+    ) -> DocumentStructure {
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let elements = blocks.map { block in
+            let kind = Self.elementKind(for: block.kind)
+            let anchorKind = Self.anchorKind(for: block.kind)
+            let sourceRange = DocumentSourceRange(
+                start: DocumentSourceLocation(
+                    paragraphIndex: block.sourceIndex,
+                    characterOffset: block.textRange.startUTF16Offset
+                ),
+                end: DocumentSourceLocation(
+                    paragraphIndex: block.sourceIndex,
+                    characterOffset: block.textRange.endUTF16Offset
+                )
+            )
+            let metadata = Self.blockMetadata(
+                block,
+                sourceFormat: sourceFormat,
+                sourceLabel: sourceLabel
+            )
+            let anchor = DocumentAnchor(
+                id: block.anchorId,
+                kind: anchorKind,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: anchorKind, index: block.sourceIndex),
+                ],
+                textRange: block.textRange,
+                sourceRange: sourceRange,
+                label: Self.blockLabel(block),
+                metadata: metadata
+            )
+            return DocumentElement(
+                kind: kind,
+                anchor: anchor,
+                text: block.text,
+                attributes: DocumentElementAttributes(
+                    role: block.kind.rawValue,
+                    level: block.headingLevel,
+                    metadata: metadata
+                )
+            )
+        }
+
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            attributes: DocumentElementAttributes(
+                metadata: [
+                    "importer": "NSAttributedString",
+                    "sourceFormat": sourceFormat.rawValue,
+                    "sourceLabel": sourceLabel,
+                ]
+            ),
+            children: elements
+        )
+        return DocumentStructure(
+            root: root,
+            textLengthUTF16: textFallback.utf16.count
+        )
+    }
+
+    private static func elementKind(for kind: RichDocumentBlock.Kind) -> DocumentElement.Kind {
+        switch kind {
+        case .paragraph: return .paragraph
+        case .heading: return .heading
+        case .listItem: return .listItem
+        }
+    }
+
+    private static func anchorKind(for kind: RichDocumentBlock.Kind) -> DocumentAnchor.Kind {
+        switch kind {
+        case .paragraph: return .paragraph
+        case .heading: return .heading
+        case .listItem: return .listItem
+        }
+    }
+
+    private static func blockLabel(_ block: RichDocumentBlock) -> String {
+        switch block.kind {
+        case .paragraph:
+            return "Paragraph \(block.sourceIndex + 1)"
+        case .heading:
+            let level = block.headingLevel ?? 0
+            return level > 0 ? "Heading \(level)" : "Heading"
+        case .listItem:
+            return "List item \(block.sourceIndex + 1)"
+        }
+    }
+
+    private static func blockMetadata(
+        _ block: RichDocumentBlock,
+        sourceFormat: RichDocumentSourceFormat,
+        sourceLabel: String
+    ) -> [String: String] {
+        var metadata = [
+            "sourceFormat": sourceFormat.rawValue,
+            "sourceIndex": "\(block.sourceIndex)",
+            "sourceLabel": sourceLabel,
+        ]
+        if let headingLevel = block.headingLevel {
+            metadata["headingLevel"] = "\(headingLevel)"
+        }
+        if let listDepth = block.listDepth {
+            metadata["listDepth"] = "\(listDepth)"
+        }
+        return metadata
+    }
+
+    private static func truncationFindings(
+        extractedText: String,
+        textFallback: String
+    ) -> [DocumentSecurityFinding] {
+        guard extractedText != textFallback else { return [] }
+        return [
+            DocumentSecurityFinding(
+                kind: .truncatedContent,
+                severity: .low,
+                message:
+                    "Rich document text fallback was character-capped; paragraph-level ranges were not preserved.",
+                metadata: [
+                    "extractedUTF16Length": "\(extractedText.utf16.count)",
+                    "fallbackUTF16Length": "\(textFallback.utf16.count)",
+                ]
+            )
+        ]
     }
 
     private struct RichSecuritySignals {

--- a/Packages/OsaurusCore/Services/Documents/XLSXAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXAdapter.swift
@@ -1,0 +1,1090 @@
+//
+//  XLSXAdapter.swift
+//  osaurus
+//
+//  Reads the stable, low-risk subset of XLSX directly from the OOXML ZIP
+//  package: workbook relationships, shared strings, worksheet rows, scalar
+//  cells, formulas, and merged ranges. This intentionally avoids adding a
+//  package dependency while the document stack is still stacked behind the
+//  foundation PR; style evaluation and richer spreadsheet features can move to
+//  a dedicated parser dependency once the package graph is less contested.
+//
+
+import Compression
+import Foundation
+
+public struct XLSXAdapter: DocumentFormatAdapter {
+    public let formatId = "xlsx"
+
+    public init() {}
+
+    public func canHandle(url: URL, uti: String?) -> Bool {
+        if url.pathExtension.lowercased() == "xlsx" { return true }
+        guard let uti = uti?.lowercased() else { return false }
+        return uti == "org.openxmlformats.spreadsheetml.sheet"
+            || uti == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    }
+
+    public func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
+        let fileSize = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        if sizeLimit > 0, fileSize > sizeLimit {
+            throw DocumentAdapterError.sizeLimitExceeded(actual: fileSize, limit: sizeLimit)
+        }
+
+        let archive: XLSXPackageArchive
+        do {
+            archive = try XLSXPackageArchive(data: Data(contentsOf: url))
+        } catch let error as DocumentAdapterError {
+            throw error
+        } catch {
+            throw DocumentAdapterError.readFailed(underlying: error.localizedDescription)
+        }
+
+        let workbookPath = try Self.workbookPath(in: archive)
+        let workbookIndex = try Self.parseWorkbookIndex(
+            data: archive.xmlData(for: workbookPath)
+        )
+        let workbookRelationships = try Self.parseRelationships(
+            data: archive.optionalXMLData(for: Self.relationshipPath(for: workbookPath)) ?? Data()
+        )
+        let sharedStrings = try Self.parseSharedStrings(in: archive)
+
+        var parsedSheets: [ParsedSheet] = []
+        for (index, sheet) in workbookIndex.sheets.enumerated() {
+            let worksheetPath = try Self.worksheetPath(
+                for: sheet,
+                sheetIndex: index,
+                workbookPath: workbookPath,
+                relationships: workbookRelationships
+            )
+            let worksheet = try Self.parseWorksheet(
+                data: archive.xmlData(for: worksheetPath),
+                sheetName: sheet.name,
+                sheetIndex: index,
+                sharedStrings: sharedStrings
+            )
+            parsedSheets.append(worksheet)
+        }
+
+        guard parsedSheets.contains(where: { !$0.rows.isEmpty }) else {
+            throw DocumentAdapterError.emptyContent
+        }
+
+        let rendered = Self.renderWorkbook(
+            parsedSheets: parsedSheets,
+            sharedStrings: sharedStrings,
+            filename: url.lastPathComponent
+        )
+        guard !rendered.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DocumentAdapterError.emptyContent
+        }
+
+        let security = Self.securityMetadata(
+            url: url,
+            archive: archive,
+            formulaCount: rendered.formulaCount
+        )
+
+        return StructuredDocument(
+            formatId: formatId,
+            filename: url.lastPathComponent,
+            fileSize: fileSize,
+            representation: AnyStructuredRepresentation(
+                formatId: formatId,
+                underlying: rendered.workbook
+            ),
+            structure: rendered.structure,
+            security: security,
+            textFallback: rendered.text
+        )
+    }
+
+    // MARK: - Package parts
+
+    fileprivate static let maxXMLPartBytes = 25 * 1024 * 1024
+
+    private static func workbookPath(in archive: XLSXPackageArchive) throws -> String {
+        if let rootRelationships = try? parseRelationships(
+            data: archive.optionalXMLData(for: "_rels/.rels") ?? Data()
+        ) {
+            if let target = rootRelationships.first(where: {
+                $0.type.hasSuffix("/officeDocument") && !$0.isExternal
+            })?.target {
+                let resolved = try XLSXPackageArchive.normalizedPackagePath(
+                    target,
+                    relativeTo: ""
+                )
+                if archive.contains(resolved) { return resolved }
+            }
+        }
+
+        guard archive.contains("xl/workbook.xml") else {
+            throw DocumentAdapterError.readFailed(underlying: "XLSX package is missing xl/workbook.xml")
+        }
+        return "xl/workbook.xml"
+    }
+
+    private static func relationshipPath(for partPath: String) -> String {
+        let nsPath = partPath as NSString
+        let directory = nsPath.deletingLastPathComponent
+        let filename = nsPath.lastPathComponent
+        if directory.isEmpty || directory == "." {
+            return "_rels/\(filename).rels"
+        }
+        return "\(directory)/_rels/\(filename).rels"
+    }
+
+    private static func worksheetPath(
+        for sheet: WorkbookSheetReference,
+        sheetIndex: Int,
+        workbookPath: String,
+        relationships: [XLSXRelationship]
+    ) throws -> String {
+        let workbookDirectory = (workbookPath as NSString).deletingLastPathComponent
+        if let relationshipId = sheet.relationshipId,
+            let relationship = relationships.first(where: { $0.id == relationshipId }),
+            !relationship.isExternal
+        {
+            return try XLSXPackageArchive.normalizedPackagePath(
+                relationship.target,
+                relativeTo: workbookDirectory
+            )
+        }
+        return "xl/worksheets/sheet\(sheetIndex + 1).xml"
+    }
+
+    // MARK: - XML parsing
+
+    private static func parseWorkbookIndex(data: Data) throws -> WorkbookIndex {
+        let parser = WorkbookIndexParser()
+        try parseXML(data: data, delegate: parser, partName: "workbook.xml")
+        return WorkbookIndex(sheets: parser.sheets)
+    }
+
+    private static func parseRelationships(data: Data) throws -> [XLSXRelationship] {
+        guard !data.isEmpty else { return [] }
+        let parser = RelationshipsParser()
+        try parseXML(data: data, delegate: parser, partName: "relationships")
+        return parser.relationships
+    }
+
+    private static func parseSharedStrings(in archive: XLSXPackageArchive) throws -> [String] {
+        guard let data = try archive.optionalXMLData(for: "xl/sharedStrings.xml") else { return [] }
+        let parser = SharedStringsParser()
+        try parseXML(data: data, delegate: parser, partName: "sharedStrings.xml")
+        return parser.items
+    }
+
+    private static func parseWorksheet(
+        data: Data,
+        sheetName: String,
+        sheetIndex: Int,
+        sharedStrings: [String]
+    ) throws -> ParsedSheet {
+        let parser = WorksheetParser(sharedStrings: sharedStrings)
+        try parseXML(data: data, delegate: parser, partName: "\(sheetName).xml")
+        return ParsedSheet(
+            name: sheetName,
+            index: sheetIndex,
+            rows: parser.rows,
+            mergedRanges: parser.mergedRanges
+        )
+    }
+
+    private static func parseXML(
+        data: Data,
+        delegate: XMLParserDelegate,
+        partName: String
+    ) throws {
+        let parser = XMLParser(data: data)
+        parser.shouldProcessNamespaces = false
+        parser.shouldReportNamespacePrefixes = false
+        parser.shouldResolveExternalEntities = false
+        parser.delegate = delegate
+        guard parser.parse() else {
+            let message = parser.parserError?.localizedDescription ?? "XML parse failed"
+            throw DocumentAdapterError.readFailed(underlying: "\(partName): \(message)")
+        }
+    }
+
+    // MARK: - Rendering and structure
+
+    private static func renderWorkbook(
+        parsedSheets: [ParsedSheet],
+        sharedStrings: [String],
+        filename: String
+    ) -> RenderedWorkbook {
+        var text = ""
+        var sheetModels: [Workbook.Sheet] = []
+        var sheetElements: [DocumentElement] = []
+        var formulaCount = 0
+
+        for sheet in parsedSheets {
+            if !text.isEmpty {
+                text.append("\n\n")
+            }
+            let sheetStart = text.utf16.count
+            text.append("## Sheet: \(sheet.name)\n")
+
+            var rowModels: [Workbook.Row] = []
+            var rowElements: [DocumentElement] = []
+
+            for row in sheet.rows {
+                let rowStart = text.utf16.count
+                text.append("\(row.number)\t")
+                var cellModels: [Workbook.Cell] = []
+                var cellElements: [DocumentElement] = []
+
+                for (cellIndex, cell) in row.cells.enumerated() {
+                    if cellIndex > 0 {
+                        text.append("\t")
+                    }
+                    let cellStart = text.utf16.count
+                    let cellText = describeCell(cell)
+                    text.append(cellText)
+                    if cell.formula != nil {
+                        formulaCount += 1
+                    }
+
+                    let anchor = cellAnchor(
+                        cell: cell,
+                        sheet: sheet,
+                        textStart: cellStart,
+                        textLength: cellText.utf16.count
+                    )
+                    cellModels.append(
+                        Workbook.Cell(
+                            reference: cell.reference,
+                            rowNumber: cell.rowNumber,
+                            columnNumber: cell.columnNumber,
+                            value: cell.value,
+                            formula: cell.formula,
+                            anchor: anchor
+                        )
+                    )
+                    cellElements.append(
+                        DocumentElement(
+                            kind: .tableCell,
+                            anchor: anchor,
+                            text: cellText,
+                            attributes: .init(metadata: cellMetadata(cell))
+                        )
+                    )
+                }
+
+                let rowTextLength = text.utf16.count - rowStart
+                let rowAnchor = DocumentAnchor(
+                    kind: .row,
+                    path: [
+                        .init(kind: .document),
+                        .init(kind: .sheet, identifier: sheet.name, index: sheet.index),
+                        .init(kind: .row, index: row.number - 1),
+                    ],
+                    textRange: DocumentTextRange(
+                        startUTF16Offset: rowStart,
+                        length: rowTextLength
+                    ),
+                    sourceRange: DocumentSourceRange(
+                        start: DocumentSourceLocation(
+                            sheetIndex: sheet.index,
+                            sheetName: sheet.name,
+                            rowIndex: row.number - 1
+                        )
+                    ),
+                    label: "\(sheet.name) row \(row.number)"
+                )
+                rowModels.append(
+                    Workbook.Row(
+                        number: row.number,
+                        cells: cellModels,
+                        anchor: rowAnchor
+                    )
+                )
+                rowElements.append(
+                    DocumentElement(
+                        kind: .tableRow,
+                        anchor: rowAnchor,
+                        text: String(text.utf16Suffix(from: rowStart)),
+                        children: cellElements
+                    )
+                )
+                text.append("\n")
+            }
+
+            if !sheet.mergedRanges.isEmpty {
+                let ranges = sheet.mergedRanges.map(\.reference).joined(separator: ", ")
+                text.append("Merged: \(ranges)\n")
+            }
+
+            let sheetLength = text.utf16.count - sheetStart
+            let sheetAnchor = DocumentAnchor(
+                kind: .sheet,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheet.name, index: sheet.index),
+                ],
+                textRange: DocumentTextRange(startUTF16Offset: sheetStart, length: sheetLength),
+                sourceRange: DocumentSourceRange(
+                    start: DocumentSourceLocation(sheetIndex: sheet.index, sheetName: sheet.name)
+                ),
+                label: sheet.name,
+                metadata: ["sheetIndex": "\(sheet.index)"]
+            )
+            let sheetModel = Workbook.Sheet(
+                name: sheet.name,
+                index: sheet.index,
+                rows: rowModels,
+                mergedRanges: sheet.mergedRanges,
+                anchor: sheetAnchor
+            )
+            sheetModels.append(sheetModel)
+            sheetElements.append(
+                DocumentElement(
+                    kind: .sheet,
+                    anchor: sheetAnchor,
+                    text: String(text.utf16Suffix(from: sheetStart)),
+                    attributes: .init(metadata: ["sheetIndex": "\(sheet.index)"]),
+                    children: rowElements
+                )
+            )
+        }
+
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: sheetElements
+        )
+        return RenderedWorkbook(
+            workbook: Workbook(sheets: sheetModels, sharedStrings: sharedStrings),
+            structure: DocumentStructure(
+                root: root,
+                textLengthUTF16: text.utf16.count
+            ),
+            text: text,
+            formulaCount: formulaCount
+        )
+    }
+
+    private static func cellAnchor(
+        cell: ParsedCell,
+        sheet: ParsedSheet,
+        textStart: Int,
+        textLength: Int
+    ) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .cell,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: sheet.name, index: sheet.index),
+                .init(kind: .cell, identifier: cell.reference),
+            ],
+            textRange: DocumentTextRange(startUTF16Offset: textStart, length: textLength),
+            sourceRange: DocumentSourceRange(
+                start: .cell(
+                    sheetName: sheet.name,
+                    rowIndex: cell.rowNumber - 1,
+                    columnIndex: cell.columnNumber - 1
+                )
+            ),
+            label: "\(sheet.name)!\(cell.reference)",
+            metadata: cellMetadata(cell)
+        )
+    }
+
+    private static func describeCell(_ cell: ParsedCell) -> String {
+        let base = cell.value.fallbackText
+        guard let formula = cell.formula, !formula.isEmpty else { return base }
+        return base.isEmpty ? "=\(formula)" : "\(base) [=\(formula)]"
+    }
+
+    private static func cellMetadata(_ cell: ParsedCell) -> [String: String] {
+        var metadata = [
+            "reference": cell.reference,
+            "rowNumber": "\(cell.rowNumber)",
+            "columnNumber": "\(cell.columnNumber)",
+            "valueKind": cell.value.kindName,
+        ]
+        if let formula = cell.formula {
+            metadata["formula"] = formula
+        }
+        return metadata
+    }
+
+    // MARK: - Security metadata
+
+    private static func securityMetadata(
+        url: URL,
+        archive: XLSXPackageArchive,
+        formulaCount: Int
+    ) -> DocumentSecurityMetadata {
+        var findings: [DocumentSecurityFinding] = [
+            DocumentSecurityFinding(
+                kind: .unsupportedFeature,
+                severity: .informational,
+                message:
+                    "Basic XLSX reader preserves cells but does not evaluate styles, macros, charts, or embedded objects."
+            )
+        ]
+        var activeContentTypes: Set<DocumentActiveContentType> = []
+        var externalReferences: [DocumentExternalReference] = []
+
+        if formulaCount > 0 {
+            activeContentTypes.insert(.formula)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .formula,
+                    severity: .informational,
+                    message: "Workbook contains formula source text.",
+                    metadata: ["count": "\(formulaCount)"]
+                )
+            )
+        }
+
+        if archive.paths.contains(where: { $0.lowercased().hasSuffix("vbaproject.bin") }) {
+            activeContentTypes.insert(.macro)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .macro,
+                    severity: .medium,
+                    message: "Workbook package contains a VBA project part."
+                )
+            )
+        }
+
+        if archive.paths.contains(where: { $0.lowercased().hasPrefix("xl/externallinks/") }) {
+            activeContentTypes.insert(.externalReference)
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .externalReference,
+                    severity: .low,
+                    message: "Workbook package contains external-link parts."
+                )
+            )
+        }
+
+        for relationshipEntry in archive.paths where relationshipEntry.hasSuffix(".rels") {
+            guard
+                let data = try? archive.optionalXMLData(for: relationshipEntry),
+                let relationships = try? parseRelationships(data: data)
+            else { continue }
+            for relationship in relationships where relationship.isExternal {
+                activeContentTypes.insert(.externalReference)
+                externalReferences.append(
+                    DocumentExternalReference(
+                        kind: .packageRelationship,
+                        urlString: relationship.target,
+                        relationshipId: relationship.id
+                    )
+                )
+            }
+        }
+
+        if !externalReferences.isEmpty {
+            findings.append(
+                DocumentSecurityFinding(
+                    kind: .externalReference,
+                    severity: .low,
+                    message: "Workbook package relationships reference external resources.",
+                    metadata: ["count": "\(externalReferences.count)"]
+                )
+            )
+        }
+
+        return DocumentFileInspector.localFileSecurityMetadata(
+            url: url,
+            formatId: "xlsx",
+            inspectionStatus: .partiallyInspected,
+            findings: findings,
+            externalReferences: externalReferences,
+            activeContentTypes: activeContentTypes
+        )
+    }
+}
+
+// MARK: - Parsed workbook staging
+
+private struct RenderedWorkbook {
+    let workbook: Workbook
+    let structure: DocumentStructure
+    let text: String
+    let formulaCount: Int
+}
+
+private struct WorkbookIndex {
+    let sheets: [WorkbookSheetReference]
+}
+
+private struct WorkbookSheetReference {
+    let name: String
+    let relationshipId: String?
+    let sheetId: Int?
+}
+
+private struct ParsedSheet {
+    let name: String
+    let index: Int
+    let rows: [ParsedRow]
+    let mergedRanges: [Workbook.CellRange]
+}
+
+private struct ParsedRow {
+    let number: Int
+    let cells: [ParsedCell]
+}
+
+private struct ParsedCell {
+    let reference: String
+    let rowNumber: Int
+    let columnNumber: Int
+    let value: Workbook.CellValue
+    let formula: String?
+}
+
+private struct XLSXRelationship {
+    let id: String
+    let type: String
+    let target: String
+    let targetMode: String?
+
+    var isExternal: Bool {
+        let lowercasedTarget = target.lowercased()
+        return targetMode?.lowercased() == "external"
+            || lowercasedTarget.hasPrefix("http://")
+            || lowercasedTarget.hasPrefix("https://")
+            || lowercasedTarget.hasPrefix("file://")
+            || lowercasedTarget.hasPrefix("//")
+    }
+}
+
+private extension Workbook.CellValue {
+    var kindName: String {
+        switch self {
+        case .empty: return "empty"
+        case .number: return "number"
+        case .string: return "string"
+        case .bool: return "bool"
+        }
+    }
+}
+
+private extension String {
+    func utf16Suffix(from startOffset: Int) -> String {
+        guard startOffset > 0 else { return self }
+        let utf16View = utf16
+        guard let start = utf16View.index(utf16View.startIndex, offsetBy: startOffset, limitedBy: utf16View.endIndex),
+            let scalarStart = String.Index(start, within: self)
+        else { return "" }
+        return String(self[scalarStart...])
+    }
+}
+
+// MARK: - XML delegates
+
+private final class WorkbookIndexParser: NSObject, XMLParserDelegate {
+    private(set) var sheets: [WorkbookSheetReference] = []
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        guard elementName.xlsxLocalName == "sheet" else { return }
+        let name = attributeDict["name"] ?? "Sheet \(sheets.count + 1)"
+        let relationshipId = attributeDict["r:id"] ?? attributeDict["id"]
+        let sheetId = attributeDict["sheetId"].flatMap(Int.init)
+        sheets.append(
+            WorkbookSheetReference(
+                name: name,
+                relationshipId: relationshipId,
+                sheetId: sheetId
+            )
+        )
+    }
+}
+
+private final class RelationshipsParser: NSObject, XMLParserDelegate {
+    private(set) var relationships: [XLSXRelationship] = []
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        guard elementName.xlsxLocalName == "Relationship",
+            let id = attributeDict["Id"] ?? attributeDict["id"],
+            let target = attributeDict["Target"] ?? attributeDict["target"]
+        else { return }
+        relationships.append(
+            XLSXRelationship(
+                id: id,
+                type: attributeDict["Type"] ?? attributeDict["type"] ?? "",
+                target: target,
+                targetMode: attributeDict["TargetMode"] ?? attributeDict["targetMode"]
+            )
+        )
+    }
+}
+
+private final class SharedStringsParser: NSObject, XMLParserDelegate {
+    private(set) var items: [String] = []
+    private var currentItem: String?
+    private var textBuffer: String?
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes _: [String: String] = [:]
+    ) {
+        switch elementName.xlsxLocalName {
+        case "si":
+            currentItem = ""
+        case "t" where currentItem != nil:
+            textBuffer = ""
+        default:
+            break
+        }
+    }
+
+    func parser(_: XMLParser, foundCharacters string: String) {
+        guard textBuffer != nil else { return }
+        textBuffer?.append(string)
+    }
+
+    func parser(
+        _: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?
+    ) {
+        switch elementName.xlsxLocalName {
+        case "t" where currentItem != nil:
+            currentItem?.append(textBuffer ?? "")
+            textBuffer = nil
+        case "si":
+            items.append(currentItem ?? "")
+            currentItem = nil
+        default:
+            break
+        }
+    }
+}
+
+private final class WorksheetParser: NSObject, XMLParserDelegate {
+    private let sharedStrings: [String]
+    private(set) var rows: [ParsedRow] = []
+    private(set) var mergedRanges: [Workbook.CellRange] = []
+
+    private var currentRowNumber: Int?
+    private var currentCells: [ParsedCell] = []
+    private var currentCell: CellBuilder?
+    private var textBuffer: String?
+    private var insideInlineString = false
+
+    init(sharedStrings: [String]) {
+        self.sharedStrings = sharedStrings
+    }
+
+    func parser(
+        _: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        switch elementName.xlsxLocalName {
+        case "row":
+            currentRowNumber = attributeDict["r"].flatMap(Int.init) ?? rows.count + 1
+            currentCells = []
+        case "c":
+            currentCell = CellBuilder(
+                reference: attributeDict["r"],
+                type: attributeDict["t"]
+            )
+        case "v", "f":
+            if currentCell != nil {
+                textBuffer = ""
+            }
+        case "is" where currentCell != nil:
+            insideInlineString = true
+        case "t" where currentCell != nil && insideInlineString:
+            textBuffer = ""
+        case "mergeCell":
+            if let ref = attributeDict["ref"], !ref.isEmpty {
+                mergedRanges.append(Workbook.CellRange(reference: ref))
+            }
+        default:
+            break
+        }
+    }
+
+    func parser(_: XMLParser, foundCharacters string: String) {
+        guard textBuffer != nil else { return }
+        textBuffer?.append(string)
+    }
+
+    func parser(
+        _: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI _: String?,
+        qualifiedName _: String?
+    ) {
+        switch elementName.xlsxLocalName {
+        case "v":
+            currentCell?.rawValue = textBuffer ?? ""
+            textBuffer = nil
+        case "f":
+            currentCell?.formula = nilIfEmpty(textBuffer)
+            textBuffer = nil
+        case "t" where insideInlineString:
+            currentCell?.inlineText.append(textBuffer ?? "")
+            textBuffer = nil
+        case "is":
+            insideInlineString = false
+        case "c":
+            if let cell = buildCurrentCell() {
+                currentCells.append(cell)
+            }
+            currentCell = nil
+        case "row":
+            if let rowNumber = currentRowNumber, !currentCells.isEmpty {
+                rows.append(ParsedRow(number: rowNumber, cells: currentCells))
+            }
+            currentRowNumber = nil
+            currentCells = []
+        default:
+            break
+        }
+    }
+
+    private func buildCurrentCell() -> ParsedCell? {
+        guard let builder = currentCell else { return nil }
+        let parsedReference = builder.reference.flatMap(Self.parseCellReference)
+        let rowNumber = parsedReference?.rowNumber ?? currentRowNumber ?? rows.count + 1
+        let columnNumber = parsedReference?.columnNumber ?? currentCells.count + 1
+        let reference = builder.reference ?? Self.cellReference(columnNumber: columnNumber, rowNumber: rowNumber)
+        let value = Self.cellValue(
+            type: builder.type,
+            rawValue: builder.rawValue,
+            inlineText: builder.inlineText,
+            sharedStrings: sharedStrings
+        )
+        guard value != .empty || builder.formula != nil else { return nil }
+        return ParsedCell(
+            reference: reference,
+            rowNumber: rowNumber,
+            columnNumber: columnNumber,
+            value: value,
+            formula: builder.formula
+        )
+    }
+
+    private static func cellValue(
+        type: String?,
+        rawValue: String?,
+        inlineText: String,
+        sharedStrings: [String]
+    ) -> Workbook.CellValue {
+        let normalizedType = type?.lowercased()
+        let raw = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        switch normalizedType {
+        case "s":
+            guard let index = Int(raw), sharedStrings.indices.contains(index) else {
+                return raw.isEmpty ? .empty : .string(raw)
+            }
+            return .string(sharedStrings[index])
+        case "b":
+            return .bool(raw == "1" || raw.lowercased() == "true")
+        case "inlinestr":
+            return inlineText.isEmpty ? .empty : .string(inlineText)
+        case "str", "d", "e":
+            return raw.isEmpty ? .empty : .string(raw)
+        default:
+            if raw.isEmpty { return .empty }
+            if let number = Double(raw) {
+                return .number(number)
+            }
+            return .string(raw)
+        }
+    }
+
+    private static func parseCellReference(_ reference: String) -> (columnNumber: Int, rowNumber: Int)? {
+        var column = 0
+        var rowText = ""
+        for scalar in reference.unicodeScalars {
+            if CharacterSet.letters.contains(scalar) {
+                let value = Int(scalar.value)
+                let upperA = Int(UnicodeScalar("A").value)
+                let lowerA = Int(UnicodeScalar("a").value)
+                if value >= upperA, value <= upperA + 25 {
+                    column = column * 26 + (value - upperA + 1)
+                } else if value >= lowerA, value <= lowerA + 25 {
+                    column = column * 26 + (value - lowerA + 1)
+                }
+            } else if CharacterSet.decimalDigits.contains(scalar) {
+                rowText.unicodeScalars.append(scalar)
+            }
+        }
+        guard column > 0, let row = Int(rowText), row > 0 else { return nil }
+        return (column, row)
+    }
+
+    private static func cellReference(columnNumber: Int, rowNumber: Int) -> String {
+        var column = columnNumber
+        var letters = ""
+        while column > 0 {
+            let remainder = (column - 1) % 26
+            let scalar = UnicodeScalar(65 + remainder)!
+            letters.insert(Character(scalar), at: letters.startIndex)
+            column = (column - 1) / 26
+        }
+        return "\(letters)\(rowNumber)"
+    }
+
+    private struct CellBuilder {
+        let reference: String?
+        let type: String?
+        var rawValue: String?
+        var inlineText = ""
+        var formula: String?
+    }
+}
+
+private func nilIfEmpty(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+private extension String {
+    var xlsxLocalName: String {
+        split(separator: ":").last.map(String.init) ?? self
+    }
+}
+
+// MARK: - Minimal ZIP reader
+
+private struct XLSXPackageArchive {
+    private struct Entry {
+        let path: String
+        let compressionMethod: Int
+        let flags: Int
+        let compressedSize: Int
+        let uncompressedSize: Int
+        let localHeaderOffset: Int
+    }
+
+    private let data: Data
+    private let entries: [String: Entry]
+
+    var paths: [String] {
+        entries.keys.sorted()
+    }
+
+    init(data: Data) throws {
+        self.data = data
+        self.entries = try Self.readCentralDirectory(data: data)
+    }
+
+    func contains(_ path: String) -> Bool {
+        entries[path] != nil
+    }
+
+    func xmlData(for path: String) throws -> Data {
+        guard let data = try optionalXMLData(for: path) else {
+            throw DocumentAdapterError.readFailed(underlying: "XLSX package is missing \(path)")
+        }
+        return data
+    }
+
+    func optionalXMLData(for path: String) throws -> Data? {
+        try entryData(for: path, maxUncompressedSize: XLSXAdapter.maxXMLPartBytes)
+    }
+
+    static func normalizedPackagePath(_ rawPath: String, relativeTo baseDirectory: String) throws -> String {
+        let combined: String
+        if rawPath.hasPrefix("/") {
+            combined = String(rawPath.drop { $0 == "/" })
+        } else if baseDirectory.isEmpty || baseDirectory == "." {
+            combined = rawPath
+        } else {
+            combined = "\(baseDirectory)/\(rawPath)"
+        }
+        return try normalizeEntryName(combined)
+    }
+
+    private func entryData(for path: String, maxUncompressedSize: Int) throws -> Data? {
+        guard let entry = entries[path] else { return nil }
+        if entry.flags & 0x1 != 0 {
+            throw DocumentAdapterError.readFailed(underlying: "Encrypted ZIP entries are not supported")
+        }
+        if entry.uncompressedSize > maxUncompressedSize {
+            throw DocumentAdapterError.readFailed(
+                underlying: "\(path) exceeds XML part limit (\(entry.uncompressedSize) bytes)"
+            )
+        }
+        let localOffset = entry.localHeaderOffset
+        guard try data.uint32LE(at: localOffset) == 0x0403_4B50 else {
+            throw DocumentAdapterError.readFailed(underlying: "\(path) has an invalid local ZIP header")
+        }
+        let fileNameLength = try data.uint16LE(at: localOffset + 26)
+        let extraLength = try data.uint16LE(at: localOffset + 28)
+        let payloadOffset = localOffset + 30 + fileNameLength + extraLength
+        let payloadEnd = payloadOffset + entry.compressedSize
+        guard payloadOffset >= 0, payloadEnd <= data.count else {
+            throw DocumentAdapterError.readFailed(underlying: "\(path) ZIP payload is truncated")
+        }
+        let payload = data.subdata(in: payloadOffset ..< payloadEnd)
+        switch entry.compressionMethod {
+        case 0:
+            guard payload.count == entry.uncompressedSize else {
+                throw DocumentAdapterError.readFailed(underlying: "\(path) stored ZIP size mismatch")
+            }
+            return payload
+        case 8:
+            return try Self.inflate(payload, uncompressedSize: entry.uncompressedSize, path: path)
+        default:
+            throw DocumentAdapterError.readFailed(
+                underlying: "\(path) uses unsupported ZIP compression method \(entry.compressionMethod)"
+            )
+        }
+    }
+
+    private static func readCentralDirectory(data: Data) throws -> [String: Entry] {
+        let eocdOffset = try findEndOfCentralDirectory(in: data)
+        let entryCount = try data.uint16LE(at: eocdOffset + 10)
+        let centralDirectorySize = try data.uint32LE(at: eocdOffset + 12)
+        let centralDirectoryOffset = try data.uint32LE(at: eocdOffset + 16)
+
+        guard centralDirectoryOffset + centralDirectorySize <= data.count else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP central directory is truncated")
+        }
+
+        var entries: [String: Entry] = [:]
+        var offset = centralDirectoryOffset
+        for _ in 0 ..< entryCount {
+            guard try data.uint32LE(at: offset) == 0x0201_4B50 else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP central directory entry is invalid")
+            }
+            let flags = try data.uint16LE(at: offset + 8)
+            let compressionMethod = try data.uint16LE(at: offset + 10)
+            let compressedSize = try data.uint32LE(at: offset + 20)
+            let uncompressedSize = try data.uint32LE(at: offset + 24)
+            let fileNameLength = try data.uint16LE(at: offset + 28)
+            let extraLength = try data.uint16LE(at: offset + 30)
+            let commentLength = try data.uint16LE(at: offset + 32)
+            let localHeaderOffset = try data.uint32LE(at: offset + 42)
+            let nameStart = offset + 46
+            let nameEnd = nameStart + fileNameLength
+            guard nameEnd <= data.count else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP entry name is truncated")
+            }
+            guard let rawName = String(data: data.subdata(in: nameStart ..< nameEnd), encoding: .utf8) else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP entry name is not UTF-8")
+            }
+            let path = try normalizeEntryName(rawName)
+            if entries[path] != nil {
+                throw DocumentAdapterError.readFailed(underlying: "Duplicate ZIP entry \(path)")
+            }
+            entries[path] = Entry(
+                path: path,
+                compressionMethod: compressionMethod,
+                flags: flags,
+                compressedSize: compressedSize,
+                uncompressedSize: uncompressedSize,
+                localHeaderOffset: localHeaderOffset
+            )
+            offset = nameEnd + extraLength + commentLength
+        }
+        return entries
+    }
+
+    private static func findEndOfCentralDirectory(in data: Data) throws -> Int {
+        guard data.count >= 22 else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP package is too small")
+        }
+        let searchStart = max(0, data.count - 65_557)
+        var offset = data.count - 22
+        while offset >= searchStart {
+            if (try? data.uint32LE(at: offset)) == 0x0605_4B50,
+                let commentLength = try? data.uint16LE(at: offset + 20),
+                offset + 22 + commentLength == data.count
+            {
+                return offset
+            }
+            offset -= 1
+        }
+        throw DocumentAdapterError.readFailed(underlying: "ZIP end of central directory was not found")
+    }
+
+    private static func inflate(_ payload: Data, uncompressedSize: Int, path: String) throws -> Data {
+        if uncompressedSize == 0 { return Data() }
+        var output = Data(count: uncompressedSize)
+        let decodedCount = output.withUnsafeMutableBytes { outputBuffer in
+            payload.withUnsafeBytes { inputBuffer in
+                guard
+                    let outputBase = outputBuffer.bindMemory(to: UInt8.self).baseAddress,
+                    let inputBase = inputBuffer.bindMemory(to: UInt8.self).baseAddress
+                else { return 0 }
+                return compression_decode_buffer(
+                    outputBase,
+                    uncompressedSize,
+                    inputBase,
+                    payload.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard decodedCount == uncompressedSize else {
+            throw DocumentAdapterError.readFailed(underlying: "\(path) deflate stream could not be decoded")
+        }
+        return output
+    }
+
+    private static func normalizeEntryName(_ rawName: String) throws -> String {
+        let normalizedSeparators = rawName.replacingOccurrences(of: "\\", with: "/")
+        guard !normalizedSeparators.hasPrefix("/") else {
+            throw DocumentAdapterError.readFailed(underlying: "Absolute ZIP entry paths are not supported")
+        }
+        var components: [String] = []
+        for component in normalizedSeparators.split(separator: "/") {
+            if component == "." { continue }
+            if component == ".." {
+                throw DocumentAdapterError.readFailed(underlying: "Parent-relative ZIP entry paths are not supported")
+            }
+            components.append(String(component))
+        }
+        guard !components.isEmpty else {
+            throw DocumentAdapterError.readFailed(underlying: "Empty ZIP entry path")
+        }
+        return components.joined(separator: "/")
+    }
+}
+
+private extension Data {
+    func uint16LE(at offset: Int) throws -> Int {
+        guard offset >= 0, offset + 2 <= count else {
+            throw DocumentAdapterError.readFailed(underlying: "Unexpected end of ZIP data")
+        }
+        return Int(self[offset])
+            | (Int(self[offset + 1]) << 8)
+    }
+
+    func uint32LE(at offset: Int) throws -> Int {
+        guard offset >= 0, offset + 4 <= count else {
+            throw DocumentAdapterError.readFailed(underlying: "Unexpected end of ZIP data")
+        }
+        return Int(self[offset])
+            | (Int(self[offset + 1]) << 8)
+            | (Int(self[offset + 2]) << 16)
+            | (Int(self[offset + 3]) << 24)
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
@@ -1,0 +1,635 @@
+//
+//  XLSXEmitter.swift
+//  osaurus
+//
+//  Writes the same conservative workbook subset the dependency-free XLSX
+//  reader can parse: sheets, sparse rows, scalar cell values, shared strings,
+//  and merged ranges. Formulas and styling are rejected instead of being
+//  silently flattened so callers do not mistake a lossy export for a faithful
+//  workbook round trip.
+//
+
+import Foundation
+
+public struct XLSXEmitter: DocumentFormatEmitter {
+    public let formatId = "xlsx"
+
+    public init() {}
+
+    public func canEmit(_ document: StructuredDocument) -> Bool {
+        (document.formatId == formatId || document.representation.formatId == formatId)
+            && document.representation.underlying is Workbook
+    }
+
+    public func emit(_ document: StructuredDocument, to url: URL) async throws {
+        guard let workbook = document.representation.underlying as? Workbook else {
+            throw DocumentAdapterError.unsupportedFormat(formatId: document.formatId)
+        }
+
+        do {
+            let data = try Self.packageData(for: workbook)
+            try data.write(to: url, options: .atomic)
+        } catch let error as DocumentAdapterError {
+            throw error
+        } catch {
+            throw DocumentAdapterError.writeFailed(underlying: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Package assembly
+
+    private static let spreadsheetNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    private static let officeRelationshipNamespace =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    private static let packageRelationshipNamespace =
+        "http://schemas.openxmlformats.org/package/2006/relationships"
+    private static let worksheetRelationshipType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+    private static let sharedStringsRelationshipType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
+    private static let officeDocumentRelationshipType =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+
+    private static func packageData(for workbook: Workbook) throws -> Data {
+        let sheets = try validatedSheets(workbook.sheets)
+        try rejectFormulaCells(in: sheets)
+
+        var sharedStrings = SharedStringTable()
+        var worksheetEntries: [(path: String, xml: String)] = []
+        for sheet in sheets {
+            worksheetEntries.append(
+                (
+                    path: "xl/worksheets/sheet\(sheet.index + 1).xml",
+                    xml: try worksheetXML(for: sheet, sharedStrings: &sharedStrings)
+                )
+            )
+        }
+
+        var entries: [(path: String, data: Data)] = [
+            (
+                "[Content_Types].xml",
+                try utf8Data(contentTypesXML(sheetCount: sheets.count, hasSharedStrings: !sharedStrings.isEmpty))
+            ),
+            ("_rels/.rels", try utf8Data(rootRelationshipsXML())),
+            ("xl/workbook.xml", try utf8Data(workbookXML(for: sheets))),
+            (
+                "xl/_rels/workbook.xml.rels",
+                try utf8Data(
+                    workbookRelationshipsXML(sheetCount: sheets.count, hasSharedStrings: !sharedStrings.isEmpty)
+                )
+            ),
+        ]
+
+        if !sharedStrings.isEmpty {
+            entries.append(("xl/sharedStrings.xml", try utf8Data(sharedStringsXML(sharedStrings))))
+        }
+
+        for worksheet in worksheetEntries {
+            entries.append((worksheet.path, try utf8Data(worksheet.xml)))
+        }
+
+        var archive = XLSXStoredZIPWriter()
+        for entry in entries {
+            try archive.append(path: entry.path, data: entry.data)
+        }
+        return try archive.finalize()
+    }
+
+    private static func contentTypesXML(sheetCount: Int, hasSharedStrings: Bool) throws -> String {
+        var overrides: [String] = [
+            """
+            <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+            """
+        ]
+        if hasSharedStrings {
+            overrides.append(
+                """
+                <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+                """
+            )
+        }
+        for index in 1 ... sheetCount {
+            overrides.append(
+                """
+                <Override PartName="/xl/worksheets/sheet\(index).xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                """
+            )
+        }
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+              <Default Extension="xml" ContentType="application/xml"/>
+              \(overrides.joined(separator: "\n  "))
+            </Types>
+            """
+    }
+
+    private static func rootRelationshipsXML() -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="\(packageRelationshipNamespace)">
+          <Relationship Id="rId1" Type="\(officeDocumentRelationshipType)" Target="xl/workbook.xml"/>
+        </Relationships>
+        """
+    }
+
+    private static func workbookXML(for sheets: [Workbook.Sheet]) throws -> String {
+        let sheetXML = try sheets.map { sheet in
+            let escapedName = try escapeXMLAttribute(sheet.name)
+            return """
+                      <sheet name="\(escapedName)" sheetId="\(sheet.index + 1)" r:id="rId\(sheet.index + 1)"/>
+                """
+        }.joined(separator: "\n")
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <workbook xmlns="\(spreadsheetNamespace)" xmlns:r="\(officeRelationshipNamespace)">
+              <sheets>
+            \(sheetXML)
+              </sheets>
+            </workbook>
+            """
+    }
+
+    private static func workbookRelationshipsXML(sheetCount: Int, hasSharedStrings: Bool) -> String {
+        var relationships = (1 ... sheetCount).map { index in
+            """
+              <Relationship Id="rId\(index)" Type="\(worksheetRelationshipType)" Target="worksheets/sheet\(index).xml"/>
+            """
+        }
+        if hasSharedStrings {
+            relationships.append(
+                """
+                  <Relationship Id="rId\(sheetCount + 1)" Type="\(sharedStringsRelationshipType)" Target="sharedStrings.xml"/>
+                """
+            )
+        }
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Relationships xmlns="\(packageRelationshipNamespace)">
+            \(relationships.joined(separator: "\n"))
+            </Relationships>
+            """
+    }
+
+    private static func worksheetXML(
+        for sheet: Workbook.Sheet,
+        sharedStrings: inout SharedStringTable
+    ) throws -> String {
+        let rows = try sheet.rows
+            .sorted { $0.number < $1.number }
+            .map { row in try rowXML(row, sheet: sheet, sharedStrings: &sharedStrings) }
+            .joined(separator: "\n")
+        let mergedRanges = try mergeCellsXML(sheet.mergedRanges)
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <worksheet xmlns="\(spreadsheetNamespace)">
+              <sheetData>
+            \(rows)
+              </sheetData>
+            \(mergedRanges)
+            </worksheet>
+            """
+    }
+
+    private static func rowXML(
+        _ row: Workbook.Row,
+        sheet: Workbook.Sheet,
+        sharedStrings: inout SharedStringTable
+    ) throws -> String {
+        let cells = try row.cells
+            .sorted { $0.columnNumber < $1.columnNumber }
+            .map { cell in try cellXML(cell, row: row, sheet: sheet, sharedStrings: &sharedStrings) }
+            .joined()
+        return """
+                <row r="\(row.number)">\(cells)</row>
+            """
+    }
+
+    private static func cellXML(
+        _ cell: Workbook.Cell,
+        row: Workbook.Row,
+        sheet: Workbook.Sheet,
+        sharedStrings: inout SharedStringTable
+    ) throws -> String {
+        guard cell.rowNumber == row.number else {
+            throw writeFailed(
+                "\(sheet.name)!\(cell.reference) rowNumber \(cell.rowNumber) does not match row \(row.number)"
+            )
+        }
+        let reference = try validatedCellReference(for: cell, sheetName: sheet.name)
+
+        switch cell.value {
+        case .empty:
+            return #"<c r="\#(reference)"/>"#
+        case .number(let value):
+            return #"<c r="\#(reference)"><v>\#(try numberText(value))</v></c>"#
+        case .string(let value):
+            let index = sharedStrings.index(for: value)
+            return #"<c r="\#(reference)" t="s"><v>\#(index)</v></c>"#
+        case .bool(let value):
+            return #"<c r="\#(reference)" t="b"><v>\#(value ? "1" : "0")</v></c>"#
+        }
+    }
+
+    private static func mergeCellsXML(_ ranges: [Workbook.CellRange]) throws -> String {
+        guard !ranges.isEmpty else { return "" }
+        let cells = try ranges.map { range in
+            guard isValidCellRangeReference(range.reference) else {
+                throw writeFailed("Invalid merged range '\(range.reference)'")
+            }
+            return #"  <mergeCell ref="\#(try escapeXMLAttribute(range.reference))"/>"#
+        }.joined(separator: "\n")
+
+        return """
+              <mergeCells count="\(ranges.count)">
+            \(cells)
+              </mergeCells>
+            """
+    }
+
+    private static func sharedStringsXML(_ table: SharedStringTable) throws -> String {
+        let items = try table.values.map { value in
+            let escaped = try escapeXMLText(value)
+            let space = needsPreservedXMLSpace(value) ? #" xml:space="preserve""# : ""
+            return """
+                  <si><t\(space)>\(escaped)</t></si>
+                """
+        }.joined(separator: "\n")
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <sst xmlns="\(spreadsheetNamespace)" count="\(table.totalReferences)" uniqueCount="\(table.values.count)">
+            \(items)
+            </sst>
+            """
+    }
+
+    // MARK: - Validation
+
+    private static let maxRows = 1_048_576
+    private static let maxColumns = 16_384
+    private static let invalidSheetNameCharacters = CharacterSet(charactersIn: "[]:*?/\\")
+
+    private static func validatedSheets(_ sheets: [Workbook.Sheet]) throws -> [Workbook.Sheet] {
+        guard !sheets.isEmpty else { throw DocumentAdapterError.emptyContent }
+
+        var names: Set<String> = []
+        for (offset, sheet) in sheets.enumerated() {
+            guard sheet.index == offset else {
+                throw writeFailed("Sheet '\(sheet.name)' has index \(sheet.index), expected \(offset)")
+            }
+            try validateSheetName(sheet.name)
+            let normalizedName = sheet.name.lowercased()
+            guard names.insert(normalizedName).inserted else {
+                throw writeFailed("Duplicate sheet name '\(sheet.name)'")
+            }
+            try validateRows(sheet.rows, sheetName: sheet.name)
+            for range in sheet.mergedRanges where !isValidCellRangeReference(range.reference) {
+                throw writeFailed("Invalid merged range '\(range.reference)'")
+            }
+        }
+        return sheets
+    }
+
+    private static func validateSheetName(_ name: String) throws {
+        guard !name.isEmpty else { throw writeFailed("Sheet name cannot be empty") }
+        guard name.utf16.count <= 31 else {
+            throw writeFailed("Sheet name '\(name)' exceeds the XLSX 31-character limit")
+        }
+        guard name.rangeOfCharacter(from: invalidSheetNameCharacters) == nil else {
+            throw writeFailed("Sheet name '\(name)' contains characters XLSX does not allow")
+        }
+        guard name.first != "'", name.last != "'" else {
+            throw writeFailed("Sheet name '\(name)' cannot start or end with apostrophe")
+        }
+    }
+
+    private static func validateRows(_ rows: [Workbook.Row], sheetName: String) throws {
+        var rowNumbers: Set<Int> = []
+        var cellReferences: Set<String> = []
+        for row in rows {
+            guard row.number >= 1, row.number <= maxRows else {
+                throw writeFailed("\(sheetName) row \(row.number) is outside XLSX row bounds")
+            }
+            guard rowNumbers.insert(row.number).inserted else {
+                throw writeFailed("\(sheetName) contains duplicate row \(row.number)")
+            }
+
+            for cell in row.cells {
+                guard cell.columnNumber >= 1, cell.columnNumber <= maxColumns else {
+                    throw writeFailed("\(sheetName)!\(cell.reference) is outside XLSX column bounds")
+                }
+                guard cell.rowNumber >= 1, cell.rowNumber <= maxRows else {
+                    throw writeFailed("\(sheetName)!\(cell.reference) is outside XLSX row bounds")
+                }
+                let normalizedReference = cell.reference.uppercased()
+                guard cellReferences.insert(normalizedReference).inserted else {
+                    throw writeFailed("\(sheetName) contains duplicate cell \(cell.reference)")
+                }
+            }
+        }
+    }
+
+    private static func rejectFormulaCells(in sheets: [Workbook.Sheet]) throws {
+        for sheet in sheets {
+            for row in sheet.rows {
+                for cell in row.cells where cell.formula != nil {
+                    throw writeFailed("XLSX emitter does not write formulas yet (\(sheet.name)!\(cell.reference))")
+                }
+            }
+        }
+    }
+
+    private static func validatedCellReference(for cell: Workbook.Cell, sheetName: String) throws -> String {
+        let expected = cellReference(columnNumber: cell.columnNumber, rowNumber: cell.rowNumber)
+        guard let parsed = parseCellReference(cell.reference),
+            parsed.columnNumber == cell.columnNumber,
+            parsed.rowNumber == cell.rowNumber,
+            cell.reference.uppercased() == expected
+        else {
+            throw writeFailed("\(sheetName)!\(cell.reference) does not match row/column \(expected)")
+        }
+        return expected
+    }
+
+    private static func isValidCellRangeReference(_ reference: String) -> Bool {
+        let endpoints = reference.split(separator: ":", omittingEmptySubsequences: false)
+        guard endpoints.count == 1 || endpoints.count == 2 else { return false }
+        return endpoints.allSatisfy { parseCellReference(String($0)) != nil }
+    }
+
+    private static func parseCellReference(_ reference: String) -> (columnNumber: Int, rowNumber: Int)? {
+        var column = 0
+        var rowText = ""
+        var readingRow = false
+
+        for scalar in reference.unicodeScalars {
+            if CharacterSet.letters.contains(scalar), !readingRow {
+                let value = Int(scalar.value)
+                let upperA = Int(UnicodeScalar("A").value)
+                let lowerA = Int(UnicodeScalar("a").value)
+                if value >= upperA, value <= upperA + 25 {
+                    column = column * 26 + (value - upperA + 1)
+                } else if value >= lowerA, value <= lowerA + 25 {
+                    column = column * 26 + (value - lowerA + 1)
+                } else {
+                    return nil
+                }
+            } else if CharacterSet.decimalDigits.contains(scalar) {
+                readingRow = true
+                rowText.unicodeScalars.append(scalar)
+            } else {
+                return nil
+            }
+        }
+
+        guard column > 0, column <= maxColumns, let row = Int(rowText), row > 0, row <= maxRows else {
+            return nil
+        }
+        return (column, row)
+    }
+
+    private static func cellReference(columnNumber: Int, rowNumber: Int) -> String {
+        var column = columnNumber
+        var letters = ""
+        while column > 0 {
+            let remainder = (column - 1) % 26
+            let scalar = UnicodeScalar(65 + remainder)!
+            letters.insert(Character(scalar), at: letters.startIndex)
+            column = (column - 1) / 26
+        }
+        return "\(letters)\(rowNumber)"
+    }
+
+    private static func numberText(_ value: Double) throws -> String {
+        guard value.isFinite else {
+            throw writeFailed("XLSX emitter cannot write non-finite numbers")
+        }
+        if value >= Double(Int64.min),
+            value <= Double(Int64.max),
+            value.rounded(.towardZero) == value
+        {
+            return String(Int64(value))
+        }
+        return String(value)
+    }
+
+    // MARK: - XML escaping
+
+    private static func utf8Data(_ xml: String) throws -> Data {
+        guard let data = xml.data(using: .utf8) else {
+            throw writeFailed("XML could not be encoded as UTF-8")
+        }
+        return data
+    }
+
+    private static func escapeXMLText(_ value: String) throws -> String {
+        try validateXMLCharacters(value)
+        return
+            value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func escapeXMLAttribute(_ value: String) throws -> String {
+        try validateXMLCharacters(value)
+        return try escapeXMLText(value)
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+
+    private static func validateXMLCharacters(_ value: String) throws {
+        for scalar in value.unicodeScalars where !isAllowedXMLCharacter(scalar) {
+            throw writeFailed("String contains a character XML 1.0 cannot encode")
+        }
+    }
+
+    private static func isAllowedXMLCharacter(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x9, 0xA, 0xD:
+            return true
+        case 0x20 ... 0xD7FF, 0xE000 ... 0xFFFD, 0x10000 ... 0x10FFFF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func needsPreservedXMLSpace(_ value: String) -> Bool {
+        guard let first = value.unicodeScalars.first,
+            let last = value.unicodeScalars.last
+        else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(first)
+            || CharacterSet.whitespacesAndNewlines.contains(last)
+    }
+
+    private static func writeFailed(_ message: String) -> DocumentAdapterError {
+        .writeFailed(underlying: message)
+    }
+}
+
+private struct SharedStringTable {
+    private var indices: [String: Int] = [:]
+    private(set) var values: [String] = []
+    private(set) var totalReferences = 0
+
+    var isEmpty: Bool { values.isEmpty }
+
+    mutating func index(for value: String) -> Int {
+        totalReferences += 1
+        if let index = indices[value] {
+            return index
+        }
+        let index = values.count
+        indices[value] = index
+        values.append(value)
+        return index
+    }
+}
+
+private struct XLSXStoredZIPWriter {
+    private struct CentralDirectoryEntry {
+        let path: String
+        let crc32: UInt32
+        let size: UInt32
+        let localHeaderOffset: UInt32
+    }
+
+    private var archive = Data()
+    private var entries: [CentralDirectoryEntry] = []
+
+    mutating func append(path: String, data: Data) throws {
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("..") else {
+            throw DocumentAdapterError.writeFailed(underlying: "Invalid ZIP entry path '\(path)'")
+        }
+        let name = Data(path.utf8)
+        let localHeaderOffset = try uint32(archive.count, label: "ZIP local header offset")
+        let size = try uint32(data.count, label: "\(path) size")
+        let nameLength = try uint16(name.count, label: "\(path) name length")
+        let checksum = crc32(data)
+
+        archive.appendUInt32LE(0x0403_4B50)
+        archive.appendUInt16LE(20)
+        archive.appendUInt16LE(0x0800)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(0)
+        archive.appendUInt32LE(checksum)
+        archive.appendUInt32LE(size)
+        archive.appendUInt32LE(size)
+        archive.appendUInt16LE(nameLength)
+        archive.appendUInt16LE(0)
+        archive.append(name)
+        archive.append(data)
+
+        entries.append(
+            CentralDirectoryEntry(
+                path: path,
+                crc32: checksum,
+                size: size,
+                localHeaderOffset: localHeaderOffset
+            )
+        )
+    }
+
+    mutating func finalize() throws -> Data {
+        var centralDirectory = Data()
+        for entry in entries {
+            let name = Data(entry.path.utf8)
+            let nameLength = try uint16(name.count, label: "\(entry.path) name length")
+
+            centralDirectory.appendUInt32LE(0x0201_4B50)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(0x0800)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(entry.crc32)
+            centralDirectory.appendUInt32LE(entry.size)
+            centralDirectory.appendUInt32LE(entry.size)
+            centralDirectory.appendUInt16LE(nameLength)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(0)
+            centralDirectory.appendUInt32LE(entry.localHeaderOffset)
+            centralDirectory.append(name)
+        }
+
+        let centralDirectoryOffset = try uint32(archive.count, label: "ZIP central directory offset")
+        let centralDirectorySize = try uint32(centralDirectory.count, label: "ZIP central directory size")
+        let entryCount = try uint16(entries.count, label: "ZIP entry count")
+
+        archive.append(centralDirectory)
+        archive.appendUInt32LE(0x0605_4B50)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(entryCount)
+        archive.appendUInt16LE(entryCount)
+        archive.appendUInt32LE(centralDirectorySize)
+        archive.appendUInt32LE(centralDirectoryOffset)
+        archive.appendUInt16LE(0)
+        return archive
+    }
+
+    private func uint16(_ value: Int, label: String) throws -> UInt16 {
+        guard value >= 0, value <= Int(UInt16.max) else {
+            throw DocumentAdapterError.writeFailed(underlying: "\(label) exceeds ZIP32 limits")
+        }
+        return UInt16(value)
+    }
+
+    private func uint32(_ value: Int, label: String) throws -> UInt32 {
+        guard value >= 0, value <= Int(UInt32.max) else {
+            throw DocumentAdapterError.writeFailed(underlying: "\(label) exceeds ZIP32 limits")
+        }
+        return UInt32(value)
+    }
+
+    private func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = (crc >> 8) ^ crc32Table[index]
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
+    private let crc32Table: [UInt32] = (0 ..< 256).map { value in
+        var crc = UInt32(value)
+        for _ in 0 ..< 8 {
+            if crc & 1 == 1 {
+                crc = 0xEDB8_8320 ^ (crc >> 1)
+            } else {
+                crc >>= 1
+            }
+        }
+        return crc
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16LE(_ value: UInt16) {
+        append(contentsOf: [
+            UInt8(value & 0x00FF),
+            UInt8((value >> 8) & 0x00FF),
+        ])
+    }
+
+    mutating func appendUInt32LE(_ value: UInt32) {
+        append(contentsOf: [
+            UInt8(value & 0x0000_00FF),
+            UInt8((value >> 8) & 0x0000_00FF),
+            UInt8((value >> 16) & 0x0000_00FF),
+            UInt8((value >> 24) & 0x0000_00FF),
+        ])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
@@ -1,0 +1,130 @@
+//
+//  CSVAdapterTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("CSVAdapter")
+struct CSVAdapterTests {
+    @Test func canHandle_acceptsCSVAndTSVExtensions() {
+        let csv = CSVAdapter(delimiter: .comma)
+        let tsv = CSVAdapter(delimiter: .tab)
+
+        #expect(csv.canHandle(url: URL(fileURLWithPath: "/tmp/table.csv"), uti: nil))
+        #expect(csv.canHandle(url: URL(fileURLWithPath: "/tmp/table.CSV"), uti: nil))
+        #expect(csv.canHandle(url: URL(fileURLWithPath: "/tmp/table.tsv"), uti: nil) == false)
+        #expect(tsv.canHandle(url: URL(fileURLWithPath: "/tmp/table.tsv"), uti: nil))
+        #expect(tsv.canHandle(url: URL(fileURLWithPath: "/tmp/table.csv"), uti: nil) == false)
+    }
+
+    @Test func parse_readsCommaCSVRowsAndCells() async throws {
+        let url = try Self.write("name,age\nAda,37\n", filename: "people.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        let csv = try #require(doc.representation.underlying as? CSVDocument)
+
+        #expect(doc.formatId == "csv")
+        #expect(csv.delimiter == .comma)
+        #expect(csv.rowCount == 2)
+        #expect(csv.columnCount == 2)
+        #expect(csv.rows[0].cells.map(\.text) == ["name", "age"])
+        #expect(csv.rows[1].cells.map(\.text) == ["Ada", "37"])
+        #expect(doc.textFallback == "name\tage\nAda\t37")
+        #expect(doc.security.inspectionStatus == .inspected)
+        #expect(doc.security.sha256?.isEmpty == false)
+    }
+
+    @Test func parse_readsTSVWithTabDelimiter() async throws {
+        let url = try Self.write("name\trole\nAda\tengineer", filename: "people.tsv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await CSVAdapter(delimiter: .tab).parse(url: url, sizeLimit: 0)
+        let csv = try #require(doc.representation.underlying as? CSVDocument)
+
+        #expect(doc.formatId == "tsv")
+        #expect(csv.delimiter == .tab)
+        #expect(csv.rows[1].cells.map(\.text) == ["Ada", "engineer"])
+        #expect(doc.textFallback == "name\trole\nAda\tengineer")
+    }
+
+    @Test func parse_unescapesQuotedFieldsAndEscapedQuotes() async throws {
+        let source = "name,quote\nAda,\"Hello, \"\"world\"\"\"\n"
+        let url = try Self.write(source, filename: "quotes.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        let csv = try #require(doc.representation.underlying as? CSVDocument)
+        let quoteCell = csv.rows[1].cells[1]
+
+        #expect(quoteCell.text == "Hello, \"world\"")
+        #expect(quoteCell.wasQuoted)
+        #expect(quoteCell.sourceRange.length == "\"Hello, \"\"world\"\"\"".utf16.count)
+        #expect(doc.textFallback == "name\tquote\nAda\tHello, \"world\"")
+    }
+
+    @Test func parse_preservesCRLFAndBlankLinesAsRows() async throws {
+        let url = try Self.write("a,b\r\n\r\nc,d", filename: "blank-lines.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        let csv = try #require(doc.representation.underlying as? CSVDocument)
+
+        #expect(csv.rows.count == 3)
+        #expect(csv.rows[1].cells.count == 1)
+        #expect(csv.rows[1].cells[0].text == "")
+        #expect(csv.rows[1].sourceRange.length == 0)
+        #expect(doc.textFallback == "a\tb\n\nc\td")
+    }
+
+    @Test func parse_buildsFallbackTextAndStructureAnchors() async throws {
+        let url = try Self.write("A😀,B\nC,D", filename: "anchors.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        let csv = try #require(doc.representation.underlying as? CSVDocument)
+        let firstCell = csv.rows[0].cells[0]
+        let secondRowAnchor = try #require(doc.structure.anchor(id: "document/table/rows/1"))
+        let firstCellAnchor = try #require(doc.structure.anchor(id: firstCell.anchorId))
+
+        #expect(doc.structure.elements(kind: .table).count == 1)
+        #expect(doc.structure.elements(kind: .tableRow).count == 2)
+        #expect(doc.structure.elements(kind: .tableCell).count == 4)
+        #expect(firstCell.textRange == DocumentTextRange(startUTF16Offset: 0, length: "A😀".utf16.count))
+        #expect(firstCell.sourceRange == DocumentTextRange(startUTF16Offset: 0, length: "A😀".utf16.count))
+        #expect(firstCellAnchor.sourceRange?.start.rowIndex == 0)
+        #expect(firstCellAnchor.sourceRange?.start.columnIndex == 0)
+        #expect(firstCellAnchor.textRange == firstCell.textRange)
+        #expect(secondRowAnchor.textRange?.startUTF16Offset == "A😀\tB\n".utf16.count)
+        #expect(doc.structure.textLengthUTF16 == doc.textFallback.utf16.count)
+    }
+
+    @Test func parse_throwsSizeLimitExceededAboveCap() async throws {
+        let url = try Self.write("a,b", filename: "too-large.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 1)
+        }
+    }
+
+    @Test func parse_throwsEmptyContentForEmptyFile() async throws {
+        let url = try Self.write("", filename: "empty.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        }
+    }
+
+    private static func write(_ content: String, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -86,7 +86,9 @@ struct DocumentParserShimTests {
         #expect(ids.contains("csv"))
         #expect(ids.contains("tsv"))
         #expect(ids.contains("pdf"))
+        #expect(ids.contains("pptx"))
         #expect(ids.contains("richdoc"))
+        #expect(ids.contains("xlsx"))
     }
 
     // MARK: - Fixtures

--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -83,6 +83,8 @@ struct DocumentParserShimTests {
         DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
         let ids = registry.registeredFormatIds()
         #expect(ids.contains("plaintext"))
+        #expect(ids.contains("csv"))
+        #expect(ids.contains("tsv"))
         #expect(ids.contains("pdf"))
         #expect(ids.contains("richdoc"))
     }

--- a/Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeDetectorTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/ExternalOfficeRuntimeDetectorTests.swift
@@ -1,0 +1,293 @@
+//
+//  ExternalOfficeRuntimeDetectorTests.swift
+//  osaurusTests
+//
+//  Uses temporary fake `soffice` executables so host-installed office suites
+//  never influence detector behavior.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("ExternalOfficeRuntimeDetector")
+struct ExternalOfficeRuntimeDetectorTests {
+    @Test func explicitURLWinsOverEnvironmentAndCommonPaths() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let explicit = root.appendingPathComponent("explicit/soffice")
+        let environment = root.appendingPathComponent("environment/soffice")
+        let common = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: explicit, output: "LibreOffice 24.2.0.3 420(Build:3)")
+        try Self.writeFakeSoffice(at: environment, output: "Apache OpenOffice 4.1.15")
+        try Self.writeFakeSoffice(at: common, output: "LibreOffice 7.6.4.1")
+
+        let snapshot = await Self.detector(
+            explicitExecutableURL: explicit,
+            environment: [
+                "OSAURUS_OFFICE_RUNTIME_PATH": environment.path
+            ],
+            commonApplicationCandidates: [
+                .init(executableURL: common, kind: .libreOffice, source: .applicationBundle)
+            ]
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == "24.2.0.3")
+        #expect(snapshot.executableURL == explicit.standardizedFileURL)
+        #expect(snapshot.source == .explicitURL)
+        #expect(snapshot.versionProbe?.status == .exited(status: 0))
+    }
+
+    @Test func environmentURLWinsWhenNoExplicitURLExists() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let environment = root.appendingPathComponent("OpenOffice.app/Contents/MacOS/soffice")
+        let common = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: environment, output: "Apache OpenOffice 4.1.15 AOO4115m1")
+        try Self.writeFakeSoffice(at: common, output: "LibreOffice 7.6.4.1")
+
+        let snapshot = await Self.detector(
+            environment: [
+                "OSAURUS_OFFICE_RUNTIME_URL": environment.absoluteString
+            ],
+            commonApplicationCandidates: [
+                .init(executableURL: common, kind: .libreOffice, source: .applicationBundle)
+            ]
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .openOffice)
+        #expect(snapshot.version == "4.1.15")
+        #expect(snapshot.executableURL == environment.standardizedFileURL)
+        #expect(snapshot.source == .environmentVariable(name: "OSAURUS_OFFICE_RUNTIME_URL"))
+    }
+
+    @Test func commonApplicationOrderPrefersLibreOfficeBeforeOpenOffice() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let libreOffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        let openOffice = root.appendingPathComponent("OpenOffice.app/Contents/MacOS/soffice")
+        try Self.writeFakeSoffice(at: libreOffice, output: "LibreOffice 7.6.4.1")
+        try Self.writeFakeSoffice(at: openOffice, output: "Apache OpenOffice 4.1.15")
+
+        let snapshot = await Self.detector(
+            commonApplicationCandidates: [
+                .init(executableURL: libreOffice, kind: .libreOffice, source: .applicationBundle),
+                .init(executableURL: openOffice, kind: .openOffice, source: .applicationBundle),
+            ]
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == "7.6.4.1")
+        #expect(snapshot.executableURL == libreOffice.standardizedFileURL)
+    }
+
+    @Test func pathSearchFindsExecutableSofficeAfterCommonMisses() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("bin/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOfficeDev 25.2.0.0.alpha0+ Build:abcd")
+
+        let snapshot = await Self.detector(
+            environment: [
+                "PATH": soffice.deletingLastPathComponent().path
+            ]
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == "25.2.0.0.alpha0")
+        #expect(snapshot.executableURL == soffice.standardizedFileURL)
+        #expect(snapshot.source == .searchPath)
+    }
+
+    @Test func nonExecutableCandidateDoesNotBecomeAvailable() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let nonExecutable = root.appendingPathComponent("bin/soffice")
+        try Self.writePlainFile(at: nonExecutable, content: "LibreOffice 24.2.0.3\n")
+
+        let snapshot = await Self.detector(
+            environment: [
+                "OSAURUS_OFFICE_RUNTIME_PATH": nonExecutable.path
+            ]
+        ).detect()
+
+        #expect(snapshot == .unavailable)
+    }
+
+    @Test func versionProbeTimeoutStillReportsExecutableRuntime() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("LibreOffice.app/Contents/MacOS/soffice")
+        try Self.writeExecutableScript(
+            at: soffice,
+            lines: [
+                "#!/bin/sh",
+                "while :; do :; done",
+            ]
+        )
+
+        let snapshot = await Self.detector(
+            commonApplicationCandidates: [
+                .init(executableURL: soffice, kind: .libreOffice, source: .applicationBundle)
+            ],
+            timeoutSeconds: 0.05
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == .libreOffice)
+        #expect(snapshot.version == nil)
+        #expect(snapshot.versionProbe?.status == .timedOut)
+    }
+
+    @Test func failedVersionProbeStillReportsExecutableRuntimeWithoutVersion() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("bin/soffice")
+        try Self.writeFakeSoffice(at: soffice, output: "LibreOffice 24.2.0.3", exitStatus: 64)
+
+        let snapshot = await Self.detector(
+            environment: [
+                "PATH": soffice.deletingLastPathComponent().path
+            ]
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.kind == nil)
+        #expect(snapshot.version == nil)
+        #expect(snapshot.versionProbe?.status == .exited(status: 64))
+    }
+
+    @Test func versionProbeOutputIsBounded() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let soffice = root.appendingPathComponent("bin/soffice")
+        try Self.writeFakeSoffice(
+            at: soffice,
+            output: "LibreOffice 24.2.0.3 " + String(repeating: "x", count: 128)
+        )
+
+        let snapshot = await Self.detector(
+            environment: [
+                "PATH": soffice.deletingLastPathComponent().path
+            ],
+            maxOutputBytes: 16
+        ).detect()
+
+        #expect(snapshot.available)
+        #expect(snapshot.version == nil)
+        #expect(snapshot.versionProbe?.capturedOutputBytes == 16)
+        #expect(snapshot.versionProbe?.outputWasTruncated == true)
+    }
+
+    @Test func representativeVersionParsing() {
+        let libreOffice = ExternalOfficeRuntimeDetector.parseVersionOutput(
+            "LibreOffice 7.5.9.2 50(Build:2)"
+        )
+        #expect(libreOffice?.kind == .libreOffice)
+        #expect(libreOffice?.version == "7.5.9.2")
+
+        let openOffice = ExternalOfficeRuntimeDetector.parseVersionOutput(
+            "Apache OpenOffice 4.1.15 AOO4115m1(Build:9813)"
+        )
+        #expect(openOffice?.kind == .openOffice)
+        #expect(openOffice?.version == "4.1.15")
+
+        #expect(ExternalOfficeRuntimeDetector.parseVersionOutput("office runtime ready") == nil)
+    }
+
+    private static func detector(
+        explicitExecutableURL: URL? = nil,
+        environment: [String: String] = [:],
+        commonApplicationCandidates: [ExternalOfficeRuntimeDetector.Candidate] = [],
+        timeoutSeconds: TimeInterval = 2.0,
+        maxOutputBytes: Int = 4_096
+    ) -> ExternalOfficeRuntimeDetector {
+        ExternalOfficeRuntimeDetector(
+            configuration: .init(
+                explicitExecutableURL: explicitExecutableURL,
+                environment: environment,
+                commonApplicationCandidates: commonApplicationCandidates,
+                versionProbeTimeoutSeconds: timeoutSeconds,
+                maxVersionProbeOutputBytes: maxOutputBytes
+            )
+        )
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ExternalOfficeRuntimeDetectorTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func writeFakeSoffice(
+        at url: URL,
+        output: String,
+        exitStatus: Int32 = 0
+    ) throws {
+        try Self.writeExecutableScript(
+            at: url,
+            lines: [
+                "#!/bin/sh",
+                #"if [ "$1" != "--version" ]; then"#,
+                "  exit 64",
+                "fi",
+                "cat <<'OSAURUS_SOFFICE_VERSION'",
+                output,
+                "OSAURUS_SOFFICE_VERSION",
+                "exit \(exitStatus)",
+            ]
+        )
+    }
+
+    private static func writePlainFile(
+        at url: URL,
+        content: String
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o644)],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static func writeExecutableScript(
+        at url: URL,
+        lines: [String]
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try (lines.joined(separator: "\n") + "\n").write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
@@ -39,13 +39,61 @@ struct PDFAdapterTests {
         #expect(doc.security.findings.contains { $0.kind == .unsupportedFeature })
     }
 
-    @Test func structureForTextFallback_usesPlainTextWhenFallbackIsCapped() {
+    @Test func parse_preservesPageSourceLocationsForMultiPagePDF() async throws {
+        let url = try Self.writePDF(pages: [
+            "First page text",
+            "Second 😀 page",
+            "Third page text",
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
+        let pages = doc.structure.elements(kind: .page)
+        #expect(pages.count == 3)
+        #expect(doc.structure.textLengthUTF16 == doc.textFallback.utf16.count)
+        try Self.expectAnchorRangesWithinFallback(pages, fallbackLength: doc.textFallback.utf16.count)
+
+        let firstText = try #require(pages[0].text)
+        let secondText = try #require(pages[1].text)
+        let firstRange = try #require(pages[0].anchor.textRange)
+        let secondRange = try #require(pages[1].anchor.textRange)
+        let thirdRange = try #require(pages[2].anchor.textRange)
+
+        #expect(firstRange.startUTF16Offset == 0)
+        #expect(secondRange.startUTF16Offset == firstText.utf16.count + 2)
+        #expect(thirdRange.startUTF16Offset == secondRange.endUTF16Offset + 2)
+        #expect(pages.map { $0.anchor.sourceRange?.start.pageIndex ?? -1 } == [0, 1, 2])
+        #expect(pages.map { $0.anchor.sourceRange?.end?.pageIndex ?? -1 } == [0, 1, 2])
+        #expect(pages[0].anchor.sourceRange?.start.characterOffset == 0)
+        #expect(pages[1].anchor.sourceRange?.end?.characterOffset == secondText.utf16.count)
+        #expect(pages.map { $0.anchor.metadata["pageOrder"] ?? "" } == ["0", "1", "2"])
+    }
+
+    @Test func parse_skipsBlankPagesButKeepsOriginalPageNumbers() async throws {
+        let url = try Self.writePDF(pages: [
+            "Visible first page",
+            "",
+            "Visible third page",
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
+        let pages = doc.structure.elements(kind: .page)
+
+        #expect(pages.count == 2)
+        #expect(pages.map { $0.anchor.sourceRange?.start.pageIndex ?? -1 } == [0, 2])
+        #expect(pages.map { $0.anchor.label ?? "" } == ["Page 1", "Page 3"])
+        #expect(pages.map { $0.anchor.metadata["pageOrder"] ?? "" } == ["0", "1"])
+    }
+
+    @Test func structureForTextFallback_clipsPageAnchorsWhenFallbackIsCapped() throws {
         let pages = [
-            DocumentPageText(pageIndex: 0, text: "first page"),
-            DocumentPageText(pageIndex: 1, text: "second page"),
+            DocumentPageText(pageIndex: 0, text: "first"),
+            DocumentPageText(pageIndex: 1, text: "😀second"),
+            DocumentPageText(pageIndex: 2, text: "third"),
         ]
-        let extracted = "first page\n\nsecond page"
-        let fallback = "first page\n\nse"
+        let extracted = "first\n\n😀second\n\nthird"
+        let fallback = "first\n\n😀se"
 
         let structure = PDFAdapter.structureForTextFallback(
             filename: "long.pdf",
@@ -54,9 +102,25 @@ struct PDFAdapterTests {
             textFallback: fallback
         )
 
-        #expect(structure.elements(kind: .page).isEmpty)
-        #expect(structure.elements(kind: .paragraph).first?.text == fallback)
-        #expect(structure.anchor(id: "document/body")?.textRange == .entireText(fallback))
+        let pageElements = structure.elements(kind: .page)
+        #expect(pageElements.count == 3)
+        #expect(structure.elements(kind: .paragraph).isEmpty)
+        #expect(structure.textLengthUTF16 == fallback.utf16.count)
+        try Self.expectAnchorRangesWithinFallback(pageElements, fallbackLength: fallback.utf16.count)
+
+        let firstRange = try #require(pageElements[0].anchor.textRange)
+        let secondRange = try #require(pageElements[1].anchor.textRange)
+        let thirdRange = try #require(pageElements[2].anchor.textRange)
+
+        #expect(firstRange == DocumentTextRange(startUTF16Offset: 0, length: "first".utf16.count))
+        #expect(secondRange.startUTF16Offset == "first\n\n".utf16.count)
+        #expect(secondRange.length == "😀se".utf16.count)
+        #expect(thirdRange.startUTF16Offset == fallback.utf16.count)
+        #expect(thirdRange.isEmpty)
+        #expect(pageElements[1].text == "😀se")
+        #expect(pageElements[2].text == nil)
+        #expect(pageElements[1].anchor.sourceRange?.end?.characterOffset == "😀se".utf16.count)
+        #expect(pageElements[2].anchor.metadata["truncatedByFallbackCap"] == "true")
     }
 
     @Test func parse_throwsEmptyContentForPDFWithNoTextLayer() async throws {
@@ -80,25 +144,33 @@ struct PDFAdapterTests {
     // MARK: - Fixtures
 
     private static func writePDF(text: String) throws -> URL {
+        try Self.writePDF(pages: [text])
+    }
+
+    private static func writePDF(pages: [String]) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-pdf-\(UUID().uuidString).pdf")
         var mediaBox = CGRect(x: 0, y: 0, width: 300, height: 200)
         guard let ctx = CGContext(url as CFURL, mediaBox: &mediaBox, nil) else {
             throw FixtureError.contextCreationFailed
         }
-        ctx.beginPDFPage(nil)
+        for text in pages {
+            ctx.beginPDFPage(nil)
 
-        // Draw the text into the PDF context via NSAttributedString so PDFKit
-        // can recover it from the text layer on read-back.
-        let gc = NSGraphicsContext(cgContext: ctx, flipped: false)
-        NSGraphicsContext.saveGraphicsState()
-        NSGraphicsContext.current = gc
-        let font = NSFont.systemFont(ofSize: 14)
-        NSAttributedString(string: text, attributes: [.font: font])
-            .draw(at: NSPoint(x: 20, y: 100))
-        NSGraphicsContext.restoreGraphicsState()
+            if !text.isEmpty {
+                // Draw the text into the PDF context via NSAttributedString so
+                // PDFKit can recover it from the text layer on read-back.
+                let gc = NSGraphicsContext(cgContext: ctx, flipped: false)
+                NSGraphicsContext.saveGraphicsState()
+                NSGraphicsContext.current = gc
+                let font = NSFont.systemFont(ofSize: 14)
+                NSAttributedString(string: text, attributes: [.font: font])
+                    .draw(at: NSPoint(x: 20, y: 100))
+                NSGraphicsContext.restoreGraphicsState()
+            }
 
-        ctx.endPDFPage()
+            ctx.endPDFPage()
+        }
         ctx.closePDF()
         return url
     }
@@ -117,4 +189,15 @@ struct PDFAdapterTests {
     }
 
     private enum FixtureError: Error { case contextCreationFailed }
+
+    private static func expectAnchorRangesWithinFallback(
+        _ pages: [DocumentElement],
+        fallbackLength: Int
+    ) throws {
+        for page in pages {
+            let range = try #require(page.anchor.textRange)
+            #expect(range.startUTF16Offset <= fallbackLength)
+            #expect(range.endUTF16Offset <= fallbackLength)
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
@@ -1,0 +1,446 @@
+//
+//  PPTXAdapterTests.swift
+//  osaurusTests
+//
+//  Builds tiny OpenXML packages directly in memory so tests exercise the
+//  bounded ZIP reader without shelling out or checking binary fixtures into
+//  the repository.
+//
+
+import Compression
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("PPTXAdapter")
+struct PPTXAdapterTests {
+    @Test func canHandle_acceptsPPTXAndPOTXExtensionsAndUTIs() {
+        let adapter = PPTXAdapter()
+
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/deck.pptx"), uti: nil))
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/template.potx"), uti: nil))
+        #expect(
+            adapter.canHandle(
+                url: URL(fileURLWithPath: "/tmp/deck"),
+                uti: "org.openxmlformats.presentationml.presentation"
+            )
+        )
+        #expect(
+            adapter.canHandle(
+                url: URL(fileURLWithPath: "/tmp/template"),
+                uti: "org.openxmlformats.presentationml.template"
+            )
+        )
+        #expect(!adapter.canHandle(url: URL(fileURLWithPath: "/tmp/deck.ppt"), uti: nil))
+        #expect(!adapter.canHandle(url: URL(fileURLWithPath: "/tmp/deck.docx"), uti: nil))
+    }
+
+    @Test func parse_extractsOrderedSlideTextSpeakerNotesAndAnchors() async throws {
+        let fixture = try makePresentationFixture(
+            fileExtension: "pptx",
+            slides: [
+                1: ["First by filename", "Later in the deck"],
+                2: ["Quarterly Review", "Revenue & retention", "Next steps"],
+            ],
+            slideOrder: [2, 1],
+            notes: [2: ["Mention pilot customers", "Pause for questions"]],
+            externalTargets: ["https://example.com/deck-context"],
+            compression: .deflated
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let document = try await PPTXAdapter().parse(url: fixture.url, sizeLimit: 100_000)
+        let presentation = try #require(document.representation.underlying as? PresentationDocument)
+
+        #expect(presentation.kind == .presentation)
+        #expect(presentation.slides.map(\.number) == [2, 1])
+        #expect(presentation.slides[0].text == "Quarterly Review\nRevenue & retention\nNext steps")
+        #expect(presentation.slides[0].speakerNotes?.text == "Mention pilot customers\nPause for questions")
+        #expect(document.textFallback.contains("Slide 1\nQuarterly Review"))
+        #expect(document.textFallback.contains("Speaker notes:\nMention pilot customers"))
+
+        let firstRun = try #require(presentation.slides[0].textRuns.first)
+        #expect(document.structure.anchor(id: firstRun.anchorId) != nil)
+        #expect(document.structure.elements(kind: .slide).count == 2)
+        #expect(
+            document.structure.elements(kind: .speakerNotes).first?.anchor.metadata["sourcePart"]
+                == "ppt/notesSlides/notesSlide2.xml"
+        )
+        #expect(document.security.externalReferences.first?.urlString == "https://example.com/deck-context")
+    }
+
+    @Test func parse_marksPOTXAsTemplate() async throws {
+        let fixture = try makePresentationFixture(
+            fileExtension: "potx",
+            slides: [1: ["Template title"]],
+            slideOrder: [1],
+            compression: .stored
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let document = try await PPTXAdapter().parse(url: fixture.url, sizeLimit: 100_000)
+        let presentation = try #require(document.representation.underlying as? PresentationDocument)
+
+        #expect(presentation.kind == .template)
+        #expect(document.textFallback.contains("Template title"))
+    }
+
+    @Test func parse_refusesFilesAboveSizeLimit() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let url = root.appendingPathComponent("too-large.pptx")
+        try Data(repeating: 0x41, count: 16).write(to: url)
+
+        do {
+            _ = try await PPTXAdapter().parse(url: url, sizeLimit: 15)
+            Issue.record("expected sizeLimitExceeded")
+        } catch DocumentAdapterError.sizeLimitExceeded(let actual, let limit) {
+            #expect(actual == 16)
+            #expect(limit == 15)
+        } catch {
+            Issue.record("expected sizeLimitExceeded, got \(error)")
+        }
+    }
+
+    @Test func parse_corruptZipThrowsReadFailed() async throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let url = root.appendingPathComponent("corrupt.pptx")
+        try Data("not a zip archive".utf8).write(to: url)
+
+        do {
+            _ = try await PPTXAdapter().parse(url: url, sizeLimit: 100_000)
+            Issue.record("expected readFailed")
+        } catch DocumentAdapterError.readFailed(let underlying) {
+            #expect(!underlying.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        } catch {
+            Issue.record("expected readFailed, got \(error)")
+        }
+    }
+
+    @Test func bootstrap_registersPPTXAdapter() {
+        let registry = DocumentFormatRegistry()
+
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+
+        #expect(registry.registeredFormatIds().contains(PPTXAdapter.id))
+    }
+
+    // MARK: - Fixture generation
+
+    private func makePresentationFixture(
+        fileExtension: String,
+        slides: [Int: [String]],
+        slideOrder: [Int],
+        notes: [Int: [String]] = [:],
+        externalTargets: [String] = [],
+        compression: FixtureCompression
+    ) throws -> (root: URL, url: URL) {
+        let root = try makeTempDirectory()
+        let url = root.appendingPathComponent("fixture.\(fileExtension)")
+        var entries: [(String, Data)] = [
+            ("[Content_Types].xml", Data(contentTypesXML.utf8)),
+            ("ppt/presentation.xml", Data(presentationXML(slideOrder: slideOrder).utf8)),
+            ("ppt/_rels/presentation.xml.rels", Data(presentationRelationshipsXML(slideOrder: slideOrder).utf8)),
+        ]
+
+        for (number, paragraphs) in slides {
+            entries.append(("ppt/slides/slide\(number).xml", Data(slideXML(paragraphs).utf8)))
+            let slideRelationships = slideRelationshipsXML(
+                slideNumber: number,
+                hasNotes: notes[number] != nil,
+                externalTargets: number == slideOrder.first ? externalTargets : []
+            )
+            if !slideRelationships.isEmpty {
+                entries.append(("ppt/slides/_rels/slide\(number).xml.rels", Data(slideRelationships.utf8)))
+            }
+        }
+
+        for (number, paragraphs) in notes {
+            entries.append(("ppt/notesSlides/notesSlide\(number).xml", Data(notesXML(paragraphs).utf8)))
+        }
+
+        try writeZip(entries: entries, to: url, compression: compression)
+        return (root, url)
+    }
+
+    private var contentTypesXML: String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+          <Default Extension="xml" ContentType="application/xml"/>
+          <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+        </Types>
+        """
+    }
+
+    private func presentationXML(slideOrder: [Int]) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <p:sldIdLst>
+            \(slideOrder.enumerated().map { index, number in #"<p:sldId id="\#(256 + index)" r:id="rId\#(number)"/>"# }.joined(separator: "\n    "))
+          </p:sldIdLst>
+        </p:presentation>
+        """
+    }
+
+    private func presentationRelationshipsXML(slideOrder: [Int]) -> String {
+        relationshipsXML(
+            slideOrder.map { number in
+                RelationshipFixture(
+                    id: "rId\(number)",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+                    target: "slides/slide\(number).xml"
+                )
+            }
+        )
+    }
+
+    private func slideRelationshipsXML(
+        slideNumber: Int,
+        hasNotes: Bool,
+        externalTargets: [String]
+    ) -> String {
+        var relationships: [RelationshipFixture] = []
+        if hasNotes {
+            relationships.append(
+                RelationshipFixture(
+                    id: "notes\(slideNumber)",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide",
+                    target: "../notesSlides/notesSlide\(slideNumber).xml"
+                )
+            )
+        }
+        relationships.append(
+            contentsOf: externalTargets.enumerated().map { index, target in
+                RelationshipFixture(
+                    id: "external\(index)",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+                    target: target,
+                    targetMode: "External"
+                )
+            }
+        )
+        guard !relationships.isEmpty else { return "" }
+        return relationshipsXML(relationships)
+    }
+
+    private func relationshipsXML(_ relationships: [RelationshipFixture]) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          \(relationships.map(\.xml).joined(separator: "\n  "))
+        </Relationships>
+        """
+    }
+
+    private func slideXML(_ paragraphs: [String]) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:cSld>
+            <p:spTree>
+              \(paragraphs.map(textShapeXML).joined(separator: "\n"))
+            </p:spTree>
+          </p:cSld>
+        </p:sld>
+        """
+    }
+
+    private func notesXML(_ paragraphs: [String]) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <p:notes xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:cSld>
+            <p:spTree>
+              \(paragraphs.map(textShapeXML).joined(separator: "\n"))
+            </p:spTree>
+          </p:cSld>
+        </p:notes>
+        """
+    }
+
+    private func textShapeXML(_ text: String) -> String {
+        """
+        <p:sp>
+          <p:txBody>
+            <a:p>
+              <a:r><a:t>\(escapeXML(text))</a:t></a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+        """
+    }
+
+    private func escapeXML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-pptx-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeZip(
+        entries: [(String, Data)],
+        to destination: URL,
+        compression: FixtureCompression
+    ) throws {
+        var output = Data()
+        var centralDirectory = Data()
+        var centralRecords: [CentralRecord] = []
+
+        for (path, data) in entries {
+            let encoded = compression.encoded(data)
+            let pathData = Data(path.utf8)
+            let localOffset = output.count
+
+            output.appendUInt32(0x0403_4B50)
+            output.appendUInt16(20)
+            output.appendUInt16(0)
+            output.appendUInt16(encoded.method)
+            output.appendUInt16(0)
+            output.appendUInt16(0)
+            output.appendUInt32(crc32(data))
+            output.appendUInt32(UInt32(encoded.data.count))
+            output.appendUInt32(UInt32(data.count))
+            output.appendUInt16(UInt16(pathData.count))
+            output.appendUInt16(0)
+            output.append(pathData)
+            output.append(encoded.data)
+
+            centralRecords.append(
+                CentralRecord(
+                    pathData: pathData,
+                    method: encoded.method,
+                    crc32: crc32(data),
+                    compressedSize: UInt32(encoded.data.count),
+                    uncompressedSize: UInt32(data.count),
+                    localOffset: UInt32(localOffset)
+                )
+            )
+        }
+
+        let centralDirectoryOffset = output.count
+        for record in centralRecords {
+            centralDirectory.appendUInt32(0x0201_4B50)
+            centralDirectory.appendUInt16(20)
+            centralDirectory.appendUInt16(20)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(record.method)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt32(record.crc32)
+            centralDirectory.appendUInt32(record.compressedSize)
+            centralDirectory.appendUInt32(record.uncompressedSize)
+            centralDirectory.appendUInt16(UInt16(record.pathData.count))
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt16(0)
+            centralDirectory.appendUInt32(0)
+            centralDirectory.appendUInt32(record.localOffset)
+            centralDirectory.append(record.pathData)
+        }
+        output.append(centralDirectory)
+
+        output.appendUInt32(0x0605_4B50)
+        output.appendUInt16(0)
+        output.appendUInt16(0)
+        output.appendUInt16(UInt16(centralRecords.count))
+        output.appendUInt16(UInt16(centralRecords.count))
+        output.appendUInt32(UInt32(centralDirectory.count))
+        output.appendUInt32(UInt32(centralDirectoryOffset))
+        output.appendUInt16(0)
+        try output.write(to: destination)
+    }
+
+    private func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc ^= UInt32(byte)
+            for _ in 0 ..< 8 {
+                let mask = UInt32(bitPattern: -Int32(crc & 1))
+                crc = (crc >> 1) ^ (0xEDB8_8320 & mask)
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}
+
+private struct RelationshipFixture {
+    let id: String
+    let type: String
+    let target: String
+    var targetMode: String?
+
+    var xml: String {
+        let mode = targetMode.map { #" TargetMode="\#($0)""# } ?? ""
+        return #"<Relationship Id="\#(id)" Type="\#(type)" Target="\#(target)"\#(mode)/>"#
+    }
+}
+
+private enum FixtureCompression {
+    case stored
+    case deflated
+
+    func encoded(_ data: Data) -> (method: UInt16, data: Data) {
+        switch self {
+        case .stored:
+            return (0, data)
+        case .deflated:
+            var output = [UInt8](repeating: 0, count: max(64, data.count + 64))
+            let written = data.withUnsafeBytes { sourceBuffer in
+                guard let source = sourceBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                    return 0
+                }
+                return compression_encode_buffer(
+                    &output,
+                    output.count,
+                    source,
+                    data.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
+            }
+            guard written > 0, written < data.count else {
+                return (0, data)
+            }
+            return (8, Data(output.prefix(written)))
+        }
+    }
+}
+
+private struct CentralRecord {
+    let pathData: Data
+    let method: UInt16
+    let crc32: UInt32
+    let compressedSize: UInt32
+    let uncompressedSize: UInt32
+    let localOffset: UInt32
+}
+
+private extension Data {
+    mutating func appendUInt16(_ value: UInt16) {
+        append(UInt8(value & 0x00FF))
+        append(UInt8((value >> 8) & 0x00FF))
+    }
+
+    mutating func appendUInt32(_ value: UInt32) {
+        append(UInt8(value & 0x0000_00FF))
+        append(UInt8((value >> 8) & 0x0000_00FF))
+        append(UInt8((value >> 16) & 0x0000_00FF))
+        append(UInt8((value >> 24) & 0x0000_00FF))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/RichDocumentAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/RichDocumentAdapterTests.swift
@@ -26,12 +26,19 @@ struct RichDocumentAdapterTests {
         #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/a.txt"), uti: nil) == false)
     }
 
-    @Test func parse_readsHTMLBodyAsPlainText() async throws {
+    @Test func parse_readsHTMLBodyAsPlainTextAndSafeStructure() async throws {
         let url = try Self.write(
             """
             <html>
               <head><script src="https://example.com/app.js"></script></head>
-              <body><h1>Title</h1><p>Body text</p></body>
+              <body>
+                <h1>Title</h1>
+                <p>Body text</p>
+                <ul>
+                  <li>First</li>
+                  <li>Second</li>
+                </ul>
+              </body>
             </html>
             """,
             filename: "page.html"
@@ -39,24 +46,46 @@ struct RichDocumentAdapterTests {
         defer { try? FileManager.default.removeItem(at: url) }
 
         let doc = try await RichDocumentAdapter().parse(url: url, sizeLimit: 0)
+        let rich = try #require(doc.representation.underlying as? RichDocumentRepresentation)
+
         #expect(doc.formatId == "richdoc")
         #expect(doc.textFallback.contains("Title"))
         #expect(doc.textFallback.contains("Body text"))
         #expect(doc.textFallback.contains("<h1>") == false)
-        #expect(doc.structure.elements(kind: .paragraph).first?.text == doc.textFallback)
+        #expect(rich.text == doc.textFallback)
+        #expect(rich.sourceFormat == .html)
+        #expect(rich.sourceLabel == "HTML document")
+        #expect(rich.blocks.contains { $0.kind == .heading && $0.headingLevel == 1 })
+        #expect(rich.blocks.filter { $0.kind == .listItem }.count == 2)
+        #expect(doc.structure.root.attributes.metadata["sourceFormat"] == "html")
+        #expect(doc.structure.elements(kind: .heading).first?.text == "Title")
+        #expect(doc.structure.elements(kind: .listItem).count == 2)
+        #expect(doc.structure.textLengthUTF16 == doc.textFallback.utf16.count)
         #expect(doc.security.inspectionStatus == .inspected)
+        #expect(doc.security.sourceTrust == .userSelectedLocalFile)
+        #expect(doc.security.fileExtension == "html")
+        #expect(doc.security.sha256 != nil)
         #expect(doc.security.activeContentTypes.contains(.script))
         #expect(doc.security.externalReferences.contains { $0.kind == .script })
     }
 
-    @Test func parse_readsRTFAsPlainText() async throws {
+    @Test func parse_readsRTFAsPlainTextAndParagraphStructure() async throws {
         let rtf = "{\\rtf1\\ansi Hello {\\b bold} world}"
         let url = try Self.write(rtf, filename: "page.rtf")
         defer { try? FileManager.default.removeItem(at: url) }
 
         let doc = try await RichDocumentAdapter().parse(url: url, sizeLimit: 0)
+        let rich = try #require(doc.representation.underlying as? RichDocumentRepresentation)
+
         #expect(doc.textFallback.contains("Hello"))
         #expect(doc.textFallback.contains("bold"))
+        #expect(rich.text == doc.textFallback)
+        #expect(rich.sourceFormat == .rtf)
+        #expect(rich.blocks.first?.kind == .paragraph)
+        #expect(doc.structure.elements(kind: .paragraph).first?.text == rich.blocks.first?.text)
+        #expect(doc.structure.root.attributes.metadata["sourceLabel"] == "Rich Text Format")
+        #expect(doc.security.inspectionStatus == .partiallyInspected)
+        #expect(doc.security.findings.contains { $0.kind == .unsupportedFeature })
     }
 
     @Test func parse_throwsSizeLimitExceededAboveCap() async throws {

--- a/Packages/OsaurusCore/Tests/Documents/XLSXAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/XLSXAdapterTests.swift
@@ -1,0 +1,316 @@
+//
+//  XLSXAdapterTests.swift
+//  osaurusTests
+//
+//  Exercises the dependency-free XLSX reader against an in-test OOXML ZIP.
+//  Keeping the fixture generated in code avoids a binary test artifact while
+//  still covering the workbook, shared-string, worksheet, and relationship
+//  parts real XLSX files use.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("XLSXAdapter")
+struct XLSXAdapterTests {
+
+    @Test func canHandle_acceptsXLSXOnly() {
+        let adapter = XLSXAdapter()
+
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/a.xlsx"), uti: nil))
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/a.XLSX"), uti: nil))
+        #expect(
+            adapter.canHandle(
+                url: URL(fileURLWithPath: "/tmp/no-extension"),
+                uti: "org.openxmlformats.spreadsheetml.sheet"
+            )
+        )
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/a.xls"), uti: nil) == false)
+        #expect(adapter.canHandle(url: URL(fileURLWithPath: "/tmp/a.csv"), uti: nil) == false)
+    }
+
+    @Test func parse_surfacesTypedWorkbookValuesAndFallbackText() async throws {
+        let url = try Self.writeFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let document = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        guard let workbook = document.representation.underlying as? Workbook else {
+            Issue.record("representation was not a Workbook")
+            return
+        }
+
+        #expect(document.formatId == "xlsx")
+        #expect(workbook.sheets.map(\.name) == ["Revenue", "Notes"])
+        #expect(workbook.sharedStrings.contains("Month"))
+        #expect(workbook.sharedStrings.contains("February"))
+
+        let revenue = try #require(workbook.sheets.first { $0.name == "Revenue" })
+        #expect(revenue.cell("A1")?.value == .string("Month"))
+        #expect(revenue.cell("B2")?.value == .number(1200))
+        #expect(revenue.cell("C2")?.value == .string("inline note"))
+        #expect(revenue.cell("C4")?.value == .bool(true))
+        #expect(revenue.cell("B4")?.formula == "SUM(B2:B3)")
+        #expect(revenue.mergedRanges.map(\.reference).contains("A5:B5"))
+
+        #expect(document.textFallback.contains("## Sheet: Revenue"))
+        #expect(document.textFallback.contains("January\t1200\tinline note"))
+        #expect(document.textFallback.contains("2500 [=SUM(B2:B3)]"))
+        #expect(document.textFallback.contains("Merged: A5:B5"))
+    }
+
+    @Test func parse_preservesSheetAndCellAnchors() async throws {
+        let url = try Self.writeFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let document = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        let workbook = try #require(document.representation.underlying as? Workbook)
+        let revenue = try #require(workbook.sheets.first { $0.name == "Revenue" })
+        let b2 = try #require(revenue.cell("B2"))
+
+        #expect(revenue.anchor.sourceRange?.start.sheetIndex == 0)
+        #expect(revenue.anchor.sourceRange?.start.sheetName == "Revenue")
+        #expect(b2.anchor.label == "Revenue!B2")
+        #expect(b2.anchor.sourceRange?.start.rowIndex == 1)
+        #expect(b2.anchor.sourceRange?.start.columnIndex == 1)
+        #expect(b2.anchor.textRange?.isEmpty == false)
+        #expect(document.structure.elements(kind: .sheet).count == 2)
+        #expect(document.structure.elements(kind: .tableCell).contains { $0.anchor.id == b2.anchor.id })
+    }
+
+    @Test func parse_recordsFormulaSecuritySignal() async throws {
+        let url = try Self.writeFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let document = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+
+        #expect(document.security.inspectionStatus == .partiallyInspected)
+        #expect(document.security.activeContentTypes.contains(.formula))
+        #expect(document.security.findings.contains { $0.kind == .formula })
+    }
+
+    @Test func parse_rejectsOversizedFilesBeforeReadingPackage() async throws {
+        let url = try Self.writeFixture()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await XLSXAdapter().parse(url: url, sizeLimit: 1)
+        }
+    }
+
+    @Test func bootstrap_registersXLSXAdapter() {
+        let registry = DocumentFormatRegistry()
+
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+
+        #expect(registry.adapter(for: URL(fileURLWithPath: "/tmp/workbook.xlsx"))?.formatId == "xlsx")
+    }
+
+    // MARK: - Fixture
+
+    private static func writeFixture() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-workbook.xlsx")
+        try makeWorkbookPackage().write(to: url)
+        return url
+    }
+
+    private static func makeWorkbookPackage() -> Data {
+        makeZip(
+            entries: [
+                (
+                    "[Content_Types].xml",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                      <Default Extension="xml" ContentType="application/xml"/>
+                      <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+                      <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+                      <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                      <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                    </Types>
+                    """
+                ),
+                (
+                    "_rels/.rels",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+                    </Relationships>
+                    """
+                ),
+                (
+                    "xl/workbook.xml",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                      <sheets>
+                        <sheet name="Revenue" sheetId="1" r:id="rId1"/>
+                        <sheet name="Notes" sheetId="2" r:id="rId2"/>
+                      </sheets>
+                    </workbook>
+                    """
+                ),
+                (
+                    "xl/_rels/workbook.xml.rels",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+                      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+                    </Relationships>
+                    """
+                ),
+                (
+                    "xl/sharedStrings.xml",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="7" uniqueCount="7">
+                      <si><t>Month</t></si>
+                      <si><t>Amount</t></si>
+                      <si><t>January</t></si>
+                      <si><t>February</t></si>
+                      <si><t>Total</t></si>
+                      <si><t>Approved</t></si>
+                      <si><t>Flag</t></si>
+                    </sst>
+                    """
+                ),
+                (
+                    "xl/worksheets/sheet1.xml",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData>
+                        <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>
+                        <row r="2"><c r="A2" t="s"><v>2</v></c><c r="B2"><v>1200</v></c><c r="C2" t="inlineStr"><is><t>inline note</t></is></c></row>
+                        <row r="3"><c r="A3" t="s"><v>3</v></c><c r="B3"><v>1300</v></c></row>
+                        <row r="4"><c r="A4" t="s"><v>4</v></c><c r="B4"><f>SUM(B2:B3)</f><v>2500</v></c><c r="C4" t="b"><v>1</v></c></row>
+                      </sheetData>
+                      <mergeCells count="1"><mergeCell ref="A5:B5"/></mergeCells>
+                    </worksheet>
+                    """
+                ),
+                (
+                    "xl/worksheets/sheet2.xml",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                      <sheetData>
+                        <row r="1"><c r="A1" t="s"><v>5</v></c><c r="B1" t="b"><v>1</v></c></row>
+                        <row r="2"><c r="A2" t="s"><v>6</v></c><c r="B2" t="b"><v>0</v></c></row>
+                      </sheetData>
+                    </worksheet>
+                    """
+                ),
+            ]
+        )
+    }
+
+    private static func makeZip(entries: [(path: String, contents: String)]) -> Data {
+        var archive = Data()
+        var centralDirectory = Data()
+        var centralEntries = 0
+
+        for entry in entries {
+            let name = Data(entry.path.utf8)
+            let payload = Data(entry.contents.utf8)
+            let crc = crc32(payload)
+            let localHeaderOffset = UInt32(archive.count)
+
+            archive.appendUInt32LE(0x0403_4B50)
+            archive.appendUInt16LE(20)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt32LE(crc)
+            archive.appendUInt32LE(UInt32(payload.count))
+            archive.appendUInt32LE(UInt32(payload.count))
+            archive.appendUInt16LE(UInt16(name.count))
+            archive.appendUInt16LE(0)
+            archive.append(name)
+            archive.append(payload)
+
+            centralDirectory.appendUInt32LE(0x0201_4B50)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(crc)
+            centralDirectory.appendUInt32LE(UInt32(payload.count))
+            centralDirectory.appendUInt32LE(UInt32(payload.count))
+            centralDirectory.appendUInt16LE(UInt16(name.count))
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(0)
+            centralDirectory.appendUInt32LE(localHeaderOffset)
+            centralDirectory.append(name)
+            centralEntries += 1
+        }
+
+        let centralDirectoryOffset = UInt32(archive.count)
+        archive.append(centralDirectory)
+        archive.appendUInt32LE(0x0605_4B50)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(UInt16(centralEntries))
+        archive.appendUInt16LE(UInt16(centralEntries))
+        archive.appendUInt32LE(UInt32(centralDirectory.count))
+        archive.appendUInt32LE(centralDirectoryOffset)
+        archive.appendUInt16LE(0)
+        return archive
+    }
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = (crc >> 8) ^ crc32Table[index]
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
+    private static let crc32Table: [UInt32] = (0 ..< 256).map { value in
+        var crc = UInt32(value)
+        for _ in 0 ..< 8 {
+            if crc & 1 == 1 {
+                crc = 0xEDB8_8320 ^ (crc >> 1)
+            } else {
+                crc >>= 1
+            }
+        }
+        return crc
+    }
+}
+
+private extension Workbook.Sheet {
+    func cell(_ reference: String) -> Workbook.Cell? {
+        rows.flatMap(\.cells).first { $0.reference == reference }
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16LE(_ value: UInt16) {
+        append(contentsOf: [
+            UInt8(value & 0x00FF),
+            UInt8((value >> 8) & 0x00FF),
+        ])
+    }
+
+    mutating func appendUInt32LE(_ value: UInt32) {
+        append(contentsOf: [
+            UInt8(value & 0x0000_00FF),
+            UInt8((value >> 8) & 0x0000_00FF),
+            UInt8((value >> 16) & 0x0000_00FF),
+            UInt8((value >> 24) & 0x0000_00FF),
+        ])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
@@ -1,0 +1,246 @@
+//
+//  XLSXEmitterTests.swift
+//  osaurusTests
+//
+//  Covers the write-side XLSX groundwork by emitting an in-memory workbook,
+//  parsing the generated package through the stacked XLSX reader, and checking
+//  that supported scalar cell types survive the round trip.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("XLSXEmitter")
+struct XLSXEmitterTests {
+
+    @Test func canEmit_requiresXLSXWorkbookRepresentation() {
+        let emitter = XLSXEmitter()
+        let workbook = Self.makeWorkbook()
+
+        #expect(emitter.canEmit(Self.document(workbook: workbook)))
+        #expect(emitter.canEmit(Self.document(workbook: workbook, formatId: "plaintext")) == false)
+    }
+
+    @Test func emit_roundTripsScalarWorkbookThroughXLSXAdapter() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await XLSXEmitter().emit(Self.document(workbook: Self.makeWorkbook()), to: url)
+
+        let parsed = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        let workbook = try #require(parsed.representation.underlying as? Workbook)
+        let revenue = try #require(workbook.sheets.first { $0.name == "Revenue" })
+        let notes = try #require(workbook.sheets.first { $0.name == "Notes" })
+
+        #expect(parsed.formatId == "xlsx")
+        #expect(workbook.sheets.map(\.name) == ["Revenue", "Notes"])
+        #expect(revenue.cell("A1")?.value == .string("Month"))
+        #expect(revenue.cell("B2")?.value == .number(1200))
+        #expect(revenue.cell("B3")?.value == .number(1300.5))
+        #expect(revenue.cell("C2")?.value == .bool(true))
+        #expect(revenue.cell("C3")?.value == .bool(false))
+        #expect(notes.cell("A1")?.value == .string(" padded "))
+        #expect(notes.cell("B1")?.value == .string("January"))
+        #expect(notes.cell("C1")?.value == .string("5 < 7 & \"ok\""))
+        #expect(revenue.mergedRanges.map(\.reference) == ["A5:B5"])
+        #expect(workbook.sharedStrings.filter { $0 == "January" }.count == 1)
+        #expect(parsed.textFallback.contains("January\t1200\tTRUE"))
+        #expect(parsed.textFallback.contains("5 < 7 & \"ok\""))
+    }
+
+    @Test func emit_rejectsFormulaCellsWithoutFlatteningThem() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            try await XLSXEmitter().emit(
+                Self.document(workbook: Self.makeWorkbook(includeFormula: true)),
+                to: url
+            )
+        }
+    }
+
+    @Test func bootstrap_registersXLSXEmitter() {
+        let registry = DocumentFormatRegistry()
+
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+
+        let emitter = registry.emitter(for: Self.document(workbook: Self.makeWorkbook()))
+        #expect(emitter?.formatId == "xlsx")
+    }
+
+    // MARK: - Fixtures
+
+    private static func document(workbook: Workbook, formatId: String = "xlsx") -> StructuredDocument {
+        StructuredDocument(
+            formatId: formatId,
+            filename: "workbook.\(formatId)",
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(
+                formatId: formatId,
+                underlying: workbook
+            ),
+            security: .notInspected(
+                formatId: formatId,
+                fileExtension: formatId,
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: ""
+        )
+    }
+
+    private static func makeWorkbook(includeFormula: Bool = false) -> Workbook {
+        let revenueRows = [
+            row(
+                number: 1,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A1", row: 1, column: 1, value: .string("Month"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("B1", row: 1, column: 2, value: .string("Amount"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("C1", row: 1, column: 3, value: .string("Approved"), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+            row(
+                number: 2,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A2", row: 2, column: 1, value: .string("January"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("B2", row: 2, column: 2, value: .number(1200), sheetName: "Revenue", sheetIndex: 0),
+                    cell("C2", row: 2, column: 3, value: .bool(true), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+            row(
+                number: 3,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A3", row: 3, column: 1, value: .string("February"), sheetName: "Revenue", sheetIndex: 0),
+                    cell(
+                        "B3",
+                        row: 3,
+                        column: 2,
+                        value: .number(1300.5),
+                        formula: includeFormula ? "SUM(B2:B3)" : nil,
+                        sheetName: "Revenue",
+                        sheetIndex: 0
+                    ),
+                    cell("C3", row: 3, column: 3, value: .bool(false), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+        ]
+        let notesRows = [
+            row(
+                number: 1,
+                sheetName: "Notes",
+                sheetIndex: 1,
+                cells: [
+                    cell("A1", row: 1, column: 1, value: .string(" padded "), sheetName: "Notes", sheetIndex: 1),
+                    cell("B1", row: 1, column: 2, value: .string("January"), sheetName: "Notes", sheetIndex: 1),
+                    cell("C1", row: 1, column: 3, value: .string("5 < 7 & \"ok\""), sheetName: "Notes", sheetIndex: 1),
+                ]
+            )
+        ]
+
+        return Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: revenueRows,
+                    mergedRanges: [Workbook.CellRange(reference: "A5:B5")],
+                    anchor: sheetAnchor(name: "Revenue", index: 0)
+                ),
+                Workbook.Sheet(
+                    name: "Notes",
+                    index: 1,
+                    rows: notesRows,
+                    anchor: sheetAnchor(name: "Notes", index: 1)
+                ),
+            ]
+        )
+    }
+
+    private static func row(
+        number: Int,
+        sheetName: String,
+        sheetIndex: Int,
+        cells: [Workbook.Cell]
+    ) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(
+                kind: .row,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .row, index: number - 1),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: DocumentSourceLocation(sheetIndex: sheetIndex, sheetName: sheetName, rowIndex: number - 1)
+                ),
+                label: "\(sheetName) row \(number)"
+            )
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        formula: String? = nil,
+        sheetName: String,
+        sheetIndex: Int
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            formula: formula,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .cell, identifier: reference),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: .cell(sheetName: sheetName, rowIndex: row - 1, columnIndex: column - 1)
+                ),
+                label: "\(sheetName)!\(reference)"
+            )
+        )
+    }
+
+    private static func sheetAnchor(name: String, index: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .sheet,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: name, index: index),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(sheetIndex: index, sheetName: name)
+            ),
+            label: name,
+            metadata: ["sheetIndex": "\(index)"]
+        )
+    }
+
+    private static func temporaryURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-emitted.xlsx")
+    }
+}
+
+private extension Workbook.Sheet {
+    func cell(_ reference: String) -> Workbook.Cell? {
+        rows.flatMap(\.cells).first { $0.reference == reference }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ osaurus tools dev com.acme.my-plugin     # Dev with hot reload
 
 20+ native plugins: Mail, Calendar, Vision, macOS Use, XLSX, PPTX, Browser, Music, Git, Filesystem, Search, Fetch, and more. Plugins target the v3 host API surface — register HTTP routes, serve web apps, persist data in SQLite, dispatch agent tasks, and call inference through any model. Older v1/v2 plugins continue to load unchanged. See the [Plugin Authoring Guide](docs/plugins/README.md).
 
+Document attachments keep structure where the file format exposes it: CSV/TSV tables, XLSX workbooks, PPTX decks, PDF page anchors, and rich document sections are parsed through the document adapter registry before they reach the agent.
+
 ## More
 
 **Skills & Methods** -- Skills import reusable AI capabilities from GitHub repos or files, compatible with [Agent Skills](https://agentskills.io/). Full Claude plugins (skills, scheduled agents, slash commands, MCP providers, and `CLAUDE.md` context) can be imported from any GitHub repo and managed as a single bundle. Methods are learned workflows that agents save and reuse over time. All are automatically selected via RAG search -- no manual configuration needed. See [Skills Guide](docs/SKILLS.md) and [Claude Plugins](docs/CLAUDE_PLUGINS.md).

--- a/docs/DEVELOPER_TOOLS.md
+++ b/docs/DEVELOPER_TOOLS.md
@@ -294,6 +294,21 @@ Currently env-gated:
 | ---------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------ |
 | `OSAURUS_RUN_SANDBOX_INTEGRATION_TESTS=1` | [`SandboxIntegrationTests`](../Packages/OsaurusCore/Tests/Sandbox/SandboxIntegrationTests.swift) | Boots a Linux VM; runs `pip`/`npm`/`go` workloads. |
 
+### Document runtime discovery
+
+Structured document parsing runs in-process for the built-in CSV/TSV, XLSX,
+PPTX/POTX, PDF, and rich-document adapters. The optional office runtime
+detector exists only to discover a local LibreOffice/OpenOffice-compatible
+`soffice` binary for future conversion flows; it probes version metadata and
+never sends document bytes to the runtime.
+
+Set either variable to point tests or local builds at a specific executable:
+
+| Env var | Purpose |
+| ------- | ------- |
+| `OSAURUS_OFFICE_RUNTIME_URL` | File URL for an explicit `soffice` executable. |
+| `OSAURUS_OFFICE_RUNTIME_PATH` | File-system path for an explicit `soffice` executable. |
+
 ### CI cache controls
 
 The `test-core` job caches `~/Library/Developer/Xcode/DerivedData` keyed on Swift sources, manifests, resources, the pinned Xcode version, and a manual `CACHE_SALT`. Two recovery levers when you suspect a bad cache:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -14,6 +14,7 @@ Canonical reference for all Osaurus features, their status, and documentation.
 | Remote Providers                 | Stable    | "Key Features"     | REMOTE_PROVIDERS.md           | Managers/RemoteProviderManager.swift, Services/Provider/RemoteProviderService.swift            |
 | Remote MCP Providers             | Stable    | "Key Features"     | REMOTE_MCP_PROVIDERS.md       | Managers/MCPProviderManager.swift, Tools/MCPProviderTool.swift                        |
 | MCP Server                       | Stable    | "MCP Server"       | (in README)                   | Networking/OsaurusServer.swift, Services/MCP/MCPServerManager.swift, CLI MCPCommand.swift |
+| Structured Document IO           | Foundation | "Tools & Plugins"  | (in README)                   | Services/Documents/, Models/Documents/, Managers/Documents/DocumentAdaptersBootstrap.swift |
 | Tools & Plugins                  | Stable    | "Tools & Plugins"  | plugins/README.md             | Tools/, Managers/Plugin/PluginManager.swift, Services/Plugin/PluginHostAPI.swift, Storage/PluginDatabase.swift, Models/Plugin/PluginHTTP.swift, Views/Plugin/PluginConfigView.swift |
 | Skills                           | Stable    | "Skills"           | SKILLS.md                     | Managers/SkillManager.swift, Views/Skill/SkillsView.swift, Services/Skill/SkillSearchService.swift |
 | Claude Plugin Import             | Stable    | "Skills"           | CLAUDE_PLUGINS.md             | Services/GitHubSkillService.swift, Services/Skill/ClaudePluginInstaller.swift, Views/Skill/GitHubImportSheet.swift, Views/Skill/InstalledPluginsSection.swift |
@@ -81,6 +82,10 @@ Canonical reference for all Osaurus features, their status, and documentation.
 │  ├── MCP                                                                 │
 │  │   ├── MCPServerManager (Osaurus as MCP server)                        │
 │  │   └── MCPProviderManager (HTTP/SSE remote MCP client connections)     │
+│  ├── Documents                                                           │
+│  │   ├── DocumentAdaptersBootstrap (built-in adapter registration)        │
+│  │   ├── PDF/CSV/XLSX/PPTX/RichDocument adapters                         │
+│  │   └── ExternalOfficeRuntimeDetector (optional runtime discovery only)  │
 │  ├── Tools                                                               │
 │  │   ├── ToolRegistry                                                    │
 │  │   ├── PluginManager                                                   │
@@ -270,6 +275,34 @@ See [INFERENCE_RUNTIME.md](./INFERENCE_RUNTIME.md) for the full runtime architec
 ```
 
 This command bridge is for external clients connecting to Osaurus. It is separate from Remote MCP Providers, which only connect from Osaurus to URL-based HTTP/SSE MCP servers.
+
+---
+
+### Structured Document IO
+
+**Purpose:** Preserve document structure for attachments before agent context assembly instead of flattening every business file into plain text.
+
+**Components:**
+
+- `Managers/Documents/DocumentAdaptersBootstrap.swift` — registers built-in document adapters.
+- `Models/Documents/Workbook.swift` — typed workbook, sheet, row, and cell representation.
+- `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, and relationship representation.
+- `Models/Documents/RichDocumentRepresentation.swift` — sections, headings, links, and metadata for rich text sources.
+- `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
+- `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
+- `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
+- `Services/Documents/PPTXAdapter.swift` — PPTX/POTX deck parsing from Office Open XML packages.
+- `Services/Documents/PDFAdapter.swift` — PDF extraction with page-level anchors.
+- `Services/Documents/RichDocumentAdapter.swift` — DOCX/RTF/HTML-style rich document structure extraction.
+- `Services/Documents/ExternalOfficeRuntimeDetector.swift` — optional LibreOffice/OpenOffice discovery for future conversion flows; detection reads version metadata only and does not send document bytes to a runtime.
+
+**Supported format surface:**
+
+- CSV and TSV tables preserve headers, rows, delimiters, and source metadata.
+- XLSX workbooks preserve sheets, cells, shared strings, relationships, and can emit a minimal valid `.xlsx` package.
+- PPTX/POTX decks preserve slide grouping, text runs, notes, and relationships.
+- PDFs preserve page boundaries and anchors so citations can point back to pages.
+- Rich documents preserve section boundaries, headings, links, and metadata.
 
 ---
 


### PR DESCRIPTION
## Business rationale

Users need document attachments to retain useful structure when they move beyond plain text: spreadsheets should keep sheets and cells, presentations should keep slide grouping, PDFs should expose page anchors, and rich documents should preserve section-level metadata. The plan already landed the document IO foundation, and this PR builds on that foundation in one functional chunk so maintainers can review the complete high-fidelity read/write surface together instead of chasing several small dependent PRs. The observable change is that CSV/TSV, XLSX, PPTX, PDF, and rich document fixtures now parse into typed document models with focused tests, XLSX workbooks can be emitted back to Office Open XML packages, and README/feature documentation now names the supported surface and runtime-discovery knobs.

## Coding rationale

The implementation stays inside the existing document adapter registry and uses in-process ZIP/XML parsing and emitting rather than shelling out to external tools or introducing new persistence paths. I considered splitting each format into its own PR, but the adapter registration and parser-shim expectations are shared, so a consolidated document-format PR gives reviewers one coherent trust-boundary review: untrusted user documents enter the document adapter layer, are bounded by existing document limits, and produce typed in-memory representations. External Office runtime detection is intentionally limited to detecting available runtimes and does not perform conversions or execute untrusted files; the docs call out that boundary and the explicit `OSAURUS_OFFICE_RUNTIME_URL` / `OSAURUS_OFFICE_RUNTIME_PATH` overrides.

## Acceptance criteria

- [x] CSV and TSV attachments parse into structured tables with headers, rows, and delimiter handling.
- [x] PDF extraction preserves page-level anchors and page metadata for downstream citations.
- [x] XLSX workbooks parse into typed sheets, cells, relationships, and shared strings.
- [x] XLSX workbooks can be emitted back to a minimal Office Open XML package.
- [x] PPTX decks parse into typed slides, notes, relationships, and text runs.
- [x] Rich document adapters preserve headings, sections, links, and metadata.
- [x] External Office runtime detection is covered without invoking conversion flows.
- [x] README, feature inventory, and developer-tools docs describe the document IO surface and office-runtime environment overrides.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Local full-gate evidence is recorded at `/tmp/osaurus-coord/evidence/T-J-FORMATS/20260517T140723Z` on head `c096100e`. The focused document-format regression run also passed 58 tests with `swift test --package-path Packages/OsaurusCore --filter 'PDFAdapter|CSV|XLSX|PPTX|RichDocument|ExternalOfficeRuntime|DocumentParserShim|DocumentFormatRegistry'`, covering the newly registered adapters and round-trip emitters. Full gate status: `PASS swift-format 2026-05-17T14:07:27Z`, `PASS swiftlint 2026-05-17T14:07:27Z`, `PASS shellcheck 2026-05-17T14:07:27Z`, `PASS cli-tests 2026-05-17T14:07:32Z`, `PASS ci-test 2026-05-17T14:08:17Z`, `PASS core-release 2026-05-17T14:08:41Z`.

## Rollback

Revert this PR to remove the new document adapter registrations, typed models, emitters, and documentation; the previously merged document IO foundation remains intact.