### PR TITLE
Harden XLSX ZIP package parsing

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/XLSXAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXAdapter.swift
@@ -936,7 +936,18 @@ private struct XLSXPackageArchive {
         }
         let fileNameLength = try data.uint16LE(at: localOffset + 26)
         let extraLength = try data.uint16LE(at: localOffset + 28)
-        let payloadOffset = localOffset + 30 + fileNameLength + extraLength
+        let localNameStart = localOffset + 30
+        let localNameEnd = localNameStart + fileNameLength
+        guard localNameEnd <= data.count,
+            let rawLocalName = String(data: data.subdata(in: localNameStart ..< localNameEnd), encoding: .utf8)
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "\(path) local ZIP header name is invalid")
+        }
+        let localPath = try Self.normalizeEntryName(rawLocalName)
+        guard localPath == entry.path else {
+            throw DocumentAdapterError.readFailed(underlying: "\(path) local ZIP header name mismatch")
+        }
+        let payloadOffset = localNameEnd + extraLength
         let payloadEnd = payloadOffset + entry.compressedSize
         guard payloadOffset >= 0, payloadEnd <= data.count else {
             throw DocumentAdapterError.readFailed(underlying: "\(path) ZIP payload is truncated")
@@ -959,18 +970,35 @@ private struct XLSXPackageArchive {
 
     private static func readCentralDirectory(data: Data) throws -> [String: Entry] {
         let eocdOffset = try findEndOfCentralDirectory(in: data)
+        let diskNumber = try data.uint16LE(at: eocdOffset + 4)
+        let centralDirectoryDisk = try data.uint16LE(at: eocdOffset + 6)
+        let entriesOnDisk = try data.uint16LE(at: eocdOffset + 8)
         let entryCount = try data.uint16LE(at: eocdOffset + 10)
         let centralDirectorySize = try data.uint32LE(at: eocdOffset + 12)
         let centralDirectoryOffset = try data.uint32LE(at: eocdOffset + 16)
 
-        guard centralDirectoryOffset + centralDirectorySize <= data.count else {
+        guard diskNumber == 0, centralDirectoryDisk == 0, entriesOnDisk == entryCount else {
+            throw DocumentAdapterError.readFailed(underlying: "Multi-disk XLSX ZIP archives are not supported")
+        }
+        guard entryCount != Int(UInt16.max),
+            centralDirectorySize != Int(UInt32.max),
+            centralDirectoryOffset != Int(UInt32.max)
+        else {
+            throw DocumentAdapterError.readFailed(underlying: "ZIP64 XLSX packages are not supported")
+        }
+        guard centralDirectoryOffset >= 0,
+            centralDirectorySize >= 0,
+            centralDirectoryOffset + centralDirectorySize <= eocdOffset
+        else {
             throw DocumentAdapterError.readFailed(underlying: "ZIP central directory is truncated")
         }
 
         var entries: [String: Entry] = [:]
         var offset = centralDirectoryOffset
         for _ in 0 ..< entryCount {
-            guard try data.uint32LE(at: offset) == 0x0201_4B50 else {
+            guard offset + 46 <= data.count,
+                try data.uint32LE(at: offset) == 0x0201_4B50
+            else {
                 throw DocumentAdapterError.readFailed(underlying: "ZIP central directory entry is invalid")
             }
             let flags = try data.uint16LE(at: offset + 8)
@@ -981,10 +1009,17 @@ private struct XLSXPackageArchive {
             let extraLength = try data.uint16LE(at: offset + 30)
             let commentLength = try data.uint16LE(at: offset + 32)
             let localHeaderOffset = try data.uint32LE(at: offset + 42)
+            guard compressedSize != Int(UInt32.max),
+                uncompressedSize != Int(UInt32.max),
+                localHeaderOffset != Int(UInt32.max)
+            else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP64 XLSX entries are not supported")
+            }
             let nameStart = offset + 46
             let nameEnd = nameStart + fileNameLength
-            guard nameEnd <= data.count else {
-                throw DocumentAdapterError.readFailed(underlying: "ZIP entry name is truncated")
+            let nextOffset = nameEnd + extraLength + commentLength
+            guard nameEnd <= data.count, nextOffset <= data.count else {
+                throw DocumentAdapterError.readFailed(underlying: "ZIP central directory entry is truncated")
             }
             guard let rawName = String(data: data.subdata(in: nameStart ..< nameEnd), encoding: .utf8) else {
                 throw DocumentAdapterError.readFailed(underlying: "ZIP entry name is not UTF-8")
@@ -1001,7 +1036,7 @@ private struct XLSXPackageArchive {
                 uncompressedSize: uncompressedSize,
                 localHeaderOffset: localHeaderOffset
             )
-            offset = nameEnd + extraLength + commentLength
+            offset = nextOffset
         }
         return entries
     }

--- a/Packages/OsaurusCore/Tests/Documents/XLSXAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/XLSXAdapterTests.swift
@@ -99,6 +99,47 @@ struct XLSXAdapterTests {
         }
     }
 
+    @Test func parse_rejectsLocalHeaderNameMismatches() async throws {
+        let package = try Self.replacingLocalHeaderName(
+            in: Self.makeWorkbookPackage(),
+            original: "xl/workbook.xml",
+            replacement: "xl/workbooK.xml"
+        )
+        let url = try Self.writePackage(package)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        }
+    }
+
+    @Test func parse_rejectsMultiDiskXLSXPackages() async throws {
+        var package = Self.makeWorkbookPackage()
+        let eocdOffset = try Self.endOfCentralDirectoryOffset(in: package)
+        try package.writeUInt16LE(1, at: eocdOffset + 4)
+        let url = try Self.writePackage(package)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        }
+    }
+
+    @Test func parse_rejectsZIP64Sentinels() async throws {
+        var package = Self.makeWorkbookPackage()
+        let centralEntryOffset = try Self.centralDirectoryEntryOffset(
+            in: package,
+            path: "xl/workbook.xml"
+        )
+        try package.writeUInt32LE(UInt32.max, at: centralEntryOffset + 42)
+        let url = try Self.writePackage(package)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await #expect(throws: DocumentAdapterError.self) {
+            _ = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        }
+    }
+
     @Test func bootstrap_registersXLSXAdapter() {
         let registry = DocumentFormatRegistry()
 
@@ -110,10 +151,86 @@ struct XLSXAdapterTests {
     // MARK: - Fixture
 
     private static func writeFixture() throws -> URL {
+        try writePackage(Self.makeWorkbookPackage())
+    }
+
+    private static func writePackage(_ package: Data) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-workbook.xlsx")
-        try makeWorkbookPackage().write(to: url)
+        try package.write(to: url)
         return url
+    }
+
+    private static func replacingLocalHeaderName(
+        in archive: Data,
+        original: String,
+        replacement: String
+    ) throws -> Data {
+        let originalName = Array(original.utf8)
+        let replacementName = Array(replacement.utf8)
+        guard originalName.count == replacementName.count else {
+            throw XLSXFixtureMutationError.replacementLengthMismatch
+        }
+
+        var mutated = archive
+        var offset = 0
+        while offset + 30 <= mutated.count {
+            guard try mutated.uint32LE(at: offset) == 0x0403_4B50 else {
+                offset += 1
+                continue
+            }
+
+            let compressedSize = Int(try mutated.uint32LE(at: offset + 18))
+            let nameLength = Int(try mutated.uint16LE(at: offset + 26))
+            let extraLength = Int(try mutated.uint16LE(at: offset + 28))
+            let nameStart = offset + 30
+            let nameEnd = nameStart + nameLength
+            guard nameEnd <= mutated.count else {
+                throw XLSXFixtureMutationError.truncatedArchive
+            }
+            if Array(mutated[nameStart ..< nameEnd]) == originalName {
+                mutated.replaceSubrange(nameStart ..< nameEnd, with: replacementName)
+                return mutated
+            }
+            offset = nameEnd + extraLength + compressedSize
+        }
+
+        throw XLSXFixtureMutationError.entryNotFound(original)
+    }
+
+    private static func centralDirectoryEntryOffset(in archive: Data, path: String) throws -> Int {
+        let eocdOffset = try endOfCentralDirectoryOffset(in: archive)
+        var offset = Int(try archive.uint32LE(at: eocdOffset + 16))
+        let entryCount = Int(try archive.uint16LE(at: eocdOffset + 10))
+        for _ in 0 ..< entryCount {
+            guard try archive.uint32LE(at: offset) == 0x0201_4B50 else {
+                throw XLSXFixtureMutationError.truncatedArchive
+            }
+            let nameLength = Int(try archive.uint16LE(at: offset + 28))
+            let extraLength = Int(try archive.uint16LE(at: offset + 30))
+            let commentLength = Int(try archive.uint16LE(at: offset + 32))
+            let nameStart = offset + 46
+            let nameEnd = nameStart + nameLength
+            guard nameEnd <= archive.count,
+                let name = String(data: archive.subdata(in: nameStart ..< nameEnd), encoding: .utf8)
+            else {
+                throw XLSXFixtureMutationError.truncatedArchive
+            }
+            if name == path { return offset }
+            offset = nameEnd + extraLength + commentLength
+        }
+        throw XLSXFixtureMutationError.entryNotFound(path)
+    }
+
+    private static func endOfCentralDirectoryOffset(in archive: Data) throws -> Int {
+        var offset = archive.count - 22
+        while offset >= 0 {
+            if try archive.uint32LE(at: offset) == 0x0605_4B50 {
+                return offset
+            }
+            offset -= 1
+        }
+        throw XLSXFixtureMutationError.entryNotFound("end-of-central-directory")
     }
 
     private static func makeWorkbookPackage() -> Data {
@@ -291,6 +408,12 @@ struct XLSXAdapterTests {
     }
 }
 
+private enum XLSXFixtureMutationError: Error {
+    case entryNotFound(String)
+    case replacementLengthMismatch
+    case truncatedArchive
+}
+
 private extension Workbook.Sheet {
     func cell(_ reference: String) -> Workbook.Cell? {
         rows.flatMap(\.cells).first { $0.reference == reference }
@@ -312,5 +435,41 @@ private extension Data {
             UInt8((value >> 16) & 0x0000_00FF),
             UInt8((value >> 24) & 0x0000_00FF),
         ])
+    }
+
+    func uint16LE(at offset: Int) throws -> UInt16 {
+        guard offset >= 0, offset + 2 <= count else {
+            throw XLSXFixtureMutationError.truncatedArchive
+        }
+        return UInt16(self[offset])
+            | (UInt16(self[offset + 1]) << 8)
+    }
+
+    func uint32LE(at offset: Int) throws -> UInt32 {
+        guard offset >= 0, offset + 4 <= count else {
+            throw XLSXFixtureMutationError.truncatedArchive
+        }
+        return UInt32(self[offset])
+            | (UInt32(self[offset + 1]) << 8)
+            | (UInt32(self[offset + 2]) << 16)
+            | (UInt32(self[offset + 3]) << 24)
+    }
+
+    mutating func writeUInt16LE(_ value: UInt16, at offset: Int) throws {
+        guard offset >= 0, offset + 2 <= count else {
+            throw XLSXFixtureMutationError.truncatedArchive
+        }
+        self[offset] = UInt8(value & 0x00FF)
+        self[offset + 1] = UInt8((value >> 8) & 0x00FF)
+    }
+
+    mutating func writeUInt32LE(_ value: UInt32, at offset: Int) throws {
+        guard offset >= 0, offset + 4 <= count else {
+            throw XLSXFixtureMutationError.truncatedArchive
+        }
+        self[offset] = UInt8(value & 0x0000_00FF)
+        self[offset + 1] = UInt8((value >> 8) & 0x0000_00FF)
+        self[offset + 2] = UInt8((value >> 16) & 0x0000_00FF)
+        self[offset + 3] = UInt8((value >> 24) & 0x0000_00FF)
     }
 }


### PR DESCRIPTION
## Business rationale
Malformed OOXML ZIP packages can disagree between central-directory metadata and local file headers, or rely on multi-disk/ZIP64 metadata that this dependency-free XLSX reader does not implement. Failing closed keeps document ingestion predictable for workbook attachments and avoids parsing a different XML payload than the package index advertised. The observable change is that normal XLSX fixtures still parse, while malformed XLSX packages with local-header name mismatches, multi-disk EOCD fields, or ZIP64 sentinels are rejected with `DocumentAdapterError`.

## Coding rationale
This keeps the existing lightweight XLSX reader and adds parity with the stricter PPTX ZIP parser instead of adding a new package dependency or replacing the archive reader. The trust boundary is the XLSX package parser: bytes from an attachment are now validated at the EOCD, central-directory entry, and local-header levels before XML part data is returned. Out of scope: full ZIP64 support, encrypted entry support, or changing workbook parsing semantics.

## Acceptance criteria
- [x] XLSX parser rejects multi-disk ZIP archives before reading workbook XML.
- [x] XLSX parser rejects ZIP64 EOCD and entry-size/offset sentinels instead of interpreting unsupported metadata.
- [x] XLSX parser verifies local header names match central-directory paths before returning XML part bytes.
- [x] Existing workbook parsing behavior remains covered by the XLSX adapter tests.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min before gate and before push)

## Debug evidence
Focused regression run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter XLSXAdapterTests` passed 9 tests, including `parse_rejectsLocalHeaderNameMismatches`, `parse_rejectsMultiDiskXLSXPackages`, and `parse_rejectsZIP64Sentinels`.

Full local gate evidence is in `/tmp/osaurus-evidence/T-J-XLSX-ZIP-GUARD-20260522T074926Z/`: strict Swift format exit 0; SwiftLint exit 0 with the existing warning backlog (`Found 1164 violations, 0 serious`); ShellCheck exit 0; CLI tests 77/77; `make ci-test` exit 0; release build finished with `Build complete! (378.07s)`.

## Rollback
Revert commit `ef7524bd83ef3a18cbea5e6ab48ac99f9ab95507` from branch `codex/t-j-xlsx-zip-guard`.
