### PR TITLE
Harden plugin artifact installs

### DIFF
--- a/Packages/OsaurusRepository/PluginInstallManager.swift
+++ b/Packages/OsaurusRepository/PluginInstallManager.swift
@@ -40,6 +40,11 @@ public enum PluginInstallError: Error, CustomStringConvertible, LocalizedError {
 
 public final class PluginInstallManager: @unchecked Sendable {
     public static let shared = PluginInstallManager()
+    /// Plugin archives should stay small enough that signature verification can map the file
+    /// safely while still blocking accidental or malicious multi-gigabyte installs.
+    static let maximumArtifactArchiveBytes: Int64 = 256 * 1024 * 1024
+    static let hashReadChunkBytes = 1024 * 1024
+    static let unzipExecutablePath = "/usr/bin/unzip"
     private init() {}
 
     public struct InstallResult: Sendable {
@@ -106,11 +111,10 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.downloadFailed("Invalid URL: \(artifact.url)")
         }
 
-        let (tmpZip, bytes) = try await download(toTempFileFrom: url)
+        let tmpZip = try await download(toTempFileFrom: url, declaredSize: artifact.size)
         defer { try? FileManager.default.removeItem(at: tmpZip) }
 
-        let digest = SHA256.hash(data: bytes)
-        let checksum = Data(digest).map { String(format: "%02x", $0) }.joined()
+        let checksum = try Self.sha256Hex(ofFile: tmpZip)
         if checksum.lowercased() != artifact.sha256.lowercased() {
             throw PluginInstallError.checksumMismatch
         }
@@ -119,6 +123,7 @@ public final class PluginInstallManager: @unchecked Sendable {
             throw PluginInstallError.signatureRequired
         }
         do {
+            let bytes = try Self.mappedFileData(at: tmpZip)
             _ = try MinisignVerifier.verify(publicKey: pubKey, signature: ms.signature, data: bytes)
         } catch {
             NSLog("[Osaurus] Minisign verification failed for \(pluginId): \(error)")
@@ -182,9 +187,7 @@ public final class PluginInstallManager: @unchecked Sendable {
             }
         }
 
-        let dylibData = try Data(contentsOf: finalDylibURL)
-        let dylibDigest = SHA256.hash(data: dylibData)
-        let dylibSha = Data(dylibDigest).map { String(format: "%02x", $0) }.joined()
+        let dylibSha = try Self.sha256Hex(ofFile: finalDylibURL)
 
         let receipt = PluginReceipt(
             plugin_id: spec.plugin_id,
@@ -338,20 +341,46 @@ public final class PluginInstallManager: @unchecked Sendable {
     }
 
     // MARK: - Download / unzip
-    private func download(toTempFileFrom url: URL) async throws -> (fileURL: URL, data: Data) {
-        let (data, response) = try await URLSession.shared.data(from: url)
+    private func download(toTempFileFrom url: URL, declaredSize: Int?) async throws -> URL {
+        let boundedDeclaredSize = try Self.validatedDeclaredArtifactSize(declaredSize)
+        let (downloadedURL, response) = try await URLSession.shared.download(from: url)
+        var movedDownloadedFile = false
+        defer {
+            if !movedDownloadedFile {
+                try? FileManager.default.removeItem(at: downloadedURL)
+            }
+        }
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
             throw PluginInstallError.downloadFailed("HTTP error")
         }
+        try Self.validateArtifactSize(
+            declaredSize: boundedDeclaredSize,
+            responseSize: http.expectedContentLength >= 0 ? http.expectedContentLength : nil,
+            actualSize: nil
+        )
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".zip")
-        try data.write(to: tmp)
-        return (tmp, data)
+        do {
+            try FileManager.default.moveItem(at: downloadedURL, to: tmp)
+            movedDownloadedFile = true
+            let actualSize = try Self.fileSize(at: tmp)
+            try Self.validateArtifactSize(
+                declaredSize: boundedDeclaredSize,
+                responseSize: nil,
+                actualSize: actualSize
+            )
+            return tmp
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
     }
 
+    /// Use the system unzip binary directly so plugin installation does not depend on
+    /// a user-controlled PATH lookup through `/usr/bin/env`.
     private func unzip(zipURL: URL, to destination: URL) throws {
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        task.arguments = ["unzip", "-o", zipURL.path, "-d", destination.path]
+        task.executableURL = URL(fileURLWithPath: Self.unzipExecutablePath)
+        task.arguments = ["-o", "-q", zipURL.path, "-d", destination.path]
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = pipe
@@ -362,6 +391,76 @@ public final class PluginInstallManager: @unchecked Sendable {
             let s = String(data: data, encoding: .utf8) ?? ""
             throw PluginInstallError.unzipFailed(s)
         }
+    }
+
+    /// Normalizes registry-provided sizes before download so a malformed catalog cannot
+    /// request an archive that exceeds the installer resource budget.
+    static func validatedDeclaredArtifactSize(_ declaredSize: Int?) throws -> Int64? {
+        guard let declaredSize else { return nil }
+        guard declaredSize >= 0 else {
+            throw PluginInstallError.downloadFailed("Artifact declared a negative size")
+        }
+        let normalized = Int64(declaredSize)
+        guard normalized <= maximumArtifactArchiveBytes else {
+            throw PluginInstallError.downloadFailed(
+                "Artifact is larger than the \(maximumArtifactArchiveBytes)-byte install limit"
+            )
+        }
+        return normalized
+    }
+
+    /// Checks each size signal independently because registries, HTTP headers, and the
+    /// downloaded file are observed at different points in the install trust boundary.
+    static func validateArtifactSize(declaredSize: Int64?, responseSize: Int64?, actualSize: Int64?) throws {
+        if let responseSize, responseSize > maximumArtifactArchiveBytes {
+            throw PluginInstallError.downloadFailed(
+                "Artifact response is larger than the \(maximumArtifactArchiveBytes)-byte install limit"
+            )
+        }
+        if let actualSize, actualSize > maximumArtifactArchiveBytes {
+            throw PluginInstallError.downloadFailed(
+                "Artifact archive is larger than the \(maximumArtifactArchiveBytes)-byte install limit"
+            )
+        }
+        if let declaredSize, let responseSize, declaredSize != responseSize {
+            throw PluginInstallError.downloadFailed(
+                "Artifact response size mismatch: expected \(declaredSize) bytes, got \(responseSize)"
+            )
+        }
+        if let declaredSize, let actualSize, declaredSize != actualSize {
+            throw PluginInstallError.downloadFailed(
+                "Artifact archive size mismatch: expected \(declaredSize) bytes, got \(actualSize)"
+            )
+        }
+    }
+
+    /// Hash from disk so the archive download path stays bounded by chunk size instead of
+    /// copying the entire zip into process memory before checksum validation.
+    static func sha256Hex(ofFile url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer {
+            try? handle.close()
+        }
+
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: hashReadChunkBytes) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return Data(hasher.finalize()).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func fileSize(at url: URL) throws -> Int64 {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        guard let fileSize = values.fileSize else {
+            throw PluginInstallError.downloadFailed("Could not determine artifact archive size")
+        }
+        return Int64(fileSize)
+    }
+
+    static func mappedFileData(at url: URL) throws -> Data {
+        try Data(contentsOf: url, options: [.mappedIfSafe])
     }
 
     private func makeTempDirectory() throws -> URL {
@@ -386,7 +485,7 @@ public final class PluginInstallManager: @unchecked Sendable {
         }
         let target = filename.lowercased()
         for case let fileURL as URL in enumerator {
-            if fileURL.lastPathComponent.lowercased() == target {
+            if fileURL.lastPathComponent.lowercased() == target && Self.isRegularPayloadFile(fileURL) {
                 return fileURL
             }
         }
@@ -407,7 +506,7 @@ public final class PluginInstallManager: @unchecked Sendable {
         }
         var results: [URL] = []
         for case let fileURL as URL in enumerator {
-            if fileURL.lastPathComponent.uppercased() == "SKILL.MD" {
+            if fileURL.lastPathComponent.uppercased() == "SKILL.MD" && Self.isRegularPayloadFile(fileURL) {
                 results.append(fileURL)
             }
         }
@@ -426,11 +525,22 @@ public final class PluginInstallManager: @unchecked Sendable {
             return nil
         }
         for case let fileURL as URL in enumerator {
-            if fileURL.pathExtension == "dylib" {
+            if fileURL.pathExtension == "dylib" && Self.isRegularPayloadFile(fileURL) {
                 return fileURL
             }
         }
         return nil
+    }
+
+    /// Signed archives should contribute real files only; symlinked payload files would let
+    /// an artifact point the installer at bytes outside the extracted archive tree.
+    static func isRegularPayloadFile(_ url: URL) -> Bool {
+        guard
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        else {
+            return false
+        }
+        return values.isRegularFile == true && values.isSymbolicLink != true
     }
 
 }

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallManagerTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/PluginInstallManagerTests.swift
@@ -211,4 +211,114 @@ final class PluginInstallManagerTests: XCTestCase {
         // Must not throw.
         PluginInstallManager.repairDanglingCurrentSymlinks()
     }
+
+    // MARK: - artifact download bounds
+
+    func test_validatedDeclaredArtifactSize_rejectsOversizedManifestValue() {
+        let tooLarge = Int(PluginInstallManager.maximumArtifactArchiveBytes + 1)
+
+        XCTAssertThrowsError(
+            try PluginInstallManager.validatedDeclaredArtifactSize(tooLarge)
+        ) { error in
+            XCTAssertTrue(
+                String(describing: error).contains("install limit"),
+                "Oversized registry values should fail before network or disk work begins"
+            )
+        }
+    }
+
+    func test_validatedDeclaredArtifactSize_rejectsNegativeManifestValue() {
+        XCTAssertThrowsError(
+            try PluginInstallManager.validatedDeclaredArtifactSize(-1)
+        ) { error in
+            XCTAssertTrue(
+                String(describing: error).contains("negative"),
+                "Negative registry sizes are malformed, not an unknown length"
+            )
+        }
+    }
+
+    func test_validateArtifactSize_rejectsOversizedContentLength() {
+        XCTAssertThrowsError(
+            try PluginInstallManager.validateArtifactSize(
+                declaredSize: nil,
+                responseSize: PluginInstallManager.maximumArtifactArchiveBytes + 1,
+                actualSize: nil
+            )
+        ) { error in
+            XCTAssertTrue(
+                String(describing: error).contains("response"),
+                "A too-large Content-Length should be rejected before the installer persists the archive"
+            )
+        }
+    }
+
+    func test_validateArtifactSize_rejectsDeclaredResponseMismatch() {
+        XCTAssertThrowsError(
+            try PluginInstallManager.validateArtifactSize(
+                declaredSize: 128,
+                responseSize: 127,
+                actualSize: nil
+            )
+        ) { error in
+            XCTAssertTrue(
+                String(describing: error).contains("response size mismatch"),
+                "Registry size and server Content-Length must agree for immutable plugin artifacts"
+            )
+        }
+    }
+
+    func test_validateArtifactSize_rejectsDeclaredActualMismatch() {
+        XCTAssertThrowsError(
+            try PluginInstallManager.validateArtifactSize(
+                declaredSize: 128,
+                responseSize: nil,
+                actualSize: 129
+            )
+        ) { error in
+            XCTAssertTrue(
+                String(describing: error).contains("archive size mismatch"),
+                "The final archive size is authoritative when the server omits Content-Length"
+            )
+        }
+    }
+
+    func test_validateArtifactSize_allowsUnknownDeclaredSizeWithinLimit() throws {
+        XCTAssertNoThrow(
+            try PluginInstallManager.validateArtifactSize(
+                declaredSize: nil,
+                responseSize: nil,
+                actualSize: PluginInstallManager.maximumArtifactArchiveBytes
+            )
+        )
+    }
+
+    func test_sha256Hex_readsFileFromDisk() throws {
+        let url = tempRoot.appendingPathComponent("artifact.zip", isDirectory: false)
+        try Data("osaurus".utf8).write(to: url)
+
+        let digest = try PluginInstallManager.sha256Hex(ofFile: url)
+
+        XCTAssertEqual(digest, "76f6ce2a444b4bfcfa21c40ac4df5adc5f4e897fdeb28c3211d69252d09304ca")
+    }
+
+    func test_unzipExecutablePath_usesSystemBinaryDirectly() {
+        XCTAssertEqual(PluginInstallManager.unzipExecutablePath, "/usr/bin/unzip")
+    }
+
+    func test_isRegularPayloadFile_acceptsRegularFiles() throws {
+        let url = tempRoot.appendingPathComponent("Plugin.dylib", isDirectory: false)
+        try Data("binary".utf8).write(to: url)
+
+        XCTAssertTrue(PluginInstallManager.isRegularPayloadFile(url))
+    }
+
+    func test_isRegularPayloadFile_rejectsSymlinkedPayloads() throws {
+        let target = tempRoot.appendingPathComponent("outside.dylib", isDirectory: false)
+        let link = tempRoot.appendingPathComponent("Plugin.dylib", isDirectory: false)
+        try Data("binary".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: target.path)
+
+        XCTAssertFalse(PluginInstallManager.isRegularPayloadFile(link))
+    }
 }


### PR DESCRIPTION
## Business rationale

Plugin installs currently pull the whole artifact archive into memory before checksum/signature validation and then invoke `unzip` through a PATH lookup. A malformed or compromised registry entry can therefore waste local-model users' RAM and disk before the install fails, and a hostile process environment could change which `unzip` binary runs. This PR keeps the plugin surface lightweight by hardening the existing install path instead of adding new default tools: archives are streamed to a temp file, registry/server/actual byte counts are bounded, hashes are computed from disk, and extracted install payloads must be regular files.

## Coding rationale

The change stays inside `OsaurusRepository` and adds no external dependencies. I chose a small installer-local policy rather than a new archive library: `URLSession.download(from:)` avoids keeping the zip in memory, SHA-256 is streamed with `FileHandle`, minisign still receives bounded mapped data, and `/usr/bin/unzip` is invoked directly with quiet output to avoid PATH-dependent execution and pipe growth. Broader zip-entry accounting and expanded-size limits are intentionally left out because the current code trusts signed plugin artifacts; this PR focuses on the concrete pre-install memory/PATH and symlink payload boundary without replacing the archive stack.

## Acceptance criteria

- [x] Plugin artifact downloads do not require loading the archive into memory before checksum validation.
- [x] Registry-declared, HTTP-reported, and actual archive sizes are bounded and mismatch-checked.
- [x] Installer invokes the system unzip binary directly instead of resolving through `env`/`PATH`.
- [x] `.dylib`, `SKILL.md`, and documentation payload discovery ignores symlinked files.
- [x] No new Swift packages, system libraries, Python, or JVM dependencies.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean enough for gate: all commands exited 0
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Local evidence directory: `/tmp/osaurus-evidence/T-P1-PLUGIN-ARTIFACT-BOUNDS-20260522T092918Z-bash`.

```text
HEAD=021c3f8209040e2a3abdc4a1a4d0a3e610be369d
ORIGIN_MAIN=fcefb3c140ca0360c70f8ee3ab262895708661f7
FETCH_TIME=2026-05-22T09:29:23Z
swift-format: END 2026-05-22T09:29:27Z status=0
swiftlint: Done linting! Found 1177 violations, 0 serious in 627 files.
swiftlint: END 2026-05-22T09:29:28Z status=0
shellcheck: END 2026-05-22T09:29:28Z status=0
cli-tests: END 2026-05-22T09:29:33Z status=0
make-ci-test: Done. Inspect failures with: open build/Tests.xcresult
make-ci-test: END 2026-05-22T09:30:32Z status=0
release-build: Build complete! (21.98s)
release-build: END 2026-05-22T09:30:54Z status=0
```

Focused repository regression evidence before the full gate:

```text
PluginInstallManagerTests: 19/19 tests executed
New coverage: oversized declared size, negative declared size, oversized Content-Length, declared/response mismatch, declared/actual mismatch, streamed SHA-256 digest, direct unzip binary path, and regular-file-only payload guard.
```

## Rollback

```bash
git revert 021c3f8209040e2a3abdc4a1a4d0a3e610be369d
```
