### PR TITLE
[codex] Contain Hugging Face download paths

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Pull.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Pull.swift
@@ -81,7 +81,9 @@ public struct PullCommand: Command {
         let totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
 
         for file in files {
-            let dest = destination.appendingPathComponent(file.path)
+            guard let dest = destinationURL(forRemotePath: file.path, under: destination) else {
+                continue
+            }
             let attrs = try? FileManager.default.attributesOfItem(atPath: dest.path)
             let existingSize = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
             if existingSize == file.size {
@@ -104,18 +106,13 @@ public struct PullCommand: Command {
         // Download each file sequentially with progress
         var completedBytes = alreadyDownloaded
         for file in filesToDownload {
-            let encodedPath =
-                file.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file.path
             guard
-                let downloadURL = URL(
-                    string: "https://huggingface.co/\(modelId)/resolve/main/\(encodedPath)"
-                )
+                let downloadURL = resolveDownloadURL(repoId: modelId, path: file.path),
+                let fileDest = destinationURL(forRemotePath: file.path, under: destination)
             else {
-                fputs("Invalid URL for file: \(file.path)\n", stderr)
+                fputs("Invalid remote path for file: \(file.path)\n", stderr)
                 continue
             }
-
-            let fileDest = destination.appendingPathComponent(file.path)
 
             // Create intermediate subdirectories if needed (e.g. for sharded weights)
             let parent = fileDest.deletingLastPathComponent()
@@ -164,6 +161,100 @@ public struct PullCommand: Command {
         }
     }
 
+    // MARK: - Remote path containment
+
+    /// HF tree entries are remote input but become local files; accept only
+    /// portable relative paths before appending them under the model directory.
+    static func normalizedRemoteFilePath(_ path: String) -> String? {
+        guard !path.isEmpty,
+            !path.contains("\\"),
+            !path.contains("\0"),
+            !(path as NSString).isAbsolutePath
+        else {
+            return nil
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.isEmpty else { return nil }
+        var normalized: [String] = []
+        for component in components {
+            guard !component.isEmpty,
+                component != ".",
+                component != ".."
+            else {
+                return nil
+            }
+            normalized.append(String(component))
+        }
+        return normalized.joined(separator: "/")
+    }
+
+    static func destinationURL(forRemotePath path: String, under directory: URL) -> URL? {
+        guard let safePath = normalizedRemoteFilePath(path) else { return nil }
+        let base = directory.standardizedFileURL
+        let destination =
+            safePath
+            .split(separator: "/")
+            .reduce(base) { partial, component in
+                partial.appendingPathComponent(String(component))
+            }
+            .standardizedFileURL
+
+        guard isContained(destination, in: base),
+            existingParentChainIsContained(for: destination, under: base)
+        else {
+            return nil
+        }
+        return destination
+    }
+
+    static func resolveDownloadURL(repoId: String, path: String) -> URL? {
+        guard let safePath = normalizedRemoteFilePath(path) else { return nil }
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = "huggingface.co"
+        comps.path = "/\(repoId)/resolve/main/\(safePath)"
+        return comps.url
+    }
+
+    private static func existingParentChainIsContained(for destination: URL, under base: URL) -> Bool {
+        let fileManager = FileManager.default
+        let resolvedBase = base.resolvingSymlinksInPath().standardizedFileURL
+        let parent = destination.deletingLastPathComponent().standardizedFileURL
+        let baseComponents = base.pathComponents
+        let parentComponents = parent.pathComponents
+        guard parentComponents.count >= baseComponents.count,
+            Array(parentComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            return false
+        }
+
+        var current = base
+        for component in parentComponents.dropFirst(baseComponents.count) {
+            current = current.appendingPathComponent(component, isDirectory: true)
+            guard isContained(current.standardizedFileURL, in: base) else { return false }
+            guard fileManager.fileExists(atPath: current.path) else { break }
+            guard (try? fileManager.destinationOfSymbolicLink(atPath: current.path)) == nil else {
+                return false
+            }
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: current.path, isDirectory: &isDirectory),
+                isDirectory.boolValue,
+                isContained(current.resolvingSymlinksInPath().standardizedFileURL, in: resolvedBase)
+            else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isContained(_ url: URL, in directory: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let directoryPath = directory.standardizedFileURL.path
+        return path == directoryPath || path.hasPrefix(directoryPath + "/")
+    }
+
     // MARK: - HuggingFace file listing
 
     private struct MatchedFile {
@@ -201,11 +292,12 @@ public struct PullCommand: Command {
 
             let files: [(path: String, size: Int64)] = nodes.compactMap { node in
                 guard node.type != "directory" else { return nil }
-                let filename = (node.path as NSString).lastPathComponent
+                guard let safePath = normalizedRemoteFilePath(node.path) else { return nil }
+                let filename = (safePath as NSString).lastPathComponent
                 guard matchers.contains(where: { $0.matches(filename) }) else { return nil }
                 let size = node.size ?? node.lfs?.size ?? 0
                 guard size > 0 else { return nil }
-                return (path: node.path, size: size)
+                return (path: safePath, size: size)
             }
             return files
         } catch {

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/PullCommandPathTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/PullCommandPathTests.swift
@@ -1,0 +1,94 @@
+//
+//  PullCommandPathTests.swift
+//  osaurus
+//
+//  Tests the remote path guard used before Hugging Face tree entries become
+//  local model-download destinations.
+//
+
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class PullCommandPathTests: XCTestCase {
+
+    func testNormalizesPortableRelativeModelPaths() {
+        XCTAssertEqual(PullCommand.normalizedRemoteFilePath("config.json"), "config.json")
+        XCTAssertEqual(
+            PullCommand.normalizedRemoteFilePath("shards/model-00001.safetensors"),
+            "shards/model-00001.safetensors"
+        )
+    }
+
+    func testRejectsEscapingOrPlatformSpecificRemotePaths() {
+        for path in [
+            "",
+            "/tmp/model.safetensors",
+            "../model.safetensors",
+            "weights/../model.safetensors",
+            "weights//model.safetensors",
+            "weights/./model.safetensors",
+            "weights\\model.safetensors",
+            "weights/model.safetensors\0",
+        ] {
+            XCTAssertNil(PullCommand.normalizedRemoteFilePath(path), "accepted \(path)")
+        }
+    }
+
+    func testDestinationURLStaysInsideModelDirectory() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = try XCTUnwrap(
+            PullCommand.destinationURL(
+                forRemotePath: "shards/model-00001.safetensors",
+                under: root
+            )
+        )
+
+        XCTAssertEqual(
+            destination.path,
+            root.appendingPathComponent("shards/model-00001.safetensors").path
+        )
+    }
+
+    func testDestinationURLRejectsSymlinkedParentEscapes() throws {
+        let root = try makeDirectory()
+        let outside = try makeDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+
+        let link = root.appendingPathComponent("shards", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        XCTAssertNil(
+            PullCommand.destinationURL(
+                forRemotePath: "shards/model-00001.safetensors",
+                under: root
+            )
+        )
+    }
+
+    func testResolveDownloadURLUsesPathComponents() {
+        let url = PullCommand.resolveDownloadURL(
+            repoId: "mlx-community/Test Model",
+            path: "weights/model 1.safetensors"
+        )
+
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://huggingface.co/mlx-community/Test%20Model/resolve/main/weights/model%201.safetensors"
+        )
+    }
+
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-cli-hf-path-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL
+    }
+}

--- a/Packages/OsaurusCore/Services/HuggingFaceService.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceService.swift
@@ -102,13 +102,14 @@ actor HuggingFaceService {
             let matchers = patterns.compactMap { Glob($0) }
             let files = nodes.compactMap { node -> MatchedFile? in
                 if node.type == "directory" { return nil }
-                let filename = (node.path as NSString).lastPathComponent
+                guard let safePath = Self.normalizedRemoteFilePath(node.path) else { return nil }
+                let filename = (safePath as NSString).lastPathComponent
                 if excludedFiles.contains(filename) { return nil }
                 let matched = matchers.contains { $0.matches(filename) }
                 guard matched else { return nil }
                 let sz = node.size ?? node.lfs?.size ?? 0
                 guard sz > 0 else { return nil }
-                return MatchedFile(path: node.path, size: sz)
+                return MatchedFile(path: safePath, size: sz)
             }
             return files.isEmpty ? nil : files
         } catch {
@@ -253,6 +254,89 @@ actor HuggingFaceService {
     }
 
     // MARK: - Private helpers
+    /// Hugging Face tree paths are network input but later become local
+    /// destination paths, so keep only simple slash-separated relative paths.
+    static func normalizedRemoteFilePath(_ path: String) -> String? {
+        guard !path.isEmpty,
+            !path.contains("\\"),
+            !path.contains("\0"),
+            !(path as NSString).isAbsolutePath
+        else {
+            return nil
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.isEmpty else { return nil }
+        var normalized: [String] = []
+        for component in components {
+            guard !component.isEmpty,
+                component != ".",
+                component != ".."
+            else {
+                return nil
+            }
+            normalized.append(String(component))
+        }
+        return normalized.joined(separator: "/")
+    }
+
+    static func destinationURL(forRemotePath path: String, under directory: URL) -> URL? {
+        guard let safePath = normalizedRemoteFilePath(path) else { return nil }
+        let base = directory.standardizedFileURL
+        let destination =
+            safePath
+            .split(separator: "/")
+            .reduce(base) { partial, component in
+                partial.appendingPathComponent(String(component))
+            }
+            .standardizedFileURL
+
+        guard isContained(destination, in: base),
+            existingParentChainIsContained(for: destination, under: base)
+        else {
+            return nil
+        }
+        return destination
+    }
+
+    private static func existingParentChainIsContained(for destination: URL, under base: URL) -> Bool {
+        let fileManager = FileManager.default
+        let resolvedBase = base.resolvingSymlinksInPath().standardizedFileURL
+        let parent = destination.deletingLastPathComponent().standardizedFileURL
+        let baseComponents = base.pathComponents
+        let parentComponents = parent.pathComponents
+        guard parentComponents.count >= baseComponents.count,
+            Array(parentComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            return false
+        }
+
+        var current = base
+        for component in parentComponents.dropFirst(baseComponents.count) {
+            current = current.appendingPathComponent(component, isDirectory: true)
+            guard isContained(current.standardizedFileURL, in: base) else { return false }
+            guard fileManager.fileExists(atPath: current.path) else { break }
+            guard (try? fileManager.destinationOfSymbolicLink(atPath: current.path)) == nil else {
+                return false
+            }
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: current.path, isDirectory: &isDirectory),
+                isDirectory.boolValue,
+                isContained(current.resolvingSymlinksInPath().standardizedFileURL, in: resolvedBase)
+            else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isContained(_ url: URL, in directory: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let directoryPath = directory.standardizedFileURL.path
+        return path == directoryPath || path.hasPrefix(directoryPath + "/")
+    }
+
     private func fetchModelMeta(repoId: String) async -> ModelMeta? {
         var comps = URLComponents()
         comps.scheme = "https"

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -282,7 +282,14 @@ final class ModelDownloadService: ObservableObject {
 
                 var filesToDownload: [HuggingFaceService.MatchedFile] = []
                 for file in files {
-                    let dest = model.localDirectory.appendingPathComponent(file.path)
+                    guard
+                        let dest = HuggingFaceService.destinationURL(
+                            forRemotePath: file.path,
+                            under: model.localDirectory
+                        )
+                    else {
+                        continue
+                    }
                     let attrs = try? FileManager.default.attributesOfItem(atPath: dest.path)
                     let existingSize = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
                     if existingSize == file.size {
@@ -332,9 +339,16 @@ final class ModelDownloadService: ObservableObject {
                 for file in filesToDownload {
                     try Task.checkCancellation()
 
+                    guard
+                        let destination = HuggingFaceService.destinationURL(
+                            forRemotePath: file.path,
+                            under: model.localDirectory
+                        )
+                    else {
+                        continue
+                    }
                     guard let downloadURL = Self.resolveURL(repoId: model.id, path: file.path)
                     else { continue }
-                    let destination = model.localDirectory.appendingPathComponent(file.path)
 
                     let baseCompleted = completedFileBytes
                     inFlightFilePath = file.path
@@ -378,7 +392,14 @@ final class ModelDownloadService: ObservableObject {
                 // disk at its expected size and report which are missing
                 let fm = FileManager.default
                 let missing: [String] = files.compactMap { file in
-                    let dest = model.localDirectory.appendingPathComponent(file.path)
+                    guard
+                        let dest = HuggingFaceService.destinationURL(
+                            forRemotePath: file.path,
+                            under: model.localDirectory
+                        )
+                    else {
+                        return file.path
+                    }
                     let attrs = try? fm.attributesOfItem(atPath: dest.path)
                     let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
                     return size == file.size ? nil : file.path
@@ -677,8 +698,12 @@ final class ModelDownloadService: ObservableObject {
     }
 
     nonisolated static func resolveURL(repoId: String, path: String) -> URL? {
-        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
-        return URL(string: "https://huggingface.co/\(repoId)/resolve/main/\(encoded)")
+        guard let safePath = HuggingFaceService.normalizedRemoteFilePath(path) else { return nil }
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = "huggingface.co"
+        comps.path = "/\(repoId)/resolve/main/\(safePath)"
+        return comps.url
     }
 
     // MARK: - Disk-space preflight
@@ -820,7 +845,14 @@ final class ModelDownloadService: ObservableObject {
 
         let fm = FileManager.default
         let missing = remoteFiles.filter { file in
-            let local = directory.appendingPathComponent(file.path)
+            guard
+                let local = HuggingFaceService.destinationURL(
+                    forRemotePath: file.path,
+                    under: directory
+                )
+            else {
+                return true
+            }
             guard let attrs = try? fm.attributesOfItem(atPath: local.path),
                 let localSize = (attrs[.size] as? NSNumber)?.int64Value
             else { return true }
@@ -832,8 +864,16 @@ final class ModelDownloadService: ObservableObject {
         defer { downloader.invalidate() }
         var allSucceeded = true
         for file in missing {
-            guard let url = resolveURL(repoId: model.id, path: file.path) else { continue }
-            let dest = directory.appendingPathComponent(file.path)
+            guard
+                let url = resolveURL(repoId: model.id, path: file.path),
+                let dest = HuggingFaceService.destinationURL(
+                    forRemotePath: file.path,
+                    under: directory
+                )
+            else {
+                allSucceeded = false
+                continue
+            }
             do {
                 try await downloader.download(
                     from: url,

--- a/Packages/OsaurusCore/Tests/Service/HuggingFaceDownloadPathTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/HuggingFaceDownloadPathTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct HuggingFaceDownloadPathTests {
+
+    @Test func normalizesPortableRelativeModelPaths() {
+        #expect(HuggingFaceService.normalizedRemoteFilePath("config.json") == "config.json")
+        #expect(
+            HuggingFaceService.normalizedRemoteFilePath("model-00001-of-00002/model.safetensors")
+                == "model-00001-of-00002/model.safetensors"
+        )
+    }
+
+    @Test func rejectsEscapingOrPlatformSpecificRemotePaths() {
+        for path in [
+            "",
+            "/tmp/model.safetensors",
+            "../model.safetensors",
+            "weights/../model.safetensors",
+            "weights//model.safetensors",
+            "weights/./model.safetensors",
+            "weights\\model.safetensors",
+            "weights/model.safetensors\0",
+        ] {
+            #expect(HuggingFaceService.normalizedRemoteFilePath(path) == nil, "accepted \(path)")
+        }
+    }
+
+    @Test func destinationURLStaysInsideModelDirectory() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let destination = try #require(
+            HuggingFaceService.destinationURL(
+                forRemotePath: "shards/model-00001.safetensors",
+                under: root
+            )
+        )
+
+        #expect(destination.path == root.appendingPathComponent("shards/model-00001.safetensors").path)
+    }
+
+    @Test func destinationURLRejectsSymlinkedParentEscapes() throws {
+        let root = try makeDirectory()
+        let outside = try makeDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+
+        let link = root.appendingPathComponent("shards", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+
+        #expect(
+            HuggingFaceService.destinationURL(
+                forRemotePath: "shards/model-00001.safetensors",
+                under: root
+            ) == nil
+        )
+    }
+
+    @Test func modelDownloadResolveURLEncodesPathComponents() {
+        let url = ModelDownloadService.resolveURL(
+            repoId: "mlx-community/Test Model",
+            path: "weights/model 1.safetensors"
+        )
+
+        #expect(
+            url?.absoluteString
+                == "https://huggingface.co/mlx-community/Test%20Model/resolve/main/weights/model%201.safetensors"
+        )
+        #expect(ModelDownloadService.resolveURL(repoId: "mlx-community/test", path: "../config.json") == nil)
+    }
+
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-hf-path-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL
+    }
+}


### PR DESCRIPTION
## Business rationale

Model downloads trust remote repository metadata to decide where files land on disk. If a model manifest advertises path traversal, absolute paths, Windows drive paths, or symlink-assisted escapes, the app and CLI should reject that path instead of writing outside the intended model directory. This PR makes the observable fix explicit: unsafe remote file paths fail before download/write, while normal nested model paths still resolve and download inside the configured destination.

## Coding rationale

The implementation keeps the existing download services and CLI pull command surface, then centralizes path validation at the trust boundary where remote path strings become local URLs. I considered only normalizing string components at call sites, but that would leave slightly different rules between app downloads and CLI pulls. The chosen approach uses file URL/path component resolution plus containment checks, rejects platform-specific absolute/escaping paths, and verifies symlinked parents cannot redirect writes outside the destination. It deliberately does not add dependencies or change Hugging Face API behavior beyond refusing unsafe paths.

## Acceptance criteria

- [x] CLI `pull` normalizes portable relative model paths into the model directory.
- [x] CLI `pull` rejects `..`, absolute, and platform-specific remote paths.
- [x] CLI destination resolution rejects symlinked parent directory escapes.
- [x] App-side Hugging Face downloads reject escaping remote file paths before writing.
- [x] App-side model download orchestration keeps resolved files inside the selected model directory.

## Quality gate

- [x] `swift-format lint --strict --recursive Packages App` — green
- [x] `swiftlint lint --reporter github-actions-logging` — green
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed with `git fetch --all --prune` immediately before push; PR head `b286800be21b8cbc5a04b6fc70cbb03b115a951b` contains `origin/main` `a692991362fcd247b069a2c6d9e2c0b0f22e1fb9`.

## Debug evidence

The CLI gate ran 82 tests and exercised the new path containment cases directly:

```text
[51/82] Testing OsaurusCLITests.PullCommandPathTests/testResolveDownloadURLUsesPathComponents
[52/82] Testing OsaurusCLITests.PullCommandPathTests/testRejectsEscapingOrPlatformSpecificRemotePaths
[53/82] Testing OsaurusCLITests.PullCommandPathTests/testNormalizesPortableRelativeModelPaths
[54/82] Testing OsaurusCLITests.PullCommandPathTests/testDestinationURLRejectsSymlinkedParentEscapes
[55/82] Testing OsaurusCLITests.PullCommandPathTests/testDestinationURLStaysInsideModelDirectory
```

The required full local gate ended with:

```text
[6/6] release build
Build complete! (421.11s)

QUALITY_GATE_OK
```

## Rollback

Revert this PR or run `git revert b286800be21b8cbc5a04b6fc70cbb03b115a951b`.
