### PR TITLE
Add family runtime matrix guard

### DIFF
--- a/docs/FAMILY_RUNTIME_MATRIX.md
+++ b/docs/FAMILY_RUNTIME_MATRIX.md
@@ -1,0 +1,66 @@
+# Family Runtime Matrix
+
+This document tracks the post-merge runtime proof lane for local model families
+whose tool parsing, reasoning templates, media paths, and cache topologies cannot
+be proven by generic OpenAI-compatible request tests alone.
+
+## Scope
+
+The next production claim requires source gates plus live Osaurus chat/API proof
+for each downloaded or locally available family:
+
+| Family | Local evidence target | Cache topology that must be proven | Live proof status |
+| --- | --- | --- | --- |
+| Nemotron Omni | `Nemotron-Omni-Nano-*` local bundles | hybrid SSM companion state, prefix/L2 disk, media cache salt for audio/video rows | pending |
+| Ling / Bailing | `Ling-2.6-flash-*` local bundles | hybrid linear-attention/SSM companion state, prefix/L2 disk | pending |
+| ZAYA text | `ZAYA1-8B-*` local bundles | ZAYA CCA companion state, path-dependent restore, prefix/L2 disk | pending |
+| ZAYA VL | `ZAYA1-VL-8B-*` local bundles | ZAYA CCA plus real image payload and media cache salt | pending |
+| HY3 / Hunyuan | local `Hy3-preview` source or bundle | Hunyuan reasoning-effort template, Hunyuan tool parser, cache topology after load | local bundle pending |
+
+## Non-Negotiables
+
+- Do not force coherence with synthetic sampler defaults, hidden repetition
+  penalties, forced thinking tags, forced reasoning closers, prompt coercion, or
+  parser-side stripping that hides protocol bugs.
+- Generation parameters must remain absent unless the user/API explicitly sends
+  them. Model defaults come from the bundle/runtime configuration.
+- Tool proof must use actual `tool_choice` and `tools` wiring through the local
+  vMLX template/decode path, then verify structured tool calls and no visible
+  protocol leakage.
+- Multi-turn proof must include a tool result followed by a second model turn in
+  the same chat/session. Load-only or one-shot output is not production proof.
+- Cache proof must match the architecture. Hybrid SSM, ZAYA CCA, DSV4 hybrid
+  pool, and media payloads need their companion-state evidence; generic KV/L2
+  counters are not enough.
+- TurboQuant KV remains opt-in until every relevant family/topology has a live
+  row proving correctness under that mode.
+
+## Required Row Shape
+
+Each live row must record:
+
+- Osaurus commit, vMLX pin, app path, app PID, model path, and request endpoint
+  or UI steps.
+- Request payload: model, messages, tools, `tool_choice`, reasoning controls,
+  and explicit sampler fields if any.
+- Visible content, reasoning deltas, tool calls, finish reason, and parser leak
+  check.
+- Token/s, load memory, generation memory, and Activity Monitor physical
+  footprint when available.
+- `/health` and `/admin/cache-stats` before/after with topology-specific
+  counters: prefix/paged hits, disk L2 hits/stores, SSM/CCA companion hits or
+  re-derives, media cache salt/hit where applicable, and TurboQuant counters
+  only when explicitly enabled.
+
+## Current Source Baseline
+
+The merged runtime already contains:
+
+- `tool_choice` propagation into local template context for required/named tool
+  calls.
+- Family matchers for Nemotron Omni, Ling, ZAYA, and ZAYA VL.
+- HY3 reasoning-effort profile and Hunyuan parser aliases.
+- `/admin/cache-stats` topology output for SSM, ZAYA CCA, hybrid pool, disk L2,
+  and TurboQuant counters.
+
+The source baseline is necessary but not sufficient. Live rows remain pending.

--- a/scripts/live-proof/assert-family-runtime-matrix-source.sh
+++ b/scripts/live-proof/assert-family-runtime-matrix-source.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+
+pass() { echo "PASS $*"; }
+fail_msg() { echo "FAIL $*" >&2; fail=1; }
+
+require_file() {
+  local file="$1" label="$2"
+  if [[ -f "$file" ]]; then
+    pass "$label exists"
+  else
+    fail_msg "missing $label: ${file#$ROOT/}"
+  fi
+}
+
+require_text() {
+  local file="$1" pattern="$2" label="$3"
+  if rg -U -q "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail_msg "missing $label in ${file#$ROOT/}"
+  fi
+}
+
+reject_text() {
+  local file="$1" pattern="$2" label="$3"
+  if rg -U -n "$pattern" "$file"; then
+    fail_msg "forbidden $label in ${file#$ROOT/}"
+  else
+    pass "no $label"
+  fi
+}
+
+FAMILY="$ROOT/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift"
+OPTIONS="$ROOT/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift"
+MEDIA="$ROOT/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift"
+RUNTIME="$ROOT/Packages/OsaurusCore/Services/ModelRuntime.swift"
+ADAPTER="$ROOT/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift"
+TOKENIZER="$ROOT/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift"
+HTTP="$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift"
+SERVER_SETTINGS="$ROOT/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift"
+TOOL_TESTS="$ROOT/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift"
+POLICY_TESTS="$ROOT/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift"
+DOC="$ROOT/docs/FAMILY_RUNTIME_MATRIX.md"
+
+for pair in \
+  "$FAMILY:ModelFamilyNames" \
+  "$OPTIONS:ModelOptions" \
+  "$MEDIA:ModelMediaCapabilities" \
+  "$RUNTIME:ModelRuntime" \
+  "$ADAPTER:MLXBatchAdapter" \
+  "$TOKENIZER:SwiftTransformersTokenizerLoader" \
+  "$HTTP:HTTPHandler" \
+  "$SERVER_SETTINGS:ServerRuntimeSettingsStore" \
+  "$TOOL_TESTS:MLXBatchAdapterTests" \
+  "$POLICY_TESTS:RuntimePolicySourceTests" \
+  "$DOC:family runtime matrix doc"; do
+  require_file "${pair%%:*}" "${pair#*:}"
+done
+
+echo "--- family detection and runtime profiles ---"
+require_text "$FAMILY" 'isNemotronOmniFamily' "Nemotron Omni family matcher"
+require_text "$FAMILY" 'isLingFamily' "Ling family matcher"
+require_text "$FAMILY" 'isZayaFamily' "ZAYA family matcher"
+require_text "$FAMILY" 'isZayaVLFamily' "ZAYA VL family matcher"
+require_text "$OPTIONS" 'struct NemotronThinkingProfile' "Nemotron thinking profile"
+require_text "$OPTIONS" 'struct Hy3ReasoningProfile' "HY3 reasoning-effort profile"
+require_text "$OPTIONS" 'struct LingRuntimeProfile' "Ling runtime profile"
+require_text "$OPTIONS" 'struct ZayaThinkingProfile' "ZAYA thinking profile"
+require_text "$MEDIA" 'ModelFamilyNames\.isNemotronOmniFamily' "Nemotron media capability detection"
+require_text "$MEDIA" 'ModelFamilyNames\.isZayaVLFamily' "ZAYA VL image capability detection"
+
+echo "--- local template/tool-choice wiring ---"
+require_text "$ADAPTER" 'toolChoice: ToolChoiceOption\? = nil' "additionalContext accepts tool_choice"
+require_text "$ADAPTER" 'context\["tool_choice"\] = "required"' "required tool_choice reaches template context"
+require_text "$ADAPTER" 'case \.required, \.function\(_\)' "named tool_choice maps to required local call"
+require_text "$RUNTIME" 'toolChoice: toolChoice' "ModelRuntime passes tool_choice into MLXBatchAdapter"
+require_text "$TOKENIZER" 'toolChoiceRequired' "tokenizer fallback observes required tool_choice"
+require_text "$ADAPTER" 'Hy3ReasoningProfile\.matches' "Osaurus maps HY3 to reasoning_effort context"
+require_text "$ADAPTER" 'context\["reasoning_effort"\] = Hy3ReasoningProfile\.normalizedEffort' \
+  "HY3 context preserves native reasoning_effort instead of generic enable_thinking"
+require_text "$TOKENIZER" 'NemotronMinimal' "Nemotron fallback remains wired"
+
+echo "--- topology-aware cache surfaces ---"
+require_text "$RUNTIME" 'layers=hybrid-ssm' "hybrid SSM cache key tag"
+require_text "$RUNTIME" 'layers=zayaCCA' "ZAYA CCA cache key tag"
+require_text "$RUNTIME" 'media=omni-audio-video' "Nemotron Omni media cache key tag"
+require_text "$RUNTIME" 'requiresSSMCompanionState' "runtime observes SSM/CCA companion topology"
+require_text "$HTTP" 'ssm_companion_cache' "cache stats exposes SSM companion cache"
+require_text "$HTTP" 'zaya_cca_layer_count' "cache stats exposes ZAYA CCA layer count"
+require_text "$HTTP" 'turbo_quant_kv_layer_count' "cache stats exposes TurboQuant KV layer count"
+require_text "$HTTP" 'requires_disk_backed_restore' "cache stats exposes disk-backed restore requirement"
+
+echo "--- TurboQuant remains opt-in until live matrix proves it ---"
+require_text "$SERVER_SETTINGS" 'liveKVCodec: \.native' "default live KV codec stays native/fp16"
+reject_text "$SERVER_SETTINGS" 'normalized\.cache\.liveKVCodec = \.engineSelected' \
+  "legacy migration silently enabling engine-selected TurboQuant KV"
+require_text "$DOC" 'TurboQuant KV remains opt-in' "matrix doc records TurboQuant opt-in policy"
+
+echo "--- regression tests cover the source contracts ---"
+require_text "$TOOL_TESTS" 'additionalContext_threadsRequiredToolChoiceToLocalTemplates' \
+  "tool_choice template-context regression test"
+require_text "$TOOL_TESTS" 'additionalContext_defaultsLingThinkingOffButHonorsExplicitOptIn' \
+  "Ling thinking-context regression test"
+require_text "$TOOL_TESTS" 'additionalContext_mapsReasoningEffortToTemplateKwarg' \
+  "HY3 reasoning-effort regression test"
+require_text "$TOOL_TESTS" 'additionalContext_normalizesHy3ReasoningEffortAliases' \
+  "HY3 reasoning-effort alias regression test"
+require_text "$POLICY_TESTS" 'localDecodeLoopKeepsToolSchemasForParserValidation' \
+  "local decode loop tool-schema source guard"
+require_text "$POLICY_TESTS" 'Runtime Tools' "settings runtime tool visibility guard"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "Family runtime matrix source guard failed." >&2
+  exit 1
+fi
+
+echo "Family runtime matrix source guard passed."

--- a/scripts/live-proof/assert-osaurus-pr-hygiene.sh
+++ b/scripts/live-proof/assert-osaurus-pr-hygiene.sh
@@ -66,8 +66,9 @@ CHAT_UI_REASONING_GUARD="$ROOT/scripts/live-proof/assert-chat-ui-reasoning-routi
 HTTP_CANCEL_GUARD="$ROOT/scripts/live-proof/assert-http-channel-load-cancellation.sh"
 TOOL_CHOICE_GUARD="$ROOT/scripts/live-proof/assert-tool-choice-required-routing.sh"
 MODEL_TOOL_CAPABILITY_GUARD="$ROOT/scripts/live-proof/assert-model-tool-capability-surfaces.sh"
+FAMILY_RUNTIME_MATRIX_GUARD="$ROOT/scripts/live-proof/assert-family-runtime-matrix-source.sh"
 
-for file in "$KEYCHAIN_GUARD" "$VMLX_READY" "$SAMPLER_GUARD" "$RESPONSES_GUARD" "$NO_FORCED_GUARD" "$SERVER_SETTINGS_GUARD" "$CHAT_REASONING_GUARD" "$CHAT_UI_REASONING_GUARD" "$HTTP_CANCEL_GUARD" "$TOOL_CHOICE_GUARD" "$MODEL_TOOL_CAPABILITY_GUARD"; do
+for file in "$KEYCHAIN_GUARD" "$VMLX_READY" "$SAMPLER_GUARD" "$RESPONSES_GUARD" "$NO_FORCED_GUARD" "$SERVER_SETTINGS_GUARD" "$CHAT_REASONING_GUARD" "$CHAT_UI_REASONING_GUARD" "$HTTP_CANCEL_GUARD" "$TOOL_CHOICE_GUARD" "$MODEL_TOOL_CAPABILITY_GUARD" "$FAMILY_RUNTIME_MATRIX_GUARD"; do
   require_file "$file" "${file#$ROOT/}"
 done
 
@@ -137,6 +138,12 @@ if "$MODEL_TOOL_CAPABILITY_GUARD"; then
   pass "model tool/capability surfaces"
 else
   fail_msg "model tool/capability surface guard failed"
+fi
+
+if "$FAMILY_RUNTIME_MATRIX_GUARD"; then
+  pass "family runtime matrix source gate"
+else
+  fail_msg "family runtime matrix source gate failed"
 fi
 
 echo "--- PR artifact hygiene ---"


### PR DESCRIPTION
## Summary
- Adds a post-merge family runtime matrix document for Nemotron Omni, Ling, ZAYA, ZAYA-VL, and HY3.
- Adds a source guard for family detection, template/tool_choice wiring, topology-aware cache telemetry, and TurboQuant opt-in policy.
- Wires the guard into the existing PR hygiene script so future family-runtime work cannot drop these contracts silently.

## Validation
- `git diff --check`
- `bash -n scripts/live-proof/assert-family-runtime-matrix-source.sh`
- `bash -n scripts/live-proof/assert-osaurus-pr-hygiene.sh`
- `scripts/live-proof/assert-family-runtime-matrix-source.sh`
- `/Users/eric/vmlx-swift/scripts/vmlx-downloaded-model-inventory-check.sh`

## Live proof status
Live Osaurus chat/API rows are intentionally still pending in this PR. This first commit creates the guardrail and matrix surface before model-specific fixes and proof rows are added.
