### PR TITLE
Stabilize storage-path CI gate

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/MemoryUserPrefixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryUserPrefixTests.swift
@@ -76,7 +76,7 @@ struct MemoryUserPrefixTests {
 
     @Test
     func composeChatContext_passesQueryToMemoryRecallGate() async throws {
-        try await SandboxTestLock.shared.run {
+        try await SandboxTestLock.runWithStoragePaths {
             let root = FileManager.default.temporaryDirectory.appendingPathComponent(
                 "osaurus-memory-query-compose-\(UUID().uuidString)",
                 isDirectory: true


### PR DESCRIPTION
## Business rationale

Feature and bug-fix lanes were blocked by intermittent `make ci-test` failures in storage/export tests even when their diffs did not touch storage. The common failure pattern pointed at process-wide `OsaurusPaths.overrideRoot` mutation racing with storage tests. This PR removes that review blocker by serializing the remaining memory-prefix test that mutates the storage root, so unrelated user-facing fixes can be gated against a stable baseline.

## Coding rationale

The change reuses the existing `SandboxTestLock.runWithStoragePaths` helper instead of adding a new synchronization primitive or changing production code. That helper already encodes the canonical lock order for tests that need both sandbox serialization and `StoragePathsTestLock`, so the scope stays to one test call site and avoids any dependency, workflow, or runtime behavior changes.

## Acceptance criteria

- [x] `MemoryUserPrefixTests.composeChatContext_passesQueryToMemoryRecallGate` still passes.
- [x] Storage-path tests no longer race against this test's temporary `OsaurusPaths.overrideRoot` mutation during the full app test gate.
- [x] No production code, dependency, or workflow changes.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Before this baseline fix, full gates on unrelated bug lanes failed in storage/export tests, including `StorageMigrationGapTests/freshInstall_stampsVersionWithoutScanning()` with a missing `.storage-version` under the temp root and `StorageExportServiceCleanupTests/cleanupRemovesOnlyOrphanedPluginDirsAndKeepsKnownOnes()` with `summary.directoriesRemoved -> 0` instead of `1`. After switching the memory-prefix test to the storage-path lock: `MemoryUserPrefixTests.composeChatContext_passesQueryToMemoryRecallGate` passed, `swift test --package-path Packages/OsaurusCLI --parallel` ran 77/77 tests green, `make ci-test` exited 0, and `swift build --package-path Packages/OsaurusCore -c release` completed successfully.

## Rollback

Revert this PR; it only changes the test lock wrapper for `MemoryUserPrefixTests.composeChatContext_passesQueryToMemoryRecallGate`.
