### PR TITLE
Pin Gemma reasoning tool routing fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
+        "revision" : "531439a05bb3c5334aa551a07481fc5234644329"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
+        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
+        "revision" : "531439a05bb3c5334aa551a07481fc5234644329"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
+        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
+            revision: "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
+            revision: "531439a05bb3c5334aa551a07481fc5234644329"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -408,7 +408,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
+        let expectedRuntimeHardenedRevision = "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -408,7 +408,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
+        let expectedRuntimeHardenedRevision = "531439a05bb3c5334aa551a07481fc5234644329"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
+        "revision" : "531439a05bb3c5334aa551a07481fc5234644329"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d496d3df8f91df4e233e3fc0e6ad4eb4ed62bc1a"
+        "revision" : "963b2488fcd9f4f4eded3c2b87487dae9710d00d"
       }
     },
     {


### PR DESCRIPTION
## Summary
- pins vMLX to the Gemma4 reasoning-channel tool routing fix
- keeps the change stacked on PR #1258 because #1258 is still open on GitHub
- does not merge or change signing/release paths

## Local source proof
- vMLX `Gemma4ZyphraToolParserFocusedTests`: 4/4 passed

## Live proof status
- pre-fix current-head app at `4510ae52` failed live Gemma tool routing: Zyphra tool XML leaked through `reasoning_content` instead of structured `tool_calls`
- rebuilt app/live proof from this PR head is pending and will be posted as a follow-up comment

## Boundaries
- no agent merge
- no signing/keychain/notarization path
- TurboQuant KV remains outside this fix; family cache rows still require architecture-specific live proof
