### PR TITLE
hide migration overlay for fresh installs

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -172,6 +172,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // updates keep painting.
         StorageMigrationCoordinator.blockingAwaitReady()
 
+        // Deferred from `ServerController.init()` to keep
+        // `~/.osaurus/` pristine until the storage gate has stamped
+        // `.storage-version`. See `bootstrapRuntimeSettings()`.
+        serverController.bootstrapRuntimeSettings()
+
         // Wire up the periodic SQLite maintenance ticker (PRAGMA
         // optimize / wal_checkpoint / VACUUM at sensible intervals).
         // Idempotent — safe even if some DBs aren't open yet, the

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -182,15 +182,16 @@ final class ServerController: ObservableObject {
     // Capture singleton pointer on init attach to UI
     init() {
         ServerControllerHolder.shared.controller = self
-        // Load persisted configuration if available
         if let saved = ServerConfigurationStore.load() {
             self.configuration = saved
         }
-        // Load (or one-time migrate) the canonical vmlx runtime
-        // settings. Migration uses the freshly-loaded
-        // `ServerConfiguration` above so the two stay aligned on first
-        // launch.
-        self.runtimeSettings = ServerRuntimeSettingsStore.loadOrMigrate()
+        // Read-only load. The legacy → vmlx migration (which writes to
+        // `~/.osaurus/config/`) is intentionally deferred to
+        // `bootstrapRuntimeSettings()` so a fresh install stays
+        // pristine until after the storage migrator's gate runs.
+        if let existing = ServerRuntimeSettingsStore.load() {
+            self.runtimeSettings = existing
+        }
         // Keep exposeToNetwork in sync with Bonjour-enabled agents
         agentsCancellable = AgentManager.shared.$agents
             .sink { agents in
@@ -209,6 +210,25 @@ final class ServerController: ObservableObject {
                     }
                 }
             }
+    }
+
+    /// Runs the one-shot legacy → vmlx runtime-settings migration and
+    /// publishes the result. Idempotent — on a non-fresh install
+    /// `loadOrMigrate()` just returns the on-disk value without
+    /// writing.
+    ///
+    /// Must be invoked from the AppDelegate immediately after
+    /// `StorageMigrationCoordinator.blockingAwaitReady()` returns.
+    /// `init()` skips this because `ServerController` is constructed
+    /// as a stored property of the AppDelegate (i.e. before
+    /// `applicationDidFinishLaunching`), and the migration's first-run
+    /// `save()` would otherwise create `config/server-runtime.json`
+    /// in `~/.osaurus/` *before* the storage migrator's
+    /// `isPristineInstall()` check, flipping a true fresh install
+    /// out of the pristine fast path and painting the "Securing your
+    /// data" overlay over onboarding.
+    func bootstrapRuntimeSettings() {
+        self.runtimeSettings = ServerRuntimeSettingsStore.loadOrMigrate()
     }
 
     /// Checks if the server is responsive

--- a/Packages/OsaurusCore/Storage/StorageMigrator.swift
+++ b/Packages/OsaurusCore/Storage/StorageMigrator.swift
@@ -233,6 +233,15 @@ public actor StorageMigrator {
             return containsOnlyBuiltInThemeJSON(url)
         }
 
+        // Belt-and-suspenders for `config/`: the primary fix defers
+        // every pre-gate write into `~/.osaurus/config/`, but allow a
+        // future regression to land without re-flashing the overlay
+        // by accepting a directory that holds only the known bootstrap
+        // files. Anything user-touched falls through.
+        if entry == "config" {
+            return containsOnlyBootstrapConfigFiles(url)
+        }
+
         return false
     }
 
@@ -261,6 +270,40 @@ public actor StorageMigrator {
                 let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                 object["isBuiltIn"] as? Bool == true
             else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Files the app can write into `~/.osaurus/config/` automatically
+    /// on first launch, before the user has touched any setting. Any
+    /// other JSON (chat, tools, memory, populated voice/*.json, …)
+    /// counts as user data.
+    private static let bootstrapConfigFileNames: Set<String> = [
+        "server-runtime.json",
+        "server.json",
+    ]
+
+    private func containsOnlyBootstrapConfigFiles(_ url: URL) -> Bool {
+        let entries =
+            (try? FileManager.default.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+
+        for entry in entries {
+            let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir {
+                // `voice/` may be eagerly created by speech services
+                // even before any save lands. Tolerate it iff empty.
+                if entry.lastPathComponent == "voice", isDirectoryEmpty(entry) {
+                    continue
+                }
+                return false
+            }
+            if !Self.bootstrapConfigFileNames.contains(entry.lastPathComponent) {
                 return false
             }
         }

--- a/Packages/OsaurusCore/Tests/Storage/StorageMigrationGapTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/StorageMigrationGapTests.swift
@@ -131,6 +131,46 @@ struct StorageMigrationGapTests {
         }
     }
 
+    /// Bootstrap files written by `ServerController` (or any future
+    /// pre-gate writer) into `config/` must not flip the install out
+    /// of the pristine fast path. Mirrors `themes/` above.
+    @Test
+    func freshInstall_ignoresServerRuntimeBootstrap() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try Self.setUpTempRoot()
+            defer { Self.tearDown(root) }
+
+            let configDir = root.appendingPathComponent("config", isDirectory: true)
+            try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: configDir.appendingPathComponent("server-runtime.json"))
+            try Data("{}".utf8).write(to: configDir.appendingPathComponent("server.json"))
+            try FileManager.default.createDirectory(
+                at: configDir.appendingPathComponent("voice", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+
+            let pristine = await StorageMigrator.shared.isPristineInstall()
+            #expect(pristine)
+        }
+    }
+
+    /// Any user-touched config file means the install is no longer
+    /// pristine and the migrator must run its full path.
+    @Test
+    func freshInstall_treatsUserConfigAsUserData() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try Self.setUpTempRoot()
+            defer { Self.tearDown(root) }
+
+            let configDir = root.appendingPathComponent("config", isDirectory: true)
+            try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: configDir.appendingPathComponent("chat.json"))
+
+            let pristine = await StorageMigrator.shared.isPristineInstall()
+            #expect(!pristine)
+        }
+    }
+
     // MARK: - Backup retention
 
     @Test

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -379,7 +379,7 @@ struct FloatingInputCard: View {
 
                 // Load voice config (cached after first load)
                 loadVoiceConfig()
-                
+
                 if voiceConfig.voiceInputEnabled && !speechService.isModelLoaded
                     && !speechService.isLoadingModel
                     && AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
@@ -576,8 +576,8 @@ struct FloatingInputCard: View {
                 primaryButton: .primary("Open System Settings") {
                     if let url = URL(
                         string:
-                            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-                    {
+                            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+                    ) {
                         NSWorkspace.shared.open(url)
                     }
                 },


### PR DESCRIPTION
## Summary

fixed bug with migration overlay

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
