### PR TITLE
Redact clipboard diagnostics

### DIFF
--- a/Packages/OsaurusCore/Services/Context/ClipboardService.swift
+++ b/Packages/OsaurusCore/Services/Context/ClipboardService.swift
@@ -24,6 +24,18 @@ public final class ClipboardService: ObservableObject {
             if case .text = self { return true }
             return false
         }
+
+        /// A privacy-preserving description for diagnostics that never includes clipboard payloads.
+        public var redactedDiagnosticDescription: String {
+            switch self {
+            case .text(let text):
+                "text(characters: \(text.count))"
+            case .image(let data):
+                "image(bytes: \(data.count))"
+            case .file(let url):
+                "file(extension: \(url.pathExtension.isEmpty ? "unknown" : url.pathExtension.lowercased()))"
+            }
+        }
     }
 
     /// The current content on the pasteboard
@@ -76,7 +88,7 @@ public final class ClipboardService: ObservableObject {
         if let content = newContent {
             // Only update if content actually changed
             if content != currentContent {
-                print("[ClipboardService] New content detected: \(content)")
+                print("[ClipboardService] New content detected: \(content.redactedDiagnosticDescription)")
                 currentContent = content
                 hasNewContent = true
 

--- a/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Clipboard content diagnostics")
+struct ClipboardContentDiagnosticsTests {
+
+    @Test func textDiagnosticsRedactClipboardPayload() {
+        let secret = "sk-live-secret-value in the copied quarterly plan"
+        let summary = ClipboardService.ClipboardContent.text(secret).redactedDiagnosticDescription
+
+        #expect(summary == "text(characters: \(secret.count))")
+        #expect(summary.contains("sk-live") == false)
+        #expect(summary.contains("quarterly") == false)
+    }
+
+    @Test func imageDiagnosticsRedactBinaryPayload() {
+        let data = Data("not really png but still sensitive bytes".utf8)
+        let summary = ClipboardService.ClipboardContent.image(data).redactedDiagnosticDescription
+
+        #expect(summary == "image(bytes: \(data.count))")
+        #expect(summary.contains("sensitive") == false)
+    }
+
+    @Test func fileDiagnosticsRedactAbsolutePathAndFilename() {
+        let url = URL(fileURLWithPath: "/Users/example/Desktop/Acquisition Targets.xlsx")
+        let summary = ClipboardService.ClipboardContent.file(url).redactedDiagnosticDescription
+
+        #expect(summary == "file(extension: xlsx)")
+        #expect(summary.contains("/Users/example") == false)
+        #expect(summary.contains("Acquisition") == false)
+    }
+}


### PR DESCRIPTION
## Business rationale
Clipboard monitoring currently logs the full `ClipboardContent` enum whenever new content appears. That means copied text, local file paths, and potentially large binary descriptions can be written into developer or user logs even though the feature only needs to know that clipboard content changed. This PR keeps the visible clipboard behavior the same while making the diagnostic path safe: logs now report only content kind and bounded metadata such as character count, byte count, or file extension.

## Coding rationale
The narrowest fix is a redacted diagnostic helper on `ClipboardService.ClipboardContent`, then routing the existing "new content" print through that helper. I considered replacing the service's print statements with `OSLog` privacy annotations, but that would be a broader logging-style migration and would still require a payload-free string for portable tests. This change deliberately stays inside the clipboard trust boundary and does not alter pasteboard polling, equality checks, selection capture, source-app detection, or downstream content use.

## Acceptance criteria
- [x] New clipboard-content diagnostics do not include copied text payloads.
- [x] Image clipboard diagnostics expose only byte count, not binary/string payload content.
- [x] File clipboard diagnostics redact absolute paths and filenames while preserving a low-risk extension hint.
- [x] No new external dependencies or tool-surface changes.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean exits
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min before gate and push)

## Debug evidence
Focused privacy tests:

```text
◇ Suite "Clipboard content diagnostics" started.
✔ Test textDiagnosticsRedactClipboardPayload() passed after 0.001 seconds.
✔ Test fileDiagnosticsRedactAbsolutePathAndFilename() passed after 0.001 seconds.
✔ Test imageDiagnosticsRedactBinaryPayload() passed after 0.001 seconds.
✔ Test run with 3 tests in 1 suite passed after 0.001 seconds.
```

Full gate evidence from `/tmp/osaurus-evidence/T-P1-CLIPBOARD-LOG-REDACTION-20260522T081047Z/`:

```text
swift-format lint --strict --recursive Packages App: exit 0
swiftlint lint --reporter github-actions-logging: exit 0; Done linting! Found 1164 violations, 0 serious in 625 files.
shellcheck --severity=warning: exit 0
swift test --package-path Packages/OsaurusCLI --parallel: 77/77 tests completed
make ci-test: Done. Inspect failures with: open build/Tests.xcresult
swift build --package-path Packages/OsaurusCore -c release: Build complete! (376.85s)
```

## Rollback
Revert this PR to restore the previous `ClipboardContent` debug print behavior.
