### PR TITLE
[codex] Contain skill file paths

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/SkillStore.swift
+++ b/Packages/OsaurusCore/Models/Agent/SkillStore.swift
@@ -8,6 +8,20 @@
 
 import Foundation
 
+/// Errors from skill file path validation before a caller-controlled path can
+/// reach the filesystem.
+public enum SkillStoreFileError: Error, LocalizedError, Sendable, Equatable {
+    case invalidRelativePath
+    case pathEscapesDirectory
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRelativePath: return "Skill file path must be a non-empty relative path"
+        case .pathEscapesDirectory: return "Skill file path escapes its containing directory"
+        }
+    }
+}
+
 public enum SkillStore {
 
     // MARK: - Public API
@@ -219,26 +233,28 @@ public enum SkillStore {
     /// Add a reference file to a skill
     public static func addReference(to skill: Skill, name: String, content: Data) async throws {
         let refsDir = skillDirectory(for: skill).appendingPathComponent("references")
-        try FileManager.default.createDirectory(at: refsDir, withIntermediateDirectories: true)
-        try content.write(to: refsDir.appendingPathComponent(name))
+        try writeSkillFile(content, named: name, in: refsDir)
     }
 
     /// Add an asset file to a skill
     public static func addAsset(to skill: Skill, name: String, content: Data) async throws {
         let assetsDir = skillDirectory(for: skill).appendingPathComponent("assets")
-        try FileManager.default.createDirectory(at: assetsDir, withIntermediateDirectories: true)
-        try content.write(to: assetsDir.appendingPathComponent(name))
+        try writeSkillFile(content, named: name, in: assetsDir)
     }
 
     /// Remove a file from a skill
     public static func removeFile(from skill: Skill, relativePath: String) async throws {
-        let fileURL = skillDirectory(for: skill).appendingPathComponent(relativePath)
+        let skillDir = skillDirectory(for: skill)
+        let fileURL = try containedFileURL(for: relativePath, in: skillDir)
+        try ensureResolvedContainment(of: fileURL, in: skillDir)
         try FileManager.default.removeItem(at: fileURL)
     }
 
     /// Read content of a skill file
     public static func readFile(from skill: Skill, relativePath: String) async throws -> Data {
-        let fileURL = skillDirectory(for: skill).appendingPathComponent(relativePath)
+        let skillDir = skillDirectory(for: skill)
+        let fileURL = try containedFileURL(for: relativePath, in: skillDir)
+        try ensureResolvedContainment(of: fileURL, in: skillDir)
         return try Data(contentsOf: fileURL)
     }
 
@@ -246,6 +262,99 @@ public enum SkillStore {
 
     private static func skillsDirectory() -> URL {
         OsaurusPaths.skills()
+    }
+
+    private static func writeSkillFile(_ content: Data, named name: String, in baseDirectory: URL) throws {
+        let fileURL = try containedFileURL(for: name, in: baseDirectory)
+        try createContainedParentDirectories(for: fileURL, in: baseDirectory)
+        try ensureResolvedContainment(of: fileURL, in: baseDirectory)
+        try content.write(to: fileURL)
+    }
+
+    private static func containedFileURL(for relativePath: String, in baseDirectory: URL) throws -> URL {
+        let normalizedPath = try normalizedRelativeSkillFilePath(relativePath)
+        let baseURL = baseDirectory.standardizedFileURL
+        let fileURL = baseURL.appendingPathComponent(normalizedPath).standardizedFileURL
+
+        guard isContained(fileURL, in: baseURL) else {
+            throw SkillStoreFileError.pathEscapesDirectory
+        }
+        return fileURL
+    }
+
+    private static func normalizedRelativeSkillFilePath(_ relativePath: String) throws -> String {
+        guard !relativePath.isEmpty,
+            !(relativePath as NSString).isAbsolutePath
+        else {
+            throw SkillStoreFileError.invalidRelativePath
+        }
+
+        let rawComponents = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        guard !rawComponents.contains("..") else {
+            throw SkillStoreFileError.invalidRelativePath
+        }
+
+        let normalizedComponents =
+            rawComponents
+            .map(String.init)
+            .filter { !$0.isEmpty && $0 != "." }
+        guard !normalizedComponents.isEmpty else {
+            throw SkillStoreFileError.invalidRelativePath
+        }
+        return normalizedComponents.joined(separator: "/")
+    }
+
+    private static func createContainedParentDirectories(for fileURL: URL, in baseDirectory: URL) throws {
+        let fileManager = FileManager.default
+        let baseURL = baseDirectory.standardizedFileURL
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseURL.pathComponents
+        let parentComponents = Array(fileComponents.dropFirst(baseComponents.count).dropLast())
+
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        guard !isSymbolicLink(baseURL) else {
+            throw SkillStoreFileError.pathEscapesDirectory
+        }
+
+        var current = baseURL
+        for component in parentComponents {
+            current = current.appendingPathComponent(component, isDirectory: true)
+            guard isContained(current, in: baseURL),
+                !isSymbolicLink(current)
+            else {
+                throw SkillStoreFileError.pathEscapesDirectory
+            }
+
+            if !fileManager.fileExists(atPath: current.path) {
+                try fileManager.createDirectory(at: current, withIntermediateDirectories: false)
+            }
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: current.path, isDirectory: &isDirectory),
+                isDirectory.boolValue
+            else {
+                throw SkillStoreFileError.invalidRelativePath
+            }
+        }
+    }
+
+    private static func ensureResolvedContainment(of fileURL: URL, in baseDirectory: URL) throws {
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedFile = fileURL.resolvingSymlinksInPath().standardizedFileURL
+        guard isContained(resolvedFile, in: resolvedBase) else {
+            throw SkillStoreFileError.pathEscapesDirectory
+        }
+    }
+
+    private static func isContained(_ fileURL: URL, in baseDirectory: URL) -> Bool {
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.pathComponents
+        return fileComponents.count >= baseComponents.count
+            && Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+    }
+
+    private static func isSymbolicLink(_ url: URL) -> Bool {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: url.path)) != nil
     }
 
     private static func loadFromDirectory(_ directoryURL: URL) -> Skill? {
@@ -281,24 +390,62 @@ public enum SkillStore {
 
     private static func loadFilesFromSubdirectory(_ skillDir: URL, subdirectory: String) -> [SkillFile] {
         let subDir = skillDir.appendingPathComponent(subdirectory)
+        return loadFiles(in: subDir, relativeTo: skillDir)
+    }
+
+    private static func loadFiles(in directory: URL, relativeTo skillDir: URL) -> [SkillFile] {
         guard
-            let files = try? FileManager.default.contentsOfDirectory(
-                at: subDir,
-                includingPropertiesForKeys: [.fileSizeKey],
+            let entries = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
                 options: [.skipsHiddenFiles]
             )
         else {
             return []
         }
 
-        return files.compactMap { fileURL -> SkillFile? in
-            guard let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey]) else { return nil }
-            return SkillFile(
-                name: fileURL.lastPathComponent,
-                relativePath: "\(subdirectory)/\(fileURL.lastPathComponent)",
-                size: Int64(values.fileSize ?? 0)
+        var files: [SkillFile] = []
+        for entry in entries.sorted(by: { $0.path < $1.path }) {
+            guard
+                let values = try? entry.resourceValues(
+                    forKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey]
+                ),
+                values.isSymbolicLink != true
+            else {
+                continue
+            }
+
+            if values.isDirectory == true {
+                files.append(contentsOf: loadFiles(in: entry, relativeTo: skillDir))
+                continue
+            }
+
+            guard values.isRegularFile == true,
+                let relativePath = relativePath(for: entry, in: skillDir)
+            else {
+                continue
+            }
+
+            files.append(
+                SkillFile(
+                    name: entry.lastPathComponent,
+                    relativePath: relativePath,
+                    size: Int64(values.fileSize ?? 0)
+                )
             )
         }
+        return files
+    }
+
+    private static func relativePath(for fileURL: URL, in baseDirectory: URL) -> String? {
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.pathComponents
+        guard fileComponents.count > baseComponents.count,
+            Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            return nil
+        }
+        return fileComponents.dropFirst(baseComponents.count).joined(separator: "/")
     }
 
     private static func saveBuiltInState(_ skill: Skill) {

--- a/Packages/OsaurusCore/Tests/Skill/SkillStoreFileContainmentTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillStoreFileContainmentTests.swift
@@ -1,0 +1,186 @@
+//
+//  SkillStoreFileContainmentTests.swift
+//  osaurusTests
+//
+//  Verifies that caller-provided skill file paths stay inside the skill,
+//  references, and assets directories they are scoped to.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SkillStoreFileContainmentTests {
+
+    @Test func validReferenceAndAssetOperationsStayContained() async throws {
+        try await Self.withTempSkill { _, skill in
+            let referenceData = Data("reference".utf8)
+            let nestedReferenceData = Data("nested reference".utf8)
+            let assetData = Data("asset".utf8)
+
+            try await SkillStore.addReference(to: skill, name: "guide.md", content: referenceData)
+            try await SkillStore.addReference(
+                to: skill,
+                name: "deep/notes.md",
+                content: nestedReferenceData
+            )
+            try await SkillStore.addAsset(to: skill, name: "images/icon.txt", content: assetData)
+
+            let skillDir = SkillStore.skillDirectory(for: skill)
+            #expect(
+                try Data(contentsOf: skillDir.appendingPathComponent("references/guide.md"))
+                    == referenceData
+            )
+            #expect(
+                try Data(contentsOf: skillDir.appendingPathComponent("references/deep/notes.md"))
+                    == nestedReferenceData
+            )
+            #expect(
+                try Data(contentsOf: skillDir.appendingPathComponent("assets/images/icon.txt"))
+                    == assetData
+            )
+
+            let loadedGuide = try await SkillStore.readFile(from: skill, relativePath: "references/guide.md")
+            let loadedNested = try await SkillStore.readFile(
+                from: skill,
+                relativePath: "references/deep/notes.md"
+            )
+            #expect(loadedGuide == referenceData)
+            #expect(loadedNested == nestedReferenceData)
+
+            let reloaded = await SkillStore.load(id: skill.id)
+            #expect(reloaded?.references.contains { $0.relativePath == "references/guide.md" } == true)
+            #expect(reloaded?.references.contains { $0.relativePath == "references/deep/notes.md" } == true)
+            #expect(reloaded?.assets.contains { $0.relativePath == "assets/images/icon.txt" } == true)
+
+            try await SkillStore.removeFile(from: skill, relativePath: "assets/images/icon.txt")
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: skillDir.appendingPathComponent("assets/images/icon.txt").path
+                )
+            )
+        }
+    }
+
+    @Test func addReferenceAndAssetRejectEscapingPaths() async throws {
+        try await Self.withTempSkill { root, skill in
+            let escapedReference = OsaurusPaths.skills().appendingPathComponent("escaped-reference.md")
+            let escapedAsset = SkillStore.skillDirectory(for: skill).appendingPathComponent("escaped-asset.bin")
+            let absoluteReference = root.appendingPathComponent("absolute-reference.md")
+            let absoluteAsset = root.appendingPathComponent("absolute-asset.bin")
+
+            for name in ["", "../escaped-reference.md", "deep/../escaped-reference.md", absoluteReference.path] {
+                await #expect(throws: SkillStoreFileError.self) {
+                    try await SkillStore.addReference(to: skill, name: name, content: Data("bad".utf8))
+                }
+            }
+
+            for name in ["", "../escaped-asset.bin", "images/../../escaped-asset.bin", absoluteAsset.path] {
+                await #expect(throws: SkillStoreFileError.self) {
+                    try await SkillStore.addAsset(to: skill, name: name, content: Data("bad".utf8))
+                }
+            }
+
+            #expect(!FileManager.default.fileExists(atPath: escapedReference.path))
+            #expect(!FileManager.default.fileExists(atPath: escapedAsset.path))
+            #expect(!FileManager.default.fileExists(atPath: absoluteReference.path))
+            #expect(!FileManager.default.fileExists(atPath: absoluteAsset.path))
+        }
+    }
+
+    @Test func readFileRejectsEscapesWithoutReturningOutsideData() async throws {
+        try await Self.withTempSkill { root, skill in
+            let outsideRead = OsaurusPaths.skills().appendingPathComponent("outside-read.txt")
+            let absoluteRead = root.appendingPathComponent("absolute-read.txt")
+            try Data("secret".utf8).write(to: outsideRead)
+            try Data("absolute secret".utf8).write(to: absoluteRead)
+
+            for path in ["", "../outside-read.txt", "references/../../outside-read.txt", absoluteRead.path] {
+                await #expect(throws: SkillStoreFileError.self) {
+                    _ = try await SkillStore.readFile(from: skill, relativePath: path)
+                }
+            }
+
+            #expect(try Data(contentsOf: outsideRead) == Data("secret".utf8))
+            #expect(try Data(contentsOf: absoluteRead) == Data("absolute secret".utf8))
+        }
+    }
+
+    @Test func removeFileRejectsEscapesWithoutDeletingOutsideFiles() async throws {
+        try await Self.withTempSkill { root, skill in
+            let outsideDelete = OsaurusPaths.skills().appendingPathComponent("outside-delete.txt")
+            let absoluteDelete = root.appendingPathComponent("absolute-delete.txt")
+            try Data("keep".utf8).write(to: outsideDelete)
+            try Data("keep absolute".utf8).write(to: absoluteDelete)
+
+            for path in ["", "../outside-delete.txt", "references/../../outside-delete.txt", absoluteDelete.path] {
+                await #expect(throws: SkillStoreFileError.self) {
+                    try await SkillStore.removeFile(from: skill, relativePath: path)
+                }
+            }
+
+            #expect(try Data(contentsOf: outsideDelete) == Data("keep".utf8))
+            #expect(try Data(contentsOf: absoluteDelete) == Data("keep absolute".utf8))
+        }
+    }
+
+    @Test func readFileRejectsSymlinkEscapes() async throws {
+        try await Self.withTempSkill { _, skill in
+            let skillDir = SkillStore.skillDirectory(for: skill)
+            let referencesDir = skillDir.appendingPathComponent("references")
+            let outsideRead = OsaurusPaths.skills().appendingPathComponent("symlink-secret.txt")
+            let linkURL = referencesDir.appendingPathComponent("linked-secret.txt")
+            try FileManager.default.createDirectory(at: referencesDir, withIntermediateDirectories: true)
+            try Data("keep symlink secret".utf8).write(to: outsideRead)
+            try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: outsideRead)
+
+            await #expect(throws: SkillStoreFileError.self) {
+                _ = try await SkillStore.readFile(from: skill, relativePath: "references/linked-secret.txt")
+            }
+            #expect(try Data(contentsOf: outsideRead) == Data("keep symlink secret".utf8))
+        }
+    }
+
+    @Test func addReferenceRejectsSymlinkedBaseDirectory() async throws {
+        try await Self.withTempSkill { _, skill in
+            let skillDir = SkillStore.skillDirectory(for: skill)
+            let outsideReferences = OsaurusPaths.skills().appendingPathComponent("outside-references")
+            let referencesDir = skillDir.appendingPathComponent("references")
+            try FileManager.default.createDirectory(at: outsideReferences, withIntermediateDirectories: true)
+            try FileManager.default.createSymbolicLink(at: referencesDir, withDestinationURL: outsideReferences)
+
+            await #expect(throws: SkillStoreFileError.self) {
+                try await SkillStore.addReference(to: skill, name: "leak.md", content: Data("bad".utf8))
+            }
+            #expect(!FileManager.default.fileExists(atPath: outsideReferences.appendingPathComponent("leak.md").path))
+        }
+    }
+
+    private static func withTempSkill<T: Sendable>(
+        _ body: @Sendable (URL, Skill) async throws -> T
+    ) async throws -> T {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-skill-containment-\(UUID().uuidString)"
+            )
+            let previousRoot = OsaurusPaths.overrideRoot
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let skill = Skill(
+                name: "Containment Test",
+                instructions: "Stay contained.",
+                directoryName: "containment-test"
+            )
+            await SkillStore.save(skill)
+
+            return try await body(root, skill)
+        }
+    }
+}


### PR DESCRIPTION
## Business rationale

Skills can carry references and assets that eventually become files read, written, or removed under the local skill directory. A malformed or hostile skill path should never escape that directory, return outside file contents, or delete outside files. This PR makes that boundary explicit so normal skill reference/asset operations still work, while traversal and symlink escape attempts fail before they touch data outside the skill root.

## Coding rationale

The change keeps `SkillStore` as the single owner of skill file operations and adds containment checks at the point where untrusted relative names become concrete file URLs. I considered placing ad hoc checks only in individual callers, but that would leave future file operations easy to miss. Instead, the store resolves canonical paths, rejects escaping inputs, and verifies symlinked base or child paths stay inside the intended skill root. No new dependencies are added, and broader skill packaging or permission policy changes are intentionally out of scope.

## Acceptance criteria

- [x] Valid skill reference and asset operations continue to read/write/remove inside the skill directory.
- [x] Reference and asset creation reject `..` traversal and absolute escape paths.
- [x] Reads reject escaping paths without returning outside data.
- [x] Removes reject escaping paths without deleting outside files.
- [x] Symlinked child paths and symlinked base directories cannot redirect operations outside the skill root.

## Quality gate

- [x] `swift-format lint --strict --recursive Packages App` — green
- [x] `swiftlint lint --reporter github-actions-logging` — green
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed with `git fetch --all --prune` immediately before push; PR head `4ed1e5d39073f51e6f4538f7f7127d8fa84fc921` contains `origin/main` `a692991362fcd247b069a2c6d9e2c0b0f22e1fb9`.

## Debug evidence

`make ci-test` exercised the new skill containment suite. The app test output included the symlink trust-boundary cases:

```text
✔ [SkillStoreFileContainmentTests] readFileRejectsSymlinkEscapes on 'My Mac - xctest (71705)'
✔ [SkillStoreFileContainmentTests] addReferenceRejectsSymlinkedBaseDirectory on 'My Mac - xctest (71705)'
```

The required full local gate ended with:

```text
[6/6] release build
Build complete! (416.99s)

QUALITY_GATE_OK
```

## Rollback

Revert this PR or run `git revert 4ed1e5d39073f51e6f4538f7f7127d8fa84fc921`.
