### PR TITLE
Abstract ZAYA tool results for required followups

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
+        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
+        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
+            revision: "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
+        let expectedRuntimeHardenedRevision = "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -207,6 +207,8 @@ struct SwiftTransformersTokenizerLoaderTests {
         let afterFinalUser = decoded[finalUserRange.upperBound...]
 
         #expect(afterFinalUser.contains(reminder), "Decoded: \(decoded)")
+        #expect(decoded.contains("Previous tool result available."), "Decoded: \(decoded)")
+        #expect(!decoded.contains(#"<zyphra_tool_response>\n{"lines":3}"#), "Decoded: \(decoded)")
         #expect(!afterFinalUser.contains("<|im_start|>system\n<IMPORTANT>"), "Decoded: \(decoded)")
         #expect(decoded.hasSuffix("<|im_start|>assistant\n"), "Decoded: \(decoded)")
     }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8b835cb7e957507d0003abd0e7bc6acf766d8bca"
+        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
       }
     },
     {


### PR DESCRIPTION
Stacked on #1251.

This pins vMLX to `a0d28581ecd969d1212dc2a70478e2b42e9aefd3`, which narrows the ZAYA VL required-tool followup fix to historical `role=tool` rendering only when `required_tool_choice` is active. It keeps ordinary/non-required ZAYA tool-result rendering intact.

Local source validation:

- `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening` passed.
- `SwiftTransformersTokenizerLoaderTests/zayaVLLocalTokenizerKeepsRequiredToolReminderInCurrentUserTurn` passed.

Live no-sign Osaurus app proof is next; do not merge by agent.