### PR TITLE
[codex] Fix chat improvements test-core flake

### DIFF
--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
@@ -26,10 +26,10 @@ import Testing
 /// mutate the process-wide `OSAURUS_TEST_ROOT` env var via `setenv`
 /// (see `isolatedRoot(label:)`). Swift Testing runs `@Test` cases in
 /// parallel by default, which lets concurrent tests trample each
-/// other's value — `OsaurusPaths.root()` reads the env var on every
-/// call, so the wrong test's path wins and the manifest store reads
-/// from / writes to a directory it doesn't own. That's why CI was
-/// hanging the three `manifestStore…` cases to the xctest timeout.
+/// other's value. Tests that also mutate `OsaurusPaths.overrideRoot`
+/// must additionally run through `StoragePathsTestLock` so they cannot
+/// race other serialized suites that share the same process-global path
+/// override.
 @Suite(.serialized)
 struct ClaudePluginSpecTests {
 
@@ -75,6 +75,17 @@ struct ClaudePluginSpecTests {
             }
         }
         return (root, teardown)
+    }
+
+    private static func withIsolatedRoot<T: Sendable>(
+        label: String,
+        _ body: @Sendable (_ root: URL) async throws -> T
+    ) async rethrows -> T {
+        try await StoragePathsTestLock.shared.run {
+            let (root, teardown) = Self.isolatedRoot(label: label)
+            defer { teardown() }
+            return try await body(root)
+        }
     }
 
     // MARK: - plugin.json decoding
@@ -280,19 +291,18 @@ struct ClaudePluginSpecTests {
     /// `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` must resolve
     /// to the per-plugin paths owned by `OsaurusPaths` so MCP servers can
     /// read from / write to a stable location.
-    @Test func expandsPluginRootAndDataPaths() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-paths")
-        defer { teardown() }
+    @Test func expandsPluginRootAndDataPaths() async {
+        await Self.withIsolatedRoot(label: "expander-paths") { _ in
+            let pluginId = "github:owner/repo/example"
+            let ctx = ClaudePluginExpansionContext(pluginId: pluginId)
+            let input = "root=${CLAUDE_PLUGIN_ROOT} data=${CLAUDE_PLUGIN_DATA}"
+            let expanded = ClaudePluginVariableExpander.expand(input, context: ctx)
 
-        let pluginId = "github:owner/repo/example"
-        let ctx = ClaudePluginExpansionContext(pluginId: pluginId)
-        let input = "root=${CLAUDE_PLUGIN_ROOT} data=${CLAUDE_PLUGIN_DATA}"
-        let expanded = ClaudePluginVariableExpander.expand(input, context: ctx)
-
-        #expect(expanded.contains(OsaurusPaths.claudePluginCacheDir(for: pluginId).path))
-        #expect(expanded.contains(OsaurusPaths.claudePluginDataDir(for: pluginId).path))
-        #expect(!expanded.contains("${CLAUDE_PLUGIN_ROOT}"))
-        #expect(!expanded.contains("${CLAUDE_PLUGIN_DATA}"))
+            #expect(expanded.contains(OsaurusPaths.claudePluginCacheDir(for: pluginId).path))
+            #expect(expanded.contains(OsaurusPaths.claudePluginDataDir(for: pluginId).path))
+            #expect(!expanded.contains("${CLAUDE_PLUGIN_ROOT}"))
+            #expect(!expanded.contains("${CLAUDE_PLUGIN_DATA}"))
+        }
     }
 
     /// `${user_config.KEY}` substitutes from the non-sensitive bag.
@@ -357,34 +367,34 @@ struct ClaudePluginSpecTests {
     /// Expansion must be idempotent — running it twice on the same
     /// string mustn't keep substituting fresh values. This pins the
     /// caller-friendly contract that `expand(expand(x)) == expand(x)`.
-    @Test func expandIsIdempotent() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-idempotent")
-        defer { teardown() }
-        let ctx = ClaudePluginExpansionContext(
-            pluginId: "github:o/r/p",
-            userConfig: ["FOO": "bar"]
-        )
-        let input = "${CLAUDE_PLUGIN_DATA}/work-${user_config.FOO}"
-        let once = ClaudePluginVariableExpander.expand(input, context: ctx)
-        let twice = ClaudePluginVariableExpander.expand(once, context: ctx)
-        #expect(once == twice)
+    @Test func expandIsIdempotent() async {
+        await Self.withIsolatedRoot(label: "expander-idempotent") { _ in
+            let ctx = ClaudePluginExpansionContext(
+                pluginId: "github:o/r/p",
+                userConfig: ["FOO": "bar"]
+            )
+            let input = "${CLAUDE_PLUGIN_DATA}/work-${user_config.FOO}"
+            let once = ClaudePluginVariableExpander.expand(input, context: ctx)
+            let twice = ClaudePluginVariableExpander.expand(once, context: ctx)
+            #expect(once == twice)
+        }
     }
 
     /// Subprocess env overlay exports the two filesystem paths plus a
     /// `CLAUDE_PLUGIN_OPTION_<KEY>` for each user_config value. This is
     /// the shape Claude Code injects into MCP processes.
-    @Test func subprocessEnvIncludesPluginOptions() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-subprocess")
-        defer { teardown() }
-        let ctx = ClaudePluginExpansionContext(
-            pluginId: "github:o/r/p",
-            userConfig: ["REGION": "us-west-2", "DEBUG": "1"]
-        )
-        let env = ClaudePluginVariableExpander.subprocessEnv(context: ctx)
-        #expect(env["CLAUDE_PLUGIN_ROOT"]?.isEmpty == false)
-        #expect(env["CLAUDE_PLUGIN_DATA"]?.isEmpty == false)
-        #expect(env["CLAUDE_PLUGIN_OPTION_REGION"] == "us-west-2")
-        #expect(env["CLAUDE_PLUGIN_OPTION_DEBUG"] == "1")
+    @Test func subprocessEnvIncludesPluginOptions() async {
+        await Self.withIsolatedRoot(label: "expander-subprocess") { _ in
+            let ctx = ClaudePluginExpansionContext(
+                pluginId: "github:o/r/p",
+                userConfig: ["REGION": "us-west-2", "DEBUG": "1"]
+            )
+            let env = ClaudePluginVariableExpander.subprocessEnv(context: ctx)
+            #expect(env["CLAUDE_PLUGIN_ROOT"]?.isEmpty == false)
+            #expect(env["CLAUDE_PLUGIN_DATA"]?.isEmpty == false)
+            #expect(env["CLAUDE_PLUGIN_OPTION_REGION"] == "us-west-2")
+            #expect(env["CLAUDE_PLUGIN_OPTION_DEBUG"] == "1")
+        }
     }
 
     // MARK: - Manifest store
@@ -392,167 +402,163 @@ struct ClaudePluginSpecTests {
     /// Round-trip: save a snapshot, load by id, and confirm every
     /// persisted field survives. Uses an isolated test root so the
     /// per-test JSON lives under `/tmp/...`.
-    @Test func manifestStoreRoundTripsSnapshot() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-rt")
-        defer { teardown() }
+    @Test func manifestStoreRoundTripsSnapshot() async {
+        await Self.withIsolatedRoot(label: "manifest-store-rt") { _ in
+            let snap = ClaudePluginManifestSnapshot(
+                pluginId: "github:acme/widgets/renewals",
+                name: "renewals",
+                displayName: "Renewals",
+                description: "Tracks contract renewals.",
+                version: "1.0.0",
+                sourceOwner: "acme",
+                sourceRepo: "widgets",
+                sourceBranch: "main",
+                sourcePath: "renewals",
+                authorName: "Ada",
+                authorEmail: "ada@example.com",
+                authorURL: nil,
+                homepage: "https://example.com",
+                repository: "https://github.com/acme/widgets",
+                license: "MIT",
+                keywords: ["contracts", "renewals"],
+                installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                userConfigSpec: [
+                    ClaudePluginUserConfigField(
+                        key: "API_KEY",
+                        type: .string,
+                        title: "API Key",
+                        description: "Vendor key",
+                        sensitive: true,
+                        required: true
+                    )
+                ],
+                declaresHooks: true,
+                declaresUnsupportedComponents: ["channels"],
+                declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1)
+            )
 
-        let snap = ClaudePluginManifestSnapshot(
-            pluginId: "github:acme/widgets/renewals",
-            name: "renewals",
-            displayName: "Renewals",
-            description: "Tracks contract renewals.",
-            version: "1.0.0",
-            sourceOwner: "acme",
-            sourceRepo: "widgets",
-            sourceBranch: "main",
-            sourcePath: "renewals",
-            authorName: "Ada",
-            authorEmail: "ada@example.com",
-            authorURL: nil,
-            homepage: "https://example.com",
-            repository: "https://github.com/acme/widgets",
-            license: "MIT",
-            keywords: ["contracts", "renewals"],
-            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
-            userConfigSpec: [
-                ClaudePluginUserConfigField(
-                    key: "API_KEY",
-                    type: .string,
-                    title: "API Key",
-                    description: "Vendor key",
-                    sensitive: true,
-                    required: true
-                )
-            ],
-            declaresHooks: true,
-            declaresUnsupportedComponents: ["channels"],
-            declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1)
-        )
-
-        #expect(ClaudePluginManifestStore.save(snap) == true)
-        let loaded = ClaudePluginManifestStore.load(pluginId: snap.pluginId)
-        #expect(loaded != nil)
-        #expect(loaded == snap)
+            #expect(ClaudePluginManifestStore.save(snap) == true)
+            let loaded = ClaudePluginManifestStore.load(pluginId: snap.pluginId)
+            #expect(loaded != nil)
+            #expect(loaded == snap)
+        }
     }
 
     /// `all()` should sort by displayName and tolerate corrupt files —
     /// one bad JSON shouldn't blank the grid for every other plugin.
-    @Test func manifestStoreAllSkipsCorruptFiles() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-all")
-        defer { teardown() }
+    @Test func manifestStoreAllSkipsCorruptFiles() async {
+        await Self.withIsolatedRoot(label: "manifest-store-all") { _ in
+            let good = ClaudePluginManifestSnapshot(
+                pluginId: "github:o/r/good",
+                name: "good",
+                displayName: "Good Plugin",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            let other = ClaudePluginManifestSnapshot(
+                pluginId: "github:o/r/another",
+                name: "another",
+                displayName: "Another Plugin",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            ClaudePluginManifestStore.save(good)
+            ClaudePluginManifestStore.save(other)
 
-        let good = ClaudePluginManifestSnapshot(
-            pluginId: "github:o/r/good",
-            name: "good",
-            displayName: "Good Plugin",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        let other = ClaudePluginManifestSnapshot(
-            pluginId: "github:o/r/another",
-            name: "another",
-            displayName: "Another Plugin",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        ClaudePluginManifestStore.save(good)
-        ClaudePluginManifestStore.save(other)
+            // Drop a non-JSON file alongside the snapshots to simulate
+            // corruption. `all()` must skip it without throwing.
+            let dir = OsaurusPaths.claudePluginsManifestsDir()
+            let garbage = dir.appendingPathComponent("garbage.json")
+            try? Data("not json".utf8).write(to: garbage)
 
-        // Drop a non-JSON file alongside the snapshots to simulate
-        // corruption. `all()` must skip it without throwing.
-        let dir = OsaurusPaths.claudePluginsManifestsDir()
-        let garbage = dir.appendingPathComponent("garbage.json")
-        try? Data("not json".utf8).write(to: garbage)
-
-        let all = ClaudePluginManifestStore.all()
-        let names = all.map(\.displayName)
-        #expect(names == ["Another Plugin", "Good Plugin"])
+            let all = ClaudePluginManifestStore.all()
+            let names = all.map(\.displayName)
+            #expect(names == ["Another Plugin", "Good Plugin"])
+        }
     }
 
     /// `delete(pluginId:)` removes the manifest, user-config, and data
     /// directories so an uninstall leaves no residue.
-    @Test func manifestStoreDeleteRemovesAllSidecars() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-del")
-        defer { teardown() }
+    @Test func manifestStoreDeleteRemovesAllSidecars() async {
+        await Self.withIsolatedRoot(label: "manifest-store-del") { _ in
+            let pluginId = "github:o/r/del"
+            let snap = ClaudePluginManifestSnapshot(
+                pluginId: pluginId,
+                name: "del",
+                displayName: "Delete Me",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            ClaudePluginManifestStore.save(snap)
+            ClaudePluginManifestStore.saveUserConfig(
+                pluginId: pluginId,
+                values: ["DEBUG": "1"]
+            )
+            _ = ClaudePluginManifestStore.ensureDataDir(for: pluginId)
 
-        let pluginId = "github:o/r/del"
-        let snap = ClaudePluginManifestSnapshot(
-            pluginId: pluginId,
-            name: "del",
-            displayName: "Delete Me",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        ClaudePluginManifestStore.save(snap)
-        ClaudePluginManifestStore.saveUserConfig(
-            pluginId: pluginId,
-            values: ["DEBUG": "1"]
-        )
-        _ = ClaudePluginManifestStore.ensureDataDir(for: pluginId)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+                )
+            )
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+                )
+            )
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+                )
+            )
 
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
-            )
-        )
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
-            )
-        )
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
-            )
-        )
+            ClaudePluginManifestStore.delete(pluginId: pluginId)
 
-        ClaudePluginManifestStore.delete(pluginId: pluginId)
-
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+                )
             )
-        )
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+                )
             )
-        )
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+                )
             )
-        )
-        #expect(ClaudePluginManifestStore.load(pluginId: pluginId) == nil)
-        #expect(ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId).isEmpty)
+            #expect(ClaudePluginManifestStore.load(pluginId: pluginId) == nil)
+            #expect(ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId).isEmpty)
+        }
     }
 
     /// User-config snapshot round-trips its keyed values verbatim. This
     /// is the non-sensitive store; sensitive keys go through Keychain.
-    @Test func manifestStoreUserConfigRoundTrip() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-uc")
-        defer { teardown() }
-
-        let pluginId = "github:o/r/uc"
-        ClaudePluginManifestStore.saveUserConfig(
-            pluginId: pluginId,
-            values: ["REGION": "us-west-2", "DEBUG": "true"]
-        )
-        let loaded = ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId)
-        #expect(loaded["REGION"] == "us-west-2")
-        #expect(loaded["DEBUG"] == "true")
+    @Test func manifestStoreUserConfigRoundTrip() async {
+        await Self.withIsolatedRoot(label: "manifest-store-uc") { _ in
+            let pluginId = "github:o/r/uc"
+            ClaudePluginManifestStore.saveUserConfig(
+                pluginId: pluginId,
+                values: ["REGION": "us-west-2", "DEBUG": "true"]
+            )
+            let loaded = ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId)
+            #expect(loaded["REGION"] == "us-west-2")
+            #expect(loaded["DEBUG"] == "true")
+        }
     }
 
     /// `claudePluginSafeId` must collapse path separators / colons so

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1990,26 +1990,25 @@ final class ChatSession: ObservableObject {
 
             // Tools that render as plain timeline nodes (avoid render_chart /
             // share_artifact / agent-loop tools, which become specialised blocks).
-            let steps:
-                [(name: String, args: String, result: String)] = [
-                    (
-                        "db_insert",
-                        #"{"table":"food_log","row":{"name":"Oatmeal","calories":320}}"#,
-                        #"{"ok":true,"id":1}"#
-                    ),
-                    (
-                        "db_insert",
-                        #"{"table":"food_log","row":{"name":"Black coffee","calories":5}}"#,
-                        #"{"ok":true,"id":2}"#
-                    ),
-                    (
-                        "db_query",
-                        #"{"sql":"SELECT SUM(calories) AS total FROM food_log"}"#,
-                        #"{"total":325}"#
-                    ),
-                    ("file_read", #"{"path":"notes/diet.md"}"#, #"{"bytes":1840}"#),
-                    ("search_memory", #"{"query":"calorie target"}"#, #"{"hits":2}"#),
-                ]
+            let steps: [(name: String, args: String, result: String)] = [
+                (
+                    "db_insert",
+                    #"{"table":"food_log","row":{"name":"Oatmeal","calories":320}}"#,
+                    #"{"ok":true,"id":1}"#
+                ),
+                (
+                    "db_insert",
+                    #"{"table":"food_log","row":{"name":"Black coffee","calories":5}}"#,
+                    #"{"ok":true,"id":2}"#
+                ),
+                (
+                    "db_query",
+                    #"{"sql":"SELECT SUM(calories) AS total FROM food_log"}"#,
+                    #"{"total":325}"#
+                ),
+                ("file_read", #"{"path":"notes/diet.md"}"#, #"{"bytes":1840}"#),
+                ("search_memory", #"{"query":"calorie target"}"#, #"{"hits":2}"#),
+            ]
 
             // Longer thinking pass (lorem ipsum) so the thinking block can be
             // exercised at a realistic length.

--- a/Packages/OsaurusCore/Views/Chat/ShimmerLabel.swift
+++ b/Packages/OsaurusCore/Views/Chat/ShimmerLabel.swift
@@ -94,7 +94,8 @@ final class ShimmerLabel: NSView {
     }
 
     private func applyColors() {
-        gradientLayer.colors = animating
+        gradientLayer.colors =
+            animating
             ? [baseColor.cgColor, highlightColor.cgColor, baseColor.cgColor]
             : [baseColor.cgColor, baseColor.cgColor, baseColor.cgColor]
         gradientLayer.locations = [0.0, 0.5, 1.0]

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -89,17 +89,21 @@ enum ToolDisplayName {
         "sandbox_edit_file": ToolLabel(L("Editing a file in sandbox"), L("Edited a file in sandbox")),
         "sandbox_search_files": ToolLabel(L("Searching files in sandbox"), L("Searched files in sandbox")),
         "sandbox_install": ToolLabel(
-            L("Installing dependencies in sandbox"), L("Installed dependencies in sandbox")
+            L("Installing dependencies in sandbox"),
+            L("Installed dependencies in sandbox")
         ),
         "sandbox_npm_install": ToolLabel(
-            L("Installing npm packages in sandbox"), L("Installed npm packages in sandbox")
+            L("Installing npm packages in sandbox"),
+            L("Installed npm packages in sandbox")
         ),
         "sandbox_pip_install": ToolLabel(
-            L("Installing Python packages in sandbox"), L("Installed Python packages in sandbox")
+            L("Installing Python packages in sandbox"),
+            L("Installed Python packages in sandbox")
         ),
         "sandbox_process": ToolLabel(L("Managing a process in sandbox"), L("Managed a process in sandbox")),
         "sandbox_plugin_register": ToolLabel(
-            L("Registering a plugin in sandbox"), L("Registered a plugin in sandbox")
+            L("Registering a plugin in sandbox"),
+            L("Registered a plugin in sandbox")
         ),
         "sandbox_secret_check": ToolLabel(L("Checking a secret in sandbox"), L("Checked a secret in sandbox")),
         "sandbox_secret_set": ToolLabel(L("Saving a secret in sandbox"), L("Saved a secret in sandbox")),


### PR DESCRIPTION
## Business rationale

PR #1259 currently has a failing `test-core` check even though the user-facing chat improvements themselves are ready for review. CI reported failures in `ClaudePluginSpecTests/manifestStoreAllSkipsCorruptFiles` and `StorageMigratorJSONRecoveryTests/runIfNeeded_restoresOsecBackToJsonViaBackup`; those tests both mutate process-global storage path state and can collide under Xcode parallel test execution. This PR makes the branch reviewable again by removing that cross-suite race and by applying the formatter fixes required by the same branch's quality gate.

## Coding rationale

The production code path is left untouched. The plugin spec tests already used an isolated root helper, but they did not participate in the shared `StoragePathsTestLock` that other storage-root tests use for `OsaurusPaths.overrideRoot` and `StorageKeyManager` state. I added a small `withIsolatedRoot` helper that wraps the existing setup/teardown in that shared lock, then converted only the affected isolated-root tests to async so they can use the actor-backed lock without blocking the test runner. Formatter-only changes in the chat UI files are deliberately included because `swift-format lint --strict --recursive Packages App` failed on the PR branch before those files were formatted.

## Acceptance criteria

- [x] PR #1259 `test-core` failures are reproducible as a shared global test-state collision and have a local fix.
- [x] `ClaudePluginSpecTests` isolated-root cases no longer race other suites that mutate `OsaurusPaths.overrideRoot`.
- [x] The failing CI-named tests pass inside the full local `make ci-test` run.
- [x] Formatter drift in the #1259 chat files is cleaned up without changing behavior.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min before gate and before push)

## Debug evidence

Failing CI evidence from run `26504953873` showed `test-core` failing on these two tests:

```text
ClaudePluginSpecTests/manifestStoreAllSkipsCorruptFiles
StorageMigratorJSONRecoveryTests/runIfNeeded_restoresOsecBackToJsonViaBackup
```

Focused and full local checks after the fix:

```text
swift test --package-path Packages/OsaurusCore --filter 'ClaudePluginSpecTests|StorageMigratorJSONRecoveryTests'
✔ Test run with 32 tests in 2 suites passed after 0.024 seconds.

make ci-test
✔ [StorageMigratorJSONRecoveryTests] runIfNeeded_restoresOsecBackToJsonViaBackup on 'My Mac - xctest (30249)' (2.055 seconds)
✔ [ClaudePluginSpecTests] manifestStoreAllSkipsCorruptFiles on 'My Mac - xctest (30249)' (1.126 seconds)
Done. Inspect failures with: open build/Tests.xcresult

swift build --package-path Packages/OsaurusCore -c release
Build complete! (362.39s)
```

## Rollback

Revert commit `4e505ea4da8132d8c46578397587cec545db72c2` from this stacked branch.
