### PR TITLE
Default Nemotron Omni chat to direct rail

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
+        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
+        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
+        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
+        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
+        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
+        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
+        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
+        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
+        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
+        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5239e56c46c6c7c44613afb454275affc00ed07f"
+            revision: "239186e475b59451d66838ec2c4e6a088efdd24a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
+            revision: "51f850b8161f8de35919d011c0796dd3d7be13d3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "144563dc3a442fb3ba97b6334b4647acfae43dd4"
+            revision: "bb51e0930b85653a1304f5af3868ca24e35cc175"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "891b6c0ba1790f4357c851e889acee515f865913"
+            revision: "144563dc3a442fb3ba97b6334b4647acfae43dd4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "bb51e0930b85653a1304f5af3868ca24e35cc175"
+            revision: "5239e56c46c6c7c44613afb454275affc00ed07f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "51f850b8161f8de35919d011c0796dd3d7be13d3"
+            revision: "891b6c0ba1790f4357c851e889acee515f865913"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -756,6 +756,8 @@ struct MLXBatchAdapter {
             if hasPositiveReasoningEffort, let normalizedReasoningEffort {
                 context["enable_thinking"] = true
                 context["reasoning_effort"] = normalizedReasoningEffort
+            } else {
+                context["enable_thinking"] = false
             }
             return context
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -110,13 +110,15 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             && upstream.convertTokenToId("</assistant>") != nil
             && upstream.convertTokenToId("<think>") != nil
             && upstream.convertTokenToId("</think>") != nil
-        let hasZayaVLVisionSentinel =
+        let hasZayaVLChatSentinel =
             upstream.bosToken == "<bos>"
+            && upstream.convertTokenToId("<|im_start|>") != nil
+            && upstream.convertTokenToId("<|im_end|>") != nil
+        let hasZayaVLVisionSentinel =
+            hasZayaVLChatSentinel
             && upstream.convertTokenToId("<|vision_start|>") != nil
             && upstream.convertTokenToId("<image>") != nil
             && upstream.convertTokenToId("<|vision_end|>") != nil
-            && upstream.convertTokenToId("<|im_start|>") != nil
-            && upstream.convertTokenToId("<|im_end|>") != nil
         let hasDSV4Sentinel =
             !hasZayaVLVisionSentinel
             && upstream.bosToken == Self.dsv4Bos
@@ -155,7 +157,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         }
 
         var adjustedContext = additionalContext
-        if hasZayaVLVisionSentinel,
+        if hasZayaVLChatSentinel,
             (Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)),
             (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {
@@ -241,7 +243,9 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                     addGenerationPrompt: addGenerationPrompt
                 )
             }
-            if hasZayaVLVisionSentinel, Self.messagesContainImageContent(messages) {
+            if hasZayaVLChatSentinel,
+                Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)
+            {
                 return try fallback(
                     label: "Zaya1VLVisionToolMinimal",
                     template: MLXLMCommon.ChatTemplateFallbacks.zayaVLVisionToolMinimal,
@@ -292,7 +296,9 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             let ordered: [(label: String, template: String)]
             if hasLagunaSentinel {
                 ordered = [("LagunaMinimal", MLXLMCommon.ChatTemplateFallbacks.lagunaMinimal)]
-            } else if hasZayaVLVisionSentinel, Self.messagesContainImageContent(messages) {
+            } else if hasZayaVLChatSentinel,
+                Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)
+            {
                 ordered = [
                     (
                         "Zaya1VLVisionToolMinimal",

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1251,10 +1251,11 @@ struct MLXBatchAdapterTests {
         }
     }
 
-    /// Nemotron Omni call/audio workloads should default to visible assistant
-    /// content according to their bundle/template defaults. Osaurus must not
-    /// synthesize hidden reasoning defaults; explicit user/API opt-in still
-    /// enables thinking and explicit direct/off efforts still disable it.
+    /// Nemotron Omni call/audio workloads default to the closed/no-thinking
+    /// rail for ordinary chat. Live JANGTQ rows otherwise stream only hidden
+    /// reasoning_content and length-stop with empty visible content. Explicit
+    /// user/API opt-in still enables thinking and explicit direct/off efforts
+    /// still disable it.
     @Test func additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(
@@ -1272,8 +1273,8 @@ struct MLXBatchAdapterTests {
                 MLXBatchAdapter.additionalContext(
                     for: unspecified,
                     modelName: modelName
-                )["enable_thinking"] == nil,
-                "Nemotron Omni should preserve its bundle/template thinking default: \(modelName)"
+                )["enable_thinking"] as? Bool == false,
+                "Nemotron Omni should default to the closed/no-thinking rail: \(modelName)"
             )
             #expect(
                 MLXBatchAdapter.additionalContext(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "891b6c0ba1790f4357c851e889acee515f865913"
+        let expectedRuntimeHardenedRevision = "144563dc3a442fb3ba97b6334b4647acfae43dd4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "bb51e0930b85653a1304f5af3868ca24e35cc175"
+        let expectedRuntimeHardenedRevision = "5239e56c46c6c7c44613afb454275affc00ed07f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "51f850b8161f8de35919d011c0796dd3d7be13d3"
+        let expectedRuntimeHardenedRevision = "891b6c0ba1790f4357c851e889acee515f865913"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "144563dc3a442fb3ba97b6334b4647acfae43dd4"
+        let expectedRuntimeHardenedRevision = "bb51e0930b85653a1304f5af3868ca24e35cc175"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1813,6 +1813,11 @@ struct RuntimePolicySourceTests {
             "ZAYA text bundles are the explicit exception: their profile default is a closed/no-thinking prompt, so omitted reasoning controls must reach vmlx as enable_thinking=false."
         )
         #expect(
+            adapter.contains("if ModelFamilyNames.isNemotronOmniFamily(modelName)")
+                && adapter.contains("context[\"enable_thinking\"] = false"),
+            "Nemotron Omni bundles are the explicit multimodal exception: live ordinary chat must default to the closed/no-thinking rail instead of hidden reasoning-only output."
+        )
+        #expect(
             !adapter.contains("dsv4MaxReasoningRepetitionPenalty")
                 && !adapter.contains("repeated \"thinking\" token loop"),
             "Decode-loop problems must not be hidden behind DSV4-specific forced repetition-penalty guards."

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
+        let expectedRuntimeHardenedRevision = "51f850b8161f8de35919d011c0796dd3d7be13d3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "5239e56c46c6c7c44613afb454275affc00ed07f"
+        let expectedRuntimeHardenedRevision = "239186e475b59451d66838ec2c4e6a088efdd24a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -126,7 +126,6 @@ struct SwiftTransformersTokenizerLoaderTests {
             additionalContext: [
                 "enable_thinking": false,
                 "tool_choice": "required",
-                "tool_choice_name": "line_count",
             ]
         )
         let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
+        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "13c6406173aa2babf1f1728fe5ccaf6d6678da0c"
+        "revision" : "51f850b8161f8de35919d011c0796dd3d7be13d3"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
+        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "891b6c0ba1790f4357c851e889acee515f865913"
+        "revision" : "144563dc3a442fb3ba97b6334b4647acfae43dd4"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bb51e0930b85653a1304f5af3868ca24e35cc175"
+        "revision" : "5239e56c46c6c7c44613afb454275affc00ed07f"
       }
     },
     {


### PR DESCRIPTION
## Summary
- default Nemotron Omni ordinary local chat to the closed/no-thinking rail so non-streaming chat does not length-stop with empty visible content
- preserve explicit thinking opt-in via `disableThinking=false` / positive `reasoning_effort`
- add source-policy coverage for the Nemotron exception next to the existing ZAYA exception

## Evidence
- Live failing row before fix: `nemotron-omni-nano-jangtq-crack` streamed only `reasoning_content`, `finish_reason=length`, `completion_tokens=32`, visible content empty. Artifact: `/private/tmp/osaurus-pr1255-410fce16-nemotron-omni-multiturn-tool-proof-20260526-183151`
- API diagnostic on the same app/model: top-level `enable_thinking=false` / `reasoning_effort=no_think` returned visible `PINEAPPLE` in 5 completion tokens.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path /private/tmp/osaurus-family-runtime-matrix-next/Packages/OsaurusCore --filter MLXBatchAdapterTests/additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path /private/tmp/osaurus-family-runtime-matrix-next/Packages/OsaurusCore --filter RuntimePolicySourceTests/mlxBatchAdapterDoesNotForceHiddenReasoningDefaults --jobs 1 --no-parallel`

## Boundary
- Stacked on PR #1255.
- This does not merge anything.
- No signing/notarization/keychain path used.