### PR TITLE
restore auto connect for remote providers at launch

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -266,9 +266,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             await serverController.startServer()
         }
 
-        // Do not auto-connect keychain-backed providers at launch. Explicit
-        // provider connect actions may read credentials; startup must not.
         Task { @MainActor in
+            await MCPProviderManager.shared.connectEnabledProviders()
+            await RemoteProviderManager.shared.connectEnabledProviders()
             await ModelPickerItemCache.shared.prewarmModelCache()
         }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -74,8 +74,8 @@ struct RuntimePolicySourceTests {
         #expect(serverStart.lowerBound < schedulerStart.lowerBound)
         #expect(serverStart.lowerBound < speechAutoload.lowerBound)
         #expect(source.contains("await serverStartupTask.value"))
-        #expect(!source.contains("MCPProviderManager.shared.connectEnabledProviders()"))
-        #expect(!source.contains("RemoteProviderManager.shared.connectEnabledProviders()"))
+        #expect(source.contains("MCPProviderManager.shared.connectEnabledProviders()"))
+        #expect(source.contains("RemoteProviderManager.shared.connectEnabledProviders()"))
     }
 
     @Test("AppDelegate does not read the storage key before database opens")


### PR DESCRIPTION
## Summary

addresses #1198 

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
