### PR TITLE
add chat rename guard

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -42,8 +42,10 @@ struct ChatSessionSidebar: View {
     }
 
     @Environment(\.theme) private var theme
+    @Environment(\.themedAlertScope) private var alertScope
     @ObservedObject private var agentManager = AgentManager.shared
     @State private var editingSessionId: UUID?
+    @State private var editingBuffer: String = ""
     @State private var searchQuery: String = ""
     @State private var sourceFilter: SourceFilter = .all
     @State private var hoveredFilter: SourceFilter?
@@ -252,6 +254,62 @@ struct ChatSessionSidebar: View {
     /// matching the Esc behavior.
     private func dismissEditing() {
         editingSessionId = nil
+        editingBuffer = ""
+    }
+
+    // MARK: - Navigate-Away Rename Guard
+
+    private func handleSelect(_ session: ChatSessionData) {
+        guard let editingId = editingSessionId, editingId != session.id else {
+            onSelect(session)
+            return
+        }
+        let original = sessions.first { $0.id == editingId }?.title ?? ""
+        let trimmed = editingBuffer.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, trimmed != original else {
+            // No real change — drop the buffer and switch right away.
+            dismissEditing()
+            onSelect(session)
+            return
+        }
+        presentUnsavedRenameAlert(
+            editingId: editingId,
+            oldTitle: original,
+            newTitle: trimmed,
+            pending: session
+        )
+    }
+
+    private func presentUnsavedRenameAlert(
+        editingId: UUID,
+        oldTitle: String,
+        newTitle: String,
+        pending: ChatSessionData
+    ) {
+        let requestId = UUID()
+        let scope = alertScope
+        ThemedAlertCenter.shared.present(
+            ThemedAlertRequest(
+                id: requestId,
+                title: "Save Renamed Title?",
+                message: "You were renaming a conversation titled \"\(oldTitle)\" to \"\(newTitle)\" but haven't saved it yet.",
+                buttons: [
+                    .destructive(L("Discard")) {
+                        dismissEditing()
+                        onSelect(pending)
+                    },
+                    .primary(L("Save")) {
+                        onRename(editingId, newTitle)
+                        dismissEditing()
+                        onSelect(pending)
+                    },
+                ],
+                onDismiss: {
+                    ThemedAlertCenter.shared.dismiss(scope: scope, id: requestId)
+                }
+            ),
+            scope: scope
+        )
     }
 
     // MARK: - Header
@@ -305,16 +363,14 @@ struct ChatSessionSidebar: View {
                         isSelected: session.id == currentSessionId,
                         isEditing: editingSessionId == session.id,
                         onSelect: {
-                            if editingSessionId != nil && editingSessionId != session.id {
-                                dismissEditing()
-                            }
-                            onSelect(session)
+                            handleSelect(session)
                         },
                         onStartRename: {
                             if editingSessionId != nil && editingSessionId != session.id {
                                 dismissEditing()
                             }
                             editingSessionId = session.id
+                            editingBuffer = session.title
                         },
                         onConfirmRename: { newTitle in
                             let trimmed = newTitle.trimmingCharacters(in: .whitespaces)
@@ -326,6 +382,7 @@ struct ChatSessionSidebar: View {
                         onCancelRename: {
                             editingSessionId = nil
                         },
+                        onBufferChange: { editingBuffer = $0 },
                         onDelete: {
                             if editingSessionId != nil {
                                 dismissEditing()
@@ -365,6 +422,7 @@ private struct SessionRow: View {
     /// Parent owns trim and persist.
     let onConfirmRename: (String) -> Void
     let onCancelRename: () -> Void
+    var onBufferChange: ((String) -> Void)? = nil
     let onDelete: () -> Void
     let onToggleArchive: () -> Void
     let onExport: (ChatSessionSidebar.ExportFormat) -> Void
@@ -753,7 +811,11 @@ private struct SessionRow: View {
         }
         .onAppear {
             editBuffer = session.title
+            onBufferChange?(session.title)
             isTextFieldFocused = true
+        }
+        .onChange(of: editBuffer) { _, newValue in
+            onBufferChange?(newValue)
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -292,7 +292,9 @@ struct ChatSessionSidebar: View {
             ThemedAlertRequest(
                 id: requestId,
                 title: "Save Renamed Title?",
-                message: "You were renaming a conversation titled \"\(oldTitle)\" to \"\(newTitle)\" but haven't saved it yet.",
+                message: L(
+                    "You were renaming a conversation titled \"\(oldTitle)\" to \"\(newTitle)\" but haven't saved it yet."
+                ),
                 buttons: [
                     .destructive(L("Discard")) {
                         dismissEditing()


### PR DESCRIPTION
## Summary

previously, renaming a chat and then tapping another chat silently dropped the edit. now, if the title was actually changed, an alert asks whether to save or discard the rename before moving on

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
