### PR TITLE
Harden provider discovery diagnostics

### DIFF
--- a/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
+++ b/Packages/OsaurusCore/Services/Context/PreflightCapabilitySearch.swift
@@ -358,7 +358,7 @@ enum CapabilitySearch {
 
         logger.notice(
             """
-            CapabilitySearch query=\(query, privacy: .public)
+            CapabilitySearch query=\(query, privacy: .private(mask: .hash))
             methodsThreshold=\(methodsThreshold, privacy: .public) skillsThreshold=\(skillsThreshold, privacy: .public) fusedCutoff=\(fusedCutoff, privacy: .public)
             health=\(healthSummary, privacy: .public)
             methods raw=\(formatHits(methodDiag.rawHits), privacy: .public)
@@ -841,7 +841,7 @@ enum PreflightCapabilitySearch {
             let fallback = safeFallbackSlice(catalog: catalog, topK: topK)
             let sliceNames = fallback.map(\.name)
             logger.notice(
-                "rankCatalog fallback: query=\(query, privacy: .public) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=empty-hits"
+                "rankCatalog fallback: query=\(query, privacy: .private(mask: .hash)) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=empty-hits"
             )
             return fallback
         }
@@ -868,7 +868,7 @@ enum PreflightCapabilitySearch {
             let fallback = safeFallbackSlice(catalog: catalog, topK: topK)
             let sliceNames = fallback.map(\.name)
             logger.notice(
-                "rankCatalog fallback: query=\(query, privacy: .public) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=no-mappable-hits"
+                "rankCatalog fallback: query=\(query, privacy: .private(mask: .hash)) catalogSize=\(catalog.count) topK=\(topK) sliceNames=\(sliceNames.joined(separator: ","), privacy: .public) reason=no-mappable-hits"
             )
             return fallback
         }
@@ -1108,7 +1108,7 @@ enum PreflightCapabilitySearch {
         cap: Int
     ) -> [String] {
         let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
-        logger.info("Pre-flight: raw LLM response: \(trimmed)")
+        logger.info("Pre-flight: raw LLM response: \(trimmed, privacy: .private(mask: .hash))")
         guard !trimmed.isEmpty else { return [] }
 
         let validNames = Dictionary(

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -3068,14 +3068,11 @@ extension RemoteProviderService {
             throw RemoteProviderServiceError.invalidURL
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-
-        // Add provider headers
-        for (key, value) in await provider.resolvedHeadersOffMainActor() {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
+        let request = modelDiscoveryRequest(
+            url: url,
+            headers: await provider.resolvedHeadersOffMainActor(),
+            timeout: provider.timeout
+        )
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -3114,6 +3111,30 @@ extension RemoteProviderService {
             }
             throw error
         }
+    }
+
+    /// Builds a bounded `/models` request so provider connect tests do not hang
+    /// longer than the user-configured discovery timeout.
+    static func modelDiscoveryRequest(
+        url: URL,
+        headers: [String: String],
+        timeout: TimeInterval
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = modelDiscoveryTimeout(timeout)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return request
+    }
+
+    static func modelDiscoveryTimeout(_ timeout: TimeInterval) -> TimeInterval {
+        guard timeout.isFinite else { return 30 }
+        return min(max(timeout, 1), 30)
     }
 
     private static func canUseManualModelDiscoveryFallback(
@@ -3266,12 +3287,7 @@ extension RemoteProviderService {
                 throw RemoteProviderServiceError.invalidURL
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            for (key, value) in headers {
-                request.setValue(value, forHTTPHeaderField: key)
-            }
+            let request = modelDiscoveryRequest(url: url, headers: headers, timeout: timeout)
 
             let (data, response) = try await URLSession.shared.data(for: request)
 

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -94,6 +94,28 @@ struct RemoteProviderModelDiscoveryTests {
         #expect(provider.url(for: "/models")?.absoluteString == "http://127.0.0.1:8000/api/v1/models")
     }
 
+    @Test func modelDiscoveryRequest_carriesBoundedTimeoutAndProviderHeaders() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:8000/v1/models"))
+
+        let request = RemoteProviderService.modelDiscoveryRequest(
+            url: url,
+            headers: ["Authorization": "Bearer test", "X-Test": "one"],
+            timeout: 45
+        )
+
+        #expect(request.httpMethod == "GET")
+        #expect(request.timeoutInterval == 30)
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test")
+        #expect(request.value(forHTTPHeaderField: "X-Test") == "one")
+    }
+
+    @Test func modelDiscoveryTimeout_clampsInvalidAndTinyValues() {
+        #expect(RemoteProviderService.modelDiscoveryTimeout(.infinity) == 30)
+        #expect(RemoteProviderService.modelDiscoveryTimeout(0) == 1)
+        #expect(RemoteProviderService.modelDiscoveryTimeout(10) == 10)
+    }
+
     @Test func lemonadeModelsResponse_parsesOpenAIListWithExtraFields() throws {
         let provider = makeProvider(basePath: "/api/v1")
         let body = Data(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -735,6 +735,24 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("Preflight logs do not publish raw prompt payloads")
+    func preflightLogsDoNotPublishRawPromptPayloads() throws {
+        let preflight = try Self.source("Services/Context/PreflightCapabilitySearch.swift")
+
+        #expect(
+            !preflight.contains("query, privacy: .public"),
+            "Preflight diagnostics must not publish the raw user query because it can contain prompt text, secrets, or document excerpts"
+        )
+        #expect(
+            preflight.contains("query, privacy: .private(mask: .hash)"),
+            "Preflight can still correlate fallback paths with a private hash instead of logging raw prompt text"
+        )
+        #expect(
+            preflight.contains("trimmed, privacy: .private(mask: .hash)"),
+            "The background LLM response can include prompt-adjacent content and should stay private in logs"
+        )
+    }
+
     @Test("MLXBatchAdapter image preprocessing preserves media, reasoning, and tool metadata")
     func mlxBatchAdapterPreprocessingPreservesMediaReasoningAndToolMetadata() throws {
         let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")


### PR DESCRIPTION
## Business rationale

Remote/provider compatibility work needs connection tests that fail quickly and diagnostics that do not leak user prompts or model responses into public logs. The audit found two concrete risks in the existing provider path: `/models` discovery was built through shared `URLSession` request defaults rather than the provider timeout settings, and preflight fallback logs could publish raw user query / LLM response payloads. This PR keeps the behavior small and user-visible: provider discovery requests carry bounded timeouts and headers, and capability-search diagnostics remain useful without exposing prompt content.

## Coding rationale

The change adds a narrow request-construction helper inside `RemoteProviderService` instead of replacing provider discovery or adding dependencies. OpenAI-compatible and Anthropic discovery both call that helper, so timeout clamping and provider headers stay consistent at the trust boundary where outbound requests are made. The log privacy change uses OSLog's private hashed interpolation so maintainers can correlate repeated failures without making prompt text public. Out of scope: changing model selection semantics, adding new providers, or changing the capability-search ranking algorithm.

## Acceptance criteria

- [x] Model discovery GET requests carry bounded timeout and provider headers.
- [x] OpenAI-compatible and Anthropic discovery share the same request construction path.
- [x] Preflight fallback diagnostics avoid public raw user query / raw LLM response logging.
- [x] No new external dependencies.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean (`swiftlint` exited 0 with the existing warning backlog: `Found 1164 violations, 0 serious in 625 files`)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green (`77/77` CLI tests completed)
- [x] make ci-test — green after sequential rerun; the first parallel attempt exposed unrelated shared keychain test contention, then the branch passed alone
- [x] swift build --package-path Packages/OsaurusCore -c release — green (`Build complete! (476.60s)`)
- [x] Archive freshness — confirmed (`git fetch --all --prune` before gate/push; `origin/main` = `fcefb3c1`)

## Debug evidence

```text
✔ Test modelDiscoveryRequest_carriesBoundedTimeoutAndProviderHeaders() passed after 0.003 seconds.
✔ Test modelDiscoveryTimeout_clampsInvalidAndTinyValues() passed after 0.001 seconds.
✔ Suite "Remote provider model discovery" passed after 0.003 seconds.
✔ Test run with 10 tests in 1 suite passed after 0.003 seconds.

✔ Test "Preflight logs do not publish raw prompt payloads" passed after 0.002 seconds.
✔ Suite "Runtime source policy" passed after 0.002 seconds.
✔ Test run with 1 test in 1 suite passed after 0.002 seconds.
```

## Rollback

`git revert 1ca7df01cd02cf42eb10c81d6e51d7bc66a070ae`
