### PR TITLE
auto-queue messages and send immediately feature

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -1,0 +1,235 @@
+//
+//  ChatSessionQueuedSendTests.swift
+//  osaurusTests
+//
+//  Covers the Cursor-style "queue + interrupt" UX on `ChatSession`:
+//
+//  - `enqueueSend(_:attachments:)` captures the payload and clears the
+//    bound input. Replacing semantics on a second call.
+//  - `cancelQueuedSend()` drops the pending payload.
+//  - Auto-flush in `completeRunCleanup` dispatches the queued send when
+//    the run ends naturally, and is gated off when `stop()` is in-flight.
+//  - `sendNowInterrupting()` cancels the active run and immediately
+//    dispatches the queued payload as a new user turn.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatSessionQueuedSendTests {
+
+    // MARK: - Pure state helpers (no streaming engine needed)
+
+    @Test
+    func enqueueSend_capturesPayloadAndClearsInput() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.input = "ignored — enqueueSend takes its arg explicitly"
+            session.pendingAttachments = []
+            session.pendingOneOffSkillId = nil
+
+            session.enqueueSend("plan B please", attachments: [])
+
+            #expect(session.queuedSend?.text == "plan B please")
+            #expect(session.queuedSend?.attachments.isEmpty == true)
+            #expect(session.queuedSend?.oneOffSkillId == nil)
+            #expect(session.input == "")
+            #expect(session.pendingAttachments.isEmpty)
+        }
+    }
+
+    @Test
+    func enqueueSend_trimsWhitespace() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.enqueueSend("   hi   ", attachments: [])
+            #expect(session.queuedSend?.text == "hi")
+        }
+    }
+
+    @Test
+    func enqueueSend_emptyIsNoOp() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.enqueueSend("   ", attachments: [])
+            #expect(session.queuedSend == nil)
+        }
+    }
+
+    @Test
+    func enqueueSend_replacesExistingQueue() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.enqueueSend("first queued", attachments: [])
+            session.enqueueSend("second queued", attachments: [])
+            #expect(session.queuedSend?.text == "second queued")
+        }
+    }
+
+    @Test
+    func enqueueSend_capturesPendingOneOffSkillId() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let skillId = UUID()
+            session.pendingOneOffSkillId = skillId
+
+            session.enqueueSend("with skill", attachments: [])
+
+            #expect(session.queuedSend?.oneOffSkillId == skillId)
+            // Skill is consumed into the queue snapshot.
+            #expect(session.pendingOneOffSkillId == nil)
+        }
+    }
+
+    @Test
+    func cancelQueuedSend_clearsQueue() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.enqueueSend("nevermind", attachments: [])
+            #expect(session.queuedSend != nil)
+
+            session.cancelQueuedSend()
+            #expect(session.queuedSend == nil)
+        }
+    }
+
+    // MARK: - Streaming integration
+
+    @Test
+    func naturalCompletion_autoFlushesQueuedSend() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 60) }
+
+            session.send("first")
+            // Wait for the streaming flag to flip so the queued send
+            // genuinely lands during an active run.
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+
+            session.enqueueSend("auto flush me", attachments: [])
+            #expect(session.queuedSend?.text == "auto flush me")
+
+            // First run drains, completeRunCleanup auto-flushes which
+            // kicks off a second run. Wait for everything to settle.
+            try await waitUntil(timeout: .seconds(3)) {
+                !session.isStreaming && session.queuedSend == nil
+            }
+
+            let userTurns = session.turns.filter { $0.role == .user }
+            #expect(userTurns.map(\.content) == ["first", "auto flush me"])
+            #expect(session.queuedSend == nil)
+        }
+    }
+
+    @Test
+    func stop_doesNotAutoFlushAndLeavesQueueIntact() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+
+            session.send("first")
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+
+            session.enqueueSend("should not auto-send", attachments: [])
+            session.stop()
+
+            #expect(session.isStreaming == false)
+            // Queue is preserved so the user can re-decide via the chip
+            // or Send Now. The plain Stop path must not dispatch.
+            #expect(session.queuedSend?.text == "should not auto-send")
+
+            // Let any pending tasks settle and confirm no follow-up
+            // run was dispatched.
+            try await Task.sleep(for: .milliseconds(200))
+            let userTurns = session.turns.filter { $0.role == .user }
+            #expect(userTurns.map(\.content) == ["first"])
+            #expect(session.queuedSend?.text == "should not auto-send")
+        }
+    }
+
+    @Test
+    func sendNowInterrupting_stopsAndDispatchesAsNewUserTurn() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            session.chatEngineFactory = { SlowFinishingChatEngine(delayMs: 500) }
+
+            session.send("first")
+            try await waitUntil(timeout: .seconds(1)) { session.isStreaming }
+
+            session.enqueueSend("urgent follow-up", attachments: [])
+            session.sendNowInterrupting()
+
+            // Queue is consumed; the new turn is appended synchronously
+            // inside send(...) (the assistant placeholder follows in the
+            // task body).
+            #expect(session.queuedSend == nil)
+            let userTurns = session.turns.filter { $0.role == .user }
+            #expect(userTurns.map(\.content) == ["first", "urgent follow-up"])
+
+            // Let the second run finish so we leave a clean session.
+            try await waitUntil(timeout: .seconds(3)) {
+                !session.isStreaming
+            }
+        }
+    }
+
+    @Test
+    func sendNowInterrupting_isNoOpWhenQueueEmpty() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            // Not streaming, no queue → no-op, no crash.
+            session.sendNowInterrupting()
+
+            #expect(session.queuedSend == nil)
+            #expect(session.turns.isEmpty)
+            #expect(session.isStreaming == false)
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+/// Mimics a real model: blocks briefly before yielding so callers can
+/// observe `isStreaming == true` and enqueue a follow-up before the run
+/// finishes. Yields one delta and finishes cleanly (so completeRunCleanup
+/// path is the "natural" finish, not the cancel path).
+private actor SlowFinishingChatEngine: ChatEngineProtocol {
+    let delayMs: Int
+
+    init(delayMs: Int) {
+        self.delayMs = delayMs
+    }
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        let delay = delayMs
+        return AsyncThrowingStream { continuation in
+            Task {
+                try? await Task.sleep(for: .milliseconds(delay))
+                continuation.yield("ok")
+                continuation.finish()
+            }
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionQueuedSendTests", code: 1)
+    }
+}
+
+// MARK: - Local waitUntil (file-private to avoid colliding with other test files)
+
+private func waitUntil(
+    timeout: Duration,
+    _ predicate: @MainActor @escaping () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw NSError(domain: "ChatSessionQueuedSendTests", code: 2)
+}

--- a/Packages/OsaurusCore/Tests/Chat/EditableTextViewFocusLockTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EditableTextViewFocusLockTests.swift
@@ -1,0 +1,128 @@
+//
+//  EditableTextViewFocusLockTests.swift
+//  osaurusTests
+//
+//  Verifies the AppKit-level focus refusal contract used by
+//  `FloatingInputCard` to hold input focus through send/queue
+//  state-mutation cascades:
+//
+//  - `CustomNSTextView.resignFirstResponder()` returns `false` while
+//    `focusLockUntil` is in the future, and reverts after the deadline.
+//  - `TextViewFocusController.lockFocus(for:)` arms the deadline and
+//    re-claims first responder if something else has already taken it.
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct EditableTextViewFocusLockTests {
+
+    /// Build a borderless host window with the given text view as its
+    /// content view. `releasedWhenClosed = false` keeps the NSWindow
+    /// alive until the test goes out of scope (avoids double-free
+    /// races during cleanup when multiple suites run in parallel).
+    /// Caller is expected to `defer { teardown(window) }`.
+    private func makeHostedTextView() -> (NSWindow, CustomNSTextView) {
+        let textView = CustomNSTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 40))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 40),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 40))
+        window.contentView?.addSubview(textView)
+        // No `orderFront` — first-responder routing works without
+        // making the window key/visible, and it keeps the test from
+        // touching the shared window list (avoids cross-suite
+        // interference under parallel execution).
+        #expect(window.makeFirstResponder(textView))
+        #expect(window.firstResponder === textView)
+        return (window, textView)
+    }
+
+    /// Symmetric teardown matched with `makeHostedTextView`.
+    private func teardown(_ window: NSWindow) {
+        // Resign before closing so the AppKit responder chain unwinds
+        // cleanly even if a previous test left the lock armed.
+        window.makeFirstResponder(nil)
+        window.contentView = nil
+        window.close()
+    }
+
+    @Test
+    func focusLock_refusesResignWhileWindowOpen() async throws {
+        let (window, textView) = makeHostedTextView()
+        defer { teardown(window) }
+
+        textView.focusLockUntil = Date().addingTimeInterval(0.15)
+
+        // While the lock is armed, the window cannot move first
+        // responder away from the text view. `makeFirstResponder(nil)`
+        // honors the refusal and returns false.
+        let resigned = window.makeFirstResponder(nil)
+        #expect(resigned == false)
+        #expect(window.firstResponder === textView)
+    }
+
+    @Test
+    func focusLock_allowsResignAfterDeadlinePasses() async throws {
+        let (window, textView) = makeHostedTextView()
+        defer { teardown(window) }
+
+        // Short window so the test isn't slow. 80 ms is comfortably
+        // longer than CI runloop jitter but short enough to stay snappy.
+        textView.focusLockUntil = Date().addingTimeInterval(0.08)
+        #expect(window.makeFirstResponder(nil) == false)
+        #expect(window.firstResponder === textView)
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        // After the deadline, resignation goes through normally.
+        #expect(window.makeFirstResponder(nil) == true)
+        #expect(window.firstResponder !== textView)
+    }
+
+    @Test
+    func focusLock_isInactiveByDefault() async throws {
+        let (window, textView) = makeHostedTextView()
+        defer { teardown(window) }
+
+        // Default `focusLockUntil = .distantPast` — never locked.
+        #expect(window.makeFirstResponder(nil) == true)
+        #expect(window.firstResponder !== textView)
+    }
+
+    @Test
+    func textViewFocusController_armsLockAndReclaimsFirstResponder() async throws {
+        let (window, textView) = makeHostedTextView()
+        defer { teardown(window) }
+
+        // Simulate something stealing first responder a microsecond
+        // before the lock was applied.
+        #expect(window.makeFirstResponder(nil) == true)
+        #expect(window.firstResponder !== textView)
+
+        let controller = TextViewFocusController()
+        controller.attach(textView)
+        controller.lockFocus(for: 0.15)
+
+        // The controller re-claims focus, then armed the lock.
+        #expect(window.firstResponder === textView)
+        #expect(window.makeFirstResponder(nil) == false)
+        #expect(window.firstResponder === textView)
+    }
+
+    @Test
+    func textViewFocusController_isNoOpWhenTextViewIsNil() {
+        let controller = TextViewFocusController()
+        // Should not crash or trap when the weak ref is empty.
+        controller.lockFocus(for: 0.15)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -24,6 +24,18 @@ final class VisibleBlocksStore: ObservableObject {
     @Published var groupHeaderMap: [UUID: UUID] = [:]
 }
 
+/// Snapshot of a pending user message that was authored while the agent
+/// was still streaming. Captured at enqueue time so attachments and the
+/// active one-off skill travel with the right turn. The view shows a chip
+/// for this; `ChatSession` consumes it either via auto-flush on natural
+/// completion or via `sendNowInterrupting()` when the user explicitly
+/// interrupts.
+struct QueuedSend: Equatable {
+    var text: String
+    var attachments: [Attachment]
+    var oneOffSkillId: UUID?
+}
+
 /// Lifecycle of the generative greeting for a single chat session. Drives
 /// the empty-state UI: `.idle` and `.failed` render the static greeting +
 /// the agent's configured quick actions, `.loading` renders an animated
@@ -124,6 +136,14 @@ final class ChatSession: ObservableObject {
     /// Set when the user selects a skill from the slash command popup; cleared after send.
     @Published var pendingOneOffSkillId: UUID?
 
+    /// Single-slot queued send. Non-nil when the user has pressed Send while
+    /// `isStreaming` is true. The chip in `FloatingInputCard` shows a preview
+    /// and a × to cancel. Auto-flushed by `completeRunCleanup` when the run
+    /// ends naturally; explicitly flushed by `sendNowInterrupting()` which
+    /// stops the current run and dispatches the queued payload as a new
+    /// user turn.
+    @Published var queuedSend: QueuedSend?
+
     // MARK: - Persistence Properties
     @Published var sessionId: UUID?
     @Published var title: String = "New Chat"
@@ -223,6 +243,10 @@ final class ChatSession: ObservableObject {
     private var currentTask: Task<Void, Never>?
     private var activeRunId: UUID?
     private var activeRunContext: RunContext?
+    /// Set to true at the start of `stop()` so `completeRunCleanup` knows the
+    /// run was cancelled by the user (or by `sendNowInterrupting`) and must
+    /// not auto-flush a queued send. Reset to false at the top of `send(...)`.
+    private var stopRequested: Bool = false
     var chatEngineFactory: @MainActor () -> ChatEngineProtocol = {
         ChatEngine(source: .chatUI)
     }
@@ -751,6 +775,7 @@ final class ChatSession: ObservableObject {
     }
 
     func stop() {
+        stopRequested = true
         let task = currentTask
         task?.cancel()
         if let runId = activeRunId {
@@ -758,6 +783,52 @@ final class ChatSession: ObservableObject {
         } else {
             completeRunCleanup()
         }
+    }
+
+    // MARK: - Queued Send (Cursor-style interrupt UX)
+
+    /// Capture the current `input` + `pendingAttachments` + `pendingOneOffSkillId`
+    /// into a single-slot pending send and clear the input. No-op if the
+    /// payload is empty. Replacing semantics: a second call while a queue
+    /// is already pending overwrites it. The transcript is NOT touched —
+    /// the queued message only materializes as a `user` turn when the run
+    /// finishes (auto-flush) or when `sendNowInterrupting()` is invoked.
+    func enqueueSend(_ text: String, attachments: [Attachment]) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasContent = !trimmed.isEmpty || !attachments.isEmpty
+        guard hasContent else { return }
+        queuedSend = QueuedSend(
+            text: trimmed,
+            attachments: attachments,
+            oneOffSkillId: pendingOneOffSkillId
+        )
+        input = ""
+        pendingAttachments = []
+        pendingOneOffSkillId = nil
+    }
+
+    /// Drop the queued send without dispatching it.
+    func cancelQueuedSend() {
+        queuedSend = nil
+    }
+
+    /// Stop the currently streaming run and immediately dispatch the queued
+    /// send as a fresh user turn. No-op if nothing is queued. The active
+    /// run is finalized synchronously (`stop()` runs through
+    /// `finalizeRun → completeRunCleanup`, flipping `isStreaming` to false)
+    /// so the follow-up `send(...)` passes the `!isStreaming` guard. The
+    /// stored `oneOffSkillId` is re-applied to `pendingOneOffSkillId` so
+    /// the skill context attaches to the new turn.
+    func sendNowInterrupting() {
+        guard let pending = queuedSend else { return }
+        queuedSend = nil
+        if isStreaming || activeRunId != nil {
+            stop()
+        }
+        if let skillId = pending.oneOffSkillId {
+            pendingOneOffSkillId = skillId
+        }
+        send(pending.text, attachments: pending.attachments)
     }
 
     /// Appends a `user`-role turn carrying a plugin-supplied interrupt
@@ -778,6 +849,7 @@ final class ChatSession: ObservableObject {
         input = ""
         pendingAttachments = []
         pendingOneOffSkillId = nil
+        queuedSend = nil
         voiceInputState = .idle
         showVoiceOverlay = false
         // Clear session identity for new chat
@@ -1369,6 +1441,21 @@ final class ChatSession: ObservableObject {
         consolidateAssistantTurns()
         rebuildVisibleBlocks()
         save()
+        flushQueuedSendIfEligible()
+    }
+
+    /// Dispatch any queued send when the run ended naturally (no `stop()`
+    /// in-flight, no streaming error). Cancelled or errored runs leave the
+    /// queue in place so the user can re-decide via the chip or Send Now.
+    /// Called from `completeRunCleanup` after state has been finalized.
+    private func flushQueuedSendIfEligible() {
+        guard !stopRequested, lastStreamError == nil else { return }
+        guard let pending = queuedSend else { return }
+        queuedSend = nil
+        if let skillId = pending.oneOffSkillId {
+            pendingOneOffSkillId = skillId
+        }
+        send(pending.text, attachments: pending.attachments)
     }
 
     private func finalizeRun(runId: UUID?, persistConversationArtifacts: Bool) {
@@ -1722,6 +1809,11 @@ final class ChatSession: ObservableObject {
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
         guard activeRunId == nil, !isStreaming else { return }
+
+        // Fresh run: a previous stop() may have left the flag true. The
+        // auto-flush in completeRunCleanup keys off this, so clear it
+        // before the new run can finalize.
+        stopRequested = false
 
         // Any new user input clears a prior completion banner — we're
         // moving on to a follow-up. Clarify prompts (when active) live
@@ -2704,7 +2796,14 @@ struct ChatView: View {
                                     if let manualText = manualText {
                                         observedSession.input = manualText
                                     }
-                                    observedSession.sendCurrent()
+                                    if observedSession.isStreaming {
+                                        observedSession.enqueueSend(
+                                            observedSession.input,
+                                            attachments: observedSession.pendingAttachments
+                                        )
+                                    } else {
+                                        observedSession.sendCurrent()
+                                    }
                                 },
                                 onStop: { observedSession.stop() },
                                 focusTrigger: focusTrigger,
@@ -2716,7 +2815,10 @@ struct ChatView: View {
                                     observedSession.pendingOneOffSkillId = skillId
                                 },
                                 pendingSkillId: $observedSession.pendingOneOffSkillId,
-                                autoSpeakAssistant: $observedSession.autoSpeakAssistant
+                                autoSpeakAssistant: $observedSession.autoSpeakAssistant,
+                                queuedSend: $observedSession.queuedSend,
+                                onSendNow: { observedSession.sendNowInterrupting() },
+                                onCancelQueued: { observedSession.cancelQueuedSend() }
                             )
                             .frame(maxWidth: 1100)
                             .frame(maxWidth: .infinity)

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -9,6 +9,34 @@
 import AppKit
 import SwiftUI
 
+/// Imperative side channel for the NSTextView's first-responder state.
+///
+/// Callers (typically a SwiftUI parent holding it as `@StateObject`)
+/// invoke `lockFocus(for:)` to refuse resignation through a
+/// state-mutation cascade that would otherwise have AppKit blur the
+/// input. Not `@Published` — purely imperative, no SwiftUI re-renders.
+@MainActor
+final class TextViewFocusController: ObservableObject {
+    /// Wired by `EditableTextView.makeNSView`. Tests use `attach(_:)`.
+    fileprivate(set) weak var textView: CustomNSTextView?
+
+    /// Test-only injection point.
+    func attach(_ textView: CustomNSTextView) {
+        self.textView = textView
+    }
+
+    /// Arm the resignation-refusal window. Also re-claims first
+    /// responder if something has already taken it (e.g. a button's
+    /// mouseDown a microsecond before the lock was applied).
+    func lockFocus(for duration: TimeInterval = 0.15) {
+        guard let tv = textView else { return }
+        tv.focusLockUntil = Date().addingTimeInterval(duration)
+        if let window = tv.window, window.firstResponder !== tv {
+            window.makeFirstResponder(tv)
+        }
+    }
+}
+
 struct EditableTextView: NSViewRepresentable {
     @Binding var text: String
     let fontSize: CGFloat
@@ -17,6 +45,10 @@ struct EditableTextView: NSViewRepresentable {
     @Binding var isFocused: Bool
     @Binding var isComposing: Bool
     var maxHeight: CGFloat = .infinity
+    /// Optional imperative focus controller. `makeNSView` populates
+    /// its weak `textView` reference; the parent uses `lockFocus(for:)`
+    /// to refuse resignation during state-mutation cascades.
+    var focusController: TextViewFocusController? = nil
     var onCommit: (() -> Void)? = nil
     var onShiftCommit: (() -> Void)? = nil
     /// Called on ↑ arrow key. Return true to consume the event (prevents cursor movement).
@@ -76,6 +108,8 @@ struct EditableTextView: NSViewRepresentable {
         textView.onPasteText = { [weak coordinator] text in
             coordinator?.parent.onPasteText?(text) ?? false
         }
+
+        focusController?.textView = textView
 
         scrollView.documentView = textView
         return scrollView
@@ -256,6 +290,13 @@ final class CustomNSTextView: NSTextView {
     /// Return true to consume the paste (skips the default insertion).
     var onPasteText: ((String) -> Bool)?
 
+    /// While `Date() < focusLockUntil`, `resignFirstResponder` returns
+    /// `false`. Set via `TextViewFocusController.lockFocus(for:)` to
+    /// keep first responder through a state-mutation cascade. No
+    /// scheduled work — the deadline self-expires on the next
+    /// resignation attempt past it.
+    var focusLockUntil: Date = .distantPast
+
     // MARK: First-responder
 
     override func becomeFirstResponder() -> Bool {
@@ -265,6 +306,7 @@ final class CustomNSTextView: NSTextView {
     }
 
     override func resignFirstResponder() -> Bool {
+        if Date() < focusLockUntil { return false }
         let resigned = super.resignFirstResponder()
         if resigned { onFocusChanged?(false) }
         return resigned

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -46,6 +46,15 @@ struct FloatingInputCard: View {
     /// Binding to the session's auto-speak preference. When true, a chip is shown
     /// so the user can disable it without waiting to be re-prompted.
     @Binding var autoSpeakAssistant: Bool
+    /// Single-slot queued send that was authored while a run was streaming.
+    /// Non-nil renders a chip + flips the Send button into "Send Now"
+    /// (interrupt) mode. Nil → ordinary Send / Queue behavior.
+    @Binding var queuedSend: QueuedSend?
+    /// Cancel + immediately dispatch the queued send. Only invoked when
+    /// `queuedSend != nil` (the SendNow button is otherwise hidden).
+    var onSendNow: (() -> Void)?
+    /// Discard the queued send without sending it. Called by the chip's ×.
+    var onCancelQueued: (() -> Void)?
 
     init(
         text: Binding<String>,
@@ -69,7 +78,10 @@ struct FloatingInputCard: View {
         onClearChat: (() -> Void)? = nil,
         onSkillSelected: ((UUID) -> Void)? = nil,
         pendingSkillId: Binding<UUID?> = .constant(nil),
-        autoSpeakAssistant: Binding<Bool> = .constant(false)
+        autoSpeakAssistant: Binding<Bool> = .constant(false),
+        queuedSend: Binding<QueuedSend?> = .constant(nil),
+        onSendNow: (() -> Void)? = nil,
+        onCancelQueued: (() -> Void)? = nil
     ) {
         self._text = text
         self._selectedModel = selectedModel
@@ -93,6 +105,9 @@ struct FloatingInputCard: View {
         self.onSkillSelected = onSkillSelected
         self._pendingSkillId = pendingSkillId
         self._autoSpeakAssistant = autoSpeakAssistant
+        self._queuedSend = queuedSend
+        self.onSendNow = onSendNow
+        self.onCancelQueued = onCancelQueued
     }
 
     // Observe managers for reactive updates
@@ -140,6 +155,10 @@ struct FloatingInputCard: View {
     @State private var localText: String = ""
     @State private var isFocused: Bool = false
     @State private var isComposing: Bool = false
+    /// Keeps focus in the input through the send/queue state cascade.
+    /// `syncAndSend` and `sendNowButton` arm `lockFocus(for:)` before
+    /// the mutations that would otherwise let AppKit blur the field.
+    @StateObject private var textViewFocusController = TextViewFocusController()
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
     @State private var isDragOver = false
@@ -204,7 +223,10 @@ struct FloatingInputCard: View {
 
         let hasText = !localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasContent = hasText || !pendingAttachments.isEmpty
-        return hasContent && !isStreaming
+        // During streaming, "send" enqueues the payload (handled by the
+        // parent). The bar swaps Send for SendQueue/SendNow visually but
+        // the keyboard path still goes through onSend → enqueueSend.
+        return hasContent
     }
 
     private var showPlaceholder: Bool {
@@ -411,9 +433,11 @@ struct FloatingInputCard: View {
                 }
             }
             .onChange(of: isStreaming) { wasStreaming, nowStreaming in
-                // re-focus the input when streaming ends so the user can type immediately.
-                // focus is cleared on send to stop the NSTextView cursor-blink display link
-                // during streaming; restore it once the response is complete.
+                // Safety net: if focus was lost during streaming (e.g.
+                // the user clicked elsewhere or dismissed a dialog),
+                // re-claim it once the agent finishes so the user can
+                // type immediately. The normal send path keeps focus
+                // throughout via `TextViewFocusController.lockFocus`.
                 if wasStreaming && !nowStreaming {
                     isFocused = true
                 }
@@ -1066,11 +1090,13 @@ extension FloatingInputCard {
     private func syncAndSend() {
         guard canSend else { return }
         let message = localText
+        // Hold first responder through the binding-flush cascade
+        // (clearing local + bound text, parent reconcile, optional
+        // new run kickoff). 300 ms covers the longest observed
+        // cascade with margin. Covers both fresh sends and queueing.
+        textViewFocusController.lockFocus(for: 0.3)
         localText = ""
         text = ""
-        // resign first responder so the NSTextView cursor-blink display link stops driving
-        // the window compositor at 60fps through the streaming response
-        isFocused = false
         onSend(message)
     }
 
@@ -1126,6 +1152,65 @@ extension FloatingInputCard {
             )
         default:
             break
+        }
+    }
+
+    // MARK: - Queued Send Chip
+
+    /// Compact chip preview of the message that's queued to flush when the
+    /// active run finishes (or be dispatched immediately via Send Now).
+    /// Visible only when `queuedSend != nil`.
+    @ViewBuilder
+    private var queuedSendChipView: some View {
+        if let queued = queuedSend {
+            let preview: String = {
+                let trimmed = queued.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    return String(localized: "Queued attachment", bundle: .module)
+                }
+                if trimmed.count <= 80 { return trimmed }
+                return String(trimmed.prefix(80)) + "\u{2026}"
+            }()
+            HStack(spacing: 5) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.accentColor)
+                Text("Queued:", bundle: .module)
+                    .font(theme.font(size: 11, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text(verbatim: preview)
+                    .font(theme.font(size: 11, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Button {
+                    withAnimation(theme.springAnimation()) {
+                        if let onCancelQueued {
+                            onCancelQueued()
+                        } else {
+                            queuedSend = nil
+                        }
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundColor(theme.secondaryText)
+                        .padding(3)
+                        .background(Circle().fill(theme.tertiaryBackground))
+                }
+                .buttonStyle(.plain)
+                .help("Cancel queued message")
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(theme.accentColor.opacity(0.12))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(theme.accentColor.opacity(0.3), lineWidth: 0.5)
+            )
         }
     }
 
@@ -2224,9 +2309,11 @@ extension FloatingInputCard {
     // MARK: - Input Card
 
     private var inputCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if !pendingAttachments.isEmpty || pendingSkillId != nil {
+        let hasChipRow = !pendingAttachments.isEmpty || pendingSkillId != nil || queuedSend != nil
+        return VStack(alignment: .leading, spacing: 0) {
+            if hasChipRow {
                 HStack(alignment: .center, spacing: 6) {
+                    queuedSendChipView
                     pendingSkillChipView
                     if !pendingAttachments.isEmpty {
                         inlinePendingAttachmentsPreview
@@ -2238,7 +2325,7 @@ extension FloatingInputCard {
 
             textInputArea
                 .padding(.horizontal, 12)
-                .padding(.top, (pendingAttachments.isEmpty && pendingSkillId == nil) ? 10 : 6)
+                .padding(.top, hasChipRow ? 6 : 10)
                 .padding(.bottom, 6)
 
             buttonBar
@@ -2596,6 +2683,7 @@ extension FloatingInputCard {
             isFocused: $isFocused,
             isComposing: $isComposing,
             maxHeight: maxHeight,
+            focusController: textViewFocusController,
             onCommit: {
                 if showSlashPopup {
                     let cmds = slashFilteredCommands
@@ -2677,8 +2765,14 @@ extension FloatingInputCard {
                 keyboardHint
                 if isStreaming {
                     stopButton
+                    if queuedSend != nil {
+                        sendNowButton
+                    } else {
+                        sendQueueButton
+                    }
+                } else {
+                    sendButton
                 }
-                sendButton
             }
         }
     }
@@ -2713,6 +2807,24 @@ extension FloatingInputCard {
 
     private var sendButton: some View {
         SendButton(canSend: canSend, action: syncAndSend)
+    }
+
+    /// Streaming + empty queue: pressing Send queues the message. Same
+    /// dispatcher as `sendButton` (`syncAndSend → onSend`); the parent
+    /// notices `isStreaming == true` and routes to `enqueueSend`.
+    private var sendQueueButton: some View {
+        SendQueueButton(canSend: canSend, action: syncAndSend)
+    }
+
+    /// Streaming + a queued message present: pressing this stops the
+    /// current run and dispatches the queued payload immediately.
+    private var sendNowButton: some View {
+        SendNowButton {
+            // Stop -> send cascade fans out across more runloop turns
+            // than syncAndSend, hence the longer lock.
+            textViewFocusController.lockFocus(for: 0.4)
+            onSendNow?()
+        }
     }
 
     // MARK: - Card Styling
@@ -3731,6 +3843,126 @@ private struct StopButton: View {
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+    }
+}
+
+// MARK: - Send Queue Button
+
+/// Used while a run is streaming and the queue is empty. Pressing it
+/// stores the current input as a single-slot pending send (handled by
+/// the parent). Shares the exact 32×32 circular footprint of
+/// `SendButton`; the only visual delta is a muted gray fill (instead of
+/// the accent gradient) plus a hover tooltip that explains the queue
+/// semantics. The icon stays `arrow.up` so users still read it as
+/// "send".
+private struct SendQueueButton: View {
+    let canSend: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(theme.tertiaryBackground.opacity(canSend ? 0.95 : 0.7))
+
+                if isHovered && canSend {
+                    Circle()
+                        .fill(theme.accentColor.opacity(0.12))
+                }
+
+                Image(systemName: "arrow.up")
+                    .font(theme.font(size: CGFloat(theme.bodySize) + 1, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+            }
+            .frame(width: 32, height: 32)
+            .overlay(
+                Circle()
+                    .strokeBorder(theme.secondaryText.opacity(isHovered ? 0.35 : 0.2), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSend)
+        .opacity(canSend ? 1 : 0.5)
+        .help("Queue message · sent when current run finishes")
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+        .animation(.easeOut(duration: 0.1), value: canSend)
+        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+    }
+}
+
+// MARK: - Send Now Button
+
+/// Accent-tinted variant that stops the active run and dispatches the
+/// queued send immediately. Visible only when a queued message exists.
+/// Same 32×32 circular footprint as `SendButton`; differentiated by a
+/// `bolt.fill` icon (signals "urgent / now") and a hover tooltip.
+private struct SendNowButton: View {
+    let action: () -> Void
+
+    @State private var isHovered = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                theme.accentColor,
+                                theme.accentColor.opacity(0.85),
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+
+                if isHovered {
+                    Circle()
+                        .fill(Color.white.opacity(0.15))
+                }
+
+                Image(systemName: "bolt.fill")
+                    .font(theme.font(size: CGFloat(theme.bodySize) + 1, weight: .semibold))
+                    .foregroundColor(.white)
+            }
+            .frame(width: 32, height: 32)
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                Color.white.opacity(isHovered ? 0.35 : 0.2),
+                                theme.accentColor.opacity(0.3),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 1
+                    )
+            )
+            .shadow(
+                color: theme.accentColor.opacity(isHovered ? 0.5 : 0.35),
+                radius: isHovered ? 10 : 6,
+                x: 0,
+                y: isHovered ? 4 : 2
+            )
+        }
+        .buttonStyle(.plain)
+        .help("Send now · interrupts current run")
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) {
                 isHovered = hovering


### PR DESCRIPTION
## Summary

allow auto-queue messages and send immediately for interruption

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
