### PR TITLE
added no timeout option for remote providers

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/RemoteProviderConfiguration.swift
@@ -153,7 +153,18 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
     public var enabled: Bool
     public var autoConnect: Bool
     public var timeout: TimeInterval
+    /// When true, requests run effectively unbounded — the request, resource, and
+    /// stream inactivity limits are all lifted. Intended for trusted long-running
+    /// workloads  where time doesn't matter.
+    /// Discovery/probe timeouts are deliberately unaffected and stay short.
+    public var disableTimeout: Bool
     public var manualModelIds: [String]
+
+    /// Sentinel applied at runtime when `disableTimeout` is set. Finite by design:
+    /// `.infinity` / `.greatestFiniteMagnitude` would crash the streaming path
+    /// (`UInt64(timeout * 1e9)` overflows) and can't be JSON encoded. One year is
+    /// no limit for any real request while staying safely within those bounds.
+    public static let unboundedTimeout: TimeInterval = 60 * 60 * 24 * 365
 
     // Keys for headers that should be stored in Keychain (not persisted in config)
     public var secretHeaderKeys: [String]
@@ -167,7 +178,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, host, providerProtocol, port, basePath
-        case customHeaders, authType, providerType, enabled, autoConnect, timeout
+        case customHeaders, authType, providerType, enabled, autoConnect, timeout, disableTimeout
         case manualModelIds
         case secretHeaderKeys, remoteAgentId, remoteAgentAddress
     }
@@ -185,6 +196,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled: Bool = true,
         autoConnect: Bool = true,
         timeout: TimeInterval = 60,
+        disableTimeout: Bool = false,
         manualModelIds: [String] = [],
         secretHeaderKeys: [String] = [],
         remoteAgentId: UUID? = nil,
@@ -202,6 +214,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         self.enabled = enabled
         self.autoConnect = autoConnect
         self.timeout = timeout
+        self.disableTimeout = disableTimeout
         self.manualModelIds = manualModelIds
         self.secretHeaderKeys = secretHeaderKeys
         self.remoteAgentId = remoteAgentId
@@ -225,6 +238,7 @@ public struct RemoteProvider: Codable, Identifiable, Sendable, Equatable {
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         autoConnect = try container.decodeIfPresent(Bool.self, forKey: .autoConnect) ?? true
         timeout = try container.decodeIfPresent(TimeInterval.self, forKey: .timeout) ?? 60
+        disableTimeout = try container.decodeIfPresent(Bool.self, forKey: .disableTimeout) ?? false
         manualModelIds = try container.decodeIfPresent([String].self, forKey: .manualModelIds) ?? []
         secretHeaderKeys = try container.decodeIfPresent([String].self, forKey: .secretHeaderKeys) ?? []
         remoteAgentId = try container.decodeIfPresent(UUID.self, forKey: .remoteAgentId)

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,70 @@
     "" : {
 
     },
+    "Requests will run with no time limit. Before enabling:" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anfragen werden ohne Zeitlimit ausgeführt. Vor dem Aktivieren:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求将在无时间限制下运行。启用前请注意："
+          }
+        }
+      }
+    },
+    "A stalled provider or dropped connection can hang a request indefinitely. You'll have to stop it manually" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein hängender Anbieter oder eine abgebrochene Verbindung kann eine Anfrage unbegrenzt blockieren. Du musst sie manuell stoppen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停滞的提供方或断开的连接可能使请求无限期挂起。你需要手动停止它"
+          }
+        }
+      }
+    },
+    "Upstream timeouts (LM Studio, proxies, tunnels) still apply" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorgelagerte Zeitlimits (LM Studio, Proxys, Tunnel) gelten weiterhin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上游超时（LM Studio、代理、隧道）仍然适用"
+          }
+        }
+      }
+    },
+    "Only use this on trusted hardware for long-running work" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur auf vertrauenswürdiger Hardware für lang laufende Aufgaben verwenden"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在受信任的硬件上用于长时间运行的任务"
+          }
+        }
+      }
+    },
     " — %@" : {
 
     },
@@ -1027,6 +1091,9 @@
       }
     },
     "A device wants to pair with **%@**.\nAllow this device to connect?" : {
+
+    },
+    "A different dino for every job. Your memories stick around, ready when you need them." : {
 
     },
     "A microphone button will appear in the chat input when voice is ready" : {
@@ -3786,6 +3853,16 @@
         }
       }
     },
+    "Choose a format to export this conversation." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a format to export this conversation."
+          }
+        }
+      }
+    },
     "Choose a passphrase (≥ 8 characters) to encrypt this agent's bundle. You'll need the same passphrase to import it on another Mac." : {
 
     },
@@ -5464,9 +5541,6 @@
         }
       }
     },
-    "Create Dino" : {
-
-    },
     "Create custom assistant personalities with unique behaviors" : {
       "localizations" : {
         "de" : {
@@ -5482,6 +5556,9 @@
           }
         }
       }
+    },
+    "Create Dino" : {
+
     },
     "Create Plugin" : {
       "localizations" : {
@@ -6484,6 +6561,16 @@
         }
       }
     },
+    "Deltas" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Deltas"
+          }
+        }
+      }
+    },
     "Deny" : {
       "localizations" : {
         "de" : {
@@ -6654,6 +6741,41 @@
           }
         }
       }
+    },
+    "Disable request timeout?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit für Anfragen deaktivieren?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用请求超时？"
+          }
+        }
+      }
+    },
+    "Disable timeout" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit deaktivieren"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用超时"
+          }
+        }
+      }
+    },
+    "Disable Timeout" : {
+
     },
     "Disable tools" : {
       "localizations" : {
@@ -8052,36 +8174,6 @@
         }
       }
     },
-    "Export failed" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Export failed"
-          }
-        }
-      }
-    },
-    "Export complete" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Export complete"
-          }
-        }
-      }
-    },
-    "Reveal in Finder" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reveal in Finder"
-          }
-        }
-      }
-    },
     "Export Bundle…" : {
       "comment" : "Swift localization key; translations need review.",
       "localizations" : {
@@ -8105,6 +8197,26 @@
         }
       }
     },
+    "Export complete" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export complete"
+          }
+        }
+      }
+    },
+    "Export Conversation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export Conversation"
+          }
+        }
+      }
+    },
     "Export CSV" : {
       "comment" : "Swift localization key; translations need review.",
       "localizations" : {
@@ -8124,6 +8236,16 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Export CSV"
+          }
+        }
+      }
+    },
+    "Export failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Export failed"
           }
         }
       }
@@ -8183,112 +8305,12 @@
     "Export Zip" : {
 
     },
-    "Export Conversation" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Export Conversation"
-          }
-        }
-      }
-    },
     "Export…" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Export…"
-          }
-        }
-      }
-    },
-    "Choose a format to export this conversation." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Choose a format to export this conversation."
-          }
-        }
-      }
-    },
-    "Markdown" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Markdown"
-          }
-        }
-      }
-    },
-    "Include in export" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Include in export"
-          }
-        }
-      }
-    },
-    "Timestamps" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Timestamps"
-          }
-        }
-      }
-    },
-    "Deltas" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Deltas"
-          }
-        }
-      }
-    },
-    "Token usage" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Token usage"
-          }
-        }
-      }
-    },
-    "No timing data captured for this conversation." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No timing data captured for this conversation."
-          }
-        }
-      }
-    },
-    "PDF" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "PDF"
-          }
-        }
-      }
-    },
-    "Zip Bundle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Zip Bundle"
           }
         }
       }
@@ -10296,6 +10318,16 @@
         }
       }
     },
+    "Include in export" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include in export"
+          }
+        }
+      }
+    },
     "Indefinitely" : {
       "localizations" : {
         "de" : {
@@ -11099,6 +11131,22 @@
         }
       }
     },
+    "Let requests run with no time limit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anfragen ohne Zeitlimit ausführen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让请求在无时间限制下运行"
+          }
+        }
+      }
+    },
     "Let tools in without sharing your password" : {
 
     },
@@ -11547,9 +11595,6 @@
         }
       }
     },
-    "A different dino for every job. Your memories stick around, ready when you need them." : {
-
-    },
     "Make My Signature" : {
 
     },
@@ -11738,6 +11783,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "地图"
+          }
+        }
+      }
+    },
+    "Markdown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Markdown"
           }
         }
       }
@@ -13051,6 +13106,22 @@
     "No invites issued yet" : {
 
     },
+    "No limit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Limit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无限制"
+          }
+        }
+      }
+    },
     "No local models fit this Mac" : {
 
     },
@@ -13396,6 +13467,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到主题"
+          }
+        }
+      }
+    },
+    "No timing data captured for this conversation." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No timing data captured for this conversation."
           }
         }
       }
@@ -14708,6 +14789,16 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Paused — %@"
+          }
+        }
+      }
+    },
+    "PDF" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PDF"
           }
         }
       }
@@ -20917,6 +21008,16 @@
         }
       }
     },
+    "Timestamps" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Timestamps"
+          }
+        }
+      }
+    },
     "Title" : {
 
     },
@@ -20995,6 +21096,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换模型推理模式"
+          }
+        }
+      }
+    },
+    "Token usage" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Token usage"
           }
         }
       }
@@ -23051,6 +23162,16 @@
     },
     "Your signature (preview)" : {
 
+    },
+    "Zip Bundle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Zip Bundle"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -95,8 +95,15 @@ public actor RemoteProviderService: ToolCapableService {
         let config = URLSessionConfiguration.default
         // Request timeout must be generous: thinking models can pause for minutes
         // between tokens. The app-level streamInactivityTimeout handles stall detection.
-        config.timeoutIntervalForRequest = max(provider.timeout, 300)
-        config.timeoutIntervalForResource = max(provider.timeout * 2, 600)
+        // When the user opts into no-timeout mode, every limit is lifted (see
+        // RemoteProvider.unboundedTimeout) so long-running turns are never interrupted.
+        if provider.disableTimeout {
+            config.timeoutIntervalForRequest = RemoteProvider.unboundedTimeout
+            config.timeoutIntervalForResource = RemoteProvider.unboundedTimeout
+        } else {
+            config.timeoutIntervalForRequest = max(provider.timeout, 300)
+            config.timeoutIntervalForResource = max(provider.timeout * 2, 600)
+        }
         self.session = GlobalProxySettings.makeSession(base: config)
     }
 
@@ -247,7 +254,9 @@ public actor RemoteProviderService: ToolCapableService {
     /// Inactivity timeout for streaming: if no bytes arrive within this interval,
     /// assume the provider has stalled and end the stream. Floor of 120s accommodates
     /// thinking models that pause between tokens during reasoning.
-    private var streamInactivityTimeout: TimeInterval { max(provider.timeout, 120) }
+    private var streamInactivityTimeout: TimeInterval {
+        provider.disableTimeout ? RemoteProvider.unboundedTimeout : max(provider.timeout, 120)
+    }
 
     /// Invalidate the URLSession to release its strong delegate reference.
     /// Must be called before discarding this service instance to avoid leaking.
@@ -2001,7 +2010,10 @@ public actor RemoteProviderService: ToolCapableService {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         if Self.isImageCapableModel(request.model) {
-            urlRequest.timeoutInterval = max(provider.timeout, Self.imageModelMinTimeout)
+            urlRequest.timeoutInterval =
+                provider.disableTimeout
+                ? RemoteProvider.unboundedTimeout
+                : max(provider.timeout, Self.imageModelMinTimeout)
         }
 
         // Set Accept header based on streaming mode

--- a/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
+++ b/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
@@ -477,6 +477,7 @@ private struct ThemedAlertModifier: ViewModifier {
     let title: String
     @Binding var isPresented: Bool
     let message: String?
+    let accessory: AnyView?
     let buttons: [AlertButtonConfig]
     let presentationStyle: ThemedAlertPresentationStyle
 
@@ -487,7 +488,7 @@ private struct ThemedAlertModifier: ViewModifier {
                     ThemedAlertDialogContent(
                         title: title,
                         message: message,
-                        accessory: nil,
+                        accessory: accessory,
                         buttons: buttons,
                         showsCloseButton: false,
                         customContent: nil,
@@ -510,6 +511,7 @@ private struct ThemedAlertPresenterModifier: ViewModifier {
     let title: String
     @Binding var isPresented: Bool
     let message: String?
+    let accessory: AnyView?
     let buttons: [AlertButtonConfig]
 
     @State private var requestId = UUID()
@@ -524,6 +526,7 @@ private struct ThemedAlertPresenterModifier: ViewModifier {
                                 id: requestId,
                                 title: title,
                                 message: message,
+                                accessory: accessory,
                                 buttons: buttons,
                                 onDismiss: { isPresented = false }
                             ),
@@ -544,6 +547,7 @@ private struct ThemedAlertPresenterModifier: ViewModifier {
                                 id: requestId,
                                 title: title,
                                 message: message,
+                                accessory: accessory,
                                 buttons: buttons,
                                 onDismiss: { isPresented = false }
                             ),
@@ -605,6 +609,7 @@ extension View {
         _ title: String,
         isPresented: Binding<Bool>,
         message: String? = nil,
+        accessory: AnyView? = nil,
         buttons: [AlertButtonConfig],
         presentationStyle: ThemedAlertPresentationStyle = .window
     ) -> some View {
@@ -614,6 +619,7 @@ extension View {
                     title: title,
                     isPresented: isPresented,
                     message: message,
+                    accessory: accessory,
                     buttons: buttons,
                     presentationStyle: .contained
                 )
@@ -625,6 +631,7 @@ extension View {
                     title: title,
                     isPresented: isPresented,
                     message: message,
+                    accessory: accessory,
                     buttons: buttons
                 )
             )

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -87,6 +87,8 @@ private struct AddProviderFlow: View {
     // Advanced settings
     @State private var showAdvanced = false
     @State private var timeout: Double = 60
+    @State private var disableTimeout: Bool = false
+    @State private var showNoTimeoutWarning = false
     @State private var customHeaders: [HeaderEntry] = []
 
     private var canTest: Bool {
@@ -148,6 +150,16 @@ private struct AddProviderFlow: View {
             }
             withAnimation { hasAppeared = true }
         }
+        .themedAlert(
+            "Disable request timeout?",
+            isPresented: $showNoTimeoutWarning,
+            accessory: AnyView(NoTimeoutWarningContent()),
+            buttons: [
+                .cancel("Cancel"),
+                .destructive("Disable Timeout") { disableTimeout = true },
+            ],
+            presentationStyle: .contained
+        )
     }
 
     private var stepTransition: AnyTransition {
@@ -426,6 +438,7 @@ private struct AddProviderFlow: View {
                 manualModelIdsText = ""
                 showAdvanced = false
                 timeout = 60
+                disableTimeout = false
                 customHeaders = []
             }
         } label: {
@@ -911,26 +924,7 @@ private struct AddProviderFlow: View {
             if showAdvanced {
                 VStack(alignment: .leading, spacing: 16) {
                     // Timeout
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("REQUEST TIMEOUT", bundle: .module)
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundColor(theme.tertiaryText)
-                                .tracking(0.5)
-                            Spacer()
-                            Text("\(Int(timeout))s", bundle: .module)
-                                .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                .foregroundColor(theme.secondaryText)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(theme.inputBackground)
-                                )
-                        }
-                        Slider(value: $timeout, in: 10 ... 300, step: 10)
-                            .tint(theme.accentColor)
-                    }
+                    timeoutSection
 
                     // Custom headers
                     VStack(alignment: .leading, spacing: 10) {
@@ -972,6 +966,66 @@ private struct AddProviderFlow: View {
                 .padding(.top, 12)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
+        }
+    }
+
+    // MARK: - Timeout
+
+    private var timeoutSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("REQUEST TIMEOUT", bundle: .module)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                    .tracking(0.5)
+                Spacer()
+                Text(disableTimeout ? "No limit" : "\(Int(timeout))s", bundle: .module)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(theme.secondaryText)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(theme.inputBackground)
+                    )
+            }
+            Slider(value: $timeout, in: 10 ... 300, step: 10)
+                .tint(theme.accentColor)
+                .disabled(disableTimeout)
+                .opacity(disableTimeout ? 0.4 : 1)
+
+            // Intercepting binding: turning the switch ON only opens the warning;
+            // `disableTimeout` flips to true after the user confirms. Turning OFF
+            // is immediate. This keeps loadProvider() (which sets the @State
+            // directly) from spuriously triggering the alert on sheet open.
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Disable timeout", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    Text("Let requests run with no time limit", bundle: .module)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                Spacer()
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { disableTimeout },
+                        set: { wantsOn in
+                            if wantsOn {
+                                showNoTimeoutWarning = true
+                            } else {
+                                disableTimeout = false
+                            }
+                        }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(theme.accentColor)
+            }
+            .padding(.top, 6)
         }
     }
 
@@ -1174,6 +1228,7 @@ private struct AddProviderFlow: View {
             enabled: true,
             autoConnect: true,
             timeout: timeout,
+            disableTimeout: disableTimeout,
             manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
@@ -1237,6 +1292,7 @@ private struct AddProviderFlow: View {
             enabled: true,
             autoConnect: true,
             timeout: timeout,
+            disableTimeout: disableTimeout,
             secretHeaderKeys: secretKeys
         )
 
@@ -1304,6 +1360,8 @@ private struct EditProviderFlow: View {
     // Advanced
     @State private var showAdvanced = false
     @State private var timeout: Double = 60
+    @State private var disableTimeout: Bool = false
+    @State private var showNoTimeoutWarning = false
     @State private var customHeaders: [HeaderEntry] = []
 
     // UI state
@@ -1358,6 +1416,16 @@ private struct EditProviderFlow: View {
             loadProvider()
             withAnimation { hasAppeared = true }
         }
+        .themedAlert(
+            "Disable request timeout?",
+            isPresented: $showNoTimeoutWarning,
+            accessory: AnyView(NoTimeoutWarningContent()),
+            buttons: [
+                .cancel("Cancel"),
+                .destructive("Disable Timeout") { disableTimeout = true },
+            ],
+            presentationStyle: .contained
+        )
     }
 
     // MARK: - Header
@@ -1831,26 +1899,7 @@ private struct EditProviderFlow: View {
                     }
 
                     // Timeout
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("REQUEST TIMEOUT", bundle: .module)
-                                .font(.system(size: 10, weight: .bold))
-                                .foregroundColor(theme.tertiaryText)
-                                .tracking(0.5)
-                            Spacer()
-                            Text("\(Int(timeout))s", bundle: .module)
-                                .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                .foregroundColor(theme.secondaryText)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(theme.inputBackground)
-                                )
-                        }
-                        Slider(value: $timeout, in: 10 ... 300, step: 10)
-                            .tint(theme.accentColor)
-                    }
+                    timeoutSection
 
                     // Custom headers
                     VStack(alignment: .leading, spacing: 10) {
@@ -1892,6 +1941,66 @@ private struct EditProviderFlow: View {
                 .padding(.top, 12)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
+        }
+    }
+
+    // MARK: - Timeout
+
+    private var timeoutSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("REQUEST TIMEOUT", bundle: .module)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                    .tracking(0.5)
+                Spacer()
+                Text(disableTimeout ? "No limit" : "\(Int(timeout))s", bundle: .module)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(theme.secondaryText)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(theme.inputBackground)
+                    )
+            }
+            Slider(value: $timeout, in: 10 ... 300, step: 10)
+                .tint(theme.accentColor)
+                .disabled(disableTimeout)
+                .opacity(disableTimeout ? 0.4 : 1)
+
+            // Intercepting binding: turning the switch ON only opens the warning;
+            // `disableTimeout` flips to true after the user confirms. Turning OFF
+            // is immediate. This keeps loadProvider() (which sets the @State
+            // directly) from spuriously triggering the alert on sheet open.
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Disable timeout", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    Text("Let requests run with no time limit", bundle: .module)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                Spacer()
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { disableTimeout },
+                        set: { wantsOn in
+                            if wantsOn {
+                                showNoTimeoutWarning = true
+                            } else {
+                                disableTimeout = false
+                            }
+                        }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .tint(theme.accentColor)
+            }
+            .padding(.top, 6)
         }
     }
 
@@ -2032,6 +2141,7 @@ private struct EditProviderFlow: View {
         authType = provider.authType
         providerType = provider.providerType
         timeout = provider.timeout
+        disableTimeout = provider.disableTimeout
         manualModelIdsText = provider.manualModelIds.joined(separator: "\n")
         customHeaders = provider.customHeaders.map { HeaderEntry(key: $0.key, value: $0.value, isSecret: false) }
         for key in provider.secretHeaderKeys {
@@ -2092,6 +2202,7 @@ private struct EditProviderFlow: View {
             enabled: provider.enabled,
             autoConnect: true,
             timeout: timeout,
+            disableTimeout: disableTimeout,
             manualModelIds: parseManualModelIds(manualModelIdsText),
             secretHeaderKeys: secretKeys
         )
@@ -2102,6 +2213,34 @@ private struct EditProviderFlow: View {
 
         onSave(updatedProvider, apiKey.isEmpty ? nil : apiKey, nil)
         dismiss()
+    }
+}
+
+// MARK: - No-Timeout Warning Content
+
+private struct NoTimeoutWarningContent: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Requests will run with no time limit. Before enabling:", bundle: .module)
+            bullet("A stalled provider or dropped connection can hang a request indefinitely. You'll have to stop it manually")
+            bullet("Upstream timeouts (LM Studio, proxies, tunnels) still apply")
+            bullet("Only use this on trusted hardware for long-running work")
+        }
+        .font(.system(size: 13))
+        .foregroundColor(theme.secondaryText)
+        .lineSpacing(2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 8)
+    }
+
+    private func bullet(_ text: LocalizedStringKey) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(verbatim: "•")
+            Text(text, bundle: .module)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

addresses #1235

added an optional "Disable timeout" toggle in the provider's advanced settings so requests can run unbounded (but under the hood it isn't literally infinte. the limit is set to one year since the json encoder cannot decode or represent infinity. so this should be more than enough for any real request)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
