### PR TITLE
[codex] Harden generated XLSX cell output

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
@@ -274,6 +274,7 @@ public struct XLSXEmitter: DocumentFormatEmitter {
 
     private static let maxRows = 1_048_576
     private static let maxColumns = 16_384
+    private static let maxCellTextUTF16Units = 32_767
     private static let invalidSheetNameCharacters = CharacterSet(charactersIn: "[]:*?/\\")
 
     private static func validatedSheets(_ sheets: [Workbook.Sheet]) throws -> [Workbook.Sheet] {
@@ -328,11 +329,22 @@ public struct XLSXEmitter: DocumentFormatEmitter {
                 guard cell.rowNumber >= 1, cell.rowNumber <= maxRows else {
                     throw writeFailed("\(sheetName)!\(cell.reference) is outside XLSX row bounds")
                 }
+                if case .string(let value) = cell.value {
+                    try validateCellText(value, reference: "\(sheetName)!\(cell.reference)")
+                }
                 let normalizedReference = cell.reference.uppercased()
                 guard cellReferences.insert(normalizedReference).inserted else {
                     throw writeFailed("\(sheetName) contains duplicate cell \(cell.reference)")
                 }
             }
+        }
+    }
+
+    private static func validateCellText(_ value: String, reference: String) throws {
+        guard value.utf16.count <= maxCellTextUTF16Units else {
+            throw writeFailed(
+                "\(reference) text exceeds Excel's \(maxCellTextUTF16Units)-character cell limit"
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/XLSXEmitterTests.swift
@@ -86,6 +86,37 @@ struct XLSXEmitterTests {
         }
     }
 
+    @Test func emit_keepsFormulaLookingTextInert() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await XLSXEmitter().emit(
+            Self.document(
+                workbook: Self.singleCellWorkbook(value: .string("=HYPERLINK(\"https://example.com\")"))
+            ),
+            to: url
+        )
+
+        let parsed = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        let workbook = try #require(parsed.representation.underlying as? Workbook)
+        let sheet = try #require(workbook.sheets.first)
+        #expect(sheet.cell("A1")?.value == .string("=HYPERLINK(\"https://example.com\")"))
+        #expect(sheet.cell("A1")?.formula == nil)
+    }
+
+    @Test func emit_rejectsStringsBeyondExcelCellLimit() async throws {
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let overlong = String(repeating: "a", count: 32_768)
+
+        await #expect(throws: DocumentAdapterError.self) {
+            try await XLSXEmitter().emit(
+                Self.document(workbook: Self.singleCellWorkbook(value: .string(overlong))),
+                to: url
+            )
+        }
+    }
+
     @Test func bootstrap_registersXLSXEmitter() {
         let registry = DocumentFormatRegistry()
 
@@ -220,6 +251,35 @@ struct XLSXEmitterTests {
                     index: 0,
                     rows: rows,
                     anchor: sheetAnchor(name: "Empty", index: 0)
+                )
+            ]
+        )
+    }
+
+    private static func singleCellWorkbook(value: Workbook.CellValue) -> Workbook {
+        Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Sheet1",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            sheetName: "Sheet1",
+                            sheetIndex: 0,
+                            cells: [
+                                cell(
+                                    "A1",
+                                    row: 1,
+                                    column: 1,
+                                    value: value,
+                                    sheetName: "Sheet1",
+                                    sheetIndex: 0
+                                )
+                            ]
+                        )
+                    ],
+                    anchor: sheetAnchor(name: "Sheet1", index: 0)
                 )
             ]
         )


### PR DESCRIPTION
## Business rationale

Generated XLSX output should be safe and predictable for users opening workbooks in Excel-compatible tools. This PR prevents generated workbooks from writing oversized cell text that Excel cannot represent, and it proves formula-looking user text remains inert text instead of becoming an executable spreadsheet formula.

## Coding rationale

The guard sits at the XLSX emitter boundary, where the workbook is serialized and where Excel's 32,767 UTF-16-unit cell-text limit is easiest to enforce. The implementation keeps the existing shared-string path for `.string` values, does not add formula generation, and adds focused tests around the two high-risk behaviors. No new external dependencies are added.

## Acceptance criteria

- Reject string cell content above Excel's 32,767 UTF-16-unit limit.
- Preserve formula-looking strings as shared-string text, not formula cells.
- Keep the existing workbook validation behavior for empty workbooks and formula cells.
- Pass the full local quality gate on the lane head.

## Quality gate

Ran on `76a292522b840dccc28bae11cf884bc12b90932f` after `git fetch --all --prune`; `origin/main` was `a692991362fcd247b069a2c6d9e2c0b0f22e1fb9` and was an ancestor of the lane head.

```text
swift-format lint --strict --recursive Packages App
swiftlint lint --reporter github-actions-logging
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
swift test --package-path Packages/OsaurusCLI --parallel
make ci-test
swift build --package-path Packages/OsaurusCore -c release
QUALITY_GATE_OK
```

## Debug evidence

```text
HEAD 76a292522b840dccc28bae11cf884bc12b90932f
origin/main a692991362fcd247b069a2c6d9e2c0b0f22e1fb9
[1/6] swift-format
[2/6] swiftlint
[3/6] shellcheck
[4/6] CLI tests
[5/6] make ci-test
[6/6] release build
Build complete! (386.15s)
QUALITY_GATE_OK
```

Focused XLSX emitter coverage was also run before the full gate:

```text
swift test --package-path Packages/OsaurusCore --filter XLSXEmitterTests
Test run with 8 tests in 1 suite passed
```

## Rollback

Revert `76a292522b840dccc28bae11cf884bc12b90932f`.
