### PR TITLE
Pin DSV4 runtime tool fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+            revision: "c8023e985c055b1506b49526f9282bdedf940f41"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c8023e985c055b1506b49526f9282bdedf940f41"
+            revision: "c3501ec92aa630102ff2c0083b96bd22c4989c29"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -472,7 +472,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        let expectedRuntimeHardenedRevision = "c8023e985c055b1506b49526f9282bdedf940f41"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -472,7 +472,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "c8023e985c055b1506b49526f9282bdedf940f41"
+        let expectedRuntimeHardenedRevision = "c3501ec92aa630102ff2c0083b96bd22c4989c29"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -1119,17 +1119,18 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(decoded.contains("Function name: line_count"), "Decoded: \(decoded)")
         #expect(decoded.contains("Required arguments: text"), "Decoded: \(decoded)")
         #expect(decoded.contains("Respond with exactly this one assistant message and nothing else:"), "Decoded: \(decoded)")
-        #expect(decoded.contains(#"{"name":"line_count","arguments":{"text":"red\ngreen\nblue"}}"#), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#), "Decoded: \(decoded)")
         #expect(decoded.contains("Copy the `text` value exactly from the current user request."), "Decoded: \(decoded)")
         #expect(decoded.contains("This value contains exactly 2 line break(s) and 0 blank lines."), "Decoded: \(decoded)")
-        #expect(decoded.contains(#"In the JSON call, each line break is represented by the two characters \n"#), "Decoded: \(decoded)")
-        #expect(decoded.contains(#"the exact `text` value encoded with JSON \n escapes is: red\ngreen\nblue"#), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"In the native LFM call, each line break is represented by the two characters \n"#), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"the exact `text` value encoded with \n escapes is: red\ngreen\nblue"#), "Decoded: \(decoded)")
         #expect(decoded.contains("Do not double any line break."), "Decoded: \(decoded)")
         #expect(decoded.contains("Do not add a blank line, leading space, trailing newline, or any other character to the copied value."), "Decoded: \(decoded)")
         #expect(decoded.contains("Do not omit `text`"), "Decoded: \(decoded)")
         #expect(decoded.contains("Do not write reasoning, XML-style tool tags, markdown, or prose."), "Decoded: \(decoded)")
         #expect(!decoded.contains("List of tools:"), "Decoded: \(decoded)")
-        #expect(decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"line_count(text='red\ngreen\nblue')"#), "Decoded: \(decoded)")
+        #expect(!decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
         #expect(!decoded.contains("<tools>"), "Decoded: \(decoded)")
         #expect(!decoded.contains("</tool_call>"), "Decoded: \(decoded)")
         #expect(decoded.contains(#"Use the line_count tool on this exact text: red\ngreen\nblue"#), "Decoded: \(decoded)")
@@ -1143,7 +1144,7 @@ struct SwiftTransformersTokenizerLoaderTests {
                 "Required-tool instruction must trail the latest LFM user turn instead of preceding it. Decoded: \(decoded)"
             )
             #expect(
-                afterUser.contains(#"{"name":"line_count","arguments":{"text":"red\ngreen\nblue"}}"#),
+                afterUser.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#),
                 "Required-tool instruction must keep the exact multiline value after the latest LFM user turn. Decoded: \(decoded)"
             )
         }

--- a/docs/VMLX_SWIFT_OSAURUS_LIVE_MATRIX_2026_05_18.md
+++ b/docs/VMLX_SWIFT_OSAURUS_LIVE_MATRIX_2026_05_18.md
@@ -13,6 +13,25 @@ repo-local live-gate artifacts. The user's requested VL/cache/UI/API/parser/
 defaults/carryover proof still requires real Osaurus app/API evidence before a
 row is production-clear.
 
+## 2026-05-30 PR #1300 LFM2.5 native-tool repin and Step boundary
+
+- Osaurus PR head at check: `9ebeca8192d3483c9895c9f716c4f5432e7c801c`.
+- vMLX main / Osaurus pin: `c3501ec92aa630102ff2c0083b96bd22c4989c29`.
+- No-sign app path: `build/DerivedData-lfm-native-nosign-9ebeca81/Build/Products/Release/osaurus.app`.
+- Launch boundary: app was launched keychain-free with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, `OSAURUS_TEST_ROOT=/tmp/osaurus-pr1300-9ebeca81-lfm-native-ui-20260530-032559`, and `OSU_MODELS_DIR=/Users/eric/.mlxstudio/models`.
+- Source/guard boundary: `git diff --check`, `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`, `SwiftTransformersTokenizerLoaderTests/lfm2LocalTokenizerUsesStrictRequiredToolFallback`, `assert-tool-choice-required-routing.sh`, `assert-server-settings-runtime-wiring.sh`, `assert-keychain-free-proof-path.sh`, `assert-osaurus-no-forced-behavior-pr.sh`, `assert-osaurus-vmlx-pr-readiness.sh`, and `assert-osaurus-pr-hygiene.sh` passed before the app proof.
+- GitHub status: PR #1300 was non-draft, mergeable, and green for `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft` on this head.
+- LFM cold artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-cold-20260530-032614`.
+- LFM warm flake artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-warm-20260530-032757`.
+- LFM warm pass artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-warm-rerun-20260530-032938`.
+- LFM result: `lfm2.5-8b-a1b-jang_2l` passed the strict three-turn required/none/required harness on the cold row and the warm rerun. Turn 1 produced exact structured `line_count` args `red\ngreen\nblue`; turn 2 produced a visible answer and no tool call; turn 3 produced exact structured `line_count` args `one\ntwo`; tool-call turns had no visible content, no protocol marker leaked, no visible loop occurred, no length-stop fake pass occurred, and `/health` stayed healthy with no in-flight request.
+- LFM topology/cache result: 24 layers, 6 KV layers, 18 Mamba/SSM companion layers, `companion=ssm`, disk-backed restore required, SSM companion state required, paged-cache incompatible, block disk L2 enabled, and TurboQuant KV layer count 0. The warm pass proved reuse with `disk_l2_hits +1`, `ssm_companion_hits +1`, and `companion_hits +1`.
+- LFM token/s: cold visible follow-up emitted 343 completion tokens at 147.00 tok/s; warm-pass visible follow-up emitted 304 completion tokens at 106.47 tok/s. Structured tool-call turns emitted zero completion tokens.
+- LFM honesty boundary: the first warm run proved `disk_l2_hits +1`, `ssm_companion_hits +1`, and `companion_hits +1`, but failed turn 3 with `finish_reason: "length"` after spending the turn in `reasoning_content`. The immediate warm rerun passed exact tool behavior with the same cache-hit requirements, so the row is green for this PR confidence pass but not a blanket deterministic guarantee for every LFM prompt shape or sibling bundle.
+- Step boundary: `step-3.7-flash-jang_2l` is listed by `/v1/models`, but a required-tool request is intentionally rejected with HTTP 400 because local MLX runtime capability detection reports tool calling unsupported. Do not claim Step tool/parser/cache E2E proof from this PR. This is a capability-policy boundary, not a hidden parser bypass.
+- TurboQuant boundary: LFM and DSV4 rows report TurboQuant KV layer count 0. The PR keeps engine-selected cache policy topology-gated; do not claim TurboQuant KV is proven for LFM, Step, or DSV4 from these rows.
+- Verdict: PR #1300 is green for the LFM2.5 JANG_2L no-sign Osaurus app row, including native tool parsing, reasoning separation, hybrid SSM topology, disk L2 reuse, and SSM companion reuse. Step tools, LFM MXFP4/MXFP8, LFM VL, and broader prompt contexts remain follow-up coverage.
+
 ## 2026-05-30 LFM2.5 JANG_2L final required-tool and warm cache pass
 
 - Osaurus PR head at check: `ccc57314f928801ded7d7fe6f0affcb758ee6432`.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c8023e985c055b1506b49526f9282bdedf940f41"
       }
     },
     {

--- a/scripts/live-proof/post1263-family-live-matrix-ledger.md
+++ b/scripts/live-proof/post1263-family-live-matrix-ledger.md
@@ -39,6 +39,28 @@ Each promoted row needs current-head evidence for:
 - Do not merge by agent.
 - Do not apply forced-behavior fixes, hidden sampler overrides, forced thinking/tool wrappers, or broad parser masks to make rows look green.
 
+## Current #1300 merge boundary
+
+### 2026-05-30 03:30 PDT LFM2.5 native-tool repin green, Step tools blocked by capability policy
+
+- Osaurus PR head at check: `9ebeca8192d3483c9895c9f716c4f5432e7c801c`.
+- vMLX main / Osaurus pin: `c3501ec92aa630102ff2c0083b96bd22c4989c29`.
+- No-sign app path: `build/DerivedData-lfm-native-nosign-9ebeca81/Build/Products/Release/osaurus.app`.
+- Launch boundary: app was launched through LaunchServices with keychain disabled via launchd env: `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, `OSAURUS_TEST_ROOT=/tmp/osaurus-pr1300-9ebeca81-lfm-native-ui-20260530-032559`, and `OSU_MODELS_DIR=/Users/eric/.mlxstudio/models`.
+- Source and PR guards passed before live proof: `git diff --check`, `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`, `SwiftTransformersTokenizerLoaderTests/lfm2LocalTokenizerUsesStrictRequiredToolFallback`, `assert-tool-choice-required-routing.sh`, `assert-server-settings-runtime-wiring.sh`, `assert-keychain-free-proof-path.sh`, `assert-osaurus-no-forced-behavior-pr.sh`, `assert-osaurus-vmlx-pr-readiness.sh`, and `assert-osaurus-pr-hygiene.sh`.
+- GitHub checks passed on the same head: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`; PR #1300 was non-draft and mergeable.
+- LFM cold artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-cold-20260530-032614`.
+- LFM warm flake artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-warm-20260530-032757`.
+- LFM warm pass artifact: `/tmp/osaurus-pr1300-9ebeca81-lfm25-jang2l-native-warm-rerun-20260530-032938`.
+- LFM cold result: `lfm2.5-8b-a1b-jang_2l` passed strict required/none/required tool history. Turn 1 emitted exact structured `line_count` args `red\ngreen\nblue`; turn 2 emitted visible answer `Three lines were counted.`; turn 3 emitted exact structured `line_count` args `one\ntwo`; no protocol marker leaked, no visible loop occurred, no length-stop fake pass occurred, and `/health` stayed healthy with no in-flight request.
+- LFM warm pass result: the immediate warm rerun passed the same strict required/none/required checks and proved cache reuse with `disk_l2_hits +1`, `ssm_companion_hits +1`, and `companion_hits +1`.
+- LFM topology: 24 layers, 6 KV layers, 18 Mamba/SSM companion layers, `companion=ssm`, disk-backed restore required, SSM companion state required, paged-cache incompatible, block disk L2 enabled, and TurboQuant KV layer count 0.
+- LFM token/s: cold visible follow-up emitted 343 completion tokens at 147.00 tok/s; warm-pass visible follow-up emitted 304 completion tokens at 106.47 tok/s. Structured tool-call turns emitted zero completion tokens as expected for OpenAI-compatible tool-call responses.
+- LFM boundary: one first warm run proved disk/SSM companion hits but failed turn 3 with `finish_reason: "length"` while the model stayed in `reasoning_content`. The immediate warm rerun passed exact tool behavior with the same hit requirements, so the current PR row is green for this confidence pass but should not be overstated as deterministic coverage for every LFM prompt shape or MXFP sibling.
+- Step boundary: `/v1/models` lists `step-3.7-flash-jang_2l`, but a required-tool request is rejected with HTTP 400 because local MLX runtime policy reports tool calling unsupported. This PR does not prove Step tool/parser/cache E2E behavior, and no parser bypass should be added to make it look supported.
+- Cache policy boundary: engine-selected cache remains topology-gated. LFM and DSV4 rows report TurboQuant KV layer count 0, so this proof covers native hybrid cache plus L2/SSM companion reuse, not TurboQuant KV for LFM/DSV4.
+- Verdict: LFM2.5 JANG_2L is green for the exact #1300 no-sign Osaurus app row. Step tools, LFM MXFP4/MXFP8, LFM VL, and broader prompt contexts remain follow-up rows.
+
 ## Current #1268 merge boundary
 
 ### 2026-05-28 10:28 PDT Nemotron Omni MXFP4 live red row


### PR DESCRIPTION
## Summary
- Pins Osaurus to vmlx-swift c8023e985c055b1506b49526f9282bdedf940f41.
- Pulls in the DSV4 embedded `api_tool` rail buffering/parser fix from vMLX main.
- Updates the RuntimePolicySourceTests pin guard so all Osaurus pin surfaces must match the new vMLX revision.

## Verified locally
- `git diff --check`
- `swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- `scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh`
- `scripts/live-proof/assert-server-settings-runtime-wiring.sh`
- `scripts/live-proof/assert-keychain-free-proof-path.sh`
- `scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh`
- `scripts/live-proof/assert-osaurus-pr-hygiene.sh`

## vMLX proof carried by pin
- vMLX commit c8023e985c055b1506b49526f9282bdedf940f41 passed focused DSV4 parser/template source tests before push to vMLX main.
- The fix is narrow: it buffers the exact DSV4 `_only_call_one_tools_without_parameters` embedded `api_tool` rail until balanced JSON, then lets the existing registered-tool parser validate it. It does not add sampler hacks, prompt coercion, close-token bias, or broad JSON repair.

## Boundary
- This PR is a pin-only Osaurus follow-up after #1268.
- Fresh no-sign app live proof against this exact Osaurus head is still required before claiming new runtime/live-matrix coverage beyond the source/readiness guards above.
