### PR TITLE
Narrow trivial local chat tool schema

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -169,11 +169,12 @@ struct ComposedContext: Sendable {
     /// prefix is what makes the prompt byte-stable across turns once preflight
     /// is cached.
     let memorySection: String?
-    /// Snapshot of the always-loaded tool names this compose used. Callers
-    /// stash it on `SessionToolState.initialAlwaysLoadedNames` after the
-    /// first compose so subsequent composes can freeze the schema against
+    /// Snapshot of the always-loaded tool names resolved for this compose.
+    /// Callers stash it on `SessionToolState.initialAlwaysLoadedNames` after
+    /// the first compose so subsequent composes can freeze the schema against
     /// it via `frozenAlwaysLoadedNames` — preventing tools that register
-    /// mid-session from silently appearing in turn 2.
+    /// mid-session from silently appearing in turn 2. It may include a
+    /// trivial-turn baseline even when `tools` is empty for that one request.
     let alwaysLoadedNames: LoadedTools
     /// Hash of the static prefix + canonical tool payloads for cache evidence.
     let cacheHint: String

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -436,7 +436,15 @@ public struct SystemPromptComposer: Sendable {
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
         )
         trace?.mark("resolve_tools_done")
-        let suppressTrivialToolSchema = isTrivialInput && !resolvedTools.isEmpty
+        let suppressTrivialToolSchema = shouldSuppressTrivialToolSchema(
+            isTrivialInput: isTrivialInput,
+            executionMode: executionMode,
+            messages: messages,
+            cachedPreflight: cachedPreflight,
+            additionalToolNames: additionalToolNames,
+            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
+            resolvedTools: resolvedTools
+        )
         if suppressTrivialToolSchema {
             trace?.set("toolSchemaSuppressed", "trivial")
         }
@@ -473,6 +481,27 @@ public struct SystemPromptComposer: Sendable {
             capabilityPromptSectionsEnabled: !isTrivialInput,
             agentLoopGuidanceEnabled: hasPriorAgentLoopUse(messages)
         )
+    }
+
+    /// Keep #1161's greeting-only fast path to the clean first-turn shape.
+    /// Cached preflight, frozen baselines, loaded tools, execution modes, or
+    /// prior messages all mean the user is already in a task context where an
+    /// acknowledgement like "ok" may still need loop/discovery tools.
+    private static func shouldSuppressTrivialToolSchema(
+        isTrivialInput: Bool,
+        executionMode: ExecutionMode,
+        messages: [ChatMessage],
+        cachedPreflight: PreflightResult?,
+        additionalToolNames: LoadedTools,
+        frozenAlwaysLoadedNames: LoadedTools?,
+        resolvedTools: [Tool]
+    ) -> Bool {
+        guard isTrivialInput, !resolvedTools.isEmpty else { return false }
+        guard case .none = executionMode else { return false }
+        return messages.isEmpty
+            && cachedPreflight == nil
+            && additionalToolNames.isEmpty
+            && frozenAlwaysLoadedNames == nil
     }
 
     /// Pick the preflight to use this turn: cached (skip the LLM call),

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -427,7 +427,7 @@ public struct SystemPromptComposer: Sendable {
         )
 
         trace?.mark("resolve_tools_start")
-        let tools = resolveTools(
+        let resolvedTools = resolveTools(
             snapshot: snapshot,
             executionMode: executionMode,
             toolsDisabled: effectiveToolsOff,
@@ -436,9 +436,18 @@ public struct SystemPromptComposer: Sendable {
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
         )
         trace?.mark("resolve_tools_done")
+        let suppressTrivialToolSchema = isTrivialInput && !resolvedTools.isEmpty
+        if suppressTrivialToolSchema {
+            trace?.set("toolSchemaSuppressed", "trivial")
+        }
+        // #1161 reports clean raw local completions but corrupted UI/local
+        // chat for greetings. Keep those tiny turns on the no-tool path, while
+        // preserving the baseline below so the next real task can still freeze
+        // against the always-loaded tools that were available at session start.
+        let tools = suppressTrivialToolSchema ? [] : resolvedTools
 
         let alwaysLoadedNames = resolveAlwaysLoadedNames(
-            tools: tools,
+            tools: resolvedTools,
             executionMode: executionMode,
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames
         )

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -203,11 +203,11 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// A greeting should not run preflight or carry dynamic discovery
-    /// prompt text. The callable bootstrap tools remain present so the
-    /// session can grow as soon as the user asks for real work.
-    @Test("compose: trivial greeting skips dynamic capability prompt sections")
-    func trivialGreeting_skipsPreflightAndDynamicPromptSections() async {
+    /// A greeting should not run preflight, carry dynamic discovery prompt
+    /// text, or enter the local tool-template path. Keep the always-loaded
+    /// baseline frozen separately so turn 2 can grow into real work.
+    @Test("compose: trivial greeting suppresses tool schema and dynamic prompt sections")
+    func trivialGreeting_suppressesToolSchemaAndDynamicPromptSections() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let context = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
@@ -220,7 +220,36 @@ struct ContextBudgetPreviewTests {
             #expect(ids.contains("capabilityNudge") == false)
             #expect(ids.contains("pluginCreator") == false)
             #expect(ids.contains("agentLoopGuidance") == false)
-            #expect(context.tools.contains { $0.function.name == "capabilities_load" })
+            #expect(context.tools.isEmpty)
+            #expect(context.toolTokens == 0)
+            #expect(context.alwaysLoadedNames.contains("capabilities_load"))
+        }
+    }
+
+    /// The greeting-only fast path must not poison the session freeze. After
+    /// a trivial first turn, a real request still gets the bootstrap catalog
+    /// needed to load/discover capabilities.
+    @Test("compose: real task after greeting restores bootstrap tools")
+    func realTaskAfterGreeting_restoresBootstrapTools() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let greeting = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "hi!"
+            )
+            let followUp = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "summarize this project",
+                cachedPreflight: greeting.preflight,
+                frozenAlwaysLoadedNames: greeting.alwaysLoadedNames
+            )
+
+            #expect(greeting.tools.isEmpty)
+            #expect(greeting.alwaysLoadedNames.contains("capabilities_load"))
+            #expect(followUp.tools.contains { $0.function.name == "capabilities_load" })
+            #expect(followUp.tools.contains { $0.function.name == "capabilities_search" })
+            #expect(followUp.toolTokens > 0)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -253,6 +253,31 @@ struct ContextBudgetPreviewTests {
         }
     }
 
+    /// "ok" is only harmless on a clean first turn. Once the session has
+    /// cached tool state or prior task history, an acknowledgement can be the
+    /// user's confirmation for a `clarify`/loop step and must keep schemas.
+    @Test("compose: trivial continuation with cached state keeps bootstrap tools")
+    func trivialContinuationWithCachedState_keepsBootstrapTools() async {
+        await withAgent(toolSelectionMode: .auto) { agentId in
+            let frozen = LoadedTools(
+                ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)
+            )
+            let context = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "ok",
+                messages: [ChatMessage(role: "user", content: "summarize this project")],
+                cachedPreflight: .empty,
+                frozenAlwaysLoadedNames: frozen
+            )
+
+            #expect(SystemPromptComposer.isTrivialPreflightQuery("ok"))
+            #expect(context.tools.contains { $0.function.name == "capabilities_load" })
+            #expect(context.tools.contains { $0.function.name == "capabilities_search" })
+            #expect(context.toolTokens > 0)
+        }
+    }
+
     /// Once history contains an agent-loop call, the continuation guide is
     /// worth the prompt cost. This keeps multi-step sessions stable without
     /// charging the first "hello" or "can you..." turn.

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1037,6 +1037,14 @@ struct RuntimePolicySourceTests {
             "The UI may pass the agent/profile temperature, but it must also mark sampling implicit so native MTP can force greedy defaults."
         )
         #expect(
+            chatView.contains("tools: toolSpecs.isEmpty ? nil : toolSpecs"),
+            "Chat UI should only send tool schemas when the composer resolved a non-empty tool set."
+        )
+        #expect(
+            chatView.contains("tool_choice: toolSpecs.isEmpty ? nil : .auto"),
+            "Chat UI should keep the local no-tool path available by omitting auto tool choice when no tools are resolved."
+        )
+        #expect(
             chatView.contains("finalReq.samplingParametersAreImplicit = true"),
             "Tool-budget wrap-up calls use the same implicit-sampling contract as normal UI turns."
         )


### PR DESCRIPTION
## Business rationale
Issue #1161 narrowed the local-model corruption report away from raw MLX/OpenAI-compatible API output and toward the UI chat / agent middleware path: the reporter reproduced clean `/v1/chat/completions` responses while UI chats and tool/agent pipelines still produced malformed repetitive text. This PR keeps clean first-turn greetings and acknowledgements off the tool-template path so a simple `hi` or `hola` does not pay for bootstrap schemas, preflight prompt prose, or dynamic capability sections before the user has asked for a task. The observable signal is that trivial first turns now compose with zero tool schema tokens, while the next real request restores the bootstrap tool catalog.

## Coding rationale
I kept the fix inside `SystemPromptComposer` instead of changing MLX/runtime generation or removing tools globally, because the bug evidence points at context/tool middleware rather than raw inference. The suppression is deliberately narrow: it only applies to trivial input in `.none` execution mode with no prior messages, no cached preflight, no extra loaded tools, and no frozen always-loaded baseline. That preserves tool discovery and loop tools for continuations like `ok` inside an active task while still reducing first-turn prompt and schema load for greetings. The trust boundary crossed here is the chat-composition boundary that decides which host tool schemas are exposed to the local model.

## Acceptance criteria
- [x] Clean trivial first-turn greetings skip preflight/dynamic capability prompt sections and expose no tool schemas.
- [x] A follow-up real task after a greeting restores bootstrap discovery tools instead of poisoning the session baseline.
- [x] Trivial continuations with cached state or prior history keep tool schemas so acknowledgements can still drive active agent/tool flows.
- [x] No new external dependencies, no workflow changes, and no `.osaurus-plan/` content pushed.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
```text
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter ContextBudgetPreviewTests
✔ Test trivialGreeting_suppressesToolSchemaAndDynamicPromptSections() passed
✔ Test realTaskAfterGreeting_restoresBootstrapTools() passed
✔ Test trivialContinuationWithCachedState_keepsBootstrapTools() passed
✔ Test run with 23 tests in 1 suite passed

DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter SystemPromptComposerToolResolutionTests --filter RuntimePolicySourceTests
✔ Test run with 59 tests in 2 suites passed

Full gate on e129bef9:
swift-format lint --strict --recursive Packages App -> exit 0
swiftlint lint --reporter github-actions-logging -> exit 0
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning -> exit 0
swift test --package-path Packages/OsaurusCLI --parallel -> 77 tests passed
make ci-test -> exit 0
swift build --package-path Packages/OsaurusCore -c release -> Build complete! (361.57s)
```

## Rollback
Revert `e129bef9` and `e4c21d36`, then rerun the full quality gate.
