### PR TITLE
Fix capability search prompt arguments

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -82,7 +82,7 @@ public enum SystemPromptTemplates {
         Your current tool list is the relevant subset for this task. If you \
         need a capability that is not listed, grow the list in two steps:
 
-        1. `capabilities_search({"query": "<what you need>"})` — returns \
+        1. `capabilities_search({"queries": ["<what you need>"]})` — returns \
         IDs like `tool/sandbox_exec` or `skill/plot-data`.
         2. `capabilities_load({"ids": ["tool/sandbox_exec"]})` — adds \
         those tools to your schema for the rest of this session.

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
@@ -131,6 +131,8 @@ struct SystemPromptDefaultIdentityTests {
         let block = SystemPromptTemplates.capabilityDiscoveryNudge
         #expect(block.contains("capabilities_search"))
         #expect(block.contains("capabilities_load"))
+        #expect(block.contains(#"capabilities_search({"queries": ["<what you need>"]})"#))
+        #expect(!block.contains(#"capabilities_search({"query": "#))
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -63,6 +63,27 @@ struct CapabilitiesSearchToolTests {
         #expect(result.contains("queries"))
     }
 
+    @Test @MainActor
+    func registryAcceptsLegacySingularQueryAlias() async throws {
+        let result = try await ToolRegistry.shared.execute(
+            name: "capabilities_search",
+            argumentsJSON: "{\"query\": \"zzz_capability_alias_probe_\(UUID().uuidString)\"}"
+        )
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("No capabilities found") || result.contains("Found"))
+    }
+
+    @Test @MainActor
+    func registryAcceptsStringifiedQueriesFromSmallModels() async throws {
+        let result = try await ToolRegistry.shared.execute(
+            name: "capabilities_search",
+            argumentsJSON:
+                "{\"queries\": \"[<|\\\"|>zzz_capability_string_probe_\(UUID().uuidString)<|\\\"|>]\"}"
+        )
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("No capabilities found") || result.contains("Found"))
+    }
+
     @Test func returnsNoMatchMessage() async throws {
         let tool = CapabilitiesSearchTool()
         let result = try await tool.execute(

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -50,13 +50,21 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         "type": .string("object"),
         "additionalProperties": .bool(false),
         "properties": .object([
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("Single search query. Prefer `queries` for new calls."),
+            ]),
             "queries": .object([
-                "type": .string("array"),
-                "items": .object(["type": .string("string")]),
+                "anyOf": .array([
+                    .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                    .object(["type": .string("string")]),
+                ]),
                 "description": .string("One or more search queries describing what you need"),
-            ])
+            ]),
         ]),
-        "required": .array([.string("queries")]),
     ])
 
     /// Cap on the number of distinct queries we'll fan out per call.
@@ -78,12 +86,7 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
-        let queriesReq = requireStringArray(
-            args,
-            "queries",
-            expected: "non-empty array of search query strings",
-            tool: name
-        )
+        let queriesReq = Self.requireQueries(args, tool: self)
         guard case .value(let rawQueries) = queriesReq else { return queriesReq.failureEnvelope ?? "" }
 
         // Normalise: trim, drop empties, dedupe case-insensitively (small
@@ -231,6 +234,51 @@ final class CapabilitiesSearchTool: OsaurusTool, @unchecked Sendable {
         return await MainActor.run {
             AgentManager.shared.effectiveEnabledToolNames(for: agentId).map(Set.init)
         }
+    }
+
+    /// Accept the canonical `queries` array plus the legacy singular
+    /// `query` spelling that older prompt text taught models to emit.
+    /// This recovery is local to the discovery tool so other array
+    /// arguments keep the stricter validator behavior.
+    private static func requireQueries(
+        _ args: [String: Any],
+        tool: CapabilitiesSearchTool
+    ) -> ArgumentRequirement<[String]> {
+        if args["queries"] != nil {
+            let req = tool.requireStringArray(
+                args,
+                "queries",
+                expected: "non-empty array of search query strings",
+                tool: tool.name
+            )
+            if case .value(let queries) = req, !queries.isEmpty {
+                return .value(queries)
+            }
+            if args["query"] == nil { return req }
+        }
+
+        guard args["query"] != nil else {
+            return .failure(
+                ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "Missing required argument `queries` (non-empty array of search query strings).",
+                    field: "queries",
+                    expected: "non-empty array of search query strings",
+                    tool: tool.name
+                )
+            )
+        }
+
+        let req = tool.requireString(
+            args,
+            "query",
+            expected: "single search query string",
+            tool: tool.name
+        )
+        guard case .value(let query) = req else {
+            return .failure(req.failureEnvelope ?? "")
+        }
+        return .value([query])
     }
 
     // MARK: - Merge


### PR DESCRIPTION
## Business rationale
Users in #823/#789 reported enabled tools still could not be found in automatic discovery. The bug audit found a prompt/schema mismatch: the gated capability discovery nudge told models to call `capabilities_search({"query": ...})`, while the tool schema accepted only `queries`. Models following the prompt could be routed into invalid-argument recovery instead of tool discovery. This PR aligns the prompt and schema so automatic discovery gets a valid search request again.

## Coding rationale
The fix is scoped to `capabilities_search`: update the prompt example to canonical plural `queries`; keep `additionalProperties: false`; add a local `query` alias and string-form `queries` acceptance so old prompt-shaped and small-model stringified calls recover without broadening every tool’s array validation. It adds no dependencies and does not change search ranking or indexing.

## Acceptance criteria
- [x] Gated capability-discovery prompt shows the canonical `queries` argument.
- [x] `capabilities_search` accepts the legacy singular `query` call shape without returning invalid args.
- [x] `capabilities_search` accepts string-form `queries` from small models without schema-preflight rejection.
- [x] Empty/missing `queries` validation still returns a structured error.

## Quality gate
- [x] `swift-format lint --strict --recursive Packages App` — passed.
- [x] `swiftlint lint --reporter github-actions-logging` — passed; existing backlog reported `Found 1164 violations, 0 serious in 624 files`.
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — passed.
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCLI --parallel` — passed, 77/77 XCTest cases.
- [x] `make ci-test` — passed with exit 0.
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path Packages/OsaurusCore -c release` — passed, `Build complete! (359.53s)`.
- [x] Archive freshness — `git fetch --all --prune` completed before push; `origin/main=fb6a5ffc48d7027b16e61c224a8ab1a182f61f19`; merge-base matched.

## Debug evidence
- Focused capability tests: `CapabilitiesSearchToolTests` passed 6 tests, including legacy singular `query` and string-form `queries` coverage.
- Prompt regression tests: `SystemPromptDefaultIdentityTests` passed 17 tests and pinned `capabilities_search({"queries": ["<what you need>"]})`.
- Full gate command output included `Build complete! (359.53s)` for the release build and `swift test --package-path Packages/OsaurusCLI --parallel` completed 77/77 XCTest cases.

## Rollback
Revert this PR; the changes are isolated to the capability search argument surface and the prompt/test coverage around it.