### PR TITLE
Isolate eval search storage roots

### DIFF
--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -58,7 +58,9 @@ Startup bootstrap is domain-aware. `preflight` suites load installed native plug
 and rebuild search indices so they mirror the host app. `capability_search`
 suites initialize only the selected tool / method / skill index lanes without
 loading native plugins; those index-only runs use isolated temporary storage so
-fixtures never touch the user's real encrypted databases or Keychain.
+fixtures never touch the user's real encrypted databases. Debug builds also use
+a deterministic in-process storage key; release builds still use OsaurusCore's
+normal noninteractive storage-key path against the isolated database files.
 Plugin-required cases are skipped unless you pass `--bootstrap-plugins`. A
 filtered run that only selects plugin-required cases skips without index
 bootstrap.

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
@@ -119,22 +119,22 @@ public enum EvalBootstrap {
     ) -> URL? {
         guard plan.usesIsolatedSearchStorage else { return nil }
 
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-evals-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        OsaurusPaths.overrideRoot = root
+
         #if DEBUG
-            let root = FileManager.default.temporaryDirectory
-                .appendingPathComponent("osaurus-evals-\(UUID().uuidString)", isDirectory: true)
-            try? FileManager.default.createDirectory(
-                at: root,
-                withIntermediateDirectories: true
-            )
-            OsaurusPaths.overrideRoot = root
             StorageMigrationCoordinator.shared._setReadyForTesting()
             StorageKeyManager.shared._setKeyForTesting(
                 SymmetricKey(data: Data(repeating: 0xA5, count: 32))
             )
-            return root
-        #else
-            return nil
         #endif
+
+        return root
     }
 
     public static func run(_ plan: EvalBootstrapPlan) async {

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -1,8 +1,10 @@
 import Foundation
+import OsaurusCore
 import Testing
 
 @testable import OsaurusEvalsKit
 
+@Suite(.serialized)
 struct EvalBootstrapPlanTests {
     @Test func pluginRequiredCapabilitySearchSkipsBootstrapByDefault() {
         let suite = makeSuite(
@@ -147,6 +149,55 @@ struct EvalBootstrapPlanTests {
                     searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
                 )
         )
+    }
+
+    @MainActor
+    @Test func isolatedSearchStorageOverridesOsaurusRoot() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        var isolatedRoot: URL?
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            StorageKeyManager.shared.wipeCache()
+            if let isolatedRoot {
+                try? FileManager.default.removeItem(at: isolatedRoot)
+            }
+        }
+
+        let root = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(
+            for: EvalBootstrapPlan(
+                loadInstalledPlugins: false,
+                searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
+            )
+        )
+        isolatedRoot = root
+
+        #expect(root != nil)
+        #expect(OsaurusPaths.overrideRoot == root)
+        #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
+
+        if let root {
+            var isDirectory: ObjCBool = false
+            #expect(FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory))
+            #expect(isDirectory.boolValue)
+        }
+    }
+
+    @MainActor
+    @Test func nonIsolatedBootstrapDoesNotReplaceExistingRootOverride() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        let existingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-evals-existing-\(UUID().uuidString)", isDirectory: true)
+        OsaurusPaths.overrideRoot = existingRoot
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+        }
+
+        let root = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(
+            for: EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false)
+        )
+
+        #expect(root == nil)
+        #expect(OsaurusPaths.overrideRoot == existingRoot)
     }
 
     private func makeSuite(cases: [EvalCase]) -> EvalSuite {


### PR DESCRIPTION
## Business rationale

Fixes #1050 by keeping index-only CapabilitySearch eval startup hermetic in both debug and release builds. Before this change, the release eval path could skip the temporary Osaurus root override and therefore risk touching the user's normal encrypted DB/Keychain-backed storage while trying to initialize search indices. The observable improvement is that eval startup uses isolated DB files, exits under explicit startup timeouts, and no longer depends on debug-only storage behavior for the no-user-storage guarantee.

## Coding rationale

The implementation moves only the temporary `OsaurusPaths.overrideRoot` setup outside the `#if DEBUG` block. The debug-only storage key/coordinator bypass remains debug-only, so production app storage semantics are not weakened; release evals simply point their normal storage stack at a per-run temporary root. This keeps the fix local to eval bootstrap, avoids new dependencies, and leaves model/eval scoring behavior unchanged. Out of scope: changing CapabilitySearch fixtures, changing thresholds, or adding plugin loading by default.

## Acceptance criteria

- [x] Index-only eval bootstrap sets a temp Osaurus root in debug and release.
- [x] Non-isolated bootstrap preserves an existing root override.
- [x] Debug-only storage key bypass remains debug-only.
- [x] CapabilitySearch eval runner exits under startup timeouts and writes JSON output instead of hanging.
- [x] No new external dependencies.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean (`swiftlint` exited 0 with the existing warning backlog: `Found 1164 violations, 0 serious in 625 files`)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green (`77/77` CLI tests completed)
- [x] make ci-test — green after sequential rerun; the first parallel attempt exposed unrelated shared keychain test contention, then the branch passed alone
- [x] swift build --package-path Packages/OsaurusCore -c release — green (`Build complete! (501.60s)`)
- [x] Archive freshness — confirmed (`git fetch --all --prune` before gate/push; `origin/main` = `fcefb3c1`)

## Debug evidence

```text
✔ Test isolatedSearchStorageOverridesOsaurusRoot() passed after 0.005 seconds.
✔ Test nonIsolatedBootstrapDoesNotReplaceExistingRootOverride() passed after 0.001 seconds.
✔ Test run with 11 tests in 2 suites passed after 0.006 seconds.

Release mode:
✔ Test isolatedSearchStorageOverridesOsaurusRoot() passed after 0.002 seconds.
✔ Test run with 1 test in 1 suite passed after 0.002 seconds.

Eval CLI:
[SKIP] capability_search.browser-prefix  score=—        —
wrote 1 cases to /tmp/osaurus-evals-td/browser-prefix.json
[PASS] capability_search.method-lexical-name  score=—      4ms
wrote 1 cases to /tmp/osaurus-evals-td/method.json
```

## Rollback

`git revert 0c938e6d37cd054267c57954ee282e33c35bfbd7`
