### PR TITLE
[codex] Harden StatsPack schema metadata

### DIFF
--- a/Packages/OsaurusPlugins/StatsPack/README.md
+++ b/Packages/OsaurusPlugins/StatsPack/README.md
@@ -8,7 +8,11 @@ First-party statistics/data-science format pack for the in-process v1
 - CSV with an optional JSON `.csvschema` sidecar. The sidecar may be either
   `data.csvschema` or `data.csv.csvschema`, and should contain
   `{ "columns": [{ "name": "field", "type": "string" }] }`.
-- TSV as UTF-8 tab-delimited rows.
+- TSV as UTF-8 tab-delimited rows, with the same optional schema behavior via
+  `.tsvschema` sidecars.
+- Delimited rows stream without buffering the full file. Records include
+  path-free metadata for delimiter, schema columns, header rows, line number,
+  and column count.
 - JSONL as one JSON value per line. Object records stream fields in sorted-key
   order; arrays and scalars stream positionally.
 - SQLite read-only for `.sqlite`, `.sqlite3`, and `.db` files. The adapter uses

--- a/Packages/OsaurusPlugins/StatsPack/Sources/OsaurusStatsPack/DelimitedText.swift
+++ b/Packages/OsaurusPlugins/StatsPack/Sources/OsaurusStatsPack/DelimitedText.swift
@@ -23,11 +23,12 @@ public struct CSVWithSchemaAdapter: FormatAdapter {
                 pathExtension: url.pathExtension.lowercased()
             )
         }
-        let schema = try CSVSchema.load(for: url)
+        let schema = try DelimitedTextSchema.load(for: url, sidecarExtension: "csvschema")
         let reference = try documentReference(
             url: url,
             formatIdentifier: Self.formatIdentifier,
-            metadata: schema?.referenceMetadata ?? ["schemaSidecar": "false"]
+            metadata: schema?.referenceMetadata(delimiter: "comma")
+                ?? ["delimiter": "comma", "schemaSidecar": "false"]
         )
         state.update(url: url, reference: reference)
         return reference
@@ -38,12 +39,14 @@ public struct CSVWithSchemaAdapter: FormatAdapter {
         guard let opened = state.openedDocument() else {
             throw FormatAdapterError.documentNotOpened(formatIdentifier: Self.formatIdentifier)
         }
-        let schema = try CSVSchema.load(for: opened.url)
+        let schema = try DelimitedTextSchema.load(for: opened.url, sidecarExtension: "csvschema")
         try streamDelimitedRecords(
             at: opened.url,
             delimiter: ",",
             reference: opened.reference,
-            extraMetadata: schema?.recordMetadata ?? ["schemaSidecar": "false"],
+            schema: schema,
+            extraMetadata: schema?.streamMetadata(delimiter: "comma")
+                ?? ["delimiter": "comma", "schemaSidecar": "false"],
             into: continuation
         )
     }
@@ -66,10 +69,12 @@ public struct TSVStatsAdapter: FormatAdapter {
                 pathExtension: url.pathExtension.lowercased()
             )
         }
+        let schema = try DelimitedTextSchema.load(for: url, sidecarExtension: "tsvschema")
         let reference = try documentReference(
             url: url,
             formatIdentifier: Self.formatIdentifier,
-            metadata: ["delimiter": "tab"]
+            metadata: schema?.referenceMetadata(delimiter: "tab")
+                ?? ["delimiter": "tab", "schemaSidecar": "false"]
         )
         state.update(url: url, reference: reference)
         return reference
@@ -80,17 +85,20 @@ public struct TSVStatsAdapter: FormatAdapter {
         guard let opened = state.openedDocument() else {
             throw FormatAdapterError.documentNotOpened(formatIdentifier: Self.formatIdentifier)
         }
+        let schema = try DelimitedTextSchema.load(for: opened.url, sidecarExtension: "tsvschema")
         try streamDelimitedRecords(
             at: opened.url,
             delimiter: "\t",
             reference: opened.reference,
-            extraMetadata: ["delimiter": "tab"],
+            schema: schema,
+            extraMetadata: schema?.streamMetadata(delimiter: "tab")
+                ?? ["delimiter": "tab", "schemaSidecar": "false"],
             into: continuation
         )
     }
 }
 
-private struct CSVSchema {
+private struct DelimitedTextSchema {
     struct Column {
         let name: String
         let type: String?
@@ -98,8 +106,15 @@ private struct CSVSchema {
 
     let columns: [Column]
 
-    var referenceMetadata: [String: String] {
+    func referenceMetadata(delimiter: String) -> [String: String] {
+        var metadata = streamMetadata(delimiter: delimiter)
+        metadata["schemaSidecar"] = "true"
+        return metadata
+    }
+
+    func streamMetadata(delimiter: String) -> [String: String] {
         var metadata = recordMetadata
+        metadata["delimiter"] = delimiter
         metadata["schemaSidecar"] = "true"
         return metadata
     }
@@ -108,15 +123,17 @@ private struct CSVSchema {
         var metadata = [
             "schemaColumnNames": columns.map(\.name).joined(separator: "\t")
         ]
-        let types = columns.compactMap(\.type)
-        if !types.isEmpty {
+        if columns.contains(where: { $0.type != nil }) {
+            let types = columns.map { $0.type ?? "" }
             metadata["schemaColumnTypes"] = types.joined(separator: "\t")
         }
         return metadata
     }
 
-    static func load(for url: URL) throws -> CSVSchema? {
-        guard let sidecar = schemaSidecarURL(for: url) else { return nil }
+    static func load(for url: URL, sidecarExtension: String) throws -> DelimitedTextSchema? {
+        guard let sidecar = schemaSidecarURL(for: url, sidecarExtension: sidecarExtension) else {
+            return nil
+        }
         let data = try Data(contentsOf: sidecar)
         let root = try JSONSerialization.jsonObject(with: data)
         guard let object = root as? [String: Any], let rawColumns = object["columns"] as? [Any] else {
@@ -138,13 +155,13 @@ private struct CSVSchema {
         guard !columns.isEmpty else {
             throw StatsPackError.invalidSchemaSidecar("columns must not be empty")
         }
-        return CSVSchema(columns: columns)
+        return DelimitedTextSchema(columns: columns)
     }
 
-    private static func schemaSidecarURL(for url: URL) -> URL? {
+    private static func schemaSidecarURL(for url: URL, sidecarExtension: String) -> URL? {
         let candidates = [
-            url.deletingPathExtension().appendingPathExtension("csvschema"),
-            url.appendingPathExtension("csvschema"),
+            url.deletingPathExtension().appendingPathExtension(sidecarExtension),
+            url.appendingPathExtension(sidecarExtension),
         ]
         return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
     }
@@ -154,23 +171,39 @@ private func streamDelimitedRecords(
     at url: URL,
     delimiter: Character,
     reference: DocumentReference,
+    schema: DelimitedTextSchema?,
     extraMetadata: [String: String],
     into continuation: AsyncStream<Record>.Continuation
 ) throws {
+    let schemaColumns = schema?.columns.map(\.name)
+    var headerColumns: [String]?
+    var rowIndex = 0
     try TextLineReader.forEachLine(at: url) { line, lineNumber in
         let fields = try DelimitedLineParser.parse(line, delimiter: delimiter, lineNumber: lineNumber)
         var metadata = extraMetadata
         metadata["documentId"] = reference.id.uuidString
         metadata["formatIdentifier"] = reference.formatIdentifier
         metadata["lineNumber"] = "\(lineNumber)"
+        metadata["columnCount"] = "\(fields.count)"
+
+        if rowIndex == 0, schemaColumns == nil || schemaColumns == fields {
+            headerColumns = fields
+            metadata["rowKind"] = "header"
+        } else {
+            metadata["rowKind"] = "data"
+        }
+        if let headerColumns {
+            metadata["headerColumnNames"] = headerColumns.joined(separator: "\t")
+        }
         continuation.yield(
             Record(
-                index: lineNumber - 1,
+                index: rowIndex,
                 fields: fields,
                 anchorIdentifier: "line/\(lineNumber)",
                 metadata: metadata
             )
         )
+        rowIndex += 1
     }
 }
 

--- a/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/DelimitedTextAdapterTests.swift
+++ b/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/DelimitedTextAdapterTests.swift
@@ -33,6 +33,8 @@ struct DelimitedTextAdapterTests {
         #expect(reference.metadata["schemaSidecar"] == "true")
         #expect(reference.metadata["schemaColumnNames"] == "name\tscore")
         #expect(records.map(\.fields) == [["name", "score"], ["Ada", "98.5"]])
+        #expect(records[0].metadata["rowKind"] == "header")
+        #expect(records[1].metadata["headerColumnNames"] == "name\tscore")
         #expect(records[1].metadata["schemaColumnTypes"] == "string\tfloat")
     }
 
@@ -45,7 +47,10 @@ struct DelimitedTextAdapterTests {
         let records = try await TestHelpers.collectRecords(from: adapter)
 
         #expect(reference.metadata["schemaSidecar"] == "false")
+        #expect(reference.metadata["delimiter"] == "comma")
         #expect(records[1].fields == ["Paris", "3"])
+        #expect(records[1].metadata["rowKind"] == "data")
+        #expect(records[1].metadata["columnCount"] == "2")
     }
 
     @Test func csvWithSchema_unescapesQuotedFields() async throws {
@@ -59,6 +64,32 @@ struct DelimitedTextAdapterTests {
         #expect(records[1].fields == ["Ada", "hi, \"team\""])
     }
 
+    @Test func csvWithSchema_treatsFirstRowAsDataWhenSchemaNamesDoNotMatch() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let csvURL = directory.appendingPathComponent("measurements.csv")
+        try "Ada,98.5\n".write(to: csvURL, atomically: true, encoding: .utf8)
+        try """
+        { "columns": [{ "name": "name", "type": "string" }, { "name": "score", "type": "float" }] }
+        """.write(
+            to: directory.appendingPathComponent("measurements.csvschema"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let adapter = CSVWithSchemaAdapter()
+        _ = try adapter.openDocument(at: csvURL)
+        let records = try await TestHelpers.collectRecords(from: adapter)
+
+        #expect(records[0].fields == ["Ada", "98.5"])
+        #expect(records[0].metadata["rowKind"] == "data")
+        #expect(records[0].metadata["headerColumnNames"] == nil)
+        #expect(records[0].metadata["schemaColumnNames"] == "name\tscore")
+    }
+
     @Test func tsv_streamsTabDelimitedRows() async throws {
         let url = try TestHelpers.write("name\trole\nAda\tengineer\n", filename: "people.tsv")
         defer { try? FileManager.default.removeItem(at: url) }
@@ -68,7 +99,9 @@ struct DelimitedTextAdapterTests {
         let records = try await TestHelpers.collectRecords(from: adapter)
 
         #expect(reference.metadata["delimiter"] == "tab")
+        #expect(reference.metadata["schemaSidecar"] == "false")
         #expect(records[1].fields == ["Ada", "engineer"])
+        #expect(records[1].metadata["headerColumnNames"] == "name\trole")
     }
 
     @Test func tsv_preservesEmptyCells() async throws {
@@ -80,6 +113,34 @@ struct DelimitedTextAdapterTests {
         let records = try await TestHelpers.collectRecords(from: adapter)
 
         #expect(records[0].fields == ["left", "", "middle"])
+    }
+
+    @Test func tsvWithSchema_streamsRowsWithSidecarMetadata() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let tsvURL = directory.appendingPathComponent("samples.tsv")
+        try "sample\tvalue\nrun-1\t42\n".write(to: tsvURL, atomically: true, encoding: .utf8)
+        try """
+        { "columns": [{ "name": "sample", "type": "string" }, { "name": "value" }] }
+        """.write(
+            to: directory.appendingPathComponent("samples.tsvschema"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let adapter = TSVStatsAdapter()
+        let reference = try adapter.openDocument(at: tsvURL)
+        let records = try await TestHelpers.collectRecords(from: adapter)
+
+        #expect(reference.metadata["schemaSidecar"] == "true")
+        #expect(reference.metadata["schemaColumnNames"] == "sample\tvalue")
+        #expect(reference.metadata["schemaColumnTypes"] == "string\t")
+        #expect(records[0].metadata["rowKind"] == "header")
+        #expect(records[1].metadata["schemaSidecar"] == "true")
+        #expect(records[1].fields == ["run-1", "42"])
     }
 
     @Test func tsv_rejectsWrongExtension() throws {

--- a/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/SQLiteReadOnlyAdapterTests.swift
+++ b/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/SQLiteReadOnlyAdapterTests.swift
@@ -36,6 +36,26 @@ struct SQLiteReadOnlyAdapterTests {
         #expect(records.isEmpty == false)
     }
 
+    @Test func streamsRowsWithoutPhysicalPathMetadata() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = try TestHelpers.writeSQLiteFixture(in: directory)
+        let adapter = SQLiteReadOnlyAdapter()
+        let reference = try adapter.openDocument(at: url)
+        let records = try await TestHelpers.collectRecords(from: adapter)
+        let metadataValues =
+            Array(reference.metadata.values)
+            + records.flatMap { Array($0.metadata.values) }
+
+        #expect(reference.displayName == url.lastPathComponent)
+        #expect(metadataValues.allSatisfy { !$0.contains(url.path) })
+        #expect(metadataValues.allSatisfy { !$0.contains(directory.path) })
+        #expect(records.allSatisfy { $0.anchorIdentifier?.contains(url.path) != true })
+    }
+
     @Test func registryDetectsSQLiteMagicBytes() throws {
         let registry = FormatAdapterRegistry()
         try registry.register(SQLiteReadOnlyAdapter.self) { SQLiteReadOnlyAdapter() }
@@ -54,6 +74,22 @@ struct SQLiteReadOnlyAdapterTests {
 
         await #expect(throws: SQLiteReadOnlyRecordStreamerError.self) {
             _ = try await TestHelpers.collectRecords(from: adapter)
+        }
+    }
+
+    @Test func invalidSQLiteErrorsRemainPathFree() async throws {
+        let url = try TestHelpers.write("not sqlite", filename: "bad.sqlite")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let adapter = SQLiteReadOnlyAdapter()
+        _ = try adapter.openDocument(at: url)
+
+        do {
+            _ = try await TestHelpers.collectRecords(from: adapter)
+            Issue.record("Expected invalid SQLite streaming to fail")
+        } catch {
+            #expect(error.localizedDescription.contains(url.path) == false)
+            #expect(error.localizedDescription.contains(url.deletingLastPathComponent().path) == false)
         }
     }
 }

--- a/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/TestHelpers.swift
+++ b/Packages/OsaurusPlugins/StatsPack/Tests/OsaurusStatsPackTests/TestHelpers.swift
@@ -16,8 +16,13 @@ enum TestHelpers {
         return url
     }
 
-    static func writeSQLiteFixture(extension pathExtension: String = "sqlite") throws -> URL {
-        let url = FileManager.default.temporaryDirectory
+    static func writeSQLiteFixture(
+        extension pathExtension: String = "sqlite",
+        in directory: URL? = nil
+    ) throws -> URL {
+        let root = directory ?? FileManager.default.temporaryDirectory
+        let url =
+            root
             .appendingPathComponent("\(UUID().uuidString)-stats.\(pathExtension)")
         let data = Data(base64Encoded: sqliteFixtureBase64, options: .ignoreUnknownCharacters)!
         try data.write(to: url, options: .atomic)


### PR DESCRIPTION
## Summary
Harden the first-party StatsPack plugin metadata for delimited text and SQLite records.

## Business rationale
StatsPack CSV/TSV/SQLite records should carry useful, path-free schema and row metadata so local agents can reason about data tables without leaking local filesystem paths or loading full files. This extends the merged StatsPack surface with precise delimiter, schema, header, and column metadata while keeping the feature optional and outside the default tool set.

## Coding rationale
The change stays additive inside the existing first-party StatsPack package. It generalizes the CSV schema loader into a delimited-text schema helper, computes schema/header metadata once, streams rows through the existing parser, and adds focused tests for TSV schema sidecars and SQLite path-free metadata. It adds no external dependencies and does not register new default tools.

## Acceptance criteria
- CSV schema sidecars expose delimiter, sidecar name, schema column names, and schema column types.
- TSV files can use `.tsvschema` sidecars and stream row metadata with the tab delimiter.
- Rows include line number, column count, row kind, and header names when available.
- Schema mismatches treat the first row as data instead of silently labeling it as a header.
- SQLite record and error metadata remains path-free.

## Quality gate
All six required gate commands passed on `96cc03e7e5b777421a3a965f9ace9d18d54c4955`:

```text
[1/6] swift-format
[2/6] swiftlint
[3/6] shellcheck
[4/6] CLI tests
[5/6] make ci-test
[6/6] release build
QUALITY_GATE_OK
```

## Debug evidence
```text
swift test --package-path Packages/OsaurusPlugins/StatsPack
✔ Test csvWithSchema_treatsFirstRowAsDataWhenSchemaNamesDoNotMatch() passed
✔ Test tsvWithSchema_streamsRowsWithSidecarMetadata() passed
✔ Test streamsRowsWithoutPhysicalPathMetadata() passed
✔ Test invalidSQLiteErrorsRemainPathFree() passed
✔ Test run with 20 tests in 4 suites passed after 0.008 seconds.
```

```text
swift-format lint --strict --recursive Packages App
swiftlint lint --reporter github-actions-logging
find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
swift test --package-path Packages/OsaurusCLI --parallel
make ci-test
swift build --package-path Packages/OsaurusCore -c release
QUALITY_GATE_OK
```

## Rollback
`git revert 96cc03e7e5b777421a3a965f9ace9d18d54c4955`
