### PR TITLE
[codex] Anchor schedule execution on trigger time

### DIFF
--- a/Packages/OsaurusCore/Managers/ScheduleManager.swift
+++ b/Packages/OsaurusCore/Managers/ScheduleManager.swift
@@ -236,7 +236,7 @@ public final class ScheduleManager {
         var schedulesToRun: [Schedule] = []
 
         for schedule in enabledSchedules {
-            guard let nextRun = schedule.frequency.nextRunDate(after: now) else { continue }
+            guard let nextRun = schedule.nextRunDateAfterExecutionAnchor(asOf: now) else { continue }
 
             if soonestDate == nil || nextRun < soonestDate! {
                 soonestDate = nextRun
@@ -277,21 +277,7 @@ public final class ScheduleManager {
         let schedulesToRun = schedules.filter { schedule in
             guard schedule.isEnabled else { return false }
             guard !runningTasks.keys.contains(schedule.id) else { return false }  // Already running
-
-            // Determine reference time for checking next run:
-            // - If schedule has run before, use lastRunAt (finds the next run after that)
-            // - Otherwise, look back up to 1 hour (handles new schedules + system sleep)
-            let checkFrom: Date
-            if let lastRun = schedule.lastRunAt {
-                checkFrom = lastRun
-            } else {
-                checkFrom = now.addingTimeInterval(-3600)  // 1 hour ago
-            }
-
-            guard let nextRun = schedule.frequency.nextRunDate(after: checkFrom) else { return false }
-
-            // Run if the scheduled time is now or in the recent past (with small future tolerance)
-            return nextRun <= now.addingTimeInterval(60)
+            return schedule.shouldRunNow(asOf: now)
         }
 
         // Execute all due schedules
@@ -314,16 +300,16 @@ public final class ScheduleManager {
             // For "once" schedules, check if the time has passed
             if case .once(let date) = schedule.frequency {
                 // If the once date is in the past but hasn't run yet
-                if date <= now && schedule.lastRunAt == nil {
+                if date <= now && schedule.executionAnchor == nil {
                     print("[Osaurus] Found missed once schedule: \(schedule.name)")
                     executeSchedule(schedule)
                 }
             } else {
                 // For recurring schedules, check if we missed the last run
-                // Only run if lastRunAt is nil or the next run after lastRunAt is in the past
-                if let lastRun = schedule.lastRunAt {
-                    if let nextAfterLast = schedule.frequency.nextRunDate(after: lastRun),
-                        nextAfterLast <= now
+                // Only run if an execution anchor exists and the next run after it is in the past.
+                if let anchor = schedule.executionAnchor {
+                    if let nextAfterAnchor = schedule.frequency.nextRunDate(after: anchor),
+                        nextAfterAnchor <= now
                     {
                         print("[Osaurus] Found missed recurring schedule: \(schedule.name)")
                         executeSchedule(schedule)
@@ -337,37 +323,43 @@ public final class ScheduleManager {
 
     /// Execute a schedule by dispatching to TaskDispatcher
     private func executeSchedule(_ schedule: Schedule) {
+        var triggeredSchedule = schedule
+        triggeredSchedule.lastTriggeredAt = Date()
+        ScheduleStore.save(triggeredSchedule)
+        refresh()
+
         let request = DispatchRequest(
-            prompt: schedule.instructions,
-            agentId: schedule.agentId,
-            title: schedule.name,
-            parameters: schedule.parameters,
-            folderPath: schedule.folderPath,
-            folderBookmark: schedule.folderBookmark,
+            prompt: triggeredSchedule.instructions,
+            agentId: triggeredSchedule.agentId,
+            title: triggeredSchedule.name,
+            parameters: triggeredSchedule.parameters,
+            folderPath: triggeredSchedule.folderPath,
+            folderBookmark: triggeredSchedule.folderBookmark,
             source: .schedule,
-            externalSessionKey: schedule.id.uuidString
+            externalSessionKey: triggeredSchedule.id.uuidString
         )
 
-        print("[Osaurus] Executing schedule: \(schedule.name)")
+        print("[Osaurus] Executing schedule: \(triggeredSchedule.name)")
 
         let task = Task { @MainActor in
             guard let handle = await TaskDispatcher.shared.dispatch(request) else {
-                print("[Osaurus] Failed to dispatch schedule: \(schedule.name)")
+                print("[Osaurus] Failed to dispatch schedule: \(triggeredSchedule.name)")
+                self.executionTasks.removeValue(forKey: triggeredSchedule.id)
                 return
             }
 
-            self.runningTasks[schedule.id] = ScheduleRunInfo(
-                scheduleId: schedule.id,
-                scheduleName: schedule.name,
-                agentId: schedule.agentId,
+            self.runningTasks[triggeredSchedule.id] = ScheduleRunInfo(
+                scheduleId: triggeredSchedule.id,
+                scheduleName: triggeredSchedule.name,
+                agentId: triggeredSchedule.agentId,
                 chatSessionId: UUID()
             )
 
             let result = await TaskDispatcher.shared.awaitCompletion(handle)
-            self.handleResult(result, schedule: schedule, request: handle.request)
+            self.handleResult(result, schedule: triggeredSchedule, request: handle.request)
         }
 
-        executionTasks[schedule.id] = task
+        executionTasks[triggeredSchedule.id] = task
     }
 
     // MARK: - Result Handling

--- a/Packages/OsaurusCore/Models/Schedule/Schedule.swift
+++ b/Packages/OsaurusCore/Models/Schedule/Schedule.swift
@@ -341,6 +341,8 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     public var isEnabled: Bool
     /// When the schedule last ran
     public var lastRunAt: Date?
+    /// When the schedule was last selected for execution
+    public var lastTriggeredAt: Date?
     /// The chat session ID from the last run (for viewing results)
     public var lastChatSessionId: UUID?
     /// When the schedule was created
@@ -359,6 +361,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         frequency: ScheduleFrequency,
         isEnabled: Bool = true,
         lastRunAt: Date? = nil,
+        lastTriggeredAt: Date? = nil,
         lastChatSessionId: UUID? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -373,6 +376,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         self.frequency = frequency
         self.isEnabled = isEnabled
         self.lastRunAt = lastRunAt
+        self.lastTriggeredAt = lastTriggeredAt
         self.lastChatSessionId = lastChatSessionId
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -385,7 +389,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         case personaId  // legacy key for migration
         case mode  // legacy key (chat / work) — ignored on decode
         case folderPath, folderBookmark
-        case frequency, isEnabled, lastRunAt, lastChatSessionId
+        case frequency, isEnabled, lastRunAt, lastTriggeredAt, lastChatSessionId
         case createdAt, updatedAt
     }
 
@@ -406,6 +410,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         frequency = try container.decode(ScheduleFrequency.self, forKey: .frequency)
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         lastRunAt = try container.decodeIfPresent(Date.self, forKey: .lastRunAt)
+        lastTriggeredAt = try container.decodeIfPresent(Date.self, forKey: .lastTriggeredAt)
         lastChatSessionId = try container.decodeIfPresent(UUID.self, forKey: .lastChatSessionId)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
@@ -423,6 +428,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         try container.encode(frequency, forKey: .frequency)
         try container.encode(isEnabled, forKey: .isEnabled)
         try container.encodeIfPresent(lastRunAt, forKey: .lastRunAt)
+        try container.encodeIfPresent(lastTriggeredAt, forKey: .lastTriggeredAt)
         try container.encodeIfPresent(lastChatSessionId, forKey: .lastChatSessionId)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
@@ -434,6 +440,19 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     public var nextRunDate: Date? {
         guard isEnabled else { return nil }
         return frequency.nextRunDate()
+    }
+
+    /// Most recent execution anchor. Trigger time wins over completion time so
+    /// failed or in-flight runs do not replay the same missed slot.
+    public var executionAnchor: Date? {
+        lastTriggeredAt ?? lastRunAt
+    }
+
+    /// Calculate the next run date from the execution anchor.
+    public func nextRunDateAfterExecutionAnchor(asOf now: Date = Date()) -> Date? {
+        guard isEnabled else { return nil }
+        if case .once = frequency, executionAnchor != nil { return nil }
+        return frequency.nextRunDate(after: executionAnchor ?? now)
     }
 
     /// Human-readable description of when this will next run
@@ -475,19 +494,24 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     }
 
     /// Whether this schedule should run now (or was missed)
-    public func shouldRunNow(toleranceSeconds: TimeInterval = 60) -> Bool {
+    public func shouldRunNow(
+        asOf now: Date = Date(),
+        toleranceSeconds: TimeInterval = 60,
+        initialLookbackSeconds: TimeInterval = 3600
+    ) -> Bool {
         guard isEnabled else { return false }
 
-        // For once schedules, check if we're within tolerance of the target time
+        let latestAllowedFireDate = now.addingTimeInterval(toleranceSeconds)
+
+        // A one-shot should never replay once it has been selected for dispatch.
         if case .once(let date) = frequency {
-            let now = Date()
-            return abs(now.timeIntervalSince(date)) <= toleranceSeconds
+            guard executionAnchor == nil else { return false }
+            return date <= latestAllowedFireDate
         }
 
-        // For recurring schedules, check if nextRunDate is in the past or within tolerance
-        guard let nextRun = frequency.nextRunDate() else { return false }
-        let now = Date()
-        return now >= nextRun.addingTimeInterval(-toleranceSeconds)
+        let checkFrom = executionAnchor ?? now.addingTimeInterval(-initialLookbackSeconds)
+        guard let nextRun = frequency.nextRunDate(after: checkFrom) else { return false }
+        return nextRun <= latestAllowedFireDate
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Schedule/ScheduleExecutionAnchorTests.swift
+++ b/Packages/OsaurusCore/Tests/Schedule/ScheduleExecutionAnchorTests.swift
@@ -1,0 +1,117 @@
+//
+//  ScheduleExecutionAnchorTests.swift
+//  osaurusTests
+//
+//  Verifies scheduled runs anchor on trigger time, not only completion time.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ScheduleExecutionAnchorTests {
+    @Test func codableRoundTripPreservesLastTriggeredAt() throws {
+        let id = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let sessionId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let lastRunAt = localDate(year: 2026, month: 5, day: 16, hour: 9, minute: 0)
+        let lastTriggeredAt = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 0)
+        let createdAt = localDate(year: 2026, month: 5, day: 1, hour: 8, minute: 0)
+        let updatedAt = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 1)
+
+        let schedule = Schedule(
+            id: id,
+            name: "Daily check",
+            instructions: "Summarize the workspace",
+            parameters: ["pluginId": "plugin.example"],
+            frequency: .daily(hour: 9, minute: 0),
+            lastRunAt: lastRunAt,
+            lastTriggeredAt: lastTriggeredAt,
+            lastChatSessionId: sessionId,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(schedule)
+        let json = String(decoding: data, as: UTF8.self)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Schedule.self, from: data)
+
+        #expect(json.contains("lastTriggeredAt"))
+        #expect(decoded.lastRunAt == lastRunAt)
+        #expect(decoded.lastTriggeredAt == lastTriggeredAt)
+        #expect(decoded.executionAnchor == lastTriggeredAt)
+        #expect(decoded.lastChatSessionId == sessionId)
+    }
+
+    @Test func recurringDueCheckUsesLastTriggeredAtBeforeLastRunAt() {
+        let lastRunAt = localDate(year: 2026, month: 5, day: 16, hour: 9, minute: 0)
+        let lastTriggeredAt = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 0)
+        let now = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 30)
+
+        let anchored = Schedule(
+            name: "Daily check",
+            instructions: "Run the daily check",
+            frequency: .daily(hour: 9, minute: 0),
+            lastRunAt: lastRunAt,
+            lastTriggeredAt: lastTriggeredAt
+        )
+        let completionOnly = Schedule(
+            name: "Daily check",
+            instructions: "Run the daily check",
+            frequency: .daily(hour: 9, minute: 0),
+            lastRunAt: lastRunAt
+        )
+
+        #expect(!anchored.shouldRunNow(asOf: now, toleranceSeconds: 0))
+        #expect(completionOnly.shouldRunNow(asOf: now, toleranceSeconds: 0))
+        let tomorrowAtNine = localDate(year: 2026, month: 5, day: 18, hour: 9, minute: 0)
+        #expect(anchored.nextRunDateAfterExecutionAnchor(asOf: now) == tomorrowAtNine)
+    }
+
+    @Test func oneShotDoesNotReplayAfterBeingTriggered() {
+        let fireDate = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 0)
+        let now = localDate(year: 2026, month: 5, day: 17, hour: 10, minute: 0)
+        let triggeredAt = localDate(year: 2026, month: 5, day: 17, hour: 9, minute: 1)
+
+        let pending = Schedule(
+            name: "One shot",
+            instructions: "Run once",
+            frequency: .once(date: fireDate)
+        )
+        let alreadyTriggered = Schedule(
+            name: "One shot",
+            instructions: "Run once",
+            frequency: .once(date: fireDate),
+            lastTriggeredAt: triggeredAt
+        )
+        let selectedForDispatch = Schedule(
+            name: "One shot",
+            instructions: "Run once",
+            frequency: .once(date: fireDate),
+            lastTriggeredAt: fireDate.addingTimeInterval(-10)
+        )
+
+        #expect(pending.shouldRunNow(asOf: now, toleranceSeconds: 0))
+        #expect(!alreadyTriggered.shouldRunNow(asOf: now, toleranceSeconds: 0))
+        #expect(alreadyTriggered.nextRunDateAfterExecutionAnchor(asOf: now) == nil)
+        #expect(!selectedForDispatch.shouldRunNow(asOf: now, toleranceSeconds: 0))
+        #expect(selectedForDispatch.nextRunDateAfterExecutionAnchor(asOf: now) == nil)
+    }
+
+    private func localDate(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar.current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return components.date!
+    }
+}

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -1623,6 +1623,11 @@ struct ScheduleEditorSheet: View {
         return nil
     }
 
+    private var existingLastTriggeredAt: Date? {
+        if case .edit(let schedule) = mode { return schedule.lastTriggeredAt }
+        return nil
+    }
+
     private var existingLastChatSessionId: UUID? {
         if case .edit(let schedule) = mode { return schedule.lastChatSessionId }
         return nil
@@ -2524,6 +2529,7 @@ struct ScheduleEditorSheet: View {
             frequency: buildFrequency(),
             isEnabled: isEnabled,
             lastRunAt: existingLastRunAt,
+            lastTriggeredAt: existingLastTriggeredAt,
             lastChatSessionId: existingLastChatSessionId,
             createdAt: existingCreatedAt ?? Date(),
             updatedAt: Date()


### PR DESCRIPTION
## Summary
- add `Schedule.lastTriggeredAt` and preserve it through Codable/edit flows
- anchor due checks and next-timer scheduling on the most recent trigger rather than completion only
- mark schedules as triggered before dispatch so in-flight or failed executions do not replay the same missed slot

## Why
Recurring schedules could be selected again from an old `lastRunAt` while a newer run was already dispatched but not completed. This records dispatch selection separately from completion metadata.

## Validation
- `git diff --check origin/main...HEAD`
- `swift test --package-path Packages/OsaurusCore --filter ScheduleExecutionAnchorTests`
- `xcrun swift-format lint --strict --recursive Packages App`
- `swiftlint lint --reporter github-actions-logging` (existing repo warnings only; exit 0)
