### PR TITLE
[codex] Refresh chat background image cache on edits

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -256,13 +256,20 @@ final class ChatWindowState: ObservableObject {
         let newConfig = newTheme.customThemeConfig
         // Skip only if the full config is identical (not just the ID)
         guard oldConfig != newConfig else { return }
+        let shouldRedecodeBackgroundImage = Self.needsBackgroundImageRedecode(
+            oldConfig: oldConfig,
+            newConfig: newConfig
+        )
 
         theme = newTheme
 
-        // Only re-decode background image when the theme itself changes (different ID)
-        if oldConfig?.metadata.id != newConfig?.metadata.id {
-            decodeBackgroundImageAsync(themeConfig: theme.customThemeConfig)
+        if shouldRedecodeBackgroundImage {
+            decodeBackgroundImageAsync(themeConfig: newConfig)
         }
+    }
+
+    nonisolated static func needsBackgroundImageRedecode(oldConfig: CustomTheme?, newConfig: CustomTheme?) -> Bool {
+        BackgroundImageDecodeKey(config: oldConfig) != BackgroundImageDecodeKey(config: newConfig)
     }
 
     func refreshAgentConfig() {
@@ -416,6 +423,18 @@ final class ChatWindowState: ObservableObject {
         Task { [weak self] in
             let decoded = themeConfig?.background.decodedImage()
             self?.cachedBackgroundImage = decoded
+        }
+    }
+
+    private struct BackgroundImageDecodeKey: Equatable {
+        let themeId: UUID?
+        let backgroundType: ThemeBackground.BackgroundType?
+        let imageData: String?
+
+        init(config: CustomTheme?) {
+            self.themeId = config?.metadata.id
+            self.backgroundType = config?.background.type
+            self.imageData = config?.background.imageData
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateThemeRefreshTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateThemeRefreshTests.swift
@@ -1,0 +1,63 @@
+//
+//  ChatWindowStateThemeRefreshTests.swift
+//  osaurusTests
+//
+//  Focused coverage for chat-window theme background image cache refreshes.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ChatWindowStateThemeRefreshTests {
+    private func makeTheme(
+        id: UUID = UUID(),
+        backgroundType: ThemeBackground.BackgroundType = .image,
+        imageData: String? = nil
+    ) -> CustomTheme {
+        CustomTheme(
+            metadata: ThemeMetadata(id: id, name: "Background Test"),
+            background: ThemeBackground(type: backgroundType, imageData: imageData)
+        )
+    }
+
+    @Test("same theme ID with new background image data re-decodes")
+    func sameThemeIdWithNewImageDataRequiresRedecode() {
+        let themeId = UUID()
+        let oldTheme = makeTheme(id: themeId, imageData: "old-image-data")
+        let newTheme = makeTheme(id: themeId, imageData: "new-image-data")
+
+        #expect(ChatWindowState.needsBackgroundImageRedecode(oldConfig: oldTheme, newConfig: newTheme))
+    }
+
+    @Test("different theme ID still re-decodes")
+    func differentThemeIdRequiresRedecode() {
+        let oldTheme = makeTheme(id: UUID(), imageData: "shared-image-data")
+        let newTheme = makeTheme(id: UUID(), imageData: "shared-image-data")
+
+        #expect(ChatWindowState.needsBackgroundImageRedecode(oldConfig: oldTheme, newConfig: newTheme))
+    }
+
+    @Test("non-image edits on same theme ID do not re-decode")
+    func nonImageEditOnSameThemeDoesNotRequireRedecode() {
+        let themeId = UUID()
+        let oldTheme = makeTheme(id: themeId, imageData: "same-image-data")
+        var newTheme = oldTheme
+        newTheme.metadata.updatedAt = Date().addingTimeInterval(60)
+        newTheme.colors.primaryText = "#abcdef"
+        newTheme.background.imageOpacity = 0.5
+        newTheme.background.imageFit = .fit
+
+        #expect(!ChatWindowState.needsBackgroundImageRedecode(oldConfig: oldTheme, newConfig: newTheme))
+    }
+
+    @Test("leaving image background clears cached image")
+    func leavingImageBackgroundRequiresRedecode() {
+        let themeId = UUID()
+        let oldTheme = makeTheme(id: themeId, imageData: "old-image-data")
+        let newTheme = makeTheme(id: themeId, backgroundType: .solid, imageData: nil)
+
+        #expect(ChatWindowState.needsBackgroundImageRedecode(oldConfig: oldTheme, newConfig: newTheme))
+    }
+}

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -445,12 +445,29 @@ struct ThemeEditorView: View {
                             .stroke(currentTheme.primaryBorder, lineWidth: 1)
                     )
 
-                Button {
-                    editingTheme.background.imageData = nil
-                } label: {
-                    Text("Remove Image", bundle: .module)
+                HStack(spacing: 8) {
+                    Button {
+                        showImagePicker = true
+                    } label: {
+                        Label {
+                            Text("Replace Image", bundle: .module)
+                        } icon: {
+                            Image(systemName: "photo.badge.plus")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        editingTheme.background.imageData = nil
+                    } label: {
+                        Label {
+                            Text("Remove Image", bundle: .module)
+                        } icon: {
+                            Image(systemName: "trash")
+                        }
+                    }
+                    .buttonStyle(.bordered)
                 }
-                .buttonStyle(.bordered)
             } else {
                 Button(action: { showImagePicker = true }) {
                     VStack(spacing: 8) {


### PR DESCRIPTION
## Summary
- refresh chat-window background image decoding when image data changes under the same theme ID
- keep non-image theme edits from needlessly re-decoding cached background images
- add replace/remove image controls next to an existing background image preview

## Why
Editing or replacing a background image could leave existing chat windows using stale decoded image cache state because refresh only looked at theme identity.

## Validation
- `git diff --check origin/main...HEAD`
- `xcrun swift-format lint --strict --recursive Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift Packages/OsaurusCore/Tests/Chat/ChatWindowStateThemeRefreshTests.swift`
- `swift test --package-path Packages/OsaurusCore --filter ChatWindowStateThemeRefreshTests`
- `swift test --package-path Packages/OsaurusCore --filter ChatWindowStateAgentSyncTests` (worker validation)
