### PR TITLE
[codex] Preview XLSX workbooks through file_read

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -315,9 +315,10 @@ struct FileTreeTool: OsaurusTool {
 struct FileReadTool: OsaurusTool {
     let name = "file_read"
     let description =
-        "Read the contents of a text file. **Use this instead of `cat` / `head` / `tail` in "
-        + "`shell_run`.** Cannot read binary files (PDFs, images, etc.). Optionally specify start_line "
-        + "and end_line for partial reads. Line numbers are 1-indexed."
+        "Read the contents of a text file or a bounded preview of an XLSX workbook. **Use this instead "
+        + "of `cat` / `head` / `tail` in `shell_run`.** Cannot read most binary files (PDFs, images, etc.). "
+        + "Optionally specify start_line and end_line for partial text reads; for workbooks they select "
+        + "worksheet row numbers. Line numbers are 1-indexed."
     let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -326,22 +327,36 @@ struct FileReadTool: OsaurusTool {
                 "type": .string("string"),
                 "description": .string("Relative path to the file from the working directory"),
             ]),
+            "sheet_name": .object([
+                "type": .string("string"),
+                "description": .string("Optional XLSX worksheet name to preview"),
+            ]),
             "start_line": .object([
                 "type": .string("integer"),
-                "description": .string("Optional start line number (1-indexed, inclusive)"),
+                "description": .string("Optional start line number or XLSX row number (1-indexed, inclusive)"),
             ]),
             "end_line": .object([
                 "type": .string("integer"),
-                "description": .string("Optional end line number (1-indexed, inclusive)"),
+                "description": .string("Optional end line number or XLSX row number (1-indexed, inclusive)"),
+            ]),
+            "max_rows": .object([
+                "type": .string("integer"),
+                "description": .string("Optional XLSX preview row cap per sheet (default 8, max 50)"),
+            ]),
+            "max_columns": .object([
+                "type": .string("integer"),
+                "description": .string("Optional XLSX preview column cap per row (default 8, max 30)"),
             ]),
         ]),
         "required": .array([.string("path")]),
     ])
 
     private let rootPath: URL
+    private let documentRegistry: DocumentFormatRegistry
 
-    init(rootPath: URL) {
+    init(rootPath: URL, documentRegistry: DocumentFormatRegistry = .shared) {
         self.rootPath = rootPath
+        self.documentRegistry = documentRegistry
     }
 
     /// Maximum characters for file_read output to prevent context window exhaustion.
@@ -380,6 +395,31 @@ struct FileReadTool: OsaurusTool {
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             throw FolderToolError.fileNotFound(relativePath)
+        }
+
+        let sheetName: String?
+        if args.keys.contains("sheet_name") {
+            let sheetReq = requireString(
+                args,
+                "sheet_name",
+                expected: "worksheet name in the XLSX workbook",
+                tool: name
+            )
+            guard case .value(let parsedSheetName) = sheetReq else {
+                return sheetReq.failureEnvelope ?? ""
+            }
+            sheetName = parsedSheetName
+        } else {
+            sheetName = nil
+        }
+
+        if let workbookPreview = try await workbookPreviewIfAvailable(
+            fileURL: fileURL,
+            relativePath: relativePath,
+            sheetName: sheetName,
+            args: args
+        ) {
+            return ToolEnvelope.success(tool: name, text: workbookPreview)
         }
 
         let ext = fileURL.pathExtension.lowercased()
@@ -519,6 +559,209 @@ struct FileReadTool: OsaurusTool {
             ext: ext.isEmpty ? nil : ext,
             detail: detail
         )
+    }
+
+    private func workbookPreviewIfAvailable(
+        fileURL: URL,
+        relativePath: String,
+        sheetName: String?,
+        args: [String: Any]
+    ) async throws -> String? {
+        guard let adapter = workbookAdapter(for: fileURL) else { return nil }
+        let document = try await adapter.parse(
+            url: fileURL,
+            sizeLimit: DocumentLimits.limit(forFormatId: adapter.formatId)
+        )
+        guard let workbook = document.representation.underlying as? Workbook else {
+            throw FolderToolError.operationFailed(
+                "Registered adapter '\(adapter.formatId)' did not produce a workbook representation."
+            )
+        }
+        if let sheetName, !workbook.sheets.contains(where: { $0.name == sheetName }) {
+            throw FolderToolError.operationFailed("Workbook has no sheet named '\(sheetName)'.")
+        }
+
+        let maxRows = Self.clamped(coerceInt(args["max_rows"]), fallback: 8, lower: 1, upper: 50)
+        let maxColumns = Self.clamped(coerceInt(args["max_columns"]), fallback: 8, lower: 1, upper: 30)
+        let startRow = max(1, coerceInt(args["start_line"]) ?? 1)
+        let endRow = max(startRow, coerceInt(args["end_line"]) ?? Int.max)
+
+        return Self.renderWorkbookPreview(
+            document: document,
+            workbook: workbook,
+            relativePath: relativePath,
+            sheetName: sheetName,
+            startRow: startRow,
+            endRow: endRow,
+            maxRows: maxRows,
+            maxColumns: maxColumns
+        )
+    }
+
+    private func workbookAdapter(for fileURL: URL) -> (any DocumentFormatAdapter)? {
+        var adapter = documentRegistry.adapter(for: fileURL)
+        if adapter == nil, documentRegistry === DocumentFormatRegistry.shared {
+            DocumentAdaptersBootstrap.registerBuiltIns(registry: documentRegistry)
+            adapter = documentRegistry.adapter(for: fileURL)
+        }
+
+        guard adapter?.formatId.lowercased() == "xlsx" else { return nil }
+        return adapter
+    }
+
+    private static func renderWorkbookPreview(
+        document: StructuredDocument,
+        workbook: Workbook,
+        relativePath: String,
+        sheetName: String?,
+        startRow: Int,
+        endRow: Int,
+        maxRows: Int,
+        maxColumns: Int
+    ) -> String {
+        let sheets = selectedSheets(in: workbook, sheetName: sheetName)
+        let sheetNames = workbook.sheets.map(\.name)
+        let formulaCount = workbook.sheets.reduce(0) { total, sheet in
+            total
+                + sheet.rows.reduce(0) { rowTotal, row in
+                    rowTotal + row.cells.filter { $0.formula != nil }.count
+                }
+        }
+
+        var lines: [String] = [
+            "Workbook: \(relativePath)",
+            "Format: \(document.formatId) (\(document.fileSize) bytes)",
+            "Sheets: \(workbook.sheets.count) — \(boundedList(sheetNames, limit: 20))",
+            "Formula cells: \(formulaCount)",
+            securityLine(for: document.security),
+            "",
+        ]
+
+        let previewSheets = sheetName == nil ? Array(sheets.prefix(3)) : sheets
+        for sheet in previewSheets {
+            appendPreview(
+                for: sheet,
+                startRow: startRow,
+                endRow: endRow,
+                maxRows: maxRows,
+                maxColumns: maxColumns,
+                lines: &lines
+            )
+        }
+
+        if sheetName == nil, sheets.count > previewSheets.count {
+            lines.append("")
+            lines.append(
+                "... \(sheets.count - previewSheets.count) more sheet(s); pass sheet_name to focus the preview."
+            )
+        }
+
+        return truncatePreview(lines.joined(separator: "\n"))
+    }
+
+    private static func appendPreview(
+        for sheet: Workbook.Sheet,
+        startRow: Int,
+        endRow: Int,
+        maxRows: Int,
+        maxColumns: Int,
+        lines: inout [String]
+    ) {
+        let rowsInRange = sheet.rows.filter { $0.number >= startRow && $0.number <= endRow }
+        let visibleRows = Array(rowsInRange.prefix(maxRows))
+        let cellCount = sheet.rows.reduce(0) { $0 + $1.cells.count }
+        let formulaCount = sheet.rows.reduce(0) { rowTotal, row in
+            rowTotal + row.cells.filter { $0.formula != nil }.count
+        }
+        let maxColumn = sheet.rows.flatMap(\.cells).map(\.columnNumber).max() ?? 0
+
+        lines.append("Sheet \(sheet.index + 1): \(sheet.name)")
+        lines.append(
+            "Rows: \(sheet.rows.count), columns: \(maxColumn), cells: \(cellCount), formulas: \(formulaCount)"
+        )
+        if !sheet.mergedRanges.isEmpty {
+            lines.append("Merged ranges: \(boundedList(sheet.mergedRanges.map(\.reference), limit: 12))")
+        }
+
+        guard !visibleRows.isEmpty else {
+            lines.append("Preview: no rows in requested range \(startRow)-\(endRow).")
+            lines.append("")
+            return
+        }
+
+        lines.append("Preview rows \(visibleRows.first?.number ?? startRow)-\(visibleRows.last?.number ?? startRow):")
+        for row in visibleRows {
+            let cells = row.cells.sorted { $0.columnNumber < $1.columnNumber }
+            let visibleCells = cells.prefix(maxColumns).map(formatCell)
+            var line = "  row \(row.number): " + visibleCells.joined(separator: " | ")
+            if cells.count > maxColumns {
+                line += " | ... \(cells.count - maxColumns) more cell(s)"
+            }
+            lines.append(line)
+        }
+        if rowsInRange.count > visibleRows.count {
+            lines.append("... \(rowsInRange.count - visibleRows.count) more row(s) in this range.")
+        }
+        lines.append("")
+    }
+
+    private static func selectedSheets(in workbook: Workbook, sheetName: String?) -> [Workbook.Sheet] {
+        guard let sheetName else { return workbook.sheets }
+        return workbook.sheets.filter { $0.name == sheetName }
+    }
+
+    private static func formatCell(_ cell: Workbook.Cell) -> String {
+        var value = cell.value.fallbackText
+        value = value.replacingOccurrences(of: "\n", with: "\\n")
+        value = value.replacingOccurrences(of: "\t", with: " ")
+        if value.isEmpty { value = "<empty>" }
+        if let formula = cell.formula {
+            return "\(cell.reference)=\(value) [=\(formula)]"
+        }
+        return "\(cell.reference)=\(value)"
+    }
+
+    private static func securityLine(for security: DocumentSecurityMetadata) -> String {
+        var parts = ["inspection=\(security.inspectionStatus.rawValue)"]
+        if !security.activeContentTypes.isEmpty {
+            let active = security.activeContentTypes.map(\.rawValue).sorted().joined(separator: ",")
+            parts.append("active=\(active)")
+        }
+        if let maximumSeverity = security.maximumSeverity {
+            parts.append("max_severity=\(maximumSeverity.rawValue)")
+        }
+
+        let notableFindings = security.findings
+            .filter { $0.kind != .unsupportedFeature || $0.severity > .informational }
+            .prefix(3)
+            .map { finding in
+                if let count = finding.metadata["count"] {
+                    return "\(finding.kind.rawValue)(\(count))"
+                }
+                return finding.kind.rawValue
+            }
+        if !notableFindings.isEmpty {
+            parts.append("findings=\(notableFindings.joined(separator: ","))")
+        }
+        return "Security: " + parts.joined(separator: "; ")
+    }
+
+    private static func boundedList(_ values: [String], limit: Int) -> String {
+        guard !values.isEmpty else { return "(none)" }
+        let prefix = values.prefix(limit).joined(separator: ", ")
+        if values.count > limit {
+            return prefix + ", ... \(values.count - limit) more"
+        }
+        return prefix
+    }
+
+    private static func truncatePreview(_ text: String) -> String {
+        guard text.count > maxOutputChars else { return text }
+        return String(text.prefix(maxOutputChars)) + "\n... (truncated workbook preview)"
+    }
+
+    private static func clamped(_ value: Int?, fallback: Int, lower: Int, upper: Int) -> Int {
+        min(max(value ?? fallback, lower), upper)
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Folder/FileReadWorkbookTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadWorkbookTests.swift
@@ -1,0 +1,309 @@
+//
+//  FileReadWorkbookTests.swift
+//
+//  Verifies workbook visibility stays on the existing folder read tool.
+//  The maintainer concern for this lane is prompt/tool-surface size, so
+//  these tests pin XLSX introspection without registering workbook-specific
+//  default tools.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("File read workbook previews")
+struct FileReadWorkbookTests {
+
+    @Test func fileReadReturnsBoundedWorkbookPreview() async throws {
+        let fixture = try await Self.fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let tool = FileReadTool(rootPath: fixture.root, documentRegistry: fixture.registry)
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path":"workbook.xlsx","max_rows":2,"max_columns":2}"#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let text = try Self.text(from: result)
+        #expect(text.contains("Workbook: workbook.xlsx"))
+        #expect(text.contains("Sheets: 2"))
+        #expect(text.contains("Sheet 1: Revenue"))
+        #expect(text.contains("A1=Month"))
+        #expect(text.contains("B2=1200"))
+        #expect(text.contains("... 1 more cell(s)"))
+        #expect(text.contains("Sheet 2: Notes"))
+    }
+
+    @Test func fileReadCanFocusWorkbookSheetAndRowRange() async throws {
+        let fixture = try await Self.fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let tool = FileReadTool(rootPath: fixture.root, documentRegistry: fixture.registry)
+        let result = try await tool.execute(
+            argumentsJSON:
+                #"{"path":"workbook.xlsx","sheet_name":"Notes","start_line":2,"end_line":2,"max_rows":5,"max_columns":3}"#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let text = try Self.text(from: result)
+        #expect(text.contains("Sheet 2: Notes"))
+        #expect(text.contains("Preview rows 2-2"))
+        #expect(text.contains("row 2: A2=Owner | B2=Finance"))
+        #expect(text.contains("Sheet 1: Revenue") == false)
+    }
+
+    @Test func fileReadRejectsUnknownWorkbookSheet() async throws {
+        let fixture = try await Self.fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let tool = FileReadTool(rootPath: fixture.root, documentRegistry: fixture.registry)
+
+        await #expect(throws: FolderToolError.self) {
+            _ = try await tool.execute(argumentsJSON: #"{"path":"workbook.xlsx","sheet_name":"Missing"}"#)
+        }
+    }
+
+    @Test func folderCoreToolsDoNotAddWorkbookSpecificDefaults() {
+        let names = FolderToolFactory.buildCoreTools(rootPath: Self.tmpRoot()).map(\.name)
+
+        #expect(names.contains("file_read"))
+        #expect(names.contains("read_workbook") == false)
+        #expect(names.contains("read_workbook_cell") == false)
+        #expect(names.contains("write_workbook") == false)
+    }
+
+    private struct Fixture {
+        let root: URL
+        let registry: DocumentFormatRegistry
+    }
+
+    private static func fixture() async throws -> Fixture {
+        let root = tmpRoot()
+        let registry = DocumentFormatRegistry()
+        registry.register(adapter: XLSXAdapter())
+
+        try await XLSXEmitter().emit(
+            document(workbook: workbook()),
+            to: root.appendingPathComponent("workbook.xlsx")
+        )
+        return Fixture(root: root, registry: registry)
+    }
+
+    private static func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-file-read-workbook-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func text(from result: String) throws -> String {
+        let payload = try #require(ToolEnvelope.successPayload(result) as? [String: Any])
+        return try #require(payload["text"] as? String)
+    }
+
+    private static func document(workbook: Workbook) -> StructuredDocument {
+        StructuredDocument(
+            formatId: "xlsx",
+            filename: "workbook.xlsx",
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: ""
+        )
+    }
+
+    private static func workbook() -> Workbook {
+        Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            sheetName: "Revenue",
+                            sheetIndex: 0,
+                            cells: [
+                                cell(
+                                    "A1",
+                                    row: 1,
+                                    column: 1,
+                                    value: .string("Month"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell(
+                                    "B1",
+                                    row: 1,
+                                    column: 2,
+                                    value: .string("Amount"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell(
+                                    "C1",
+                                    row: 1,
+                                    column: 3,
+                                    value: .string("Approved"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            sheetName: "Revenue",
+                            sheetIndex: 0,
+                            cells: [
+                                cell(
+                                    "A2",
+                                    row: 2,
+                                    column: 1,
+                                    value: .string("January"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .number(1200),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell("C2", row: 2, column: 3, value: .bool(true), sheetName: "Revenue", sheetIndex: 0),
+                            ]
+                        ),
+                    ],
+                    mergedRanges: [Workbook.CellRange(reference: "A5:B5")],
+                    anchor: sheetAnchor(name: "Revenue", index: 0)
+                ),
+                Workbook.Sheet(
+                    name: "Notes",
+                    index: 1,
+                    rows: [
+                        row(
+                            number: 1,
+                            sheetName: "Notes",
+                            sheetIndex: 1,
+                            cells: [
+                                cell(
+                                    "A1",
+                                    row: 1,
+                                    column: 1,
+                                    value: .string("Label"),
+                                    sheetName: "Notes",
+                                    sheetIndex: 1
+                                ),
+                                cell(
+                                    "B1",
+                                    row: 1,
+                                    column: 2,
+                                    value: .string("Value"),
+                                    sheetName: "Notes",
+                                    sheetIndex: 1
+                                ),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            sheetName: "Notes",
+                            sheetIndex: 1,
+                            cells: [
+                                cell(
+                                    "A2",
+                                    row: 2,
+                                    column: 1,
+                                    value: .string("Owner"),
+                                    sheetName: "Notes",
+                                    sheetIndex: 1
+                                ),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .string("Finance"),
+                                    sheetName: "Notes",
+                                    sheetIndex: 1
+                                ),
+                            ]
+                        ),
+                    ],
+                    anchor: sheetAnchor(name: "Notes", index: 1)
+                ),
+            ]
+        )
+    }
+
+    private static func row(
+        number: Int,
+        sheetName: String,
+        sheetIndex: Int,
+        cells: [Workbook.Cell]
+    ) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(
+                kind: .row,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .row, index: number - 1),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: DocumentSourceLocation(sheetIndex: sheetIndex, sheetName: sheetName, rowIndex: number - 1)
+                ),
+                label: "\(sheetName) row \(number)"
+            )
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        sheetName: String,
+        sheetIndex: Int
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .cell, identifier: reference),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: .cell(sheetName: sheetName, rowIndex: row - 1, columnIndex: column - 1)
+                ),
+                label: "\(sheetName)!\(reference)"
+            )
+        )
+    }
+
+    private static func sheetAnchor(name: String, index: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .sheet,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: name, index: index),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(sheetIndex: index, sheetName: name)
+            ),
+            label: name,
+            metadata: ["sheetIndex": "\(index)"]
+        )
+    }
+}

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -107,7 +107,7 @@ Built by [`FolderToolFactory`](../Packages/OsaurusCore/Folder/FolderTools.swift)
 | Tool            | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
 | `file_tree`     | List directory structure with project-aware ignore patterns. Use this instead of `ls`/`tree` in `shell_run`. |
-| `file_read`     | Read file contents (supports line ranges and tail-only mode). Use this instead of `cat`/`head`/`tail`. |
+| `file_read`     | Read text with line ranges and XLSX workbooks with bounded sheet previews. Use this instead of `cat`/`head`/`tail`. |
 | `file_write`    | Create or overwrite files. Use this instead of `echo`/`cat` heredoc. |
 | `file_edit`     | Surgical exact-string replacement. Use this instead of `sed`/`awk`. |
 | `file_search`   | ripgrep-style search across the folder. Use this instead of `grep`/`rg`/`find`. |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -632,7 +632,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 | Tool              | Category | Description                                                       |
 | ----------------- | -------- | ----------------------------------------------------------------- |
 | `file_tree`       | Core     | Directory structure with project-aware ignore patterns            |
-| `file_read`       | Core     | Read with line ranges or tail mode                                |
+| `file_read`       | Core     | Read text ranges or bounded XLSX sheet previews                   |
 | `file_write`      | Core     | Create or overwrite                                               |
 | `file_edit`       | Core     | Surgical exact-string replacement                                 |
 | `file_search`     | Core     | ripgrep-style search                                              |


### PR DESCRIPTION
## Business rationale

Maintainer feedback on #1177 called out that new default workbook tools could burden local models, and asked whether this could be handled through the existing `read_file` surface instead. This PR makes XLSX inspection available through `file_read`, so agents can inspect workbook content when a folder contains spreadsheets without adding new default tool names or increasing the baseline tool-selection surface.

## Coding rationale

The implementation routes workbook reads through the existing document format adapter/registry path and the existing folder tool containment checks rather than introducing workbook-specific defaults. It deliberately keeps write/edit workbook tools out of scope, bounds sheet previews by row and column caps, supports sheet/range focus through the existing read arguments, and surfaces security/metadata details already produced by the XLSX adapter.

## Acceptance criteria

- [x] `file_read` can read `.xlsx` files and return a bounded workbook preview.
- [x] Workbook reads can focus a sheet and row range without exposing new default workbook tools.
- [x] Invalid sheet names are rejected with a clear error.
- [x] `read_workbook`, `read_workbook_cell`, and `write_workbook` are not registered as folder defaults.
- [x] Docs describe workbook previews as part of `file_read`, not as new default tools.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean exit
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed with `git fetch --all --prune` before gate and before push

## Debug evidence

```text
swift test --package-path Packages/OsaurusCore --filter FileReadWorkbookTests
✔ Test folderCoreToolsDoNotAddWorkbookSpecificDefaults() passed
✔ Test fileReadRejectsUnknownWorkbookSheet() passed
✔ Test fileReadCanFocusWorkbookSheetAndRowRange() passed
✔ Test fileReadReturnsBoundedWorkbookPreview() passed
✔ Test run with 4 tests in 1 suite passed after 0.010 seconds.

Full local gate on e2dc65c388b05a4b55570ea0d5457825d2de1d28:
[1/6] swift-format
[2/6] swiftlint
Done linting! Found 1286 violations, 0 serious in 693 files.
[3/6] shellcheck
[4/6] CLI tests
[77/77] Testing OsaurusCLITests.ToolsPackageTests/testFindDylibsIgnoresNonDylibExtensions
[5/6] make ci-test
Done. Inspect failures with: open build/Tests.xcresult
[6/6] release build
Build complete! (329.69s)
QUALITY_GATE_OK
```

## Rollback

`git revert e2dc65c388b05a4b55570ea0d5457825d2de1d28`
