### PR TITLE
feat(documents): add PDF table extraction

### DIFF
--- a/Packages/OsaurusCore/Models/Documents/PDFDocumentRepresentation.swift
+++ b/Packages/OsaurusCore/Models/Documents/PDFDocumentRepresentation.swift
@@ -1,0 +1,121 @@
+//
+//  PDFDocumentRepresentation.swift
+//  osaurus
+//
+//  Typed PDF representation for text-layer extraction. PDF files do not carry
+//  table semantics, so tables here are deliberately provenance-heavy heuristic
+//  detections: callers can cite the page, bounding box, and source character
+//  span instead of treating the result as an author-declared structure.
+//
+
+import Foundation
+
+/// PDF-native parse output carried by `StructuredDocument` while the legacy
+/// attachment path keeps using the plain text fallback.
+public struct PDFDocumentRepresentation: StructuredRepresentation, Codable, Equatable, Sendable {
+    public let pages: [PDFPageRepresentation]
+
+    public init(pages: [PDFPageRepresentation]) {
+        self.pages = pages
+    }
+}
+
+/// A page keeps its recovered text and any layout-derived tables together so
+/// consumers can decide whether to trust prose order, table geometry, or both.
+public struct PDFPageRepresentation: Codable, Equatable, Sendable {
+    public let pageIndex: Int
+    public let text: String
+    public let bounds: DocumentBoundingBox?
+    public let tables: [PDFTable]
+    public let anchor: DocumentAnchor
+
+    public init(
+        pageIndex: Int,
+        text: String,
+        bounds: DocumentBoundingBox? = nil,
+        tables: [PDFTable] = [],
+        anchor: DocumentAnchor
+    ) {
+        precondition(pageIndex >= 0, "PDF page index must be non-negative")
+        self.pageIndex = pageIndex
+        self.text = text
+        self.bounds = bounds
+        self.tables = tables
+        self.anchor = anchor
+    }
+}
+
+/// A heuristic table extracted from glyph geometry. Row and cell anchors keep
+/// enough source identity for audit/debug even when a complex PDF layout is
+/// later tuned into a different detection.
+public struct PDFTable: Codable, Equatable, Sendable {
+    public let pageIndex: Int
+    public let index: Int
+    public let rows: [PDFTableRow]
+    public let bounds: DocumentBoundingBox
+    public let anchor: DocumentAnchor
+
+    public var columnCount: Int {
+        rows.map(\.cells.count).max() ?? 0
+    }
+
+    public init(
+        pageIndex: Int,
+        index: Int,
+        rows: [PDFTableRow],
+        bounds: DocumentBoundingBox,
+        anchor: DocumentAnchor
+    ) {
+        precondition(pageIndex >= 0, "PDF table page index must be non-negative")
+        precondition(index >= 0, "PDF table index must be non-negative")
+        self.pageIndex = pageIndex
+        self.index = index
+        self.rows = rows
+        self.bounds = bounds
+        self.anchor = anchor
+    }
+}
+
+public struct PDFTableRow: Codable, Equatable, Sendable {
+    public let index: Int
+    public let cells: [PDFTableCell]
+    public let bounds: DocumentBoundingBox
+    public let anchor: DocumentAnchor
+
+    public init(
+        index: Int,
+        cells: [PDFTableCell],
+        bounds: DocumentBoundingBox,
+        anchor: DocumentAnchor
+    ) {
+        precondition(index >= 0, "PDF table row index must be non-negative")
+        self.index = index
+        self.cells = cells
+        self.bounds = bounds
+        self.anchor = anchor
+    }
+}
+
+public struct PDFTableCell: Codable, Equatable, Sendable {
+    public let rowIndex: Int
+    public let columnIndex: Int
+    public let text: String
+    public let bounds: DocumentBoundingBox
+    public let anchor: DocumentAnchor
+
+    public init(
+        rowIndex: Int,
+        columnIndex: Int,
+        text: String,
+        bounds: DocumentBoundingBox,
+        anchor: DocumentAnchor
+    ) {
+        precondition(rowIndex >= 0, "PDF table cell row index must be non-negative")
+        precondition(columnIndex >= 0, "PDF table cell column index must be non-negative")
+        self.rowIndex = rowIndex
+        self.columnIndex = columnIndex
+        self.text = text
+        self.bounds = bounds
+        self.anchor = anchor
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PDFAdapter.swift
@@ -6,9 +6,7 @@
 //  Intentionally does NOT cover the image-rendering fallback — when a PDF has
 //  no extractable text, this adapter throws `.emptyContent` and the
 //  `DocumentParser` shim falls through to the legacy switch, which still
-//  renders each page as PNG. Moving that path onto the adapter surface is
-//  deferred to stage-4 PR 8 (layout-aware table extraction), where the
-//  typed `PDFDocument` representation gets introduced.
+//  renders each page as PNG.
 //
 
 import Foundation
@@ -33,7 +31,7 @@ public struct PDFAdapter: DocumentFormatAdapter {
             throw DocumentAdapterError.readFailed(underlying: "PDFKit could not open document")
         }
 
-        let pages = Self.extractTextPages(from: document)
+        let pages = Self.extractPages(from: document)
         let extracted = pages.map(\.text).joined(separator: "\n\n")
         guard !extracted.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             // No text layer — let the shim fall through to the legacy image-
@@ -42,11 +40,14 @@ public struct PDFAdapter: DocumentFormatAdapter {
         }
 
         let truncated = PlainTextAdapter.applyCharacterCap(extracted)
-        let pageTexts = pages.map { DocumentPageText(pageIndex: $0.pageIndex, text: $0.text) }
-        let structure = Self.structureForTextFallback(
-            filename: url.lastPathComponent,
-            pages: pageTexts,
+        let pdfPages = Self.pageRepresentations(
+            pages: pages,
             extractedText: extracted,
+            textFallback: truncated
+        )
+        let structure = Self.structureForPDFPages(
+            filename: url.lastPathComponent,
+            pages: pdfPages,
             textFallback: truncated
         )
         let securitySignals = Self.securitySignals(for: document)
@@ -68,7 +69,7 @@ public struct PDFAdapter: DocumentFormatAdapter {
             fileSize: fileSize,
             representation: AnyStructuredRepresentation(
                 formatId: formatId,
-                underlying: PlainTextRepresentation(text: truncated)
+                underlying: PDFDocumentRepresentation(pages: pdfPages)
             ),
             structure: structure,
             security: security,
@@ -76,16 +77,365 @@ public struct PDFAdapter: DocumentFormatAdapter {
         )
     }
 
-    private static func extractTextPages(from document: PDFDocument) -> [ExtractedPageText] {
-        var pages: [ExtractedPageText] = []
+    private static func extractPages(from document: PDFDocument) -> [ExtractedPDFPage] {
+        var pages: [ExtractedPDFPage] = []
         for index in 0 ..< document.pageCount {
             guard let page = document.page(at: index),
                 let text = page.string,
                 !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             else { continue }
-            pages.append(ExtractedPageText(pageIndex: index, text: text))
+            let glyphs = Self.glyphs(from: page, pageIndex: index, text: text)
+            pages.append(
+                ExtractedPDFPage(
+                    pageIndex: index,
+                    text: text,
+                    bounds: page.bounds(for: .cropBox),
+                    tables: PDFTableDetector.detectTables(glyphs: glyphs, pageText: text)
+                )
+            )
         }
         return pages
+    }
+
+    private static func glyphs(
+        from page: PDFPage,
+        pageIndex: Int,
+        text: String
+    ) -> [PDFTableDetector.Glyph] {
+        let nsText = text as NSString
+        let count = min(page.numberOfCharacters, nsText.length)
+        guard count > 0 else { return [] }
+
+        return (0 ..< count).compactMap { index in
+            let character = nsText.substring(with: NSRange(location: index, length: 1))
+            let bounds = page.characterBounds(at: index)
+            guard bounds.width.isFinite, bounds.height.isFinite else { return nil }
+            return PDFTableDetector.Glyph(
+                pageIndex: pageIndex,
+                characterIndex: index,
+                text: character,
+                bounds: bounds
+            )
+        }
+    }
+
+    private static func pageRepresentations(
+        pages: [ExtractedPDFPage],
+        extractedText: String,
+        textFallback: String
+    ) -> [PDFPageRepresentation] {
+        let visiblePrefixLength = Self.visibleExtractedPrefixUTF16Length(
+            extractedText: extractedText,
+            textFallback: textFallback
+        )
+        var extractedOffset = 0
+        var representations: [PDFPageRepresentation] = []
+
+        for (order, page) in pages.enumerated() {
+            if order > 0 {
+                extractedOffset += Self.pageSeparatorUTF16Length
+            }
+
+            let sourceLength = page.text.utf16.count
+            let visibleLength = min(sourceLength, max(0, visiblePrefixLength - extractedOffset))
+            let fallbackStart = min(extractedOffset, visiblePrefixLength)
+            let pageAnchor = Self.pageAnchor(
+                pageIndex: page.pageIndex,
+                order: order,
+                sourceLength: sourceLength,
+                visibleLength: visibleLength,
+                fallbackStart: fallbackStart
+            )
+            let tables = page.tables.map { table in
+                Self.pdfTable(
+                    table,
+                    pageIndex: page.pageIndex,
+                    fallbackStart: fallbackStart,
+                    visibleLength: visibleLength
+                )
+            }
+
+            representations.append(
+                PDFPageRepresentation(
+                    pageIndex: page.pageIndex,
+                    text: page.text,
+                    bounds: Self.documentBoundingBox(page.bounds),
+                    tables: tables,
+                    anchor: pageAnchor
+                )
+            )
+            extractedOffset += sourceLength
+        }
+
+        return representations
+    }
+
+    private static func pageAnchor(
+        pageIndex: Int,
+        order: Int,
+        sourceLength: Int,
+        visibleLength: Int,
+        fallbackStart: Int
+    ) -> DocumentAnchor {
+        let range = DocumentTextRange(startUTF16Offset: fallbackStart, length: visibleLength)
+        let metadata = Self.pageMetadata(
+            pageIndex: pageIndex,
+            order: order,
+            sourceLength: sourceLength,
+            visibleLength: visibleLength,
+            range: range,
+            wasClipped: visibleLength < sourceLength
+        )
+        return DocumentAnchor(
+            kind: .page,
+            path: [
+                .init(kind: .document),
+                .init(kind: .page, index: pageIndex),
+            ],
+            textRange: range,
+            sourceRange: .init(
+                start: .init(pageIndex: pageIndex, characterOffset: 0),
+                end: .init(pageIndex: pageIndex, characterOffset: visibleLength)
+            ),
+            label: "Page \(pageIndex + 1)",
+            metadata: metadata
+        )
+    }
+
+    private static func pdfTable(
+        _ table: PDFTableDetector.Table,
+        pageIndex: Int,
+        fallbackStart: Int,
+        visibleLength: Int
+    ) -> PDFTable {
+        let rows = table.rows.map { row in
+            Self.pdfTableRow(
+                row,
+                pageIndex: pageIndex,
+                tableIndex: table.index,
+                fallbackStart: fallbackStart,
+                visibleLength: visibleLength
+            )
+        }
+        let anchor = Self.anchor(
+            kind: .table,
+            pageIndex: pageIndex,
+            path: Self.path(pageIndex: pageIndex, tableIndex: table.index),
+            sourceRange: table.characterRange,
+            bounds: table.bounds,
+            fallbackStart: fallbackStart,
+            visibleLength: visibleLength,
+            label: "Page \(pageIndex + 1) Table \(table.index + 1)",
+            metadata: [
+                "pageIndex": "\(pageIndex)",
+                "pageNumber": "\(pageIndex + 1)",
+                "tableIndex": "\(table.index)",
+                "rowCount": "\(rows.count)",
+                "columnCount": "\(rows.map(\.cells.count).max() ?? 0)",
+                "detector": "glyph-geometry",
+            ]
+        )
+        return PDFTable(
+            pageIndex: pageIndex,
+            index: table.index,
+            rows: rows,
+            bounds: Self.documentBoundingBox(table.bounds) ?? .zeroPage,
+            anchor: anchor
+        )
+    }
+
+    private static func pdfTableRow(
+        _ row: PDFTableDetector.Row,
+        pageIndex: Int,
+        tableIndex: Int,
+        fallbackStart: Int,
+        visibleLength: Int
+    ) -> PDFTableRow {
+        let cells = row.cells.map { cell in
+            Self.pdfTableCell(
+                cell,
+                pageIndex: pageIndex,
+                tableIndex: tableIndex,
+                fallbackStart: fallbackStart,
+                visibleLength: visibleLength
+            )
+        }
+        let anchor = Self.anchor(
+            kind: .row,
+            pageIndex: pageIndex,
+            path: Self.path(pageIndex: pageIndex, tableIndex: tableIndex, rowIndex: row.cells.first?.rowIndex ?? 0),
+            sourceRange: row.characterRange,
+            bounds: row.bounds,
+            fallbackStart: fallbackStart,
+            visibleLength: visibleLength,
+            label: "Row \((row.cells.first?.rowIndex ?? 0) + 1)",
+            metadata: [
+                "pageIndex": "\(pageIndex)",
+                "tableIndex": "\(tableIndex)",
+                "rowIndex": "\(row.cells.first?.rowIndex ?? 0)",
+                "cellCount": "\(cells.count)",
+            ]
+        )
+        return PDFTableRow(
+            index: row.cells.first?.rowIndex ?? 0,
+            cells: cells,
+            bounds: Self.documentBoundingBox(row.bounds) ?? .zeroPage,
+            anchor: anchor
+        )
+    }
+
+    private static func pdfTableCell(
+        _ cell: PDFTableDetector.Cell,
+        pageIndex: Int,
+        tableIndex: Int,
+        fallbackStart: Int,
+        visibleLength: Int
+    ) -> PDFTableCell {
+        let anchor = Self.anchor(
+            kind: .cell,
+            pageIndex: pageIndex,
+            path: Self.path(
+                pageIndex: pageIndex,
+                tableIndex: tableIndex,
+                rowIndex: cell.rowIndex,
+                columnIndex: cell.columnIndex
+            ),
+            sourceRange: cell.characterRange,
+            bounds: cell.bounds,
+            fallbackStart: fallbackStart,
+            visibleLength: visibleLength,
+            label: "R\(cell.rowIndex + 1)C\(cell.columnIndex + 1)",
+            metadata: [
+                "pageIndex": "\(pageIndex)",
+                "tableIndex": "\(tableIndex)",
+                "rowIndex": "\(cell.rowIndex)",
+                "columnIndex": "\(cell.columnIndex)",
+            ]
+        )
+        return PDFTableCell(
+            rowIndex: cell.rowIndex,
+            columnIndex: cell.columnIndex,
+            text: cell.text,
+            bounds: Self.documentBoundingBox(cell.bounds) ?? .zeroPage,
+            anchor: anchor
+        )
+    }
+
+    private static func anchor(
+        kind: DocumentAnchor.Kind,
+        pageIndex: Int,
+        path: [DocumentAnchor.PathComponent],
+        sourceRange: Range<Int>,
+        bounds: CGRect,
+        fallbackStart: Int,
+        visibleLength: Int,
+        label: String,
+        metadata: [String: String]
+    ) -> DocumentAnchor {
+        let visibleStart = min(max(sourceRange.lowerBound, 0), visibleLength)
+        let visibleEnd = min(max(sourceRange.upperBound, visibleStart), visibleLength)
+        return DocumentAnchor(
+            kind: kind,
+            path: path,
+            textRange: DocumentTextRange(
+                startUTF16Offset: fallbackStart + visibleStart,
+                length: visibleEnd - visibleStart
+            ),
+            sourceRange: .init(
+                start: .init(pageIndex: pageIndex, characterOffset: sourceRange.lowerBound),
+                end: .init(pageIndex: pageIndex, characterOffset: sourceRange.upperBound),
+                boundingBox: Self.documentBoundingBox(bounds)
+            ),
+            label: label,
+            metadata: metadata
+        )
+    }
+
+    private static func path(
+        pageIndex: Int,
+        tableIndex: Int,
+        rowIndex: Int? = nil,
+        columnIndex: Int? = nil
+    ) -> [DocumentAnchor.PathComponent] {
+        var path: [DocumentAnchor.PathComponent] = [
+            .init(kind: .document),
+            .init(kind: .page, index: pageIndex),
+            .init(kind: .table, index: tableIndex),
+        ]
+        if let rowIndex {
+            path.append(.init(kind: .row, index: rowIndex))
+        }
+        if let columnIndex {
+            path.append(.init(kind: .cell, index: columnIndex))
+        }
+        return path
+    }
+
+    private static func documentBoundingBox(_ rect: CGRect) -> DocumentBoundingBox? {
+        guard !rect.isNull, !rect.isEmpty else { return nil }
+        return DocumentBoundingBox(
+            x: Double(rect.origin.x),
+            y: Double(rect.origin.y),
+            width: Double(rect.width),
+            height: Double(rect.height),
+            coordinateSpace: .page
+        )
+    }
+
+    private static func structureForPDFPages(
+        filename: String,
+        pages: [PDFPageRepresentation],
+        textFallback: String
+    ) -> DocumentStructure {
+        guard !pages.isEmpty else {
+            return DocumentStructure.plainText(filename: filename, text: textFallback)
+        }
+
+        let rootAnchor = DocumentAnchor.root(label: filename)
+        let pageElements = pages.map { page in
+            DocumentElement(
+                kind: .page,
+                anchor: page.anchor,
+                text: page.anchor.textRange?.isEmpty == true ? nil : clippedPageText(page),
+                attributes: .init(metadata: page.anchor.metadata),
+                children: page.tables.map(Self.tableElement)
+            )
+        }
+        let root = DocumentElement(
+            id: rootAnchor.id,
+            kind: .document,
+            anchor: rootAnchor,
+            children: pageElements
+        )
+        return DocumentStructure(root: root, textLengthUTF16: textFallback.utf16.count)
+    }
+
+    private static func tableElement(_ table: PDFTable) -> DocumentElement {
+        DocumentElement(
+            kind: .table,
+            anchor: table.anchor,
+            attributes: .init(metadata: table.anchor.metadata),
+            children: table.rows.map { row in
+                DocumentElement(
+                    kind: .tableRow,
+                    anchor: row.anchor,
+                    attributes: .init(metadata: row.anchor.metadata),
+                    children: row.cells.map { cell in
+                        DocumentElement(
+                            kind: .tableCell,
+                            anchor: cell.anchor,
+                            text: cell.text,
+                            attributes: .init(metadata: cell.anchor.metadata)
+                        )
+                    }
+                )
+            }
+        )
+    }
+
+    private static func clippedPageText(_ page: PDFPageRepresentation) -> String? {
+        guard let range = page.anchor.textRange, range.length > 0 else { return nil }
+        return Self.prefix(page.text, maxUTF16Length: range.length)
     }
 
     static func structureForTextFallback(
@@ -185,10 +535,8 @@ public struct PDFAdapter: DocumentFormatAdapter {
         var extractedIndex = extractedText.startIndex
         var fallbackIndex = textFallback.startIndex
         var length = 0
-        while extractedIndex < extractedText.endIndex,
-            fallbackIndex < textFallback.endIndex,
-            extractedText[extractedIndex] == textFallback[fallbackIndex]
-        {
+        while extractedIndex < extractedText.endIndex && fallbackIndex < textFallback.endIndex {
+            guard extractedText[extractedIndex] == textFallback[fallbackIndex] else { break }
             let nextExtractedIndex = extractedText.index(after: extractedIndex)
             length += extractedText[extractedIndex ..< nextExtractedIndex].utf16.count
             extractedIndex = nextExtractedIndex
@@ -287,10 +635,22 @@ public struct PDFAdapter: DocumentFormatAdapter {
         ]
     }
 
-    private struct ExtractedPageText {
+    private struct ExtractedPDFPage {
         let pageIndex: Int
         let text: String
+        let bounds: CGRect
+        let tables: [PDFTableDetector.Table]
     }
 
     private static let pageSeparatorUTF16Length = "\n\n".utf16.count
+}
+
+private extension DocumentBoundingBox {
+    static let zeroPage = DocumentBoundingBox(
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        coordinateSpace: .page
+    )
 }

--- a/Packages/OsaurusCore/Services/Documents/PDFTableDetector.swift
+++ b/Packages/OsaurusCore/Services/Documents/PDFTableDetector.swift
@@ -1,0 +1,329 @@
+//
+//  PDFTableDetector.swift
+//  osaurus
+//
+//  Recovers simple text-layer tables from PDF glyph geometry. PDFs do not
+//  encode rows or columns, so this stays a deterministic heuristic pipeline:
+//  cluster glyphs into visual rows, split rows on large horizontal gaps, then
+//  group similarly aligned rows into tables.
+//
+
+import CoreGraphics
+import Foundation
+
+struct PDFTableDetector {
+    struct Glyph: Equatable {
+        let pageIndex: Int
+        let characterIndex: Int
+        let text: String
+        let bounds: CGRect
+
+        var midY: CGFloat { bounds.midY }
+    }
+
+    struct Row: Equatable {
+        let pageIndex: Int
+        let glyphs: [Glyph]
+        let bounds: CGRect
+        let cells: [Cell]
+
+        var characterRange: Range<Int> {
+            let indexes = glyphs.map(\.characterIndex)
+            guard let min = indexes.min(), let max = indexes.max() else { return 0 ..< 0 }
+            return min ..< (max + 1)
+        }
+    }
+
+    struct Cell: Equatable {
+        let pageIndex: Int
+        let rowIndex: Int
+        let columnIndex: Int
+        let glyphs: [Glyph]
+        let text: String
+        let bounds: CGRect
+
+        var characterRange: Range<Int> {
+            let indexes = glyphs.map(\.characterIndex)
+            guard let min = indexes.min(), let max = indexes.max() else { return 0 ..< 0 }
+            return min ..< (max + 1)
+        }
+    }
+
+    struct Table: Equatable {
+        let pageIndex: Int
+        let index: Int
+        let rows: [Row]
+        let bounds: CGRect
+
+        var characterRange: Range<Int> {
+            let indexes = rows.flatMap(\.glyphs).map(\.characterIndex)
+            guard let min = indexes.min(), let max = indexes.max() else { return 0 ..< 0 }
+            return min ..< (max + 1)
+        }
+    }
+
+    static func detectTables(glyphs: [Glyph], pageText: String? = nil) -> [Table] {
+        let visualRows = rows(from: glyphs)
+        let detectedTables = tables(from: visualRows)
+        guard let pageText else { return detectedTables }
+        return reconcileCellText(in: detectedTables, visualRows: visualRows, pageText: pageText)
+    }
+
+    static func rows(from glyphs: [Glyph]) -> [Row] {
+        let visibleGlyphs =
+            glyphs
+            .filter { !$0.text.isNewline && !$0.bounds.isNull && !$0.bounds.isEmpty }
+            .sorted {
+                if abs($0.midY - $1.midY) > 0.5 {
+                    return $0.midY > $1.midY
+                }
+                return $0.bounds.minX < $1.bounds.minX
+            }
+        guard !visibleGlyphs.isEmpty else { return [] }
+
+        let tolerance = max(3, median(visibleGlyphs.map(\.bounds.height)) * 0.65)
+        var buckets: [[Glyph]] = []
+        var current: [Glyph] = []
+        var currentMidY = visibleGlyphs[0].midY
+
+        for glyph in visibleGlyphs {
+            if current.isEmpty || abs(glyph.midY - currentMidY) <= tolerance {
+                current.append(glyph)
+                currentMidY = averageMidY(current)
+            } else {
+                buckets.append(current)
+                current = [glyph]
+                currentMidY = glyph.midY
+            }
+        }
+        if !current.isEmpty {
+            buckets.append(current)
+        }
+
+        return buckets.compactMap { bucket in
+            let ordered = bucket.sorted {
+                if abs($0.bounds.minX - $1.bounds.minX) > 0.5 {
+                    return $0.bounds.minX < $1.bounds.minX
+                }
+                return $0.characterIndex < $1.characterIndex
+            }
+            let cells = cells(from: ordered)
+            guard let pageIndex = ordered.first?.pageIndex else { return nil }
+            return Row(
+                pageIndex: pageIndex,
+                glyphs: ordered,
+                bounds: unionBounds(ordered.map(\.bounds)),
+                cells: cells
+            )
+        }
+    }
+
+    static func cells(from glyphs: [Glyph]) -> [Cell] {
+        guard let pageIndex = glyphs.first?.pageIndex else { return [] }
+        let medianWidth = median(glyphs.map(\.bounds.width).filter { $0 > 0 })
+        let gapThreshold = max(8, medianWidth * 2.2)
+        var groups: [[Glyph]] = []
+        var current: [Glyph] = []
+        var previousTextGlyph: Glyph?
+
+        for glyph in glyphs {
+            if glyph.text.isWhitespace {
+                let isWideDelimiter =
+                    previousTextGlyph.map { glyph.bounds.minX - $0.bounds.minX > gapThreshold } ?? false
+                if isWideDelimiter, !current.isEmpty {
+                    groups.append(current)
+                    current = []
+                    previousTextGlyph = nil
+                }
+                continue
+            }
+
+            if let previous = previousTextGlyph {
+                let xAdvance = glyph.bounds.minX - previous.bounds.minX
+                if xAdvance > gapThreshold + medianWidth, !current.isEmpty {
+                    groups.append(current)
+                    current = []
+                }
+            }
+            current.append(glyph)
+            previousTextGlyph = glyph
+        }
+        if !current.isEmpty {
+            groups.append(current)
+        }
+
+        return groups.enumerated().compactMap { columnIndex, group in
+            let text = normalizeCellText(group.map(\.text).joined())
+            guard !text.isEmpty else { return nil }
+            return Cell(
+                pageIndex: pageIndex,
+                rowIndex: 0,
+                columnIndex: columnIndex,
+                glyphs: group,
+                text: text,
+                bounds: unionBounds(group.map(\.bounds))
+            )
+        }
+    }
+
+    static func tables(from rows: [Row]) -> [Table] {
+        let candidates = rows.filter { $0.cells.count >= 2 }
+        guard !candidates.isEmpty else { return [] }
+
+        var groups: [[Row]] = []
+        var current: [Row] = []
+
+        for row in candidates {
+            if let last = current.last, canGroup(last, row) {
+                current.append(row)
+            } else {
+                if current.count >= 2 {
+                    groups.append(current)
+                }
+                current = [row]
+            }
+        }
+        if current.count >= 2 {
+            groups.append(current)
+        }
+
+        return groups.enumerated().map { tableIndex, group in
+            Table(
+                pageIndex: group[0].pageIndex,
+                index: tableIndex,
+                rows: group.enumerated().map { rowIndex, row in
+                    let cells = row.cells.enumerated().map { columnIndex, cell in
+                        Cell(
+                            pageIndex: cell.pageIndex,
+                            rowIndex: rowIndex,
+                            columnIndex: columnIndex,
+                            glyphs: cell.glyphs,
+                            text: cell.text,
+                            bounds: cell.bounds
+                        )
+                    }
+                    return Row(
+                        pageIndex: row.pageIndex,
+                        glyphs: row.glyphs,
+                        bounds: row.bounds,
+                        cells: cells
+                    )
+                },
+                bounds: unionBounds(group.map(\.bounds))
+            )
+        }
+    }
+
+    private static func canGroup(_ upper: Row, _ lower: Row) -> Bool {
+        guard upper.pageIndex == lower.pageIndex, upper.cells.count == lower.cells.count else {
+            return false
+        }
+
+        let rowHeight = max(upper.bounds.height, lower.bounds.height, 1)
+        let verticalGap = max(0, upper.bounds.minY - lower.bounds.maxY)
+        guard verticalGap <= max(36, rowHeight * 3.5) else { return false }
+
+        let tolerance = max(12, median((upper.cells + lower.cells).map(\.bounds.width)) * 0.2)
+        for (left, right) in zip(upper.cells, lower.cells) {
+            guard abs(left.bounds.minX - right.bounds.minX) <= tolerance else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func reconcileCellText(
+        in tables: [Table],
+        visualRows: [Row],
+        pageText: String
+    ) -> [Table] {
+        let lineTokens =
+            pageText
+            .components(separatedBy: .newlines)
+            .map { line in
+                line.components(separatedBy: .whitespaces)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+            }
+            .filter { !$0.isEmpty }
+        guard !lineTokens.isEmpty else { return tables }
+
+        let rowOrderByKey = Dictionary(
+            uniqueKeysWithValues: visualRows.enumerated().map { order, row in
+                (rowKey(row), order)
+            }
+        )
+
+        return tables.map { table in
+            let rows = table.rows.map { row -> Row in
+                guard let order = rowOrderByKey[rowKey(row)],
+                    order < lineTokens.count,
+                    lineTokens[order].count == row.cells.count
+                else {
+                    return row
+                }
+
+                let cells = zip(row.cells, lineTokens[order]).map { cell, text in
+                    Cell(
+                        pageIndex: cell.pageIndex,
+                        rowIndex: cell.rowIndex,
+                        columnIndex: cell.columnIndex,
+                        glyphs: cell.glyphs,
+                        text: text,
+                        bounds: cell.bounds
+                    )
+                }
+                return Row(
+                    pageIndex: row.pageIndex,
+                    glyphs: row.glyphs,
+                    bounds: row.bounds,
+                    cells: cells
+                )
+            }
+            return Table(pageIndex: table.pageIndex, index: table.index, rows: rows, bounds: table.bounds)
+        }
+    }
+
+    private static func rowKey(_ row: Row) -> String {
+        let range = row.characterRange
+        return "\(row.pageIndex):\(range.lowerBound):\(range.upperBound)"
+    }
+
+    private static func averageMidY(_ glyphs: [Glyph]) -> CGFloat {
+        guard !glyphs.isEmpty else { return 0 }
+        return glyphs.reduce(CGFloat(0)) { $0 + $1.midY } / CGFloat(glyphs.count)
+    }
+
+    private static func median(_ values: [CGFloat]) -> CGFloat {
+        let sorted = values.filter { $0.isFinite && $0 > 0 }.sorted()
+        guard !sorted.isEmpty else { return 0 }
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private static func normalizeCellText(_ text: String) -> String {
+        text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private static func unionBounds(_ rects: [CGRect]) -> CGRect {
+        rects.reduce(CGRect.null) { partial, rect in
+            partial.isNull ? rect : partial.union(rect)
+        }
+    }
+}
+
+private extension String {
+    var isNewline: Bool {
+        self == "\n" || self == "\r" || self == "\u{2028}" || self == "\u{2029}"
+    }
+
+    var isWhitespace: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
@@ -33,6 +33,9 @@ struct PDFAdapterTests {
         let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
         #expect(doc.formatId == "pdf")
         #expect(doc.textFallback.contains("Hello PDF body content"))
+        let representation = try #require(doc.representation.underlying as? PDFDocumentRepresentation)
+        #expect(representation.pages.count == 1)
+        #expect(representation.pages[0].text.contains("Hello PDF body content"))
         #expect(doc.structure.elements(kind: .page).count == 1)
         #expect(doc.structure.elements(kind: .page).first?.anchor.sourceRange?.start.pageIndex == 0)
         #expect(doc.security.inspectionStatus == .partiallyInspected)
@@ -141,6 +144,28 @@ struct PDFAdapterTests {
         }
     }
 
+    @Test func parse_detectsSimpleTextLayerTable() async throws {
+        let url = try Self.writeTablePDF(rows: [
+            ["Quarter", "Revenue"],
+            ["Q1", "1200"],
+            ["Q2", "1800"],
+        ])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
+        let representation = try #require(doc.representation.underlying as? PDFDocumentRepresentation)
+        let table = try #require(representation.pages.first?.tables.first)
+
+        #expect(table.rows.count == 3)
+        #expect(table.columnCount == 2)
+        #expect(table.rows[0].cells.map(\.text) == ["Quarter", "Revenue"])
+        #expect(table.rows[2].cells.map(\.text) == ["Q2", "1800"])
+        #expect(table.anchor.sourceRange?.start.pageIndex == 0)
+        #expect(table.anchor.sourceRange?.boundingBox?.coordinateSpace == .page)
+        #expect(doc.structure.elements(kind: .table).count == 1)
+        #expect(doc.structure.elements(kind: .tableCell).map(\.text).contains("Revenue"))
+    }
+
     // MARK: - Fixtures
 
     private static func writePDF(text: String) throws -> URL {
@@ -171,6 +196,33 @@ struct PDFAdapterTests {
 
             ctx.endPDFPage()
         }
+        ctx.closePDF()
+        return url
+    }
+
+    private static func writeTablePDF(rows: [[String]]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-pdf-table-\(UUID().uuidString).pdf")
+        var mediaBox = CGRect(x: 0, y: 0, width: 320, height: 220)
+        guard let ctx = CGContext(url as CFURL, mediaBox: &mediaBox, nil) else {
+            throw FixtureError.contextCreationFailed
+        }
+        ctx.beginPDFPage(nil)
+
+        let gc = NSGraphicsContext(cgContext: ctx, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = gc
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        for (rowIndex, row) in rows.enumerated() {
+            let y = 160 - rowIndex * 24
+            for (columnIndex, text) in row.enumerated() {
+                NSAttributedString(string: text, attributes: [.font: font])
+                    .draw(at: NSPoint(x: CGFloat(40 + columnIndex * 120), y: CGFloat(y)))
+            }
+        }
+        NSGraphicsContext.restoreGraphicsState()
+
+        ctx.endPDFPage()
         ctx.closePDF()
         return url
     }

--- a/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFAdapterTests.swift
@@ -166,6 +166,35 @@ struct PDFAdapterTests {
         #expect(doc.structure.elements(kind: .tableCell).map(\.text).contains("Revenue"))
     }
 
+    @Test func parse_detectsTableInsideMixedProsePDF() async throws {
+        let url = try Self.writeMixedProseAndTablePDF()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
+        let representation = try #require(doc.representation.underlying as? PDFDocumentRepresentation)
+        let page = try #require(representation.pages.first)
+        let table = try #require(page.tables.first)
+
+        #expect(doc.textFallback.contains("Quarterly summary"))
+        #expect(doc.textFallback.contains("Prepared by Finance"))
+        #expect(page.tables.count == 1)
+        #expect(table.rows.count == 3)
+        #expect(table.rows[0].cells.map(\.text) == ["Metric", "Value"])
+        #expect(table.rows[1].cells.map(\.text) == ["Revenue", "1200"])
+        #expect(table.anchor.metadata["detector"] == "glyph-geometry")
+    }
+
+    @Test func parse_ignoresSingleRowTableCandidateWithoutCrashing() async throws {
+        let url = try Self.writeTablePDF(rows: [["Label", "Value"]])
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let doc = try await PDFAdapter().parse(url: url, sizeLimit: 0)
+        let representation = try #require(doc.representation.underlying as? PDFDocumentRepresentation)
+
+        #expect(representation.pages.first?.tables.isEmpty == true)
+        #expect(doc.structure.elements(kind: .table).isEmpty)
+    }
+
     // MARK: - Fixtures
 
     private static func writePDF(text: String) throws -> URL {
@@ -220,6 +249,48 @@ struct PDFAdapterTests {
                     .draw(at: NSPoint(x: CGFloat(40 + columnIndex * 120), y: CGFloat(y)))
             }
         }
+        NSGraphicsContext.restoreGraphicsState()
+
+        ctx.endPDFPage()
+        ctx.closePDF()
+        return url
+    }
+
+    private static func writeMixedProseAndTablePDF() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-pdf-mixed-table-\(UUID().uuidString).pdf")
+        var mediaBox = CGRect(x: 0, y: 0, width: 360, height: 280)
+        guard let ctx = CGContext(url as CFURL, mediaBox: &mediaBox, nil) else {
+            throw FixtureError.contextCreationFailed
+        }
+        ctx.beginPDFPage(nil)
+
+        let gc = NSGraphicsContext(cgContext: ctx, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = gc
+        let bodyFont = NSFont.systemFont(ofSize: 12)
+        let tableFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+        NSAttributedString(string: "Quarterly summary", attributes: [.font: bodyFont])
+            .draw(at: NSPoint(x: 30, y: 220))
+        NSAttributedString(string: "The table below captures reported values.", attributes: [.font: bodyFont])
+            .draw(at: NSPoint(x: 30, y: 200))
+
+        let rows = [
+            ["Metric", "Value"],
+            ["Revenue", "1200"],
+            ["Expenses", "800"],
+        ]
+        for (rowIndex, row) in rows.enumerated() {
+            let y = 160 - rowIndex * 24
+            for (columnIndex, text) in row.enumerated() {
+                NSAttributedString(string: text, attributes: [.font: tableFont])
+                    .draw(at: NSPoint(x: CGFloat(40 + columnIndex * 130), y: CGFloat(y)))
+            }
+        }
+
+        NSAttributedString(string: "Prepared by Finance", attributes: [.font: bodyFont])
+            .draw(at: NSPoint(x: 30, y: 70))
         NSGraphicsContext.restoreGraphicsState()
 
         ctx.endPDFPage()

--- a/Packages/OsaurusCore/Tests/Documents/PDFTableDetectorTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFTableDetectorTests.swift
@@ -1,0 +1,85 @@
+//
+//  PDFTableDetectorTests.swift
+//  osaurusTests
+//
+//  Pins the pure geometry stages separately from PDFKit so table heuristics can
+//  be tuned without needing binary PDF fixtures for every edge case.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("PDFTableDetector")
+struct PDFTableDetectorTests {
+    @Test func rows_clusterGlyphsByVisualYAndSplitCellsOnWideGaps() {
+        let glyphs = Self.gridGlyphs([
+            ["Name", "Amount", "Status"],
+            ["Alice", "1200", "Paid"],
+        ])
+
+        let rows = PDFTableDetector.rows(from: glyphs)
+
+        #expect(rows.count == 2)
+        #expect(rows[0].cells.map(\.text) == ["Name", "Amount", "Status"])
+        #expect(rows[1].cells.map(\.text) == ["Alice", "1200", "Paid"])
+    }
+
+    @Test func detectTables_groupsAlignedRowsIntoOneTable() {
+        let glyphs = Self.gridGlyphs([
+            ["Quarter", "Revenue"],
+            ["Q1", "1200"],
+            ["Q2", "1800"],
+        ])
+
+        let tables = PDFTableDetector.detectTables(glyphs: glyphs)
+
+        #expect(tables.count == 1)
+        #expect(tables[0].rows.count == 3)
+        #expect(tables[0].rows[2].cells.map(\.text) == ["Q2", "1800"])
+        #expect(tables[0].rows[2].cells.map(\.rowIndex) == [2, 2])
+        #expect(tables[0].rows[2].cells.map(\.columnIndex) == [0, 1])
+    }
+
+    @Test func detectTables_ignoresSingleRowCandidates() {
+        let glyphs = Self.gridGlyphs([["Only", "One", "Row"]])
+
+        #expect(PDFTableDetector.detectTables(glyphs: glyphs).isEmpty)
+    }
+
+    private static func gridGlyphs(_ rows: [[String]]) -> [PDFTableDetector.Glyph] {
+        var glyphs: [PDFTableDetector.Glyph] = []
+        var index = 0
+        let rowHeight: CGFloat = 12
+        let cellWidth: CGFloat = 90
+        let charWidth: CGFloat = 6
+
+        for (rowIndex, row) in rows.enumerated() {
+            let baseline = CGFloat(200 - rowIndex * 24)
+            for (columnIndex, cell) in row.enumerated() {
+                let cellOriginX = CGFloat(40) + CGFloat(columnIndex) * cellWidth
+                var x = cellOriginX
+                for character in cell.map(String.init) {
+                    glyphs.append(
+                        PDFTableDetector.Glyph(
+                            pageIndex: 0,
+                            characterIndex: index,
+                            text: character,
+                            bounds: CGRect(
+                                x: x,
+                                y: baseline,
+                                width: charWidth,
+                                height: rowHeight
+                            )
+                        )
+                    )
+                    index += 1
+                    x += charWidth + 1
+                }
+            }
+        }
+        return glyphs
+    }
+}

--- a/docs/DEVELOPER_TOOLS.md
+++ b/docs/DEVELOPER_TOOLS.md
@@ -297,7 +297,9 @@ Currently env-gated:
 ### Document runtime discovery
 
 Structured document parsing runs in-process for the built-in CSV/TSV, XLSX,
-PPTX/POTX, PDF, and rich-document adapters. The optional office runtime
+PPTX/POTX, PDF, and rich-document adapters. PDF table extraction uses the
+text-layer glyph geometry already exposed by PDFKit; it does not add OCR or a
+third-party PDF engine. The optional office runtime
 detector exists only to discover a local LibreOffice/OpenOffice-compatible
 `soffice` binary for future conversion flows; it probes version metadata and
 never sends document bytes to the runtime.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -299,13 +299,14 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 
 - `Managers/Documents/DocumentAdaptersBootstrap.swift` — registers built-in document adapters.
 - `Models/Documents/Workbook.swift` — typed workbook, sheet, row, and cell representation.
+- `Models/Documents/PDFDocumentRepresentation.swift` — typed PDF pages and heuristic table detections with source anchors.
 - `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, and relationship representation.
 - `Models/Documents/RichDocumentRepresentation.swift` — sections, headings, links, and metadata for rich text sources.
 - `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
 - `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
 - `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
 - `Services/Documents/PPTXAdapter.swift` — PPTX/POTX deck parsing from Office Open XML packages.
-- `Services/Documents/PDFAdapter.swift` — PDF extraction with page-level anchors.
+- `Services/Documents/PDFAdapter.swift` — PDF extraction with page-level anchors and layout-aware text-layer table detection.
 - `Services/Documents/RichDocumentAdapter.swift` — DOCX/RTF/HTML-style rich document structure extraction.
 - `Services/Documents/ExternalOfficeRuntimeDetector.swift` — optional LibreOffice/OpenOffice discovery for future conversion flows; detection reads version metadata only and does not send document bytes to a runtime.
 
@@ -314,7 +315,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - CSV and TSV tables preserve headers, rows, delimiters, and source metadata.
 - XLSX workbooks preserve sheets, cells, shared strings, relationships, and can emit a minimal valid `.xlsx` package.
 - PPTX/POTX decks preserve slide grouping, text runs, notes, and relationships.
-- PDFs preserve page boundaries and anchors so citations can point back to pages.
+- PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
 - Rich documents preserve section boundaries, headings, links, and metadata.
 
 ---


### PR DESCRIPTION
## Business rationale
PDFs are a core business file format, but flat text extraction collapses invoices, statements, and financial reports into prose that loses row and column relationships. This restores user-visible table structure for text-layer PDFs so agents and downstream document tools can inspect pages, tables, rows, and cells without guessing from the text fallback.

## Coding rationale
The PDF adapter now emits a typed `PDFDocumentRepresentation` with page-level `PDFTable` values and table/table-row/table-cell structure elements anchored to page-space bounding boxes. Detection stays inside the existing adapter path, uses PDFKit/CoreGraphics glyph geometry plus deterministic heuristics, adds no new external dependencies or third-party PDF/table libraries, and leaves image-only/scanned PDFs on the existing `emptyContent` fall-through path.

## Acceptance criteria
- [x] Layout-aware PDF table extraction extends the existing PDF adapter without replacing the adapter registry path.
- [x] Output exposes structured table data as rows x columns via `PDFTable`, `PDFTableRow`, and `PDFTableCell`.
- [x] PDF structure emits page/table/row/cell anchors with page-space bounding boxes.
- [x] Tests cover a clean tabular PDF, mixed prose plus table, and a graceful no-table/no-crash heuristic miss.
- [x] Documentation lists PDF table extraction as a supported PDF feature.
- [x] No new external dependencies, Python dependencies, JVM dependencies, or third-party PDF table libraries.

## Quality gate
- [x] `swift-format lint --strict --recursive Packages App` - green
- [x] `swiftlint lint --reporter github-actions-logging` - green (`Done linting! Found 1118 violations, 0 serious in 585 files.`)
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` - green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` - green
- [x] `make ci-test` - green
- [x] `swift build --package-path Packages/OsaurusCore -c release` - green
- [x] Archive freshness - confirmed with `git fetch --all --prune` before gate and again before push; final base `origin/main=e0fea4a2e9d8f2d0d7084164f7cac5f82b870245`, merge-base matches.

## Debug evidence
Focused PDF evidence:
```text
✔ Test parse_detectsSimpleTextLayerTable() passed after 0.037 seconds.
✔ Test parse_detectsTableInsideMixedProsePDF() passed after 0.037 seconds.
✔ Test parse_ignoresSingleRowTableCandidateWithoutCrashing() passed after 0.037 seconds.
✔ Test run with 13 tests in 2 suites passed after 0.038 seconds.
```

Full gate evidence after the clean rebase onto `origin/main=e0fea4a2e9d8f2d0d7084164f7cac5f82b870245`:
```text
swift-format: exited 0 with no output
swiftlint: Done linting! Found 1118 violations, 0 serious in 585 files.
shellcheck: exited 0 with no output
swift test --package-path Packages/OsaurusCLI --parallel: ✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
make ci-test: Done. Inspect failures with: open build/Tests.xcresult
swift build --package-path Packages/OsaurusCore -c release: Build complete! (177.39s)
```

Rebase/freshness evidence:
```text
origin/main advanced from 6075636106c26a51c43847cb56798e7595027900 to e0fea4a2e9d8f2d0d7084164f7cac5f82b870245 during the first pre-push freshness check.
git rebase origin/main: Successfully rebased and updated refs/heads/codex/t-j-pdf-tables.
final HEAD: 55623072ee98cd5cb5ce8cc1713bbb80a295a77b
final merge-base: e0fea4a2e9d8f2d0d7084164f7cac5f82b870245
```

## Rollback
Revert this PR's commits. There are no migrations, feature flags, package additions, or dependency changes to unwind.
