### PR TITLE
Keep ZAYA required tools stable after history

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d1442f914220a82d9c528e9506860578d87aa4da"
+        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d1442f914220a82d9c528e9506860578d87aa4da"
+        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d1442f914220a82d9c528e9506860578d87aa4da"
+            revision: "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d1442f914220a82d9c528e9506860578d87aa4da"
+        let expectedRuntimeHardenedRevision = "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -141,6 +141,76 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(decoded.contains("Use line_count on red\ngreen\nblue."), "Decoded: \(decoded)")
     }
 
+    @Test func zayaVLLocalTokenizerKeepsRequiredToolReminderInCurrentUserTurn() async throws {
+        let defaultPath = "/Users/eric/models/Osaurus/ZAYA1-VL-8B-MXFP4"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_ZAYA_VL_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object([
+                            "type": .string("string"),
+                            "description": .string("Text to count lines for."),
+                        ])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let finalUser = "Now use line_count on this exact text:\none\ntwo"
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                ["role": "user", "content": "Use line_count on this text:\nred\ngreen\nblue"],
+                [
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        [
+                            "id": "call_lines_1",
+                            "type": "function",
+                            "function": [
+                                "name": "line_count",
+                                "arguments": ["text": "red\ngreen\nblue"],
+                            ] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                    ],
+                ] as [String: any Sendable],
+                ["role": "tool", "tool_call_id": "call_lines_1", "content": #"{"lines":3}"#],
+                ["role": "user", "content": "How many lines were counted? Do not call another tool."],
+                ["role": "assistant", "content": "Three lines were counted."],
+                ["role": "user", "content": finalUser],
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+        let reminder = "The current assistant response MUST be a tool call."
+        let finalUserRange = try #require(decoded.range(of: finalUser))
+        let afterFinalUser = decoded[finalUserRange.upperBound...]
+
+        #expect(afterFinalUser.contains(reminder), "Decoded: \(decoded)")
+        #expect(!afterFinalUser.contains("<|im_start|>system\n<IMPORTANT>"), "Decoded: \(decoded)")
+        #expect(decoded.hasSuffix("<|im_start|>assistant\n"), "Decoded: \(decoded)")
+    }
+
     @Test func gemma4LocalTokenizerRendersUnionToolSchemaTypeNatively() async throws {
         let defaultPath = "/Users/eric/models/dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_GEMMA4_TEST_MODEL"] ?? defaultPath

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d1442f914220a82d9c528e9506860578d87aa4da"
+        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
       }
     },
     {


### PR DESCRIPTION
## Summary

- pin vMLX to `8b835cb7e957507d0003abd0e7bc6acf766d8bca` for the ZAYA required-tool prompt fix
- add an Osaurus tokenizer regression proving required tool guidance stays in the current user turn after tool history
- keep this stacked on #1251 until `codex/family-runtime-matrix-next` lands

## Local source validation

- `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening` passed
- `SwiftTransformersTokenizerLoaderTests/zayaVLLocalTokenizerKeepsRequiredToolReminderInCurrentUserTurn` passed

## Live proof status

Pending: no-sign Release rebuild and live ZAYA multi-turn tool/cache proof against the rebuilt app.

## Boundaries

- no signing, notarization, or keychain validation path used
- no forced sampler/default/template coercion added
- do not merge by agent
