### PR TITLE
[codex] Add plugin adapter ABI

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
@@ -9,16 +9,78 @@
 
 import Foundation
 
-public struct CSVAdapter: DocumentFormatAdapter {
+/// CSV is the validation adapter for the plugin ABI because it already has a
+/// mature core parser while still behaving like a simple record stream.
+public struct CSVAdapter: DocumentFormatAdapter, FormatAdapter {
+    public static var formatIdentifier: String { CSVDelimiter.comma.formatId }
+    public static var detectionBytePatterns: [Data] { [] }
+
     public let delimiter: CSVDelimiter
+    private let openState: OpenState
+
     public var formatId: String { delimiter.formatId }
 
     public init(delimiter: CSVDelimiter = .comma) {
         self.delimiter = delimiter
+        self.openState = OpenState()
     }
 
     public func canHandle(url: URL, uti: String?) -> Bool {
         url.pathExtension.lowercased() == delimiter.fileExtension
+    }
+
+    public func openDocument(at url: URL) throws -> DocumentReference {
+        guard canHandle(url: url, uti: nil) else {
+            throw FormatAdapterError.unsupportedURL(
+                formatIdentifier: formatId,
+                pathExtension: url.pathExtension.lowercased()
+            )
+        }
+        guard (try? url.checkResourceIsReachable()) == true else {
+            throw DocumentAdapterError.readFailed(underlying: "File is not reachable")
+        }
+
+        let fileSize = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        let reference = DocumentReference(
+            formatIdentifier: formatId,
+            displayName: url.lastPathComponent,
+            fileSize: fileSize,
+            metadata: ["delimiter": delimiter.rawValue]
+        )
+        openState.update(url: url, reference: reference)
+        return reference
+    }
+
+    public func streamRecords(into continuation: AsyncStream<Record>.Continuation) async throws {
+        defer { continuation.finish() }
+        guard let opened = openState.openedDocument() else {
+            throw FormatAdapterError.documentNotOpened(formatIdentifier: formatId)
+        }
+
+        let document = try await parse(
+            url: opened.url,
+            sizeLimit: DocumentLimits.limit(forFormatId: formatId)
+        )
+        guard let csv = document.representation.underlying as? CSVDocument else {
+            throw FormatAdapterError.representationMismatch(formatIdentifier: formatId)
+        }
+
+        for row in csv.rows {
+            try Task.checkCancellation()
+            continuation.yield(
+                Record(
+                    index: row.rowIndex,
+                    fields: row.cells.map(\.text),
+                    anchorIdentifier: row.anchorId,
+                    metadata: [
+                        "documentId": opened.reference.id.uuidString,
+                        "formatIdentifier": opened.reference.formatIdentifier,
+                        "sourceStartUTF16": "\(row.sourceRange.startUTF16Offset)",
+                        "sourceLengthUTF16": "\(row.sourceRange.length)",
+                    ]
+                )
+            )
+        }
     }
 
     public func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
@@ -435,5 +497,27 @@ public struct CSVAdapter: DocumentFormatAdapter {
     private struct BuiltCSVDocument {
         let document: CSVDocument
         let structure: DocumentStructure
+    }
+
+    private final class OpenState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var current: OpenedDocument?
+
+        func update(url: URL, reference: DocumentReference) {
+            lock.lock()
+            defer { lock.unlock() }
+            current = OpenedDocument(url: url, reference: reference)
+        }
+
+        func openedDocument() -> OpenedDocument? {
+            lock.lock()
+            defer { lock.unlock() }
+            return current
+        }
+    }
+
+    private struct OpenedDocument: Sendable {
+        let url: URL
+        let reference: DocumentReference
     }
 }

--- a/Packages/OsaurusCore/Services/Plugin/FormatAdapter.swift
+++ b/Packages/OsaurusCore/Services/Plugin/FormatAdapter.swift
@@ -1,0 +1,105 @@
+//
+//  FormatAdapter.swift
+//  osaurus
+//
+//  In-process v1 surface for plugin-provided format readers. The protocol
+//  intentionally stays record-oriented so plugin packs can add new tabular or
+//  domain formats without inheriting the richer core `StructuredDocument`
+//  pipeline before they need it.
+//
+
+import Foundation
+
+/// A contained document identity that plugins can safely cite without
+/// retaining or exposing the physical source path.
+public struct DocumentReference: Codable, Equatable, Hashable, Identifiable, Sendable {
+    public let id: UUID
+    public let formatIdentifier: String
+    public let displayName: String
+    public let fileSize: Int64
+    public let openedAt: Date
+    public let metadata: [String: String]
+
+    public init(
+        id: UUID = UUID(),
+        formatIdentifier: String,
+        displayName: String,
+        fileSize: Int64,
+        openedAt: Date = Date(),
+        metadata: [String: String] = [:]
+    ) {
+        precondition(fileSize >= 0, "DocumentReference fileSize must be non-negative")
+        self.id = id
+        self.formatIdentifier = formatIdentifier
+        self.displayName = displayName
+        self.fileSize = fileSize
+        self.openedAt = openedAt
+        self.metadata = metadata
+    }
+}
+
+/// A streamed plugin record keeps row-like data generic enough for domain
+/// packs while preserving a text form for indexing and retrieval fallbacks.
+public struct Record: Codable, Equatable, Hashable, Sendable {
+    public let index: Int
+    public let fields: [String]
+    public let text: String
+    public let anchorIdentifier: String?
+    public let metadata: [String: String]
+
+    public init(
+        index: Int,
+        fields: [String],
+        text: String? = nil,
+        anchorIdentifier: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        precondition(index >= 0, "Record index must be non-negative")
+        self.index = index
+        self.fields = fields
+        self.text = text ?? fields.joined(separator: "\t")
+        self.anchorIdentifier = anchorIdentifier
+        self.metadata = metadata
+    }
+}
+
+/// Adapter errors stay path-free so plugin-facing failures can cross logging
+/// and tool boundaries without exposing user-selected filesystem locations.
+public enum FormatAdapterError: LocalizedError, Equatable, Sendable {
+    case unsupportedURL(formatIdentifier: String, pathExtension: String)
+    case documentNotOpened(formatIdentifier: String)
+    case representationMismatch(formatIdentifier: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedURL(let formatIdentifier, let pathExtension):
+            return "Format adapter '\(formatIdentifier)' cannot open extension '\(pathExtension)'"
+        case .documentNotOpened(let formatIdentifier):
+            return "Format adapter '\(formatIdentifier)' has no opened document"
+        case .representationMismatch(let formatIdentifier):
+            return "Format adapter '\(formatIdentifier)' produced an unexpected representation"
+        }
+    }
+}
+
+/// Plugin format adapters use this small surface so future packs can stream
+/// domain records without depending on core document internals.
+public protocol FormatAdapter: Sendable {
+    /// Stable plugin ABI key. This is static so a registry can reject
+    /// duplicate plugin registrations before constructing parser state.
+    static var formatIdentifier: String { get }
+
+    /// Leading-byte signatures for cheap detection. Text formats that do not
+    /// have reliable magic bytes should return an empty list and let callers
+    /// choose them by extension, MIME type, or explicit user intent.
+    static var detectionBytePatterns: [Data] { get }
+
+    /// Opens a contained host URL and returns a path-free reference that can
+    /// be recorded in logs, tests, or later indexing metadata.
+    func openDocument(at url: URL) throws -> DocumentReference
+
+    /// Streams format-native records after `openDocument(at:)` succeeds.
+    /// The continuation is explicit so callers decide whether to bridge into
+    /// `AsyncStream`, tool output, or a future back-pressured record sink.
+    func streamRecords(into continuation: AsyncStream<Record>.Continuation) async throws
+}

--- a/Packages/OsaurusCore/Services/Plugin/FormatAdapterRegistry.swift
+++ b/Packages/OsaurusCore/Services/Plugin/FormatAdapterRegistry.swift
@@ -1,0 +1,145 @@
+//
+//  FormatAdapterRegistry.swift
+//  osaurus
+//
+//  Registry for plugin format adapter factories. It is separate from
+//  `DocumentFormatRegistry` because plugin packs stream generic records while
+//  the existing document stack returns typed `StructuredDocument` values.
+//
+
+import Foundation
+
+/// Registry errors are explicit because duplicate plugin claims need to fail
+/// during startup instead of silently changing format ownership.
+public enum FormatAdapterRegistryError: LocalizedError, Equatable, Sendable {
+    case emptyFormatIdentifier
+    case duplicateRegistration(formatIdentifier: String)
+    case unknownFormat(formatIdentifier: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyFormatIdentifier:
+            return "Format adapter identifiers must not be empty"
+        case .duplicateRegistration(let formatIdentifier):
+            return "Format adapter '\(formatIdentifier)' is already registered"
+        case .unknownFormat(let formatIdentifier):
+            return "No format adapter is registered for '\(formatIdentifier)'"
+        }
+    }
+}
+
+/// The adapter registry owns factories instead of parser instances so each
+/// open document receives isolated streaming state.
+public final class FormatAdapterRegistry: @unchecked Sendable {
+    public static let shared = FormatAdapterRegistry()
+
+    private struct Registration {
+        let formatIdentifier: String
+        let detectionBytePatterns: [Data]
+        let makeAdapter: @Sendable () -> any FormatAdapter
+    }
+
+    private let lock = NSLock()
+    private var registrations: [String: Registration] = [:]
+    private var registrationOrder: [String] = []
+
+    /// Tests and plugin hosts need isolated registries so duplicate checks
+    /// can be exercised without mutating process-wide plugin state.
+    public init() {}
+
+    /// Registers a factory rather than a singleton because adapter instances
+    /// may hold per-document open state while streaming records.
+    public func register<Adapter: FormatAdapter>(
+        _ adapterType: Adapter.Type,
+        makeAdapter: @escaping @Sendable () -> Adapter
+    ) throws {
+        let formatIdentifier = try Self.normalizedFormatIdentifier(Adapter.formatIdentifier)
+        let registration = Registration(
+            formatIdentifier: formatIdentifier,
+            detectionBytePatterns: Adapter.detectionBytePatterns,
+            makeAdapter: { makeAdapter() }
+        )
+
+        lock.lock()
+        defer { lock.unlock() }
+        if registrations[formatIdentifier] != nil {
+            throw FormatAdapterRegistryError.duplicateRegistration(formatIdentifier: formatIdentifier)
+        }
+        registrations[formatIdentifier] = registration
+        registrationOrder.append(formatIdentifier)
+    }
+
+    public func makeAdapter(formatIdentifier: String) throws -> any FormatAdapter {
+        let normalized = try Self.normalizedFormatIdentifier(formatIdentifier)
+        lock.lock()
+        let registration = registrations[normalized]
+        lock.unlock()
+        guard let registration else {
+            throw FormatAdapterRegistryError.unknownFormat(formatIdentifier: normalized)
+        }
+        return registration.makeAdapter()
+    }
+
+    public func adapter(detecting prefix: Data) -> (any FormatAdapter)? {
+        lock.lock()
+        let registrationsInOrder = registrationOrder.compactMap { registrations[$0] }
+        lock.unlock()
+
+        for registration in registrationsInOrder
+        where registration.detectionBytePatterns.contains(where: { Self.prefix(prefix, matches: $0) }) {
+            return registration.makeAdapter()
+        }
+        return nil
+    }
+
+    public func adapter(detecting url: URL, maxBytes: Int = 4096) throws -> (any FormatAdapter)? {
+        let bytesToRead = min(maxPatternLength(), maxBytes)
+        guard bytesToRead > 0 else { return nil }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let prefix = try handle.read(upToCount: bytesToRead) ?? Data()
+        return adapter(detecting: prefix)
+    }
+
+    public func registeredFormatIdentifiers() -> Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return Set(registrations.keys)
+    }
+
+    @discardableResult
+    public func unregister(formatIdentifier: String) -> Bool {
+        guard let normalized = try? Self.normalizedFormatIdentifier(formatIdentifier) else { return false }
+        lock.lock()
+        defer { lock.unlock() }
+        let removed = registrations.removeValue(forKey: normalized) != nil
+        if removed {
+            registrationOrder.removeAll { $0 == normalized }
+        }
+        return removed
+    }
+
+    private func maxPatternLength() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return registrations.values
+            .flatMap(\.detectionBytePatterns)
+            .map(\.count)
+            .max() ?? 0
+    }
+
+    private static func normalizedFormatIdentifier(_ id: String) throws -> String {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else {
+            throw FormatAdapterRegistryError.emptyFormatIdentifier
+        }
+        return trimmed
+    }
+
+    private static func prefix(_ bytes: Data, matches pattern: Data) -> Bool {
+        !pattern.isEmpty
+            && bytes.count >= pattern.count
+            && bytes.prefix(pattern.count).elementsEqual(pattern)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
@@ -121,10 +121,43 @@ struct CSVAdapterTests {
         }
     }
 
+    @Test func formatAdapter_opensDocumentAndStreamsRows() async throws {
+        let url = try Self.write("name,age\nAda,37\n", filename: "people.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let adapter = CSVAdapter(delimiter: .comma)
+        let reference = try adapter.openDocument(at: url)
+        let (stream, continuation) = Self.makeRecordStream()
+
+        let task = Task {
+            try await adapter.streamRecords(into: continuation)
+        }
+
+        var records: [Record] = []
+        for await record in stream {
+            records.append(record)
+        }
+        try await task.value
+
+        #expect(reference.formatIdentifier == "csv")
+        #expect(reference.displayName.hasSuffix("people.csv"))
+        #expect(records.map(\.fields) == [["name", "age"], ["Ada", "37"]])
+        #expect(records[1].text == "Ada\t37")
+        #expect(records[1].metadata["documentId"] == reference.id.uuidString)
+    }
+
     private static func write(_ content: String, filename: String) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-\(filename)")
         try content.write(to: url, atomically: true, encoding: .utf8)
         return url
+    }
+
+    private static func makeRecordStream() -> (
+        stream: AsyncStream<Record>,
+        continuation: AsyncStream<Record>.Continuation
+    ) {
+        var continuation: AsyncStream<Record>.Continuation?
+        let stream = AsyncStream<Record> { continuation = $0 }
+        return (stream, continuation!)
     }
 }

--- a/Packages/OsaurusCore/Tests/Documents/FormatAdapterRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/FormatAdapterRegistryTests.swift
@@ -1,0 +1,68 @@
+//
+//  FormatAdapterRegistryTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("FormatAdapterRegistry")
+struct FormatAdapterRegistryTests {
+    @Test func register_addsFactoryByFormatIdentifier() throws {
+        let registry = FormatAdapterRegistry()
+        try registry.register(MagicFormatAdapter.self) { MagicFormatAdapter() }
+
+        #expect(registry.registeredFormatIdentifiers() == ["magic"])
+        #expect(try registry.makeAdapter(formatIdentifier: "MAGIC") is MagicFormatAdapter)
+    }
+
+    @Test func register_rejectsDuplicateFormatIdentifier() throws {
+        let registry = FormatAdapterRegistry()
+        try registry.register(MagicFormatAdapter.self) { MagicFormatAdapter() }
+
+        do {
+            try registry.register(MagicFormatAdapter.self) { MagicFormatAdapter() }
+            Issue.record("Expected duplicate format registration to throw")
+        } catch let error as FormatAdapterRegistryError {
+            #expect(error == .duplicateRegistration(formatIdentifier: "magic"))
+        }
+    }
+
+    @Test func adapter_detectsByBytePattern() throws {
+        let registry = FormatAdapterRegistry()
+        try registry.register(MagicFormatAdapter.self) { MagicFormatAdapter() }
+
+        #expect(registry.adapter(detecting: Data([0xCA, 0xFE, 0x01])) is MagicFormatAdapter)
+        #expect(registry.adapter(detecting: Data([0xBA, 0xAD, 0xF0, 0x0D])) == nil)
+    }
+
+    @Test func adapter_detectsURLByBoundedBytePatternRead() throws {
+        let registry = FormatAdapterRegistry()
+        try registry.register(MagicFormatAdapter.self) { MagicFormatAdapter() }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-magic.bin")
+        try Data([0xCA, 0xFE, 0x99, 0x00]).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(try registry.adapter(detecting: url) is MagicFormatAdapter)
+    }
+
+    private final class MagicFormatAdapter: FormatAdapter, @unchecked Sendable {
+        static let formatIdentifier = "magic"
+        static let detectionBytePatterns = [Data([0xCA, 0xFE])]
+
+        func openDocument(at url: URL) throws -> DocumentReference {
+            DocumentReference(
+                formatIdentifier: Self.formatIdentifier,
+                displayName: url.lastPathComponent,
+                fileSize: 0
+            )
+        }
+
+        func streamRecords(into continuation: AsyncStream<Record>.Continuation) async throws {
+            continuation.finish()
+        }
+    }
+}

--- a/docs/PLUGIN_ADAPTER_ABI.md
+++ b/docs/PLUGIN_ADAPTER_ABI.md
@@ -1,0 +1,54 @@
+# Plugin Adapter ABI
+
+Osaurus plugin format adapters are an in-process Swift v1 surface for file
+formats that should live in plugin packs instead of core. The ABI is small by
+design: an adapter declares a stable format identifier, optional leading-byte
+detection patterns, a contained document open step, and a record streaming step.
+XPC isolation, runtime dynamic loading, and sandbox policy negotiation are
+deliberately outside v1.
+
+## Registry Relationship
+
+`FormatAdapterRegistry` and `DocumentFormatRegistry` are peer registries. The
+existing `DocumentFormatRegistry` remains the route for core
+`StructuredDocument` parsing, emitting, and chat attachment fallbacks, while
+`FormatAdapterRegistry` is the route for plugin-pack record streaming and
+byte-pattern detection. Neither registry calls the other in v1; callers choose
+the registry that matches the data path they need, and code that supports both
+structured documents and plugin records should query both explicitly at its
+own boundary.
+
+## Adapter Contract
+
+Plugin packs register adapter factories at startup:
+
+```swift
+try FormatAdapterRegistry.shared.register(MyAdapter.self) {
+    MyAdapter()
+}
+```
+
+The registry is keyed by `FormatAdapter.formatIdentifier`, so duplicate
+registration throws immediately. Identifiers should be stable lowercase names
+such as `jsonl`, `sqlite`, or `csv-with-schema`.
+
+Adapters are opened against a contained host-provided URL, not an arbitrary
+source path. The returned `DocumentReference` contains user-safe identity and
+metadata for the opened file; plugin code must not persist or expose physical
+paths. After opening, callers ask the same adapter instance to stream `Record`
+values into an `AsyncStream<Record>.Continuation`.
+
+## Detection
+
+`detectionBytePatterns` is for formats with reliable magic bytes. The registry
+reads only the longest registered pattern length, capped by the caller's byte
+limit, and matches patterns against the file prefix. Text formats such as CSV
+may leave this list empty and rely on extension, MIME, or explicit user choice
+at a higher layer.
+
+## Out of Scope For v1
+
+- XPC or out-of-process isolation.
+- Runtime dynamic bundle loading.
+- Plugin access to raw user-selected paths.
+- Python, JVM, or new parser runtime dependencies.


### PR DESCRIPTION
## Business rationale

This PR gives plugin-backed document work a small, testable adapter surface before the stats, workbook, and PDF-table follow-up lanes build on it. The evidence is the reopened T-J unpark request and the stale historical #941 document-format PR stack: downstream work needs a current-main plugin format contract, but the older branch mixed unrelated ABI and document IO concerns. The observable change is that OsaurusCore now has a path-free `FormatAdapter` protocol, a factory-backed registry, documented registry boundaries, and a CSV validation adapter proving that plugin-style record streaming can be exercised without adding new parser dependencies.

## Coding rationale

The implementation keeps `FormatAdapterRegistry` and `DocumentFormatRegistry` as peer registries rather than replacing the existing structured-document stack. A factory registry was chosen over singleton adapter storage because adapters may hold per-open document state while streaming records; `CSVAdapter` was refactored as the validation case because it already has mature parsing and gives a low-risk proof of the record stream shape. Out of scope are dynamic plugin loading, XPC isolation, host API ABI changes, Python/JVM runtimes, and any new external dependencies. The trust boundary crossed here is file identity: `DocumentReference` deliberately exposes a contained, path-free reference while adapters open host-provided URLs.

## Acceptance criteria

- [x] Add a stable `FormatAdapter` protocol for plugin-provided record streaming.
- [x] Add a thread-safe `FormatAdapterRegistry` with duplicate registration rejection and byte-prefix detection.
- [x] Keep `FormatAdapterRegistry` and `DocumentFormatRegistry` as documented peer registries.
- [x] Refactor one existing adapter, CSV, as the validation adapter without changing its existing document parser behavior.
- [x] Add focused tests for registry registration/detection and CSV record streaming.
- [x] Add docs for the plugin adapter ABI and explicitly note that v1 adds no new external dependencies.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — commands exited 0 (`swiftlint` reports the repository's existing warning backlog: 1119 violations, 0 serious; no new lane warning remains)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green, 77 tests
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (`git fetch --all --prune` immediately before gate/rebase and again before push; `origin/main` unchanged before push)

## Debug evidence

Focused ABI proof after implementation:

```text
◇ Suite "CSVAdapter" started.
◇ Suite "FormatAdapterRegistry" started.
✔ Test register_rejectsDuplicateFormatIdentifier() passed after 0.001 seconds.
✔ Test register_addsFactoryByFormatIdentifier() passed after 0.001 seconds.
✔ Test adapter_detectsByBytePattern() passed after 0.001 seconds.
✔ Test adapter_detectsURLByBoundedBytePatternRead() passed after 0.002 seconds.
✔ Suite "FormatAdapterRegistry" passed after 0.002 seconds.
✔ Test formatAdapter_opensDocumentAndStreamsRows() passed after 0.005 seconds.
✔ Suite "CSVAdapter" passed after 0.006 seconds.
✔ Test run with 5 tests in 2 suites passed after 0.006 seconds.
```

Full gate tail included:

```text
swift test --package-path Packages/OsaurusCLI --parallel
[77/77] Testing OsaurusCLITests.ToolsPackageTests/testFindDylibsFindsOnlyDylibs
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.

make ci-test
Done. Inspect failures with: open build/Tests.xcresult

swift build --package-path Packages/OsaurusCore -c release
Build complete! (172.14s)
```

## Rollback

```bash
git revert acedfb305f3affbdecce3144363b3fe4c3acec73
```
