### PR TITLE
[codex] Harden office runtime version probe stdin

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntimeDetector.swift
+++ b/Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntimeDetector.swift
@@ -379,6 +379,9 @@ public struct ExternalOfficeRuntimeDetector: Sendable {
         process.arguments = ["--version"]
         process.standardOutput = outputHandle
         process.standardError = outputHandle
+        let inputHandle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: "/dev/null"))
+        defer { try? inputHandle?.close() }
+        process.standardInput = inputHandle
 
         do {
             try process.run()


### PR DESCRIPTION
## Summary
- close the office runtime `--version` probe's stdin by wiring it to `/dev/null`
- keep stdout/stderr capture, timeout behavior, and version parsing unchanged

## Why
`make ci-test` was failing on current `main` in `ExternalOfficeRuntimeDetectorTests` under the Xcode test harness while the same tests passed under SwiftPM. The fake `soffice` probes were timing out in xcodebuild, leaving version metadata nil. Closing stdin makes the probe bounded with respect to inherited test-runner or app input streams and removes that harness sensitivity.

## Validation
- `xcrun swift-format lint --strict --recursive Packages/OsaurusCore/Services/Documents/ExternalOfficeRuntimeDetector.swift`
- `swift test --package-path Packages/OsaurusCore --filter ExternalOfficeRuntimeDetectorTests`
- `make ci-test`
