### PR TITLE
feat(tools): add workbook folder tools

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1316,6 +1316,9 @@ enum FolderToolFactory {
             FileWriteTool(rootPath: rootPath),
             FileEditTool(rootPath: rootPath),
             FileSearchTool(rootPath: rootPath),
+            ReadWorkbookTool(rootPath: rootPath),
+            ReadWorkbookCellTool(rootPath: rootPath),
+            WriteWorkbookTool(rootPath: rootPath),
             ShellRunTool(rootPath: rootPath),
         ]
     }

--- a/Packages/OsaurusCore/Services/Tool/WorkbookTools.swift
+++ b/Packages/OsaurusCore/Services/Tool/WorkbookTools.swift
@@ -1,0 +1,689 @@
+//
+//  WorkbookTools.swift
+//  osaurus
+//
+//  Folder-context tools for reading and writing the conservative Workbook
+//  representation carried by the document adapter stack. The tools route
+//  through DocumentFormatRegistry so XLSX support stays behind the same
+//  adapter/emitter seam as attachment ingestion and artifact emission.
+//
+
+import Foundation
+
+struct ReadWorkbookTool: OsaurusTool {
+    let name = "read_workbook"
+    let description =
+        "Read an XLSX workbook in the working directory and return structured sheets, rows, and cells."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Relative path to the workbook from the working directory"),
+            ]),
+            "sheet_name": .object([
+                "type": .string("string"),
+                "description": .string("Optional exact worksheet name to read"),
+            ]),
+            "max_rows": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum rows per sheet to return (default: 100)"),
+            ]),
+            "max_columns": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum cells per row to return (default: 50)"),
+            ]),
+        ]),
+        "required": .array([.string("path")]),
+    ])
+
+    private let rootPath: URL
+    private let registry: DocumentFormatRegistry
+
+    init(rootPath: URL, registry: DocumentFormatRegistry = .shared) {
+        self.rootPath = rootPath
+        self.registry = registry
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let pathReq = requireString(
+            args,
+            "path",
+            expected: "relative path to an .xlsx workbook under the working folder",
+            tool: name
+        )
+        guard case .value(let relativePath) = pathReq else {
+            return pathReq.failureEnvelope ?? ""
+        }
+
+        let sheetReq = optionalString(
+            args,
+            "sheet_name",
+            expected: "exact worksheet name",
+            tool: name
+        )
+        guard case .value(let sheetName) = sheetReq else { return sheetReq.failureEnvelope ?? "" }
+
+        let maxRows = max(1, coerceInt(args["max_rows"]) ?? 100)
+        let maxColumns = max(1, coerceInt(args["max_columns"]) ?? 50)
+        let workbookDocument = try await WorkbookToolSupport.loadWorkbook(
+            relativePath: relativePath,
+            rootPath: rootPath,
+            registry: registry
+        )
+        let sheets = try WorkbookToolSupport.selectedSheets(
+            in: workbookDocument.workbook,
+            sheetName: sheetName,
+            toolName: name
+        )
+
+        return ToolEnvelope.success(
+            tool: name,
+            result: [
+                "path": relativePath,
+                "format_id": workbookDocument.document.formatId,
+                "filename": workbookDocument.document.filename,
+                "sheet_count": workbookDocument.workbook.sheets.count,
+                "sheets": sheets.map {
+                    WorkbookToolSupport.sheetPayload(
+                        $0,
+                        maxRows: maxRows,
+                        maxColumns: maxColumns
+                    )
+                },
+            ]
+        )
+    }
+}
+
+struct ReadWorkbookCellTool: OsaurusTool {
+    let name = "read_workbook_cell"
+    let description =
+        "Read one cell from an XLSX workbook in the working directory. Defaults to the first sheet when sheet_name is omitted."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Relative path to the workbook from the working directory"),
+            ]),
+            "cell": .object([
+                "type": .string("string"),
+                "description": .string("A1 cell reference, e.g. B2"),
+            ]),
+            "sheet_name": .object([
+                "type": .string("string"),
+                "description": .string("Optional exact worksheet name; defaults to the first sheet"),
+            ]),
+        ]),
+        "required": .array([.string("path"), .string("cell")]),
+    ])
+
+    private let rootPath: URL
+    private let registry: DocumentFormatRegistry
+
+    init(rootPath: URL, registry: DocumentFormatRegistry = .shared) {
+        self.rootPath = rootPath
+        self.registry = registry
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let pathReq = requireString(
+            args,
+            "path",
+            expected: "relative path to an .xlsx workbook under the working folder",
+            tool: name
+        )
+        guard case .value(let relativePath) = pathReq else {
+            return pathReq.failureEnvelope ?? ""
+        }
+
+        let cellReq = requireString(
+            args,
+            "cell",
+            expected: "A1 cell reference, e.g. B2",
+            tool: name
+        )
+        guard case .value(let rawCellReference) = cellReq else {
+            return cellReq.failureEnvelope ?? ""
+        }
+        let cellReference = rawCellReference.uppercased()
+        guard WorkbookToolSupport.parseCellReference(cellReference) != nil else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Argument `cell` must be a valid A1 reference.",
+                field: "cell",
+                expected: "A1 cell reference, e.g. B2",
+                tool: name
+            )
+        }
+
+        let sheetReq = optionalString(
+            args,
+            "sheet_name",
+            expected: "exact worksheet name",
+            tool: name
+        )
+        guard case .value(let sheetName) = sheetReq else { return sheetReq.failureEnvelope ?? "" }
+
+        let workbookDocument = try await WorkbookToolSupport.loadWorkbook(
+            relativePath: relativePath,
+            rootPath: rootPath,
+            registry: registry
+        )
+        let sheet = try WorkbookToolSupport.selectedSheet(
+            in: workbookDocument.workbook,
+            sheetName: sheetName,
+            toolName: name
+        )
+        let cell = sheet.rows.lazy
+            .flatMap(\.cells)
+            .first { $0.reference.uppercased() == cellReference }
+
+        var payload: [String: Any] = [
+            "path": relativePath,
+            "sheet": ["name": sheet.name, "index": sheet.index],
+            "reference": cellReference,
+            "found": cell != nil,
+            "cell": NSNull(),
+        ]
+        if let cell {
+            payload["cell"] = WorkbookToolSupport.cellPayload(cell)
+        }
+
+        return ToolEnvelope.success(tool: name, result: payload)
+    }
+}
+
+struct WriteWorkbookTool: OsaurusTool, PermissionedTool {
+    let name = "write_workbook"
+    let description =
+        "Write an XLSX workbook under the working directory from structured sheet rows. This action requires approval."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Relative destination path ending in .xlsx"),
+            ]),
+            "sheets": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Workbook sheets. Each sheet is an object with `name` and `rows`; rows is an array of cell-value arrays."
+                ),
+                "items": .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "name": .object([
+                            "type": .string("string"),
+                            "description": .string("Worksheet name"),
+                        ]),
+                        "rows": .object([
+                            "type": .string("array"),
+                            "description": .string(
+                                "Rows as arrays of scalar values, nulls, strings, numbers, or booleans"
+                            ),
+                            "items": .object([
+                                "type": .string("array")
+                            ]),
+                        ]),
+                    ]),
+                    "required": .array([.string("name"), .string("rows")]),
+                ]),
+            ]),
+        ]),
+        "required": .array([.string("path"), .string("sheets")]),
+    ])
+
+    var requirements: [String] { [] }
+    var defaultPermissionPolicy: ToolPermissionPolicy { .ask }
+
+    private let rootPath: URL
+    private let registry: DocumentFormatRegistry
+
+    init(rootPath: URL, registry: DocumentFormatRegistry = .shared) {
+        self.rootPath = rootPath
+        self.registry = registry
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let pathReq = requireString(
+            args,
+            "path",
+            expected: "relative destination path ending in .xlsx",
+            tool: name
+        )
+        guard case .value(let relativePath) = pathReq else {
+            return pathReq.failureEnvelope ?? ""
+        }
+        guard relativePath.lowercased().hasSuffix(".xlsx") else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Argument `path` must end in .xlsx.",
+                field: "path",
+                expected: "relative destination path ending in .xlsx",
+                tool: name
+            )
+        }
+
+        guard let rawSheets = args["sheets"] as? [Any] else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Missing or invalid `sheets` array.",
+                field: "sheets",
+                expected: "array of sheet objects with `name` and `rows`",
+                tool: name
+            )
+        }
+
+        let fileURL = try FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        let workbook: Workbook
+        do {
+            workbook = try WorkbookToolSupport.workbook(from: rawSheets, toolName: name)
+        } catch let error as WorkbookToolInputError {
+            return error.envelope
+        }
+        let document = StructuredDocument(
+            formatId: "xlsx",
+            filename: fileURL.lastPathComponent,
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: WorkbookToolSupport.textFallback(for: workbook)
+        )
+        let emitter = try WorkbookToolSupport.emitter(
+            for: document,
+            registry: registry,
+            toolName: name
+        )
+
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try await emitter.emit(document, to: fileURL)
+
+        return ToolEnvelope.success(
+            tool: name,
+            result: [
+                "path": relativePath,
+                "format_id": "xlsx",
+                "sheet_count": workbook.sheets.count,
+                "written": true,
+            ]
+        )
+    }
+}
+
+private enum WorkbookToolSupport {
+    struct LoadedWorkbook {
+        let document: StructuredDocument
+        let workbook: Workbook
+    }
+
+    static func loadWorkbook(
+        relativePath: String,
+        rootPath: URL,
+        registry: DocumentFormatRegistry
+    ) async throws -> LoadedWorkbook {
+        let fileURL = try FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw FolderToolError.fileNotFound(relativePath)
+        }
+        let adapter = try adapter(for: fileURL, registry: registry, toolName: "workbook")
+        let document = try await adapter.parse(
+            url: fileURL,
+            sizeLimit: DocumentLimits.limit(forFormatId: adapter.formatId)
+        )
+        guard let workbook = document.representation.underlying as? Workbook else {
+            throw FolderToolError.operationFailed(
+                "Registered adapter '\(adapter.formatId)' did not produce a Workbook representation."
+            )
+        }
+        return LoadedWorkbook(document: document, workbook: workbook)
+    }
+
+    static func selectedSheets(
+        in workbook: Workbook,
+        sheetName: String?,
+        toolName: String
+    ) throws -> [Workbook.Sheet] {
+        if let sheetName {
+            return [try selectedSheet(in: workbook, sheetName: sheetName, toolName: toolName)]
+        }
+        return workbook.sheets
+    }
+
+    static func selectedSheet(
+        in workbook: Workbook,
+        sheetName: String?,
+        toolName: String
+    ) throws -> Workbook.Sheet {
+        guard let sheetName else {
+            guard let first = workbook.sheets.first else {
+                throw FolderToolError.operationFailed("Workbook has no sheets.")
+            }
+            return first
+        }
+        guard let sheet = workbook.sheets.first(where: { $0.name == sheetName }) else {
+            throw FolderToolError.operationFailed("Workbook has no sheet named '\(sheetName)' for \(toolName).")
+        }
+        return sheet
+    }
+
+    static func sheetPayload(
+        _ sheet: Workbook.Sheet,
+        maxRows: Int,
+        maxColumns: Int
+    ) -> [String: Any] {
+        let rows = sheet.rows.prefix(maxRows)
+        let rowPayloads: [[String: Any]] = rows.map { row in
+            let cells = row.cells.prefix(maxColumns)
+            return [
+                "number": row.number,
+                "cell_count": row.cells.count,
+                "truncated_columns": row.cells.count > maxColumns,
+                "cells": cells.map(cellPayload),
+            ]
+        }
+        return [
+            "name": sheet.name,
+            "index": sheet.index,
+            "row_count": sheet.rows.count,
+            "merged_ranges": sheet.mergedRanges.map(\.reference),
+            "truncated_rows": sheet.rows.count > maxRows,
+            "rows": rowPayloads,
+        ]
+    }
+
+    static func cellPayload(_ cell: Workbook.Cell) -> [String: Any] {
+        var payload: [String: Any] = [
+            "reference": cell.reference,
+            "row": cell.rowNumber,
+            "column": cell.columnNumber,
+            "value": valuePayload(cell.value),
+        ]
+        if let formula = cell.formula {
+            payload["formula"] = formula
+        }
+        return payload
+    }
+
+    static func valuePayload(_ value: Workbook.CellValue) -> [String: Any] {
+        switch value {
+        case .empty:
+            return ["type": "empty", "value": NSNull(), "text": ""]
+        case .number(let value):
+            return ["type": "number", "value": value, "text": Workbook.CellValue.number(value).fallbackText]
+        case .string(let value):
+            return ["type": "string", "value": value, "text": value]
+        case .bool(let value):
+            return ["type": "boolean", "value": value, "text": value ? "TRUE" : "FALSE"]
+        }
+    }
+
+    static func workbook(from rawSheets: [Any], toolName: String) throws -> Workbook {
+        guard !rawSheets.isEmpty else {
+            throw invalid(field: "sheets", expected: "at least one sheet object", toolName: toolName)
+        }
+
+        var sheets: [Workbook.Sheet] = []
+        var names: Set<String> = []
+        for (index, rawSheet) in rawSheets.enumerated() {
+            guard let sheetObject = rawSheet as? [String: Any] else {
+                throw invalid(field: "sheets", expected: "each sheet must be an object", toolName: toolName)
+            }
+            guard let name = sheetObject["name"] as? String, !name.isEmpty else {
+                throw invalid(field: "name", expected: "non-empty sheet name", toolName: toolName)
+            }
+            guard names.insert(name.lowercased()).inserted else {
+                throw invalid(field: "name", expected: "unique sheet names", toolName: toolName)
+            }
+            guard let rawRows = sheetObject["rows"] as? [Any] else {
+                throw invalid(field: "rows", expected: "array of row arrays", toolName: toolName)
+            }
+            let rows = try workbookRows(
+                from: rawRows,
+                sheetName: name,
+                sheetIndex: index,
+                toolName: toolName
+            )
+            sheets.append(
+                Workbook.Sheet(
+                    name: name,
+                    index: index,
+                    rows: rows,
+                    anchor: sheetAnchor(name: name, index: index)
+                )
+            )
+        }
+
+        return Workbook(sheets: sheets)
+    }
+
+    static func textFallback(for workbook: Workbook) -> String {
+        workbook.sheets.map { sheet in
+            var text = "## Sheet: \(sheet.name)"
+            for row in sheet.rows {
+                let values = row.cells.map { $0.value.fallbackText }.joined(separator: "\t")
+                text += "\n\(row.number)\t\(values)"
+            }
+            return text
+        }.joined(separator: "\n\n")
+    }
+
+    static func parseCellReference(_ reference: String) -> (columnNumber: Int, rowNumber: Int)? {
+        var column = 0
+        var rowText = ""
+        for scalar in reference.unicodeScalars {
+            switch scalar.value {
+            case 65 ... 90:
+                guard rowText.isEmpty else { return nil }
+                column = column * 26 + Int(scalar.value - 65 + 1)
+            case 97 ... 122:
+                guard rowText.isEmpty else { return nil }
+                column = column * 26 + Int(scalar.value - 97 + 1)
+            case 48 ... 57:
+                rowText.unicodeScalars.append(scalar)
+            default:
+                return nil
+            }
+        }
+        guard column > 0, let row = Int(rowText), row > 0 else { return nil }
+        return (column, row)
+    }
+
+    private static func adapter(
+        for url: URL,
+        registry: DocumentFormatRegistry,
+        toolName: String
+    ) throws -> any DocumentFormatAdapter {
+        var adapter = registry.adapter(for: url)
+        if adapter == nil, registry === DocumentFormatRegistry.shared {
+            DocumentAdaptersBootstrap.registerBuiltIns()
+            adapter = registry.adapter(for: url)
+        }
+        guard let adapter else {
+            throw FolderToolError.operationFailed("No registered workbook adapter for \(toolName).")
+        }
+        return adapter
+    }
+
+    static func emitter(
+        for document: StructuredDocument,
+        registry: DocumentFormatRegistry,
+        toolName: String
+    ) throws -> any DocumentFormatEmitter {
+        var emitter = registry.emitter(for: document)
+        if emitter == nil, registry === DocumentFormatRegistry.shared {
+            DocumentAdaptersBootstrap.registerBuiltIns()
+            emitter = registry.emitter(for: document)
+        }
+        guard let emitter else {
+            throw FolderToolError.operationFailed("No registered workbook emitter for \(toolName).")
+        }
+        return emitter
+    }
+
+    private static func workbookRows(
+        from rawRows: [Any],
+        sheetName: String,
+        sheetIndex: Int,
+        toolName: String
+    ) throws -> [Workbook.Row] {
+        try rawRows.enumerated().map { rowOffset, rawRow in
+            guard let rawCells = rawRow as? [Any] else {
+                throw invalid(field: "rows", expected: "each row must be an array", toolName: toolName)
+            }
+            let rowNumber = rowOffset + 1
+            let cells = try rawCells.enumerated().map { columnOffset, rawValue in
+                let columnNumber = columnOffset + 1
+                let reference = cellReference(columnNumber: columnNumber, rowNumber: rowNumber)
+                return Workbook.Cell(
+                    reference: reference,
+                    rowNumber: rowNumber,
+                    columnNumber: columnNumber,
+                    value: try cellValue(from: rawValue, toolName: toolName),
+                    anchor: cellAnchor(
+                        reference: reference,
+                        rowNumber: rowNumber,
+                        columnNumber: columnNumber,
+                        sheetName: sheetName,
+                        sheetIndex: sheetIndex
+                    )
+                )
+            }
+            return Workbook.Row(
+                number: rowNumber,
+                cells: cells,
+                anchor: rowAnchor(number: rowNumber, sheetName: sheetName, sheetIndex: sheetIndex)
+            )
+        }
+    }
+
+    private static func cellValue(from rawValue: Any, toolName: String) throws -> Workbook.CellValue {
+        if rawValue is NSNull { return .empty }
+        if let bool = rawValue as? Bool { return .bool(bool) }
+        if let int = rawValue as? Int { return .number(Double(int)) }
+        if let double = rawValue as? Double { return .number(double) }
+        if let number = rawValue as? NSNumber { return .number(number.doubleValue) }
+        if let string = rawValue as? String { return .string(string) }
+        throw invalid(
+            field: "rows",
+            expected: "cells must be strings, numbers, booleans, or null",
+            toolName: toolName
+        )
+    }
+
+    private static func sheetAnchor(name: String, index: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .sheet,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: name, index: index),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(sheetIndex: index, sheetName: name)
+            ),
+            label: name,
+            metadata: ["sheetIndex": "\(index)"]
+        )
+    }
+
+    private static func rowAnchor(number: Int, sheetName: String, sheetIndex: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .row,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                .init(kind: .row, index: number - 1),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(
+                    sheetIndex: sheetIndex,
+                    sheetName: sheetName,
+                    rowIndex: number - 1
+                )
+            ),
+            label: "\(sheetName) row \(number)"
+        )
+    }
+
+    private static func cellAnchor(
+        reference: String,
+        rowNumber: Int,
+        columnNumber: Int,
+        sheetName: String,
+        sheetIndex: Int
+    ) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .cell,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                .init(kind: .cell, identifier: reference),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: .cell(
+                    sheetName: sheetName,
+                    rowIndex: rowNumber - 1,
+                    columnIndex: columnNumber - 1
+                )
+            ),
+            label: "\(sheetName)!\(reference)"
+        )
+    }
+
+    private static func cellReference(columnNumber: Int, rowNumber: Int) -> String {
+        var column = columnNumber
+        var letters = ""
+        while column > 0 {
+            let remainder = (column - 1) % 26
+            let scalar = UnicodeScalar(65 + UInt32(remainder))!
+            letters.insert(
+                Character(scalar),
+                at: letters.startIndex
+            )
+            column = (column - 1) / 26
+        }
+        return "\(letters)\(rowNumber)"
+    }
+
+    private static func invalid(
+        field: String,
+        expected: String,
+        toolName: String
+    ) -> WorkbookToolInputError {
+        WorkbookToolInputError(
+            envelope: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "Invalid workbook payload field `\(field)`.",
+                field: field,
+                expected: expected,
+                tool: toolName
+            )
+        )
+    }
+}
+
+private struct WorkbookToolInputError: Error {
+    let envelope: String
+}

--- a/Packages/OsaurusCore/Tests/Folder/WorkbookToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/WorkbookToolsTests.swift
@@ -1,0 +1,303 @@
+//
+//  WorkbookToolsTests.swift
+//
+//  Covers the folder-facing workbook tools against the document registry
+//  and the existing XLSX adapter/emitter pair.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Workbook folder tools")
+struct WorkbookToolsTests {
+
+    @Test func readWorkbookReturnsStructuredSheetsFromRegistryAdapter() async throws {
+        let fixture = try await Self.fixture()
+        let tool = ReadWorkbookTool(rootPath: fixture.root, registry: fixture.registry)
+
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path":"sample.xlsx","sheet_name":"Revenue","max_rows":2,"max_columns":2}"#
+        )
+        let payload = try Self.successPayload(result)
+        let sheets = try #require(payload["sheets"] as? [[String: Any]])
+        let firstSheet = try #require(sheets.first)
+        let rows = try #require(firstSheet["rows"] as? [[String: Any]])
+        let firstRow = try #require(rows.first)
+        let cells = try #require(firstRow["cells"] as? [[String: Any]])
+
+        #expect(payload["format_id"] as? String == "xlsx")
+        #expect(firstSheet["name"] as? String == "Revenue")
+        #expect(firstSheet["row_count"] as? Int == 3)
+        #expect(firstSheet["truncated_rows"] as? Bool == true)
+        #expect(cells.count == 2)
+        #expect(cells.first?["reference"] as? String == "A1")
+    }
+
+    @Test func readWorkbookFailsForMissingSheet() async throws {
+        let fixture = try await Self.fixture()
+        let tool = ReadWorkbookTool(rootPath: fixture.root, registry: fixture.registry)
+
+        do {
+            _ = try await tool.execute(argumentsJSON: #"{"path":"sample.xlsx","sheet_name":"Missing"}"#)
+            Issue.record("read_workbook should reject an unknown sheet")
+        } catch let error as FolderToolError {
+            guard case .operationFailed(let message) = error else {
+                Issue.record("expected operationFailed, got \(error)")
+                return
+            }
+            #expect(message.contains("Missing"))
+        }
+    }
+
+    @Test func readWorkbookCellReturnsOneCell() async throws {
+        let fixture = try await Self.fixture()
+        let tool = ReadWorkbookCellTool(rootPath: fixture.root, registry: fixture.registry)
+
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path":"sample.xlsx","sheet_name":"Revenue","cell":"B2"}"#
+        )
+        let payload = try Self.successPayload(result)
+        let cell = try #require(payload["cell"] as? [String: Any])
+        let value = try #require(cell["value"] as? [String: Any])
+
+        #expect(payload["found"] as? Bool == true)
+        #expect(cell["reference"] as? String == "B2")
+        #expect(value["type"] as? String == "number")
+        #expect(value["text"] as? String == "1200")
+    }
+
+    @Test func readWorkbookCellRejectsInvalidReference() async throws {
+        let tool = ReadWorkbookCellTool(rootPath: Self.tmpRoot(), registry: Self.registry())
+        let result = try await tool.execute(argumentsJSON: #"{"path":"sample.xlsx","cell":"not-a-cell"}"#)
+
+        #expect(ToolEnvelope.isError(result))
+        #expect(EnvelopeAssertions.failureKind(result) == "invalid_args")
+        #expect(EnvelopeAssertions.failureField(result) == "cell")
+    }
+
+    @Test func writeWorkbookUsesRegistryEmitterAndRoundTrips() async throws {
+        let root = Self.tmpRoot()
+        let registry = Self.registry()
+        let tool = WriteWorkbookTool(rootPath: root, registry: registry)
+
+        let result = try await tool.execute(
+            argumentsJSON:
+                #"{"path":"created/report.xlsx","sheets":[{"name":"Revenue","rows":[["Month","Amount"],["January",1200],["Approved",true]]}]}"#
+        )
+        let payload = try Self.successPayload(result)
+        let fileURL = root.appendingPathComponent("created/report.xlsx")
+        let parsed = try await XLSXAdapter().parse(url: fileURL, sizeLimit: 0)
+        let workbook = try #require(parsed.representation.underlying as? Workbook)
+        let revenue = try #require(workbook.sheets.first)
+
+        #expect(payload["written"] as? Bool == true)
+        #expect(payload["sheet_count"] as? Int == 1)
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        #expect(revenue.rows[1].cells[1].value == .number(1200))
+        #expect(revenue.rows[2].cells[1].value == .bool(true))
+    }
+
+    @Test func writeWorkbookRequiresApprovalAndRejectsEscapingPath() async throws {
+        let root = Self.tmpRoot()
+        let tool = WriteWorkbookTool(rootPath: root, registry: Self.registry())
+
+        #expect(tool.defaultPermissionPolicy == .ask)
+        do {
+            _ = try await tool.execute(
+                argumentsJSON:
+                    #"{"path":"../escape.xlsx","sheets":[{"name":"Sheet1","rows":[["x"]]}]}"#
+            )
+            Issue.record("write_workbook should reject paths outside the root")
+        } catch let error as FolderToolError {
+            guard case .pathOutsideRoot = error else {
+                Issue.record("expected pathOutsideRoot, got \(error)")
+                return
+            }
+        }
+    }
+
+    @MainActor
+    @Test func folderRegistrationIncludesWorkbookTools() {
+        let manager = FolderToolManager.shared
+        let context = FolderContext(
+            rootPath: Self.tmpRoot(),
+            projectType: .unknown,
+            tree: "",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false
+        )
+        manager.registerFolderTools(for: context)
+        defer { manager.unregisterFolderTools() }
+
+        for name in ["read_workbook", "read_workbook_cell", "write_workbook"] {
+            #expect(manager.folderToolNames.contains(name))
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let root: URL
+        let registry: DocumentFormatRegistry
+    }
+
+    private static func fixture() async throws -> Fixture {
+        let root = tmpRoot()
+        let url = root.appendingPathComponent("sample.xlsx")
+        try await XLSXEmitter().emit(document(workbook: makeWorkbook()), to: url)
+        return Fixture(root: root, registry: registry())
+    }
+
+    private static func registry() -> DocumentFormatRegistry {
+        let registry = DocumentFormatRegistry()
+        registry.register(adapter: XLSXAdapter())
+        registry.register(emitter: XLSXEmitter())
+        return registry
+    }
+
+    private static func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-workbook-tools-test-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        return dir
+    }
+
+    private static func successPayload(_ raw: String) throws -> [String: Any] {
+        try #require(ToolEnvelope.successPayload(raw) as? [String: Any])
+    }
+
+    private static func document(workbook: Workbook) -> StructuredDocument {
+        StructuredDocument(
+            formatId: "xlsx",
+            filename: "sample.xlsx",
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: ""
+        )
+    }
+
+    private static func makeWorkbook() -> Workbook {
+        let rows = [
+            row(
+                number: 1,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A1", row: 1, column: 1, value: .string("Month"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("B1", row: 1, column: 2, value: .string("Amount"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("C1", row: 1, column: 3, value: .string("Approved"), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+            row(
+                number: 2,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A2", row: 2, column: 1, value: .string("January"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("B2", row: 2, column: 2, value: .number(1200), sheetName: "Revenue", sheetIndex: 0),
+                    cell("C2", row: 2, column: 3, value: .bool(true), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+            row(
+                number: 3,
+                sheetName: "Revenue",
+                sheetIndex: 0,
+                cells: [
+                    cell("A3", row: 3, column: 1, value: .string("February"), sheetName: "Revenue", sheetIndex: 0),
+                    cell("B3", row: 3, column: 2, value: .number(1300.5), sheetName: "Revenue", sheetIndex: 0),
+                    cell("C3", row: 3, column: 3, value: .bool(false), sheetName: "Revenue", sheetIndex: 0),
+                ]
+            ),
+        ]
+
+        return Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: rows,
+                    anchor: sheetAnchor(name: "Revenue", index: 0)
+                )
+            ]
+        )
+    }
+
+    private static func row(
+        number: Int,
+        sheetName: String,
+        sheetIndex: Int,
+        cells: [Workbook.Cell]
+    ) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(
+                kind: .row,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .row, index: number - 1),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: DocumentSourceLocation(sheetIndex: sheetIndex, sheetName: sheetName, rowIndex: number - 1)
+                ),
+                label: "\(sheetName) row \(number)"
+            )
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        sheetName: String,
+        sheetIndex: Int
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .cell, identifier: reference),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: .cell(sheetName: sheetName, rowIndex: row - 1, columnIndex: column - 1)
+                ),
+                label: "\(sheetName)!\(reference)"
+            )
+        )
+    }
+
+    private static func sheetAnchor(name: String, index: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .sheet,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: name, index: index),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(sheetIndex: index, sheetName: name)
+            ),
+            label: name,
+            metadata: ["sheetIndex": "\(index)"]
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
@@ -2123,6 +2123,7 @@ private struct AgentSettingsSection: View {
         [(name: String, display: String, desc: String, destructive: Bool, defaultPolicy: ToolPermissionPolicy)] = [
             ("file_write", "Write Files", "Create and modify files", false, .auto),
             ("file_edit", "Edit Files", "Edit file content with search/replace", false, .auto),
+            ("write_workbook", "Write Workbooks", "Create workbook files", false, .ask),
             ("shell_run", "Run Shell Commands", "Execute shell commands in the folder", true, .ask),
             ("git_commit", "Git Commit", "Commit changes to git repository", true, .ask),
         ]


### PR DESCRIPTION
## Business rationale
Workbook files are common user artifacts for agents, but the folder tool surface previously did not provide a structured way to inspect workbook contents or create workbook outputs. This adds workbook read, single-cell read, and workbook write tools so agents can work with spreadsheet-style data through Osaurus' native tool permissions and project-root containment rather than ad hoc shell parsing or manual file generation.

## Coding rationale
The workbook tools route through `DocumentFormatRegistry` and the existing XLSX adapter/emitter path, so the implementation adds no external dependencies and keeps workbook behavior aligned with the locked foundation-format design. `read_workbook` and `read_workbook_cell` parse via registry-backed adapters; `write_workbook` is a `PermissionedTool` with the default `.ask` policy, validates project-root containment through `FolderToolHelpers`, and emits workbook bytes through the registry.

## Acceptance criteria
- [x] Register `read_workbook`, `read_workbook_cell`, and `write_workbook` in the folder tool surface.
- [x] Parse workbook reads through the existing document-format registry and adapter path.
- [x] Emit workbook writes through the existing registry/emitter path without adding dependencies.
- [x] Gate workbook writes through the existing tool permission policy and default to ask.
- [x] Cover successful workbook reads/writes and failure cases for missing sheets, invalid cells, denied writes, and escaping paths.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
Focused lane validation:

```text
swift test --package-path Packages/OsaurusCore --filter WorkbookToolsTests
✔ Suite "Workbook folder tools" passed after 1.001 seconds.
✔ Test run with 7 tests in 1 suite passed after 1.001 seconds.
```

Full gate evidence from `/tmp/osaurus-coord/evidence/T-J-WORKBOOK-TOOLS/20260520T014352Z`:

```text
swift-format lint --strict --recursive Packages App
# empty output, exit 0

swiftlint lint --reporter github-actions-logging
Done linting! Found 1119 violations, 0 serious in 584 files.

find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
# empty output, exit 0

swift test --package-path Packages/OsaurusCLI --parallel
Build complete! (26.43s)
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.

make ci-test
Done. Inspect failures with: open build/Tests.xcresult

swift build --package-path Packages/OsaurusCore -c release
Build complete! (361.31s)
```

Archive freshness:

```text
git fetch --all --prune
Fetching origin
Fetching fork
HEAD/origin-main/merge-base = 6075636106c26a51c43847cb56798e7595027900
```

## Rollback
Revert commit `2c376936` to remove the workbook tools, settings policy row, and tests. No migrations or dependency changes are involved.
