### PR TITLE
added view in finder feature for agent sandbox workspace folders

### DIFF
--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -6,6 +6,7 @@
 //  Provides consistent directory structure across all components.
 //
 
+import AppKit
 import Foundation
 
 /// Centralized path management for all Osaurus app data.
@@ -473,6 +474,17 @@ public enum OsaurusPaths {
     /// Ensures a directory exists (non-throwing version)
     public static func ensureExistsSilent(_ url: URL) {
         try? ensureExists(url)
+    }
+
+    /// Opens `url` in Finder, creating the directory first if needed.
+    /// Centralises the ensure-dir + `NSWorkspace.shared.open` pair so
+    /// "Open in Finder" affordances behave identically across the UI
+    /// (and don't fail silently when a lazily-provisioned folder
+    /// hasn't been created yet).
+    @MainActor
+    public static func revealInFinder(_ url: URL) {
+        ensureExistsSilent(url)
+        NSWorkspace.shared.open(url)
     }
 
     // MARK: - File Utilities

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -3763,6 +3763,7 @@ struct AgentDetailView: View {
                             "Container-based execution requires macOS 26 or later. Native plugins continue to work normally on this device."
                     )
                 } else if !sandboxRunning {
+                    workspaceFolderRow
                     AgentSectionEmptyState(
                         icon: "shippingbox",
                         title: "Sandbox not running",
@@ -3771,10 +3772,68 @@ struct AgentDetailView: View {
                     )
                     secretsSubsection
                 } else {
+                    workspaceFolderRow
                     sandboxExecToggles(execConfig: execConfig)
                     secretsSubsection
                 }
             }
+        }
+    }
+
+    /// Row inside the agent's Sandbox section that reveals the agent's
+    /// host-side workspace folder in Finder. The folder is the same one
+    /// bind-mounted into the guest at `/workspace/agents/<linuxName>/`,
+    /// so any edit the user makes from Finder is visible to the agent
+    /// immediately. `OsaurusPaths.revealInFinder` lazily creates the
+    /// directory so agents that have never executed inside the
+    /// sandbox still get a usable folder.
+    private var workspaceFolderRow: some View {
+        let linuxName = SandboxAgentProvisioner.linuxName(for: agent.id.uuidString)
+        let workspaceURL = OsaurusPaths.containerAgentDir(linuxName)
+        let isProvisioned = SandboxManager.State.shared.status != .notProvisioned
+
+        return HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Workspace Folder", bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                Text(
+                    "Browse and edit files in this agent's /workspace/agents/… home.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+            }
+            Spacer()
+            Button {
+                OsaurusPaths.revealInFinder(workspaceURL)
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text("Open in Finder", bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .foregroundColor(theme.accentColor)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(theme.accentColor.opacity(0.08))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(theme.accentColor.opacity(0.2), lineWidth: 1)
+                        )
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(!isProvisioned)
+            .opacity(isProvisioned ? 1 : 0.45)
+            .help(
+                isProvisioned
+                    ? "Reveal this agent's sandbox home folder in Finder."
+                    : "Set up the sandbox to enable the workspace."
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
+++ b/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
@@ -110,6 +110,7 @@ private extension SandboxView {
                         SandboxLogConsoleCard()
                         diagnosticsCard
                     }
+                    workspaceCard
                     resourceConfigCard
                     dangerZoneCard
                 }
@@ -672,6 +673,35 @@ private extension SandboxView {
                         .stroke(theme.inputBorder, lineWidth: 1)
                 )
         )
+    }
+}
+
+// MARK: - Workspace Card
+
+private extension SandboxView {
+
+    /// Top-level shortcut into the container's `/workspace` directory,
+    /// which is a host bind mount at `~/.osaurus/container/workspace/`.
+    /// Lets users browse and edit sandbox files in Finder without
+    /// running anything inside the guest.
+    var workspaceCard: some View {
+        sectionCard(title: "Workspace", icon: "folder") {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(
+                    "The container's /workspace directory is bind-mounted from ~/.osaurus/container/workspace/. Open it in Finder to browse or edit files directly on the host.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+
+                HStack {
+                    Spacer()
+                    accentButton("Open in Finder", icon: "folder") {
+                        OsaurusPaths.revealInFinder(OsaurusPaths.containerWorkspace())
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

added ability for users to access agent sandbox workspace folders.

<img width="1012" height="784" alt="Screenshot 2026-05-18 at 6 02 03 PM" src="https://github.com/user-attachments/assets/f566e4f1-3b1a-42b6-baed-dd0d2d07b1a5" />

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
