### PR TITLE
Fix zero free space on external model volumes

### DIFF
--- a/Packages/OsaurusCore/Services/SystemMonitorService.swift
+++ b/Packages/OsaurusCore/Services/SystemMonitorService.swift
@@ -189,8 +189,8 @@ class SystemMonitorService: ObservableObject {
         // the dashboard reported `Available: 0 GB` even when Finder showed
         // tens of GB free. `OsaurusPaths.volumeFreeBytes` uses the modern
         // URL-keyed `.volumeAvailableCapacityForImportantUsageKey` first
-        // (the value Finder shows) and falls back to the legacy API only
-        // when the modern query is unavailable. Same helper as
+        // (the value Finder shows) and falls back to the legacy API when
+        // the modern query is unavailable or returns 0. Same helper as
         // `ModelDownloadService.freeBytesOnVolume` so the two read-outs
         // can never silently drift.
         let gb = 1024.0 * 1024.0 * 1024.0

--- a/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
@@ -105,4 +105,19 @@ struct ModelDownloadServiceStorageTests {
             #expect(bytes >= 0)
         }
     }
+
+    @Test func zeroImportantCapacityFallsBackToLegacyFreeSpace() {
+        // Some external volumes report 0 for the modern
+        // volumeAvailableCapacityForImportantUsage query while the legacy
+        // filesystem attributes still expose the real writable space.
+        let expected: Int64 = 6 * 1024 * 1024 * 1024
+        guard let bytes = OsaurusPaths.resolvedVolumeFreeBytes(
+            importantCapacity: 0,
+            legacyFree: expected
+        ) else {
+            Issue.record("expected legacy free space fallback")
+            return
+        }
+        #expect(bytes == expected)
+    }
 }

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -163,24 +163,42 @@ public enum OsaurusPaths {
 
     /// Returns the free-for-important-usage byte count on the volume that
     /// hosts `path`. Falls back to the legacy
-    /// `attributesOfFileSystem(.systemFreeSize)` only when the modern
-    /// query is unavailable. Returns `nil` if both queries fail —
+    /// `attributesOfFileSystem(.systemFreeSize)` when the modern
+    /// query is unavailable or reports zero. Returns `nil` if both queries fail —
     /// callers should treat `nil` as "unknown, render 'unknown'" rather
     /// than coercing to zero.
     public static func volumeFreeBytes(forPath path: String) -> Int64? {
         let url = URL(fileURLWithPath: path)
+        var importantCapacity: Int64?
         let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
         if let values = try? url.resourceValues(forKeys: keys),
             let capacity = values.volumeAvailableCapacityForImportantUsage
         {
-            return capacity
+            importantCapacity = capacity
         }
+        var legacyFree: Int64?
         if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
             let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
         {
-            return free
+            legacyFree = free
         }
-        return nil
+        return resolvedVolumeFreeBytes(
+            importantCapacity: importantCapacity,
+            legacyFree: legacyFree
+        )
+    }
+
+    static func resolvedVolumeFreeBytes(
+        importantCapacity: Int64?,
+        legacyFree: Int64?
+    ) -> Int64? {
+        if let importantCapacity, importantCapacity > 0 {
+            return importantCapacity
+        }
+        if let legacyFree, legacyFree > 0 {
+            return legacyFree
+        }
+        return importantCapacity ?? legacyFree
     }
 
     /// Returns total volume capacity in bytes for the volume that hosts


### PR DESCRIPTION
## Summary

- fall back to `attributesOfFileSystem(.systemFreeSize)` when `volumeAvailableCapacityForImportantUsage` reports `0`
- keep the modern capacity query as the preferred source when it returns a positive value
- add a regression test for external volumes that expose writable free space through the legacy filesystem attributes

## Why

On some external model volumes, `volumeAvailableCapacityForImportantUsage` can return `0` even though the same path has real writable free space according to filesystem attributes. That causes model download preflight checks to fail immediately with zero available space, while already-installed models can still run from the same volume.

The storage helper already centralizes the free-space lookup used by model download preflight and the system monitor. This change keeps that central behavior, but treats a modern `0` value as unusable when the legacy query has a positive free-space value.

## Test

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter ModelDownloadServiceStorageTests/zeroImportantCapacityFallsBackToLegacyFreeSpace
```
