### PR TITLE
[codex] Bound document parser adapter bridge

### DIFF
--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -77,6 +77,36 @@ struct DocumentParserShimTests {
         #expect(attachments.first?.documentContent == "legacy path still works")
     }
 
+    @Test func parseAll_timesOutSlowRegistryAdapter() throws {
+        DocumentFormatRegistry.shared.register(
+            adapter: SlowFixtureAdapter(
+                formatId: Self.fixtureFormatId,
+                extensions: [Self.fixtureExtension],
+                sleepNanoseconds: 2_000_000_000
+            )
+        )
+        defer { cleanUp() }
+
+        let url = try writeFile(content: "ignored", ext: Self.fixtureExtension)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let start = Date()
+        do {
+            try DocumentParser.withRegistryAdapterTimeoutForTesting(0.05) {
+                _ = try DocumentParser.parseAll(url: url)
+            }
+            Issue.record("Expected slow adapter to time out")
+        } catch let error as DocumentParser.ParseError {
+            guard case .readFailed(let reason) = error else {
+                Issue.record("Expected readFailed timeout, got \(error)")
+                return
+            }
+            #expect(reason.contains("timed out"))
+        }
+
+        #expect(Date().timeIntervalSince(start) < 1.0)
+    }
+
     // MARK: - Bootstrap
 
     @Test func bootstrap_registersExpectedBuiltInsOnIsolatedRegistry() {
@@ -142,6 +172,30 @@ struct DocumentParserShimTests {
                     underlying: PlainTextRepresentation(text: produce)
                 ),
                 textFallback: produce
+            )
+        }
+    }
+
+    private struct SlowFixtureAdapter: DocumentFormatAdapter {
+        let formatId: String
+        let extensions: Set<String>
+        let sleepNanoseconds: UInt64
+
+        func canHandle(url: URL, uti: String?) -> Bool {
+            extensions.contains(url.pathExtension.lowercased())
+        }
+
+        func parse(url: URL, sizeLimit: Int64) async throws -> StructuredDocument {
+            try await Task.sleep(nanoseconds: sleepNanoseconds)
+            return StructuredDocument(
+                formatId: formatId,
+                filename: url.lastPathComponent,
+                fileSize: 0,
+                representation: AnyStructuredRepresentation(
+                    formatId: formatId,
+                    underlying: PlainTextRepresentation(text: "late")
+                ),
+                textFallback: "late"
             )
         }
     }

--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -20,6 +20,7 @@ enum DocumentParser {
     /// latin-1 or rich-document input could still balloon RAM during decode.
     /// Matches the image cap in `FloatingInputCard`.
     static let maxFileSize = 10 * 1024 * 1024
+    private static let registryAdapterTimeout = UnfairLockedBox<TimeInterval>(15)
 
     enum ParseError: LocalizedError {
         case unsupportedFormat(String)
@@ -38,6 +39,16 @@ enum DocumentParser {
     }
 
     // MARK: - Public API
+
+    static func withRegistryAdapterTimeoutForTesting<T>(
+        _ timeout: TimeInterval,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let previous = registryAdapterTimeout.get()
+        registryAdapterTimeout.set(timeout)
+        defer { registryAdapterTimeout.set(previous) }
+        return try body()
+    }
 
     static func parse(url: URL) throws -> Attachment {
         let results = try parseAll(url: url)
@@ -316,6 +327,8 @@ enum DocumentParser {
             throw ParseError.readFailed(reason)
         } catch DocumentAdapterError.writeFailed, DocumentAdapterError.cancelled {
             throw ParseError.readFailed("Adapter emitted non-read error for ingress")
+        } catch BlockingAwaitError.timedOut(let timeout) {
+            throw ParseError.readFailed("Document adapter timed out after \(formatTimeout(timeout)) seconds")
         } catch {
             throw ParseError.readFailed(error.localizedDescription)
         }
@@ -329,7 +342,7 @@ enum DocumentParser {
         let semaphore = DispatchSemaphore(value: 0)
         let resultBox = UnfairLockedBox<Result<T, Error>?>(nil)
 
-        Task.detached {
+        let task = Task.detached {
             let result: Result<T, Error>
             do {
                 result = .success(try await body())
@@ -340,11 +353,39 @@ enum DocumentParser {
             semaphore.signal()
         }
 
-        semaphore.wait()
-        switch resultBox.get()! {
+        let waitResult = semaphore.wait(timeout: deadline(after: registryAdapterTimeout.get()))
+        guard waitResult == .success else {
+            // Adapter implementations are extension points. A hung adapter
+            // should lose its ingest attempt, not wedge the synchronous UI
+            // bridge that is still in place while parser callers migrate.
+            task.cancel()
+            throw BlockingAwaitError.timedOut(registryAdapterTimeout.get())
+        }
+
+        guard let result = resultBox.get() else {
+            throw BlockingAwaitError.missingResult
+        }
+        switch result {
         case .success(let value): return value
         case .failure(let error): throw error
         }
+    }
+
+    private static func deadline(after timeout: TimeInterval) -> DispatchTime {
+        guard timeout.isFinite, timeout > 0 else { return .now() }
+        let milliseconds = max(1, Int((min(timeout, 86_400) * 1_000).rounded(.up)))
+        return .now() + .milliseconds(milliseconds)
+    }
+
+    private static func formatTimeout(_ timeout: TimeInterval) -> String {
+        timeout.rounded() == timeout
+            ? String(Int(timeout))
+            : String(format: "%.2f", timeout)
+    }
+
+    private enum BlockingAwaitError: Error {
+        case timedOut(TimeInterval)
+        case missingResult
     }
 }
 


### PR DESCRIPTION
## Business rationale

A document adapter can sit behind the synchronous `DocumentParser.parseAll` bridge; if that adapter stalls, attaching or importing a document can block instead of giving the user a controlled failure. This PR bounds the registry-routed parse path so unsupported or slow adapter behavior falls back or fails predictably while preserving the existing user-facing parser behavior for plain text, rich documents, and PDF fallback.

## Coding rationale

The change keeps `DocumentParser` and `DocumentFormatRegistry` in their existing relationship: `DocumentParser` queries the registry opportunistically before using its legacy switch. I considered moving the whole parser onto async registry plumbing, but that would widen call-site churn and trust-boundary changes for a small robustness fix. Instead, the adapter bridge runs in a detached task, races it against a bounded timeout, cancels the adapter task on timeout, maps adapter errors back onto the legacy `ParseError` surface, and deliberately leaves adapter internals and registry ownership out of scope.

## Acceptance criteria

- [x] Registry adapters still claim and parse matching files before the legacy switch.
- [x] Adapter `.emptyContent` still falls through to the legacy parser path.
- [x] Slow registry adapters time out with a controlled `ParseError.readFailed` instead of hanging the caller.
- [x] Built-in structured document picker support remains registered for `xlsx`, `pptx`, and `potx`.

## Quality gate

- [x] `swift-format lint --strict --recursive Packages App` — green
- [x] `swiftlint lint --reporter github-actions-logging` — green
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed with `git fetch --all --prune` immediately before push; PR head `b92a8fa71d93688b967d2df88fb7f7de4a3b80b5` contains `origin/main` `a692991362fcd247b069a2c6d9e2c0b0f22e1fb9`.

## Debug evidence

`make ci-test` exercised `DocumentParserShimTests` on the full app test run, including the new timeout coverage. The required final gate ended with:

```text
[6/6] release build
Build complete! (415.31s)

QUALITY_GATE_OK
```

The focused shim test added here asserts the slow adapter path finishes under one second while a fixture adapter sleeps for two seconds:

```swift
try DocumentParser.withRegistryAdapterTimeoutForTesting(0.05) {
    _ = try DocumentParser.parseAll(url: url)
}
#expect(reason.contains("timed out"))
#expect(Date().timeIntervalSince(start) < 1.0)
```

## Rollback

Revert this PR or run `git revert b92a8fa71d93688b967d2df88fb7f7de4a3b80b5`.
