### PR TITLE
improved skills page in settings

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -47,6 +47,38 @@ public final class SkillManager {
         skills = await SkillStore.loadAll()
     }
 
+    // MARK: - Batch Updates
+
+    /// Depth counter so nested batches collapse to a single trailing refresh.
+    private var batchDepth = 0
+    /// Skills saved during a batch, so `skill(for:)` (and the file-attachment
+    /// helpers) can resolve a just-saved skill without a full `refresh()`.
+    private var batchStagedSkills: [UUID: Skill] = [:]
+
+    private var isBatching: Bool { batchDepth > 0 }
+
+    /// Run `body` as a bulk mutation: per-operation refreshes are suppressed
+    /// and `skills` is reloaded once when the outermost batch finishes. The
+    /// Claude plugin installer otherwise saves 170+ skills one-by-one, making
+    /// the Skills view flash as it re-renders the list on every save.
+    @discardableResult
+    public func batchUpdates<T>(_ body: () async -> T) async -> T {
+        batchDepth += 1
+        let result = await body()
+        batchDepth -= 1
+        if batchDepth == 0 {
+            batchStagedSkills.removeAll()
+            await refresh()
+        }
+        return result
+    }
+
+    /// `refresh()` unless a bulk batch is in flight (see `batchUpdates`).
+    private func refreshUnlessBatching() async {
+        guard !isBatching else { return }
+        await refresh()
+    }
+
     @discardableResult
     public func create(
         name: String,
@@ -162,7 +194,8 @@ public final class SkillManager {
     // MARK: - Lookup
 
     public func skill(for id: UUID) -> Skill? {
-        skills.first { $0.id == id }
+        if isBatching, let staged = batchStagedSkills[id] { return staged }
+        return skills.first { $0.id == id }
     }
 
     public func skill(named name: String) -> Skill? {
@@ -269,10 +302,11 @@ public final class SkillManager {
                 pluginId: parsedSkill.pluginId
             )
             await SkillStore.save(skill)
+            if isBatching { batchStagedSkills[skill.id] = skill }
             imported.append(skill)
         }
         if !imported.isEmpty {
-            await refresh()
+            await refreshUnlessBatching()
 
             Task {
                 for skill in imported {
@@ -298,7 +332,7 @@ public final class SkillManager {
             throw SkillFileError.cannotModifyBuiltIn
         }
         try await SkillStore.addReference(to: skill, name: name, content: content)
-        await refresh()
+        await refreshUnlessBatching()
 
     }
 
@@ -307,7 +341,7 @@ public final class SkillManager {
             throw SkillFileError.cannotModifyBuiltIn
         }
         try await SkillStore.addAsset(to: skill, name: name, content: content)
-        await refresh()
+        await refreshUnlessBatching()
 
     }
 

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -486,6 +486,16 @@
         }
       }
     },
+    "%lld of %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld of %2$lld"
+          }
+        }
+      }
+    },
     "%lld of %lld facts" : {
       "localizations" : {
         "en" : {
@@ -10244,16 +10254,6 @@
         }
       }
     },
-    "Importing %lld of %lld..." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Importing %1$lld of %2$lld..."
-          }
-        }
-      }
-    },
     "Importing..." : {
       "localizations" : {
         "de" : {
@@ -10577,6 +10577,9 @@
       }
     },
     "Installing" : {
+
+    },
+    "Installing selected plugins" : {
 
     },
     "Instructions" : {
@@ -23036,6 +23039,16 @@
     },
     "You may be asked to authenticate to sign the upload." : {
 
+    },
+    "You were renaming a conversation titled \"%@\" to \"%@\" but haven't saved it yet." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "You were renaming a conversation titled \"%1$@\" to \"%2$@\" but haven't saved it yet."
+          }
+        }
+      }
     },
     "You're already set up" : {
 

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -13385,6 +13385,9 @@
     "No services match \"%@\"" : {
 
     },
+    "No skills match \"%@\"" : {
+
+    },
     "No system prompt" : {
 
     },
@@ -17922,6 +17925,9 @@
           }
         }
       }
+    },
+    "Search skills" : {
+
     },
     "Search tools" : {
 

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -13061,6 +13061,9 @@
     "No identity yet. Chat with Osaurus and the memory system will build your identity from session distillations." : {
 
     },
+    "No installed skills yet" : {
+
+    },
     "No invites issued yet" : {
 
     },
@@ -13383,6 +13386,9 @@
 
     },
     "No services match \"%@\"" : {
+
+    },
+    "No skills here" : {
 
     },
     "No skills match \"%@\"" : {

--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -898,6 +898,40 @@ public final class GitHubSkillService: ObservableObject {
         return result.sorted { $0.displayName < $1.displayName }
     }
 
+    // MARK: - Tolerant discovery probes
+
+    // Tolerate a missing directory (404 → none) but re-throw `.rateLimited`
+    // so `fetchPlugins` surfaces it. Plain `try?` swallowed the 403 too,
+    // making a throttled import silently report 0 skills.
+
+    private nonisolated func discoverSkillDirectoriesTolerant(
+        repo: GitHubRepo,
+        source: String
+    ) async throws -> [ClaudeSkillEntry] {
+        do {
+            return try await discoverSkillDirectories(repo: repo, source: source)
+        } catch let error as GitHubSkillError {
+            if case .rateLimited = error { throw error }
+            return []
+        } catch {
+            return []
+        }
+    }
+
+    private nonisolated func listDirectoryTolerant(
+        repo: GitHubRepo,
+        path: String
+    ) async throws -> [GitHubTreeEntry]? {
+        do {
+            return try await listDirectory(repo: repo, path: path)
+        } catch let error as GitHubSkillError {
+            if case .rateLimited = error { throw error }
+            return nil
+        } catch {
+            return nil
+        }
+    }
+
     // MARK: - Sibling Dependency Resolution
 
     /// Walk every plugin's agent markdown files looking for references to
@@ -1090,23 +1124,18 @@ public final class GitHubSkillService: ObservableObject {
             )
         }
 
-        // New-style plugins: discover from the source directory.  Walk it
-        // with a trailing slash semantically: when `source == ""` (external
-        // repo at root) we probe top-level paths like `skills`, `agents`.
+        // New-style plugins: discover from the source directory. Empty
+        // `source` (external repo at root) probes top-level `skills`/`agents`.
         let prefix = source.isEmpty ? "" : "\(source)/"
 
-        // Run the discovery probes concurrently. Each one is at least one
-        // HTTP round-trip; serializing them was the main contributor to the
-        // ~10-second wait on the picker for repos with ~13 plugins like
-        // `claude-for-legal`. The probes themselves go through the shared
-        // concurrency limiter (`SharedFetchLimiter`) to keep total in-flight
-        // GitHub calls below the rate-limit budget.
+        // Probe concurrently — serializing these round-trips was the main
+        // cause of the ~10s picker wait for repos with ~13 plugins.
         async let skillsTask: [ClaudeSkillEntry] =
-            (try? await discoverSkillDirectories(repo: sourceRepo, source: source)) ?? []
-        async let agentsListing =
-            (try? await listDirectory(repo: sourceRepo, path: "\(prefix)agents")) ?? nil
-        async let commandsListing =
-            (try? await listDirectory(repo: sourceRepo, path: "\(prefix)commands")) ?? nil
+            discoverSkillDirectoriesTolerant(repo: sourceRepo, source: source)
+        async let agentsListing: [GitHubTreeEntry]? =
+            listDirectoryTolerant(repo: sourceRepo, path: "\(prefix)agents")
+        async let commandsListing: [GitHubTreeEntry]? =
+            listDirectoryTolerant(repo: sourceRepo, path: "\(prefix)commands")
         async let hasClaudeMd: Bool = fileExists(repo: sourceRepo, path: "\(prefix)CLAUDE.md")
         async let hasConnectorsMd: Bool = fileExists(
             repo: sourceRepo,
@@ -1115,16 +1144,16 @@ public final class GitHubSkillService: ObservableObject {
         async let hasReadmeMd: Bool = fileExists(repo: sourceRepo, path: "\(prefix)README.md")
         async let hasMCPJson: Bool = fileExists(repo: sourceRepo, path: "\(prefix).mcp.json")
 
-        let skills = await skillsTask
+        let skills = try await skillsTask
         let agents: [ClaudeAgentEntry] =
-            (await agentsListing).map { entries in
+            (try await agentsListing).map { entries in
                 entries
                     .filter { $0.type == "file" && $0.name.hasSuffix(".md") }
                     .map { ClaudeAgentEntry(path: $0.path) }
                     .sorted { $0.displayName < $1.displayName }
             } ?? []
         let commands: [ClaudeCommandEntry] =
-            (await commandsListing).map { entries in
+            (try await commandsListing).map { entries in
                 entries
                     .filter { $0.type == "file" && $0.name.hasSuffix(".md") }
                     .map { ClaudeCommandEntry(path: $0.path) }

--- a/Packages/OsaurusCore/Views/Common/AnimatedTabSelector.swift
+++ b/Packages/OsaurusCore/Views/Common/AnimatedTabSelector.swift
@@ -147,6 +147,22 @@ enum ToolsTab: String, CaseIterable, AnimatedTabItem {
     var title: String { rawValue }
 }
 
+// MARK: - Skills Tab (for SkillsView)
+
+enum SkillsTab: String, CaseIterable, AnimatedTabItem {
+    case all = "All"
+    case installed = "Installed"
+    case defaults = "Default"
+
+    var title: String {
+        switch self {
+        case .all: return L("All")
+        case .installed: return L("Installed")
+        case .defaults: return L("Default")
+        }
+    }
+}
+
 // MARK: - Plugins Tab (for PluginsView)
 
 enum PluginsTab: String, CaseIterable, AnimatedTabItem {

--- a/Packages/OsaurusCore/Views/Skill/GitHubImportSheet.swift
+++ b/Packages/OsaurusCore/Views/Skill/GitHubImportSheet.swift
@@ -174,7 +174,7 @@ struct GitHubImportSheet: View {
             return L("\(result.skills.count) skills available")
         case .pluginSelection(let result):
             return L("\(result.plugins.count) plugins available")
-        case .importing(let progress, let total): return L("Importing \(progress) of \(total)")
+        case .importing: return L("Installing selected plugins")
         case .installComplete(let report):
             let totals =
                 report.totalImportedSkills + report.totalImportedAgents
@@ -741,8 +741,9 @@ struct GitHubImportSheet: View {
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundColor(theme.primaryText)
 
-                Text("Importing \(progress) of \(total)...", bundle: .module)
+                Text("\(progress) of \(total)", bundle: .module)
                     .font(.system(size: 12))
+                    .monospacedDigit()
                     .foregroundColor(theme.secondaryText)
             }
 
@@ -993,21 +994,21 @@ struct GitHubImportSheet: View {
         importState = .importing(progress: 0, total: totalSteps)
 
         activeTask = Task { @MainActor in
-            let report = await ClaudePluginInstaller.shared.install(
-                selections: selections,
-                from: result.repo,
-                progressHandler: { @MainActor current, total in
-                    // The installer runs on the main actor, so this fires
-                    // synchronously inside `install`. Updating `@State`
-                    // directly (no inner `Task`) avoids two problems:
-                    //   1. a flood of queued Tasks racing to set
-                    //      `importState`, which can leave us stuck at
-                    //      "N of N" because a late-arriving progress task
-                    //      overwrites `.installComplete`.
-                    //   2. one extra runloop tick of jank per artifact.
-                    importState = .importing(progress: current, total: total)
-                }
-            )
+            // Batch so SkillManager reloads `skills` once at the end instead
+            // of after every per-skill save — which made the Skills view
+            // behind this sheet flash continuously during a 170-skill import.
+            let report = await SkillManager.shared.batchUpdates {
+                await ClaudePluginInstaller.shared.install(
+                    selections: selections,
+                    from: result.repo,
+                    progressHandler: { @MainActor current, total in
+                        // Fires synchronously on the main actor; set `@State`
+                        // directly so late progress Tasks can't overwrite
+                        // `.installComplete`.
+                        importState = .importing(progress: current, total: total)
+                    }
+                )
+            }
             guard !Task.isCancelled else { return }
             onPluginInstallComplete?(report)
             importState = .installComplete(report)

--- a/Packages/OsaurusCore/Views/Skill/InstalledPluginsSection.swift
+++ b/Packages/OsaurusCore/Views/Skill/InstalledPluginsSection.swift
@@ -302,8 +302,18 @@ struct InstalledPluginsSection: View {
     let onMessage: (String, Bool) -> Void
 
     @State private var pendingUninstall: InstalledPluginsAggregator.Summary?
+    /// Backs the alert's "Don't ask again" checkbox. An observable object
+    /// (rather than `@State`) because the global alert host snapshots the
+    /// accessory once at present-time — the toggle only updates visually if
+    /// the view it lives in subscribes to this model directly.
+    @StateObject private var uninstallPrompt = UninstallPromptModel()
     @State private var isExpanded = true
     @State private var isHeaderHovered = false
+
+    /// When the user checks "Don't ask again", skip the confirmation for the
+    /// rest of the app session. Static so it survives this view being
+    /// recreated as the user navigates between tabs.
+    @MainActor private static var skipUninstallConfirm = false
     /// Coalesces aggregator refreshes during heavy imports — claude-for-legal
     /// lands ~170 skills one-by-one, and refreshing on every tick produced
     /// visible jank behind the import sheet.
@@ -323,11 +333,15 @@ struct InstalledPluginsSection: View {
                         set: { if !$0 { pendingUninstall = nil } }
                     ),
                     message: pendingUninstall.map(Self.confirmMessage(for:)) ?? "",
-                    primaryButton: .destructive("Uninstall") {
-                        if let target = pendingUninstall { confirmUninstall(target) }
-                        pendingUninstall = nil
-                    },
-                    secondaryButton: .cancel("Cancel")
+                    accessory: AnyView(UninstallDontAskAgainToggle(model: uninstallPrompt)),
+                    buttons: [
+                        .cancel("Cancel"),
+                        .destructive("Uninstall") {
+                            if uninstallPrompt.dontAskAgain { Self.skipUninstallConfirm = true }
+                            if let target = pendingUninstall { confirmUninstall(target) }
+                            pendingUninstall = nil
+                        },
+                    ]
                 )
             }
         }
@@ -366,7 +380,7 @@ struct InstalledPluginsSection: View {
             ForEach(aggregator.plugins) { plugin in
                 PluginRow(
                     plugin: plugin,
-                    onUninstall: { pendingUninstall = plugin }
+                    onUninstall: { requestUninstall(plugin) }
                 )
             }
         }
@@ -492,6 +506,18 @@ struct InstalledPluginsSection: View {
             """
     }
 
+    /// Either confirm immediately (when the user opted out of the prompt this
+    /// session) or open the confirmation alert with a fresh, unchecked
+    /// "Don't ask again" box.
+    private func requestUninstall(_ plugin: InstalledPluginsAggregator.Summary) {
+        if Self.skipUninstallConfirm {
+            confirmUninstall(plugin)
+        } else {
+            uninstallPrompt.dontAskAgain = false
+            pendingUninstall = plugin
+        }
+    }
+
     private func confirmUninstall(_ plugin: InstalledPluginsAggregator.Summary) {
         let label = plugin.displayName
         let items = Self.pluralize(plugin.totalCount, "item")
@@ -517,6 +543,32 @@ struct InstalledPluginsSection: View {
 
     private static func pluralize(_ count: Int, _ noun: String) -> String {
         "\(count) \(noun)\(count == 1 ? "" : "s")"
+    }
+}
+
+// MARK: - Uninstall confirmation accessory
+
+@MainActor
+private final class UninstallPromptModel: ObservableObject {
+    @Published var dontAskAgain = false
+}
+
+/// "Don't ask again" checkbox shown beneath the uninstall-alert message.
+/// Owns an `@ObservedObject` so it re-renders on toggle even though the
+/// global alert host snapshots the accessory once at present-time.
+private struct UninstallDontAskAgainToggle: View {
+    @Environment(\.theme) private var theme
+    @ObservedObject var model: UninstallPromptModel
+
+    var body: some View {
+        Toggle(isOn: $model.dontAskAgain) {
+            Text("Don't ask me again", bundle: .module)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+        }
+        .toggleStyle(.checkbox)
+        .fixedSize()
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -27,13 +27,33 @@ struct SkillsView: View {
     @State private var isProcessing = false
     @State private var showProgress = false
     @State private var searchText = ""
+    @State private var selectedTab: SkillsTab = .all
 
-    /// Skills matching the current search query (name, description, category,
-    /// or keywords). Returns all skills when the query is empty.
+    /// Base skill set for a tab: All, Installed (user-created + plugin), or
+    /// Default (built-in).
+    private func skills(in tab: SkillsTab) -> [Skill] {
+        switch tab {
+        case .all: return skillManager.skills
+        case .installed: return skillManager.skills.filter { !$0.isBuiltIn }
+        case .defaults: return skillManager.skills.filter { $0.isBuiltIn }
+        }
+    }
+
+    private var tabCounts: [SkillsTab: Int] {
+        [
+            .all: skillManager.skills.count,
+            .installed: skillManager.skills.filter { !$0.isBuiltIn }.count,
+            .defaults: skillManager.skills.filter { $0.isBuiltIn }.count,
+        ]
+    }
+
+    /// Skills for the selected tab, further narrowed by the search query
+    /// (name, description, category, or keywords).
     private var filteredSkills: [Skill] {
+        let base = skills(in: selectedTab)
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return skillManager.skills }
-        return skillManager.skills.filter { skill in
+        guard !query.isEmpty else { return base }
+        return base.filter { skill in
             skill.name.lowercased().contains(query)
                 || skill.description.lowercased().contains(query)
                 || (skill.category?.lowercased().contains(query) ?? false)
@@ -89,17 +109,18 @@ struct SkillsView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 12) {
-                            // Hide the plugins section while searching so the
-                            // results focus on matching skills.
-                            if searchText.isEmpty {
+                            // Plugins are "installed" artifacts, so the section
+                            // only belongs on All/Installed — and not while
+                            // searching, so results focus on matching skills.
+                            if searchText.isEmpty && selectedTab != .defaults {
                                 InstalledPluginsSection(onMessage: { message, isError in
                                     showToast(message, isError: isError)
                                 })
                             }
 
                             let shown = filteredSkills
-                            if shown.isEmpty && !searchText.isEmpty {
-                                noSearchResults
+                            if shown.isEmpty {
+                                emptyState
                             }
 
                             ForEach(Array(shown.enumerated()), id: \.element.id) { index, skill in
@@ -369,16 +390,27 @@ struct SkillsView: View {
         }
     }
 
-    // MARK: - Search Empty State
+    // MARK: - Empty State
 
-    private var noSearchResults: some View {
+    @ViewBuilder
+    private var emptyState: some View {
         VStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
+            Image(systemName: searchText.isEmpty ? "sparkles" : "magnifyingglass")
                 .font(.system(size: 28, weight: .light))
                 .foregroundColor(theme.tertiaryText)
-            Text("No skills match \"\(searchText)\"", bundle: .module)
-                .font(.system(size: 13))
-                .foregroundColor(theme.secondaryText)
+            if !searchText.isEmpty {
+                Text("No skills match \"\(searchText)\"", bundle: .module)
+                    .font(.system(size: 13))
+                    .foregroundColor(theme.secondaryText)
+            } else if selectedTab == .installed {
+                Text("No installed skills yet", bundle: .module)
+                    .font(.system(size: 13))
+                    .foregroundColor(theme.secondaryText)
+            } else {
+                Text("No skills here", bundle: .module)
+                    .font(.system(size: 13))
+                    .foregroundColor(theme.secondaryText)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 48)
@@ -389,8 +421,7 @@ struct SkillsView: View {
     private var headerView: some View {
         ManagerHeaderWithTabs(
             title: L("Skills"),
-            subtitle: L("Specialized knowledge and guidance for the AI"),
-            count: skillManager.skills.isEmpty ? nil : skillManager.enabledCount
+            subtitle: L("Specialized knowledge and guidance for the AI")
         ) {
             HeaderIconButton("arrow.clockwise", isLoading: skillManager.isRefreshing, help: "Refresh skills") {
                 Task { @MainActor in
@@ -408,10 +439,12 @@ struct SkillsView: View {
             }
             .disabled(isProcessing || skillManager.isRefreshing)
         } tabsRow: {
-            HStack {
-                Spacer()
-                SearchField(text: $searchText, placeholder: "Search skills", width: 240)
-            }
+            HeaderTabsRow(
+                selection: $selectedTab,
+                counts: tabCounts,
+                searchText: $searchText,
+                searchPlaceholder: "Search skills"
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -26,6 +26,20 @@ struct SkillsView: View {
     @State private var exportingSkill: Skill?
     @State private var isProcessing = false
     @State private var showProgress = false
+    @State private var searchText = ""
+
+    /// Skills matching the current search query (name, description, category,
+    /// or keywords). Returns all skills when the query is empty.
+    private var filteredSkills: [Skill] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return skillManager.skills }
+        return skillManager.skills.filter { skill in
+            skill.name.lowercased().contains(query)
+                || skill.description.lowercased().contains(query)
+                || (skill.category?.lowercased().contains(query) ?? false)
+                || skill.keywords.contains { $0.lowercased().contains(query) }
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,11 +89,20 @@ struct SkillsView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 12) {
-                            InstalledPluginsSection(onMessage: { message, isError in
-                                showToast(message, isError: isError)
-                            })
+                            // Hide the plugins section while searching so the
+                            // results focus on matching skills.
+                            if searchText.isEmpty {
+                                InstalledPluginsSection(onMessage: { message, isError in
+                                    showToast(message, isError: isError)
+                                })
+                            }
 
-                            ForEach(Array(skillManager.skills.enumerated()), id: \.element.id) { index, skill in
+                            let shown = filteredSkills
+                            if shown.isEmpty && !searchText.isEmpty {
+                                noSearchResults
+                            }
+
+                            ForEach(Array(shown.enumerated()), id: \.element.id) { index, skill in
                                 SkillRow(
                                     skill: skill,
                                     animationDelay: Double(index) * 0.03,
@@ -346,10 +369,25 @@ struct SkillsView: View {
         }
     }
 
+    // MARK: - Search Empty State
+
+    private var noSearchResults: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 28, weight: .light))
+                .foregroundColor(theme.tertiaryText)
+            Text("No skills match \"\(searchText)\"", bundle: .module)
+                .font(.system(size: 13))
+                .foregroundColor(theme.secondaryText)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 48)
+    }
+
     // MARK: - Header
 
     private var headerView: some View {
-        ManagerHeaderWithActions(
+        ManagerHeaderWithTabs(
             title: L("Skills"),
             subtitle: L("Specialized knowledge and guidance for the AI"),
             count: skillManager.skills.isEmpty ? nil : skillManager.enabledCount
@@ -369,6 +407,11 @@ struct SkillsView: View {
                 isCreating = true
             }
             .disabled(isProcessing || skillManager.isRefreshing)
+        } tabsRow: {
+            HStack {
+                Spacer()
+                SearchField(text: $searchText, placeholder: "Search skills", width: 240)
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -467,25 +467,23 @@ private struct ImportDropdownButton: View {
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "square.and.arrow.down")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.system(size: 13, weight: .medium))
                 Text("Import", bundle: .module)
                     .font(.system(size: 13, weight: .medium))
             }
-            .foregroundColor(theme.primaryText)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(theme.tertiaryBackground)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(theme.inputBorder, lineWidth: 1)
-                    )
-                    .opacity(isHovering ? 0.8 : 1)
-            )
+            .foregroundStyle(theme.secondaryText)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        .tint(theme.secondaryText)
+        .fixedSize()
+        .padding(.horizontal, 12)
+        .frame(height: 32)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.tertiaryBackground)
+                .opacity(isHovering ? 0.8 : 1)
+        )
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) {
                 isHovering = hovering


### PR DESCRIPTION
## Summary

  - Stopped the skills list from flashing during plugin imports by batching skill saves into a single refresh
  - Properly handled github rate limit errors during plugin import instead of silently showing zero skills
  - Added a search field to the skills page
  - Added All / Installed / Default tabs to the Skills page
  - Added a "Don't ask me again" option to the plugin uninstall confirmation

<img width="682" height="674" alt="image" src="https://github.com/user-attachments/assets/a8570dcf-d10a-4e74-b07a-a7493eb38186" />

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
