### PR TITLE
Reject empty XLSX workbook output

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
@@ -53,6 +53,7 @@ public struct XLSXEmitter: DocumentFormatEmitter {
     private static func packageData(for workbook: Workbook) throws -> Data {
         let sheets = try validatedSheets(workbook.sheets)
         try rejectFormulaCells(in: sheets)
+        try requireRenderableContent(in: sheets)
 
         var sharedStrings = SharedStringTable()
         var worksheetEntries: [(path: String, xml: String)] = []
@@ -342,6 +343,19 @@ public struct XLSXEmitter: DocumentFormatEmitter {
                     throw writeFailed("XLSX emitter does not write formulas yet (\(sheet.name)!\(cell.reference))")
                 }
             }
+        }
+    }
+
+    private static func requireRenderableContent(in sheets: [Workbook.Sheet]) throws {
+        let hasRenderableCell = sheets.contains { sheet in
+            sheet.rows.contains { row in
+                row.cells.contains { cell in
+                    !cell.value.fallbackText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                }
+            }
+        }
+        guard hasRenderableCell else {
+            throw DocumentAdapterError.emptyContent
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
@@ -62,6 +62,30 @@ struct XLSXEmitterTests {
         }
     }
 
+    @Test func emit_rejectsWorkbookWithoutRenderableCells() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await Self.expectEmptyContent {
+            try await XLSXEmitter().emit(
+                Self.document(workbook: Self.makeEmptyWorkbook()),
+                to: url
+            )
+        }
+    }
+
+    @Test func emit_rejectsRowsContainingOnlyEmptyOrWhitespaceCells() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        await Self.expectEmptyContent {
+            try await XLSXEmitter().emit(
+                Self.document(workbook: Self.makeWorkbookWithOnlyEmptyCells()),
+                to: url
+            )
+        }
+    }
+
     @Test func bootstrap_registersXLSXEmitter() {
         let registry = DocumentFormatRegistry()
 
@@ -164,6 +188,43 @@ struct XLSXEmitterTests {
         )
     }
 
+    private static func makeEmptyWorkbook() -> Workbook {
+        Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Empty",
+                    index: 0,
+                    rows: [],
+                    anchor: sheetAnchor(name: "Empty", index: 0)
+                )
+            ]
+        )
+    }
+
+    private static func makeWorkbookWithOnlyEmptyCells() -> Workbook {
+        let rows = [
+            row(
+                number: 1,
+                sheetName: "Empty",
+                sheetIndex: 0,
+                cells: [
+                    cell("A1", row: 1, column: 1, value: .empty, sheetName: "Empty", sheetIndex: 0),
+                    cell("B1", row: 1, column: 2, value: .string("   "), sheetName: "Empty", sheetIndex: 0),
+                ]
+            )
+        ]
+        return Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Empty",
+                    index: 0,
+                    rows: rows,
+                    anchor: sheetAnchor(name: "Empty", index: 0)
+                )
+            ]
+        )
+    }
+
     private static func row(
         number: Int,
         sheetName: String,
@@ -236,6 +297,17 @@ struct XLSXEmitterTests {
     private static func temporaryURL() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-emitted.xlsx")
+    }
+
+    private static func expectEmptyContent(_ operation: () async throws -> Void) async {
+        do {
+            try await operation()
+            Issue.record("Expected XLSX emitter to reject workbook with no renderable content")
+        } catch DocumentAdapterError.emptyContent {
+            return
+        } catch {
+            Issue.record("Expected emptyContent, received \(error)")
+        }
     }
 }
 


### PR DESCRIPTION
## Business rationale

A generated XLSX package that contains no renderable workbook content looks valid to downstream tools but gives users a blank result and gives agents no useful document signal. This PR makes the emitter fail fast for empty workbooks and whitespace-only rows, so callers get the existing `DocumentAdapterError.emptyContent` contract instead of silently producing a misleading empty spreadsheet.

## Coding rationale

The change stays inside the existing `XLSXEmitter` boundary and adds no dependencies or tool-surface changes. It validates the normalized `Workbook` model before ZIP/package assembly, using each cell value's existing fallback text as the renderability signal. That keeps scalar/string/number/bool/date output behavior intact while making the empty-output path explicit and testable.

## Acceptance criteria

- [x] Workbook output without any rows/cells is rejected with `DocumentAdapterError.emptyContent`.
- [x] Workbook output containing only empty or whitespace-only cells is rejected with `DocumentAdapterError.emptyContent`.
- [x] Existing scalar workbook output still emits and parses successfully.
- [x] No new external dependencies, default tools, or workflow changes.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Focused document-output regression:

```text
Test Suite 'XLSXEmitterTests' passed at 2026-05-22 08:29:08.116.
     Executed 6 tests, with 0 failures (0 unexpected) in 0.018 (0.018) seconds
```

Full local gate on head `3f5c3898fe96a82e5c95216d44334f54df8ec0d4`:

```text
swift-format lint --strict --recursive Packages App: exit 0
swiftlint lint --reporter github-actions-logging: exit 0
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning: exit 0
swift test --package-path Packages/OsaurusCLI --parallel: Test Suite 'All tests' passed. Executed 77 tests, with 0 failures
make ci-test: exit 0
swift build --package-path Packages/OsaurusCore -c release: Build complete! (375.90s)
```

Pre-push refresh:

```text
Current branch codex/t-j-xlsx-empty-workbook-contract is up to date.
head_before=3f5c3898fe96a82e5c95216d44334f54df8ec0d4
origin_main=fcefb3c140ca0360c70f8ee3ab262895708661f7
head_after=3f5c3898fe96a82e5c95216d44334f54df8ec0d4
```

## Rollback

Revert this PR to restore the previous behavior of emitting empty XLSX packages.
