### PR TITLE
[codex] Guard remote provider connect retry invalidation

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -672,6 +672,9 @@ public actor RemoteProviderService: ToolCapableService {
                     throw lastError ?? CancellationError()
                 }
             }
+            if Task.isCancelled || isCancelled() {
+                throw lastError ?? CancellationError()
+            }
             do {
                 return try await session.bytes(for: urlRequest)
             } catch {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderConnectRetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderConnectRetryTests.swift
@@ -1,0 +1,33 @@
+//
+//  RemoteProviderConnectRetryTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("RemoteProviderService connect retry")
+struct RemoteProviderConnectRetryTests {
+
+    @Test func connectWithRetry_stopsBeforeFirstAttemptWhenCancelled() async throws {
+        let session = URLSession(configuration: .ephemeral)
+        session.invalidateAndCancel()
+
+        let request = URLRequest(url: try #require(URL(string: "http://127.0.0.1:9/v1/chat/completions")))
+
+        do {
+            _ = try await RemoteProviderService.connectWithRetry(
+                session: session,
+                urlRequest: request,
+                isCancelled: { true }
+            )
+            Issue.record("Expected connectWithRetry to throw before using an invalidated URLSession.")
+        } catch is CancellationError {
+            // Expected: the invalidation guard fires before URLSession.bytes(for:).
+        } catch {
+            Issue.record("Expected CancellationError, got \(error).")
+        }
+    }
+}


### PR DESCRIPTION
## Business rationale

GitHub's `test-core` job for #1192 crashed the entire xctest process while running otherwise unrelated tests. The diagnostic artifact shows an uncatchable `NSURLSession.bytes(for:)` exception raised from `RemoteProviderService.connectWithRetry` after a sibling task invalidated the service session. That makes the CI gate unreliable for humans reviewing small PRs: a green local gate can still fail remotely with a process abort instead of an actionable assertion. This PR closes the race so invalidated-session work exits through Swift cancellation handling instead of crashing the test process.

## Coding rationale

`RemoteProviderService` already carried the architectural choice: `invalidateSession()` sets a lock-backed invalidation flag, and `_streamRemote` passes that flag into `connectWithRetry` as an `isCancelled` closure. The missing piece was that `connectWithRetry` only consulted the closure after retry backoff, not before the first `URLSession.bytes(for:)` attempt. I considered changing session lifetime ownership or adding a broader Objective-C exception bridge, but both would be larger trust-boundary changes in networking code. The narrow fix keeps the existing registry of responsibility intact: check the existing cancellation closure before every `bytes(for:)` attempt, including attempt zero. No new dependencies are added.

## Acceptance criteria

- [x] `connectWithRetry` checks task cancellation / service invalidation before the first `URLSession.bytes(for:)` attempt.
- [x] Regression coverage proves an already-invalidated session with `isCancelled == true` returns a Swift `CancellationError` path rather than touching Foundation's invalid-session trap.
- [x] Existing retry behavior remains otherwise unchanged.
- [x] No new external dependencies.

## Quality gate

- [x] `swift-format lint --strict --recursive Packages App` — green
- [x] `swiftlint lint --reporter github-actions-logging` — green (`Done linting! Found 1158 violations, 0 serious in 616 files.`)
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green (`77/77` listed, Swift Testing runner passed)
- [x] `make ci-test` — green (`Done. Inspect failures with: open build/Tests.xcresult`)
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green (`Build complete! (218.54s)`)
- [x] Archive freshness — confirmed (`git fetch --all --prune` immediately before push; `origin/main...HEAD` was `0 1`)

## Debug evidence

Failing GitHub artifact from #1192 `test-core`:

```text
lastExceptionBacktrace: -[__NSURLSessionLocal taskForClassInfo:]
NSURLSession.bytes(for:delegate:)
RemoteProviderService.connectWithRetry(session:urlRequest:maxAttempts:isCancelled:) sourceLine 676
RemoteProviderService._streamRemote(...) sourceLine 1383
triggered thread: abort -> objc_exception_throw -> NSURLSession.bytes(for:delegate:) -> connectWithRetry
```

Focused local regression after the fix:

```text
Testing started
Test Suite RemoteProviderConnectRetryTests started on 'My Mac - xctest'
xcodebuild ... -only-testing:OsaurusCoreTests/RemoteProviderConnectRetryTests/connectWithRetry_stopsBeforeFirstAttemptWhenCancelled
exit 0
```

Full local CI reproduction after the fix:

```text
✔ [SandboxPluginRegistrationTests] validateAndStage_rejectsMissingSecrets on 'My Mac - xctest'
Done. Inspect failures with: open build/Tests.xcresult
```

## Rollback

```sh
git revert c02b7cc2
```
