### PR TITLE
Wire global proxy into providers and model downloads

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1097,7 +1097,7 @@ extension ModelManager {
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         guard
-            let (data, response) = try? await URLSession.shared.data(for: request),
+            let (data, response) = try? await GlobalProxySettings.makeSession().data(for: request),
             let http = response as? HTTPURLResponse,
             (200 ..< 300).contains(http.statusCode)
         else { return nil }
@@ -1109,7 +1109,7 @@ extension ModelManager {
     fileprivate static func requestHFModels(at url: URL) async throws -> [HFModel] {
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await GlobalProxySettings.makeSession().data(for: request)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
             return []
         }

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -566,7 +566,7 @@ public final class RemoteProviderManager: ObservableObject {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await GlobalProxySettings.makeSession().data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 print("[Osaurus] Test Connection: Invalid response type")

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -66,6 +66,9 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
     /// List of allowed origins for CORS. Empty disables CORS. Use "*" to allow any origin.
     public var allowedOrigins: [String]
 
+    /// Optional validated proxy endpoint used by outbound URLSession traffic.
+    public var globalProxyURL: String?
+
     /// Memory management policy for loaded models
     public var modelEvictionPolicy: ModelEvictionPolicy
 
@@ -94,6 +97,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         case genTopP
         case genMaxKVSize
         case allowedOrigins
+        case globalProxyURL
         case modelEvictionPolicy
         case modelIdleResidencyPolicy
         case maxRequestBodyBytes
@@ -120,6 +124,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         self.allowedOrigins =
             try container.decodeIfPresent([String].self, forKey: .allowedOrigins)
             ?? defaults.allowedOrigins
+        self.globalProxyURL = try container.decodeIfPresent(String.self, forKey: .globalProxyURL)
         self.modelEvictionPolicy =
             try container.decodeIfPresent(ModelEvictionPolicy.self, forKey: .modelEvictionPolicy)
             ?? defaults.modelEvictionPolicy
@@ -145,6 +150,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         genTopP: Float,
         genMaxKVSize: Int?,
         allowedOrigins: [String] = [],
+        globalProxyURL: String? = nil,
         modelEvictionPolicy: ModelEvictionPolicy = .strictSingleModel,
         modelIdleResidencyPolicy: ModelIdleResidencyPolicy = .defaultWarm,
         maxRequestBodyBytes: Int = 32 * 1024 * 1024,
@@ -160,6 +166,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         self.genTopP = genTopP
         self.genMaxKVSize = genMaxKVSize
         self.allowedOrigins = allowedOrigins
+        self.globalProxyURL = globalProxyURL
         self.modelEvictionPolicy = modelEvictionPolicy
         self.modelIdleResidencyPolicy = modelIdleResidencyPolicy
         self.maxRequestBodyBytes = maxRequestBodyBytes
@@ -179,6 +186,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
             genTopP: 1.0,
             genMaxKVSize: nil,
             allowedOrigins: [],
+            globalProxyURL: nil,
             modelEvictionPolicy: .strictSingleModel,
             modelIdleResidencyPolicy: .defaultWarm,
             maxRequestBodyBytes: 32 * 1024 * 1024,

--- a/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
+++ b/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
@@ -1,0 +1,68 @@
+//
+//  GlobalProxySettings.swift
+//  osaurus
+//
+
+import Foundation
+
+/// Disk-backed resolver for the global proxy endpoint that can be used from
+/// background services without crossing the `@MainActor` settings store.
+public enum GlobalProxySettings {
+    /// Read the persisted server configuration and return the validated proxy
+    /// endpoint. Invalid or missing values fail closed to normal networking so
+    /// a stale config file cannot break all outbound traffic.
+    public static func currentConfiguration() -> GlobalProxyConfiguration? {
+        configuration(from: diskBackedServerConfiguration())
+    }
+
+    /// Shape a copied session configuration with the current proxy endpoint.
+    public static func makeConfiguration(
+        base: URLSessionConfiguration = .default
+    ) -> URLSessionConfiguration {
+        GlobalProxyURLSessionFactory.makeConfiguration(
+            base: base,
+            proxy: currentConfiguration()
+        )
+    }
+
+    /// Build a URLSession that honors the global proxy endpoint while leaving
+    /// the caller's delegate and TLS policy untouched.
+    public static func makeSession(
+        base: URLSessionConfiguration = .default,
+        delegate: URLSessionDelegate? = nil,
+        delegateQueue: OperationQueue? = nil
+    ) -> URLSession {
+        GlobalProxyURLSessionFactory.makeSession(
+            base: base,
+            proxy: currentConfiguration(),
+            delegate: delegate,
+            delegateQueue: delegateQueue
+        )
+    }
+
+    /// Testable adapter from persisted settings to proxy configuration. This
+    /// stays separate from disk I/O so validation can be pinned without
+    /// mutating process-global storage roots.
+    static func configuration(from serverConfiguration: ServerConfiguration?) -> GlobalProxyConfiguration? {
+        guard
+            let rawURL = serverConfiguration?.globalProxyURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawURL.isEmpty
+        else {
+            return nil
+        }
+        return try? GlobalProxyConfiguration(urlString: rawURL)
+    }
+
+    /// Network services are frequently initialized off the main actor, while
+    /// `ServerConfigurationStore` is main-actor isolated because it is also
+    /// used by SwiftUI state. Reading the same JSON file directly keeps
+    /// session construction synchronous and side-effect free.
+    static func diskBackedServerConfiguration() -> ServerConfiguration? {
+        let url = OsaurusPaths.resolvePath(
+            new: OsaurusPaths.serverConfigFile(),
+            legacy: "ServerConfiguration.json"
+        )
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(ServerConfiguration.self, from: data)
+    }
+}

--- a/Packages/OsaurusCore/Services/HuggingFaceService.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceService.swift
@@ -93,7 +93,7 @@ actor HuggingFaceService {
         var req = URLRequest(url: url)
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         do {
-            let (data, response) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await GlobalProxySettings.makeSession().data(for: req)
             guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
                 return nil
             }
@@ -182,7 +182,7 @@ actor HuggingFaceService {
         req.setValue("application/json", forHTTPHeaderField: "Accept")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await GlobalProxySettings.makeSession().data(for: req)
             guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
                 return nil
             }
@@ -261,7 +261,7 @@ actor HuggingFaceService {
         var req = URLRequest(url: url)
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         do {
-            let (data, response) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await GlobalProxySettings.makeSession().data(for: req)
             guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
                 return nil
             }

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -950,7 +950,7 @@ final class DirectDownloader: NSObject, URLSessionDownloadDelegate, @unchecked S
     private static let progressInterval: CFAbsoluteTime = 0.25
 
     private lazy var session: URLSession = {
-        URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        GlobalProxySettings.makeSession(base: .default, delegate: self, delegateQueue: nil)
     }()
 
     func download(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2368,7 +2368,7 @@ public actor ModelRuntime {
         }
         var request = URLRequest(url: url)
         request.timeoutInterval = 60
-        let (tempURL, response) = try await URLSession.shared.download(for: request)
+        let (tempURL, response) = try await GlobalProxySettings.makeSession().download(for: request)
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -97,7 +97,7 @@ public actor RemoteProviderService: ToolCapableService {
         // between tokens. The app-level streamInactivityTimeout handles stall detection.
         config.timeoutIntervalForRequest = max(provider.timeout, 300)
         config.timeoutIntervalForResource = max(provider.timeout * 2, 600)
-        self.session = URLSession(configuration: config)
+        self.session = GlobalProxySettings.makeSession(base: config)
     }
 
     /// Minimum timeout for image generation models (5 minutes).
@@ -3077,7 +3077,7 @@ extension RemoteProviderService {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await GlobalProxySettings.makeSession().data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw RemoteProviderServiceError.invalidResponse
@@ -3163,7 +3163,7 @@ extension RemoteProviderService {
             req.setValue("application/json", forHTTPHeaderField: "Accept")
             req.timeoutInterval = min(provider.timeout, 10)
             for (key, value) in headers { req.setValue(value, forHTTPHeaderField: key) }
-            if let (data, response) = try? await URLSession.shared.data(for: req),
+            if let (data, response) = try? await GlobalProxySettings.makeSession().data(for: req),
                 let http = response as? HTTPURLResponse, http.statusCode < 400,
                 let parsed = try? JSONDecoder().decode(ModelsResponse.self, from: data),
                 !parsed.data.isEmpty
@@ -3183,7 +3183,7 @@ extension RemoteProviderService {
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.timeoutInterval = min(provider.timeout, 10)
         for (key, value) in headers { req.setValue(value, forHTTPHeaderField: key) }
-        guard let (data, response) = try? await URLSession.shared.data(for: req),
+        guard let (data, response) = try? await GlobalProxySettings.makeSession().data(for: req),
             let http = response as? HTTPURLResponse, http.statusCode < 400
         else {
             return ["default"]
@@ -3210,7 +3210,7 @@ extension RemoteProviderService {
 
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = min(provider.timeout, 30)
-        let session = URLSession(configuration: config)
+        let session = GlobalProxySettings.makeSession(base: config)
 
         let (data, response) = try await session.data(for: request)
 
@@ -3273,7 +3273,7 @@ extension RemoteProviderService {
                 request.setValue(value, forHTTPHeaderField: key)
             }
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await GlobalProxySettings.makeSession().data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw RemoteProviderServiceError.invalidResponse

--- a/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
@@ -97,6 +97,48 @@ struct GlobalProxyConfigurationTests {
         )
     }
 
+    @Test func settingsResolverNormalizesPersistedProxyURL() throws {
+        var configuration = ServerConfiguration.default
+        configuration.globalProxyURL = " socks5://Proxy.EXAMPLE.com:1080/ "
+
+        let proxy = try #require(GlobalProxySettings.configuration(from: configuration))
+
+        #expect(proxy.redactedDescription == "socks://proxy.example.com:1080")
+    }
+
+    @Test func settingsResolverIgnoresMissingAndInvalidProxyURL() {
+        var configuration = ServerConfiguration.default
+        #expect(GlobalProxySettings.configuration(from: configuration) == nil)
+
+        configuration.globalProxyURL = "http://localhost:8080"
+        #expect(GlobalProxySettings.configuration(from: configuration) == nil)
+    }
+
+    @Test func settingsResolverReadsDiskBackedServerConfiguration() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-proxy-settings-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            let data = try JSONEncoder().encode(configuration)
+            try data.write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let proxy = try #require(GlobalProxySettings.currentConfiguration())
+            #expect(proxy.redactedDescription == "https://proxy.example.com:8443")
+        }
+    }
+
     @Test func rejectsUnsafeProxyURLInput() {
         let cases: [(String, GlobalProxyConfiguration.ValidationError)] = [
             ("", .empty),

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -25,6 +25,7 @@ struct ServerConfigurationStoreTests {
         #expect(decoded.backlog == defaults.backlog)
         #expect(decoded.genTopP == defaults.genTopP)
         #expect(decoded.genMaxKVSize == nil)
+        #expect(decoded.globalProxyURL == nil)
         #expect(decoded.modelIdleResidencyPolicy == defaults.modelIdleResidencyPolicy)
     }
 
@@ -47,6 +48,7 @@ struct ServerConfigurationStoreTests {
         config.exposeToNetwork = true
         config.genTopP = 0.7
         config.genMaxKVSize = 16384
+        config.globalProxyURL = "http://proxy.example.com:8080"
 
         ServerConfigurationStore.save(config)
         let loaded = ServerConfigurationStore.load()

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/GlobalProxySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/GlobalProxySection.swift
@@ -1,0 +1,75 @@
+//
+//  GlobalProxySection.swift
+//  osaurus
+//
+//  Optional outbound proxy endpoint. This edits the legacy
+//  `ServerConfiguration` field because network clients need a tiny,
+//  synchronous setting that is available before the server controller
+//  has finished building runtime state.
+//
+
+import SwiftUI
+
+struct GlobalProxySection: View {
+    @Binding var draft: ServerConfiguration
+
+    @Environment(\.theme) private var theme
+    @State private var proxyText: String = ""
+    @State private var validationMessage: String?
+    @State private var initialized: Bool = false
+
+    var body: some View {
+        ServerSettingsCard(
+            section: .globalProxy,
+            status: .engineReady,
+            blurb: "Outbound provider, plugin, and model-download sessions use this endpoint when they are created."
+        ) {
+            StyledSettingsTextField(
+                label: "Proxy URL",
+                text: $proxyText,
+                placeholder: "http://proxy.example.com:8080",
+                help:
+                    "Supports http, https, socks, and socks5 URLs with an explicit host and port. Credentials are not accepted here."
+            )
+            .onChange(of: proxyText) { _, _ in commitProxy() }
+
+            if let validationMessage {
+                Text(LocalizedStringKey(validationMessage), bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.errorColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onAppear {
+            guard !initialized else { return }
+            initialized = true
+            proxyText = draft.globalProxyURL ?? ""
+        }
+        .onChange(of: draft.globalProxyURL) { _, newValue in
+            let desired = newValue ?? ""
+            if proxyText != desired { proxyText = desired }
+        }
+    }
+
+    private func commitProxy() {
+        let trimmed = proxyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            validationMessage = nil
+            if draft.globalProxyURL != nil { draft.globalProxyURL = nil }
+            return
+        }
+
+        do {
+            let proxy = try GlobalProxyConfiguration(urlString: trimmed)
+            validationMessage = nil
+            if draft.globalProxyURL != proxy.redactedDescription {
+                draft.globalProxyURL = proxy.redactedDescription
+            }
+            if proxyText != proxy.redactedDescription {
+                proxyText = proxy.redactedDescription
+            }
+        } catch {
+            validationMessage = error.localizedDescription
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// should render.
 enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
     case connection
+    case globalProxy
     case authentication
     case sampling
     case concurrency
@@ -34,6 +35,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
     var title: String {
         switch self {
         case .connection: return "Connection"
+        case .globalProxy: return "Global Proxy"
         case .authentication: return "Authentication"
         case .sampling: return "Sampling Defaults"
         case .concurrency: return "Concurrency & Batching"
@@ -52,6 +54,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
     var icon: String {
         switch self {
         case .connection: return "network"
+        case .globalProxy: return "shield.lefthalf.filled"
         case .authentication: return "key.horizontal"
         case .sampling: return "slider.horizontal.3"
         case .concurrency: return "gauge.with.dots.needle.bottom.0percent"
@@ -68,7 +71,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
 
     var group: ServerSettingsSectionGroup {
         switch self {
-        case .connection, .authentication:
+        case .connection, .globalProxy, .authentication:
             return .server
         case .sampling:
             return .generation

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -61,6 +61,7 @@ struct ServerSettingsTabContent: View {
     private var hasUnsavedChanges: Bool {
         draft != server.runtimeSettings
             || draftLegacy.modelEvictionPolicy != server.configuration.modelEvictionPolicy
+            || draftLegacy.globalProxyURL != server.configuration.globalProxyURL
             || draftLegacy.modelIdleResidencyPolicy != server.configuration.modelIdleResidencyPolicy
             || draftLegacy.maxRequestBodyBytes != server.configuration.maxRequestBodyBytes
             || draftLegacy.maxPairingBodyBytes != server.configuration.maxPairingBodyBytes
@@ -143,6 +144,8 @@ struct ServerSettingsTabContent: View {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     ConnectionSection(draft: $draft)
                         .id(ServerSettingsSection.connection)
+                    GlobalProxySection(draft: $draftLegacy)
+                        .id(ServerSettingsSection.globalProxy)
                     AuthenticationSection(draft: $draft)
                         .id(ServerSettingsSection.authentication)
                     GenerationDefaultsSection(draft: $draft)
@@ -197,6 +200,7 @@ struct ServerSettingsTabContent: View {
         var reset = draftLegacy
         reset.modelEvictionPolicy = defaults.modelEvictionPolicy
         reset.modelIdleResidencyPolicy = defaults.modelIdleResidencyPolicy
+        reset.globalProxyURL = defaults.globalProxyURL
         reset.maxRequestBodyBytes = defaults.maxRequestBodyBytes
         reset.maxPairingBodyBytes = defaults.maxPairingBodyBytes
         draftLegacy = reset
@@ -211,6 +215,7 @@ struct ServerSettingsTabContent: View {
         var updatedConfig = server.configuration
         updatedConfig.modelEvictionPolicy = draftLegacy.modelEvictionPolicy
         updatedConfig.modelIdleResidencyPolicy = draftLegacy.modelIdleResidencyPolicy
+        updatedConfig.globalProxyURL = draftLegacy.globalProxyURL
         updatedConfig.maxRequestBodyBytes = draftLegacy.maxRequestBodyBytes
         updatedConfig.maxPairingBodyBytes = draftLegacy.maxPairingBodyBytes
         if updatedConfig != server.configuration {

--- a/docs/GLOBAL_PROXY.md
+++ b/docs/GLOBAL_PROXY.md
@@ -9,11 +9,12 @@ boundaries.
 
 ## Status
 
-This PR only adds the design note, URL validation, and a URLSession factory
-reference implementation. It does not add settings UI, persistence, provider
-rewiring, model-download rewiring, plugin rewiring, or per-provider overrides.
-Those are rollout steps so the shared network policy can be reviewed before it
-touches every network path.
+The current rollout adds the validated URL format, URLSession factory, settings
+persistence, and first call-site wiring for remote provider traffic plus model
+and Hugging Face downloads. Plugin HTTP, MCP OAuth, relay, theme sharing, GitHub
+skill import, sandbox provisioning, local health checks, and per-provider
+overrides remain follow-up work so the shared network policy can be reviewed in
+bounded steps.
 
 ## Proxy Policy
 
@@ -47,20 +48,22 @@ single global web proxy covers both web request families. SOCKS and SOCKS5 URLs
 populate only the SOCKS keys. The foundation does not install PAC files, bypass
 lists, environment variables, or destination rewrites.
 
+`GlobalProxySettings` reads the persisted optional URL from `server.json` and
+fails closed when the value is missing or invalid. It reads that JSON directly
+instead of calling `ServerConfigurationStore` so background networking services
+can create sessions synchronously without crossing the Settings UI's main-actor
+store boundary.
+
 ## Rollout Plan
 
-1. Add encrypted settings storage for an optional global proxy URL. Invalid
-   values should fail closed at save time with the validator's error reason.
-2. Add settings UI that displays only the redacted endpoint. Proxy credentials,
-   if supported later, must be edited as separate secret fields.
-3. Migrate URLSession call sites in small PRs. Known affected paths include
-   remote provider requests, model downloads and catalog refreshes, plugin
-   fetch/search traffic, MCP HTTP/SSE traffic, GitHub skill requests, and remote
-   agent HTTP traffic.
-4. Add smoke coverage with a stub proxy that records CONNECT/HTTP/SOCKS attempts
+1. Migrate the remaining URLSession call sites in small PRs. Known affected
+   paths include plugin fetch/search traffic, MCP HTTP/SSE and OAuth traffic,
+   GitHub skill requests, relay traffic, theme sharing, sandbox provisioning,
+   and remote agent HTTP traffic.
+2. Add smoke coverage with a stub proxy that records CONNECT/HTTP/SOCKS attempts
    for provider and model-download flows. Include a DNS-leak check before
    marking #1091 complete.
-5. Keep per-provider proxy selection and model mirror selection as separate
+3. Keep per-provider proxy selection and model mirror selection as separate
    designs. The global endpoint is intentionally simpler and should apply before
    more granular routing is considered.
 


### PR DESCRIPTION
## Business rationale
Users behind corporate, campus, or country-level network proxies have open requests for Osaurus to route outbound network access through a configurable HTTP/SOCKS endpoint (#1091, #232). The existing proxy foundation validated URLs and shaped `URLSessionConfiguration`, but users still had no persisted setting and the highest-value traffic paths still built ordinary sessions. This PR makes the first user-visible slice work: a saved global proxy URL is available in Server settings, and new remote-provider, model-download, and Hugging Face metadata sessions use that endpoint when created.

## Coding rationale
The implementation keeps the trust boundary narrow: proxy credentials are still rejected by the existing validator, TLS delegates are untouched, and no external dependencies are added. `ServerConfiguration` stores one optional redacted proxy URL, while `GlobalProxySettings` reads `server.json` directly so background networking services can create sessions synchronously without depending on the main-actor settings store. The PR intentionally wires only remote providers plus model/Hugging Face download/catalog paths; plugin HTTP, MCP OAuth/SSE, relay, themes, GitHub skill import, sandbox provisioning, and per-provider proxy selection remain follow-up PRs so review stays bounded.

## Acceptance criteria
- [x] Server settings can persist and clear one optional global proxy URL.
- [x] Missing or invalid persisted proxy values fail closed to normal networking.
- [x] New remote provider, provider test-connection, model download, sidecar, and Hugging Face metadata/catalog sessions apply the global proxy configuration.
- [x] Global proxy docs explain the current coverage and remaining rollout paths.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean command exits (`swiftlint` exit 0 with existing repository warnings only)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min before gate and push)

## Debug evidence
Focused tests:

```text
✔ Suite GlobalProxyConfigurationTests passed after 0.003 seconds.
✔ Test run with 11 tests in 1 suite passed after 0.003 seconds.
✔ Suite ServerConfigurationStoreTests passed after 0.002 seconds.
✔ Test run with 9 tests in 1 suite passed after 0.002 seconds.
```

Gate excerpts:

```text
swift-format lint --strict --recursive Packages App
# exit 0
swiftlint lint --reporter github-actions-logging
Done linting! Found 1164 violations, 0 serious in 627 files.
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
# exit 0
swift test --package-path Packages/OsaurusCLI --parallel
[77/77] Testing OsaurusCLITests.ToolsCreateTests/testModuleNamePassesThroughSimpleName
make ci-test
Done. Inspect failures with: open build/Tests.xcresult
swift build --package-path Packages/OsaurusCore -c release
Build complete! (336.91s)
```

## Rollback
Clear the saved proxy URL in Server settings to return new sessions to normal system networking, or revert commit `08dc9b01` to remove the persistence/UI/call-site wiring together.
