### PR TITLE
Add Osaurus Guide onboarding starter

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/AgentStarterTemplate.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentStarterTemplate.swift
@@ -14,6 +14,7 @@ import Foundation
 
 enum AgentStarterTemplate: String, CaseIterable, Identifiable {
     case blank
+    case osaurusGuide
     case writer
     case researcher
     case coder
@@ -24,6 +25,7 @@ enum AgentStarterTemplate: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .blank: return "Blank"
+        case .osaurusGuide: return "Guide"
         case .writer: return "Writer"
         case .researcher: return "Researcher"
         case .coder: return "Coder"
@@ -34,6 +36,7 @@ enum AgentStarterTemplate: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .blank: return "doc"
+        case .osaurusGuide: return "sparkles"
         case .writer: return "pencil.line"
         case .researcher: return "magnifyingglass"
         case .coder: return "chevron.left.forwardslash.chevron.right"
@@ -46,6 +49,7 @@ enum AgentStarterTemplate: String, CaseIterable, Identifiable {
     var defaultName: String {
         switch self {
         case .blank: return ""
+        case .osaurusGuide: return "Osaurus Guide"
         case .writer: return "Writer"
         case .researcher: return "Researcher"
         case .coder: return "Coder"
@@ -57,6 +61,19 @@ enum AgentStarterTemplate: String, CaseIterable, Identifiable {
         switch self {
         case .blank:
             return ""
+        case .osaurusGuide:
+            return """
+                You are Osaurus Guide, a calm onboarding partner for people \
+                learning what Osaurus can do. Help the user turn a rough goal \
+                into a useful agent, prompt, skill, plugin, or tool plan. Explain \
+                Osaurus concepts in practical language, connect ideas to built-in \
+                agents, skills, plugins, tools, documents, and Swift extension \
+                points, and propose the smallest next step they can try inside \
+                the app. If the use case seems unsupported, say what is missing \
+                and draft a feature request the user can review. Do not pretend \
+                you searched GitHub or external docs unless tool output in the \
+                current conversation proves it.
+                """
         case .writer:
             return """
                 You are a thoughtful writing partner. Help the user draft, edit, and \

--- a/Packages/OsaurusCore/Tests/Agent/AgentStarterTemplateTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentStarterTemplateTests.swift
@@ -1,0 +1,39 @@
+//
+//  AgentStarterTemplateTests.swift
+//  osaurusTests
+//
+//  Pins the create-agent starter catalog used by onboarding and the
+//  in-app Agent editor.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Agent starter templates")
+struct AgentStarterTemplateTests {
+    @Test("Osaurus Guide starter is available and scoped to onboarding help")
+    func osaurusGuideStarterIsAvailable() {
+        #expect(AgentStarterTemplate.allCases.contains(.osaurusGuide))
+        #expect(AgentStarterTemplate.osaurusGuide.label == "Guide")
+        #expect(AgentStarterTemplate.osaurusGuide.defaultName == "Osaurus Guide")
+
+        let prompt = AgentStarterTemplate.osaurusGuide.systemPrompt.lowercased()
+        #expect(prompt.contains("agent"))
+        #expect(prompt.contains("skills"))
+        #expect(prompt.contains("plugins"))
+        #expect(prompt.contains("feature request"))
+        #expect(prompt.contains("do not pretend"))
+        #expect(prompt.contains("github"))
+    }
+
+    @Test("Onboarding create-agent step defaults to Osaurus Guide")
+    @MainActor
+    func onboardingCreateAgentDefaultsToGuide() {
+        let state = CreateAgentState()
+
+        #expect(state.selectedTemplate == .osaurusGuide)
+        #expect(state.name == "Osaurus Guide")
+        #expect(state.systemPrompt == AgentStarterTemplate.osaurusGuide.systemPrompt)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
@@ -26,10 +26,10 @@ import Testing
 /// mutate the process-wide `OSAURUS_TEST_ROOT` env var via `setenv`
 /// (see `isolatedRoot(label:)`). Swift Testing runs `@Test` cases in
 /// parallel by default, which lets concurrent tests trample each
-/// other's value — `OsaurusPaths.root()` reads the env var on every
-/// call, so the wrong test's path wins and the manifest store reads
-/// from / writes to a directory it doesn't own. That's why CI was
-/// hanging the three `manifestStore…` cases to the xctest timeout.
+/// other's value. Tests that also mutate `OsaurusPaths.overrideRoot`
+/// must additionally run through `StoragePathsTestLock` so they cannot
+/// race other serialized suites that share the same process-global path
+/// override.
 @Suite(.serialized)
 struct ClaudePluginSpecTests {
 
@@ -75,6 +75,17 @@ struct ClaudePluginSpecTests {
             }
         }
         return (root, teardown)
+    }
+
+    private static func withIsolatedRoot<T: Sendable>(
+        label: String,
+        _ body: @Sendable (_ root: URL) async throws -> T
+    ) async rethrows -> T {
+        try await StoragePathsTestLock.shared.run {
+            let (root, teardown) = Self.isolatedRoot(label: label)
+            defer { teardown() }
+            return try await body(root)
+        }
     }
 
     // MARK: - plugin.json decoding
@@ -280,19 +291,18 @@ struct ClaudePluginSpecTests {
     /// `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` must resolve
     /// to the per-plugin paths owned by `OsaurusPaths` so MCP servers can
     /// read from / write to a stable location.
-    @Test func expandsPluginRootAndDataPaths() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-paths")
-        defer { teardown() }
+    @Test func expandsPluginRootAndDataPaths() async {
+        await Self.withIsolatedRoot(label: "expander-paths") { _ in
+            let pluginId = "github:owner/repo/example"
+            let ctx = ClaudePluginExpansionContext(pluginId: pluginId)
+            let input = "root=${CLAUDE_PLUGIN_ROOT} data=${CLAUDE_PLUGIN_DATA}"
+            let expanded = ClaudePluginVariableExpander.expand(input, context: ctx)
 
-        let pluginId = "github:owner/repo/example"
-        let ctx = ClaudePluginExpansionContext(pluginId: pluginId)
-        let input = "root=${CLAUDE_PLUGIN_ROOT} data=${CLAUDE_PLUGIN_DATA}"
-        let expanded = ClaudePluginVariableExpander.expand(input, context: ctx)
-
-        #expect(expanded.contains(OsaurusPaths.claudePluginCacheDir(for: pluginId).path))
-        #expect(expanded.contains(OsaurusPaths.claudePluginDataDir(for: pluginId).path))
-        #expect(!expanded.contains("${CLAUDE_PLUGIN_ROOT}"))
-        #expect(!expanded.contains("${CLAUDE_PLUGIN_DATA}"))
+            #expect(expanded.contains(OsaurusPaths.claudePluginCacheDir(for: pluginId).path))
+            #expect(expanded.contains(OsaurusPaths.claudePluginDataDir(for: pluginId).path))
+            #expect(!expanded.contains("${CLAUDE_PLUGIN_ROOT}"))
+            #expect(!expanded.contains("${CLAUDE_PLUGIN_DATA}"))
+        }
     }
 
     /// `${user_config.KEY}` substitutes from the non-sensitive bag.
@@ -357,34 +367,34 @@ struct ClaudePluginSpecTests {
     /// Expansion must be idempotent — running it twice on the same
     /// string mustn't keep substituting fresh values. This pins the
     /// caller-friendly contract that `expand(expand(x)) == expand(x)`.
-    @Test func expandIsIdempotent() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-idempotent")
-        defer { teardown() }
-        let ctx = ClaudePluginExpansionContext(
-            pluginId: "github:o/r/p",
-            userConfig: ["FOO": "bar"]
-        )
-        let input = "${CLAUDE_PLUGIN_DATA}/work-${user_config.FOO}"
-        let once = ClaudePluginVariableExpander.expand(input, context: ctx)
-        let twice = ClaudePluginVariableExpander.expand(once, context: ctx)
-        #expect(once == twice)
+    @Test func expandIsIdempotent() async {
+        await Self.withIsolatedRoot(label: "expander-idempotent") { _ in
+            let ctx = ClaudePluginExpansionContext(
+                pluginId: "github:o/r/p",
+                userConfig: ["FOO": "bar"]
+            )
+            let input = "${CLAUDE_PLUGIN_DATA}/work-${user_config.FOO}"
+            let once = ClaudePluginVariableExpander.expand(input, context: ctx)
+            let twice = ClaudePluginVariableExpander.expand(once, context: ctx)
+            #expect(once == twice)
+        }
     }
 
     /// Subprocess env overlay exports the two filesystem paths plus a
     /// `CLAUDE_PLUGIN_OPTION_<KEY>` for each user_config value. This is
     /// the shape Claude Code injects into MCP processes.
-    @Test func subprocessEnvIncludesPluginOptions() {
-        let (_, teardown) = Self.isolatedRoot(label: "expander-subprocess")
-        defer { teardown() }
-        let ctx = ClaudePluginExpansionContext(
-            pluginId: "github:o/r/p",
-            userConfig: ["REGION": "us-west-2", "DEBUG": "1"]
-        )
-        let env = ClaudePluginVariableExpander.subprocessEnv(context: ctx)
-        #expect(env["CLAUDE_PLUGIN_ROOT"]?.isEmpty == false)
-        #expect(env["CLAUDE_PLUGIN_DATA"]?.isEmpty == false)
-        #expect(env["CLAUDE_PLUGIN_OPTION_REGION"] == "us-west-2")
-        #expect(env["CLAUDE_PLUGIN_OPTION_DEBUG"] == "1")
+    @Test func subprocessEnvIncludesPluginOptions() async {
+        await Self.withIsolatedRoot(label: "expander-subprocess") { _ in
+            let ctx = ClaudePluginExpansionContext(
+                pluginId: "github:o/r/p",
+                userConfig: ["REGION": "us-west-2", "DEBUG": "1"]
+            )
+            let env = ClaudePluginVariableExpander.subprocessEnv(context: ctx)
+            #expect(env["CLAUDE_PLUGIN_ROOT"]?.isEmpty == false)
+            #expect(env["CLAUDE_PLUGIN_DATA"]?.isEmpty == false)
+            #expect(env["CLAUDE_PLUGIN_OPTION_REGION"] == "us-west-2")
+            #expect(env["CLAUDE_PLUGIN_OPTION_DEBUG"] == "1")
+        }
     }
 
     // MARK: - Manifest store
@@ -392,167 +402,163 @@ struct ClaudePluginSpecTests {
     /// Round-trip: save a snapshot, load by id, and confirm every
     /// persisted field survives. Uses an isolated test root so the
     /// per-test JSON lives under `/tmp/...`.
-    @Test func manifestStoreRoundTripsSnapshot() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-rt")
-        defer { teardown() }
+    @Test func manifestStoreRoundTripsSnapshot() async {
+        await Self.withIsolatedRoot(label: "manifest-store-rt") { _ in
+            let snap = ClaudePluginManifestSnapshot(
+                pluginId: "github:acme/widgets/renewals",
+                name: "renewals",
+                displayName: "Renewals",
+                description: "Tracks contract renewals.",
+                version: "1.0.0",
+                sourceOwner: "acme",
+                sourceRepo: "widgets",
+                sourceBranch: "main",
+                sourcePath: "renewals",
+                authorName: "Ada",
+                authorEmail: "ada@example.com",
+                authorURL: nil,
+                homepage: "https://example.com",
+                repository: "https://github.com/acme/widgets",
+                license: "MIT",
+                keywords: ["contracts", "renewals"],
+                installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                userConfigSpec: [
+                    ClaudePluginUserConfigField(
+                        key: "API_KEY",
+                        type: .string,
+                        title: "API Key",
+                        description: "Vendor key",
+                        sensitive: true,
+                        required: true
+                    )
+                ],
+                declaresHooks: true,
+                declaresUnsupportedComponents: ["channels"],
+                declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1)
+            )
 
-        let snap = ClaudePluginManifestSnapshot(
-            pluginId: "github:acme/widgets/renewals",
-            name: "renewals",
-            displayName: "Renewals",
-            description: "Tracks contract renewals.",
-            version: "1.0.0",
-            sourceOwner: "acme",
-            sourceRepo: "widgets",
-            sourceBranch: "main",
-            sourcePath: "renewals",
-            authorName: "Ada",
-            authorEmail: "ada@example.com",
-            authorURL: nil,
-            homepage: "https://example.com",
-            repository: "https://github.com/acme/widgets",
-            license: "MIT",
-            keywords: ["contracts", "renewals"],
-            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
-            userConfigSpec: [
-                ClaudePluginUserConfigField(
-                    key: "API_KEY",
-                    type: .string,
-                    title: "API Key",
-                    description: "Vendor key",
-                    sensitive: true,
-                    required: true
-                )
-            ],
-            declaresHooks: true,
-            declaresUnsupportedComponents: ["channels"],
-            declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1)
-        )
-
-        #expect(ClaudePluginManifestStore.save(snap) == true)
-        let loaded = ClaudePluginManifestStore.load(pluginId: snap.pluginId)
-        #expect(loaded != nil)
-        #expect(loaded == snap)
+            #expect(ClaudePluginManifestStore.save(snap) == true)
+            let loaded = ClaudePluginManifestStore.load(pluginId: snap.pluginId)
+            #expect(loaded != nil)
+            #expect(loaded == snap)
+        }
     }
 
     /// `all()` should sort by displayName and tolerate corrupt files —
     /// one bad JSON shouldn't blank the grid for every other plugin.
-    @Test func manifestStoreAllSkipsCorruptFiles() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-all")
-        defer { teardown() }
+    @Test func manifestStoreAllSkipsCorruptFiles() async {
+        await Self.withIsolatedRoot(label: "manifest-store-all") { _ in
+            let good = ClaudePluginManifestSnapshot(
+                pluginId: "github:o/r/good",
+                name: "good",
+                displayName: "Good Plugin",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            let other = ClaudePluginManifestSnapshot(
+                pluginId: "github:o/r/another",
+                name: "another",
+                displayName: "Another Plugin",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            ClaudePluginManifestStore.save(good)
+            ClaudePluginManifestStore.save(other)
 
-        let good = ClaudePluginManifestSnapshot(
-            pluginId: "github:o/r/good",
-            name: "good",
-            displayName: "Good Plugin",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        let other = ClaudePluginManifestSnapshot(
-            pluginId: "github:o/r/another",
-            name: "another",
-            displayName: "Another Plugin",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        ClaudePluginManifestStore.save(good)
-        ClaudePluginManifestStore.save(other)
+            // Drop a non-JSON file alongside the snapshots to simulate
+            // corruption. `all()` must skip it without throwing.
+            let dir = OsaurusPaths.claudePluginsManifestsDir()
+            let garbage = dir.appendingPathComponent("garbage.json")
+            try? Data("not json".utf8).write(to: garbage)
 
-        // Drop a non-JSON file alongside the snapshots to simulate
-        // corruption. `all()` must skip it without throwing.
-        let dir = OsaurusPaths.claudePluginsManifestsDir()
-        let garbage = dir.appendingPathComponent("garbage.json")
-        try? Data("not json".utf8).write(to: garbage)
-
-        let all = ClaudePluginManifestStore.all()
-        let names = all.map(\.displayName)
-        #expect(names == ["Another Plugin", "Good Plugin"])
+            let all = ClaudePluginManifestStore.all()
+            let names = all.map(\.displayName)
+            #expect(names == ["Another Plugin", "Good Plugin"])
+        }
     }
 
     /// `delete(pluginId:)` removes the manifest, user-config, and data
     /// directories so an uninstall leaves no residue.
-    @Test func manifestStoreDeleteRemovesAllSidecars() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-del")
-        defer { teardown() }
+    @Test func manifestStoreDeleteRemovesAllSidecars() async {
+        await Self.withIsolatedRoot(label: "manifest-store-del") { _ in
+            let pluginId = "github:o/r/del"
+            let snap = ClaudePluginManifestSnapshot(
+                pluginId: pluginId,
+                name: "del",
+                displayName: "Delete Me",
+                description: nil,
+                version: nil,
+                sourceOwner: "o",
+                sourceRepo: "r",
+                installedAt: Date(),
+                declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
+            )
+            ClaudePluginManifestStore.save(snap)
+            ClaudePluginManifestStore.saveUserConfig(
+                pluginId: pluginId,
+                values: ["DEBUG": "1"]
+            )
+            _ = ClaudePluginManifestStore.ensureDataDir(for: pluginId)
 
-        let pluginId = "github:o/r/del"
-        let snap = ClaudePluginManifestSnapshot(
-            pluginId: pluginId,
-            name: "del",
-            displayName: "Delete Me",
-            description: nil,
-            version: nil,
-            sourceOwner: "o",
-            sourceRepo: "r",
-            installedAt: Date(),
-            declaredCounts: .init(skills: 0, agents: 0, commands: 0, mcp: 0)
-        )
-        ClaudePluginManifestStore.save(snap)
-        ClaudePluginManifestStore.saveUserConfig(
-            pluginId: pluginId,
-            values: ["DEBUG": "1"]
-        )
-        _ = ClaudePluginManifestStore.ensureDataDir(for: pluginId)
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+                )
+            )
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+                )
+            )
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+                )
+            )
 
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
-            )
-        )
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
-            )
-        )
-        #expect(
-            FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
-            )
-        )
+            ClaudePluginManifestStore.delete(pluginId: pluginId)
 
-        ClaudePluginManifestStore.delete(pluginId: pluginId)
-
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginManifestFile(for: pluginId).path
+                )
             )
-        )
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginUserConfigFile(for: pluginId).path
+                )
             )
-        )
-        #expect(
-            !FileManager.default.fileExists(
-                atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: OsaurusPaths.claudePluginDataDir(for: pluginId).path
+                )
             )
-        )
-        #expect(ClaudePluginManifestStore.load(pluginId: pluginId) == nil)
-        #expect(ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId).isEmpty)
+            #expect(ClaudePluginManifestStore.load(pluginId: pluginId) == nil)
+            #expect(ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId).isEmpty)
+        }
     }
 
     /// User-config snapshot round-trips its keyed values verbatim. This
     /// is the non-sensitive store; sensitive keys go through Keychain.
-    @Test func manifestStoreUserConfigRoundTrip() {
-        let (_, teardown) = Self.isolatedRoot(label: "manifest-store-uc")
-        defer { teardown() }
-
-        let pluginId = "github:o/r/uc"
-        ClaudePluginManifestStore.saveUserConfig(
-            pluginId: pluginId,
-            values: ["REGION": "us-west-2", "DEBUG": "true"]
-        )
-        let loaded = ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId)
-        #expect(loaded["REGION"] == "us-west-2")
-        #expect(loaded["DEBUG"] == "true")
+    @Test func manifestStoreUserConfigRoundTrip() async {
+        await Self.withIsolatedRoot(label: "manifest-store-uc") { _ in
+            let pluginId = "github:o/r/uc"
+            ClaudePluginManifestStore.saveUserConfig(
+                pluginId: pluginId,
+                values: ["REGION": "us-west-2", "DEBUG": "true"]
+            )
+            let loaded = ClaudePluginManifestStore.loadUserConfig(pluginId: pluginId)
+            #expect(loaded["REGION"] == "us-west-2")
+            #expect(loaded["DEBUG"] == "true")
+        }
     }
 
     /// `claudePluginSafeId` must collapse path separators / colons so

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 @MainActor
 final class CreateAgentState: ObservableObject {
-    @Published var selectedTemplate: AgentStarterTemplate = .writer
+    @Published var selectedTemplate: AgentStarterTemplate = .osaurusGuide
     @Published var name: String = ""
     @Published var systemPrompt: String = ""
     /// Flips to `true` once the user types into the name field, so switching
@@ -37,7 +37,7 @@ final class CreateAgentState: ObservableObject {
     @Published private(set) var createdAgentId: UUID?
 
     init() {
-        applyTemplate(.writer)
+        applyTemplate(.osaurusGuide)
     }
 
     var trimmedName: String {


### PR DESCRIPTION
## Business rationale
Issue #1236 asks for an Osaurus Guide experience that helps new users understand how to turn goals into agents, prompts, skills, plugins, and tool choices. Today the first-run create-agent flow defaults to a generic writer template, which leaves onboarding users without a product-specific guide inside the app. This PR adds a built-in Osaurus Guide starter and makes it the default onboarding template so a new user lands on a concrete helper agent immediately.

## Coding rationale
The implementation stays inside the existing starter-template and onboarding state path: it adds one `AgentStarterTemplate` case, a focused prompt, and default onboarding selection wiring, plus tests for template availability and default create-agent state. It deliberately does not add networked GitHub search, issue drafting, new tools, new packages, or any external dependency; that broader automation remains parked until product/security scope is explicit. The trust boundary is prompt/UI defaults only.

## Acceptance criteria
- [x] New onboarding users default to an Osaurus Guide starter instead of the generic writer template.
- [x] The guide prompt explains Osaurus concepts and suggests small next steps without pretending to search GitHub or external systems.
- [x] Focused tests cover the guide template and onboarding default state.
- [x] Full local quality gate is green on the stacked lane head.

## Quality gate
- [x] swift-format / swiftlint / shellcheck — clean by exit code (`swiftlint`: 1272 existing warnings, 0 serious)
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green (77/77 XCTest cases, Swift Testing runner green)
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green (`Build complete! (380.74s)`)
- [x] Archive freshness — confirmed (`git fetch --all --prune` at 2026-05-27T12:50:56Z; branch rebased cleanly)

## Debug evidence
Focused validation from the lane added two tests for the guide starter and onboarding default; the full `make ci-test` run includes `AgentStarterTemplateTests` and completed successfully:

```text
Test Suite AgentStarterTemplateTests started on 'My Mac - xctest (86228)'
Done. Inspect failures with: open build/Tests.xcresult
```

The same stacked full gate also rechecked the root-isolation baseline from #1261, including the formerly failing overlap area:

```text
✔ [ClaudePluginSpecTests] manifestStoreAllSkipsCorruptFiles on 'My Mac - xctest (86228)'
✔ [SandboxManagerCleanupTests] cleanupAfterFailure_isIdempotent on 'My Mac - xctest (86228)'
```

CLI and release evidence:

```text
swift test --package-path Packages/OsaurusCLI --parallel
[77/77] Testing OsaurusCLITests.ToolsPackageTests/testFindDylibsIgnoresNonDylibExtensions
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.

swift build --package-path Packages/OsaurusCore -c release
Build complete! (380.74s)
```

Dependency note: this branch intentionally contains #1261's root-isolation commit (`48ec55c0`) underneath the product commit (`5de22525`) so the mandatory full local gate can run green before #1261 merges. The product diff is only these files: `AgentStarterTemplate.swift`, `OnboardingCreateAgentView.swift`, and `AgentStarterTemplateTests.swift`.

## Rollback
`git revert 5de22525c7ec84530d0a5e470e3631d914fcb855`
