### PR TITLE
Accept Responses message input without type

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
@@ -91,7 +91,12 @@ public enum OpenResponsesInputItem: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decodeIfPresent(String.self, forKey: .type)
+        let type: String?
+        if container.contains(.type) {
+            type = try container.decode(String.self, forKey: .type)
+        } else {
+            type = nil
+        }
 
         switch type {
         case "message":
@@ -144,7 +149,12 @@ public struct OpenResponsesMessageItem: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let decodedType = try container.decodeIfPresent(String.self, forKey: .type) ?? "message"
+        let decodedType: String
+        if container.contains(.type) {
+            decodedType = try container.decode(String.self, forKey: .type)
+        } else {
+            decodedType = "message"
+        }
         guard decodedType == "message" else {
             throw DecodingError.dataCorruptedError(
                 forKey: .type,

--- a/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
@@ -91,7 +91,7 @@ public enum OpenResponsesInputItem: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
+        let type = try container.decodeIfPresent(String.self, forKey: .type)
 
         switch type {
         case "message":
@@ -100,11 +100,14 @@ public enum OpenResponsesInputItem: Codable, Sendable {
             self = .functionCall(try OpenResponsesFunctionCall(from: decoder))
         case "function_call_output":
             self = .functionCallOutput(try OpenResponsesFunctionCallOutputItem(from: decoder))
+        case nil:
+            // OpenAI Responses clients omit this discriminator for plain message input items.
+            self = .message(try OpenResponsesMessageItem(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
                 in: container,
-                debugDescription: "Unknown input item type: \(type)"
+                debugDescription: "Unknown input item type: \(type ?? "<missing>")"
             )
         }
     }
@@ -127,10 +130,32 @@ public struct OpenResponsesMessageItem: Codable, Sendable {
     public let role: String
     public let content: OpenResponsesMessageContent
 
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case role
+        case content
+    }
+
     public init(role: String, content: OpenResponsesMessageContent) {
         self.type = "message"
         self.role = role
         self.content = content
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedType = try container.decodeIfPresent(String.self, forKey: .type) ?? "message"
+        guard decodedType == "message" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Expected message input item type"
+            )
+        }
+
+        self.type = "message"
+        self.role = try container.decode(String.self, forKey: .role)
+        self.content = try container.decode(OpenResponsesMessageContent.self, forKey: .content)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -76,6 +76,33 @@ struct RemoteChatRequestEncodingTests {
         #expect(payload["input"] is [[String: Any]])
     }
 
+    @Test func openResponsesRequest_decodesOpenAIStyleMessageItemWithoutType() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "foundation",
+              "input": [
+                {
+                  "role": "user",
+                  "content": "Hello!"
+                }
+              ],
+              "stream": false
+            }
+            """#.utf8
+        )
+
+        let responsesRequest = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        let chatRequest = responsesRequest.toChatCompletionRequest()
+        let payload = try Self.encodeAsDictionary(responsesRequest)
+        let input = try #require(payload["input"] as? [[String: Any]])
+        let item = try #require(input.first)
+
+        #expect(chatRequest.messages.map(\.role) == ["user"])
+        #expect(chatRequest.messages.first?.content == "Hello!")
+        #expect(item["type"] as? String == "message")
+    }
+
     @Test func codexRequest_removesMaxOutputTokens() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
         let payload = try Self.decodeAsDictionary(request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData())

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -103,6 +103,50 @@ struct RemoteChatRequestEncodingTests {
         #expect(item["type"] as? String == "message")
     }
 
+    @Test func openResponsesRequest_rejectsExplicitNullMessageType() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "foundation",
+              "input": [
+                {
+                  "type": null,
+                  "role": "user",
+                  "content": "Hello!"
+                }
+              ],
+              "stream": false
+            }
+            """#.utf8
+        )
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        }
+    }
+
+    @Test func openResponsesRequest_rejectsInvalidExplicitMessageType() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "foundation",
+              "input": [
+                {
+                  "type": "not_message",
+                  "role": "user",
+                  "content": "Hello!"
+                }
+              ],
+              "stream": false
+            }
+            """#.utf8
+        )
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        }
+    }
+
     @Test func codexRequest_removesMaxOutputTokens() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
         let payload = try Self.decodeAsDictionary(request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData())


### PR DESCRIPTION
## Business rationale
Some OpenAI Responses clients send plain message input items without an explicit `type` discriminator, while still using the standard `role` and `content` fields. Osaurus previously rejected that otherwise-valid message shape as an invalid request, which is part of the provider/API compatibility class tracked in #662. This PR makes the user-visible behavior match the Responses API expectation: omitted `type` decodes as a normal message and is re-emitted canonically as `"message"`.

## Coding rationale
The implementation keeps the wire contract strict by distinguishing an omitted discriminator from a malformed one. I avoided `decodeIfPresent` because it would treat explicit JSON `null` the same as a missing key; instead the decoder checks `container.contains(.type)`, defaults only the absent key to `message`, and still rejects explicit `null` or unknown explicit types. That preserves the trust boundary at the API decoder: compatibility improves for valid OpenAI-style payloads without silently accepting ambiguous or corrupted request bodies.

## Acceptance criteria
- [x] Responses message input items with omitted `type` decode successfully.
- [x] Accepted omitted-type message items re-encode with canonical `"type": "message"`.
- [x] Explicit `"type": null` remains rejected.
- [x] Explicit non-message input item types remain rejected unless they are one of the supported function-call variants.
- [x] No new dependencies, no workflow changes, and no `.osaurus-plan/` content pushed.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence
```text
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter RemoteChatRequestEncodingTests
✔ Test openResponsesRequest_decodesOpenAIStyleMessageItemWithoutType() passed
✔ Test openResponsesRequest_rejectsExplicitNullMessageType() passed
✔ Test openResponsesRequest_rejectsInvalidExplicitMessageType() passed
✔ Test run with 51 tests in 1 suite passed

Full gate on 2e76c988:
swift-format lint --strict --recursive Packages App -> exit 0
swiftlint lint --reporter github-actions-logging -> exit 0
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning -> exit 0
swift test --package-path Packages/OsaurusCLI --parallel -> 77 tests passed
make ci-test -> exit 0
swift build --package-path Packages/OsaurusCore -c release -> Build complete! (361.66s)
```

## Rollback
Revert `2e76c988` and `1d1c862e`, then rerun the full quality gate.
