### PR TITLE
[codex] Add ChatGPT auth diagnostics

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -279,10 +279,11 @@ public final class RemoteProviderManager: ObservableObject {
             notifyModelsChanged()
 
         } catch {
+            let errorMessage = userFacingErrorMessage(error, for: provider)
             // Update state with error
             state.isConnecting = false
             state.isConnected = false
-            state.lastError = error.localizedDescription
+            state.lastError = errorMessage
             state.discoveredModels = []
             providerStates[providerId] = state
 
@@ -291,7 +292,7 @@ public final class RemoteProviderManager: ObservableObject {
                 Task { await service.invalidateSession() }
             }
 
-            print("[Osaurus] Remote Provider '\(provider.name)': Connection failed - \(error)")
+            print("[Osaurus] Remote Provider '\(provider.name)': Connection failed - \(errorMessage)")
 
             notifyStatusChanged()
             throw error
@@ -667,6 +668,13 @@ public final class RemoteProviderManager: ObservableObject {
 
     private func notifyModelsChanged() {
         NotificationCenter.default.post(name: .remoteProviderModelsChanged, object: nil)
+    }
+
+    private func userFacingErrorMessage(_ error: Error, for provider: RemoteProvider) -> String {
+        guard provider.authType == .openAICodexOAuth || provider.providerType == .openAICodex else {
+            return error.localizedDescription
+        }
+        return OpenAICodexOAuthService.diagnosticMessage(for: error)
     }
 
     // MARK: - Test Helpers

--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -12,21 +12,48 @@ public enum OpenAICodexOAuthError: LocalizedError, Sendable {
     case invalidAuthorizationCallback
     case invalidPKCE
     case invalidTokenResponse
+    case missingSignInTokens
     case missingAccountId
     case tokenRequestFailed(String)
+    case loopbackBindFailed(String)
+    case browserOpenFailed
+    case authorizationCallbackFailed(String)
+    case authorizationCallbackRejected(String)
+    case modelCatalogRequestFailed(String)
+    case modelCatalogDecodeFailed(String)
 
     public var errorDescription: String? {
         switch self {
         case .invalidAuthorizationCallback:
-            return "OpenAI did not return a valid authorization code"
+            return
+                "ChatGPT sign-in did not return a valid authorization code. Try the sign-in again from the same browser window."
         case .invalidPKCE:
             return "Could not create a secure login challenge"
         case .invalidTokenResponse:
-            return "OpenAI returned an invalid token response"
+            return "OpenAI returned an invalid token response during ChatGPT sign-in"
+        case .missingSignInTokens:
+            return "Missing ChatGPT/Codex sign-in tokens. Sign in with ChatGPT again, then retry the provider."
         case .missingAccountId:
-            return "Could not identify the ChatGPT account from the sign-in token"
+            return
+                "Could not identify the ChatGPT account from the sign-in token. Sign in with the ChatGPT account that has Codex access, then retry."
         case .tokenRequestFailed(let message):
-            return "OpenAI token request failed: \(message)"
+            return "OpenAI token request failed: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
+        case .loopbackBindFailed(let message):
+            return
+                "Could not start the ChatGPT sign-in callback server on localhost:1455. Close any other in-progress sign-in or app using that port, then retry. Details: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
+        case .browserOpenFailed:
+            return
+                "Could not open the browser for ChatGPT sign-in. Check the macOS default browser setting, then retry."
+        case .authorizationCallbackFailed(let message):
+            return "ChatGPT sign-in callback failed: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
+        case .authorizationCallbackRejected(let message):
+            return "ChatGPT rejected the sign-in callback: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
+        case .modelCatalogRequestFailed(let message):
+            return
+                "ChatGPT/Codex model catalog request failed: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
+        case .modelCatalogDecodeFailed(let message):
+            return
+                "OpenAI returned an unreadable Codex model catalog: \(OpenAICodexOAuthService.safeDiagnosticFragment(message))"
         }
     }
 }
@@ -126,9 +153,10 @@ public enum OpenAICodexOAuthService {
         request.setValue("codex_cli_rs", forHTTPHeaderField: "originator")
         request.setValue("responses=experimental", forHTTPHeaderField: "OpenAI-Beta")
 
-        let data = try await performRequest(request)
+        let data = try await performRequest(request, operation: .modelCatalog)
         guard let decoded = try? JSONDecoder().decode(ModelsResponse.self, from: data) else {
-            throw OpenAICodexOAuthError.invalidTokenResponse
+            let preview = String(data: data.prefix(200), encoding: .utf8) ?? "non-text response"
+            throw OpenAICodexOAuthError.modelCatalogDecodeFailed(preview)
         }
 
         return decoded.models
@@ -173,6 +201,49 @@ public enum OpenAICodexOAuthService {
             return supportedModels
         }
         return live
+    }
+
+    /// Convert Codex OAuth failures into a short, safe-to-paste message for
+    /// UI surfaces and GitHub issue replies. The raw failures may include HTTP
+    /// bodies, callback URLs, or provider diagnostics, so this always applies
+    /// the same redaction rules before text leaves the service boundary.
+    public static func diagnosticMessage(for error: Error) -> String {
+        if let codexError = error as? OpenAICodexOAuthError {
+            return codexError.errorDescription ?? "ChatGPT/Codex sign-in failed"
+        }
+
+        if let loopbackError = error as? OAuthLoopbackError {
+            return mapLoopbackError(loopbackError).errorDescription ?? "ChatGPT/Codex sign-in failed"
+        }
+
+        return "ChatGPT/Codex sign-in failed: \(safeDiagnosticFragment(error.localizedDescription))"
+    }
+
+    /// Redact OAuth credentials from provider diagnostics while preserving
+    /// enough status/body detail for maintainers to understand what failed.
+    public static func safeDiagnosticFragment(_ raw: String, maxLength: Int = 240) -> String {
+        var value = raw
+        let replacements: [(pattern: String, template: String)] = [
+            (#"(?i)authorization\s*[:=]\s*(?:bearer\s+)?[^\s,;}]+\"?"#, "credential=***"),
+            (#"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"#, "credential=***"),
+            (#"(?i)\"(access_token|refresh_token|code_verifier|code|verifier)\"\s*:\s*\"[^\"]*\""#, #""$1":"***""#),
+            (#"(?i)\b(access_token|refresh_token|code_verifier|code|verifier)=([^&\s,;}]+)"#, "$1=***"),
+            (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
+        ]
+        for replacement in replacements {
+            value = value.replacingMatches(of: replacement.pattern, with: replacement.template)
+        }
+
+        value = value.replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.contains("  ") {
+            value = value.replacingOccurrences(of: "  ", with: " ")
+        }
+
+        guard !value.isEmpty else { return "No details returned" }
+        guard value.count > maxLength else { return value }
+        return String(value.prefix(maxLength)) + "..."
     }
 
     // MARK: - OAuth Helpers
@@ -269,17 +340,44 @@ public enum OpenAICodexOAuthService {
 
     // MARK: Networking
 
-    /// Executes `request`, returning the body on success. Throws
-    /// `.invalidTokenResponse` for non-HTTP responses and `.tokenRequestFailed`
-    /// for any HTTP error (body included in the message for diagnostics).
-    private static func performRequest(_ request: URLRequest) async throws -> Data {
-        let (data, response) = try await URLSession.shared.data(for: request)
+    private enum RequestOperation {
+        case token
+        case modelCatalog
+    }
+
+    /// Executes `request`, preserving whether the failure happened during token
+    /// exchange or catalog lookup so the UI can give the user the right next step.
+    private static func performRequest(_ request: URLRequest, operation: RequestOperation) async throws -> Data {
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let message = "Network error: \(error.localizedDescription)"
+            switch operation {
+            case .token:
+                throw OpenAICodexOAuthError.tokenRequestFailed(message)
+            case .modelCatalog:
+                throw OpenAICodexOAuthError.modelCatalogRequestFailed(message)
+            }
+        }
         guard let http = response as? HTTPURLResponse else {
-            throw OpenAICodexOAuthError.invalidTokenResponse
+            switch operation {
+            case .token:
+                throw OpenAICodexOAuthError.invalidTokenResponse
+            case .modelCatalog:
+                throw OpenAICodexOAuthError.modelCatalogRequestFailed("Non-HTTP response")
+            }
         }
         guard http.statusCode < 400 else {
             let body = String(data: data, encoding: .utf8) ?? "HTTP \(http.statusCode)"
-            throw OpenAICodexOAuthError.tokenRequestFailed(body)
+            let message = "HTTP \(http.statusCode): \(body)"
+            switch operation {
+            case .token:
+                throw OpenAICodexOAuthError.tokenRequestFailed(message)
+            case .modelCatalog:
+                throw OpenAICodexOAuthError.modelCatalogRequestFailed(message)
+            }
         }
         return data
     }
@@ -290,7 +388,7 @@ public enum OpenAICodexOAuthService {
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = OAuthFormEncoding.encode(form).data(using: .utf8)
 
-        let data = try await performRequest(request)
+        let data = try await performRequest(request, operation: .token)
         guard let response = try? JSONDecoder().decode(TokenResponse.self, from: data) else {
             throw OpenAICodexOAuthError.invalidTokenResponse
         }
@@ -318,24 +416,52 @@ public enum OpenAICodexOAuthService {
                 callbackPath: "/auth/callback"
             )
             try await server.start()
+        } catch let error as OAuthLoopbackError {
+            throw mapLoopbackError(error)
         } catch {
-            throw OpenAICodexOAuthError.invalidAuthorizationCallback
+            throw OpenAICodexOAuthError.loopbackBindFailed(error.localizedDescription)
         }
         defer { server.stop() }
 
         guard NSWorkspace.shared.open(url) else {
-            throw OpenAICodexOAuthError.invalidAuthorizationCallback
+            throw OpenAICodexOAuthError.browserOpenFailed
         }
 
         do {
             return try await server.waitForCallback()
+        } catch let error as OAuthLoopbackError {
+            throw mapLoopbackError(error)
         } catch {
-            throw OpenAICodexOAuthError.invalidAuthorizationCallback
+            throw OpenAICodexOAuthError.authorizationCallbackFailed(error.localizedDescription)
+        }
+    }
+
+    private static func mapLoopbackError(_ error: OAuthLoopbackError) -> OpenAICodexOAuthError {
+        switch error {
+        case .bindFailed(let message):
+            return .loopbackBindFailed(message)
+        case .stateMismatch:
+            return .authorizationCallbackRejected("state mismatch from browser callback")
+        case .missingCode:
+            return .authorizationCallbackRejected("missing authorization code")
+        case .oauthError(let error, let description):
+            let detail = [error, description].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: ": ")
+            return .authorizationCallbackRejected(detail.isEmpty ? "OAuth provider returned an error" : detail)
+        case .invalidCallback:
+            return .authorizationCallbackFailed("invalid callback path or request")
         }
     }
 }
 
 // MARK: - Helpers
+
+extension String {
+    fileprivate func replacingMatches(of pattern: String, with template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return self }
+        let range = NSRange(startIndex ..< endIndex, in: self)
+        return regex.stringByReplacingMatches(in: self, range: range, withTemplate: template)
+    }
+}
 
 extension Sequence where Element: Hashable {
     /// Returns the receiver's elements in order, dropping later duplicates.

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1893,7 +1893,7 @@ public actor RemoteProviderService: ToolCapableService {
     private func refreshCodexOAuthIfNeeded() async throws {
         guard provider.authType == .openAICodexOAuth else { return }
         guard let tokens = cachedOAuthTokens else {
-            throw RemoteProviderServiceError.requestFailed("Missing ChatGPT/Codex sign-in tokens")
+            throw OpenAICodexOAuthError.missingSignInTokens
         }
         guard tokens.isExpired else { return }
 
@@ -1904,7 +1904,7 @@ public actor RemoteProviderService: ToolCapableService {
 
     private func codexOAuthHeaders() throws -> [String: String] {
         guard let tokens = cachedOAuthTokens else {
-            throw RemoteProviderServiceError.requestFailed("Missing ChatGPT/Codex sign-in tokens")
+            throw OpenAICodexOAuthError.missingSignInTokens
         }
         return [
             "Authorization": "Bearer \(tokens.accessToken)",
@@ -3142,7 +3142,7 @@ extension RemoteProviderService {
     public static func fetchModels(from provider: RemoteProvider) async throws -> [String] {
         if provider.providerType == .openAICodex {
             guard var tokens = await provider.getOAuthTokensOffMainActor() else {
-                throw RemoteProviderServiceError.requestFailed("Missing ChatGPT/Codex sign-in tokens")
+                throw OpenAICodexOAuthError.missingSignInTokens
             }
             if tokens.isExpired {
                 let refreshed = try await OpenAICodexOAuthService.refresh(tokens)

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
@@ -91,6 +91,61 @@ struct OpenAICodexOAuthServiceTests {
         }
     }
 
+    @Test func diagnostics_redactOAuthSecretsFromPasteableMessages() {
+        let raw = """
+            Authorization: Bearer access.secret
+            {"access_token":"token-123","refresh_token":"refresh-456","code":"auth-code"}
+            code_verifier=verifier-789
+            eyJheader.eyJpayload.signature
+            """
+
+        let sanitized = OpenAICodexOAuthService.safeDiagnosticFragment(raw, maxLength: 500)
+
+        for secret in ["access.secret", "token-123", "refresh-456", "auth-code", "verifier-789"] {
+            #expect(!sanitized.contains(secret), "diagnostic leaked \(secret)")
+        }
+        #expect(sanitized.range(of: "Authorization", options: .caseInsensitive) == nil)
+        #expect(sanitized.range(of: "Bearer", options: .caseInsensitive) == nil)
+        #expect(sanitized.contains("***"))
+    }
+
+    @Test func diagnostics_explainLoopbackPortCollision() {
+        let error = OpenAICodexOAuthError.loopbackBindFailed("Address already in use")
+        let message = OpenAICodexOAuthService.diagnosticMessage(for: error)
+
+        #expect(message.contains("localhost:1455"))
+        #expect(message.contains("Close any other in-progress sign-in"))
+        #expect(message.contains("Address already in use"))
+    }
+
+    @Test func diagnostics_distinguishCallbackRejectionAndMissingTokens() {
+        let callback = OpenAICodexOAuthService.diagnosticMessage(
+            for: OpenAICodexOAuthError.authorizationCallbackRejected("state mismatch from browser callback")
+        )
+        let missing = OpenAICodexOAuthService.diagnosticMessage(for: OpenAICodexOAuthError.missingSignInTokens)
+
+        #expect(callback.contains("rejected the sign-in callback"))
+        #expect(callback.contains("state mismatch"))
+        #expect(missing.contains("Missing ChatGPT/Codex sign-in tokens"))
+        #expect(missing.contains("Sign in with ChatGPT again"))
+    }
+
+    @Test func diagnostics_distinguishModelCatalogHTTPAndDecodeFailures() {
+        let http = OpenAICodexOAuthService.diagnosticMessage(
+            for: OpenAICodexOAuthError.modelCatalogRequestFailed(
+                #"HTTP 401: {"error":"bad","access_token":"secret-token"}"#
+            )
+        )
+        let decode = OpenAICodexOAuthService.diagnosticMessage(
+            for: OpenAICodexOAuthError.modelCatalogDecodeFailed(#"{"models":"unexpected"}"#)
+        )
+
+        #expect(http.contains("model catalog request failed"))
+        #expect(http.contains("HTTP 401"))
+        #expect(!http.contains("secret-token"))
+        #expect(decode.contains("unreadable Codex model catalog"))
+    }
+
     private static func makeJWT(payload: [String: Any]) throws -> String {
         let headerData = try JSONSerialization.data(withJSONObject: ["alg": "none"])
         let payloadData = try JSONSerialization.data(withJSONObject: payload)

--- a/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
@@ -39,7 +39,8 @@ struct KeychainDataProtectionTests {
         let body = try Self.writeFunctionBody(in: source)
         // Strip line comments so prose that mentions the call (e.g. the comment
         // explaining why it must not happen) doesn't trip the check.
-        let code = body
+        let code =
+            body
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map { line -> Substring in
                 guard let comment = line.range(of: "//") else { return line }

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -1294,9 +1294,13 @@ private struct AddProviderFlow: View {
                     }
                 }
             } catch {
+                let message =
+                    preset == .openai && openAIAuthMode == .chatGPTSubscription
+                    ? OpenAICodexOAuthService.diagnosticMessage(for: error)
+                    : error.localizedDescription
                 await MainActor.run {
                     withAnimation {
-                        testResult = .failure(error.localizedDescription); isTesting = false
+                        testResult = .failure(message); isTesting = false
                     }
                 }
             }
@@ -2274,8 +2278,12 @@ private struct EditProviderFlow: View {
                     isTesting = false
                 }
             } catch {
+                let message =
+                    authType == .openAICodexOAuth || providerType == .openAICodex
+                    ? OpenAICodexOAuthService.diagnosticMessage(for: error)
+                    : error.localizedDescription
                 await MainActor.run {
-                    testResult = .failure(error.localizedDescription)
+                    testResult = .failure(message)
                     isTesting = false
                 }
             }


### PR DESCRIPTION
## Business rationale

Users hitting ChatGPT subscription / Codex OAuth failures currently get generic provider errors that are hard to act on and unsafe to paste into an issue because raw HTTP bodies can include authorization details. This PR turns the #1225 failure path into clear, user-facing diagnostics for missing sign-in tokens, localhost callback failures, callback rejection, token exchange failure, and Codex model-catalog failures. The observable improvement is that the settings connection flow and provider manager now show a specific remediation message while preserving enough sanitized detail for maintainers to debug.

## Coding rationale

The change keeps the existing OpenAI Codex OAuth/provider architecture and adds diagnostic mapping at the service boundary instead of changing keychain storage, provider identity, or auth refresh semantics. I inspected #1291 before rebasing; that PR changes the data-protection keychain layer, while this lane changes Codex OAuth error classification and presentation. Raw network/callback details cross a trust boundary when shown in UI or copied into GitHub, so all diagnostic fragments pass through explicit redaction and truncation before leaving `OpenAICodexOAuthService`. #1293 is included as a temporary baseline dependency because current `main` fails strict Swift format without that one-file keychain test formatting fix; after #1293 merges, this PR can be rebased to a five-file product diff.

## Acceptance criteria

- [x] Codex OAuth missing-token failures produce a ChatGPT-specific remediation message
- [x] Loopback port/callback failures are distinguishable from token/model-catalog failures
- [x] Diagnostic text redacts OAuth tokens, bearer credentials, code verifiers, auth codes, and JWTs
- [x] Add/edit provider settings surfaces use the sanitized Codex diagnostic message
- [x] Full local quality gate passes on the PR head

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

Focused coverage added in `OpenAICodexOAuthServiceTests` verifies redaction and distinct user-facing diagnostics:

```text
diagnostics_redactOAuthSecretsFromPasteableMessages
diagnostics_explainLoopbackPortCollision
diagnostics_distinguishCallbackRejectionAndMissingTokens
diagnostics_distinguishModelCatalogHTTPAndDecodeFailures
```

The full gate on `07084677b7be0e56955687e5d8f842bb18dbdead` completed with:

```text
[4/6] swift test --package-path Packages/OsaurusCLI --parallel
[1/82] ...
[82/82] Testing OsaurusCLITests.ToolsCreateTests/testRustLibContainsV2EntryPoint
[5/6] make ci-test
Done. Inspect failures with: open build/Tests.xcresult
[6/6] swift build --package-path Packages/OsaurusCore -c release
Build complete! (221.16s)
QUALITY_GATE_OK 2026-05-29T20:41:30Z
```

## Rollback

Revert commit `07084677b7be0e56955687e5d8f842bb18dbdead`. If #1293 has not merged yet, keep or merge #1293 separately because it restores the current-main formatter gate.
