### PR TITLE
chat polish with smoother streaming, stable tool call animations and scroll cache fixes

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -20889,6 +20889,9 @@
         }
       }
     },
+    "Smooth streaming" : {
+
+    },
     "Soft-Delete %lld Rows" : {
       "comment" : "Auto-extracted format-string key (Apple String.LocalizationValue canonical form).",
       "extractionState" : "manual",

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -19,6 +19,35 @@
 
 import Foundation
 
+/// Temporary pacing diagnostic logger — writes to /tmp/osaurus-pacing.log.
+enum PacingLog {
+    static let url = URL(fileURLWithPath: "/tmp/osaurus-pacing.log")
+    private static let queue = DispatchQueue(label: "osaurus.pacing.log")
+    nonisolated(unsafe) private static var sessionStartLogged = false
+    static func log(_ msg: String) {
+        let t = CFAbsoluteTimeGetCurrent()
+        queue.async {
+            if !sessionStartLogged {
+                sessionStartLogged = true
+                let header = "===== session start \(Date()) (CACurrentMediaTime=\(t)) =====\n"
+                if let d = header.data(using: .utf8) {
+                    try? d.write(to: url)
+                }
+            }
+            let line = "[\(String(format: "%.4f", t))] \(msg)\n"
+            guard let data = line.data(using: .utf8) else { return }
+            if FileManager.default.fileExists(atPath: url.path),
+               let fh = try? FileHandle(forWritingTo: url) {
+                defer { try? fh.close() }
+                _ = try? fh.seekToEnd()
+                try? fh.write(contentsOf: data)
+            } else {
+                try? data.write(to: url)
+            }
+        }
+    }
+}
+
 /// Processes streaming LLM deltas into a ChatTurn with buffering and
 /// throttled UI updates.
 @MainActor
@@ -50,6 +79,37 @@ final class StreamingDeltaProcessor {
     private var lastFlushTime = Date()
     private var syncCount = 0
 
+    /// Paced-reveal state. When `smoothStreamingEnabled` is on, incoming
+    /// deltas accumulate in `deltaBuffer` but are revealed to the UI at a
+    /// fixed rate via `pacingTimer` instead of flushing immediately. This
+    /// hides server-side SSE micro-batching from remote providers and the
+    /// peak burst behavior of ultra-fast providers (Cerebras-class), so
+    /// streaming looks like a typewriter regardless of network delivery
+    /// pattern. Local MLX at typical token rates is unaffected — its
+    /// natural pace is below the reveal rate.
+    private var pacingTimer: Timer?
+
+    /// User-facing reveal rate floor. ~12 chars per 16ms ≈ 750 chars/s ≈
+    /// ~180 tok/s display rate. Fast enough not to drag, slow enough that
+    /// the fade-in is perceptible. Per-tick chunk size scales up
+    /// adaptively when the pending buffer is large (see `pacingTick`).
+    private static let pacingTickInterval: TimeInterval = 0.016
+    private static let pacingCharsPerTick: Int = 12
+
+    /// Number of pacing ticks (~16ms each) we aim to drain a fully-arrived
+    /// burst over. 60 ticks ≈ 1 second. Smaller bursts paced at the
+    /// natural floor rate finish sooner; larger ones accelerate to stay
+    /// within this window. Tuned so that even a 4000-char response after
+    /// finalize() drains in roughly 1s without feeling rushed.
+    private static let pacingDrainTicks: Int = 60
+
+    /// Reads `chatSmoothStreamingEnabled` from `UserDefaults` (default
+    /// true). Cheap to re-read per delta — `UserDefaults.bool(forKey:)`
+    /// is an in-memory dictionary lookup.
+    private var smoothStreamingEnabled: Bool {
+        UserDefaults.standard.object(forKey: "chatSmoothStreamingEnabled") as? Bool ?? true
+    }
+
     // MARK: - Init
 
     init(
@@ -69,6 +129,13 @@ final class StreamingDeltaProcessor {
         ChatPerfTrace.shared.count("stream.delta")
         ChatPerfTrace.shared.count("stream.deltaBytes", delta.utf8.count)
         deltaBuffer += delta
+
+        PacingLog.log("receiveDelta size=\(delta.count) bufferAfter=\(deltaBuffer.count) smooth=\(smoothStreamingEnabled) pacingTimerActive=\(pacingTimer != nil)")
+
+        if smoothStreamingEnabled {
+            startPacingTimerIfNeeded()
+            return
+        }
 
         let now = Date()
         let timeSinceFlush = now.timeIntervalSince(lastFlushTime) * 1000
@@ -121,21 +188,43 @@ final class StreamingDeltaProcessor {
     }
 
     /// Finalize streaming: drain any remaining buffer and sync to UI.
+    ///
+    /// In smooth-streaming mode we deliberately keep the pacing timer
+    /// running so the buffered tail continues to type out at the same
+    /// cadence as it did during streaming — otherwise small responses
+    /// (which arrive entirely in one network burst, finalize ~60ms
+    /// later) would show no animation at all, and long responses with
+    /// big tail buffers would dump the last several hundred chars at
+    /// once after a smooth start.
     func finalize() {
+        PacingLog.log("finalize() called bufferSize=\(deltaBuffer.count) smooth=\(smoothStreamingEnabled) pacingTimerActive=\(pacingTimer != nil)")
         invalidateTimer()
 
+        if smoothStreamingEnabled {
+            // Sync whatever's already been appended (pre-pacing). Leave
+            // the deltaBuffer alone — pacingTick will continue draining
+            // it and stop the timer when empty.
+            syncToTurn()
+            if !deltaBuffer.isEmpty {
+                startPacingTimerIfNeeded()
+            }
+            return
+        }
+
+        stopPacingTimer()
         if !deltaBuffer.isEmpty {
             let remaining = deltaBuffer
             deltaBuffer = ""
+            PacingLog.log("finalize() DRAINED \(remaining.count) chars immediately")
             appendContent(remaining)
         }
-
         syncToTurn()
     }
 
     /// Reset for a new streaming session with a new turn.
     func reset(turn: ChatTurn) {
         invalidateTimer()
+        stopPacingTimer()
         self.turn = turn
         deltaBuffer = ""
         contentLength = 0
@@ -154,6 +243,50 @@ final class StreamingDeltaProcessor {
     private func invalidateTimer() {
         flushTimer?.invalidate()
         flushTimer = nil
+    }
+
+    private func startPacingTimerIfNeeded() {
+        guard pacingTimer == nil else { return }
+        PacingLog.log("startPacingTimer pending=\(deltaBuffer.count)")
+        pacingTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.pacingTickInterval,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.pacingTick()
+            }
+        }
+    }
+
+    private func stopPacingTimer() {
+        if pacingTimer != nil {
+            PacingLog.log("stopPacingTimer pending=\(deltaBuffer.count)")
+        }
+        pacingTimer?.invalidate()
+        pacingTimer = nil
+    }
+
+    /// Drain a chunk from the head of `deltaBuffer` into the turn + push
+    /// one sync. Chunk size adapts to the pending buffer so a giant
+    /// response that arrived in one shot still finishes typing out within
+    /// ~2 seconds, while normal bursts stay at the perceptible floor rate.
+    /// Stops the timer once the buffer is drained so it doesn't idle-tick
+    /// between bursts.
+    private func pacingTick() {
+        let pending = deltaBuffer.count
+        if pending == 0 {
+            PacingLog.log("pacingTick EMPTY → stop timer")
+            stopPacingTimer()
+            return
+        }
+        let scaled = pending / Self.pacingDrainTicks
+        let take = min(pending, max(Self.pacingCharsPerTick, scaled))
+        let chunk = String(deltaBuffer.prefix(take))
+        deltaBuffer = String(deltaBuffer.dropFirst(take))
+        PacingLog.log("pacingTick pending=\(pending) take=\(take) remaining=\(deltaBuffer.count)")
+        appendContent(chunk)
+        lastFlushTime = Date()
+        syncToTurn()
     }
 
     private func appendContent(_ s: String) {

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -79,6 +79,14 @@ final class StreamingDeltaProcessor {
     private var lastFlushTime = Date()
     private var syncCount = 0
 
+    /// Continuation resumed by `pacingTick` the first time it observes
+    /// an empty `deltaBuffer` after `finalize()` started awaiting. Lets
+    /// the caller's `await processor.finalize()` block until the smooth
+    /// streaming tail has fully typed out — without this, the processor
+    /// deallocates the moment `send()` returns and the residual buffer
+    /// is silently dropped.
+    private var pacingDoneContinuation: CheckedContinuation<Void, Never>?
+
     /// Paced-reveal state. When `smoothStreamingEnabled` is on, incoming
     /// deltas accumulate in `deltaBuffer` but are revealed to the UI at a
     /// fixed rate via `pacingTimer` instead of flushing immediately. This
@@ -189,30 +197,28 @@ final class StreamingDeltaProcessor {
 
     /// Finalize streaming: drain any remaining buffer and sync to UI.
     ///
-    /// In smooth-streaming mode we deliberately keep the pacing timer
-    /// running so the buffered tail continues to type out at the same
-    /// cadence as it did during streaming — otherwise small responses
-    /// (which arrive entirely in one network burst, finalize ~60ms
-    /// later) would show no animation at all, and long responses with
-    /// big tail buffers would dump the last several hundred chars at
-    /// once after a smooth start.
-    func finalize() {
+    /// In smooth-streaming mode the residual `deltaBuffer` continues to
+    /// type out via the pacing timer. We `await` here until that buffer
+    /// is fully drained — without the await, this processor instance
+    /// deallocates the moment `send()` returns, the pacing timer's
+    /// `[weak self]` closure goes nil on the next tick, and the rest of
+    /// the response is silently dropped (the visible text ends
+    /// mid-sentence even though the model produced the full content).
+    func finalize() async {
         PacingLog.log("finalize() called bufferSize=\(deltaBuffer.count) smooth=\(smoothStreamingEnabled) pacingTimerActive=\(pacingTimer != nil)")
         invalidateTimer()
 
-        if smoothStreamingEnabled {
-            // Sync whatever's already been appended (pre-pacing). Leave
-            // the deltaBuffer alone — pacingTick will continue draining
-            // it and stop the timer when empty.
-            syncToTurn()
-            if !deltaBuffer.isEmpty {
-                startPacingTimerIfNeeded()
+        if smoothStreamingEnabled && !deltaBuffer.isEmpty {
+            startPacingTimerIfNeeded()
+            // Block here until `pacingTick` empties the buffer and
+            // resumes us. The processor stays alive for the duration
+            // because the surrounding `send(...)` is awaiting.
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                self.pacingDoneContinuation = continuation
             }
-            return
-        }
-
-        stopPacingTimer()
-        if !deltaBuffer.isEmpty {
+        } else if !deltaBuffer.isEmpty {
+            // Non-smooth path: drain immediately.
+            stopPacingTimer()
             let remaining = deltaBuffer
             deltaBuffer = ""
             PacingLog.log("finalize() DRAINED \(remaining.count) chars immediately")
@@ -277,6 +283,11 @@ final class StreamingDeltaProcessor {
         if pending == 0 {
             PacingLog.log("pacingTick EMPTY → stop timer")
             stopPacingTimer()
+            // Wake up `finalize()` if it's waiting for the tail to drain.
+            if let cont = pacingDoneContinuation {
+                pacingDoneContinuation = nil
+                cont.resume()
+            }
             return
         }
         let scaled = pending / Self.pacingDrainTicks

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -19,35 +19,6 @@
 
 import Foundation
 
-/// Temporary pacing diagnostic logger — writes to /tmp/osaurus-pacing.log.
-enum PacingLog {
-    static let url = URL(fileURLWithPath: "/tmp/osaurus-pacing.log")
-    private static let queue = DispatchQueue(label: "osaurus.pacing.log")
-    nonisolated(unsafe) private static var sessionStartLogged = false
-    static func log(_ msg: String) {
-        let t = CFAbsoluteTimeGetCurrent()
-        queue.async {
-            if !sessionStartLogged {
-                sessionStartLogged = true
-                let header = "===== session start \(Date()) (CACurrentMediaTime=\(t)) =====\n"
-                if let d = header.data(using: .utf8) {
-                    try? d.write(to: url)
-                }
-            }
-            let line = "[\(String(format: "%.4f", t))] \(msg)\n"
-            guard let data = line.data(using: .utf8) else { return }
-            if FileManager.default.fileExists(atPath: url.path),
-               let fh = try? FileHandle(forWritingTo: url) {
-                defer { try? fh.close() }
-                _ = try? fh.seekToEnd()
-                try? fh.write(contentsOf: data)
-            } else {
-                try? data.write(to: url)
-            }
-        }
-    }
-}
-
 /// Processes streaming LLM deltas into a ChatTurn with buffering and
 /// throttled UI updates.
 @MainActor
@@ -138,8 +109,6 @@ final class StreamingDeltaProcessor {
         ChatPerfTrace.shared.count("stream.deltaBytes", delta.utf8.count)
         deltaBuffer += delta
 
-        PacingLog.log("receiveDelta size=\(delta.count) bufferAfter=\(deltaBuffer.count) smooth=\(smoothStreamingEnabled) pacingTimerActive=\(pacingTimer != nil)")
-
         if smoothStreamingEnabled {
             startPacingTimerIfNeeded()
             return
@@ -205,7 +174,6 @@ final class StreamingDeltaProcessor {
     /// the response is silently dropped (the visible text ends
     /// mid-sentence even though the model produced the full content).
     func finalize() async {
-        PacingLog.log("finalize() called bufferSize=\(deltaBuffer.count) smooth=\(smoothStreamingEnabled) pacingTimerActive=\(pacingTimer != nil)")
         invalidateTimer()
 
         if smoothStreamingEnabled && !deltaBuffer.isEmpty {
@@ -221,7 +189,6 @@ final class StreamingDeltaProcessor {
             stopPacingTimer()
             let remaining = deltaBuffer
             deltaBuffer = ""
-            PacingLog.log("finalize() DRAINED \(remaining.count) chars immediately")
             appendContent(remaining)
         }
         syncToTurn()
@@ -253,7 +220,6 @@ final class StreamingDeltaProcessor {
 
     private func startPacingTimerIfNeeded() {
         guard pacingTimer == nil else { return }
-        PacingLog.log("startPacingTimer pending=\(deltaBuffer.count)")
         pacingTimer = Timer.scheduledTimer(
             withTimeInterval: Self.pacingTickInterval,
             repeats: true
@@ -265,9 +231,6 @@ final class StreamingDeltaProcessor {
     }
 
     private func stopPacingTimer() {
-        if pacingTimer != nil {
-            PacingLog.log("stopPacingTimer pending=\(deltaBuffer.count)")
-        }
         pacingTimer?.invalidate()
         pacingTimer = nil
     }
@@ -281,7 +244,6 @@ final class StreamingDeltaProcessor {
     private func pacingTick() {
         let pending = deltaBuffer.count
         if pending == 0 {
-            PacingLog.log("pacingTick EMPTY → stop timer")
             stopPacingTimer()
             // Wake up `finalize()` if it's waiting for the tail to drain.
             if let cont = pacingDoneContinuation {
@@ -294,7 +256,6 @@ final class StreamingDeltaProcessor {
         let take = min(pending, max(Self.pacingCharsPerTick, scaled))
         let chunk = String(deltaBuffer.prefix(take))
         deltaBuffer = String(deltaBuffer.dropFirst(take))
-        PacingLog.log("pacingTick pending=\(pending) take=\(take) remaining=\(deltaBuffer.count)")
         appendContent(chunk)
         lastFlushTime = Date()
         syncToTurn()

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1812,12 +1812,12 @@ final class ChatSession: ObservableObject {
         do {
             for try await delta in stream {
                 if !isRunActive(runId) {
-                    processor.finalize()
+                    await processor.finalize()
                     return ([], currentTurn)
                 }
                 // Server-side tool call complete: add the call card + result turn to the chat log
                 if let done = StreamingToolHint.decodeDone(delta) {
-                    processor.finalize()
+                    await processor.finalize()
                     let call = ToolCall(
                         id: done.callId,
                         type: "function",
@@ -1942,8 +1942,12 @@ final class ChatSession: ObservableObject {
             capturedInvocations = [inv]
         }
 
-        // Flush any remaining buffered content (including partial tags)
-        processor.finalize()
+        // Flush any remaining buffered content (including partial tags).
+        // In smooth-streaming mode this awaits until the pacing tail
+        // finishes typing out — keeping the processor alive past
+        // `send()`'s return so the residual buffer is rendered, not
+        // dropped on dealloc.
+        await processor.finalize()
 
         if let first = firstDeltaTime {
             currentTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
@@ -2848,7 +2852,7 @@ final class ChatSession: ObservableObject {
                                 if !isRunActive(runId) { break }
                                 if !delta.isEmpty { processor.receiveDelta(delta) }
                             }
-                            processor.finalize()
+                            await processor.finalize()
                         } catch {
                             debugLog("send: final wrap-up call failed: \(error.localizedDescription)")
                         }

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -230,6 +230,12 @@ struct MessageTableRepresentable: NSViewRepresentable {
             },
             cacheChartView: { [weak coordinator] id, view in
                 coordinator?.chartViewCache[id] = view
+            },
+            cachedToolGroupView: { [weak coordinator] id in
+                coordinator?.toolGroupViewCache[id]
+            },
+            cacheToolGroupView: { [weak coordinator] id, view in
+                coordinator?.toolGroupViewCache[id] = view
             }
         )
     }
@@ -422,6 +428,11 @@ extension MessageTableRepresentable {
         /// a chart out and back in reparents the same view instead of
         /// rebuilding it. Pruned to `newIds` on each `applyBlocks`.
         var chartViewCache: [String: NativeChartView] = [:]
+
+        /// Same pattern as `chartViewCache`, for tool-call group blocks.
+        /// Keeps the rendered ring/icon/title across cell recycles so the
+        /// appearance animation only ever plays once per call.
+        var toolGroupViewCache: [String: NativeToolCallGroupView] = [:]
 
         private var minimapUpdateWork: DispatchWorkItem?
         private let minimapUpdateInterval: TimeInterval = 0.05
@@ -661,11 +672,15 @@ extension MessageTableRepresentable {
                 if !drawnChartBlockIds.isEmpty {
                     drawnChartBlockIds.formIntersection(newIds)
                 }
-                if !chartViewCache.isEmpty {
+                if !chartViewCache.isEmpty || !toolGroupViewCache.isEmpty {
                     let newIdSet = Set(newIds)
                     for key in chartViewCache.keys where !newIdSet.contains(key) {
                         chartViewCache[key]?.removeFromSuperview()
                         chartViewCache.removeValue(forKey: key)
+                    }
+                    for key in toolGroupViewCache.keys where !newIdSet.contains(key) {
+                        toolGroupViewCache[key]?.removeFromSuperview()
+                        toolGroupViewCache.removeValue(forKey: key)
                     }
                 }
             }

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -218,7 +218,19 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onDelete: onDelete,
             onSpeak: onSpeak,
             onUserImagePreview: onUserImagePreview,
-            sessionRedactions: sessionRedactions
+            sessionRedactions: sessionRedactions,
+            hasChartBeenDrawn: { [weak coordinator] id in
+                coordinator?.drawnChartBlockIds.contains(id) ?? false
+            },
+            markChartDrawn: { [weak coordinator] id in
+                coordinator?.drawnChartBlockIds.insert(id)
+            },
+            cachedChartView: { [weak coordinator] id in
+                coordinator?.chartViewCache[id]
+            },
+            cacheChartView: { [weak coordinator] id, view in
+                coordinator?.chartViewCache[id] = view
+            }
         )
     }
 
@@ -393,6 +405,24 @@ extension MessageTableRepresentable {
         private var lastEmittedUserTurnId: UUID?
         /// Tracks the last observed scroll-to-turn trigger from the view.
         var lastScrollToTurnTrigger: Int = 0
+
+        // MARK: Chart Animation Tracking
+
+        /// Block ids of charts already drawn at least once in this chat.
+        /// Used to suppress the entry animation when NSTableView recycles
+        /// a cell back into view (each scroll-in otherwise spins up a
+        /// fresh `NativeChartView` with `hasDrawn = false`). Pruned to the
+        /// current `newIds` on each `applyBlocks` so loading a different
+        /// chat clears the set.
+        var drawnChartBlockIds: Set<String> = []
+
+        /// Cache of `NativeChartView` instances keyed by chart block id.
+        /// Holds a strong reference across cell recycles so the embedded
+        /// `AAChartView` (WKWebView) keeps its rendered contents — scrolling
+        /// a chart out and back in reparents the same view instead of
+        /// rebuilding it. Pruned to `newIds` on each `applyBlocks`.
+        var chartViewCache: [String: NativeChartView] = [:]
+
         private var minimapUpdateWork: DispatchWorkItem?
         private let minimapUpdateInterval: TimeInterval = 0.05
         nonisolated(unsafe) private var minimapBoundsObserver: NSObjectProtocol?
@@ -625,6 +655,20 @@ extension MessageTableRepresentable {
             }
 
             let newIds = blocks.map(\.id)
+            // Drop chart "already animated" entries that are no longer in
+            // the thread (covers chat switch / session reload).
+            if newIds != blockIds {
+                if !drawnChartBlockIds.isEmpty {
+                    drawnChartBlockIds.formIntersection(newIds)
+                }
+                if !chartViewCache.isEmpty {
+                    let newIdSet = Set(newIds)
+                    for key in chartViewCache.keys where !newIdSet.contains(key) {
+                        chartViewCache[key]?.removeFromSuperview()
+                        chartViewCache.removeValue(forKey: key)
+                    }
+                }
+            }
             // Use uniquingKeysWith instead of uniqueKeysWithValues to avoid a
             // precondition crash if block IDs collide (e.g. stale memoizer cache
             // during session restore). Last-write-wins preserves correct behavior.

--- a/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeChartView.swift
@@ -159,7 +159,12 @@ final class NativeChartView: NSView {
 
     // MARK: - Configure
 
-    func configure(spec: ChartSpec, theme: any ThemeProtocol) {
+    /// `animateInitialDraw` controls only the first paint on this NSView
+    /// instance. Cells get recycled across scroll, so the coordinator tracks
+    /// which block ids have already animated once and passes `false` on
+    /// re-attach to suppress the entry animation. Picker-driven redraws
+    /// always animate (see `chartTypeChanged`).
+    func configure(spec: ChartSpec, theme: any ThemeProtocol, animateInitialDraw: Bool = true) {
         let bgColor = NSColor(theme.cardBackground)
         let bgHex = bgColor.hexString
         let textColor = NSColor(theme.primaryText)
@@ -199,7 +204,7 @@ final class NativeChartView: NSView {
             typePicker.selectItem(at: idx)
         }
 
-        redraw(spec: spec, bgHex: bgHex, textHex: textColor.hexString, theme: theme)
+        redraw(spec: spec, bgHex: bgHex, textHex: textColor.hexString, theme: theme, animate: animateInitialDraw)
     }
 
     func measuredCardHeight() -> CGFloat {
@@ -236,9 +241,10 @@ final class NativeChartView: NSView {
         bgHex: String,
         textHex: String,
         theme: any ThemeProtocol,
-        forceFullRedraw: Bool = false
+        forceFullRedraw: Bool = false,
+        animate: Bool = true
     ) {
-        let (options, seriesElements) = buildChartModel(from: spec, bgHex: bgHex, textHex: textHex, theme: theme)
+        let (options, seriesElements) = buildChartModel(from: spec, bgHex: bgHex, textHex: textHex, theme: theme, animate: animate)
 
         if !hasDrawn || forceFullRedraw {
             hasDrawn = true
@@ -254,7 +260,8 @@ final class NativeChartView: NSView {
         from spec: ChartSpec,
         bgHex: String,
         textHex: String,
-        theme: any ThemeProtocol
+        theme: any ThemeProtocol,
+        animate: Bool = true
     ) -> (AAOptions, [AASeriesElement]) {
         let gridHex = NSColor(theme.primaryBorder).withAlphaComponent(0.2).hexString
 
@@ -278,7 +285,7 @@ final class NativeChartView: NSView {
             .chartType(AAChartType(rawValue: spec.chartType) ?? .column)
             .backgroundColor(bgHex)
             .animationType(.easeInOutQuart)
-            .animationDuration(600)
+            .animationDuration(animate ? 600 : 0)
             .dataLabelsEnabled(spec.dataLabelsEnabled ?? false)
             .dataLabelsStyle(AAStyle().color(textHex).fontSize(11))
             .tooltipValueSuffix(spec.tooltipSuffix ?? "")

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -1011,17 +1011,16 @@ final class NativeMarkdownView: NSView {
 
         let storageLength = tv.textStorage?.length ?? 0
         let origin = tv.textContainerOrigin
-        let lineHeight = (tv.font ?? .systemFont(ofSize: 13)).boundingRectForFont.height
+        let font = tv.font ?? .systemFont(ofSize: 13)
+        let lineHeight = font.boundingRectForFont.height
         let trailingPadding: CGFloat = 6
         let slotWidth: CGFloat = StreamingCursorOverlay.dotDiameter + 4
 
         let trailingX: CGFloat
-        let lineTopInTV: CGFloat
         let lineBottomInTV: CGFloat
 
         if storageLength == 0 {
             trailingX = origin.x + trailingPadding
-            lineTopInTV = origin.y
             lineBottomInTV = origin.y + lineHeight
         } else {
             let lastCharIdx = storageLength - 1
@@ -1031,21 +1030,30 @@ final class NativeMarkdownView: NSView {
                 effectiveRange: nil
             )
             trailingX = usedRect.maxX + origin.x + trailingPadding
-            lineTopInTV = usedRect.minY + origin.y
             lineBottomInTV = usedRect.maxY + origin.y
         }
 
-        let topInSelf = tv.convert(NSPoint(x: trailingX, y: lineTopInTV), to: self)
-        let bottomInSelf = tv.convert(NSPoint(x: trailingX, y: lineBottomInTV), to: self)
-
-        let frameMinY = min(topInSelf.y, bottomInSelf.y)
-        let frameHeight = max(abs(topInSelf.y - bottomInSelf.y), lineHeight)
-
+        // Anchor slot to the line BOTTOM in self coords + give it the
+        // font's natural line height. Computing the slot height from the
+        // rect difference (top vs. bottom) was picking up extra leading
+        // on some lines, which made the slot taller than the line and
+        // pushed the centered dot above the visible text.
+        let bottomInSelf = tv.convert(
+            NSPoint(x: trailingX, y: lineBottomInTV),
+            to: self
+        )
+        // Slot spans exactly the line, dot is centered inside, plus a
+        // small downward nudge so the dot's center axis lands on the
+        // text's visual middle (x-height middle / mid-strike line)
+        // rather than the geometric center of the full line height —
+        // body text's center-of-mass sits below the geometric middle
+        // because ascenders extend higher than descenders.
+        let baselineNudge: CGFloat = -3
         cursor.frame = NSRect(
-            x: topInSelf.x,
-            y: frameMinY,
+            x: bottomInSelf.x,
+            y: bottomInSelf.y + baselineNudge,
             width: slotWidth,
-            height: frameHeight
+            height: lineHeight
         )
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -53,6 +53,27 @@ final class NativeMarkdownView: NSView {
 
     private var coordinator = SelectableTextView.Coordinator()
     private let fader = TrailingTextFader()
+    /// Blinking interpunct shown at the trailing edge of streaming text
+    /// **only during quiet gaps** — when the SSE source has stopped
+    /// emitting tokens for a moment but the stream is still alive. While
+    /// text is actively being revealed, the cursor stays hidden so it
+    /// doesn't race the moving text. Cleared when streaming ends.
+    private var streamingCursor: StreamingCursorOverlay?
+    /// Timestamp of the last text-storage mutation made while streaming.
+    /// `nil` means we haven't received a streaming reveal yet.
+    private var lastTextRevealAt: Date?
+    /// Idle-check timer (~50ms) that flips the cursor on whenever
+    /// `now - lastTextRevealAt > pauseThreshold`. Lives only while
+    /// `isStreaming == true`.
+    private var idleTimer: Timer?
+    /// Captured at `enterStreamingMode` so `idleTick` doesn't need to
+    /// re-resolve the theme on every tick.
+    private var streamingCursorColor: NSColor?
+    /// How long the stream must be silent before the cursor blinks on.
+    /// 150ms is short enough that it appears during real network gaps
+    /// (200-500ms typical) but long enough that brief sync hiccups don't
+    /// flash it during a steady reveal.
+    private static let cursorPauseThreshold: TimeInterval = 0.15
     private var lastText: String = ""
     private var lastBlocks: [SelectableTextBlock] = []
     private var lastWidth: CGFloat = 0
@@ -122,6 +143,9 @@ final class NativeMarkdownView: NSView {
         // so row height and text wrapping match (avoids clipped last line + trailing edge mismatch).
         let w = bounds.width
         guard textView != nil, w > 0.5 else { return }
+        if streamingCursor != nil {
+            repositionStreamingCursor()
+        }
         guard abs(w - lastLayoutWidthForHeight) > 0.5 else { return }
         lastLayoutWidthForHeight = w
         let before = heightConstraint?.constant ?? 0
@@ -378,11 +402,19 @@ final class NativeMarkdownView: NSView {
                 tv.needsDisplay = true
             }
             applyRedactionHighlightsIfNeeded(theme: theme)
+            if isStreaming && textChanged {
+                notifyTextReveal()
+            }
         }
 
         // nested NativeMarkdownView (text segment inside mixed content) must update heightConstraint
         // or the default 100pt sticks and following segments overlap the text.
         _ = measuredHeight(for: width)
+        if isStreaming {
+            enterStreamingMode(theme: theme)
+        } else {
+            exitStreamingMode()
+        }
         onHeightChanged?()
     }
 
@@ -544,10 +576,18 @@ final class NativeMarkdownView: NSView {
                 tv.needsDisplay = true
             }
             applyRedactionHighlightsIfNeeded(theme: theme)
+            if isStreaming && textChanged {
+                notifyTextReveal()
+            }
         }
 
         // must update heightConstraint — init leaves 100pt; otherwise user bubbles stay artificially tall
         _ = measuredHeight(for: width)
+        if isStreaming {
+            enterStreamingMode(theme: theme)
+        } else {
+            exitStreamingMode()
+        }
         onHeightChanged?()
     }
 
@@ -606,6 +646,16 @@ final class NativeMarkdownView: NSView {
         var prevAnchor: NSLayoutYAxisAnchor = topAnchor
         var prevOffset: CGFloat = 4
 
+        // The streaming cursor lives on exactly one nested text segment —
+        // the last one in document order. Other text segments configure
+        // with `isStreaming: false` so they don't blink alongside it.
+        let lastTextSegmentId: String? = {
+            for seg in segments.reversed() {
+                if case .textGroup = seg.kind { return seg.id }
+            }
+            return nil
+        }()
+
         for seg in segments {
             let existingEntry = segmentViews.first(where: { $0.key == seg.id })
             let segView: NSView
@@ -624,7 +674,8 @@ final class NativeMarkdownView: NSView {
                 mv.onHeightChanged = { [weak self] in
                     self?.onHeightChanged?()
                 }
-                mv.configureWithBlocks(blocks, width: width, theme: theme, cacheKey: cacheKey, isStreaming: isStreaming)
+                let segIsStreaming = isStreaming && (seg.id == lastTextSegmentId)
+                mv.configureWithBlocks(blocks, width: width, theme: theme, cacheKey: cacheKey, isStreaming: segIsStreaming)
                 segView = mv
 
             case .codeBlock(let code, let language):
@@ -788,6 +839,10 @@ final class NativeMarkdownView: NSView {
         lastRedactionHighlightsHash = 0
         textView?.removeFromSuperview()
         textView = nil
+        // Tear down the streaming cursor + idle timer if they were
+        // attached to this textView. Re-arms cleanly if streaming resumes
+        // (mixed-segment ↔ pure-text transitions).
+        exitStreamingMode()
         lastBlocks = []
         lastLayoutWidthForHeight = -1
     }
@@ -864,5 +919,206 @@ final class NativeMarkdownView: NSView {
 
     private func makeThemeFingerprint(_ theme: any ThemeProtocol) -> String {
         "\(theme.primaryFontName)|\(theme.bodySize)|\(theme.codeSize)"
+    }
+
+    // MARK: - Streaming Cursor (interpunct)
+
+    /// Enter "streaming" lifecycle: start the idle-check timer that flips
+    /// the cursor on whenever tokens have been quiet for the threshold.
+    /// Does **not** show the cursor itself — that's gated on the idle
+    /// elapsed time, decided by `idleTick`.
+    fileprivate func enterStreamingMode(theme: any ThemeProtocol) {
+        streamingCursorColor = NSColor(theme.primaryText)
+        guard idleTimer == nil else { return }
+        idleTimer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.idleTick()
+            }
+        }
+    }
+
+    /// Exit "streaming" lifecycle: stop the idle timer, remove the cursor,
+    /// and clear the reveal timestamp so a future stream starts fresh.
+    fileprivate func exitStreamingMode() {
+        idleTimer?.invalidate()
+        idleTimer = nil
+        lastTextRevealAt = nil
+        streamingCursor?.removeFromSuperview()
+        streamingCursor = nil
+    }
+
+    /// Called from the text-update paths when text storage actually
+    /// changed during streaming. Stamps the reveal time and *removes*
+    /// the cursor if it was visible — active reveal is the opposite of
+    /// "still waiting."
+    fileprivate func notifyTextReveal() {
+        lastTextRevealAt = Date()
+        if streamingCursor != nil {
+            streamingCursor?.removeFromSuperview()
+            streamingCursor = nil
+        }
+    }
+
+    /// Idle-check tick. If the stream has been quiet long enough, show
+    /// (or refresh) the cursor at the trailing edge. Otherwise ensure
+    /// it's hidden.
+    private func idleTick() {
+        guard idleTimer != nil else { return }
+        let elapsed: TimeInterval
+        if let last = lastTextRevealAt {
+            elapsed = Date().timeIntervalSince(last)
+        } else {
+            // Stream started, no token yet. Treat as paused so the user
+            // sees the cursor while waiting for TTFT to elapse.
+            elapsed = Self.cursorPauseThreshold + 1
+        }
+        if elapsed > Self.cursorPauseThreshold {
+            installCursorIfNeeded()
+            repositionStreamingCursor()
+        } else {
+            if streamingCursor != nil {
+                streamingCursor?.removeFromSuperview()
+                streamingCursor = nil
+            }
+        }
+    }
+
+    private func installCursorIfNeeded() {
+        guard textView != nil, let color = streamingCursorColor else { return }
+        if streamingCursor == nil {
+            let cv = StreamingCursorOverlay()
+            cv.updateColor(color)
+            addSubview(cv)
+            streamingCursor = cv
+        } else {
+            streamingCursor?.updateColor(color)
+        }
+    }
+
+    /// Position the cursor frame to vertically align with the line that
+    /// contains the last character of the text storage, with horizontal
+    /// padding past the trailing glyph. Uses the line fragment's used
+    /// rect (not `boundingRect(forGlyphRange:)`) so soft-wrapped
+    /// trailing whitespace doesn't pull the cursor back to the previous
+    /// line. Converts the top AND bottom of the line through
+    /// `tv.convert(_:to:)` so it works whether the NSTextView is flipped
+    /// or not — `frame.origin.y` in a non-flipped parent must be the
+    /// **lower** of the two converted y values.
+    fileprivate func repositionStreamingCursor() {
+        guard let cursor = streamingCursor, let tv = textView else { return }
+        guard let lm = tv.layoutManager, let tc = tv.textContainer else { return }
+        lm.ensureLayout(for: tc)
+
+        let storageLength = tv.textStorage?.length ?? 0
+        let origin = tv.textContainerOrigin
+        let lineHeight = (tv.font ?? .systemFont(ofSize: 13)).boundingRectForFont.height
+        let trailingPadding: CGFloat = 6
+        let slotWidth: CGFloat = StreamingCursorOverlay.dotDiameter + 4
+
+        let trailingX: CGFloat
+        let lineTopInTV: CGFloat
+        let lineBottomInTV: CGFloat
+
+        if storageLength == 0 {
+            trailingX = origin.x + trailingPadding
+            lineTopInTV = origin.y
+            lineBottomInTV = origin.y + lineHeight
+        } else {
+            let lastCharIdx = storageLength - 1
+            let lastGlyphIdx = lm.glyphIndexForCharacter(at: lastCharIdx)
+            let usedRect = lm.lineFragmentUsedRect(
+                forGlyphAt: lastGlyphIdx,
+                effectiveRange: nil
+            )
+            trailingX = usedRect.maxX + origin.x + trailingPadding
+            lineTopInTV = usedRect.minY + origin.y
+            lineBottomInTV = usedRect.maxY + origin.y
+        }
+
+        let topInSelf = tv.convert(NSPoint(x: trailingX, y: lineTopInTV), to: self)
+        let bottomInSelf = tv.convert(NSPoint(x: trailingX, y: lineBottomInTV), to: self)
+
+        let frameMinY = min(topInSelf.y, bottomInSelf.y)
+        let frameHeight = max(abs(topInSelf.y - bottomInSelf.y), lineHeight)
+
+        cursor.frame = NSRect(
+            x: topInSelf.x,
+            y: frameMinY,
+            width: slotWidth,
+            height: frameHeight
+        )
+    }
+}
+
+// MARK: - StreamingCursorOverlay
+
+/// Tiny overlay view that renders a blinking dot. Used by
+/// `NativeMarkdownView` to indicate "still streaming" during the SSE
+/// quiet gaps that no amount of pacing can fully smooth over.
+private final class StreamingCursorOverlay: NSView {
+
+    /// Diameter of the dot in points. Tuned to read as a deliberate
+    /// "still going" pulse without competing with the body text.
+    static let dotDiameter: CGFloat = 12
+
+    private let dotLayer = CAShapeLayer()
+    private static let suppressedActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "position": NSNull(),
+        "frame": NSNull(),
+        "path": NSNull(),
+        "fillColor": NSNull(),
+    ]
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        // Frame-based positioning — caller sets the frame each time the
+        // trailing glyph rect changes. Auto Layout would otherwise pin the
+        // overlay to (0, 0) at its zero intrinsic size and ignore our
+        // frame writes.
+        translatesAutoresizingMaskIntoConstraints = true
+        wantsLayer = true
+        layer?.actions = Self.suppressedActions
+        dotLayer.actions = Self.suppressedActions
+        layer?.addSublayer(dotLayer)
+        startBlinking()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        // Center the dot within the overlay view.
+        let d = Self.dotDiameter
+        let dotFrame = CGRect(
+            x: (bounds.width - d) / 2,
+            y: (bounds.height - d) / 2,
+            width: d,
+            height: d
+        )
+        dotLayer.frame = dotFrame
+        dotLayer.path = CGPath(ellipseIn: CGRect(origin: .zero, size: dotFrame.size), transform: nil)
+        CATransaction.commit()
+    }
+
+    func updateColor(_ color: NSColor) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        dotLayer.fillColor = color.cgColor
+        CATransaction.commit()
+    }
+
+    private func startBlinking() {
+        let anim = CABasicAnimation(keyPath: "opacity")
+        anim.fromValue = 1.0
+        anim.toValue = 0.2
+        anim.duration = 0.65
+        anim.autoreverses = true
+        anim.repeatCount = .infinity
+        anim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        anim.isRemovedOnCompletion = false
+        layer?.add(anim, forKey: "blink")
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -47,6 +47,25 @@ struct CellRenderingContext {
     /// bubbles. Empty dict means no privacy redactions in this
     /// session yet (the highlight pass short-circuits).
     var sessionRedactions: [String: String] = [:]
+    /// Coordinator-scoped predicate: has the chart with this block id ever
+    /// been drawn (and thus already played its entry animation) in the
+    /// current chat? Used by `configureAsChart` to suppress the animation
+    /// when a recycled cell re-mounts a NativeChartView for a chart the
+    /// user has already seen.
+    var hasChartBeenDrawn: ((String) -> Bool)? = nil
+    /// Coordinator-scoped callback: record that the chart with this block
+    /// id has been drawn so subsequent re-mounts skip the entry animation.
+    var markChartDrawn: ((String) -> Void)? = nil
+    /// Coordinator-scoped chart view cache lookup. Returning a non-nil
+    /// view lets `configureAsChart` reparent an existing (already-rendered)
+    /// `NativeChartView` instead of allocating a fresh `AAChartView`/
+    /// WKWebView — eliminating the visible re-render when a chart row
+    /// scrolls back into view after cell recycling.
+    var cachedChartView: ((String) -> NativeChartView?)? = nil
+    /// Coordinator-scoped callback: stash a newly created chart view in
+    /// the coordinator's cache so subsequent re-mounts hit the lookup
+    /// above. Pruned to the current block ids on each `applyBlocks`.
+    var cacheChartView: ((String, NativeChartView) -> Void)? = nil
 }
 
 // MARK: - Cell-Isolated ExpandedBlocksStore Proxy
@@ -1966,7 +1985,19 @@ final class NativeMessageCellView: NSTableCellView {
     ) {
         if !sameKind || nativeChartView == nil {
             removeAllContentViews()
-            let cv = NativeChartView()
+            // Reuse a cached NativeChartView for this block id when one exists.
+            // The cached instance still holds its rendered WKWebView contents,
+            // so reparenting avoids a fresh chart load (no flash, no animation).
+            // Cache misses (first appearance, or after session-switch pruning)
+            // fall back to a new instance and seed the cache.
+            let cv: NativeChartView
+            if let cached = context.cachedChartView?(block.id) {
+                cached.removeFromSuperview()
+                cv = cached
+            } else {
+                cv = NativeChartView()
+                context.cacheChartView?(block.id, cv)
+            }
             cv.translatesAutoresizingMaskIntoConstraints = false
             addSubview(cv)
             let bottomToCell = cv.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6)
@@ -1990,7 +2021,9 @@ final class NativeMessageCellView: NSTableCellView {
         wantsLayer = true
         layer?.masksToBounds = true
         let blockId = block.id
-        nativeChartView?.configure(spec: spec, theme: context.theme)
+        let animateInitialDraw = !(context.hasChartBeenDrawn?(blockId) ?? false)
+        nativeChartView?.configure(spec: spec, theme: context.theme, animateInitialDraw: animateInitialDraw)
+        context.markChartDrawn?(blockId)
         DispatchQueue.main.async { [weak self] in
             guard let self, let cv = self.nativeChartView else { return }
             guard self.currentBlockId == blockId else { return }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1498,7 +1498,19 @@ final class NativeMessageCellView: NSTableCellView {
         context: CellRenderingContext,
         sameKind: Bool
     ) {
-        if !sameKind || nativeToolCallGroupView == nil {
+        // Consult the cache up front. `sameKind` alone isn't enough — the
+        // same cell can be asked to render a *different* tool-call group
+        // block id in back-to-back configures (snapshot diff reorder /
+        // recycle). The existing `nativeToolCallGroupView` belongs to the
+        // PREVIOUS block id; reusing it for the new block puts it under
+        // the wrong cache binding and the new block's actual cached
+        // view stays orphaned. Remount whenever the currently mounted
+        // gv isn't the one the cache says belongs to `block.id`.
+        let cachedGV = context.cachedToolGroupView?(block.id)
+        let needsRemount = !sameKind
+            || nativeToolCallGroupView == nil
+            || nativeToolCallGroupView !== cachedGV && cachedGV != nil
+        if needsRemount {
             removeAllContentViews()
             // Reuse a cached group view for this block id when one exists.
             // The cached instance retains its rendered layers (ring stroke,
@@ -1506,7 +1518,7 @@ final class NativeMessageCellView: NSTableCellView {
             // instantly with no re-animation. Cache misses (first
             // appearance, or session-switch pruning) create fresh.
             let gv: NativeToolCallGroupView
-            if let cached = context.cachedToolGroupView?(block.id) {
+            if let cached = cachedGV {
                 cached.removeFromSuperview()
                 gv = cached
             } else {
@@ -2008,7 +2020,14 @@ final class NativeMessageCellView: NSTableCellView {
         context: CellRenderingContext,
         sameKind: Bool
     ) {
-        if !sameKind || nativeChartView == nil {
+        // See `configureAsToolCallGroup` for the same-kind/different-id
+        // explanation — chart cells suffer the identical bug if we trust
+        // `sameKind` alone.
+        let cachedCV = context.cachedChartView?(block.id)
+        let needsRemount = !sameKind
+            || nativeChartView == nil
+            || nativeChartView !== cachedCV && cachedCV != nil
+        if needsRemount {
             removeAllContentViews()
             // Reuse a cached NativeChartView for this block id when one exists.
             // The cached instance still holds its rendered WKWebView contents,
@@ -2016,7 +2035,7 @@ final class NativeMessageCellView: NSTableCellView {
             // Cache misses (first appearance, or after session-switch pruning)
             // fall back to a new instance and seed the cache.
             let cv: NativeChartView
-            if let cached = context.cachedChartView?(block.id) {
+            if let cached = cachedCV {
                 cached.removeFromSuperview()
                 cv = cached
             } else {
@@ -2121,7 +2140,12 @@ final class NativeMessageCellView: NSTableCellView {
         nativeHeaderHeightConstraint = nil
         nativeMarkdownView?.removeFromSuperview(); nativeMarkdownView = nil
         nativeThinkingView?.removeFromSuperview(); nativeThinkingView = nil
-        nativeToolCallGroupView?.removeFromSuperview(); nativeToolCallGroupView = nil
+        // Coordinator-cached views: only call `removeFromSuperview` if
+        // we're still the parent. After cache reuse the view may live
+        // in a sibling cell already; blindly calling `removeFromSuperview`
+        // would yank the view out of its new home and the row-now-owning
+        // cell would render empty until the next reconfigure.
+        detachIfStillParented(nativeToolCallGroupView); nativeToolCallGroupView = nil
         nativePendingView?.removeFromSuperview(); nativePendingView = nil
         nativeTypingView?.removeFromSuperview(); nativeTypingView = nil
         nativeArtifactView?.removeFromSuperview(); nativeArtifactView = nil
@@ -2133,7 +2157,7 @@ final class NativeMessageCellView: NSTableCellView {
         // chart keeps rendering at its previous frame underneath the new
         // content — visible as charts bleeding through unrelated rows once
         // the user starts scrolling and recycling kicks in.
-        nativeChartView?.removeFromSuperview(); nativeChartView = nil
+        detachIfStillParented(nativeChartView); nativeChartView = nil
         nativePreflightView?.removeFromSuperview(); nativePreflightView = nil
         nativeStatsView?.removeFromSuperview(); nativeStatsView = nil
         nativeAssistantActionsView?.removeFromSuperview(); nativeAssistantActionsView = nil
@@ -2149,6 +2173,18 @@ final class NativeMessageCellView: NSTableCellView {
         userBubbleWidthConstraint = nil
         userAttachmentsHeight = 0
         userMessageInlineEditActive = false
+    }
+
+    /// Only call `removeFromSuperview()` if the view is still parented
+    /// to us. Cache-shared content views (tool-call group, chart) may
+    /// have already been reparented into a sibling cell via the
+    /// coordinator's cache; in that case removing them would steal them
+    /// back from the cell that legitimately owns them now, and that cell
+    /// would silently render empty until a reconfigure repositioned the
+    /// view. No-op when `view` is nil.
+    private func detachIfStillParented(_ view: NSView?) {
+        guard let view, view.superview === self else { return }
+        view.removeFromSuperview()
     }
 }
 

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1761,7 +1761,12 @@ final class NativeMessageCellView: NSTableCellView {
                 width: bubbleWidth - 24,
                 theme: theme,
                 cacheKey: block.id,
-                isStreaming: context.isStreaming
+                // User messages are never themselves streaming — the
+                // global `context.isStreaming` flag is true whenever the
+                // assistant is generating, but propagating that here
+                // would light up the streaming cursor / trailing fade on
+                // the user bubble. Always false for user bubbles.
+                isStreaming: false
             )
             // User bubble: the verbatim string in `ChatTurn.content`
             // is what the user TYPED, but the wire saw the

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -66,6 +66,14 @@ struct CellRenderingContext {
     /// the coordinator's cache so subsequent re-mounts hit the lookup
     /// above. Pruned to the current block ids on each `applyBlocks`.
     var cacheChartView: ((String, NativeChartView) -> Void)? = nil
+    /// Same pattern as `cachedChartView`, but for tool-call groups. When
+    /// the tool finishes and blocks reflow, NSTableView often redequeues
+    /// the row into a different cell — without this cache the old
+    /// `NativeToolCallGroupView` is torn down and a fresh one is mounted
+    /// from zero bounds, which reads as the appearance animation
+    /// replaying.
+    var cachedToolGroupView: ((String) -> NativeToolCallGroupView?)? = nil
+    var cacheToolGroupView: ((String, NativeToolCallGroupView) -> Void)? = nil
 }
 
 // MARK: - Cell-Isolated ExpandedBlocksStore Proxy
@@ -1492,7 +1500,19 @@ final class NativeMessageCellView: NSTableCellView {
     ) {
         if !sameKind || nativeToolCallGroupView == nil {
             removeAllContentViews()
-            let gv = NativeToolCallGroupView()
+            // Reuse a cached group view for this block id when one exists.
+            // The cached instance retains its rendered layers (ring stroke,
+            // icon, title), so reparenting after a cell recycle paints
+            // instantly with no re-animation. Cache misses (first
+            // appearance, or session-switch pruning) create fresh.
+            let gv: NativeToolCallGroupView
+            if let cached = context.cachedToolGroupView?(block.id) {
+                cached.removeFromSuperview()
+                gv = cached
+            } else {
+                gv = NativeToolCallGroupView()
+                context.cacheToolGroupView?(block.id, gv)
+            }
             gv.translatesAutoresizingMaskIntoConstraints = false
             addSubview(gv)
             NSLayoutConstraint.activate([

--- a/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
@@ -315,7 +315,11 @@ final class RailLineView: NSView {
     private static let animationKey = "rail.draw"
 
     private var drawPending = false
-    private var pendingDelay: CFTimeInterval = 0
+    /// Absolute begin time (CACurrentMediaTime()-based) captured when `drawIn`
+    /// is called. Stored absolute, not relative, so a deferred layout pass
+    /// can't drift the begin time later than the rail/ring/icon animations
+    /// scheduled in the same configure() call.
+    private var pendingBeginAt: CFTimeInterval = 0
 
     /// Backing layer (returned from `makeBackingLayer`) — kept typed so we never
     /// need to force-cast `layer`.
@@ -328,7 +332,26 @@ final class RailLineView: NSView {
         shape.fillColor = NSColor.clear.cgColor
         shape.strokeEnd = 1
         wantsLayer = true
+        // Disable CALayer's default implicit animations on the properties
+        // we touch / lay out. Without this, post-finish cell recreation
+        // (when the tool call's row goes through teardown + redequeue)
+        // triggers 0.25s implicit bounds/position/strokeEnd transitions
+        // that look identical to a re-play of the rail draw animation.
+        shape.actions = Self.suppressedActions
     }
+
+    private static let suppressedActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "position": NSNull(),
+        "strokeEnd": NSNull(),
+        "strokeColor": NSNull(),
+        "fillColor": NSNull(),
+        "path": NSNull(),
+        "opacity": NSNull(),
+        "hidden": NSNull(),
+        "contents": NSNull(),
+        "transform": NSNull(),
+    ]
 
     required init?(coder: NSCoder) { fatalError() }
 
@@ -355,15 +378,23 @@ final class RailLineView: NSView {
         shape.path = p
     }
 
-    /// Animate the rail drawing in after `delay`. Safe to call from `configure`:
-    /// it holds at `strokeEnd = 0` until the begin time, then sweeps to full.
-    /// Ignores repeat calls while a draw is already pending/in-flight, so the
-    /// per-token reconfigures that fire mid-stream can't restart or cut it short.
-    func drawIn(delay: CFTimeInterval) {
+    /// Animate the rail drawing in at `beginAt` (absolute `CACurrentMediaTime()`
+    /// timeline). Safe to call from `configure`: holds at `strokeEnd = 0` until
+    /// the begin time, then sweeps to full. Ignores repeat calls while a draw
+    /// is already pending/in-flight, so per-token reconfigures can't restart
+    /// or cut it short.
+    func drawIn(beginAt: CFTimeInterval) {
         if drawPending || shape.animation(forKey: Self.animationKey) != nil { return }
         drawPending = true
-        pendingDelay = delay
+        pendingBeginAt = beginAt
+        // Hide synchronously WITHOUT triggering CALayer's default 0.25s
+        // implicit animation on `strokeEnd`. Before this fix the rail
+        // briefly fade-collapsed from 1→0 instead of being invisible,
+        // racing the subsequent explicit draw-in animation.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         shape.strokeEnd = 0
+        CATransaction.commit()
         if bounds.height > 0 {
             startDrawIfReady()
         } else {
@@ -386,10 +417,20 @@ final class RailLineView: NSView {
         anim.fromValue = 0
         anim.toValue = 1
         anim.duration = Self.drawDuration
-        anim.beginTime = CACurrentMediaTime() + pendingDelay
-        anim.fillMode = .backwards  // hold at 0 until the (possibly delayed) begin time
+        anim.beginTime = pendingBeginAt
+        // `.both` + `removedOnCompletion = false` makes the presentation
+        // strictly track the animation: hidden (fromValue) before begin,
+        // animating during, and pinned to toValue afterwards. We don't
+        // rely on the model value matching the presentation.
+        anim.fillMode = .both
+        anim.isRemovedOnCompletion = false
         anim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        shape.strokeEnd = 1  // model value lands full when the animation is removed
+        // Set model to final state with implicit actions disabled so the
+        // 1→ assignment doesn't trigger CALayer's default fade.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        shape.strokeEnd = 1
+        CATransaction.commit()
         shape.add(anim, forKey: Self.animationKey)
     }
 }
@@ -408,7 +449,16 @@ final class TimelineNodeView: NSView {
     static let ringDrawDuration: CFTimeInterval = 0.34
 
     private var drawPending = false
-    private var pendingDelay: CFTimeInterval = 0
+    /// Absolute begin time captured at `drawRing` call site so a deferred
+    /// layout pass can't desync the ring's begin from the icon/title
+    /// animations scheduled in the same configure() call.
+    private var pendingBeginAt: CFTimeInterval = 0
+    /// Target disc fill captured synchronously in `drawRing` before the
+    /// model value is cleared. We must clear immediately so the disc
+    /// doesn't render at the target color in the window between
+    /// `drawRing` and `startDrawIfReady` (which can be deferred via
+    /// layout) — otherwise the disc pops in before the ring traces.
+    private var pendingFillTarget: CGColor?
 
     /// Backing layer (returned from `makeBackingLayer`) — kept typed so we never
     /// need to force-cast `layer`.
@@ -419,7 +469,22 @@ final class TimelineNodeView: NSView {
         shape.lineWidth = 1.5
         shape.strokeEnd = 1
         wantsLayer = true
+        // See RailLineView.suppressedActions — same rationale.
+        shape.actions = Self.suppressedActions
     }
+
+    private static let suppressedActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "position": NSNull(),
+        "strokeEnd": NSNull(),
+        "strokeColor": NSNull(),
+        "fillColor": NSNull(),
+        "path": NSNull(),
+        "opacity": NSNull(),
+        "hidden": NSNull(),
+        "contents": NSNull(),
+        "transform": NSNull(),
+    ]
 
     required init?(coder: NSCoder) { fatalError() }
 
@@ -459,12 +524,23 @@ final class TimelineNodeView: NSView {
         shape.path = p
     }
 
-    /// Trace the ring in clockwise (+ fade the fill in) after `delay`.
-    func drawRing(delay: CFTimeInterval) {
+    /// Trace the ring in clockwise (+ fade the fill in) starting at `beginAt`
+    /// (absolute `CACurrentMediaTime()` timeline).
+    func drawRing(beginAt: CFTimeInterval) {
         if drawPending || shape.animation(forKey: Self.animationKey) != nil { return }
         drawPending = true
-        pendingDelay = delay
+        pendingBeginAt = beginAt
+        pendingFillTarget = shape.fillColor
+        // Hide the disc + ring synchronously (no implicit fades). Before
+        // this fix, the disc rendered at its target color during the
+        // window between `drawRing` and the deferred `startDrawIfReady`
+        // — which manifested as the colored disc popping in before the
+        // ring traced over it.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         shape.strokeEnd = 0
+        shape.fillColor = NSColor.clear.cgColor
+        CATransaction.commit()
         if bounds.width > 1 {
             startDrawIfReady()
         } else {
@@ -481,21 +557,31 @@ final class TimelineNodeView: NSView {
     private func startDrawIfReady() {
         guard drawPending, bounds.width > 1 else { return }
         drawPending = false
-        let begin = CACurrentMediaTime() + pendingDelay
+        let begin = pendingBeginAt
+        let fillTarget = pendingFillTarget ?? shape.fillColor
         let stroke = CABasicAnimation(keyPath: "strokeEnd")
         stroke.fromValue = 0
         stroke.toValue = 1
+        stroke.fillMode = .both
         stroke.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        // Fade the disc fill in alongside the ring so the node isn't a bare ring.
         let fill = CABasicAnimation(keyPath: "fillColor")
         fill.fromValue = NSColor.clear.cgColor
-        fill.toValue = shape.fillColor
+        fill.toValue = fillTarget
+        fill.fillMode = .both
         let group = CAAnimationGroup()
         group.animations = [stroke, fill]
         group.duration = Self.ringDrawDuration
         group.beginTime = begin
-        group.fillMode = .backwards  // hold hidden (strokeEnd 0 / clear fill) until begin
-        shape.strokeEnd = 1  // resting model values
+        group.fillMode = .both
+        group.isRemovedOnCompletion = false
+        // Restore model to final state (without triggering implicit fades)
+        // so subsequent property reads / future animations see the right
+        // baseline. The explicit animation drives the presentation.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        shape.strokeEnd = 1
+        shape.fillColor = fillTarget
+        CATransaction.commit()
         shape.add(group, forKey: Self.animationKey)
     }
 }
@@ -771,6 +857,22 @@ final class NativeToolCallRowView: NSView {
     var onToggle: (() -> Void)?
     var onHeightChanged: (() -> Void)?
 
+    /// Implicit-animation suppression dict for layers we mount in this row
+    /// (icon, name, shimmer). Prevents CALayer's default 0.25s `contents`
+    /// / `bounds` / `position` / `opacity` transitions from running when
+    /// the cell is redequeued post-finish — which otherwise reads as a
+    /// spurious re-play of the appearance animation.
+    static let suppressedLayerActions: [String: CAAction] = [
+        "bounds": NSNull(),
+        "position": NSNull(),
+        "contents": NSNull(),
+        "opacity": NSNull(),
+        "hidden": NSNull(),
+        "transform": NSNull(),
+        "backgroundColor": NSNull(),
+        "foregroundColor": NSNull(),
+    ]
+
     // MARK: Init
 
     override init(frame: NSRect) {
@@ -844,12 +946,20 @@ final class NativeToolCallRowView: NSView {
         currentItemId = item.call.id
         currentItem = item
 
+
         // Node: category icon shape in the foreground. The icon/circle colors and
         // the running shimmer are applied in `applyStatusAndShimmer()` below.
         let category = ToolCategory.from(toolName: item.call.function.name)
         let cfg = NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+        // Suppress the default `contents` action so the symbol swap doesn't
+        // run its own 0.25s implicit fade alongside `playNodeAppearance`'s
+        // explicit opacity animation (the two would race and pop the icon in
+        // before the ring finishes tracing).
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         categoryIcon.image = NSImage(systemSymbolName: category.icon, accessibilityDescription: nil)?
             .withSymbolConfiguration(cfg)
+        CATransaction.commit()
 
         // Rail connects consecutive calls; a lone call (only row) shows none.
         let railColor = NSColor(theme.tertiaryText).withAlphaComponent(0.28).cgColor
@@ -860,13 +970,17 @@ final class NativeToolCallRowView: NSView {
         // A freshly connected segment (streaming append) sweeps in; everything
         // else shows fully. `showFull`/`drawIn` are no-ops mid-draw, so the
         // per-token reconfigures that follow can't interrupt the animation.
+        // Capture `now` once so the rail/ring/icon animations scheduled below
+        // share an anchor — deferred-layout starts can't drift the rail or
+        // ring later than the icon's already-locked begin time.
+        let now = CACurrentMediaTime()
         if let delay = drawRailAboveAfter, !railAbove.isHidden {
-            railAbove.drawIn(delay: delay)
+            railAbove.drawIn(beginAt: now + delay)
         } else {
             railAbove.showFull()
         }
         if let delay = drawRailBelowAfter, !railBelow.isHidden {
-            railBelow.drawIn(delay: delay)
+            railBelow.drawIn(beginAt: now + delay)
         } else {
             railBelow.showFull()
         }
@@ -913,7 +1027,7 @@ final class NativeToolCallRowView: NSView {
         // Freshly appearing node: stage in the ring → glyph → title. Otherwise
         // (load / reuse / already revealed) show the full ring with no animation.
         if let delay = animateAppearanceAfter {
-            playNodeAppearance(delay: delay)
+            playNodeAppearance(beginAt: now + delay)
         } else {
             categoryBg.showRingFull()
         }
@@ -1227,15 +1341,23 @@ final class NativeToolCallRowView: NSView {
         categoryIcon.translatesAutoresizingMaskIntoConstraints = false
         categoryIcon.wantsLayer = true  // animatable for the staged glyph reveal
         categoryIcon.imageScaling = .scaleProportionallyUpOrDown
+        // Suppress implicit CALayer animations on `contents`/`opacity`/`bounds`
+        // etc. Post-finish cell teardown + redequeue otherwise rebuilds the
+        // image view from zero bounds → 14×14, animating the glyph in over
+        // 0.25s and giving the impression the appearance sequence is replaying.
+        categoryIcon.layer?.actions = Self.suppressedLayerActions
         categoryBg.addSubview(categoryIcon)
 
         // Shimmering title (running state); overlays the static nameLabel slot.
         shimmerLabel.translatesAutoresizingMaskIntoConstraints = false
         shimmerLabel.isHidden = true
+        shimmerLabel.wantsLayer = true
+        shimmerLabel.layer?.actions = Self.suppressedLayerActions
         addSubview(shimmerLabel)
 
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
         nameLabel.wantsLayer = true  // animatable for the appended-node title bloom
+        nameLabel.layer?.actions = Self.suppressedLayerActions
         nameLabel.isEditable = false; nameLabel.isBordered = false; nameLabel.drawsBackground = false
         nameLabel.lineBreakMode = .byTruncatingTail; nameLabel.maximumNumberOfLines = 1
         nameLabel.alignment = .left
@@ -1522,9 +1644,17 @@ final class NativeToolCallRowView: NSView {
     private func applyStatusAndShimmer() {
         guard let item = currentItem, let theme = lastConfiguredTheme else { return }
         let color = nodeStatusColor(item: item, theme: theme)
+        // Suppress CALayer's default property actions. Setting `fillColor` /
+        // `strokeColor` / `contentTintColor` otherwise spins up implicit
+        // 0.25s fades on the disc and tint, which race the explicit ring /
+        // icon / title appearance animations scheduled in
+        // `playNodeAppearance` and read as the node glitch-popping in.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         categoryIcon.contentTintColor = color
         categoryBg.fillColor = color.withAlphaComponent(0.14).cgColor
         categoryBg.strokeColor = color.withAlphaComponent(0.55).cgColor
+        CATransaction.commit()
 
         if isRunning(item) {
             shimmerLabel.configure(
@@ -1551,25 +1681,43 @@ final class NativeToolCallRowView: NSView {
     /// Purely presentational: model values stay at rest and `fillMode = .backwards`
     /// holds each stage hidden until its begin time, so there's no pre-flash and
     /// the per-token reconfigures that follow can't disturb an in-flight reveal.
-    private func playNodeAppearance(delay: CFTimeInterval) {
-        let begin = CACurrentMediaTime() + delay
+    private func playNodeAppearance(beginAt begin: CFTimeInterval) {
         let ringDuration = TimelineNodeView.ringDrawDuration
+        let iconDuration: CFTimeInterval = 0.20
+        let titleDuration: CFTimeInterval = 0.24
+
+        // Strict sequencing: rail (already done by `begin`) → ring →
+        // icon → title, each waiting for the previous to fully complete.
+        // The earlier overlap (icon at ring*0.75, title 0.16s after that)
+        // read as "rushing" — stages stepped on each other instead of
+        // letting the eye track one element at a time.
+        let iconBegin = begin + ringDuration
+        let titleBegin = iconBegin + iconDuration
 
         // 1) Ring traces in clockwise (the disc fill fades in alongside it).
-        categoryBg.drawRing(delay: delay)
+        // Passing the absolute begin time (rather than a relative delay)
+        // guarantees the ring's begin matches the icon/title begin even
+        // if the node's layout pass is deferred a frame.
+        categoryBg.drawRing(beginAt: begin)
 
-        // 2) Glyph settles in — subtle fade + slight scale — as the ring finishes.
+        // 2) Glyph settles in — subtle fade + slight scale — after the ring.
+        // `fillMode = .backwards` is set on both the group AND each child
+        // so the layer reliably presents `fromValue` (opacity 0, scaled
+        // 0.6) before `beginTime` regardless of CAAnimationGroup-vs-child
+        // fillMode inheritance quirks.
         if let iconLayer = categoryIcon.layer {
             let fade = CABasicAnimation(keyPath: "opacity")
             fade.fromValue = 0.0
             fade.toValue = 1.0
+            fade.fillMode = .backwards
             let scale = CABasicAnimation(keyPath: "transform.scale")
             scale.fromValue = 0.6
             scale.toValue = 1.0
+            scale.fillMode = .backwards
             let group = CAAnimationGroup()
             group.animations = [fade, scale]
-            group.duration = 0.20
-            group.beginTime = begin + ringDuration * 0.75
+            group.duration = iconDuration
+            group.beginTime = iconBegin
             group.fillMode = .backwards
             group.timingFunction = CAMediaTimingFunction(name: .easeOut)
             iconLayer.add(group, forKey: "icon.appear")
@@ -1581,13 +1729,15 @@ final class NativeToolCallRowView: NSView {
             let fade = CABasicAnimation(keyPath: "opacity")
             fade.fromValue = 0.0
             fade.toValue = 1.0
+            fade.fillMode = .backwards
             let slide = CABasicAnimation(keyPath: "transform.translation.x")
             slide.fromValue = -8.0
             slide.toValue = 0.0
+            slide.fillMode = .backwards
             let group = CAAnimationGroup()
             group.animations = [fade, slide]
-            group.duration = 0.24
-            group.beginTime = begin + ringDuration * 0.75 + 0.16
+            group.duration = titleDuration
+            group.beginTime = titleBegin
             group.fillMode = .backwards
             group.timingFunction = CAMediaTimingFunction(name: .easeOut)
             titleLayer.add(group, forKey: "title.appear")

--- a/Packages/OsaurusCore/Views/Chat/TrailingTextFader.swift
+++ b/Packages/OsaurusCore/Views/Chat/TrailingTextFader.swift
@@ -15,7 +15,14 @@ final class TrailingTextFader {
 
     /// If a single recorded append exceeds this, treat it as a full rebuild and
     /// don't animate (avoids a giant gradient on cache hits / width changes).
-    private let appendAnimationCap = 64
+    ///
+    /// Must be comfortably above `StreamingDeltaProcessor.maxBufferSize` (64),
+    /// since that throttle's flush condition can overshoot its target by up to
+    /// the size of the final delta. The vmlx-swift runtime emits 5-11-char token
+    /// chunks, so flushes routinely land at 65-75 chars — at the old cap of 64,
+    /// every one of those was treated as a "big rebuild" and the streaming fade
+    /// was suppressed, even though they're just normal token bursts.
+    private let appendAnimationCap = 128
 
     private weak var textView: NSTextView?
     /// Active fade ranges, oldest first. Indices refer to textStorage character offsets.

--- a/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ConfigurationView.swift
@@ -31,6 +31,11 @@ struct ConfigurationView: View {
     @State private var tempCoreModelName: String = ""
     @State private var coreModelPickerItems: [ModelPickerItem] = []
     @State private var tempEnableClipboardMonitoring: Bool = false
+    /// Smooth streaming: pace the visible reveal at ~180 tok/s regardless
+    /// of how fast / bursty the network delivers tokens. Default on.
+    /// Bound to `UserDefaults` key `chatSmoothStreamingEnabled` which
+    /// `StreamingDeltaProcessor` reads per delta.
+    @AppStorage("chatSmoothStreamingEnabled") private var smoothStreamingEnabled: Bool = true
     /// Master switch for AI-generated empty-state greetings. Defaults to
     /// OFF; users opt in here. Per-agent overrides on
     /// `AgentSettings.generativeGreetingsEnabled` still win when set.
@@ -302,6 +307,17 @@ struct ConfigurationView: View {
                                                 defaultValue: 15
                                             )
                                         }
+                                    }
+
+                                    SettingsDivider()
+
+                                    SettingsSubsection(label: "Display") {
+                                        SettingsToggle(
+                                            title: L("Smooth streaming"),
+                                            description:
+                                                "Pace incoming tokens at a steady rate so streaming looks like a typewriter across all providers. Disable to render tokens as soon as they arrive — useful with very fast remote providers that you'd rather see complete instantly.",
+                                            isOn: $smoothStreamingEnabled
+                                        )
                                     }
 
                                     SettingsDivider()


### PR DESCRIPTION
## Summary

  - added a paced streaming reveal with a smooth streaming toggle in Chat settings (default on)
  - made stream finalization await the paced tail so fast remote providers no longer drop the end of responses
  - added a blinking dot at the trailing edge of streaming text during quiet network gaps (hidden while tokens flow and after stream end)
  - enforced a strict tool-call appearance sequence
  - suppressed implicit layer animations so tool call cells no longer look like they replay on cell reuse
  - cached tool call group views and chart views across cell recycles to avoid rebuilding on scroll
  - fixed same kind cell reuse to consult the cache by block id to fix single tool calls disappearing on scroll

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
