### PR TITLE
Decode ZAYA tool line breaks

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
+        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
+        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
+            revision: "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
@@ -168,6 +168,49 @@ struct DSV4ParserPipelineTests {
         #expect(call.function.arguments["text"] == .string("alpha\nbeta\ngamma"))
     }
 
+    @Test("ZAYA XML tool parser decodes live HTML line breaks")
+    func zayaXMLToolParserDecodesLiveHTMLLineBreaks() throws {
+        let toolCallProcessor = ToolCallProcessor(format: .zayaXml, tools: lineCountToolSchema())
+        var events: [Generation] = []
+        let output = #"""
+            <zyphra_tool_call>
+            <function=line_count>
+            <parameter=text>one<br>two</parameter>
+            </function>
+            </zyphra_tool_call>
+            """#
+
+        for ch in output {
+            events.append(
+                contentsOf: routeGenerationText(
+                    String(ch),
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        if let visible = toolCallProcessor.processEOS() {
+            events.append(
+                contentsOf: routeGenerationText(
+                    visible,
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        events.append(contentsOf: drainToolCallEvents(from: toolCallProcessor))
+
+        let visible = events.compactMap(\.chunk).joined()
+        let calls = events.compactMap(\.toolCall)
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(!visible.contains("zyphra_tool_call"))
+        #expect(calls.count == 1)
+        let call = try #require(calls.first)
+        #expect(call.function.name == "line_count")
+        #expect(call.function.arguments["text"] == .string("one\ntwo"))
+    }
+
     @Test("live DSV4 bare-name JSON split after tool marker routes to a tool call")
     func liveBareNameJSONAfterToolMarkerRoutesToToolCall() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: lineCountToolSchema())

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
+        let expectedRuntimeHardenedRevision = "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a0d28581ecd969d1212dc2a70478e2b42e9aefd3"
+        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
       }
     },
     {


### PR DESCRIPTION
Stacked on #1251.

This pins vMLX to `13c6406173aa2babf1f1728fe5ccaf6d6678da0c`, which keeps the ZAYA required-tool history abstraction from #1254 and adds a constrained ZAYA XML parser fix for live tool arguments such as `one<br>two`. The parser decodes HTML line-break tags only for ZAYA XML schema-declared string parameters.

Local validation:

- vMLX: `DeepseekV4ChatTemplateFallbackFocusedTests/zayaXMLParserDecodesLiveHTMLLineBreaksInStringParameters` passed.
- vMLX: `DeepseekV4ChatTemplateFallbackFocusedTests/zayaVLRequiredToolChoiceRepeatsAfterNoToolHistory` passed.
- Osaurus: `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening` passed.
- Osaurus: `DSV4ParserPipelineTests/zayaXMLToolParserDecodesLiveHTMLLineBreaks` passed.

Live no-sign Osaurus app proof is next; do not merge by agent.