### PR TITLE
fixed remote providers failing to authenticate after keychain migration

### DIFF
--- a/Packages/OsaurusCore/Services/Keychain/KeychainDataProtection.swift
+++ b/Packages/OsaurusCore/Services/Keychain/KeychainDataProtection.swift
@@ -39,10 +39,59 @@ enum KeychainDataProtection {
         status == errSecSuccess || status == errSecItemNotFound
     }
 
-    /// Upsert `data` for (`service`, `account`). Prefers the data-protection
-    /// keychain and removes the stale legacy copy on success so a later read can
-    /// never return outdated data. Falls back to the legacy keychain when the
-    /// data-protection keychain is unavailable.
+    // MARK: - Data-protection keychain availability
+
+    /// Whether the data-protection keychain is available in this process,
+    /// determined once (lazily) via a sentinel write → read-back → delete.
+    ///
+    /// Un-entitled hosts — e.g. `swift test` binaries with no
+    /// `keychain-access-groups` entitlement — get `errSecMissingEntitlement` from
+    /// the data-protection keychain. Probing once lets `read`/`write` route those
+    /// processes to the legacy keychain without repeating the check (and without
+    /// ever deleting from it).
+    static let isUsable: Bool = {
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "ai.osaurus.dpprobe",
+            kSecAttrAccount as String: "roundtrip",
+        ]
+        let dpBase = KeychainQueryHelpers.dataProtection(base)
+        let sentinel = Data("osaurus-dp-probe".utf8)
+
+        // Clear any sentinel left by a prior launch so the add path is exercised.
+        SecItemDelete(dpBase as CFDictionary)
+
+        var add = dpBase
+        add[kSecValueData as String] = sentinel
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let addStatus = SecItemAdd(add as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            // `errSecMissingEntitlement` (un-entitled hosts) and friends: the
+            // data-protection keychain simply isn't available here.
+            log.error("data-protection keychain unavailable (probe add status \(addStatus)); using legacy keychain")
+            return false
+        }
+
+        var readBack = dpBase
+        readBack[kSecReturnData as String] = true
+        readBack[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let readStatus = SecItemCopyMatching(readBack as CFDictionary, &result)
+        SecItemDelete(dpBase as CFDictionary)
+
+        let roundTrips = readStatus == errSecSuccess && (result as? Data) == sentinel
+        if !roundTrips {
+            log.error(
+                "data-protection keychain did not round-trip a probe write (read status \(readStatus)); using legacy keychain"
+            )
+        }
+        return roundTrips
+    }()
+
+    // MARK: - CRUD
+
+    /// Upsert `data` for (`service`, `account`). Writes to the data-protection
+    /// keychain when it is usable, otherwise to the legacy keychain.
     @discardableResult
     static func write(
         service: String,
@@ -56,22 +105,31 @@ enum KeychainDataProtection {
             kSecAttrAccessible as String: accessible,
         ]
 
-        // Data-protection keychain first (update-or-add).
-        let dpBase = KeychainQueryHelpers.dataProtection(base)
-        if SecItemUpdate(dpBase as CFDictionary, attributes as CFDictionary) == errSecSuccess {
-            SecItemDelete(base as CFDictionary)
-            return true
+        if isUsable {
+            // Data-protection keychain (update-or-add).
+            //
+            // IMPORTANT: do NOT issue a `SecItemDelete(base)` here to clean up a
+            // legacy copy. On an app entitled for the data-protection keychain, a
+            // delete query that omits `kSecUseDataProtectionKeychain` is not
+            // reliably scoped to the legacy keychain — it matches and deletes the
+            // data-protection item we just wrote, so every subsequent read returns
+            // errSecItemNotFound. A stale legacy copy is harmless instead: `read`
+            // checks the data-protection keychain first, and `delete` clears both.
+            let dpBase = KeychainQueryHelpers.dataProtection(base)
+            if SecItemUpdate(dpBase as CFDictionary, attributes as CFDictionary) == errSecSuccess {
+                return true
+            }
+            var dpAdd = dpBase
+            dpAdd.merge(attributes) { _, new in new }
+            if SecItemAdd(dpAdd as CFDictionary, nil) == errSecSuccess {
+                return true
+            }
+            // Unexpected: probe said the keychain works but this write didn't.
+            // Fall through to the legacy keychain rather than losing the value.
         }
-        var dpAdd = dpBase
-        dpAdd.merge(attributes) { _, new in new }
-        let dpStatus = SecItemAdd(dpAdd as CFDictionary, nil)
-        if dpStatus == errSecSuccess {
-            SecItemDelete(base as CFDictionary)
-            return true
-        }
-        guard KeychainQueryHelpers.isMissingEntitlement(dpStatus) else { return false }
 
-        // Legacy fallback (data-protection keychain unavailable on this host).
+        // Legacy keychain. Never deletes — when the data-protection keychain is
+        // unusable this is the only durable store.
         if SecItemUpdate(base as CFDictionary, attributes as CFDictionary) == errSecSuccess {
             return true
         }
@@ -80,47 +138,50 @@ enum KeychainDataProtection {
         return SecItemAdd(legacyAdd as CFDictionary, nil) == errSecSuccess
     }
 
-    /// Read (`service`, `account`), preferring the data-protection keychain and
-    /// falling back to (and migrating from) the legacy keychain.
+    /// Read (`service`, `account`), preferring the data-protection keychain (when
+    /// usable) and falling back to — and migrating forward from — the legacy
+    /// keychain.
     static func read(
         service: String,
         account: String,
         accessible: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     ) -> Data? {
-        var query = baseQuery(service: service, account: account)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        query[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
+        let base = baseQuery(service: service, account: account)
 
-        var result: AnyObject?
-        let dpStatus = SecItemCopyMatching(
-            KeychainQueryHelpers.dataProtection(query) as CFDictionary,
-            &result
-        )
-        if dpStatus == errSecSuccess { return result as? Data }
-
-        // Only fall back to the legacy keychain when the data-protection item is
-        // genuinely absent (never written there) or this host can't use the
-        // data-protection keychain at all. Any other status — e.g.
-        // `errSecInteractionNotAllowed` / `errSecAuthFailed` — means a
-        // data-protection item *exists* but is intentionally inaccessible right
-        // now; querying the legacy keychain there would risk a login-keychain
-        // prompt and could return a stale value that shadows the real item. Fail
-        // closed instead.
-        guard dpStatus == errSecItemNotFound || KeychainQueryHelpers.isMissingEntitlement(dpStatus)
-        else {
-            log.error(
-                "data-protection read for \(service, privacy: .public) failed (status \(dpStatus)); not falling back to legacy keychain"
-            )
-            return nil
+        if isUsable {
+            // The data-protection items use `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+            // with no access control, so the query needs no authentication context
+            // and there is no biometric/passcode UI to suppress.
+            var dpQuery = KeychainQueryHelpers.dataProtection(base)
+            dpQuery[kSecReturnData as String] = true
+            dpQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+            var result: AnyObject?
+            if SecItemCopyMatching(dpQuery as CFDictionary, &result) == errSecSuccess {
+                return result as? Data
+            }
+            // Not in the data-protection keychain yet: fall through to the legacy
+            // keychain and migrate the value forward on hit.
         }
 
+        // Legacy query. Here the auth params matter: this is where the per-binary
+        // ACL "wants to use your confidential information" password prompt would
+        // appear, and `kSecUseAuthenticationUISkip` + a non-interactive
+        // `LAContext` suppress it (the read simply fails instead of prompting).
+        var legacyQuery = base
+        legacyQuery[kSecReturnData as String] = true
+        legacyQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        legacyQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        legacyQuery[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
         var legacyResult: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &legacyResult) == errSecSuccess,
+        guard SecItemCopyMatching(legacyQuery as CFDictionary, &legacyResult) == errSecSuccess,
             let data = legacyResult as? Data
         else { return nil }
-        write(service: service, account: account, data: data, accessible: accessible)
+
+        // Migrate the legacy value into the data-protection keychain only when it
+        // actually works; otherwise leave it where it is.
+        if isUsable {
+            write(service: service, account: account, data: data, accessible: accessible)
+        }
         return data
     }
 
@@ -137,19 +198,24 @@ enum KeychainDataProtection {
     /// de-duplicated on account name (the data-protection copy wins so migrated
     /// values shadow stale legacy data).
     static func fetchAll(service: String, returnData: Bool) -> [[String: Any]] {
-        var query: [String: Any] = [
+        var base: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecMatchLimit as String: kSecMatchLimitAll,
             kSecReturnAttributes as String: true,
-            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
-            kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
         ]
-        if returnData { query[kSecReturnData as String] = true }
+        if returnData { base[kSecReturnData as String] = true }
+
+        // The legacy query keeps the non-interactive auth params to suppress the
+        // login-keychain password prompt; the data-protection query needs none.
+        let dpQuery = KeychainQueryHelpers.dataProtection(base)
+        var legacyQuery = base
+        legacyQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        legacyQuery[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
 
         // Legacy first so data-protection entries win on duplicate accounts.
         var merged: [String: [String: Any]] = [:]
-        for q in [query, KeychainQueryHelpers.dataProtection(query)] {
+        for q in [legacyQuery, dpQuery] {
             var result: AnyObject?
             guard SecItemCopyMatching(q as CFDictionary, &result) == errSecSuccess,
                 let items = result as? [[String: Any]]

--- a/Packages/OsaurusCore/Services/Keychain/KeychainDataProtection.swift
+++ b/Packages/OsaurusCore/Services/Keychain/KeychainDataProtection.swift
@@ -66,9 +66,13 @@ enum KeychainDataProtection {
         add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         let addStatus = SecItemAdd(add as CFDictionary, nil)
         guard addStatus == errSecSuccess else {
-            // `errSecMissingEntitlement` (un-entitled hosts) and friends: the
-            // data-protection keychain simply isn't available here.
-            log.error("data-protection keychain unavailable (probe add status \(addStatus)); using legacy keychain")
+            // `errSecMissingEntitlement` is the expected status on un-entitled
+            // hosts (e.g. `swift test` binaries); anything else is unexpected.
+            if KeychainQueryHelpers.isMissingEntitlement(addStatus) {
+                log.debug("data-protection keychain unavailable (missing entitlement); using legacy keychain")
+            } else {
+                log.error("data-protection keychain probe add failed (status \(addStatus)); using legacy keychain")
+            }
             return false
         }
 
@@ -167,11 +171,15 @@ enum KeychainDataProtection {
         // ACL "wants to use your confidential information" password prompt would
         // appear, and `kSecUseAuthenticationUISkip` + a non-interactive
         // `LAContext` suppress it (the read simply fails instead of prompting).
-        var legacyQuery = base
-        legacyQuery[kSecReturnData as String] = true
-        legacyQuery[kSecMatchLimit as String] = kSecMatchLimitOne
-        legacyQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        legacyQuery[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
+        let legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+            kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
+        ]
         var legacyResult: AnyObject?
         guard SecItemCopyMatching(legacyQuery as CFDictionary, &legacyResult) == errSecSuccess,
             let data = legacyResult as? Data
@@ -209,9 +217,15 @@ enum KeychainDataProtection {
         // The legacy query keeps the non-interactive auth params to suppress the
         // login-keychain password prompt; the data-protection query needs none.
         let dpQuery = KeychainQueryHelpers.dataProtection(base)
-        var legacyQuery = base
-        legacyQuery[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
-        legacyQuery[kSecUseAuthenticationContext as String] = KeychainQueryHelpers.nonInteractiveContext()
+        var legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip,
+            kSecUseAuthenticationContext as String: KeychainQueryHelpers.nonInteractiveContext(),
+        ]
+        if returnData { legacyQuery[kSecReturnData as String] = true }
 
         // Legacy first so data-protection entries win on duplicate accounts.
         var merged: [String: [String: Any]] = [:]

--- a/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
@@ -1,0 +1,61 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Keychain data-protection round-trip")
+struct KeychainDataProtectionTests {
+    private static func packageRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Service/
+        cursor.deleteLastPathComponent()  // Tests/
+        return cursor.deletingLastPathComponent()  // OsaurusCore/
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = packageRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Returns the body of `static func write(...)` up to the next `static func`.
+    private static func writeFunctionBody(in source: String) throws -> String {
+        let start = try #require(source.range(of: "static func write("))
+        let rest = source[start.lowerBound...]
+        let nextFunc = try #require(rest.range(of: "static func read("))
+        return String(source[start.lowerBound ..< nextFunc.lowerBound])
+    }
+
+    // The regression: `write(...)` used to delete the legacy copy with a query
+    // that wasn't scoped to the legacy keychain. On an entitled app that delete
+    // matched and removed the data-protection item it had just written, so every
+    // later read returned errSecItemNotFound. The write path must therefore never
+    // issue a delete — a lingering legacy copy is harmless because `read` checks
+    // the data-protection keychain first and `delete` clears both keychains.
+    @Test("write never deletes (so it cannot wipe the item it just wrote)")
+    func writeDoesNotDelete() throws {
+        let source = try Self.source("Services/Keychain/KeychainDataProtection.swift")
+        let body = try Self.writeFunctionBody(in: source)
+        #expect(!body.contains("SecItemDelete"))
+    }
+
+    // Behavioral guard: a value written through the helper must read back
+    // unchanged. This exercises whichever backend is active in this process
+    // (legacy when un-entitled, data-protection when entitled). When no keychain
+    // backend is writable — e.g. a barren CI runner — `write` returns false and
+    // the round-trip assertion is skipped rather than failing spuriously.
+    @Test("a written value survives and reads back")
+    func valueSurvivesWrite() {
+        let service = "ai.osaurus.test.dp"
+        let account = "roundtrip-\(UUID().uuidString)"
+        let secret = Data("s3cr3t-\(UUID().uuidString)".utf8)
+        defer { KeychainDataProtection.delete(service: service, account: account) }
+
+        guard KeychainDataProtection.write(service: service, account: account, data: secret) else {
+            return  // No writable keychain backend in this environment.
+        }
+
+        #expect(KeychainDataProtection.read(service: service, account: account) == secret)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
@@ -37,7 +37,16 @@ struct KeychainDataProtectionTests {
     func writeDoesNotDelete() throws {
         let source = try Self.source("Services/Keychain/KeychainDataProtection.swift")
         let body = try Self.writeFunctionBody(in: source)
-        #expect(!body.contains("SecItemDelete"))
+        // Strip line comments so prose that mentions the call (e.g. the comment
+        // explaining why it must not happen) doesn't trip the check.
+        let code = body
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                guard let comment = line.range(of: "//") else { return line }
+                return line[line.startIndex ..< comment.lowerBound]
+            }
+            .joined(separator: "\n")
+        #expect(!code.contains("SecItemDelete"))
     }
 
     // Behavioral guard: a value written through the helper must read back


### PR DESCRIPTION
after the keychain migration, remote providers stopped connecting because their saved API keys could not be read back. saving a credential immediately removed it from the keychain so every later lookup came up empty and the request failed 
authentication

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
