### PR TITLE
Harden structured document ingress metadata

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
@@ -636,12 +636,7 @@ public struct PPTXAdapter: DocumentFormatAdapter {
 
     private static func resolveRelationshipTarget(from sourcePart: String, target: String) -> String? {
         guard !target.contains("\\") else { return nil }
-        let lowercased = target.lowercased()
-        guard !lowercased.hasPrefix("http://"),
-            !lowercased.hasPrefix("https://"),
-            !lowercased.hasPrefix("file://"),
-            !lowercased.hasPrefix("//")
-        else {
+        guard !isExternallyAddressedRelationshipTarget(target) else {
             return nil
         }
 
@@ -779,6 +774,14 @@ private enum Constants {
     static let maxTextPartUTF16 = 1_000_000
     static let maxXMLDepth = 512
     static let maxRelationshipFiles = 512
+}
+
+private func isExternallyAddressedRelationshipTarget(_ target: String) -> Bool {
+    let lowercased = target.lowercased()
+    return lowercased.hasPrefix("http://")
+        || lowercased.hasPrefix("https://")
+        || lowercased.hasPrefix("file://")
+        || lowercased.hasPrefix("//")
 }
 
 private struct OpenXMLRelationship: Sendable {
@@ -979,6 +982,7 @@ private final class OpenXMLRelationshipCollector: NSObject, XMLParserDelegate {
 
         let mode =
             OpenXMLName.attribute("TargetMode", in: attributeDict)?.lowercased() == "external"
+                || isExternallyAddressedRelationshipTarget(target)
             ? OpenXMLRelationship.TargetMode.external
             : .internalPackage
         relationships.append(

--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import Testing
+import UniformTypeIdentifiers
 
 @testable import OsaurusCore
 
@@ -89,6 +90,25 @@ struct DocumentParserShimTests {
         #expect(ids.contains("pptx"))
         #expect(ids.contains("richdoc"))
         #expect(ids.contains("xlsx"))
+    }
+
+    @Test func canParse_acceptsRegisteredStructuredOfficeFormats() {
+        DocumentAdaptersBootstrap.registerBuiltIns()
+
+        for ext in ["xlsx", "pptx", "potx"] {
+            #expect(DocumentParser.canParse(url: URL(fileURLWithPath: "/tmp/fixture.\(ext)")))
+        }
+    }
+
+    @Test func supportedDocumentTypes_includeStructuredOfficePickerTypes() throws {
+        let xlsx = try #require(UTType(filenameExtension: "xlsx"))
+        let pptx = try #require(UTType(filenameExtension: "pptx"))
+        let potx = try #require(UTType(filenameExtension: "potx"))
+        let supported = Set(DocumentParser.supportedDocumentTypes)
+
+        #expect(supported.contains(xlsx))
+        #expect(supported.contains(pptx))
+        #expect(supported.contains(potx))
     }
 
     // MARK: - Fixtures

--- a/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
@@ -86,6 +86,56 @@ struct PPTXAdapterTests {
         #expect(document.textFallback.contains("Template title"))
     }
 
+    @Test func parse_reportsExternallyAddressedRelationshipsWithoutValidTargetMode() async throws {
+        let fixture = try makePresentationFixture(
+            fileExtension: "pptx",
+            slides: [1: ["External relationships"]],
+            slideOrder: [1],
+            externalRelationships: [
+                RelationshipFixture(
+                    id: "urlMissingMode",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+                    target: "https://example.com/no-target-mode"
+                ),
+                RelationshipFixture(
+                    id: "fileMalformedMode",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+                    target: "file:///tmp/linked-image.png",
+                    targetMode: "Externall"
+                ),
+                RelationshipFixture(
+                    id: "schemeRelativeMissingMode",
+                    type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/video",
+                    target: "//cdn.example.com/clip.mp4"
+                ),
+            ],
+            compression: .stored
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let document = try await PPTXAdapter().parse(url: fixture.url, sizeLimit: 100_000)
+        let references = document.security.externalReferences
+        let targets = Set(references.map(\.urlString))
+
+        #expect(
+            targets
+                == Set([
+                    "https://example.com/no-target-mode",
+                    "file:///tmp/linked-image.png",
+                    "//cdn.example.com/clip.mp4",
+                ])
+        )
+        #expect(document.security.activeContentTypes.contains(.externalReference))
+        #expect(references.first { $0.relationshipId == "urlMissingMode" }?.kind == .hyperlink)
+        #expect(references.first { $0.relationshipId == "fileMalformedMode" }?.kind == .image)
+        #expect(references.first { $0.relationshipId == "schemeRelativeMissingMode" }?.kind == .media)
+        #expect(
+            document.security.findings.contains {
+                $0.kind == .externalReference && $0.metadata["count"] == "3"
+            }
+        )
+    }
+
     @Test func parse_refusesFilesAboveSizeLimit() async throws {
         let root = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -137,6 +187,7 @@ struct PPTXAdapterTests {
         slideOrder: [Int],
         notes: [Int: [String]] = [:],
         externalTargets: [String] = [],
+        externalRelationships: [RelationshipFixture] = [],
         compression: FixtureCompression
     ) throws -> (root: URL, url: URL) {
         let root = try makeTempDirectory()
@@ -152,7 +203,8 @@ struct PPTXAdapterTests {
             let slideRelationships = slideRelationshipsXML(
                 slideNumber: number,
                 hasNotes: notes[number] != nil,
-                externalTargets: number == slideOrder.first ? externalTargets : []
+                externalTargets: number == slideOrder.first ? externalTargets : [],
+                externalRelationships: number == slideOrder.first ? externalRelationships : []
             )
             if !slideRelationships.isEmpty {
                 entries.append(("ppt/slides/_rels/slide\(number).xml.rels", Data(slideRelationships.utf8)))
@@ -203,7 +255,8 @@ struct PPTXAdapterTests {
     private func slideRelationshipsXML(
         slideNumber: Int,
         hasNotes: Bool,
-        externalTargets: [String]
+        externalTargets: [String],
+        externalRelationships: [RelationshipFixture]
     ) -> String {
         var relationships: [RelationshipFixture] = []
         if hasNotes {
@@ -225,6 +278,7 @@ struct PPTXAdapterTests {
                 )
             }
         )
+        relationships.append(contentsOf: externalRelationships)
         guard !relationships.isEmpty else { return "" }
         return relationshipsXML(relationships)
     }

--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -101,7 +101,12 @@ enum DocumentParser {
 
     static func canParse(url: URL) -> Bool {
         let ext = url.pathExtension.lowercased()
-        return isPlainText(ext: ext) || richDocumentExtensions.contains(ext)
+        if isPlainText(ext: ext) || richDocumentExtensions.contains(ext) {
+            return true
+        }
+
+        let uti = UTType(filenameExtension: ext)?.identifier
+        return DocumentFormatRegistry.shared.adapter(for: url, uti: uti) != nil
     }
 
     static func isImageFile(url: URL) -> Bool {
@@ -123,8 +128,14 @@ enum DocumentParser {
             UTType("public.swift-source") ?? .data,
             UTType("com.netscape.javascript-source") ?? .data,
             UTType("public.shell-script") ?? .data,
-        ].compactMap { $0 }
+        ].compactMap { $0 } + structuredDocumentTypes
     }
+
+    private static let structuredDocumentTypes: [UTType] = [
+        UTType(filenameExtension: "xlsx"),
+        UTType(filenameExtension: "pptx"),
+        UTType(filenameExtension: "potx"),
+    ].compactMap { $0 }
 
     // MARK: - Plain Text
 


### PR DESCRIPTION
## Business rationale

The high-fidelity document adapters are only useful if the normal document ingress path recognizes structured Office files and reports risky links accurately. After the workbook/plugin direction shifted away from new default tools, the better user-facing move is to make existing document/read paths work more faithfully. This PR makes `.xlsx`, `.pptx`, and `.potx` eligible through the existing document registry and tightens PPTX metadata so externally addressed relationships are surfaced even when a malformed deck omits or corrupts `TargetMode`.

## Coding rationale

The implementation bridges `DocumentParser` to the existing `DocumentFormatRegistry` instead of adding tools, adding dependencies, or replacing the registry. That keeps format detection centralized: the parser still handles text/rich documents first, then asks the registry whether a structured adapter claims the URL/UTI. For PPTX security metadata, the parser and relationship resolver now share the same external-target predicate so `http(s)`, `file://`, and scheme-relative targets are classified consistently. Out of scope: new workbook editing tools, PDF table extraction, or a new parser/emitter ABI.

## Acceptance criteria

- [x] `.xlsx`, `.pptx`, and `.potx` are accepted by `DocumentParser.canParse` when adapters are registered.
- [x] Picker supported document types include structured Office formats.
- [x] PPTX external-reference metadata reports URL, file, and scheme-relative targets even without a valid `TargetMode`.
- [x] No new default tools and no new external dependencies.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean (`swiftlint` exited 0 with the existing warning backlog: `Found 1164 violations, 0 serious in 625 files`)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green (`77/77` CLI tests completed)
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green (`Build complete! (495.98s)`)
- [x] Archive freshness — confirmed (`git fetch --all --prune` before gate/push; `origin/main` = `fcefb3c1`)

## Debug evidence

```text
✔ Test canParse_acceptsRegisteredStructuredOfficeFormats() passed after 0.002 seconds.
✔ Test supportedDocumentTypes_includeStructuredOfficePickerTypes() passed after 0.001 seconds.
✔ Test parse_reportsExternallyAddressedRelationshipsWithoutValidTargetMode() passed after 0.042 seconds.
✔ Suite "DocumentParser.parseAll registry shim" passed after 0.042 seconds.
✔ Suite "PPTXAdapter" passed after 0.042 seconds.
✔ Test run with 13 tests in 2 suites passed after 0.043 seconds.
```

## Rollback

`git revert 8e35ba276880d3a0a843fccadd704090ee50770f`
