### PR TITLE
Redact provider secret header logs

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -551,17 +551,12 @@ public final class RemoteProviderManager: ObservableObject {
 
         // Add headers
         for (key, value) in testHeaders {
-            // Don't log the full auth header for security
-            let lowercasedKey = key.lowercased()
-            let shouldRedact =
-                lowercasedKey == "authorization"
-                || lowercasedKey == "x-api-key"
-                || lowercasedKey == "x-goog-api-key"
-            if shouldRedact {
-                print("[Osaurus] Test Connection: Adding header \(key)=***")
-            } else {
-                print("[Osaurus] Test Connection: Adding header \(key)=\(value)")
-            }
+            let logValue = RemoteProviderHeaderRedactor.valueForLogging(
+                headerName: key,
+                value: value,
+                configuredSecretHeaderKeys: tempProvider.secretHeaderKeys
+            )
+            print("[Osaurus] Test Connection: Adding header \(key)=\(logValue)")
             request.setValue(value, forHTTPHeaderField: key)
         }
 

--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -31,6 +31,71 @@ public enum RemoteProviderAuthType: String, Codable, Sendable, CaseIterable {
     case openAICodexOAuth
 }
 
+enum RemoteProviderHeaderRedactor {
+    static let redactedValue = "***"
+
+    private static let exactSensitiveHeaderNames: Set<String> = [
+        "authorization",
+        "api-key",
+        "proxy-authorization",
+        "x-api-key",
+        "x-goog-api-key",
+    ]
+
+    private static let likelySensitiveNameFragments = [
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "key",
+    ]
+
+    /// Custom provider headers are user-defined, so log redaction treats likely credential names as sensitive.
+    static func isSensitiveHeader(_ name: String, configuredSecretHeaderKeys: [String] = []) -> Bool {
+        let normalizedName = normalize(name)
+        guard !normalizedName.isEmpty else { return false }
+
+        if exactSensitiveHeaderNames.contains(normalizedName) {
+            return true
+        }
+
+        if configuredSecretHeaderKeys.contains(where: { normalize($0) == normalizedName }) {
+            return true
+        }
+
+        return likelySensitiveNameFragments.contains { normalizedName.contains($0) }
+    }
+
+    static func valueForLogging(
+        headerName: String,
+        value: String,
+        configuredSecretHeaderKeys: [String] = []
+    ) -> String {
+        isSensitiveHeader(headerName, configuredSecretHeaderKeys: configuredSecretHeaderKeys)
+            ? redactedValue
+            : value
+    }
+
+    static func redactedHeaders(
+        _ headers: [String: String],
+        configuredSecretHeaderKeys: [String] = []
+    ) -> [String: String] {
+        var redacted = headers
+        for (name, value) in headers {
+            redacted[name] = valueForLogging(
+                headerName: name,
+                value: value,
+                configuredSecretHeaderKeys: configuredSecretHeaderKeys
+            )
+        }
+        return redacted
+    }
+
+    private static func normalize(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
 // MARK: - Provider Type
 
 /// Type of remote provider (determines API format)

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderHeaderRedactorTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderHeaderRedactorTests.swift
@@ -1,0 +1,52 @@
+//
+//  RemoteProviderHeaderRedactorTests.swift
+//  OsaurusCoreTests
+//
+//  Keeps provider connection diagnostics from leaking user-supplied secrets.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("RemoteProviderHeaderRedactor")
+struct RemoteProviderHeaderRedactorTests {
+    @Test func redactsBuiltInProviderCredentialHeaders() {
+        for header in ["Authorization", "x-api-key", "x-goog-api-key", "api-key", "Proxy-Authorization"] {
+            #expect(
+                RemoteProviderHeaderRedactor.valueForLogging(headerName: header, value: "super-secret")
+                    == RemoteProviderHeaderRedactor.redactedValue
+            )
+        }
+    }
+
+    @Test func redactsConfiguredSecretHeaderKeysCaseInsensitively() {
+        #expect(
+            RemoteProviderHeaderRedactor.valueForLogging(
+                headerName: "X-Custom-Provider-Secret",
+                value: "private",
+                configuredSecretHeaderKeys: ["x-custom-provider-secret"]
+            ) == RemoteProviderHeaderRedactor.redactedValue
+        )
+    }
+
+    @Test func redactsLikelySecretHeaderNames() {
+        for header in ["X-Session-Token", "provider-password", "vendor-secret", "subscription-key"] {
+            #expect(
+                RemoteProviderHeaderRedactor.valueForLogging(headerName: header, value: "private")
+                    == RemoteProviderHeaderRedactor.redactedValue
+            )
+        }
+    }
+
+    @Test func preservesNonSecretDiagnostics() {
+        #expect(
+            RemoteProviderHeaderRedactor.valueForLogging(headerName: "anthropic-version", value: "2023-06-01")
+                == "2023-06-01"
+        )
+        #expect(
+            RemoteProviderHeaderRedactor.valueForLogging(headerName: "Accept", value: "application/json")
+                == "application/json"
+        )
+    }
+}


### PR DESCRIPTION
## Business rationale

Remote provider setup diagnostics are useful when a user is trying to connect OpenAI-compatible, Gemini, Anthropic, Azure, or custom providers, but the test-connection path printed configured request headers directly. That can expose API keys or provider-specific secret headers in local logs/screenshots. This PR keeps the diagnostic signal while replacing credential-like header values with `***`, so a human can review connection traces without leaking provider secrets.

## Coding rationale

The implementation adds a small `RemoteProviderHeaderRedactor` next to the remote provider configuration model and routes `RemoteProviderManager.testConnection` logging through it. The outbound `URLRequest` still receives the original header value; only the log string changes. The redactor covers built-in auth headers, Azure `api-key`, configured secret header keys, and likely secret names containing token/secret/password/key. It deliberately does not change request encoding, provider auth behavior, response redaction, or MCP provider logging.

## Acceptance criteria

- [x] `Authorization`, `Proxy-Authorization`, `x-api-key`, `x-goog-api-key`, and `api-key` values are redacted in test-connection diagnostics.
- [x] Configured secret header keys are redacted case-insensitively.
- [x] Likely custom secret header names containing token/secret/password/key are redacted.
- [x] Non-secret diagnostic headers such as `Accept` and `anthropic-version` remain visible.
- [x] No new dependencies, workflow changes, or outbound request header changes.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Focused redaction tests:

```text
Suite "RemoteProviderHeaderRedactor" passed after 0.001 seconds.
Test run with 4 tests in 1 suite passed after 0.001 seconds.
```

Full local gate on head `5c458a7166203593ea336e8f0a0d4283e0ffd1bd`:

```text
swift-format exit 0
swiftlint exit 0
shellcheck exit 0
cli-tests exit 0
make-ci-test exit 0
release-build exit 0
```

Pre-push refresh:

```text
fetch_completed=2026-05-22T09:09:44Z
origin_main=fcefb3c140ca0360c70f8ee3ab262895708661f7
Current branch codex/t-p1-provider-secret-header-redaction is up to date.
```

## Rollback

Revert this PR to restore the previous test-connection header logging behavior.
