### PR TITLE
Add Keenable to Remote MCP Providers catalog

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/MCPProviderTemplate.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MCPProviderTemplate.swift
@@ -191,6 +191,14 @@ public struct MCPProviderTemplate: Identifiable, Sendable, Equatable {
             tagline: "Search models, datasets, papers, and Spaces"
         ),
         MCPProviderTemplate(
+            id: "keenable",
+            displayName: "Keenable",
+            url: "https://api.keenable.ai/mcp",
+            authType: .none,
+            iconSystemName: "magnifyingglass",
+            tagline: "Web search for AI agents"
+        ),
+        MCPProviderTemplate(
             id: "linear",
             displayName: "Linear",
             url: "https://mcp.linear.app/mcp",

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -60,7 +60,7 @@ The key is written to your macOS Keychain (never to disk in plaintext) and sent 
 
 #### No Auth
 
-Used by DeepWiki, Exa Search.
+Used by DeepWiki, Exa Search, Keenable.
 
 - A small green **This server doesn't require authentication.** confirmation.
 - Click **Add Provider**.
@@ -94,6 +94,7 @@ The catalog is hardcoded in [`MCPProviderTemplate.swift`](../Packages/OsaurusCor
 | **Google Workspace** | Productivity        | _self-hosted_ | (user-supplied — see [community project](https://github.com/taylorwilsdon/google_workspace_mcp)) |
 | **HubSpot**          | CRM                 | API Key  | `https://app.hubspot.com/mcp/v1/http`                                                               |
 | **Hugging Face**     | AI                  | OAuth    | `https://huggingface.co/mcp`                                                                        |
+| **Keenable**         | Search              | None     | `https://api.keenable.ai/mcp`                                                                       |
 | **Linear**           | Project Management  | OAuth    | `https://mcp.linear.app/mcp`                                                                        |
 | **monday.com**       | Project Management  | OAuth    | `https://mcp.monday.com/mcp`                                                                        |
 | **Neon**             | Database            | OAuth    | `https://mcp.neon.tech/mcp`                                                                         |


### PR DESCRIPTION
## Summary

- New `MCPProviderTemplate` entry for **Keenable** (web search for AI agents), inserted alphabetically between Hugging Face and Linear.
- `authType: .none` — Keenable's MCP endpoint at `https://api.keenable.ai/mcp` is unauthenticated under per-IP rate limits (verified live: returns `keenable-mcp-server 0.1.7` on `initialize`).
- Icon `magnifyingglass` matches Exa Search; tagline mirrors Keenable's positioning.
- `docs/REMOTE_MCP_PROVIDERS.md` updated with the catalog row + no-auth section.

## Test plan

- [ ] `swift test --filter MCPProviderTemplateTests` passes (no new template-test edits required — entry satisfies https-URL, populated icon/tagline, unique id/name, and the alphabetical-order assertion by construction).
- [ ] App: `⌘⇧M → Providers → + Add Provider` → confirm Keenable card appears between Hugging Face and Linear with the magnifying-glass icon, the no-auth confirm screen shows, and Add Provider creates a working `MCPProvider` against `https://api.keenable.ai/mcp`.
- [ ] Tool discovery: Keenable's tools (`search_web_pages`, `fetch_page_content`, `submit_search_feedback`) appear in the tool inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)