### PR TITLE
improved model download error handling

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -507,6 +507,10 @@ final class ModelManager: NSObject, ObservableObject {
     var totalDownloadedSize: Int64 { downloadService.totalDownloadedSize }
     var totalDownloadedSizeString: String { downloadService.totalDownloadedSizeString }
     var activeDownloadsCount: Int { downloadService.activeDownloadsCount }
+    var downloadAlert: String? {
+        get { downloadService.downloadAlert }
+        set { downloadService.downloadAlert = newValue }
+    }
 
     /// Deduplicated merge of suggestedModels + availableModels, preferring curated descriptions.
     func deduplicatedModels() -> [MLXModel] {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -507,7 +507,7 @@ final class ModelManager: NSObject, ObservableObject {
     var totalDownloadedSize: Int64 { downloadService.totalDownloadedSize }
     var totalDownloadedSizeString: String { downloadService.totalDownloadedSizeString }
     var activeDownloadsCount: Int { downloadService.activeDownloadsCount }
-    var downloadAlert: String? {
+    var downloadAlert: ModelDownloadService.DownloadAlertInfo? {
         get { downloadService.downloadAlert }
         set { downloadService.downloadAlert = newValue }
     }

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -63,8 +63,74 @@ final class ModelDownloadService: ObservableObject {
 
     @Published var downloadStates: [String: DownloadState] = [:]
     @Published var downloadMetrics: [String: DownloadMetrics] = [:]
-    /// Blocking error that prevented a download from starting
-    @Published var downloadAlert: String?
+    /// Last download failure surfaced to the UI.
+    @Published var downloadAlert: DownloadAlertInfo?
+
+    /// Categorised failure info shown in the alert. The `title` describes
+    /// the kind of failure, `message` is the human-readable cause, and
+    /// `details` is a copyable diagnostic line users can paste into bug
+    /// reports.
+    struct DownloadAlertInfo: Equatable, Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+        let details: String
+    }
+
+    /// Build a categorised alert from a raw error message and the affected
+    /// model. Routes well-known patterns (disk, network, gated, etc.) to
+    /// friendlier titles. falls back to a generic one.
+    private static func makeAlert(
+        modelId: String,
+        rawError: String,
+        stage: String,
+        filePath: String? = nil
+    ) -> DownloadAlertInfo {
+        let lower = rawError.lowercased()
+        let title: String
+        let message: String
+        if lower.contains("not enough disk space") || lower.contains("no space") {
+            title = "Not enough disk space"
+            message = rawError
+        } else if lower.contains("hugging face") || lower.contains("file list") {
+            title = "Repository unavailable"
+            message =
+                "Couldn't reach this model on Hugging Face. The repo may be private, gated, removed, or temporarily unreachable."
+        } else if lower.hasPrefix("http ") {
+            title = "Repository unavailable"
+            message =
+                "Hugging Face responded with \(rawError). Private or gated repos aren't supported yet; otherwise try again in a moment."
+        } else if lower.contains("offline") || lower.contains("internet connection")
+            || lower.contains("network") || lower.contains("timed out")
+        {
+            title = "Network error"
+            message = rawError
+        } else if lower.contains("size mismatch") {
+            title = "Downloaded file corrupted"
+            message =
+                "A file came back at the wrong size, which usually means the connection was interrupted. Retrying should fix this."
+        } else if lower.contains("download incomplete") {
+            title = "Download incomplete"
+            message = rawError
+        } else if lower.contains("create directory") || lower.contains("couldn't")
+            || lower.contains("permission") || lower.contains("read-only")
+        {
+            title = "Couldn't save files"
+            message = rawError
+        } else {
+            title = "Model download failed"
+            message = rawError
+        }
+
+        var detailParts: [String] = [
+            "model=\(modelId)",
+            "stage=\(stage)",
+        ]
+        if let filePath { detailParts.append("file=\(filePath)") }
+        detailParts.append("raw=\(rawError)")
+        let details = detailParts.joined(separator: " | ")
+        return DownloadAlertInfo(title: title, message: message, details: details)
+    }
 
     // MARK: - Properties
 
@@ -133,7 +199,9 @@ final class ModelDownloadService: ObservableObject {
             let freeBytes = OsaurusPaths.volumeFreeBytes(forPath: probePath.path),
             let refusal = Self.storageRefusalMessage(neededBytes: needed, freeBytes: freeBytes)
         {
-            downloadAlert = refusal
+            downloadAlert = Self.makeAlert(
+                modelId: model.id, rawError: refusal, stage: "preflight"
+            )
             return
         }
 
@@ -157,8 +225,10 @@ final class ModelDownloadService: ObservableObject {
                 withIntermediateDirectories: true
             )
         } catch {
-            downloadStates[model.id] = .failed(
-                error: "Failed to create directory: \(error.localizedDescription)"
+            let message = "Failed to create directory: \(error.localizedDescription)"
+            downloadStates[model.id] = .failed(error: message)
+            downloadAlert = Self.makeAlert(
+                modelId: model.id, rawError: message, stage: "create-directory"
             )
             clearDownloadTracking(for: model.id)
             return
@@ -196,7 +266,8 @@ final class ModelDownloadService: ObservableObject {
                             token: token,
                             finalState: .failed(
                                 error: "Could not retrieve file list from Hugging Face"
-                            )
+                            ),
+                            failureStage: "fetch-manifest"
                         )
                     }
                     return
@@ -235,7 +306,8 @@ final class ModelDownloadService: ObservableObject {
                         self.finalizeOrchestration(
                             modelId: model.id,
                             token: token,
-                            finalState: .failed(error: refusal)
+                            finalState: .failed(error: refusal),
+                            failureStage: "preflight-in-task"
                         )
                     }
                     return
@@ -295,14 +367,38 @@ final class ModelDownloadService: ObservableObject {
                     inFlightFilePath = nil
                 }
 
-                let isComplete = model.isDownloaded
-                let finalState: DownloadState =
-                    isComplete ? .completed : .failed(error: "Download incomplete")
+                // Manifest driven completion check. `model.isDownloaded` only
+                // looks for config + tokenizer + ≥1 shard on disc so a
+                // multi shard download with a silently skipped file would
+                // still pass that test. Verify every manifest entry is on
+                // disk at its expected size and report which are missing
+                let fm = FileManager.default
+                let missing: [String] = files.compactMap { file in
+                    let dest = model.localDirectory.appendingPathComponent(file.path)
+                    let attrs = try? fm.attributesOfItem(atPath: dest.path)
+                    let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+                    return size == file.size ? nil : file.path
+                }
+                let isComplete = missing.isEmpty
+                let finalState: DownloadState
+                if isComplete {
+                    finalState = .completed
+                } else if missing.count == 1 {
+                    finalState = .failed(
+                        error: "Download incomplete: \(missing[0]) is missing or has wrong size"
+                    )
+                } else {
+                    finalState = .failed(
+                        error: "Download incomplete: \(missing.count) of \(files.count) files are missing or have wrong size"
+                    )
+                }
                 await MainActor.run {
                     let didFinalize = self.finalizeOrchestration(
                         modelId: model.id,
                         token: token,
-                        finalState: finalState
+                        finalState: finalState,
+                        failureStage: "completion-check",
+                        failureFilePath: missing.first
                     )
                     if didFinalize && isComplete {
                         NotificationService.shared.postModelReady(
@@ -335,11 +431,14 @@ final class ModelDownloadService: ObservableObject {
                     )
                 }
             } catch {
+                let snapshotPath = inFlightFilePath
                 await MainActor.run {
                     self.finalizeOrchestration(
                         modelId: model.id,
                         token: token,
-                        finalState: .failed(error: error.localizedDescription)
+                        finalState: .failed(error: error.localizedDescription),
+                        failureStage: snapshotPath != nil ? "file-transfer" : "orchestration",
+                        failureFilePath: snapshotPath
                     )
                 }
             }
@@ -551,7 +650,9 @@ final class ModelDownloadService: ObservableObject {
     private func finalizeOrchestration(
         modelId: String,
         token: UUID,
-        finalState: DownloadState
+        finalState: DownloadState,
+        failureStage: String = "download",
+        failureFilePath: String? = nil
     ) -> Bool {
         guard downloadTokens[modelId] == token else { return false }
         downloadStates[modelId] = finalState
@@ -559,6 +660,14 @@ final class ModelDownloadService: ObservableObject {
         pausedDownloads[modelId] = nil
         activeDownloaders[modelId]?.invalidate()
         activeDownloaders[modelId] = nil
+        if case .failed(let error) = finalState {
+            downloadAlert = Self.makeAlert(
+                modelId: modelId,
+                rawError: error,
+                stage: failureStage,
+                filePath: failureFilePath
+            )
+        }
         return true
     }
 

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -63,6 +63,8 @@ final class ModelDownloadService: ObservableObject {
 
     @Published var downloadStates: [String: DownloadState] = [:]
     @Published var downloadMetrics: [String: DownloadMetrics] = [:]
+    /// Blocking error that prevented a download from starting
+    @Published var downloadAlert: String?
 
     // MARK: - Properties
 
@@ -118,12 +120,22 @@ final class ModelDownloadService: ObservableObject {
     }
 
     private func startOrchestration(model: MLXModel, resuming: PausedSnapshot?) {
-        if model.isDownloaded {
-            downloadStates[model.id] = .completed
-            return
-        }
+        // `model.isDownloaded` is satisfied by config + tokenizer + any single
+        // shard so don't short-circuit on it. the per-file size check below
+        // is authoritative
         let state = downloadStates[model.id] ?? .notStarted
         if case .downloading = state { return }
+
+        // upfront disk-space preflight so we alert instead of flashing a
+        // progress bar that the in-task check would rip down ~300ms later.
+        if let needed = model.totalSizeEstimateBytes,
+            let probePath = Self.existingAncestor(of: model.localDirectory),
+            let freeBytes = OsaurusPaths.volumeFreeBytes(forPath: probePath.path),
+            let refusal = Self.storageRefusalMessage(neededBytes: needed, freeBytes: freeBytes)
+        {
+            downloadAlert = refusal
+            return
+        }
 
         activeDownloadTasks[model.id]?.cancel()
         activeDownloaders[model.id]?.invalidate()
@@ -592,6 +604,19 @@ final class ModelDownloadService: ObservableObject {
     /// "unknown, proceed" rather than "zero, block".
     static func freeBytesOnVolume(containing url: URL) -> Int64? {
         OsaurusPaths.volumeFreeBytes(forPath: url.path)
+    }
+
+    /// Nearest ancestor of `url` that exists on disk, so volume-capacity
+    /// queries have a statable path before the per-model dir is created.
+    static func existingAncestor(of url: URL) -> URL? {
+        var current = url
+        let fm = FileManager.default
+        while !fm.fileExists(atPath: current.path) {
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path { return nil }
+            current = parent
+        }
+        return current
     }
 
     private func updateDownloadProgress(

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -181,6 +181,15 @@ struct ModelDownloadView: View {
             )
             .environment(\.theme, themeManager.currentTheme)
         }
+        .themedAlert(
+            "Not enough disk space to download this model",
+            isPresented: Binding(
+                get: { modelManager.downloadAlert != nil },
+                set: { if !$0 { modelManager.downloadAlert = nil } }
+            ),
+            message: modelManager.downloadAlert,
+            primaryButton: .primary("OK") { modelManager.downloadAlert = nil }
+        )
     }
 
     // MARK: - Header View

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -182,13 +182,25 @@ struct ModelDownloadView: View {
             .environment(\.theme, themeManager.currentTheme)
         }
         .themedAlert(
-            "Not enough disk space to download this model",
+            modelManager.downloadAlert?.title ?? "Model download failed",
             isPresented: Binding(
                 get: { modelManager.downloadAlert != nil },
                 set: { if !$0 { modelManager.downloadAlert = nil } }
             ),
-            message: modelManager.downloadAlert,
-            primaryButton: .primary("OK") { modelManager.downloadAlert = nil }
+            message: modelManager.downloadAlert.map { info in
+                "\(info.message)\n\nDetails (tap Copy to share):\n\(info.details)"
+            },
+            buttons: [
+                .cancel("Copy details") {
+                    if let details = modelManager.downloadAlert?.details {
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.setString(details, forType: .string)
+                    }
+                    modelManager.downloadAlert = nil
+                },
+                .primary("OK") { modelManager.downloadAlert = nil },
+            ]
         )
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -76,15 +76,6 @@ struct ModelRowView: View {
                             .lineLimit(1)
                     }
 
-                    switch downloadState {
-                    case .downloading(let progress):
-                        downloadProgressView(progress: progress, isPaused: false)
-                    case .paused(let progress):
-                        downloadProgressView(progress: progress, isPaused: true)
-                    default:
-                        EmptyView()
-                    }
-
                     Spacer(minLength: 0)
                 }
                 .padding(14)
@@ -158,9 +149,97 @@ struct ModelRowView: View {
                 Spacer(minLength: 0)
             }
             .padding(10)
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                headerProgressStrip
+            }
         }
-        .frame(height: 110)
+        .frame(height: 140)
         .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var headerProgressStrip: some View {
+        switch downloadState {
+        case .downloading(let progress):
+            progressStrip(progress: progress, isPaused: false)
+        case .paused(let progress):
+            progressStrip(progress: progress, isPaused: true)
+        default:
+            EmptyView()
+        }
+    }
+
+    private func progressStrip(progress: Double, isPaused: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(.white.opacity(0.25))
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(isPaused ? Color.white.opacity(0.6) : .white)
+                            .frame(width: geometry.size.width * progress)
+                            .animation(.easeOut(duration: 0.3), value: progress)
+                    }
+                }
+                .frame(height: 4)
+
+                Text("\(Int(progress * 100))%")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white)
+
+                if isPaused, let onResume {
+                    Button(action: onResume) {
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help(Text("Resume download", bundle: .module))
+                } else if !isPaused, let onPause {
+                    Button(action: onPause) {
+                        Image(systemName: "pause.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help(Text("Pause download", bundle: .module))
+                }
+
+                if let onCancel {
+                    Button(action: onCancel) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(.white.opacity(0.9))
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help(Text("Cancel download", bundle: .module))
+                }
+            }
+
+            if isPaused {
+                Text("Paused", bundle: .module)
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.9))
+            } else if let line = metrics?.formattedLine {
+                Text(line)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.8))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            LinearGradient(
+                colors: [.black.opacity(0), .black.opacity(0.55)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
     }
 
     @ViewBuilder
@@ -272,75 +351,6 @@ struct ModelRowView: View {
         )
     }
 
-    // MARK: - Download Progress View
-
-    private func downloadProgressView(progress: Double, isPaused: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                GeometryReader { geometry in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(theme.tertiaryBackground)
-
-                        RoundedRectangle(cornerRadius: 3)
-                            .fill(isPaused ? theme.tertiaryText : theme.accentColor)
-                            .frame(width: geometry.size.width * progress)
-                            .animation(.easeOut(duration: 0.3), value: progress)
-                    }
-                }
-                .frame(height: 6)
-
-                if isPaused, let onResume = onResume {
-                    Button(action: onResume) {
-                        Image(systemName: "play.circle.fill")
-                            .font(.system(size: 16))
-                            .foregroundColor(theme.accentColor)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .help(Text("Resume download", bundle: .module))
-                } else if !isPaused, let onPause = onPause {
-                    Button(action: onPause) {
-                        Image(systemName: "pause.circle.fill")
-                            .font(.system(size: 16))
-                            .foregroundColor(theme.secondaryText)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .help(Text("Pause download", bundle: .module))
-                }
-
-                if let onCancel = onCancel {
-                    Button(action: onCancel) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 16))
-                            .foregroundColor(theme.tertiaryText)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .help(Text("Cancel download", bundle: .module))
-                }
-            }
-
-            if isPaused {
-                Text("Paused", bundle: .module)
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .foregroundColor(theme.warningColor)
-            } else if let line = formattedMetricsLine() {
-                Text(line)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(theme.tertiaryText)
-            }
-        }
-    }
-
-    // MARK: - Metrics Formatting
-
-    /// Formats download metrics into a single human-readable line
-    ///
-    /// Example output: "150 MB / 2 GB • 5.2 MB/s • ETA 3:45"
-    ///
-    /// - Returns: Formatted string with available metrics, or nil if no metrics exist
-    private func formattedMetricsLine() -> String? {
-        metrics?.formattedLine
-    }
 }
 
 // MARK: - Metadata Pill Component


### PR DESCRIPTION
## Summary

  - silent failures now surface a themed alert instead of leaving the card empty
  - alert titles categorise the issue (disk, network, repo, corruption, incomplete, filesystem)
  - copy details button copies a one line diagnostic (model, stage, file, raw error) for bug reports
  - completion check now verifies every manifest file exists on disk at expected size and catches multi shard downloads that previously looked complete but were missing files
  - Incomplete downloads name the missing file (or count) in the error
  - disk space preflight runs before the progress bar shows, so insufficient space refusals don't flash
  - no change to download orchestration, resume or retry behaviour

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
