### PR TITLE
[codex] Restore keychain test formatting gate

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
@@ -39,7 +39,8 @@ struct KeychainDataProtectionTests {
         let body = try Self.writeFunctionBody(in: source)
         // Strip line comments so prose that mentions the call (e.g. the comment
         // explaining why it must not happen) doesn't trip the check.
-        let code = body
+        let code =
+            body
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map { line -> Substring in
                 guard let comment = line.range(of: "//") else { return line }


### PR DESCRIPTION
## Business rationale

#1291 added a keychain data-protection regression test, but current `origin/main` no longer passes the mandatory strict Swift format gate. That blocks every follow-on development lane from producing a clean, independently reviewable PR because `swift-format lint --strict --recursive Packages App` fails before lane-specific code is evaluated. This PR restores the current-main gate with the smallest possible user-visible impact: maintainers get a green baseline again, and downstream auth/tooling PRs can be reviewed without carrying unrelated formatter noise.

## Coding rationale

The fix is intentionally limited to the single formatter finding in `Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift`. I used the repository's configured `swift-format` output instead of hand-editing surrounding test logic, so the keychain migration behavior from #1291 is unchanged. Alternatives considered were stacking product PRs on top of an unformatted baseline or broad-formatting the tree; both would make human review noisier. This change crosses no runtime trust boundary and adds no dependencies.

## Acceptance criteria

- [x] Current `origin/main` strict Swift format failure is corrected
- [x] No production behavior changes
- [x] Full local quality gate passes on the PR head

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Before this patch, the gate stopped immediately with:

```text
Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift:42:19: error: [AddLines] add 1 line break
```

After formatting the file, the full gate on `0756008dc7445ff6f35dc78686be642ceda93670` completed with:

```text
[4/6] swift test --package-path Packages/OsaurusCLI --parallel
[1/82] ...
[82/82] Testing OsaurusCLITests.ToolsPackageTests/testFindDylibsIgnoresNonDylibExtensions
[5/6] make ci-test
Done. Inspect failures with: open build/Tests.xcresult
[6/6] swift build --package-path Packages/OsaurusCore -c release
Build complete! (454.12s)
QUALITY_GATE_OK 2026-05-29T20:34:28Z
```

## Rollback

Revert commit `0756008dc7445ff6f35dc78686be642ceda93670`.
