### PR TITLE
Add post-1257 family runtime chat matrix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
+        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
+        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
+        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
+        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
+        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
+        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
+        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
+        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
+        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
+        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
+        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
+        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
+        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
+        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
+        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
+        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
+            revision: "3304c89b72207dac5624e3e3ab23cf334da5183a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "db655e11606fead8321c74f525524f7480db49ff"
+            revision: "de1330b4837e9df2e36fb4162a1cd13a7783af64"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3304c89b72207dac5624e3e3ab23cf334da5183a"
+            revision: "db655e11606fead8321c74f525524f7480db49ff"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "447c6fba690ea80c5226480be6c940bc80d22c80"
+            revision: "d457472d6cda4b3e16b8268564373410369d698b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "de1330b4837e9df2e36fb4162a1cd13a7783af64"
+            revision: "a771034fe49c06bbcf07536a8b136c25b0b56449"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a771034fe49c06bbcf07536a8b136c25b0b56449"
+            revision: "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d457472d6cda4b3e16b8268564373410369d698b"
+            revision: "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
+            revision: "447c6fba690ea80c5226480be6c940bc80d22c80"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -601,12 +601,6 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
 
         let toolChoiceRequired =
             Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
-        if toolChoiceRequired,
-            let idx = dsv4Messages.lastIndex(where: { $0.role == .user || $0.role == .developer }),
-            dsv4Messages[idx].task == nil
-        {
-            dsv4Messages[idx].task = "action"
-        }
 
         var prompt = MLXLMCommon.DeepseekV4ChatEncoder().encode(
             messages: dsv4Messages,

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -601,13 +601,15 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
 
         let toolChoiceRequired =
             Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
+        let toolChoiceName = Self.deepseekV4String(additionalContext?["tool_choice_name"])
 
         var prompt = MLXLMCommon.DeepseekV4ChatEncoder().encode(
             messages: dsv4Messages,
             thinkingMode: thinkingMode,
             reasoningEffort: effort,
             dropEarlierReasoning: true,
-            toolChoiceRequired: toolChoiceRequired
+            toolChoiceRequired: toolChoiceRequired,
+            toolChoiceName: toolChoiceName
         )
         if !addGenerationPrompt,
             let lastRole = dsv4Messages.last?.role,

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -549,6 +549,12 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                 task: Self.deepseekV4String(raw["task"])
             )
         }
+        let toolChoiceRequired =
+            Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
+        let toolChoiceName = Self.deepseekV4String(additionalContext?["tool_choice_name"])
+        if toolChoiceRequired || !(toolChoiceName?.isEmpty ?? true) {
+            dsv4Messages = Self.compactCompletedDSV4ToolHistory(dsv4Messages)
+        }
 
         if let tools, !tools.isEmpty {
             if let idx = dsv4Messages.firstIndex(where: {
@@ -599,10 +605,6 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             effort = nil
         }
 
-        let toolChoiceRequired =
-            Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
-        let toolChoiceName = Self.deepseekV4String(additionalContext?["tool_choice_name"])
-
         var prompt = MLXLMCommon.DeepseekV4ChatEncoder().encode(
             messages: dsv4Messages,
             thinkingMode: thinkingMode,
@@ -625,6 +627,73 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             }
         }
         return upstream.encode(text: prompt, addSpecialTokens: false)
+    }
+
+    private static func compactCompletedDSV4ToolHistory(
+        _ messages: [MLXLMCommon.DeepseekV4ChatEncoder.Message]
+    ) -> [MLXLMCommon.DeepseekV4ChatEncoder.Message] {
+        guard let latestUserIndex = messages.lastIndex(where: {
+            $0.role == .user || $0.role == .developer
+        }) else {
+            return messages
+        }
+
+        let hasLaterAssistantAnswerBeforeLatestUser: (Int) -> Bool = { index in
+            guard index + 1 < latestUserIndex else { return false }
+            return messages[(index + 1)..<latestUserIndex].contains { message in
+                guard message.role == .assistant else { return false }
+                if let content = message.content,
+                   !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    return true
+                }
+                if let reasoning = message.reasoningContent,
+                   !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    return true
+                }
+                return false
+            }
+        }
+
+        var compacted: [MLXLMCommon.DeepseekV4ChatEncoder.Message] = []
+        compacted.reserveCapacity(messages.count)
+        var droppingClosedToolResult = false
+
+        for (index, message) in messages.enumerated() {
+            if index >= latestUserIndex {
+                compacted.append(message)
+                continue
+            }
+
+            if message.role == .assistant,
+               let toolCalls = message.toolCalls,
+               !toolCalls.isEmpty,
+               hasLaterAssistantAnswerBeforeLatestUser(index)
+            {
+                droppingClosedToolResult = true
+                let content = message.content?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let reasoning = message.reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !content.isEmpty || !reasoning.isEmpty else {
+                    continue
+                }
+                var copy = message
+                copy.toolCalls = nil
+                compacted.append(copy)
+                continue
+            }
+
+            if message.role == .tool, droppingClosedToolResult {
+                continue
+            }
+
+            if message.role != .tool {
+                droppingClosedToolResult = false
+            }
+            compacted.append(message)
+        }
+
+        return compacted
     }
 
     private func fallback(

--- a/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
@@ -211,6 +211,55 @@ struct DSV4ParserPipelineTests {
         #expect(call.function.arguments["text"] == .string("one\ntwo"))
     }
 
+    @Test("Gemma4 parser routes live Zyphra multiline tool envelope without visible leakage")
+    func gemma4ParserRoutesLiveZyphraMultilineToolEnvelopeWithoutVisibleLeakage() throws {
+        let toolCallProcessor = ToolCallProcessor(format: .gemma4, tools: lineCountToolSchema())
+        var events: [Generation] = []
+        let output = #"""
+            <zyphra_tool_call>
+            <function=line_count
+            <parameter=text
+            >red
+            green
+            blue
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """#
+
+        for ch in output {
+            events.append(
+                contentsOf: routeGenerationText(
+                    String(ch),
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        if let visible = toolCallProcessor.processEOS() {
+            events.append(
+                contentsOf: routeGenerationText(
+                    visible,
+                    channel: .content,
+                    through: toolCallProcessor
+                )
+            )
+        }
+        events.append(contentsOf: drainToolCallEvents(from: toolCallProcessor))
+
+        let visible = events.compactMap(\.chunk).joined()
+        let calls = events.compactMap(\.toolCall)
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(!visible.contains("zyphra_tool_call"))
+        #expect(!visible.contains("function=line_count"))
+        #expect(!visible.contains("parameter=text"))
+        #expect(calls.count == 1)
+        let call = try #require(calls.first)
+        #expect(call.function.name == "line_count")
+        #expect(call.function.arguments["text"] == .string("red\ngreen\nblue"))
+    }
+
     @Test("live DSV4 bare-name JSON split after tool marker routes to a tool call")
     func liveBareNameJSONAfterToolMarkerRoutesToToolCall() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: lineCountToolSchema())

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
+        let expectedRuntimeHardenedRevision = "3304c89b72207dac5624e3e3ab23cf334da5183a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -408,7 +408,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "447c6fba690ea80c5226480be6c940bc80d22c80"
+        let expectedRuntimeHardenedRevision = "d457472d6cda4b3e16b8268564373410369d698b"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "db655e11606fead8321c74f525524f7480db49ff"
+        let expectedRuntimeHardenedRevision = "de1330b4837e9df2e36fb4162a1cd13a7783af64"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -408,7 +408,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d457472d6cda4b3e16b8268564373410369d698b"
+        let expectedRuntimeHardenedRevision = "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1753,9 +1753,9 @@ struct RuntimePolicySourceTests {
             "DSV4 native prompt rendering must pass required tool_choice into DeepseekV4ChatEncoder so second-turn/named required tool calls keep the DSML must-call directive."
         )
         #expect(
-            !tokenizerLoader.contains("dsv4HasPriorToolResult")
-                && tokenizerLoader.contains("dsv4Messages[idx].task = \"action\""),
-            "DSV4 required/named tool_choice must keep the native action task rail even after tool-result history so multi-turn required tool calls do not silently degrade to ordinary chat."
+            !tokenizerLoader.contains("dsv4Messages[idx].task = \"action\"")
+                && tokenizerLoader.contains("toolChoiceRequired: toolChoiceRequired"),
+            "DSV4 required/named tool_choice must use the DSML required-template contract without injecting the native action task rail; live repeat rows showed that rail can leak as visible text after tool-result history."
         )
         #expect(
             tokenizerLoader.contains("&& upstream.bosToken == Self.dsv4Bos")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "de1330b4837e9df2e36fb4162a1cd13a7783af64"
+        let expectedRuntimeHardenedRevision = "a771034fe49c06bbcf07536a8b136c25b0b56449"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "a771034fe49c06bbcf07536a8b136c25b0b56449"
+        let expectedRuntimeHardenedRevision = "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -401,12 +401,14 @@ struct RuntimePolicySourceTests {
         // the vMLX regression harness, plus the Nemotron Omni tool-template
         // fallback that keeps tool schemas rendered through the model-native
         // [AVAILABLE_TOOLS]/XML function-call contract instead of leaking
-        // role-token/DSML fragments in Osaurus tool turns.
+        // role-token/DSML fragments in Osaurus tool turns, plus the Gemma4
+        // Zyphra XML tool-call parser used by live JANG_4M multiline tool
+        // envelopes.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
+        let expectedRuntimeHardenedRevision = "447c6fba690ea80c5226480be6c940bc80d22c80"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -406,7 +406,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "3304c89b72207dac5624e3e3ab23cf334da5183a"
+        let expectedRuntimeHardenedRevision = "db655e11606fead8321c74f525524f7480db49ff"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -623,8 +623,12 @@ struct SwiftTransformersTokenizerLoaderTests {
             "DSV4 must merge the prior tool result and the next user request into one content block. Decoded: \(decoded)"
         )
         #expect(
-            decoded.hasSuffix("<\u{FF5C}Assistant\u{FF5C}></think><\u{FF5C}action\u{FF5C}>"),
-            "DSV4 required/named tool_choice must preserve the action task after tool-result history. Decoded: \(decoded)"
+            decoded.hasSuffix("<\u{FF5C}Assistant\u{FF5C}></think>"),
+            "DSV4 required/named tool_choice must keep the ordinary assistant tail; the action task rail can leak as visible model text after tool-result history. Decoded: \(decoded)"
+        )
+        #expect(
+            !decoded.contains("<\u{FF5C}action\u{FF5C}>"),
+            "DSV4 required/named tool_choice must not inject the action task token after live repeat rows showed it can leak as visible text. Decoded: \(decoded)"
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -632,6 +632,76 @@ struct SwiftTransformersTokenizerLoaderTests {
         )
     }
 
+    @Test func dsv4RequiredToolChoiceCompactsClosedToolHistoryBeforeNextToolCall() async throws {
+        let defaultPath = "/Users/eric/models/JANGQ/DeepSeek-V4-Flash-JANGTQ2"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_DSV4_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let lineCountTool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let priorLineCountCall: [String: any Sendable] = [
+            "id": "call_line_count_1",
+            "type": "function",
+            "function": [
+                "name": "line_count",
+                "arguments": ["text": "red\ngreen\nblue"] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                ["role": "user", "content": "Use line_count on red green blue."],
+                ["role": "assistant", "content": "", "tool_calls": [priorLineCountCall]],
+                ["role": "tool", "content": "{\"lines\":3}", "tool_call_id": "call_line_count_1"],
+                ["role": "user", "content": "How many lines were counted?"],
+                ["role": "assistant", "content": "The line_count tool counted 3 lines."],
+                ["role": "user", "content": "Now use line_count on this exact text: one\ntwo"],
+            ],
+            tools: [lineCountTool.toTokenizerToolSpec()],
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(
+            !decoded.contains("<\u{FF5C}DSML\u{FF5C}tool_calls>"),
+            "Closed historical DSV4 tool calls must not be replayed before a later required tool call. Decoded: \(decoded)"
+        )
+        #expect(
+            !decoded.contains("<tool_result>{\"lines\":3}</tool_result>"),
+            "Closed historical DSV4 tool results must not poison the next required tool-call turn. Decoded: \(decoded)"
+        )
+        #expect(decoded.contains("The line_count tool counted 3 lines."))
+        #expect(decoded.contains("Now use line_count on this exact text: one\ntwo"))
+        #expect(decoded.contains("Use the `line_count` function."))
+        #expect(
+            decoded.hasSuffix("<\u{FF5C}Assistant\u{FF5C}></think>"),
+            "DSV4 compacted history must still leave the ordinary assistant tail. Decoded: \(decoded)"
+        )
+    }
+
     @Test func dsv4LocalTokenizerPreservesRawMaxPromptPath() async throws {
         let defaultPath = "/Users/eric/models/JANGQ/DeepSeek-V4-Flash-JANGTQ-K"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_DSV4_TEST_MODEL"] ?? defaultPath

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
+        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cb6a7c88bc5fed073c913fb0eb91e4736d865187"
+        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
+        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
+        "revision" : "de1330b4837e9df2e36fb4162a1cd13a7783af64"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a771034fe49c06bbcf07536a8b136c25b0b56449"
+        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a11cbbf51e60ab654e9713cf178bfa9c0fb6b8d8"
+        "revision" : "447c6fba690ea80c5226480be6c940bc80d22c80"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3304c89b72207dac5624e3e3ab23cf334da5183a"
+        "revision" : "db655e11606fead8321c74f525524f7480db49ff"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d457472d6cda4b3e16b8268564373410369d698b"
+        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
       }
     },
     {

--- a/scripts/live-proof/family-runtime-chat-matrix.json
+++ b/scripts/live-proof/family-runtime-chat-matrix.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "zaya-vl-jangtq4",
+    "model": "zaya1-vl-8b-jangtq4",
+    "family": "zaya",
+    "topology": "zaya-cca-vl",
+    "required_cache_evidence": ["zaya_cca_companion_cache", "disk_l2_hits", "requires_disk_backed_restore"],
+    "priority": "required",
+    "notes": "CCA companion/pooling and VL path; TurboQuant KV is not a substitute."
+  },
+  {
+    "id": "zaya-text-jangtq4",
+    "model": "zaya1-8b-jangtq4",
+    "family": "zaya",
+    "topology": "zaya-cca",
+    "required_cache_evidence": ["zaya_cca_companion_cache", "disk_l2_hits", "requires_disk_backed_restore"],
+    "priority": "required",
+    "notes": "Text CCA companion and disk restore proof."
+  },
+  {
+    "id": "ling-jangtq2",
+    "model": "ling-2.6-flash-jangtq2-crack",
+    "family": "ling",
+    "topology": "hybrid",
+    "required_cache_evidence": ["cache_topology", "disk_l2_hits", "companion_cache"],
+    "priority": "required",
+    "notes": "Hybrid path needs structured tool-call, multi-turn, cache reuse, and no visible protocol leak."
+  },
+  {
+    "id": "ling-mxfp4",
+    "model": "ling-2.6-flash-mxfp4-crack",
+    "family": "ling",
+    "topology": "hybrid",
+    "required_cache_evidence": ["cache_topology", "disk_l2_hits", "companion_cache"],
+    "priority": "required",
+    "notes": "MXFP sibling must not rely on JANGTQ-only parser/cache assumptions."
+  },
+  {
+    "id": "nemotron-omni-jangtq",
+    "model": "nemotron-omni-nano-jangtq-crack",
+    "family": "nemotron-omni",
+    "topology": "hybrid-ssm-omni",
+    "required_cache_evidence": ["ssm_companion_cache", "disk_l2_hits", "cache_topology"],
+    "priority": "required",
+    "notes": "Nemo Omni direct/default rail must not emit assistant header loops or raw protocol tokens."
+  },
+  {
+    "id": "nemotron-omni-jangtq4",
+    "model": "nemotron-omni-nano-jangtq4-crack",
+    "family": "nemotron-omni",
+    "topology": "hybrid-ssm-omni",
+    "required_cache_evidence": ["ssm_companion_cache", "disk_l2_hits", "cache_topology"],
+    "priority": "required",
+    "notes": "JANGTQ4 sibling of Nemo Omni must pass the same tool/history/cache proof."
+  },
+  {
+    "id": "nemotron-omni-mxfp4",
+    "model": "nemotron-omni-nano-mxfp4-crack",
+    "family": "nemotron-omni",
+    "topology": "hybrid-ssm-omni",
+    "required_cache_evidence": ["ssm_companion_cache", "disk_l2_hits", "cache_topology"],
+    "priority": "required",
+    "notes": "MXFP sibling covers the recent assistant-header loop report."
+  },
+  {
+    "id": "dsv4-jangtq2",
+    "model": "deepseek-v4-flash-jangtq2",
+    "family": "dsv4",
+    "topology": "csa-hsa-swa-hybrid-pool",
+    "required_cache_evidence": ["hybrid_pool_layer_count", "rotating_kv_layer_count", "disk_l2_hits"],
+    "priority": "required",
+    "notes": "Production DSV4 row; CSA/HSA/SWA hybrid pool proof is required."
+  },
+  {
+    "id": "dsv4-jangtq-k",
+    "model": "deepseek-v4-flash-jangtq-k",
+    "family": "dsv4",
+    "topology": "csa-hsa-swa-hybrid-pool",
+    "required_cache_evidence": ["hybrid_pool_layer_count", "rotating_kv_layer_count", "disk_l2_hits"],
+    "priority": "required",
+    "notes": "JANGTQ-K sibling of DSV4 production path."
+  },
+  {
+    "id": "qwen27-mxfp4-mtp",
+    "model": "qwen3.6-27b-mxfp4-crack-mtp",
+    "family": "qwen",
+    "topology": "hybrid-ssm",
+    "required_cache_evidence": ["ssm_companion_cache", "disk_l2_hits", "cache_topology"],
+    "priority": "red-row",
+    "notes": "Known red row: hybrid SSM/cache reuse produced hidden-reasoning length stop; rerun only when intentionally investigating Qwen."
+  },
+  {
+    "id": "gemma4-26b-jang4m",
+    "model": "gemma-4-26b-a4b-it-jang_4m-crack",
+    "family": "gemma",
+    "topology": "swa-rotating",
+    "required_cache_evidence": ["rotating_kv_layer_count", "disk_l2_hits", "cache_topology"],
+    "priority": "required",
+    "notes": "Gemma parser/template row must prove no thought/header leak through Osaurus chat."
+  },
+  {
+    "id": "hy3-local-if-present",
+    "model": "hy3",
+    "family": "hy3",
+    "topology": "cca-pooling",
+    "required_cache_evidence": ["companion_cache", "disk_l2_hits", "cache_topology"],
+    "priority": "optional-local",
+    "notes": "Run only if a local HY3 bundle/model id is actually present."
+  }
+]

--- a/scripts/live-proof/run-family-runtime-chat-matrix.sh
+++ b/scripts/live-proof/run-family-runtime-chat-matrix.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT/scripts/live-proof/family-runtime-chat-matrix.json"
+HARNESS="$ROOT/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py"
+
+BASE_URL="${OSAURUS_BASE_URL:-http://127.0.0.1:1337}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-/tmp/osaurus-family-runtime-chat-matrix-$(date +%Y%m%d-%H%M%S)}"
+FAMILY_FILTER="${FAMILY_FILTER:-}"
+MODEL_FILTER="${MODEL_FILTER:-}"
+MAX_TOKENS="${MAX_TOKENS:-384}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1200}"
+SETTLE_SECONDS="${SETTLE_SECONDS:-2}"
+DRY_RUN="${DRY_RUN:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --help|-h)
+      cat <<'EOF'
+usage: run-family-runtime-chat-matrix.sh [--dry-run] [KEY=value ...]
+
+Environment/KEY options:
+  OSAURUS_BASE_URL=http://127.0.0.1:1337
+  ARTIFACT_ROOT=/tmp/osaurus-family-runtime-chat-matrix-...
+  FAMILY_FILTER=zaya|ling|nemotron-omni|dsv4|qwen|gemma|hy3
+  MODEL_FILTER=<model id or row id>
+  MAX_TOKENS=384
+  TIMEOUT_SECONDS=1200
+  SETTLE_SECONDS=2
+  DRY_RUN=1
+EOF
+      exit 0
+      ;;
+    OSAURUS_BASE_URL=*)
+      BASE_URL="${arg#*=}"
+      ;;
+    ARTIFACT_ROOT=*)
+      ARTIFACT_ROOT="${arg#*=}"
+      ;;
+    FAMILY_FILTER=*)
+      FAMILY_FILTER="${arg#*=}"
+      ;;
+    MODEL_FILTER=*)
+      MODEL_FILTER="${arg#*=}"
+      ;;
+    MAX_TOKENS=*)
+      MAX_TOKENS="${arg#*=}"
+      ;;
+    TIMEOUT_SECONDS=*)
+      TIMEOUT_SECONDS="${arg#*=}"
+      ;;
+    SETTLE_SECONDS=*)
+      SETTLE_SECONDS="${arg#*=}"
+      ;;
+    DRY_RUN=*)
+      DRY_RUN="${arg#*=}"
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      echo "use --help for usage" >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "missing manifest: $MANIFEST" >&2
+  exit 66
+fi
+
+if [[ ! -x "$HARNESS" ]]; then
+  echo "missing executable harness: $HARNESS" >&2
+  exit 66
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+
+python3 - "$MANIFEST" "$FAMILY_FILTER" "$MODEL_FILTER" >"$ARTIFACT_ROOT/selected.tsv" <<'PY'
+import json
+import sys
+
+manifest_path, family_filter, model_filter = sys.argv[1:4]
+rows = json.load(open(manifest_path, encoding="utf-8"))
+for row in rows:
+    if family_filter and row.get("family") != family_filter:
+        continue
+    if model_filter and row.get("model") != model_filter and row.get("id") != model_filter:
+        continue
+    print("\t".join([
+        row.get("id", ""),
+        row.get("model", ""),
+        row.get("family", ""),
+        row.get("topology", ""),
+        row.get("priority", ""),
+    ]))
+PY
+
+if [[ ! -s "$ARTIFACT_ROOT/selected.tsv" ]]; then
+  echo "no rows selected; FAMILY_FILTER=$FAMILY_FILTER MODEL_FILTER=$MODEL_FILTER" >&2
+  exit 64
+fi
+
+echo "base_url=$BASE_URL"
+echo "artifact_root=$ARTIFACT_ROOT"
+echo "selected_rows:"
+cat "$ARTIFACT_ROOT/selected.tsv"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  exit 0
+fi
+
+curl -fsS --max-time 10 "$BASE_URL/health" >"$ARTIFACT_ROOT/health-before.json"
+curl -fsS --max-time 20 "$BASE_URL/admin/cache-stats" >"$ARTIFACT_ROOT/cache-before.json" || true
+
+fail=0
+while IFS=$'\t' read -r row_id model family topology priority; do
+  row_root="$ARTIFACT_ROOT/$row_id"
+  mkdir -p "$row_root"
+  {
+    echo "row_id=$row_id"
+    echo "model=$model"
+    echo "family=$family"
+    echo "topology=$topology"
+    echo "priority=$priority"
+  } >"$row_root/row.txt"
+
+  echo "--- running $row_id ($model) ---"
+  if "$HARNESS" \
+    --base-url "$BASE_URL" \
+    --artifact-root "$row_root" \
+    --model "$model" \
+    --max-tokens "$MAX_TOKENS" \
+    --timeout "$TIMEOUT_SECONDS" \
+    --settle-seconds "$SETTLE_SECONDS"; then
+    echo "PASS $row_id" | tee "$row_root/status.txt"
+  else
+    echo "FAIL $row_id" | tee "$row_root/status.txt"
+    fail=1
+  fi
+done <"$ARTIFACT_ROOT/selected.tsv"
+
+curl -fsS --max-time 10 "$BASE_URL/health" >"$ARTIFACT_ROOT/health-after.json" || true
+curl -fsS --max-time 20 "$BASE_URL/admin/cache-stats" >"$ARTIFACT_ROOT/cache-after.json" || true
+
+python3 - "$ARTIFACT_ROOT" >"$ARTIFACT_ROOT/SUMMARY.json" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+rows = []
+for row_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+    status = row_dir.joinpath("status.txt").read_text(encoding="utf-8").strip() if row_dir.joinpath("status.txt").exists() else "UNKNOWN"
+    summaries = sorted(row_dir.glob("*_summary.json"))
+    row = {"id": row_dir.name, "status": status, "summary_files": [str(p) for p in summaries]}
+    if summaries:
+        try:
+            payload = json.loads(summaries[0].read_text(encoding="utf-8"))
+            row["passed"] = payload.get("passed")
+            row["failed_checks"] = payload.get("failed_checks", [])
+            row["cache_delta"] = payload.get("cache_delta", {})
+            row["turns"] = payload.get("turns", {})
+        except Exception as exc:
+            row["parse_error"] = repr(exc)
+    rows.append(row)
+print(json.dumps({"artifact_root": str(root), "passed": all(r.get("passed") is True for r in rows), "rows": rows}, indent=2, sort_keys=True))
+PY
+
+cat "$ARTIFACT_ROOT/SUMMARY.json"
+exit "$fail"

--- a/scripts/live-proof/run-family-runtime-chat-matrix.sh
+++ b/scripts/live-proof/run-family-runtime-chat-matrix.sh
@@ -96,6 +96,7 @@ for row in rows:
         row.get("family", ""),
         row.get("topology", ""),
         row.get("priority", ""),
+        ",".join(row.get("required_cache_evidence") or []),
     ]))
 PY
 
@@ -117,7 +118,7 @@ curl -fsS --max-time 10 "$BASE_URL/health" >"$ARTIFACT_ROOT/health-before.json"
 curl -fsS --max-time 20 "$BASE_URL/admin/cache-stats" >"$ARTIFACT_ROOT/cache-before.json" || true
 
 fail=0
-while IFS=$'\t' read -r row_id model family topology priority; do
+while IFS=$'\t' read -r row_id model family topology priority required_cache_evidence; do
   row_root="$ARTIFACT_ROOT/$row_id"
   mkdir -p "$row_root"
   {
@@ -126,16 +127,25 @@ while IFS=$'\t' read -r row_id model family topology priority; do
     echo "family=$family"
     echo "topology=$topology"
     echo "priority=$priority"
+    echo "required_cache_evidence=$required_cache_evidence"
   } >"$row_root/row.txt"
 
   echo "--- running $row_id ($model) ---"
+  cache_args=()
+  IFS=',' read -r -a cache_items <<<"$required_cache_evidence"
+  for item in "${cache_items[@]}"; do
+    if [[ -n "$item" ]]; then
+      cache_args+=(--required-cache-evidence "$item")
+    fi
+  done
   if "$HARNESS" \
     --base-url "$BASE_URL" \
     --artifact-root "$row_root" \
     --model "$model" \
     --max-tokens "$MAX_TOKENS" \
     --timeout "$TIMEOUT_SECONDS" \
-    --settle-seconds "$SETTLE_SECONDS"; then
+    --settle-seconds "$SETTLE_SECONDS" \
+    "${cache_args[@]}"; then
     echo "PASS $row_id" | tee "$row_root/status.txt"
   else
     echo "FAIL $row_id" | tee "$row_root/status.txt"

--- a/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
+++ b/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
@@ -127,6 +127,69 @@ def model_entry(cache: dict[str, Any] | None, model: str) -> dict[str, Any]:
     return {}
 
 
+def current_health_model_matches(health: dict[str, Any], model: str) -> bool:
+    if health.get("current_model") == model:
+        return True
+    loaded = health.get("loaded")
+    if isinstance(loaded, list) and model in loaded:
+        return True
+    return False
+
+
+def cache_evidence_checks(
+    required: list[str],
+    cache_after: dict[str, Any],
+    delta: dict[str, int],
+    model: str,
+) -> dict[str, bool]:
+    entry = model_entry(cache_after, model)
+    topology = entry.get("cache_topology") if isinstance(entry, dict) else None
+    topology = topology if isinstance(topology, dict) else {}
+    block_disk = entry.get("block_disk_store") if isinstance(entry, dict) else None
+    block_disk = block_disk if isinstance(block_disk, dict) else {}
+    companion = entry.get("companion_cache") if isinstance(entry, dict) else None
+    companion = companion if isinstance(companion, dict) else {}
+    ssm = entry.get("ssm_companion_cache") if isinstance(entry, dict) else None
+    ssm = ssm if isinstance(ssm, dict) else {}
+    zaya = entry.get("zaya_cca_companion_cache") if isinstance(entry, dict) else None
+    zaya = zaya if isinstance(zaya, dict) else {}
+
+    checks: dict[str, bool] = {}
+    for name in required:
+        if name == "cache_topology":
+            checks["cache_evidence_cache_topology"] = bool(topology) and topology.get("layer_count", 0) > 0
+        elif name == "disk_l2_hits":
+            checks["cache_evidence_disk_l2_hits"] = delta.get("block_disk_hits", 0) > 0
+        elif name == "requires_disk_backed_restore":
+            checks["cache_evidence_requires_disk_backed_restore"] = topology.get("requires_disk_backed_restore") is True
+        elif name == "ssm_companion_cache":
+            checks["cache_evidence_ssm_companion_cache"] = (
+                topology.get("requires_ssm_companion_state") is True
+                and (bool(ssm) or "companion=ssm" in (companion.get("kinds") or []))
+            )
+        elif name == "companion_cache":
+            checks["cache_evidence_companion_cache"] = (
+                bool(companion.get("kinds"))
+                or companion.get("hits", 0) > 0
+                or companion.get("rederives", 0) > 0
+                or topology.get("requires_ssm_companion_state") is True
+                or topology.get("zaya_cca_layer_count", 0) > 0
+            )
+        elif name == "zaya_cca_companion_cache":
+            checks["cache_evidence_zaya_cca_companion_cache"] = (
+                bool(zaya)
+                or topology.get("zaya_cca_layer_count", 0) > 0
+                or "companion=zaya_cca" in (companion.get("kinds") or [])
+            )
+        elif name == "hybrid_pool_layer_count":
+            checks["cache_evidence_hybrid_pool_layer_count"] = topology.get("hybrid_pool_layer_count", 0) > 0
+        elif name == "rotating_kv_layer_count":
+            checks["cache_evidence_rotating_kv_layer_count"] = topology.get("rotating_kv_layer_count", 0) > 0
+        else:
+            checks[f"cache_evidence_unknown_{name}"] = False
+    return checks
+
+
 def flatten_cache_counters(entry: dict[str, Any]) -> dict[str, int]:
     counters: dict[str, int] = {}
 
@@ -287,9 +350,13 @@ def run_model(args: argparse.Namespace, model: str, root: pathlib.Path) -> dict[
     save(root / f"{label}_health_after.json", health_after)
     save(root / f"{label}_cache_after.json", cache_after)
 
+    delta = model_delta(cache_before, cache_after, model)
     checks = {
+        "no_inflight_before": not health_before.get("inflight"),
         "server_healthy_after": health_after.get("status") == "healthy",
         "no_inflight_after": not health_after.get("inflight"),
+        "requested_model_current_after": current_health_model_matches(health_after, model),
+        "requested_model_cache_entry_after": bool(model_entry(cache_after, model)),
         "turn1_finish_tool_calls": finish(resp1) == "tool_calls",
         "turn1_has_one_tool_call": len(calls1) == 1,
         "turn1_name_line_count": call1.get("function", {}).get("name") == "line_count",
@@ -308,6 +375,7 @@ def run_model(args: argparse.Namespace, model: str, root: pathlib.Path) -> dict[
         "turn3_no_visible_content": msg3.get("content") in (None, ""),
         "turn3_no_protocol_leak": marker_leaks(resp3) == [],
     }
+    checks.update(cache_evidence_checks(args.required_cache_evidence, cache_after, delta, model))
     summary.update(
         {
             "checks": checks,
@@ -326,7 +394,8 @@ def run_model(args: argparse.Namespace, model: str, root: pathlib.Path) -> dict[
                 "turn3_finish": finish(resp3),
                 "turn3_args": args3,
             },
-            "cache_delta": model_delta(cache_before, cache_after, model),
+            "required_cache_evidence": args.required_cache_evidence,
+            "cache_delta": delta,
             "aggregate_cache_delta": aggregate_delta(cache_before, cache_after),
             "cache_after": cache_after,
             "health_after": health_after,
@@ -346,6 +415,7 @@ def main() -> int:
     parser.add_argument("--max-tokens", type=int, default=384)
     parser.add_argument("--timeout", type=int, default=1200)
     parser.add_argument("--settle-seconds", type=float, default=2)
+    parser.add_argument("--required-cache-evidence", action="append", default=[])
     args = parser.parse_args()
 
     root = pathlib.Path(args.artifact_root)

--- a/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
+++ b/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py
@@ -115,15 +115,59 @@ def aggregate(cache: dict[str, Any] | None) -> dict[str, int]:
     return value if isinstance(value, dict) else {}
 
 
-def delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, int]:
-    left = aggregate(before)
-    right = aggregate(after)
+def model_entry(cache: dict[str, Any] | None, model: str) -> dict[str, Any]:
+    if not isinstance(cache, dict):
+        return {}
+    models = cache.get("models")
+    if not isinstance(models, list):
+        return {}
+    for entry in models:
+        if isinstance(entry, dict) and entry.get("name") == model:
+            return entry
+    return {}
+
+
+def flatten_cache_counters(entry: dict[str, Any]) -> dict[str, int]:
+    counters: dict[str, int] = {}
+
+    def add(prefix: str, value: Any) -> None:
+        if not isinstance(value, dict):
+            return
+        for key, raw in value.items():
+            if isinstance(raw, int):
+                counters[f"{prefix}_{key}"] = raw
+
+    add("block_disk", entry.get("block_disk_store"))
+    add("paged", entry.get("paged_cache"))
+    add("companion", entry.get("companion_cache"))
+    add("ssm_companion", entry.get("ssm_companion_cache"))
+    add("zaya_cca_companion", entry.get("zaya_cca_companion_cache"))
+    topology = entry.get("cache_topology")
+    if isinstance(topology, dict):
+        for key, raw in topology.items():
+            if isinstance(raw, int):
+                counters[f"topology_{key}"] = raw
+    return counters
+
+
+def counter_delta(left: dict[str, int], right: dict[str, int]) -> dict[str, int]:
     keys = sorted(set(left) | set(right))
     out: dict[str, int] = {}
     for key in keys:
         if isinstance(left.get(key, 0), int) and isinstance(right.get(key, 0), int):
             out[key] = int(right.get(key, 0)) - int(left.get(key, 0))
     return out
+
+
+def aggregate_delta(before: dict[str, Any] | None, after: dict[str, Any] | None) -> dict[str, int]:
+    return counter_delta(aggregate(before), aggregate(after))
+
+
+def model_delta(before: dict[str, Any] | None, after: dict[str, Any] | None, model: str) -> dict[str, int]:
+    return counter_delta(
+        flatten_cache_counters(model_entry(before, model)),
+        flatten_cache_counters(model_entry(after, model)),
+    )
 
 
 def call_chat(base_url: str, payload: dict[str, Any], timeout: int) -> tuple[dict[str, Any], float]:
@@ -282,7 +326,8 @@ def run_model(args: argparse.Namespace, model: str, root: pathlib.Path) -> dict[
                 "turn3_finish": finish(resp3),
                 "turn3_args": args3,
             },
-            "cache_delta": delta(cache_before, cache_after),
+            "cache_delta": model_delta(cache_before, cache_after, model),
+            "aggregate_cache_delta": aggregate_delta(cache_before, cache_after),
             "cache_after": cache_after,
             "health_after": health_after,
             "passed": all(checks.values()),


### PR DESCRIPTION
This starts the post-1257 family runtime/chat matrix lane.

Scope:

- Adds a tracked family runtime matrix manifest for Osaurus live chat proof rows.
- Adds a wrapper around the existing live `/v1/chat/completions` multi-turn tool/cache harness.
- Rows cover ZAYA CCA/VL, Ling JANGTQ/MXFP, Nemotron Omni JANGTQ/JANGTQ4/MXFP, DSV4 JANGTQ2/JANGTQ-K, the known Qwen hybrid red row, Gemma 4 26B, and HY3 if a local model id exists.
- The wrapper supports `--dry-run`, `KEY=value` filters, and rejects unknown args so a dry-run typo cannot silently launch heavy rows.

Why stacked:

- Eric reported PR #1257 as merged, but GitHub currently reports #1257 as still open.
- This PR targets `codex/live-family-runtime-matrix` for now so it is stacked on #1257 instead of dragging that entire diff into a main-targeted follow-up.
- Once #1257 actually lands, retarget this PR to `main`.

Initial live evidence already gathered while validating the wrapper:

- Artifact: `/tmp/osaurus-family-runtime-chat-matrix-20260527-005459/zaya-vl-jangtq4/SUMMARY.json`
- Model: `zaya1-vl-8b-jangtq4`
- Passed strict 3-turn OpenAI-compatible chat row:
  - required `line_count` tool call
  - no-tool follow-up after tool result
  - required tool call again after history
  - no protocol marker leak
  - cache telemetry recorded ZAYA CCA companion topology and disk L2 deltas
- This is one row only; it does not close the broader ZAYA/VL matrix.

Known boundaries:

- Qwen hybrid SSM/cache reuse is still a red row from the previous lane and must not be called fixed here until rerun and repaired.
- Nemo Omni, HY3, Ling, ZAYA, DSV4, Gemma, and VL/media rows still need live app/chat/API proof one by one.
- No signing, notarization, or keychain lane should be used for this PR.
- No merge by agent.
