### PR TITLE
Harden plugin static file containment

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -913,10 +913,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     let webDir = versionDir.appendingPathComponent(webSpec.static_dir, isDirectory: true)
                     let fileURL = webDir.appendingPathComponent(filePath)
 
-                    // Prevent escaping the web directory
-                    let resolvedPath = fileURL.standardizedFileURL.path
-                    let webDirPath = webDir.standardizedFileURL.path
-                    guard resolvedPath.hasPrefix(webDirPath) else {
+                    guard
+                        let resolvedFileURL = Self.containedPluginStaticFileURL(
+                            for: fileURL,
+                            webDirectory: webDir
+                        )
+                    else {
                         return self.sendPluginErrorFromTask(
                             loop: loop,
                             ctxBound: ctxBound,
@@ -932,12 +934,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
 
                     let apiMount = webSpec.api_mount ?? "/api"
-                    if FileManager.default.fileExists(atPath: resolvedPath) {
+                    if FileManager.default.fileExists(atPath: resolvedFileURL.path) {
                         return self.serveStaticFile(
                             loop: loop,
                             ctxBound: ctxBound,
                             version: version,
-                            filePath: resolvedPath,
+                            filePath: resolvedFileURL.path,
                             pluginId: pluginId,
                             apiMount: apiMount,
                             agentId: agentIdStr,
@@ -950,13 +952,32 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
 
                     // SPA fallback: serve entry point for non-file paths
-                    let entryPath = webDir.appendingPathComponent(webSpec.entry).path
-                    if FileManager.default.fileExists(atPath: entryPath) {
+                    let entryURL = webDir.appendingPathComponent(webSpec.entry)
+                    guard
+                        let resolvedEntryURL = Self.containedPluginStaticFileURL(
+                            for: entryURL,
+                            webDirectory: webDir
+                        )
+                    else {
+                        return self.sendPluginErrorFromTask(
+                            loop: loop,
+                            ctxBound: ctxBound,
+                            version: version,
+                            status: .forbidden,
+                            message: "Access denied",
+                            corsHeaders: corsHeaders,
+                            startTime: startTime,
+                            method: method,
+                            path: path,
+                            userAgent: userAgent
+                        )
+                    }
+                    if FileManager.default.fileExists(atPath: resolvedEntryURL.path) {
                         return self.serveStaticFile(
                             loop: loop,
                             ctxBound: ctxBound,
                             version: version,
-                            filePath: entryPath,
+                            filePath: resolvedEntryURL.path,
                             pluginId: pluginId,
                             apiMount: apiMount,
                             agentId: agentIdStr,
@@ -1430,6 +1451,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 userAgent: userAgent
             )
         }
+    }
+
+    /// Resolves symlinks before plugin static serving so path checks use the real filesystem boundary.
+    static func containedPluginStaticFileURL(for candidateURL: URL, webDirectory: URL) -> URL? {
+        let baseURL = webDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedURL = candidateURL.resolvingSymlinksInPath().standardizedFileURL
+        let basePath = baseURL.path
+        let resolvedPath = resolvedURL.path
+
+        guard resolvedPath == basePath || resolvedPath.hasPrefix(basePath + "/") else {
+            return nil
+        }
+        return resolvedURL
     }
 
     /// Validates a Bearer token from the Authorization header.

--- a/Packages/OsaurusCore/Tests/Plugin/PluginRoutingTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginRoutingTests.swift
@@ -114,6 +114,68 @@ struct PluginWebSpecAPIMountTests {
     }
 }
 
+// MARK: - Plugin static file containment
+
+struct PluginStaticFileContainmentTests {
+    @Test func staticFileContainmentAllowsFilesInsideWebDirectory() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let webDir = root.appendingPathComponent("web", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        let fileURL = webDir.appendingPathComponent("index.html")
+        try "ok".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let resolved = try #require(HTTPHandler.containedPluginStaticFileURL(for: fileURL, webDirectory: webDir))
+
+        #expect(resolved.path == fileURL.resolvingSymlinksInPath().standardizedFileURL.path)
+    }
+
+    @Test func staticFileContainmentRejectsSiblingPrefixDirectories() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let webDir = root.appendingPathComponent("web", isDirectory: true)
+        let sibling = root.appendingPathComponent("web-other", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
+        let secretURL = sibling.appendingPathComponent("secret.txt")
+        try "secret".write(to: secretURL, atomically: true, encoding: .utf8)
+
+        #expect(HTTPHandler.containedPluginStaticFileURL(for: secretURL, webDirectory: webDir) == nil)
+    }
+
+    @Test func staticFileContainmentRejectsTraversalOutsideWebDirectory() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let webDir = root.appendingPathComponent("web", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        let secretURL = root.appendingPathComponent("secret.txt")
+        try "secret".write(to: secretURL, atomically: true, encoding: .utf8)
+        let traversalURL = webDir.appendingPathComponent("../secret.txt")
+
+        #expect(HTTPHandler.containedPluginStaticFileURL(for: traversalURL, webDirectory: webDir) == nil)
+    }
+
+    @Test func staticFileContainmentRejectsSymlinksEscapingWebDirectory() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let webDir = root.appendingPathComponent("web", isDirectory: true)
+        try FileManager.default.createDirectory(at: webDir, withIntermediateDirectories: true)
+        let secretURL = root.appendingPathComponent("secret.txt")
+        try "secret".write(to: secretURL, atomically: true, encoding: .utf8)
+        let linkURL = webDir.appendingPathComponent("linked-secret.txt")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: secretURL)
+
+        #expect(HTTPHandler.containedPluginStaticFileURL(for: linkURL, webDirectory: webDir) == nil)
+    }
+
+    private func makeTemporaryRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-plugin-static-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+
 // MARK: - Tunnel exposure flag
 
 struct PluginTunnelExposureTests {


### PR DESCRIPTION
## Business rationale

Plugin web routes serve files out of a plugin bundle's declared static directory. The previous containment check used a raw string prefix, which is fragile for sibling-prefix paths and symlinks that resolve outside the web directory. This PR tightens that trust boundary so plugin UI assets can still be served normally, while traversal, sibling-directory, and escaping-symlink paths fail closed instead of being eligible for static file reads.

## Coding rationale

The implementation adds one filesystem-boundary helper on `HTTPHandler` and uses it for both direct static asset lookup and SPA entry fallback. The helper resolves symlinks and standardizes both the web root and candidate file, then accepts only `candidate == webRoot` or `candidate` under `webRoot/`. This keeps the existing plugin routing, CORS, auth, MIME, and context-injection behavior intact; it only hardens the file path chosen for `serveStaticFile`. No dependencies or public plugin APIs changed.

## Acceptance criteria

- [x] Static files inside the configured plugin web directory still resolve and serve through the existing path.
- [x] Sibling-prefix paths such as `web-other/...` are rejected.
- [x] `..` traversal outside the web directory is rejected after resolution.
- [x] Symlinked static assets that resolve outside the web directory are rejected.
- [x] SPA fallback entry resolution uses the same containment guard.
- [x] No new dependencies, default tools, workflow changes, or plugin manifest API changes.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Focused plugin containment tests:

```text
Suite PluginStaticFileContainmentTests passed after 0.004 seconds.
Test run with 4 tests in 1 suite passed after 0.004 seconds.
```

Full local gate on head `ee53a1854b75cd01d56f4c81e6291ace2afae7a7`:

```text
swift-format exit 0
swiftlint exit 0
shellcheck exit 0
cli-tests exit 0
make-ci-test exit 0
release-build exit 0
```

Pre-push refresh:

```text
fetch_completed=2026-05-22T09:09:44Z
origin_main=fcefb3c140ca0360c70f8ee3ab262895708661f7
Current branch codex/t-p1-plugin-static-containment is up to date.
```

## Rollback

Revert this PR to restore the previous plugin static-file path containment behavior.
