### PR TITLE
Keep chat completions context pass-through

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1837,14 +1837,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     // MARK: - Chat handlers
 
-    /// Enrich a chat request with the agent's system prompt and memory context
-    /// when an agent ID is provided via the `X-Osaurus-Agent-Id` header.
+    /// Enrich an agent-loop request with the agent's system prompt and memory context.
     ///
-    /// Goes through `composeChatContext` (the same entry point the chat UI
-    /// uses) and then injects the rendered prompt + memory snippet into the
-    /// outgoing message array. `executionMode: .none` matches the original
-    /// HTTP-path semantics — sandbox / folder modes are chat-window-only;
-    /// HTTP requests don't have one of those bound.
+    /// Goes through `composeChatContext` and injects the rendered prompt +
+    /// memory snippet into the outgoing message array. Do not call this from
+    /// the strict OpenAI-compatible `/chat/completions` path; that endpoint
+    /// passes client messages/tools through unchanged.
     private static func enrichWithAgentContext(
         _ request: ChatCompletionRequest,
         agentId: String?
@@ -3774,12 +3772,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 do {
                     httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
-                    let enrichedReq = await Self.enrichWithAgentContext(req, agentId: memoryAgentId)
-                    httpTrace.mark("http_enrich_done")
+                    let enrichedReq = req
+                    httpTrace.mark("http_context_passthrough_done")
                     httpTrace.set("http_enriched_message_count", enrichedReq.messages.count)
 
-                    // Compute prefix evidence after enrichment so it tracks
-                    // the actual system prompt + tool schema payload sent.
+                    // Compute prefix evidence from the exact request sent to
+                    // the OpenAI-compatible server path. Agent context is
+                    // intentionally not injected here; the app chat and
+                    // /agents/{id}/run paths own composed context.
                     let prefixHash: String = {
                         let sysContent = enrichedReq.messages.first(where: { $0.role == "system" })?.content ?? ""
                         return ModelRuntime.computePrefixHash(
@@ -4059,14 +4059,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 do {
                     httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
-                    let enrichedReq = await Self.enrichWithAgentContext(req, agentId: memoryAgentId)
-                    httpTrace.mark("http_enrich_done")
+                    let enrichedReq = req
+                    httpTrace.mark("http_context_passthrough_done")
                     httpTrace.set("http_enriched_message_count", enrichedReq.messages.count)
                     httpTrace.mark("http_complete_chat_start")
                     var resp = try await chatEngine.completeChat(request: enrichedReq)
                     httpTrace.mark("http_complete_chat_done")
-                    // Compute prefix evidence after enrichment so it tracks
-                    // the actual system prompt + tool schema payload sent.
+                    // Compute prefix evidence from the exact request sent to
+                    // the OpenAI-compatible server path. Agent context is
+                    // intentionally not injected here; the app chat and
+                    // /agents/{id}/run paths own composed context.
                     let sysContent = enrichedReq.messages.first(where: { $0.role == "system" })?.content ?? ""
                     resp.prefix_hash = ModelRuntime.computePrefixHash(
                         systemContent: sysContent,

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -18,6 +18,112 @@ fileprivate extension URLRequest {
 }
 
 struct HTTPHandlerChatStreamingTests {
+    @Test func chatCompletions_agentHeaderDoesNotInjectAgentContext() async throws {
+        actor Capture {
+            var request: ChatCompletionRequest?
+            func record(_ request: ChatCompletionRequest) { self.request = request }
+        }
+
+        struct CaptureEngine: ChatEngineProtocol {
+            let capture: Capture
+
+            func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+                fatalError("not used")
+            }
+
+            func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+                await capture.record(request)
+                let choice = ChatChoice(
+                    index: 0,
+                    message: ChatMessage(role: "assistant", content: "ok"),
+                    finish_reason: "stop"
+                )
+                return ChatCompletionResponse(
+                    id: "chatcmpl-test",
+                    created: 0,
+                    model: request.model,
+                    choices: [choice],
+                    usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0),
+                    system_fingerprint: nil
+                )
+            }
+        }
+
+        try await SandboxTestLock.runWithStoragePaths {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-http-strict-context-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            AgentManager.shared.refresh()
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let agent = Agent(
+                name: "HTTPStrictContext-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "DO-NOT-INJECT-HTTP-CONTEXT",
+                agentAddress: "http-strict-\(UUID().uuidString)",
+                manualToolNames: ["capabilities_search"]
+            )
+            AgentManager.shared.add(agent)
+
+            let capture = Capture()
+            let server = try await startTestServer(with: CaptureEngine(capture: capture))
+            defer { Task { await server.shutdown() } }
+
+            let clientTool = Tool(
+                type: "function",
+                function: ToolFunction(
+                    name: "client_only_tool",
+                    description: "Client supplied tool",
+                    parameters: .object(["type": .string("object")])
+                )
+            )
+            var request = URLRequest(
+                url: URL(string: "http://\(server.host):\(server.port)/chat/completions")!
+            )
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue(agent.id.uuidString, forHTTPHeaderField: "X-Osaurus-Agent-Id")
+            request.authenticate()
+            request.disablePersistenceForTests()
+            let reqBody = ChatCompletionRequest(
+                model: "fake",
+                messages: [ChatMessage(role: "user", content: "plain API request")],
+                temperature: 0.5,
+                max_tokens: 16,
+                stream: false,
+                top_p: nil,
+                frequency_penalty: nil,
+                presence_penalty: nil,
+                stop: nil,
+                n: nil,
+                tools: [clientTool],
+                tool_choice: nil,
+                session_id: nil
+            )
+            request.httpBody = try JSONEncoder().encode(reqBody)
+
+            let (_, resp) = try await URLSession.shared.data(for: request)
+            #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+
+            let captured = await capture.request
+            #expect(captured?.messages.count == 1)
+            #expect(captured?.messages.first?.role == "user")
+            #expect(captured?.messages.first?.content == "plain API request")
+            #expect(captured?.messages.contains { $0.role == "system" } == false)
+            #expect(captured?.messages.first?.content?.contains("[Memory]") == false)
+            #expect(captured?.messages.first?.content?.contains("DO-NOT-INJECT-HTTP-CONTEXT") == false)
+            #expect(captured?.tools?.map(\.function.name) == ["client_only_tool"])
+            #expect(captured?.tool_choice == nil)
+            _ = await AgentManager.shared.delete(id: agent.id)
+        }
+    }
 
     @Test func sse_path_writes_role_content_finish_done() async throws {
         let server = try await startTestServer(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -194,7 +194,7 @@ struct RuntimePolicySourceTests {
         #expect(serverView.contains("reloadAccessKeys(readKeychain: true)"))
     }
 
-    @Test("plugin host inference carries agent memory like HTTP chat")
+    @Test("plugin host inference carries agent memory")
     func pluginHostInferenceInjectsAgentMemoryPrefix() throws {
         let source = try Self.source("Services/Plugin/PluginHostAPI.swift")
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1216,7 +1216,7 @@ Eight settings total, down from v1's 18. The per-section budget knobs, MMR tunin
 
 **Tool API:** `search_memory(scope, query)` with three scopes: `pinned`, `episodes`, `transcript`. Replaces v1's five-scope tool.
 
-**HTTP API:** Same `X-Osaurus-Agent-Id` header for read-side context injection. `POST /memory/ingest` writes transcripts and triggers an immediate distillation flush after the batch (no need to wait for the writer's debounce).
+**HTTP API:** `POST /memory/ingest` writes transcripts and triggers an immediate distillation flush after the batch (no need to wait for the writer's debounce). Strict `/chat/completions` requests do not inject read-side memory; app chat, `POST /agents/{id}/run`, and plugin host inference own composed agent context.
 
 **Storage:** `~/.osaurus/memory/memory.sqlite` (SQLite with WAL mode), `~/.osaurus/memory/vectura/` (vector index)
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -210,9 +210,11 @@ The MMR reranker uses 4-character word shingles for cheap content overlap — mu
 
 ## API Integration
 
-### Memory Context Injection — `X-Osaurus-Agent-Id`
+### Runtime Context Injection
 
-Add the `X-Osaurus-Agent-Id` header to any `POST /chat/completions` request. Osaurus runs the relevance gate against the user's message, picks at most one memory section, and prepends it (along with always-on identity overrides) to the request.
+Memory context is injected only by Osaurus-composed agent surfaces: app chat windows, `POST /agents/{id}/run`, and plugin host inference. Those paths run the relevance gate against the user's message, pick at most one memory section, and prepend it to the latest user message.
+
+Strict `POST /chat/completions` requests do not inject Osaurus memory, agent prompts, skills, or tools. `X-Osaurus-Agent-Id` may associate persisted HTTP history with an agent/session, but it is not a memory injection switch.
 
 ```python
 from openai import OpenAI
@@ -220,7 +222,6 @@ from openai import OpenAI
 client = OpenAI(
     base_url="http://127.0.0.1:1337/v1",
     api_key="osaurus",
-    default_headers={"X-Osaurus-Agent-Id": "my-agent"},
 )
 
 response = client.chat.completions.create(
@@ -228,8 +229,6 @@ response = client.chat.completions.create(
     messages=[{"role": "user", "content": "What did we talk about last week?"}],
 )
 ```
-
-Header values are arbitrary strings.
 
 ### Memory Ingestion — `POST /memory/ingest`
 

--- a/docs/OpenAI_API_GUIDE.md
+++ b/docs/OpenAI_API_GUIDE.md
@@ -548,13 +548,21 @@ curl http://127.0.0.1:1337/v1/responses \
 
 ## Memory API
 
-Osaurus provides a persistent memory system that can be used via the API. The v2 system distills sessions in the background, then injects at most one compact memory section (~800 tokens by default) into requests where the user's query actually needs it. See [docs/MEMORY.md](MEMORY.md) for the full architecture.
+Osaurus provides a persistent memory system that can be used by the app chat and agent APIs. The v2 system distills sessions in the background, then the composed agent context can include at most one compact memory section (~800 tokens by default) when the user's query actually needs it. See [docs/MEMORY.md](MEMORY.md) for the full architecture.
 
-### Memory Context Injection — `X-Osaurus-Agent-Id` Header
+### Agent Context and `/chat/completions`
 
-Add the `X-Osaurus-Agent-Id` header to any `POST /chat/completions` request. Osaurus runs a relevance gate against the latest user message, picks at most one memory section (identity, pinned facts, episodes, or transcript), and prepends it — together with always-on identity overrides — to the user message.
+`POST /chat/completions` is a strict OpenAI-compatible inference endpoint. It does not inject Osaurus agent prompts, memory, skills, or tools into the request. Client-supplied `messages`, `tools`, and `tool_choice` are passed through as the server-side inference contract.
 
-The header value is an arbitrary string that identifies the agent or user session whose memory should be retrieved.
+Use these surfaces when you want Osaurus-composed agent context:
+
+- App chat windows: system prompt, memory, folder/sandbox context, selected skills, and tools are composed by the app before inference.
+- `POST /agents/{id}/run`: runs a server-side autonomous agent loop with that agent's context and tool execution.
+- Plugin host inference APIs: carry the plugin's active agent context by design.
+
+`X-Osaurus-Agent-Id` on `/chat/completions` may still be used to associate persisted HTTP chat history with an agent/session, but it is not a prompt/context injection switch.
+
+Strict pass-through example:
 
 ```bash
 curl http://127.0.0.1:1337/chat/completions \
@@ -585,8 +593,6 @@ response = client.chat.completions.create(
 )
 print(response.choices[0].message.content)
 ```
-
-When the header is absent or empty, the request is processed normally without memory injection.
 
 ### Memory Ingestion — `POST /memory/ingest`
 


### PR DESCRIPTION
## Summary
- keep strict `/chat/completions` requests as pass-through for caller messages, tools, and tool_choice even when `X-Osaurus-Agent-Id` is present
- preserve composed agent context for app chat, `/agents/{id}/run`, and plugin host inference
- update memory/API docs to remove stale read-side injection claims

## Evidence
- Red before fix: `HTTPHandlerChatStreamingTests/chatCompletions_agentHeaderDoesNotInjectAgentContext` showed injected system prompt, agent tools, and `tool_choice=.auto`
- Green after fix: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter HTTPHandlerChatStreamingTests/chatCompletions_agentHeaderDoesNotInjectAgentContext`
- Source-policy guard: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter RuntimePolicySourceTests/pluginHostInferenceInjectsAgentMemoryPrefix`

## Notes
- `X-Osaurus-Agent-Id` on `/chat/completions` remains usable for HTTP history association, but it is no longer a prompt/context injection switch.
- `/agents/{id}/run` still owns server-side autonomous agent context and tool execution.