### PR TITLE
Consolidate family runtime live matrix fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a8a8e65451beebd0ef6e115f9e66bb9cde2988de"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
+        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
+        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
+        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
+        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
+        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -39,6 +39,8 @@ public enum ServerRuntimeSettingsStore {
     private static let fileName = "server-runtime.json"
     private static let cacheDefaultsMigrationMarkerName =
         ".server-runtime-cache-defaults-v2-migrated"
+    private static let engineSelectedCacheRepairMarkerName =
+        ".server-runtime-engine-selected-cache-v3-repaired"
 
     // MARK: - Load / Save
 
@@ -152,6 +154,10 @@ public enum ServerRuntimeSettingsStore {
             normalized.cache.enableSSMReDerive = true
             writeCacheDefaultsMigrationMarker()
         }
+        if shouldRepairAutoMigratedEngineSelectedCacheDefault(normalized.cache) {
+            normalized.cache.liveKVCodec = .native
+            writeEngineSelectedCacheRepairMarker()
+        }
         return normalized
     }
 
@@ -183,8 +189,46 @@ public enum ServerRuntimeSettingsStore {
             && cache.enableSSMReDerive == false
     }
 
+    private nonisolated static func shouldRepairAutoMigratedEngineSelectedCacheDefault(
+        _ cache: VMLXServerCacheSettings
+    ) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: cacheDefaultsMigrationMarkerURL().path),
+            !fileManager.fileExists(atPath: engineSelectedCacheRepairMarkerURL().path)
+        else {
+            return false
+        }
+        return cache.prefix.enabled
+            && cache.prefix.legacyEntryCountCache == false
+            && cache.prefix.memoryLimitMB == nil
+            && cache.prefix.memoryPercent == 15.0
+            && cache.prefix.ttlMinutes == nil
+            && cache.pagedKV.enabled
+            && cache.pagedKV.blockSize == nil
+            && cache.pagedKV.maxBlocks == nil
+            && cache.liveKVCodec == .engineSelected
+            && cache.turboQuantKeyBits == nil
+            && cache.turboQuantValueBits == nil
+            && cache.defaultMaxKVSize == 65536
+            && cache.longPromptMultiplier == 2.0
+            && cache.storedKVCodec == .auto
+            && cache.legacyDisk.enabled == false
+            && cache.legacyDisk.maxSizeGB == nil
+            && cache.legacyDisk.directory == nil
+            && cache.blockDisk.enabled
+            && cache.blockDisk.maxSizeGB == nil
+            && cache.blockDisk.directory == nil
+            && cache.enableSSMReDerive
+    }
+
     private nonisolated static func writeCacheDefaultsMigrationMarker() {
         let url = cacheDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
+    }
+
+    private nonisolated static func writeEngineSelectedCacheRepairMarker() {
+        let url = engineSelectedCacheRepairMarkerURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         try? Data().write(to: url, options: [.atomic])
     }
@@ -336,6 +380,10 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func cacheDefaultsMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(cacheDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func engineSelectedCacheRepairMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(engineSelectedCacheRepairMarkerName)
     }
 
     private nonisolated static func legacyConfigurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -643,9 +643,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "disk_l2_hits": 0,
                 "disk_l2_misses": 0,
                 "disk_l2_stores": 0,
+                "companion_hits": 0,
+                "companion_misses": 0,
+                "companion_rederives": 0,
                 "ssm_companion_hits": 0,
                 "ssm_companion_misses": 0,
                 "ssm_companion_rederives": 0,
+                "zaya_cca_companion_hits": 0,
+                "zaya_cca_companion_misses": 0,
+                "zaya_cca_companion_rederives": 0,
             ]
 
             let models: [[String: Any]] = cached.map { summary in
@@ -738,14 +744,45 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 row["block_disk_store"] = disk
 
                 let ssm = stats.ssmStats
-                row["ssm_companion_cache"] = [
+                let companionKinds = summary.cacheTopology?.topologyTags.filter {
+                    $0.hasPrefix("companion=")
+                } ?? []
+                let hasSSMCompanion = companionKinds.contains("companion=ssm")
+                let hasZayaCCACompanion =
+                    (summary.cacheTopology?.zayaCCALayerCount ?? 0) > 0
+                row["companion_cache"] = [
                     "hits": ssm.hits,
                     "misses": ssm.misses,
                     "rederives": ssm.reDerives,
+                    "kinds": companionKinds,
                 ]
-                aggregate["ssm_companion_hits", default: 0] += ssm.hits
-                aggregate["ssm_companion_misses", default: 0] += ssm.misses
-                aggregate["ssm_companion_rederives", default: 0] += ssm.reDerives
+                if hasSSMCompanion {
+                    row["ssm_companion_cache"] = [
+                        "hits": ssm.hits,
+                        "misses": ssm.misses,
+                        "rederives": ssm.reDerives,
+                    ]
+                }
+                if hasZayaCCACompanion {
+                    row["zaya_cca_companion_cache"] = [
+                        "hits": ssm.hits,
+                        "misses": ssm.misses,
+                        "rederives": ssm.reDerives,
+                    ]
+                }
+                aggregate["companion_hits", default: 0] += ssm.hits
+                aggregate["companion_misses", default: 0] += ssm.misses
+                aggregate["companion_rederives", default: 0] += ssm.reDerives
+                if hasSSMCompanion {
+                    aggregate["ssm_companion_hits", default: 0] += ssm.hits
+                    aggregate["ssm_companion_misses", default: 0] += ssm.misses
+                    aggregate["ssm_companion_rederives", default: 0] += ssm.reDerives
+                }
+                if hasZayaCCACompanion {
+                    aggregate["zaya_cca_companion_hits", default: 0] += ssm.hits
+                    aggregate["zaya_cca_companion_misses", default: 0] += ssm.misses
+                    aggregate["zaya_cca_companion_rederives", default: 0] += ssm.reDerives
+                }
                 return row
             }
 
@@ -3147,7 +3184,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // the actual on-wire status (200) so dashboards don't
                     // mis-attribute a delivered stream as a 500.
                     hop {
-                        writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                        writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                         writerBound.value.writeEnd(ctx.value)
                     }
                     logSelf.logRequest(
@@ -3867,10 +3904,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let writerBound = NIOLoopBound(writer, eventLoop: loop)
             hop { writerBound.value.writeHeaders(ctx.value, extraHeaders: cors) }
             let keepaliveTask = Self.startSSEKeepalive(
-                writer: writerBound,
-                channel: context.channel,
-                loop: loop,
-                ctx: ctx
+                writer: writerBound, channel: context.channel, loop: loop, ctx: ctx
             )
             runRequestTask(priority: .userInitiated) {
                 defer { keepaliveTask.cancel() }
@@ -3891,10 +3925,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         if delta.isEmpty { continue }
                         accumulated += delta
                         let chunk = CompletionResponseDTO(
-                            id: responseId,
-                            object: "text_completion",
-                            created: created,
-                            model: model,
+                            id: responseId, object: "text_completion", created: created, model: model,
                             choices: [CompletionChoiceDTO(text: delta, index: 0, finish_reason: nil)],
                             usage: nil
                         )
@@ -3906,10 +3937,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     hop { writerBound.value.writeError(error.localizedDescription, context: ctx.value) }
                 }
                 let final = CompletionResponseDTO(
-                    id: responseId,
-                    object: "text_completion",
-                    created: created,
-                    model: model,
+                    id: responseId, object: "text_completion", created: created, model: model,
                     choices: [CompletionChoiceDTO(text: "", index: 0, finish_reason: finishReason)],
                     usage: nil
                 )
@@ -3920,17 +3948,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     writerBound.value.writeEnd(ctx.value)
                 }
                 logSelf.logRequest(
-                    method: "POST",
-                    path: "/completions",
-                    userAgent: logUserAgent,
-                    requestBody: logRequestBody,
-                    responseStatus: 200,
-                    startTime: startTime,
-                    model: model,
-                    tokensInput: promptTokens,
+                    method: "POST", path: "/completions", userAgent: logUserAgent,
+                    requestBody: logRequestBody, responseStatus: 200, startTime: startTime,
+                    model: model, tokensInput: promptTokens,
                     tokensOutput: TokenEstimator.estimate(accumulated),
-                    temperature: req.temperature,
-                    maxTokens: req.resolvedMaxTokens
+                    temperature: req.temperature, maxTokens: req.resolvedMaxTokens
                 )
             }
             return
@@ -3951,10 +3973,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
                 let completionTokens = TokenEstimator.estimate(text)
                 let response = CompletionResponseDTO(
-                    id: responseId,
-                    object: "text_completion",
-                    created: created,
-                    model: model,
+                    id: responseId, object: "text_completion", created: created, model: model,
                     choices: [CompletionChoiceDTO(text: text, index: 0, finish_reason: "stop")],
                     usage: CompletionUsageDTO(
                         prompt_tokens: promptTokens,
@@ -3968,27 +3987,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 let headersCopy = headers
                 hop {
                     Self.writeFullResponse(
-                        ctx: ctx,
-                        version: version,
-                        status: .ok,
-                        headers: headersCopy,
-                        body: body
+                        ctx: ctx, version: version, status: .ok, headers: headersCopy, body: body
                     )
                 }
                 logSelf.logRequest(
-                    method: "POST",
-                    path: "/completions",
-                    userAgent: logUserAgent,
-                    requestBody: logRequestBody,
-                    responseBody: body,
-                    responseStatus: 200,
-                    startTime: startTime,
-                    model: model,
-                    tokensInput: promptTokens,
-                    tokensOutput: completionTokens,
-                    temperature: req.temperature,
-                    maxTokens: req.resolvedMaxTokens,
-                    finishReason: .stop
+                    method: "POST", path: "/completions", userAgent: logUserAgent,
+                    requestBody: logRequestBody, responseBody: body, responseStatus: 200,
+                    startTime: startTime, model: model, tokensInput: promptTokens,
+                    tokensOutput: completionTokens, temperature: req.temperature,
+                    maxTokens: req.resolvedMaxTokens, finishReason: .stop
                 )
             } catch {
                 let message = error.localizedDescription
@@ -3997,22 +4004,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 let body = Self.errorBody(.openai(type: "internal_error"), message: message)
                 hop {
                     Self.writeFullResponse(
-                        ctx: ctx,
-                        version: version,
-                        status: status,
-                        headers: [("Content-Type", "application/json; charset=utf-8")],
-                        body: body
+                        ctx: ctx, version: version, status: status,
+                        headers: [("Content-Type", "application/json; charset=utf-8")], body: body
                     )
                 }
                 logSelf.logRequest(
-                    method: "POST",
-                    path: "/completions",
-                    userAgent: logUserAgent,
-                    requestBody: logRequestBody,
-                    responseStatus: Int(status.code),
-                    startTime: startTime,
-                    model: model,
-                    errorMessage: message
+                    method: "POST", path: "/completions", userAgent: logUserAgent,
+                    requestBody: logRequestBody, responseStatus: Int(status.code),
+                    startTime: startTime, model: model, errorMessage: message
                 )
             }
         }
@@ -4487,7 +4486,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // the actual on-wire status (200) so dashboards don't
                     // mis-attribute a delivered stream as a 500.
                     hop {
-                        writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                        writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                         writerBound.value.writeEnd(ctx.value)
                     }
                     httpTrace.mark("http_sse_error_written")
@@ -4866,7 +4865,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 // NDJSON response head was already 200 — surface as in-band
                 // NDJSON error chunk and log actual on-wire status.
                 hop {
-                    writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                    writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
                 }
                 logSelf.logRequest(
@@ -5191,7 +5190,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 )
             } catch {
                 hop {
-                    writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                    writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
                 }
                 logSelf.logRequest(
@@ -6532,7 +6531,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 // SSE response head was already 200 — surface as in-band
                 // SSE error chunk and log actual on-wire status.
                 hop {
-                    writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                    writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
                 }
                 logSelf.logRequest(
@@ -7379,7 +7378,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 // SSE response head was already 200 — surface as in-band
                 // SSE error chunk and log actual on-wire status.
                 hop {
-                    writerBound.value.writeErrorFromThrown(error, context: ctx.value)
+                    writerBound.value.writeError(error.localizedDescription, context: ctx.value)
                     writerBound.value.writeEnd(ctx.value)
                 }
                 logSelf.logRequest(

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
+        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ad333bcfec95b4ef2be32bafcce97eee618fba9b75b61fe7b328d2a88a9a07ea",
+  "originHash" : "800592e10dc43e3501acf8645c92ed446ccd73f88eaf20a1abbd805d349a2ae3",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a8a8e65451beebd0ef6e115f9e66bb9cde2988de"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
+        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
+        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
+        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
+        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a8a8e65451beebd0ef6e115f9e66bb9cde2988de"
+            revision: "239186e475b59451d66838ec2c4e6a088efdd24a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
+            revision: "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
+            revision: "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "239186e475b59451d66838ec2c4e6a088efdd24a"
+            revision: "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
+            revision: "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
+            revision: "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -829,6 +829,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         requestedModel: request.model
                     )
                     var text = ""
+                    var reasoning = ""
                     var terminalStopReason = "stop"
                     for try await delta in stream {
                         if let stats = StreamingStatsHint.decode(delta) {
@@ -837,8 +838,11 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                             }
                             continue
                         }
+                        if let reasoningDelta = StreamingReasoningHint.decode(delta) {
+                            reasoning += reasoningDelta
+                            continue
+                        }
                         if StreamingToolHint.isSentinel(delta) { continue }
-                        if StreamingReasoningHint.decode(delta) != nil { continue }
                         text += delta
                     }
                     let outputTokens = TokenEstimator.estimate(text)
@@ -848,7 +852,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                             role: "assistant",
                             content: text,
                             tool_calls: nil,
-                            tool_call_id: nil
+                            tool_call_id: nil,
+                            reasoning_content: reasoning.isEmpty ? nil : reasoning
                         ),
                         finish_reason: terminalStopReason
                     )
@@ -928,6 +933,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 stopSequences: stopSequences
             )
             var text = ""
+            var reasoning = ""
             var terminalStopReason = "stop"
             var authoritativeOutputTokens: Int?
             for try await delta in stream {
@@ -938,14 +944,23 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     }
                     continue
                 }
+                if let reasoningDelta = StreamingReasoningHint.decode(delta) {
+                    reasoning += reasoningDelta
+                    continue
+                }
                 if StreamingToolHint.isSentinel(delta) { continue }
-                if StreamingReasoningHint.decode(delta) != nil { continue }
                 text += delta
             }
             let outputTokens = authoritativeOutputTokens ?? TokenEstimator.estimate(text)
             let choice = ChatChoice(
                 index: 0,
-                message: ChatMessage(role: "assistant", content: text, tool_calls: nil, tool_call_id: nil),
+                message: ChatMessage(
+                    role: "assistant",
+                    content: text,
+                    tool_calls: nil,
+                    tool_call_id: nil,
+                    reasoning_content: reasoning.isEmpty ? nil : reasoning
+                ),
                 finish_reason: terminalStopReason
             )
             let usage = Usage(

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -239,6 +239,13 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         return s
     }
 
+    private static func allowsLocalToolDispatch(_ toolChoice: ToolChoiceOption?) -> Bool {
+        if case .some(.none) = toolChoice {
+            return false
+        }
+        return true
+    }
+
     /// Build the response body to log for a streamed chat completion.
     /// Prefers a JSON envelope when the stream resolved to a tool call so
     /// the Insights Response tab still shows something meaningful (the
@@ -271,7 +278,11 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         return accumulated.isEmpty ? nil : accumulated
     }
 
-    private static func canonicalToolArgumentsJSON(_ json: String, schema: JSONValue? = nil) -> String {
+    private static func canonicalToolArgumentsJSON(
+        _ json: String,
+        schema: JSONValue? = nil,
+        toolName: String? = nil
+    ) -> String {
         let candidates = [
             json,
             json.replacingOccurrences(of: #"\""#, with: #"""#),
@@ -289,7 +300,16 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         if let schema {
             let candidate = SchemaValidator.coerceArguments(normalized, against: schema)
             let result = SchemaValidator.validate(arguments: candidate, against: schema)
-            coerced = result.isValid ? candidate : normalized
+            if result.isValid {
+                coerced = candidate
+            } else if let invalid = invalidToolArgumentsJSON(
+                toolName: toolName,
+                result: result
+            ) {
+                return invalid
+            } else {
+                coerced = normalized
+            }
         } else {
             coerced = normalized
         }
@@ -298,6 +318,33 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             let string = String(data: data, encoding: .utf8)
         else {
             return json
+        }
+        return string
+    }
+
+    private static func invalidToolArgumentsJSON(
+        toolName: String?,
+        result: SchemaValidator.ValidationResult
+    ) -> String? {
+        var object: [String: Any] = [
+            "_error": "invalid_tool_arguments",
+            "_message": result.errorMessage ?? "invalid tool arguments",
+            "_expected": "schema-compliant arguments",
+        ]
+        if let field = result.field {
+            object["_field"] = field
+        }
+        if let toolName {
+            object["_tool"] = toolName
+        }
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: .osaurusCanonical
+            ),
+            let string = String(data: data, encoding: .utf8)
+        else {
+            return nil
         }
         return string
     }
@@ -334,8 +381,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         temperature: Float?,
         maxTokens: Int,
         requestBodyJSON: String? = nil,
-        tools: [Tool]? = nil,
-        wireProbe: WireTransportProbe? = nil
+        tools: [Tool]? = nil
     ) -> ChatCompletionResponse {
         let schemasByName = Dictionary(
             uniqueKeysWithValues: (tools ?? []).map { ($0.function.name, $0.function.parameters) }
@@ -350,7 +396,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     name: inv.toolName,
                     arguments: canonicalToolArgumentsJSON(
                         inv.jsonArguments,
-                        schema: schemasByName[inv.toolName] ?? nil
+                        schema: schemasByName[inv.toolName] ?? nil,
+                        toolName: inv.toolName
                     )
                 ),
                 geminiThoughtSignature: inv.geminiThoughtSignature
@@ -376,7 +423,6 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
         if inferenceSource == .chatUI {
             let durationMs = Date().timeIntervalSince(startTime) * 1000
-            let wireSnapshot = wireProbe?.snapshot()
             InsightsService.logInference(
                 source: inferenceSource,
                 model: effectiveModel,
@@ -390,9 +436,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 },
                 finishReason: .toolCalls,
                 requestBody: requestBodyJSON,
-                responseBody: serializeResponseForLog(response),
-                wireRequestBody: wireSnapshot?.request,
-                wireResponseBody: wireSnapshot?.response
+                responseBody: serializeResponseForLog(response)
             )
         }
 
@@ -429,45 +473,33 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         switch route {
         case .service(let service, let effectiveModel):
             let innerStream: AsyncThrowingStream<String, Error>
-            // Wire-verification probe captures the post-scrub
-            // request body + pre-unscrub response bytes. Installed
-            // for every inference source (chatUI, httpAPI, plugin,
-            // agent) so the Insights "Wire" tab can show exactly
-            // what hit the network on any route — that's the only
-            // way users can verify the Privacy Filter scrub
-            // actually happened. Memory cost is bounded by
-            // `WireTransportProbe.maxResponseBytes` (1 MiB) per
-            // in-flight request.
-            let probe: WireTransportProbe? = WireTransportProbe()
 
             // If tools were provided and supported, use message-based tool streaming
-            if let tools = request.tools, !tools.isEmpty, let toolSvc = service as? ToolCapableService {
+            if Self.allowsLocalToolDispatch(request.tool_choice),
+                let tools = request.tools, !tools.isEmpty, let toolSvc = service as? ToolCapableService
+            {
                 let stopSequences = request.stop ?? []
                 debugLog("[ChatEngine] streamChat: calling streamWithTools tools=\(tools.count)")
                 trace?.mark("chatengine_streamWithTools_start")
-                innerStream = try await WireTransportProbe.$current.withValue(probe) {
-                    try await toolSvc.streamWithTools(
-                        messages: messages,
-                        parameters: params,
-                        stopSequences: stopSequences,
-                        tools: tools,
-                        toolChoice: request.tool_choice,
-                        requestedModel: request.model
-                    )
-                }
+                innerStream = try await toolSvc.streamWithTools(
+                    messages: messages,
+                    parameters: params,
+                    stopSequences: stopSequences,
+                    tools: tools,
+                    toolChoice: request.tool_choice,
+                    requestedModel: request.model
+                )
                 trace?.mark("chatengine_streamWithTools_done")
                 debugLog("[ChatEngine] streamChat: streamWithTools returned")
             } else {
                 debugLog("[ChatEngine] streamChat: calling streamDeltas")
                 trace?.mark("chatengine_streamDeltas_start")
-                innerStream = try await WireTransportProbe.$current.withValue(probe) {
-                    try await service.streamDeltas(
-                        messages: messages,
-                        parameters: params,
-                        requestedModel: request.model,
-                        stopSequences: request.stop ?? []
-                    )
-                }
+                innerStream = try await service.streamDeltas(
+                    messages: messages,
+                    parameters: params,
+                    requestedModel: request.model,
+                    stopSequences: request.stop ?? []
+                )
                 trace?.mark("chatengine_streamDeltas_done")
                 debugLog("[ChatEngine] streamChat: streamDeltas returned")
             }
@@ -489,8 +521,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 inputTokens: inputTokens,
                 temperature: temp,
                 maxTokens: maxTok,
-                requestBodyJSON: requestBodyJSON,
-                wireProbe: probe
+                requestBodyJSON: requestBodyJSON
             )
 
         case .none:
@@ -508,8 +539,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         inputTokens: Int,
         temperature: Float?,
         maxTokens: Int,
-        requestBodyJSON: String? = nil,
-        wireProbe: WireTransportProbe? = nil
+        requestBodyJSON: String? = nil
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
@@ -714,13 +744,6 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             if source == .chatUI {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
                 let toolCallsLog = toolInvocation.map { [ToolCallLog(name: $0.name, arguments: $0.args)] }
-                // Wire-level bodies (post-scrub request + raw pre-
-                // unscrub response). Snapshotted here AFTER the
-                // stream finishes so the captured response includes
-                // every chunk we observed. Nil snapshot means the
-                // route was MLX/Foundation (no probe installed) or
-                // the request never reached URLSession.
-                let wireSnapshot = wireProbe?.snapshot()
 
                 InsightsService.logInference(
                     source: source,
@@ -737,9 +760,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     responseBody: Self.streamResponseBody(
                         accumulated: responseAccumulator,
                         toolInvocation: toolInvocation
-                    ),
-                    wireRequestBody: wireSnapshot?.request,
-                    wireResponseBody: wireSnapshot?.response
+                    )
                 )
             }
         }
@@ -793,27 +814,20 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             defer {
                 Task { await InferenceLoadCoordinator.shared.endChatGeneration() }
             }
-            // Wire-verification probe — same contract as the
-            // streaming path, installed for every inference source
-            // so HTTP / plugin / agent completes also surface their
-            // wire bodies in Insights. Bound around every call into
-            // the service so the remote layer can pick up the
-            // binding via task-local lookup.
-            let probe: WireTransportProbe? = WireTransportProbe()
             // If tools were provided and the service supports them, use the message-based API
-            if let tools = request.tools, !tools.isEmpty, let toolSvc = service as? ToolCapableService {
+            if Self.allowsLocalToolDispatch(request.tool_choice),
+                let tools = request.tools, !tools.isEmpty, let toolSvc = service as? ToolCapableService
+            {
                 let stopSequences = request.stop ?? []
                 do {
-                    let stream = try await WireTransportProbe.$current.withValue(probe) {
-                        try await toolSvc.streamWithTools(
-                            messages: messages,
-                            parameters: params,
-                            stopSequences: stopSequences,
-                            tools: tools,
-                            toolChoice: request.tool_choice,
-                            requestedModel: request.model
-                        )
-                    }
+                    let stream = try await toolSvc.streamWithTools(
+                        messages: messages,
+                        parameters: params,
+                        stopSequences: stopSequences,
+                        tools: tools,
+                        toolChoice: request.tool_choice,
+                        requestedModel: request.model
+                    )
                     var text = ""
                     var terminalStopReason = "stop"
                     for try await delta in stream {
@@ -856,7 +870,6 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     // Log the inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
                     if inferenceSource == .chatUI {
                         let durationMs = Date().timeIntervalSince(startTime) * 1000
-                        let wireSnapshot = probe?.snapshot()
                         InsightsService.logInference(
                             source: inferenceSource,
                             model: effectiveModel,
@@ -867,9 +880,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                             maxTokens: maxTokens,
                             finishReason: RequestLog.FinishReason(rawValue: terminalStopReason) ?? .stop,
                             requestBody: requestBodyJSON,
-                            responseBody: Self.serializeResponseForLog(response),
-                            wireRequestBody: wireSnapshot?.request,
-                            wireResponseBody: wireSnapshot?.response
+                            responseBody: Self.serializeResponseForLog(response)
                         )
                     }
 
@@ -886,8 +897,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         temperature: temperature,
                         maxTokens: maxTokens,
                         requestBodyJSON: requestBodyJSON,
-                        tools: tools,
-                        wireProbe: probe
+                        tools: tools
                     )
                 } catch let inv as ServiceToolInvocation {
                     return Self.makeToolCallResponse(
@@ -901,8 +911,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         temperature: temperature,
                         maxTokens: maxTokens,
                         requestBodyJSON: requestBodyJSON,
-                        tools: tools,
-                        wireProbe: probe
+                        tools: tools
                     )
                 }
             }
@@ -912,14 +921,12 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // sentinel preserves vmlx's authoritative token count and stop
             // reason (`length` vs natural `stop`).
             let stopSequences = request.stop ?? []
-            let stream = try await WireTransportProbe.$current.withValue(probe) {
-                try await service.streamDeltas(
-                    messages: messages,
-                    parameters: params,
-                    requestedModel: request.model,
-                    stopSequences: stopSequences
-                )
-            }
+            let stream = try await service.streamDeltas(
+                messages: messages,
+                parameters: params,
+                requestedModel: request.model,
+                stopSequences: stopSequences
+            )
             var text = ""
             var terminalStopReason = "stop"
             var authoritativeOutputTokens: Int?
@@ -959,7 +966,6 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // Log the inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
             if inferenceSource == .chatUI {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
-                let wireSnapshot = probe?.snapshot()
                 InsightsService.logInference(
                     source: inferenceSource,
                     model: effectiveModel,
@@ -970,9 +976,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     maxTokens: maxTokens,
                     finishReason: RequestLog.FinishReason(rawValue: terminalStopReason) ?? .stop,
                     requestBody: requestBodyJSON,
-                    responseBody: Self.serializeResponseForLog(response),
-                    wireRequestBody: wireSnapshot?.request,
-                    wireResponseBody: wireSnapshot?.response
+                    responseBody: Self.serializeResponseForLog(response)
                 )
             }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1257,7 +1257,13 @@ public actor ModelRuntime {
         )
         let augmented = ModelRuntime.applyJSONMode(forcedToolMessages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented, trace: parameters.ttftTrace) },
+            chatBuilder: {
+                ModelRuntime.mapOpenAIChatToMLX(
+                    augmented,
+                    trace: parameters.ttftTrace,
+                    preserveStructuredToolHistory: !tools.isEmpty
+                )
+            },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -1356,7 +1362,13 @@ public actor ModelRuntime {
         )
         let augmented = ModelRuntime.applyJSONMode(forcedToolMessages, jsonMode: parameters.jsonMode)
         let events = try await generateEventStream(
-            chatBuilder: { ModelRuntime.mapOpenAIChatToMLX(augmented, trace: parameters.ttftTrace) },
+            chatBuilder: {
+                ModelRuntime.mapOpenAIChatToMLX(
+                    augmented,
+                    trace: parameters.ttftTrace,
+                    preserveStructuredToolHistory: !tools.isEmpty
+                )
+            },
             parameters: parameters,
             stopSequences: stopSequences,
             tools: tools,
@@ -1647,7 +1659,8 @@ public actor ModelRuntime {
     /// previous assistant message with a tool call!"` on MiniMax).
     nonisolated static func mapOpenAIChatToMLX(
         _ msgs: [ChatMessage],
-        trace: TTFTTrace? = nil
+        trace: TTFTTrace? = nil,
+        preserveStructuredToolHistory: Bool = true
     ) -> [MLXLMCommon.Chat.Message] {
         var out: [MLXLMCommon.Chat.Message] = []
         out.reserveCapacity(max(6, msgs.count))
@@ -1680,7 +1693,7 @@ public actor ModelRuntime {
             case "assistant":
                 let content = (m.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
                 let reasoningContent = m.reasoning_content?.trimmingCharacters(in: .whitespacesAndNewlines)
-                let toolCalls = toMLXToolCalls(m.tool_calls)
+                let toolCalls = preserveStructuredToolHistory ? toMLXToolCalls(m.tool_calls) : nil
                 // Skip fully-empty assistant turns. Reasoning-only assistant
                 // turns are NOT empty for local MLX templates: ZAYA,
                 // Nemotron-H/Omni, MiniMax and DSV4 read
@@ -1705,17 +1718,29 @@ public actor ModelRuntime {
                     )
                 )
             case "tool":
-                out.append(
-                    MLXLMCommon.Chat.Message(
-                        role: .tool,
-                        content: m.content ?? "",
-                        images: images,
-                        videos: videos,
-                        audios: audios,
-                        toolCalls: nil,
-                        toolCallId: m.tool_call_id
+                if preserveStructuredToolHistory {
+                    out.append(
+                        MLXLMCommon.Chat.Message(
+                            role: .tool,
+                            content: m.content ?? "",
+                            images: images,
+                            videos: videos,
+                            audios: audios,
+                            toolCalls: nil,
+                            toolCallId: m.tool_call_id
+                        )
                     )
-                )
+                } else if let content = m.content, !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    out.append(
+                        MLXLMCommon.Chat.Message(
+                            role: .user,
+                            content: "Tool result: \(content)",
+                            images: images,
+                            videos: videos,
+                            audios: audios
+                        )
+                    )
+                }
             default:
                 out.append(
                     MLXLMCommon.Chat.Message(

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -667,11 +667,17 @@ struct MLXBatchAdapter {
     static func additionalContext(
         for generation: GenerationParameters,
         modelName: String,
-        toolChoice: ToolChoiceOption? = nil
+        toolChoice: ToolChoiceOption? = nil,
+        toolChoiceName: String? = nil
     ) -> [String: any Sendable] {
         var context: [String: any Sendable] = [:]
         if toolChoiceRequiresLocalCall(toolChoice) {
             context["tool_choice"] = "required"
+        }
+        if let toolChoiceName,
+           !toolChoiceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            context["tool_choice_name"] = toolChoiceName
         }
         let normalizedReasoningEffort: String? = {
             guard let effort = generation.modelOptions["reasoningEffort"]?.stringValue else {
@@ -750,6 +756,8 @@ struct MLXBatchAdapter {
             if hasPositiveReasoningEffort, let normalizedReasoningEffort {
                 context["enable_thinking"] = true
                 context["reasoning_effort"] = normalizedReasoningEffort
+            } else {
+                context["enable_thinking"] = false
             }
             return context
         }
@@ -761,6 +769,8 @@ struct MLXBatchAdapter {
             if hasPositiveReasoningEffort, let normalizedReasoningEffort {
                 context["enable_thinking"] = true
                 context["reasoning_effort"] = normalizedReasoningEffort
+            } else {
+                context["enable_thinking"] = false
             }
             return context
         }
@@ -783,6 +793,24 @@ struct MLXBatchAdapter {
             return true
         case .auto, .none:
             return false
+        }
+    }
+
+    private static func requiredToolChoiceName(
+        toolChoice: ToolChoiceOption?,
+        toolsSpec: [[String: any Sendable]]?
+    ) -> String? {
+        guard let toolChoice else { return nil }
+        switch toolChoice {
+        case .function(let target):
+            return target.function.name
+        case .required:
+            guard let toolsSpec, toolsSpec.count == 1 else { return nil }
+            let tool = toolsSpec[0]
+            let function = (tool["function"] as? [String: any Sendable]) ?? tool
+            return function["name"] as? String
+        case .auto, .none:
+            return nil
         }
     }
 
@@ -1043,6 +1071,9 @@ struct MLXBatchAdapter {
                 let toolsSpec = buildToolsSpec()
                 box.toolsBuiltAt = CFAbsoluteTimeGetCurrent()
                 box.toolCount = toolsSpec?.count ?? 0
+                let requiredToolName = requiredToolChoiceName(
+                    toolChoice: toolChoice,
+                    toolsSpec: toolsSpec)
 
                 // Reasoning template context. Only explicit request controls are
                 // translated into model-specific template kwargs; omitted controls
@@ -1050,7 +1081,8 @@ struct MLXBatchAdapter {
                 let additionalContext = additionalContext(
                     for: generation,
                     modelName: modelName,
-                    toolChoice: toolChoice
+                    toolChoice: toolChoice,
+                    toolChoiceName: requiredToolName
                 )
                 box.contextBuiltAt = CFAbsoluteTimeGetCurrent()
                 box.contextKeys = additionalContext.keys.sorted()
@@ -1080,7 +1112,11 @@ struct MLXBatchAdapter {
                 trace?.mark("batch_tokenization_done")
             }
 
-            let tokens = lmInput.text.tokens.asArray(Int.self)
+            let tokens =
+                lmInput.text.tokenIds
+                ?? MLXCacheIOLock.withSerializedMLXCacheIO {
+                    lmInput.text.tokens.asArray(Int.self)
+                }
             box.tokenArrayDoneAt = CFAbsoluteTimeGetCurrent()
             box.promptTokenCount = tokens.count
             guard !tokens.isEmpty else {

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -110,18 +110,18 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             && upstream.convertTokenToId("</assistant>") != nil
             && upstream.convertTokenToId("<think>") != nil
             && upstream.convertTokenToId("</think>") != nil
-        let hasZayaVLVisionSentinel =
+        let hasZayaVLChatSentinel =
             upstream.bosToken == "<bos>"
+            && upstream.convertTokenToId("<|im_start|>") != nil
+            && upstream.convertTokenToId("<|im_end|>") != nil
+        let hasZayaVLVisionSentinel =
+            hasZayaVLChatSentinel
             && upstream.convertTokenToId("<|vision_start|>") != nil
             && upstream.convertTokenToId("<image>") != nil
             && upstream.convertTokenToId("<|vision_end|>") != nil
-            && upstream.convertTokenToId("<|im_start|>") != nil
-            && upstream.convertTokenToId("<|im_end|>") != nil
         let hasDSV4Sentinel =
             !hasZayaVLVisionSentinel
-            && (upstream.bosToken == Self.dsv4Bos
-                || (upstream.convertTokenToId(Self.dsv4Bos) != nil
-                    && upstream.convertTokenToId(Self.dsv4Eos) != nil))
+            && upstream.bosToken == Self.dsv4Bos
         if hasLagunaSentinel
             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {
@@ -157,8 +157,8 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         }
 
         var adjustedContext = additionalContext
-        if hasZayaVLVisionSentinel,
-            Self.messagesContainImageContent(messages),
+        if hasZayaVLChatSentinel,
+            (Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)),
             (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {
             return try fallback(
@@ -193,7 +193,20 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                 addGenerationPrompt: addGenerationPrompt
             )
         }
-
+        if !(chatTemplateTools?.isEmpty ?? true),
+            upstream.bosToken == "<s>",
+            upstream.convertTokenToId("<|im_end|>") != nil,
+            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
+        {
+            return try fallback(
+                label: "NemotronMinimal",
+                template: MLXLMCommon.ChatTemplateFallbacks.nemotronMinimal,
+                messages: messages,
+                tools: chatTemplateTools,
+                additionalContext: adjustedContext,
+                addGenerationPrompt: addGenerationPrompt
+            )
+        }
         do {
             return try upstream.applyChatTemplate(
                 messages: messages,
@@ -230,7 +243,9 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                     addGenerationPrompt: addGenerationPrompt
                 )
             }
-            if hasZayaVLVisionSentinel, Self.messagesContainImageContent(messages) {
+            if hasZayaVLChatSentinel,
+                Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)
+            {
                 return try fallback(
                     label: "Zaya1VLVisionToolMinimal",
                     template: MLXLMCommon.ChatTemplateFallbacks.zayaVLVisionToolMinimal,
@@ -281,7 +296,9 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             let ordered: [(label: String, template: String)]
             if hasLagunaSentinel {
                 ordered = [("LagunaMinimal", MLXLMCommon.ChatTemplateFallbacks.lagunaMinimal)]
-            } else if hasZayaVLVisionSentinel, Self.messagesContainImageContent(messages) {
+            } else if hasZayaVLChatSentinel,
+                Self.messagesContainImageContent(messages) || !(chatTemplateTools?.isEmpty ?? true)
+            {
                 ordered = [
                     (
                         "Zaya1VLVisionToolMinimal",
@@ -584,9 +601,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
 
         let toolChoiceRequired =
             Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
-        let dsv4HasPriorToolResult = dsv4Messages.contains { $0.role == .tool }
         if toolChoiceRequired,
-            !dsv4HasPriorToolResult,
             let idx = dsv4Messages.lastIndex(where: { $0.role == .user || $0.role == .developer }),
             dsv4Messages[idx].task == nil
         {

--- a/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
@@ -280,6 +280,37 @@ struct ChatEngineTests {
         #expect(resp.choices.first?.message.content == "hello")
     }
 
+    @Test func completeChat_preservesReasoningContentForPlainNonStreamingCompletion() async throws {
+        let svc = FakeModelService(
+            deltas: [
+                StreamingReasoningHint.encode("first thought. "),
+                StreamingReasoningHint.encode("second thought."),
+                "visible answer",
+            ]
+        )
+        let engine = ChatEngine(services: [svc], installedModelsProvider: { [] })
+        let req = ChatCompletionRequest(
+            model: "fake",
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_tokens: 32,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+
+        let resp = try await engine.completeChat(request: req)
+
+        #expect(resp.choices.first?.message.content == "visible answer")
+        #expect(resp.choices.first?.message.reasoning_content == "first thought. second thought.")
+    }
+
     @Test func completeChat_usesStreamingStatsForPlainNonStreamingCompletion() async throws {
         let svc = FakeModelService(
             deltas: [
@@ -1003,6 +1034,74 @@ struct ChatEngineTests {
         let resp = try await engine.completeChat(request: req)
         #expect(resp.choices.first?.message.content == "truncated")
         #expect(resp.choices.first?.finish_reason == "length")
+    }
+
+    @Test func completeChat_preservesReasoningContentForToolCapableNonStreamingCompletion() async throws {
+        struct FakeReasoningToolService: ToolCapableService {
+            var id: String { "fake" }
+            func isAvailable() -> Bool { true }
+            func handles(requestedModel: String?) -> Bool { (requestedModel ?? "") == "fake" }
+            func streamDeltas(
+                messages: [ChatMessage],
+                parameters: GenerationParameters,
+                requestedModel: String?,
+                stopSequences: [String]
+            ) async throws -> AsyncThrowingStream<String, Error> { AsyncThrowingStream { $0.finish() } }
+            func generateOneShot(
+                messages: [ChatMessage],
+                parameters: GenerationParameters,
+                requestedModel: String?
+            ) async throws -> String { "" }
+            func respondWithTools(
+                messages: [ChatMessage],
+                parameters: GenerationParameters,
+                stopSequences: [String],
+                tools: [Tool],
+                toolChoice: ToolChoiceOption?,
+                requestedModel: String?
+            ) async throws -> String { "unused" }
+            func streamWithTools(
+                messages: [ChatMessage],
+                parameters: GenerationParameters,
+                stopSequences: [String],
+                tools: [Tool],
+                toolChoice: ToolChoiceOption?,
+                requestedModel: String?
+            ) async throws -> AsyncThrowingStream<String, Error> {
+                AsyncThrowingStream { continuation in
+                    continuation.yield(StreamingReasoningHint.encode("tool reasoning"))
+                    continuation.yield("tool-visible answer")
+                    continuation.finish()
+                }
+            }
+        }
+
+        let engine = ChatEngine(services: [FakeReasoningToolService()], installedModelsProvider: { [] })
+        let req = ChatCompletionRequest(
+            model: "fake",
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_tokens: 32,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: [
+                Tool(
+                    type: "function",
+                    function: ToolFunction(name: "lookup", description: nil, parameters: .object([:]))
+                )
+            ],
+            tool_choice: .auto,
+            session_id: nil
+        )
+
+        let resp = try await engine.completeChat(request: req)
+
+        #expect(resp.choices.first?.message.content == "tool-visible answer")
+        #expect(resp.choices.first?.message.reasoning_content == "tool reasoning")
     }
 
     @Test func streamChat_throws_when_no_route() async throws {

--- a/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
@@ -158,6 +158,50 @@ struct ChatEngineTests {
         #expect(args == #"{"path":"/Users/eric/Desktop/testmandel/mandelbrot.py"}"#)
     }
 
+    @Test func toolCallResponse_marksMissingRequiredArgumentsInvalid() throws {
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated lines in a local text file.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "path": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("path")]),
+                    "additionalProperties": .bool(false),
+                ])
+            )
+        )
+
+        let response = ChatEngine.makeToolCallResponse(
+            invocations: [
+                ServiceToolInvocation(
+                    toolName: "line_count",
+                    jsonArguments: #"{}"#
+                )
+            ],
+            responseId: "chatcmpl-test",
+            created: 1,
+            effectiveModel: "fake",
+            inputTokens: 10,
+            startTime: Date(timeIntervalSince1970: 1),
+            inferenceSource: .httpAPI,
+            temperature: nil,
+            maxTokens: 128,
+            tools: [tool]
+        )
+
+        let args = try #require(response.choices.first?.message.tool_calls?.first?.function.arguments)
+        let data = try #require(args.data(using: .utf8))
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(object["_error"] as? String == "invalid_tool_arguments")
+        #expect(object["_field"] as? String == "path")
+        #expect(object["_tool"] as? String == "line_count")
+    }
+
     @Test func streamChat_yields_deltas_success() async throws {
         let svc = FakeModelService(deltas: ["a", "b", "c"])
         let engine = ChatEngine(services: [svc], installedModelsProvider: { [] })

--- a/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
@@ -132,6 +132,43 @@ struct ModelRuntimeMappingTests {
         #expect(mapped[5].role == .user)
     }
 
+    @Test func flattensToolHistoryWhenStructuredToolsAreDisabled() throws {
+        let call = ToolCall(
+            id: "c1",
+            type: "function",
+            function: ToolCallFunction(
+                name: "line_count",
+                arguments: "{\"text\":\"red\\ngreen\\nblue\"}"
+            )
+        )
+        let assistant = ChatMessage(
+            role: "assistant",
+            content: nil,
+            tool_calls: [call],
+            tool_call_id: nil
+        )
+        let tool = ChatMessage(
+            role: "tool",
+            content: "{\"lines\":3}",
+            tool_calls: nil,
+            tool_call_id: "c1"
+        )
+        let user = ChatMessage(role: "user", content: "How many lines?")
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX(
+            [assistant, tool, user],
+            preserveStructuredToolHistory: false
+        )
+
+        #expect(mapped.count == 2)
+        #expect(mapped[0].role == .user)
+        #expect(mapped[0].content == "Tool result: {\"lines\":3}")
+        #expect(mapped[0].toolCalls == nil)
+        #expect(mapped[0].toolCallId == nil)
+        #expect(mapped[1].role == .user)
+        #expect(mapped[1].content == "How many lines?")
+    }
+
     /// Empty assistant turn (no content AND no tool_calls) must still be
     /// dropped so downstream templates don't see a stray empty message.
     @Test func skipsFullyEmptyAssistantTurns() throws {

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -183,6 +183,60 @@ struct ServerRuntimeSettingsStoreTests {
         }
     }
 
+    @Test @MainActor func load_repairsAutoMigratedEngineSelectedCacheDefaultToNative() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var autoMigrated = VMLXServerRuntimeSettings()
+            autoMigrated.cache.liveKVCodec = .engineSelected
+            autoMigrated.cache.enableSSMReDerive = true
+            autoMigrated.cache.defaultMaxKVSize = 65536
+            autoMigrated.cache.longPromptMultiplier = 2.0
+            autoMigrated.cache.legacyDisk = VMLXDiskCacheSettings(
+                enabled: false,
+                maxSizeGB: nil,
+                directory: nil
+            )
+            autoMigrated.cache.blockDisk = VMLXBlockDiskCacheSettings(
+                enabled: true,
+                maxSizeGB: nil,
+                directory: nil
+            )
+            try writeSettings(autoMigrated, to: dir)
+            try Data().write(
+                to: dir.appendingPathComponent(".server-runtime-cache-defaults-v2-migrated"),
+                options: [.atomic]
+            )
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+            #expect(loaded.cache.liveKVCodec == .native)
+            #expect(loaded.cache.enableSSMReDerive == true)
+
+            let data = try Data(contentsOf: dir.appendingPathComponent("server-runtime.json"))
+            let persisted = try JSONDecoder().decode(VMLXServerRuntimeSettings.self, from: data)
+            #expect(persisted.cache.liveKVCodec == .native)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: dir.appendingPathComponent(".server-runtime-engine-selected-cache-v3-repaired").path
+                )
+            )
+        }
+    }
+
+    @Test @MainActor func load_preservesExplicitEngineSelectedWithoutMigrationMarker() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var explicitEngineSelected = VMLXServerRuntimeSettings()
+            explicitEngineSelected.cache.liveKVCodec = .engineSelected
+            explicitEngineSelected.cache.enableSSMReDerive = true
+            try writeSettings(explicitEngineSelected, to: dir)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+            #expect(loaded.cache.liveKVCodec == .engineSelected)
+        }
+    }
+
     @Test func migratedFromLegacy_projectsCorsAndPort() async throws {
         var legacy = ServerConfiguration.default
         legacy.port = 9000

--- a/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
@@ -168,6 +168,49 @@ struct DSV4ParserPipelineTests {
         #expect(call.function.arguments["text"] == .string("alpha\nbeta\ngamma"))
     }
 
+    @Test("ZAYA XML tool parser decodes live HTML line breaks")
+    func zayaXMLToolParserDecodesLiveHTMLLineBreaks() throws {
+        let toolCallProcessor = ToolCallProcessor(format: .zayaXml, tools: lineCountToolSchema())
+        var events: [Generation] = []
+        let output = #"""
+            <zyphra_tool_call>
+            <function=line_count>
+            <parameter=text>one<br>two</parameter>
+            </function>
+            </zyphra_tool_call>
+            """#
+
+        for ch in output {
+            events.append(
+                contentsOf: routeGenerationText(
+                    String(ch),
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        if let visible = toolCallProcessor.processEOS() {
+            events.append(
+                contentsOf: routeGenerationText(
+                    visible,
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        events.append(contentsOf: drainToolCallEvents(from: toolCallProcessor))
+
+        let visible = events.compactMap(\.chunk).joined()
+        let calls = events.compactMap(\.toolCall)
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(!visible.contains("zyphra_tool_call"))
+        #expect(calls.count == 1)
+        let call = try #require(calls.first)
+        #expect(call.function.name == "line_count")
+        #expect(call.function.arguments["text"] == .string("one\ntwo"))
+    }
+
     @Test("live DSV4 bare-name JSON split after tool marker routes to a tool call")
     func liveBareNameJSONAfterToolMarkerRoutesToToolCall() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: lineCountToolSchema())

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -904,6 +904,15 @@ struct MLXBatchAdapterTests {
                 == nil
         )
 
+        let zayaUnspecified = MLXBatchAdapter.additionalContext(
+            for: unspecified,
+            modelName: "zaya1-8b-jangtq_k"
+        )
+        #expect(
+            zayaUnspecified["enable_thinking"] as? Bool == false,
+            "ZAYA text bundles default to closed/no-thinking prompts; omitting enable_thinking must not route direct answers into reasoning-only output."
+        )
+
         let staleOffEffort = MLXBatchAdapter.additionalContext(
             for: GenerationParameters(
                 temperature: nil,
@@ -1078,9 +1087,11 @@ struct MLXBatchAdapterTests {
                     type: "function",
                     function: ToolChoiceOption.Name(name: "file_read")
                 )
-            )
+            ),
+            toolChoiceName: "file_read"
         )
         #expect(namedFunction["tool_choice"] as? String == "required")
+        #expect(namedFunction["tool_choice_name"] as? String == "file_read")
 
         let auto = MLXBatchAdapter.additionalContext(
             for: generation,
@@ -1162,11 +1173,12 @@ struct MLXBatchAdapterTests {
         }
     }
 
-    /// ZAYA1 (Zyphra; `model_type=zaya`) is reasoning-capable but defaults
-    /// thinking off (`think_in_template=false`). When no request option is
-    /// present, preserve the bundle/template default by sending no synthetic
-    /// thinking kwarg; when the user/API explicitly opts in via
-    /// `disableThinking=false`, pass `enable_thinking=true`.
+    /// ZAYA1 text bundles (Zyphra; `model_type=zaya`) are reasoning-capable,
+    /// but their stable chat rail is the closed/no-thinking path. When no
+    /// request option is present, pass `enable_thinking=false` explicitly so a
+    /// direct follow-up does not decode into hidden reasoning-only output.
+    /// Explicit user/API opt-in via `disableThinking=false` still passes
+    /// `enable_thinking=true`.
     @Test func additionalContext_defaultsZayaThinkingOffButHonorsExplicitOptIn() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(
@@ -1187,8 +1199,8 @@ struct MLXBatchAdapterTests {
                 MLXBatchAdapter.additionalContext(
                     for: unspecified,
                     modelName: modelName
-                )["enable_thinking"] == nil,
-                "ZAYA should preserve its bundle/template thinking default: \(modelName)"
+                )["enable_thinking"] as? Bool == false,
+                "ZAYA text bundles should default to the closed/no-thinking rail: \(modelName)"
             )
             #expect(
                 MLXBatchAdapter.additionalContext(
@@ -1239,10 +1251,11 @@ struct MLXBatchAdapterTests {
         }
     }
 
-    /// Nemotron Omni call/audio workloads should default to visible assistant
-    /// content according to their bundle/template defaults. Osaurus must not
-    /// synthesize hidden reasoning defaults; explicit user/API opt-in still
-    /// enables thinking and explicit direct/off efforts still disable it.
+    /// Nemotron Omni call/audio workloads default to the closed/no-thinking
+    /// rail for ordinary chat. Live JANGTQ rows otherwise stream only hidden
+    /// reasoning_content and length-stop with empty visible content. Explicit
+    /// user/API opt-in still enables thinking and explicit direct/off efforts
+    /// still disable it.
     @Test func additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(
@@ -1260,8 +1273,8 @@ struct MLXBatchAdapterTests {
                 MLXBatchAdapter.additionalContext(
                     for: unspecified,
                     modelName: modelName
-                )["enable_thinking"] == nil,
-                "Nemotron Omni should preserve its bundle/template thinking default: \(modelName)"
+                )["enable_thinking"] as? Bool == false,
+                "Nemotron Omni should default to the closed/no-thinking rail: \(modelName)"
             )
             #expect(
                 MLXBatchAdapter.additionalContext(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
+        let expectedRuntimeHardenedRevision = "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -398,12 +398,15 @@ struct RuntimePolicySourceTests {
         // bare-name key/value DSV4 tool attempts such as
         // `file_read\npath=...` being parsed as tools instead of visible text,
         // and Qwen multi-turn tool/cache matrix coverage staying present in
-        // the vMLX regression harness.
+        // the vMLX regression harness, plus the Nemotron Omni tool-template
+        // fallback that keeps tool schemas rendered through the model-native
+        // [AVAILABLE_TOOLS]/XML function-call contract instead of leaking
+        // role-token/DSML fragments in Osaurus tool turns.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "a8a8e65451beebd0ef6e115f9e66bb9cde2988de"
+        let expectedRuntimeHardenedRevision = "239186e475b59451d66838ec2c4e6a088efdd24a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -709,8 +712,14 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains(#""block_disk_store""#))
         #expect(httpHandler.contains(#""disk_l2_hits""#))
         #expect(httpHandler.contains(#""prefix_hits""#))
+        #expect(httpHandler.contains(#""companion_cache""#))
+        #expect(httpHandler.contains(#""zaya_cca_companion_cache""#))
+        #expect(httpHandler.contains(#""zaya_cca_companion_hits""#))
+        #expect(httpHandler.contains(#"let hasSSMCompanion = companionKinds.contains("companion=ssm")"#))
+        #expect(httpHandler.contains("if hasSSMCompanion"))
         #expect(httpHandler.contains(#""cache_topology""#))
         #expect(httpHandler.contains("hybrid_pool_layer_count"))
+        #expect(httpHandler.contains("zaya_cca_layer_count"))
         #expect(httpHandler.contains("requires_disk_backed_restore"))
         #expect(!httpHandler.contains(#"aggregate["prefix_hits", default: 0] += diskStats.hits"#))
         #expect(!httpHandler.contains(#"aggregate["prefix_misses", default: 0] += diskStats.misses"#))
@@ -849,6 +858,12 @@ struct RuntimePolicySourceTests {
         #expect(adapter.contains("acquireSoloLease"))
         #expect(adapter.contains("await soloLease.release()"))
         #expect(
+            adapter.contains("lmInput.text.tokenIds")
+                && adapter.contains("?? MLXCacheIOLock.withSerializedMLXCacheIO")
+                && adapter.contains("lmInput.text.tokens.asArray(Int.self)"),
+            "prompt token extraction must use vmlx's CPU tokenIds when available and fall back to the serialized MLX readback only for legacy processors"
+        )
+        #expect(
             adapter.contains("post-generation disk-cache store")
                 && adapter.contains("for await event in upstream")
                 && adapter.contains(
@@ -910,6 +925,36 @@ struct RuntimePolicySourceTests {
                 "for try await delta in inner {\n                    // Check for task cancellation to allow early termination\n                    if Task.isCancelled"
             ),
             "ChatEngine stream logging wrapper must pass StreamingStatsHint through before honoring cancellation"
+        )
+    }
+
+    @Test("ChatEngine honors tool choice none by bypassing local tool dispatch")
+    func chatEngineHonorsToolChoiceNoneBypassingLocalToolDispatch() throws {
+        let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")
+
+        #expect(chatEngine.contains("private static func allowsLocalToolDispatch"))
+        #expect(chatEngine.contains("if case .some(.none) = toolChoice"))
+        #expect(
+            chatEngine.contains("if Self.allowsLocalToolDispatch(request.tool_choice),\n                let tools = request.tools"),
+            "ChatEngine must not route tool_choice none requests through local streamWithTools just because tool schemas are present."
+        )
+    }
+
+    @Test("ModelRuntime drops structured tool history when no active tools are routed")
+    func modelRuntimeDropsStructuredToolHistoryWithoutActiveTools() throws {
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+
+        #expect(
+            runtime.contains("preserveStructuredToolHistory: !tools.isEmpty"),
+            "ModelRuntime must not preserve structured assistant/tool history when the request is routed with no active tool schemas."
+        )
+        #expect(
+            runtime.contains("let toolCalls = preserveStructuredToolHistory ? toMLXToolCalls(m.tool_calls) : nil"),
+            "Assistant tool_calls must be omitted from the MLX template context when structured tool history is disabled."
+        )
+        #expect(
+            runtime.contains("role: .user,\n                            content: \"Tool result: \\(content)\""),
+            "Tool-role results should be converted to ordinary text context when structured tool history is disabled, so follow-up answers can use the result without re-entering tool-call mode."
         )
     }
 
@@ -1656,6 +1701,13 @@ struct RuntimePolicySourceTests {
                 && adapter.contains("case .required, .function(_)"),
             "Required or named local tool_choice must become template context instead of being reduced to a tools-available-only prompt."
         )
+        #expect(
+            adapter.contains("context[\"tool_choice_name\"] = toolChoiceName")
+                && adapter.contains("private static func requiredToolChoiceName(")
+                && adapter.contains("case .function(let target):")
+                && adapter.contains("guard let toolsSpec, toolsSpec.count == 1"),
+            "Required/named local tool_choice must pass the target tool name into vmlx template context so Nemotron-family required tool templates do not fall back to generic placeholders."
+        )
         let tokenizerLoader = try Self.source("Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift")
         #expect(
             tokenizerLoader.contains("let toolChoiceRequired =")
@@ -1666,10 +1718,15 @@ struct RuntimePolicySourceTests {
             "DSV4 native prompt rendering must pass required tool_choice into DeepseekV4ChatEncoder so second-turn/named required tool calls keep the DSML must-call directive."
         )
         #expect(
-            tokenizerLoader.contains("let dsv4HasPriorToolResult = dsv4Messages.contains { $0.role == .tool }")
-                && tokenizerLoader.contains("!dsv4HasPriorToolResult")
+            !tokenizerLoader.contains("dsv4HasPriorToolResult")
                 && tokenizerLoader.contains("dsv4Messages[idx].task = \"action\""),
-            "DSV4 first-turn required/named tool_choice may use the native action task rail, but multi-turn tool-result prompts must stay on the DSML directive path instead of leaking action metadata."
+            "DSV4 required/named tool_choice must keep the native action task rail even after tool-result history so multi-turn required tool calls do not silently degrade to ordinary chat."
+        )
+        #expect(
+            tokenizerLoader.contains("&& upstream.bosToken == Self.dsv4Bos")
+                && !tokenizerLoader.contains("convertTokenToId(Self.dsv4Bos)")
+                && !tokenizerLoader.contains("convertTokenToId(Self.dsv4Eos)"),
+            "DSV4 template routing must require the actual DSV4 BOS token; token-id convertibility is too broad and can misroute Nemotron Omni into DSML placeholders."
         )
         #expect(
             registry.contains("invalidToolArgumentsEnvelope")
@@ -1749,6 +1806,16 @@ struct RuntimePolicySourceTests {
                 "context[\"enable_thinking\"] = hasPositiveReasoningEffort\n            if hasPositiveReasoningEffort"
             ),
             "Family-specific reasoning profiles must not force enable_thinking=false by writing a false boolean when no positive effort was requested."
+        )
+        #expect(
+            adapter.contains("if ModelFamilyNames.isZayaFamily(modelName)")
+                && adapter.contains("context[\"enable_thinking\"] = false"),
+            "ZAYA text bundles are the explicit exception: their profile default is a closed/no-thinking prompt, so omitted reasoning controls must reach vmlx as enable_thinking=false."
+        )
+        #expect(
+            adapter.contains("if ModelFamilyNames.isNemotronOmniFamily(modelName)")
+                && adapter.contains("context[\"enable_thinking\"] = false"),
+            "Nemotron Omni bundles are the explicit multimodal exception: live ordinary chat must default to the closed/no-thinking rail instead of hidden reasoning-only output."
         )
         #expect(
             !adapter.contains("dsv4MaxReasoningRepetitionPenalty")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1533,6 +1533,37 @@ struct RuntimePolicySourceTests {
         #expect(yieldReasoning.lowerBound < textEstimate.lowerBound)
     }
 
+    @Test("ChatEngine completeChat preserves reasoning_content before generic sentinel filtering")
+    func chatEngineCompleteChatPreservesReasoningContentBeforeSentinelFiltering() throws {
+        let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")
+
+        let toolStreamStart = try #require(chatEngine.range(of: "let stream = try await toolSvc.streamWithTools("))
+        let toolResponseStart = try #require(
+            chatEngine.range(
+                of: "let outputTokens = TokenEstimator.estimate(text)",
+                range: toolStreamStart.upperBound ..< chatEngine.endIndex
+            )
+        )
+        let toolSlice = chatEngine[toolStreamStart.lowerBound ..< toolResponseStart.lowerBound]
+        let toolReasoning = try #require(toolSlice.range(of: "if let reasoningDelta = StreamingReasoningHint.decode(delta)"))
+        let toolSentinel = try #require(toolSlice.range(of: "if StreamingToolHint.isSentinel(delta)"))
+        #expect(toolReasoning.lowerBound < toolSentinel.lowerBound)
+
+        let plainStreamStart = try #require(chatEngine.range(of: "let stream = try await service.streamDeltas("))
+        let plainResponseStart = try #require(
+            chatEngine.range(
+                of: "let outputTokens = authoritativeOutputTokens",
+                range: plainStreamStart.upperBound ..< chatEngine.endIndex
+            )
+        )
+        let plainSlice = chatEngine[plainStreamStart.lowerBound ..< plainResponseStart.lowerBound]
+        let plainReasoning = try #require(plainSlice.range(of: "if let reasoningDelta = StreamingReasoningHint.decode(delta)"))
+        let plainSentinel = try #require(plainSlice.range(of: "if StreamingToolHint.isSentinel(delta)"))
+        #expect(plainReasoning.lowerBound < plainSentinel.lowerBound)
+
+        #expect(chatEngine.contains("reasoning_content: reasoning.isEmpty ? nil : reasoning"))
+    }
+
     @Test("ModelRuntime wires idle residency around model leases")
     func modelRuntimeWiresIdleResidencyAroundLeases() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
+        let expectedRuntimeHardenedRevision = "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
+        let expectedRuntimeHardenedRevision = "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "239186e475b59451d66838ec2c4e6a088efdd24a"
+        let expectedRuntimeHardenedRevision = "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
+        let expectedRuntimeHardenedRevision = "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -698,6 +698,10 @@ struct RuntimePolicySourceTests {
             "Legacy cache migration must not silently flip existing users to engine-selected TurboQuant KV"
         )
         #expect(
+            store.contains("shouldRepairAutoMigratedEngineSelectedCacheDefault"),
+            "ServerRuntimeSettingsStore must demote the old auto-migrated engine-selected cache default back to native/fp16"
+        )
+        #expect(
             store.contains("shouldRepairLegacyCacheDefaults"),
             "ServerRuntimeSettingsStore must still repair stale persisted hybrid cache companion defaults"
         )

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -85,6 +85,136 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(decoded.contains("<|vision_end|>"), "Decoded: \(decoded)")
     }
 
+    @Test func zayaVLLocalTokenizerRendersTextOnlyToolsFromOsaurusFallback() async throws {
+        let defaultPath = "/Users/eric/models/Osaurus/ZAYA1-VL-8B-MXFP4"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_ZAYA_VL_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object([
+                            "type": .string("string"),
+                            "description": .string("Text to count lines for."),
+                        ])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                [
+                    "role": "user",
+                    "content": "Use line_count on red\ngreen\nblue.",
+                ]
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(decoded.contains("<tools>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<name>line_count</name>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<name>text</name>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<type>string</type>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<required>[\"text\"]</required>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("MUST be a tool call"), "Decoded: \(decoded)")
+        #expect(decoded.contains("Use the `line_count` function."), "Decoded: \(decoded)")
+        #expect(decoded.contains("Use line_count on red\ngreen\nblue."), "Decoded: \(decoded)")
+    }
+
+    @Test func zayaVLLocalTokenizerKeepsRequiredToolReminderInCurrentUserTurn() async throws {
+        let defaultPath = "/Users/eric/models/Osaurus/ZAYA1-VL-8B-MXFP4"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_ZAYA_VL_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object([
+                            "type": .string("string"),
+                            "description": .string("Text to count lines for."),
+                        ])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let finalUser = "Now use line_count on this exact text:\none\ntwo"
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                ["role": "user", "content": "Use line_count on this text:\nred\ngreen\nblue"],
+                [
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        [
+                            "id": "call_lines_1",
+                            "type": "function",
+                            "function": [
+                                "name": "line_count",
+                                "arguments": ["text": "red\ngreen\nblue"],
+                            ] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                    ],
+                ] as [String: any Sendable],
+                ["role": "tool", "tool_call_id": "call_lines_1", "content": #"{"lines":3}"#],
+                ["role": "user", "content": "How many lines were counted? Do not call another tool."],
+                ["role": "assistant", "content": "Three lines were counted."],
+                ["role": "user", "content": finalUser],
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+        let reminder = "The current assistant response MUST be a tool call."
+        let finalUserRange = try #require(decoded.range(of: finalUser))
+        let afterFinalUser = decoded[finalUserRange.upperBound...]
+
+        #expect(afterFinalUser.contains(reminder), "Decoded: \(decoded)")
+        #expect(!decoded.contains("Previous tool result available."), "Decoded: \(decoded)")
+        #expect(!decoded.contains(#"<zyphra_tool_response>\n{"lines":3}"#), "Decoded: \(decoded)")
+        #expect(!decoded.contains("Use line_count on this text:\nred\ngreen\nblue"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("How many lines were counted? Do not call another tool."), "Decoded: \(decoded)")
+        #expect(!decoded.contains("Three lines were counted."), "Decoded: \(decoded)")
+        #expect(!afterFinalUser.contains("<|im_start|>system\n<IMPORTANT>"), "Decoded: \(decoded)")
+        #expect(decoded.hasSuffix("<|im_start|>assistant\n"), "Decoded: \(decoded)")
+    }
+
     @Test func gemma4LocalTokenizerRendersUnionToolSchemaTypeNatively() async throws {
         let defaultPath = "/Users/eric/models/dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_GEMMA4_TEST_MODEL"] ?? defaultPath
@@ -240,6 +370,65 @@ struct SwiftTransformersTokenizerLoaderTests {
                 "<\u{FF5C}User\u{FF5C}>Turn 2.<\u{FF5C}Assistant\u{FF5C}></think>"
             ),
             "DSV4 final instruct tail must be closed-thinking. Decoded: \(multiTurnDecoded)"
+        )
+    }
+
+    @Test func nemotronLocalTokenizerDoesNotRouteThroughDSV4Template() async throws {
+        let defaultPath = "/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_NEMOTRON_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                [
+                    "role": "user",
+                    "content": "Use line_count on red\ngreen\nblue.",
+                ]
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: ["enable_thinking": false, "tool_choice": "required"]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(decoded.contains("<|im_start|>"), "Nemotron should keep its ChatML template. Decoded: \(decoded)")
+        #expect(decoded.contains("<tools>"), "Nemotron should render XML tools. Decoded: \(decoded)")
+        #expect(decoded.contains("<tool_call>"), "Nemotron should show XML tool call contract. Decoded: \(decoded)")
+        #expect(decoded.contains("line_count"), "Nemotron should include the requested tool schema. Decoded: \(decoded)")
+        #expect(
+            decoded.contains("one available tool and no prose before the tool result"),
+            "Nemotron required tool_choice must use the strict fallback contract, not the permissive native template. Decoded: \(decoded)"
+        )
+        #expect(
+            !decoded.contains("optional reasoning for your function call"),
+            "Nemotron required tool_choice must not keep the native template's optional reasoning-before-tool allowance. Decoded: \(decoded)"
+        )
+        #expect(
+            !decoded.contains("<\u{FF5C}DSML\u{FF5C}tool_calls>")
+                && !decoded.contains("$TOOL_NAME")
+                && !decoded.contains("<\u{FF5C}Assistant\u{FF5C}>"),
+            "Nemotron must not be misrouted through the DSV4 DSML template. Decoded: \(decoded)"
         )
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4805c7dfda4f171cc50e7f1a29d29ec75b187d1d5efe618be3465a448a32e99e",
+  "originHash" : "356bebb71bc957e56d1a6075ed0fa330b773e0bf9f085d572c3d8222d50269d7",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a8a8e65451beebd0ef6e115f9e66bb9cde2988de"
+        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
+        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
+        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "239186e475b59451d66838ec2c4e6a088efdd24a"
+        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1d7364979b49447818bf2b4b36d8e1ef84cbd3f0"
+        "revision" : "6ac73a2597aeaa386ccd7dc16250cfd3fe98f156"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "728a070f8d8b2aa336ddb5c69ffc4f2190a597e3"
+        "revision" : "eb488cfda2e8eacbbe9d6bd06ec0f0a3318ae287"
       }
     },
     {

--- a/scripts/live-proof/run-local-family-chat-tool-proof.py
+++ b/scripts/live-proof/run-local-family-chat-tool-proof.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Run a live local Osaurus chat/tool/cache proof against the app server.
+
+This is a proof harness, not model-runtime code. It intentionally talks to the
+same OpenAI-compatible endpoint used by clients so rows can be replayed against
+a no-sign PR app build without involving signing, notarization, or keychain.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from typing import Any
+
+
+PROTOCOL_MARKERS = (
+    "<｜",
+    "</｜",
+    "</s>",
+    "DSML",
+    ":json{",
+    "tool_ccalls",
+    "tool_crs",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<tool_call>",
+    "</tool_call>",
+)
+
+
+def request_json(base_url: str, method: str, path: str, payload: Any | None = None, timeout: int = 900) -> Any:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        base_url.rstrip("/") + path,
+        data=data,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read()
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.decode("utf-8", "replace")
+
+
+def save(path: pathlib.Path, value: Any) -> None:
+    if isinstance(value, (dict, list)):
+        path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    else:
+        path.write_text(str(value), encoding="utf-8")
+
+
+def process_snapshot() -> str:
+    cmd = (
+        "ps -axo pid,ppid,stat,etime,rss,command | "
+        "rg -i 'CodeSigningHelper|/Contents/MacOS/osaurus|RunBench|vmlx_engine\\.cli' | "
+        "rg -v 'rg -i|codex|zsh -lc' || true"
+    )
+    return subprocess.run(cmd, shell=True, text=True, capture_output=True).stdout
+
+
+def vm_snapshot() -> str:
+    cmd = "vm_stat | sed -n '1,10p'; sysctl vm.swapusage"
+    result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    return result.stdout + result.stderr
+
+
+def marker_leaks(value: Any) -> list[str]:
+    text = json.dumps(value, ensure_ascii=False)
+    return [marker for marker in PROTOCOL_MARKERS if marker in text]
+
+
+def choice_message(response: dict[str, Any]) -> dict[str, Any]:
+    return response["choices"][0]["message"]
+
+
+def choice_finish(response: dict[str, Any]) -> str | None:
+    return response["choices"][0].get("finish_reason")
+
+
+def run(args: argparse.Namespace) -> int:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    root = pathlib.Path(args.artifact_root or f"/tmp/osaurus-family-proof-{args.label}-{stamp}")
+    root.mkdir(parents=True, exist_ok=True)
+
+    fixture = root / "fixture.txt"
+    fixture.write_text("alpha\nbravo\ncharlie\ndelta\necho\n", encoding="utf-8")
+
+    summary: dict[str, Any] = {
+        "artifact": str(root),
+        "base_url": args.base_url,
+        "label": args.label,
+        "model": args.model,
+        "started": datetime.now().isoformat(),
+        "checks": {},
+    }
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "line_count",
+            "description": "Count newline-separated lines in a local text file.",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    try:
+        save(root / "process-before.txt", process_snapshot())
+        save(root / "vm-before.txt", vm_snapshot())
+        summary["health_before"] = request_json(args.base_url, "GET", "/health", timeout=30)
+        save(root / "health-before.json", summary["health_before"])
+        try:
+            save(root / "cache-before.json", request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30))
+        except Exception as exc:  # cache stats may be gated in some app modes
+            save(root / "cache-before-error.txt", repr(exc))
+
+        req1 = {
+            "model": args.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": f"Use the line_count tool on this exact path: {fixture}. Return only a tool call.",
+                }
+            ],
+            "tools": [tool],
+            "tool_choice": "required",
+            "max_tokens": args.max_tokens,
+        }
+        save(root / "request1.json", req1)
+        start = time.monotonic()
+        resp1 = request_json(args.base_url, "POST", "/v1/chat/completions", req1, timeout=args.timeout)
+        summary["request1_elapsed_s"] = round(time.monotonic() - start, 3)
+        save(root / "response1.json", resp1)
+
+        msg1 = choice_message(resp1)
+        calls = msg1.get("tool_calls") or []
+        summary["request1_finish_reason"] = choice_finish(resp1)
+        summary["request1_usage"] = resp1.get("usage")
+        summary["request1_protocol_leaks"] = marker_leaks(resp1)
+        summary["checks"]["request1_finish_tool_calls"] = choice_finish(resp1) == "tool_calls"
+        summary["checks"]["request1_content_null_or_empty"] = msg1.get("content") in (None, "")
+        summary["checks"]["request1_one_tool_call"] = len(calls) == 1
+        summary["checks"]["request1_no_protocol_leak"] = summary["request1_protocol_leaks"] == []
+
+        if not calls:
+            raise RuntimeError("first request did not produce structured tool_calls")
+
+        call = calls[0]
+        summary["request1_tool_name"] = call.get("function", {}).get("name")
+        args_raw = call.get("function", {}).get("arguments") or "{}"
+        try:
+            summary["request1_tool_args"] = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+        except json.JSONDecodeError:
+            summary["request1_tool_args"] = {"_raw": args_raw}
+        tool_args = summary["request1_tool_args"]
+        if isinstance(tool_args, dict) and tool_args.get("path") == str(fixture):
+            summary["request1_tool_args_classification"] = "exact_path"
+        elif isinstance(tool_args, dict) and tool_args.get("_error") == "invalid_tool_arguments":
+            summary["request1_tool_args_classification"] = "invalid_tool_arguments"
+        else:
+            summary["request1_tool_args_classification"] = "missing_required_path"
+        summary["checks"]["request1_tool_args_path_or_invalid"] = (
+            summary["request1_tool_args_classification"] in ("exact_path", "invalid_tool_arguments")
+        )
+
+        req2 = {
+            "model": args.model,
+            "messages": [
+                req1["messages"][0],
+                {"role": "assistant", "content": msg1.get("content"), "tool_calls": calls},
+                {
+                    "role": "tool",
+                    "tool_call_id": call.get("id"),
+                    "name": call.get("function", {}).get("name"),
+                    "content": json.dumps({"path": str(fixture), "lines": 5}, sort_keys=True),
+                },
+                {
+                    "role": "user",
+                    "content": "How many lines did the file have? Answer plainly in one short sentence. Do not call another tool.",
+                },
+            ],
+            "tools": [tool],
+            "tool_choice": "auto",
+            "max_tokens": args.max_tokens,
+        }
+        save(root / "request2.json", req2)
+        start = time.monotonic()
+        resp2 = request_json(args.base_url, "POST", "/v1/chat/completions", req2, timeout=args.timeout)
+        summary["request2_elapsed_s"] = round(time.monotonic() - start, 3)
+        save(root / "response2.json", resp2)
+
+        msg2 = choice_message(resp2)
+        content2 = msg2.get("content") or ""
+        summary["request2_content"] = content2
+        summary["request2_finish_reason"] = choice_finish(resp2)
+        summary["request2_usage"] = resp2.get("usage")
+        summary["request2_protocol_leaks"] = marker_leaks(resp2)
+        summary["checks"]["request2_visible_answer"] = bool(content2.strip())
+        summary["checks"]["request2_mentions_5_or_five"] = "5" in content2 or "five" in content2.lower()
+        summary["checks"]["request2_no_protocol_leak"] = summary["request2_protocol_leaks"] == []
+
+        time.sleep(args.settle_seconds)
+        summary["health_after"] = request_json(args.base_url, "GET", "/health", timeout=30)
+        save(root / "health-after.json", summary["health_after"])
+        try:
+            save(root / "cache-after.json", request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30))
+        except Exception as exc:
+            save(root / "cache-after-error.txt", repr(exc))
+        save(root / "process-after.txt", process_snapshot())
+        save(root / "vm-after.txt", vm_snapshot())
+        summary["checks"]["health_after_ok"] = summary["health_after"].get("status") == "healthy"
+        summary["checks"]["model_resident_after"] = args.model in json.dumps(summary["health_after"])
+        summary["passed"] = all(summary["checks"].values())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        summary["error"] = f"HTTPError {exc.code}"
+        summary["error_body"] = body
+        save(root / "http-error-body.txt", body)
+        summary["passed"] = False
+    except Exception as exc:
+        summary["error"] = repr(exc)
+        summary["passed"] = False
+    finally:
+        try:
+            summary["health_final"] = request_json(args.base_url, "GET", "/health", timeout=10)
+        except Exception as exc:
+            summary["health_final_error"] = repr(exc)
+        save(root / "process-final.txt", process_snapshot())
+        save(root / "SUMMARY.json", summary)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+    return 0 if summary.get("passed") else 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default=os.environ.get("OSAURUS_BASE_URL", "http://127.0.0.1:1337"))
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--label", default="local")
+    parser.add_argument("--artifact-root")
+    parser.add_argument("--max-tokens", type=int, default=160)
+    parser.add_argument("--timeout", type=int, default=1200)
+    parser.add_argument("--settle-seconds", type=float, default=2.0)
+    return run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
+++ b/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Run strict live multi-turn tool/cache proof against a local Osaurus app.
+
+This harness exercises the OpenAI-compatible chat endpoint used by real
+clients. It verifies a required tool call, a no-tool follow-up after a tool
+result, and a second required tool call after tool history while recording
+health/cache telemetry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import time
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+
+PROTOCOL_MARKERS = (
+    "<｜",
+    "</｜",
+    "</s>",
+    "DSML",
+    ":json{",
+    "tool_ccalls",
+    "tool_crs",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<tool_call>",
+    "</tool_call>",
+)
+
+
+def request_json(base_url: str, method: str, path: str, payload: Any | None = None, timeout: int = 900) -> Any:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        base_url.rstrip("/") + path,
+        data=data,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read()
+    return json.loads(raw)
+
+
+def save(path: pathlib.Path, value: Any) -> None:
+    if isinstance(value, (dict, list)):
+        path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    else:
+        path.write_text(str(value), encoding="utf-8")
+
+
+def process_snapshot() -> str:
+    cmd = (
+        "ps -axo pid,ppid,stat,etime,rss,command | "
+        "rg -i 'CodeSigningHelper|/Contents/MacOS/osaurus|RunBench|vmlx_engine\\.cli' | "
+        "rg -v 'rg -i|codex|zsh -lc' || true"
+    )
+    return subprocess.run(cmd, shell=True, text=True, capture_output=True).stdout
+
+
+def vm_snapshot() -> str:
+    cmd = "vm_stat | sed -n '1,10p'; sysctl vm.swapusage"
+    result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    return result.stdout + result.stderr
+
+
+def marker_leaks(value: Any) -> list[str]:
+    text = json.dumps(value, ensure_ascii=False)
+    return [marker for marker in PROTOCOL_MARKERS if marker in text]
+
+
+def message(response: dict[str, Any]) -> dict[str, Any]:
+    return response["choices"][0]["message"]
+
+
+def finish(response: dict[str, Any]) -> str | None:
+    return response["choices"][0].get("finish_reason")
+
+
+def token_rate(response: dict[str, Any], elapsed: float) -> dict[str, float | int | None]:
+    usage = response.get("usage")
+    completion_tokens = usage.get("completion_tokens") if isinstance(usage, dict) else None
+    if isinstance(completion_tokens, int) and elapsed > 0:
+        return {
+            "completion_tokens": completion_tokens,
+            "elapsed_seconds": elapsed,
+            "tokens_per_second": completion_tokens / elapsed,
+        }
+    return {
+        "completion_tokens": completion_tokens,
+        "elapsed_seconds": elapsed,
+        "tokens_per_second": None,
+    }
+
+
+def parse_args(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"_raw": raw}
+    return value if isinstance(value, dict) else {"_raw": value}
+
+
+def aggregate(cache: dict[str, Any] | None) -> dict[str, int]:
+    if not isinstance(cache, dict):
+        return {}
+    value = cache.get("aggregate")
+    return value if isinstance(value, dict) else {}
+
+
+def delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, int]:
+    left = aggregate(before)
+    right = aggregate(after)
+    keys = sorted(set(left) | set(right))
+    out: dict[str, int] = {}
+    for key in keys:
+        if isinstance(left.get(key, 0), int) and isinstance(right.get(key, 0), int):
+            out[key] = int(right.get(key, 0)) - int(left.get(key, 0))
+    return out
+
+
+def call_chat(base_url: str, payload: dict[str, Any], timeout: int) -> tuple[dict[str, Any], float]:
+    start = time.monotonic()
+    response = request_json(base_url, "POST", "/v1/chat/completions", payload, timeout=timeout)
+    return response, time.monotonic() - start
+
+
+def run_model(args: argparse.Namespace, model: str, root: pathlib.Path) -> dict[str, Any]:
+    label = model.replace("/", "_").replace(":", "_")
+    summary: dict[str, Any] = {
+        "model": model,
+        "checks": {},
+        "started": datetime.now(timezone.utc).isoformat(),
+    }
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "line_count",
+            "description": "Count newline-separated text lines.",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    health_before = request_json(args.base_url, "GET", "/health", timeout=30)
+    cache_before = request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30)
+    save(root / f"{label}_health_before.json", health_before)
+    save(root / f"{label}_cache_before.json", cache_before)
+
+    req1 = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Use the line_count tool on this exact text: red\ngreen\nblue"}],
+        "tools": [tool],
+        "tool_choice": "required",
+        "max_tokens": args.max_tokens,
+    }
+    resp1, elapsed1 = call_chat(args.base_url, req1, args.timeout)
+    save(root / f"{label}_01_required.request.json", req1)
+    save(root / f"{label}_01_required.response.json", resp1)
+    msg1 = message(resp1)
+    calls1 = msg1.get("tool_calls") or []
+    call1 = calls1[0] if calls1 else {}
+    args1 = parse_args(call1.get("function", {}).get("arguments"))
+    history_valid = finish(resp1) == "tool_calls" and len(calls1) == 1 and bool(call1.get("id"))
+
+    if history_valid:
+        req2 = {
+            "model": model,
+            "messages": [
+                req1["messages"][0],
+                {"role": "assistant", "content": msg1.get("content"), "tool_calls": calls1},
+                {
+                    "role": "tool",
+                    "tool_call_id": call1.get("id"),
+                    "content": json.dumps({"lines": 3}, sort_keys=True),
+                },
+                {
+                    "role": "user",
+                    "content": "How many lines were counted? Answer plainly in one short sentence. Do not call another tool.",
+                },
+            ],
+            "tools": [tool],
+            "tool_choice": "none",
+            "max_tokens": args.max_tokens,
+        }
+        resp2, elapsed2 = call_chat(args.base_url, req2, args.timeout)
+        save(root / f"{label}_02_none_followup.request.json", req2)
+        save(root / f"{label}_02_none_followup.response.json", resp2)
+        msg2 = message(resp2)
+        content2 = msg2.get("content") or ""
+
+        req3 = {
+            "model": model,
+            "messages": [
+                *req2["messages"],
+                {"role": "assistant", "content": content2},
+                {"role": "user", "content": "Now use line_count on this exact text: one\ntwo"},
+            ],
+            "tools": [tool],
+            "tool_choice": "required",
+            "max_tokens": args.max_tokens,
+        }
+        resp3, elapsed3 = call_chat(args.base_url, req3, args.timeout)
+        save(root / f"{label}_03_required_again.request.json", req3)
+        save(root / f"{label}_03_required_again.response.json", resp3)
+        msg3 = message(resp3)
+        calls3 = msg3.get("tool_calls") or []
+        call3 = calls3[0] if calls3 else {}
+        args3 = parse_args(call3.get("function", {}).get("arguments"))
+    else:
+        req2 = {"skipped": "turn1 did not produce a valid structured tool call"}
+        req3 = {"skipped": "turn1 did not produce a valid structured tool call"}
+        resp2 = {"choices": [{"message": {}, "finish_reason": "skipped"}], "usage": {}}
+        resp3 = {"choices": [{"message": {}, "finish_reason": "skipped"}], "usage": {}}
+        elapsed2 = 0.0
+        elapsed3 = 0.0
+        msg2 = {}
+        msg3 = {}
+        content2 = ""
+        calls3 = []
+        call3 = {}
+        args3 = {}
+        save(root / f"{label}_02_none_followup.request.json", req2)
+        save(root / f"{label}_02_none_followup.response.json", resp2)
+        save(root / f"{label}_03_required_again.request.json", req3)
+        save(root / f"{label}_03_required_again.response.json", resp3)
+
+    time.sleep(args.settle_seconds)
+    health_after = request_json(args.base_url, "GET", "/health", timeout=30)
+    cache_after = request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30)
+    save(root / f"{label}_health_after.json", health_after)
+    save(root / f"{label}_cache_after.json", cache_after)
+
+    checks = {
+        "server_healthy_after": health_after.get("status") == "healthy",
+        "no_inflight_after": not health_after.get("inflight"),
+        "turn1_finish_tool_calls": finish(resp1) == "tool_calls",
+        "turn1_has_one_tool_call": len(calls1) == 1,
+        "turn1_name_line_count": call1.get("function", {}).get("name") == "line_count",
+        "turn1_args_exact": args1.get("text") == "red\ngreen\nblue",
+        "turn1_no_visible_content": msg1.get("content") in (None, ""),
+        "turn1_no_protocol_leak": marker_leaks(resp1) == [],
+        "history_valid_after_turn1": history_valid,
+        "turn2_no_tool_calls": not msg2.get("tool_calls"),
+        "turn2_visible_mentions_3": "3" in content2 or "three" in content2.lower(),
+        "turn2_not_length_stop": finish(resp2) != "length",
+        "turn2_no_protocol_leak": marker_leaks(resp2) == [],
+        "turn3_finish_tool_calls": finish(resp3) == "tool_calls",
+        "turn3_has_one_tool_call": len(calls3) == 1,
+        "turn3_name_line_count": call3.get("function", {}).get("name") == "line_count",
+        "turn3_args_exact": args3.get("text") == "one\ntwo",
+        "turn3_no_visible_content": msg3.get("content") in (None, ""),
+        "turn3_no_protocol_leak": marker_leaks(resp3) == [],
+    }
+    summary.update(
+        {
+            "checks": checks,
+            "failed_checks": [key for key, value in checks.items() if not value],
+            "durations": {"turn1": elapsed1, "turn2": elapsed2, "turn3": elapsed3},
+            "token_rates": {
+                "turn1": token_rate(resp1, elapsed1),
+                "turn2": token_rate(resp2, elapsed2),
+                "turn3": token_rate(resp3, elapsed3),
+            },
+            "turns": {
+                "turn1_finish": finish(resp1),
+                "turn1_args": args1,
+                "turn2_finish": finish(resp2),
+                "turn2_content": content2,
+                "turn3_finish": finish(resp3),
+                "turn3_args": args3,
+            },
+            "cache_delta": delta(cache_before, cache_after),
+            "cache_after": cache_after,
+            "health_after": health_after,
+            "passed": all(checks.values()),
+            "finished": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    save(root / f"{label}_summary.json", summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:1337")
+    parser.add_argument("--artifact-root", required=True)
+    parser.add_argument("--model", action="append", required=True)
+    parser.add_argument("--max-tokens", type=int, default=384)
+    parser.add_argument("--timeout", type=int, default=1200)
+    parser.add_argument("--settle-seconds", type=float, default=2)
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.artifact_root)
+    root.mkdir(parents=True, exist_ok=True)
+    save(root / "process-before.txt", process_snapshot())
+    save(root / "vm-before.txt", vm_snapshot())
+    started = datetime.now(timezone.utc).isoformat()
+    results = {model: run_model(args, model, root) for model in args.model}
+    save(root / "process-after.txt", process_snapshot())
+    save(root / "vm-after.txt", vm_snapshot())
+    summary = {
+        "artifact_dir": str(root),
+        "started": started,
+        "finished": datetime.now(timezone.utc).isoformat(),
+        "models": results,
+        "passed": all(row.get("passed") for row in results.values()),
+    }
+    save(root / "SUMMARY.json", summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["passed"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live-proof/run-local-vl-media-cache-proof.py
+++ b/scripts/live-proof/run-local-vl-media-cache-proof.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Run a live Osaurus VLM media/cache proof against the app server.
+
+This harness uses the OpenAI-compatible chat endpoint with a real data-URL
+image payload. It verifies that the model sees the image, that the repeated
+request has a stable prefix hash, and that cache telemetry records L2 reuse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import pathlib
+import struct
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import zlib
+from datetime import datetime, timezone
+from typing import Any
+
+
+PROTOCOL_MARKERS = (
+    "<｜",
+    "</｜",
+    "</s>",
+    "DSML",
+    ":json{",
+    "tool_ccalls",
+    "tool_crs",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<tool_call>",
+    "</tool_call>",
+)
+
+
+def request_json(base_url: str, method: str, path: str, payload: Any | None = None, timeout: int = 900) -> Any:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        base_url.rstrip("/") + path,
+        data=data,
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read()
+    return json.loads(raw)
+
+
+def save(path: pathlib.Path, value: Any) -> None:
+    if isinstance(value, (dict, list)):
+        path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    else:
+        path.write_text(str(value), encoding="utf-8")
+
+
+def process_snapshot() -> str:
+    cmd = (
+        "ps -axo pid,ppid,stat,etime,rss,command | "
+        "rg -i 'CodeSigningHelper|/Contents/MacOS/osaurus|RunBench|vmlx_engine\\.cli' | "
+        "rg -v 'rg -i|codex|zsh -lc' || true"
+    )
+    return subprocess.run(cmd, shell=True, text=True, capture_output=True).stdout
+
+
+def vm_snapshot() -> str:
+    cmd = "vm_stat | sed -n '1,10p'; sysctl vm.swapusage"
+    result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    return result.stdout + result.stderr
+
+
+def marker_leaks(value: Any) -> list[str]:
+    text = json.dumps(value, ensure_ascii=False)
+    return [marker for marker in PROTOCOL_MARKERS if marker in text]
+
+
+def make_png(width: int, height: int, rgb: tuple[int, int, int]) -> bytes:
+    raw = b"".join(b"\x00" + bytes(rgb) * width for _ in range(height))
+
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + kind
+            + data
+            + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+def aggregate(cache: dict[str, Any] | None) -> dict[str, int]:
+    if not isinstance(cache, dict):
+        return {}
+    value = cache.get("aggregate")
+    return value if isinstance(value, dict) else {}
+
+
+def delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, int]:
+    left = aggregate(before)
+    right = aggregate(after)
+    keys = sorted(set(left) | set(right))
+    out: dict[str, int] = {}
+    for key in keys:
+        if isinstance(left.get(key, 0), int) and isinstance(right.get(key, 0), int):
+            out[key] = int(right.get(key, 0)) - int(left.get(key, 0))
+    return out
+
+
+def answer_text(response: dict[str, Any]) -> str:
+    return response["choices"][0]["message"].get("content") or ""
+
+
+def finish_reason(response: dict[str, Any]) -> str | None:
+    return response["choices"][0].get("finish_reason")
+
+
+def run(args: argparse.Namespace) -> int:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    root = pathlib.Path(args.artifact_root or f"/tmp/osaurus-vl-media-proof-{args.model}-{stamp}")
+    root.mkdir(parents=True, exist_ok=True)
+
+    if args.color != "red":
+        raise ValueError("only red is currently supported by this deterministic harness")
+
+    png = make_png(args.size, args.size, (255, 0, 0))
+    save(root / "red.png.base64.txt", base64.b64encode(png).decode("ascii"))
+    (root / "red.png").write_bytes(png)
+    data_url = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+    payload = {
+        "model": args.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is the dominant color in this image? Answer one word only."},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            }
+        ],
+        "max_tokens": args.max_tokens,
+    }
+
+    summary: dict[str, Any] = {
+        "artifact_dir": str(root),
+        "base_url": args.base_url,
+        "model": args.model,
+        "image": {"color": args.color, "width": args.size, "height": args.size},
+        "started": datetime.now(timezone.utc).isoformat(),
+        "checks": {},
+    }
+
+    save(root / "process-before.txt", process_snapshot())
+    save(root / "vm-before.txt", vm_snapshot())
+    cache_before = request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30)
+    save(root / "cache-before.json", cache_before)
+    health_before = request_json(args.base_url, "GET", "/health", timeout=30)
+    save(root / "health-before.json", health_before)
+    save(root / "request.json", payload)
+
+    try:
+        start = time.monotonic()
+        first = request_json(args.base_url, "POST", "/v1/chat/completions", payload, timeout=args.timeout)
+        first_elapsed = time.monotonic() - start
+        save(root / "response-first.json", first)
+
+        cache_before_repeat = request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30)
+        save(root / "cache-before-repeat.json", cache_before_repeat)
+        start = time.monotonic()
+        repeat = request_json(args.base_url, "POST", "/v1/chat/completions", payload, timeout=args.timeout)
+        repeat_elapsed = time.monotonic() - start
+        save(root / "response-repeat.json", repeat)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        save(root / "http-error-body.txt", body)
+        summary["error"] = f"HTTPError {exc.code}"
+        summary["error_body"] = body
+        summary["passed"] = False
+        save(root / "SUMMARY.json", summary)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 2
+
+    time.sleep(args.settle_seconds)
+    cache_after = request_json(args.base_url, "GET", "/admin/cache-stats", timeout=30)
+    health_after = request_json(args.base_url, "GET", "/health", timeout=30)
+    save(root / "cache-after.json", cache_after)
+    save(root / "health-after.json", health_after)
+    save(root / "process-after.txt", process_snapshot())
+    save(root / "vm-after.txt", vm_snapshot())
+
+    first_text = answer_text(first)
+    repeat_text = answer_text(repeat)
+    first_rate = (first.get("usage", {}).get("completion_tokens") or 0) / first_elapsed if first_elapsed > 0 else None
+    repeat_rate = (repeat.get("usage", {}).get("completion_tokens") or 0) / repeat_elapsed if repeat_elapsed > 0 else None
+    repeat_delta = delta(cache_before_repeat, cache_after)
+
+    checks = {
+        "server_healthy_after": health_after.get("status") == "healthy",
+        "model_resident_after": args.model in json.dumps(health_after),
+        "first_stop": finish_reason(first) == "stop",
+        "repeat_stop": finish_reason(repeat) == "stop",
+        "first_mentions_red": "red" in first_text.lower(),
+        "repeat_mentions_red": "red" in repeat_text.lower(),
+        "first_no_protocol_leak": marker_leaks(first) == [],
+        "repeat_no_protocol_leak": marker_leaks(repeat) == [],
+        "stable_prefix_hash": bool(first.get("prefix_hash")) and first.get("prefix_hash") == repeat.get("prefix_hash"),
+        "repeat_disk_l2_hit": repeat_delta.get("disk_l2_hits", 0) > 0,
+    }
+    summary.update(
+        {
+            "checks": checks,
+            "failed_checks": [key for key, value in checks.items() if not value],
+            "first": {
+                "content": first_text,
+                "finish_reason": finish_reason(first),
+                "prefix_hash": first.get("prefix_hash"),
+                "elapsed_seconds": first_elapsed,
+                "tokens_per_second": first_rate,
+                "usage": first.get("usage"),
+            },
+            "repeat": {
+                "content": repeat_text,
+                "finish_reason": finish_reason(repeat),
+                "prefix_hash": repeat.get("prefix_hash"),
+                "elapsed_seconds": repeat_elapsed,
+                "tokens_per_second": repeat_rate,
+                "usage": repeat.get("usage"),
+            },
+            "cache_delta_total": delta(cache_before, cache_after),
+            "cache_delta_repeat": repeat_delta,
+            "cache_after": cache_after,
+            "health_after": health_after,
+            "passed": all(checks.values()),
+            "finished": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    save(root / "SUMMARY.json", summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["passed"] else 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:1337")
+    parser.add_argument("--artifact-root")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--settle-seconds", type=float, default=2)
+    parser.add_argument("--color", default="red")
+    parser.add_argument("--size", type=int, default=64)
+    args = parser.parse_args()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Consolidates the post-merge family runtime fixes for DSV4, Nemotron/Nemo Omni, Ling, ZAYA, HY3, Qwen/Gemma tokenizer surfaces, tool routing, reasoning defaults, residency/cancellation, and cache proof scripts.
- Pins Osaurus to vMLX `239186e475b59451d66838ec2c4e6a088efdd24a` from `vmlx-origin/codex/live-family-runtime-matrix`.
- Keeps TurboQuant KV opt-in/default-off (`liveKVCodec: .native`) and keeps SSE chat keepalive on the 15s default, not the earlier 250ms cadence.

## Verified locally before PR
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests --jobs 1 --no-parallel` - 71/71 passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter MLXBatchAdapterTests --jobs 1 --no-parallel` - 47/47 passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter SwiftTransformersTokenizerLoaderTests --jobs 1 --no-parallel` - 13/13 passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ChatEngineTests --jobs 1 --no-parallel` - 26/26 passed
- `git diff --cached --check` / `git diff --check` passed before commit.

## Merge boundary
Do not merge this PR until GitHub CI is green and the current head has a no-sign Release app smoke/live row. This PR is intentionally draft until that proof exists.

## Live proof still required on this head
- Build no-sign Release app without signing/keychain/notary paths.
- Launch keychain-disabled app and verify `/health` plus `/v1/models`.
- Run at least one current-head local family tool/cache row, starting with Nemotron/Nemo Omni because it previously emitted repeated `<|Assistant|>`-style control text.
- Record DSV4 JANGTQ2/JANGTQ-K status; plain affine DSV4 JANG remains intentionally production-gated unless engine diagnostics opt in.
