### PR TITLE
[codex] Prove folder artifact tool exposure

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/FolderContextRenderTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/FolderContextRenderTests.swift
@@ -115,6 +115,14 @@ struct FolderContextRenderTests {
         #expect(!guide.contains("instead of"))
     }
 
+    @Test("artifact reminder names write, edit, and share tools")
+    func artifactReminderNamesArtifactSurfaceTools() {
+        let rendered = SystemPromptTemplates.folderContext(from: ctx())
+        #expect(rendered.contains("`file_write`"))
+        #expect(rendered.contains("`file_edit`"))
+        #expect(rendered.contains("`share_artifact`"))
+    }
+
     // MARK: - Subsection ordering
 
     /// The rendered folder section should land subsections in this order:

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -61,6 +61,20 @@ struct SystemPromptComposerToolResolutionTests {
         ToolRegistry.shared.unregisterAllSandboxTools()
     }
 
+    private func withRegisteredFolderTools(_ body: @MainActor @Sendable (FolderContext) -> Void) {
+        let folder = FolderContext(
+            rootPath: URL(fileURLWithPath: "/tmp/osaurus-tool-resolution-\(UUID().uuidString)"),
+            projectType: .swift,
+            tree: "./\nREADME.md\nSources/App.swift",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false
+        )
+        FolderToolManager.shared.registerFolderTools(for: folder)
+        body(folder)
+        FolderToolManager.shared.unregisterFolderTools()
+    }
+
     // MARK: - Auto mode
 
     @Test
@@ -136,6 +150,22 @@ struct SystemPromptComposerToolResolutionTests {
                 #expect(names.contains("share_artifact"))
                 #expect(names.contains("sandbox_exec"))
                 #expect(names.contains("capabilities_search"))
+            }
+        }
+    }
+
+    @Test
+    func hostFolderMode_includesFolderMutationAndArtifactTools() async {
+        await withSandboxAgent(autonomous: false) { agentId in
+            withRegisteredFolderTools { folder in
+                let tools = SystemPromptComposer.resolveTools(
+                    agentId: agentId,
+                    executionMode: .hostFolder(folder)
+                )
+                let names = Set(tools.map { $0.function.name })
+                #expect(names.contains("file_write"))
+                #expect(names.contains("file_edit"))
+                #expect(names.contains("share_artifact"))
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainDataProtectionTests.swift
@@ -39,7 +39,8 @@ struct KeychainDataProtectionTests {
         let body = try Self.writeFunctionBody(in: source)
         // Strip line comments so prose that mentions the call (e.g. the comment
         // explaining why it must not happen) doesn't trip the check.
-        let code = body
+        let code =
+            body
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map { line -> Substring in
                 guard let comment = line.range(of: "//") else { return line }


### PR DESCRIPTION
## Business rationale

Recent maintainer feedback pushed document/workbook functionality away from adding heavier default tools and toward targeted tool discovery and existing read/file surfaces. This PR adds regression proof for the existing host-folder artifact path instead of adding new default tools: when a folder context is active, Osaurus must expose the mutation/output tools users need (`file_write`, `file_edit`, and `share_artifact`) and the folder prompt must name that boundary clearly. That directly supports #823, #789, and #647 by making the intended artifact-output behavior testable without increasing the default tool burden on local models.

## Coding rationale

This is intentionally test-only. It does not change the runtime tool registry, prompt implementation, or default tool set; it pins the current behavior that should remain true after the read-file/plugin-hint work. The tests register a concrete host-folder context and then assert the resolved tool names and rendered folder reminder, which is cleaner than relying on snapshots of the full prompt. #1293 is included as a temporary baseline dependency because current `main` fails strict Swift format without that one-file keychain test formatting fix; after #1293 merges, this PR can be rebased to a two-file test diff.

## Acceptance criteria

- [x] Host-folder mode exposes `file_write`
- [x] Host-folder mode exposes `file_edit`
- [x] Host-folder mode exposes `share_artifact`
- [x] Folder context reminder names the same artifact surface tools
- [x] Full local quality gate passes on the PR head

## Quality gate

- [x] swift-format / swiftlint / shellcheck — clean
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed (fetch within 15 min)

## Debug evidence

New focused assertions were exercised by `make ci-test`:

```text
SystemPromptComposerToolResolutionTests.hostFolderMode_includesFolderMutationAndArtifactTools
FolderContextRenderTests.artifactReminderNamesArtifactSurfaceTools
```

The full gate on `0abb0c47cbc77981b88f5204d43994f36be97828` completed with:

```text
[4/6] swift test --package-path Packages/OsaurusCLI --parallel
[1/82] ...
[82/82] Testing OsaurusCLITests.ToolsPackageTests/testCompanionDirsListIsCorrect
[5/6] make ci-test
✔ [SystemPromptComposerToolResolutionTests] hostFolderMode_includesFolderMutationAndArtifactTools
Done. Inspect failures with: open build/Tests.xcresult
[6/6] swift build --package-path Packages/OsaurusCore -c release
Build complete! (225.44s)
QUALITY_GATE_OK 2026-05-29T20:48:22Z
```

## Rollback

Revert commit `0abb0c47cbc77981b88f5204d43994f36be97828`. If #1293 has not merged yet, keep or merge #1293 separately because it restores the current-main formatter gate.
