### PR TITLE
[codex] Restore local quality gate baseline

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
@@ -21,8 +21,9 @@ enum ChatSessionExportCoordinator {
         // in-memory manager (freshly created sessions are not flushed yet,
         // and `loadSession` is intermittently returning nil for rows that
         // do exist).
-        guard let full = ChatSessionStore.load(id: metadataSession.id)
-            ?? ChatSessionsManager.shared.session(for: metadataSession.id)
+        guard
+            let full = ChatSessionStore.load(id: metadataSession.id)
+                ?? ChatSessionsManager.shared.session(for: metadataSession.id)
         else {
             presentError(ChatSessionExporter.ExportError.sessionMissing)
             return
@@ -157,4 +158,3 @@ private struct ExportProgressIndicator: View {
         .frame(maxWidth: .infinity)
     }
 }
-

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
@@ -123,7 +123,10 @@ public enum ChatSessionExporter {
     public static func writeZip(session: ChatSessionData, to url: URL) async throws {
         let fm = FileManager.default
         let bundleName = sanitizeFilename(session.title.isEmpty ? "chat" : session.title)
-        let workRoot = fm.temporaryDirectory.appendingPathComponent("osaurus-export-\(UUID().uuidString)", isDirectory: true)
+        let workRoot = fm.temporaryDirectory.appendingPathComponent(
+            "osaurus-export-\(UUID().uuidString)",
+            isDirectory: true
+        )
         let bundleDir = workRoot.appendingPathComponent(bundleName, isDirectory: true)
         let attachmentsDir = bundleDir.appendingPathComponent("attachments", isDirectory: true)
         defer { try? fm.removeItem(at: workRoot) }
@@ -227,34 +230,42 @@ public enum ChatSessionExporter {
             meta.append("Model: \(model)")
         }
         meta.append("Source: \(session.source.rawValue)")
-        body.append(NSAttributedString(
-            string: meta.joined(separator: " · ") + "\n\n",
-            attributes: [.font: metaFont, .foregroundColor: secondary]
-        ))
+        body.append(
+            NSAttributedString(
+                string: meta.joined(separator: " · ") + "\n\n",
+                attributes: [.font: metaFont, .foregroundColor: secondary]
+            )
+        )
 
         for (idx, turn) in session.turns.enumerated() {
-            body.append(NSAttributedString(
-                string: "\(turn.role.rawValue.capitalized) — turn \(idx + 1)\n",
-                attributes: [.font: roleFont]
-            ))
+            body.append(
+                NSAttributedString(
+                    string: "\(turn.role.rawValue.capitalized) — turn \(idx + 1)\n",
+                    attributes: [.font: roleFont]
+                )
+            )
             let trimmed = turn.content.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty {
                 body.append(NSAttributedString(string: trimmed + "\n", attributes: [.font: textFont]))
             }
             if !turn.attachments.isEmpty {
                 let listing = turn.attachments.map { "  - \(describe($0))" }.joined(separator: "\n")
-                body.append(NSAttributedString(
-                    string: "Attachments\n\(listing)\n",
-                    attributes: [.font: metaFont, .foregroundColor: secondary]
-                ))
+                body.append(
+                    NSAttributedString(
+                        string: "Attachments\n\(listing)\n",
+                        attributes: [.font: metaFont, .foregroundColor: secondary]
+                    )
+                )
             }
             if let calls = turn.toolCalls, !calls.isEmpty {
                 let listing = calls.map { "  - \($0.function.name)(\($0.function.arguments))" }
                     .joined(separator: "\n")
-                body.append(NSAttributedString(
-                    string: "Tool calls\n\(listing)\n",
-                    attributes: [.font: monoFont, .foregroundColor: secondary]
-                ))
+                body.append(
+                    NSAttributedString(
+                        string: "Tool calls\n\(listing)\n",
+                        attributes: [.font: monoFont, .foregroundColor: secondary]
+                    )
+                )
             }
             body.append(NSAttributedString(string: "\n", attributes: [.font: textFont]))
         }

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionsManager.swift
@@ -86,8 +86,9 @@ final class ChatSessionsManager: ObservableObject {
     /// flushed to `ChatSessionStore` after their first turn writes, so a
     /// rename issued before that flush would otherwise be dropped.
     func rename(id: UUID, title: String) {
-        guard var session = sessions.first(where: { $0.id == id })
-            ?? ChatSessionStore.load(id: id)
+        guard
+            var session = sessions.first(where: { $0.id == id })
+                ?? ChatSessionStore.load(id: id)
         else { return }
         session.title = title
         session.updatedAt = Date()
@@ -100,8 +101,9 @@ final class ChatSessionsManager: ObservableObject {
     /// Does not touch `updatedAt` so an archive doesn't bubble the row to
     /// the top of the recent list and confuse the user.
     func setArchived(id: UUID, archived: Bool) {
-        guard var session = sessions.first(where: { $0.id == id })
-            ?? ChatSessionStore.load(id: id)
+        guard
+            var session = sessions.first(where: { $0.id == id })
+                ?? ChatSessionStore.load(id: id)
         else { return }
         guard session.archived != archived else { return }
         session.archived = archived

--- a/Packages/OsaurusCore/Tests/Plugin/PluginAgentScopingTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginAgentScopingTests.swift
@@ -561,6 +561,7 @@ struct PlanDispatchTests {
 /// Sweeps every plugin's per-agent entry by `"{agentId}."` prefix.
 /// Uses synthetic agent UUIDs and a synthetic plugin id so the test
 /// only touches keychain entries it created and cleaned up itself.
+@Suite(.serialized)
 struct ToolSecretsKeychainAgentSweepTests {
 
     @Test func deletesOnlyEntriesForTargetAgent() {
@@ -603,6 +604,7 @@ struct ToolSecretsKeychainAgentSweepTests {
 /// "Tavily key saved but agent silently routes to DDG" bug. Uses synthetic
 /// UUIDs (not `Agent.defaultId`) to avoid pre-populated production keychain
 /// entries on CI runners.
+@Suite(.serialized)
 struct ResolvedSecretsMergingTests {
 
     @Test func defaultsFlowToPrimary() {

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -99,7 +99,9 @@ struct ChatSessionSidebar: View {
             if SearchService.matches(query: searchQuery, in: session.title) { return true }
             if let key = session.externalSessionKey,
                 SearchService.matches(query: searchQuery, in: key)
-            { return true }
+            {
+                return true
+            }
             // Match capability labels so "vision" / "code" finds tagged chats.
             return session.capabilities.contains { cap in
                 SearchService.matches(query: searchQuery, in: cap.label)
@@ -474,9 +476,21 @@ private struct SessionRow: View {
                 }
                 Button(action: onStartRename) { Text("Rename", bundle: .module) }
                 Divider()
-                Button { onExport(.markdown) } label: { Text("Export Markdown", bundle: .module) }
-                Button { onExport(.pdf) } label: { Text("Export PDF", bundle: .module) }
-                Button { onExport(.zip) } label: { Text("Export Zip", bundle: .module) }
+                Button {
+                    onExport(.markdown)
+                } label: {
+                    Text("Export Markdown", bundle: .module)
+                }
+                Button {
+                    onExport(.pdf)
+                } label: {
+                    Text("Export PDF", bundle: .module)
+                }
+                Button {
+                    onExport(.zip)
+                } label: {
+                    Text("Export Zip", bundle: .module)
+                }
                 Divider()
                 Button(action: onToggleArchive) {
                     Text(session.archived ? "Unarchive" : "Archive", bundle: .module)


### PR DESCRIPTION
## Business rationale

Current `origin/main` fails the required local quality gate before feature lanes can reach their own changes: the strict formatter reports chat export/sidebar violations, and the full Xcode test pass exposed a Keychain-backed test race in the plugin secret merge suites. That makes every unrelated security or document-I/O PR harder to review because authors either inherit a red gate or have to mix baseline repairs into their feature diff. This PR restores the baseline so follow-up work can remain small, green, and reviewable.

## Coding rationale

The formatting changes are intentionally mechanical `swift-format` output for the chat files touched by the merged sidebar/export work. The only non-format change marks the two real-Keychain plugin secret test suites as serialized, because they share process/global Keychain state under Xcode’s parallel runner; production locking would not address the test runner race and would broaden the diff for no user-facing gain. No runtime behavior, package dependencies, or external tool defaults change here.

## Acceptance criteria

- [x] Strict `swift-format` is green on the PR head.
- [x] Full `make ci-test` is green after serializing the Keychain-backed plugin secret suites.
- [x] No product behavior changes and no new dependencies are introduced.
- [x] Follow-on feature/security lanes can run the required gate without inheriting the current-main formatter failure.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean enough for required commands; swiftlint exits 0 with existing warnings
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed with `git fetch --all --prune` at 2026-05-22T10:00:04Z before push

## Debug evidence

Before this baseline PR, the OAuth lane’s gate failed immediately on current-main formatting:

```text
Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift:24:14: error: [AddLines] add 1 line break
Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift:126:1: error: [LineLength] line is too long
Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift:477:25: error: [AddLines] add 1 line break
==== swift-format END status=1 2026-05-22T09:41:33Z ====
```

The first baseline gate run then exposed the Keychain test race:

```text
✖ [ResolvedSecretsMergingTests] primaryOverridesDefault on 'My Mac - xctest (23555)'
==== make-ci-test END status=2 2026-05-22T09:48:17Z ====
```

After formatting and serializing the shared-Keychain suites, the rerun evidence is green:

```text
==== swift-format END status=0 2026-05-22T09:51:53Z ====
==== swiftlint END status=0 2026-05-22T09:51:53Z ====
==== shellcheck END status=0 2026-05-22T09:51:53Z ====
==== cli-tests END status=0 2026-05-22T09:51:54Z ====
==== make-ci-test END status=0 2026-05-22T09:52:32Z ====
==== core-release END status=0 2026-05-22T09:59:49Z ====
```

## Rollback

```bash
git revert 4a82d39275cf6a6cd606ee3e8e4bed224b6ec080
```
