### PR TITLE
[codex] Validate relay public URL before showing connected

### DIFF
--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -19,6 +19,111 @@ public enum AgentRelayStatus: Equatable {
     case error(String)
 }
 
+// MARK: - Public URL Probe
+
+/// Captures the public-route verdict separately from tunnel auth so callers can
+/// keep the UI out of a false-green state until the HTTPS route works.
+struct RelayPublicRouteCheckResult: Equatable, Sendable {
+    let reachable: Bool
+    let statusCode: Int?
+    let failureDescription: String?
+}
+
+/// Performs the cheap public `/health` request that proves the relay hostname
+/// can actually proxy back to the local Osaurus server.
+struct RelayPublicURLProbe: Sendable {
+    typealias Transport = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    private static let timeout: TimeInterval = 8
+    private let transport: Transport
+
+    init(transport: @escaping Transport) {
+        self.transport = transport
+    }
+
+    static func live() -> RelayPublicURLProbe {
+        RelayPublicURLProbe { request in
+            let config = URLSessionConfiguration.ephemeral
+            config.waitsForConnectivity = false
+            config.timeoutIntervalForRequest = timeout
+            config.timeoutIntervalForResource = timeout
+            let session = URLSession(configuration: config)
+            defer { session.finishTasksAndInvalidate() }
+            return try await session.data(for: request)
+        }
+    }
+
+    static func makeHealthRequest(baseURL: String) -> URLRequest? {
+        guard let base = URL(string: baseURL),
+            let scheme = base.scheme?.lowercased(),
+            scheme == "https" || scheme == "http",
+            base.host?.isEmpty == false
+        else { return nil }
+        let healthURL = base.appendingPathComponent("health")
+        var request = URLRequest(url: healthURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = timeout
+        request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+        request.setValue("OsaurusRelayHealthCheck/1", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    func check(
+        baseURL: String,
+        attempts: Int = 3,
+        retryDelayNanoseconds: UInt64 = 1_000_000_000
+    ) async -> RelayPublicRouteCheckResult {
+        guard let request = Self.makeHealthRequest(baseURL: baseURL) else {
+            return RelayPublicRouteCheckResult(
+                reachable: false,
+                statusCode: nil,
+                failureDescription: "Public link URL is invalid."
+            )
+        }
+
+        let maxAttempts = max(1, attempts)
+        var lastResult = RelayPublicRouteCheckResult(
+            reachable: false,
+            statusCode: nil,
+            failureDescription: "Public link check did not run."
+        )
+
+        for attempt in 1 ... maxAttempts {
+            guard !Task.isCancelled else { return lastResult }
+
+            do {
+                let (_, response) = try await transport(request)
+                let statusCode = (response as? HTTPURLResponse)?.statusCode
+                if statusCode == 200 {
+                    return RelayPublicRouteCheckResult(
+                        reachable: true,
+                        statusCode: statusCode,
+                        failureDescription: nil
+                    )
+                }
+                lastResult = RelayPublicRouteCheckResult(
+                    reachable: false,
+                    statusCode: statusCode,
+                    failureDescription: "Public link health check returned HTTP \(statusCode ?? 0)."
+                )
+            } catch {
+                lastResult = RelayPublicRouteCheckResult(
+                    reachable: false,
+                    statusCode: nil,
+                    failureDescription: "Public link check failed: \(error.localizedDescription)"
+                )
+            }
+
+            if attempt < maxAttempts, retryDelayNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
+                guard !Task.isCancelled else { return lastResult }
+            }
+        }
+
+        return lastResult
+    }
+}
+
 // MARK: - Relay Frame Types
 
 private struct RelayRequestFrame: Decodable {
@@ -84,6 +189,11 @@ public final class RelayTunnelManager: ObservableObject {
     private var addressToAgentId: [String: UUID] = [:]
     /// Set before expecting a `challenge` frame; consumed when the nonce arrives.
     private var pendingNonceHandler: ((String) -> Void)?
+    /// Public-link checks run after relay auth so green UI means the public
+    /// HTTPS route, not just the WebSocket auth handshake, is usable.
+    private let publicURLProbe = RelayPublicURLProbe.live()
+    private var publicCheckTasks: [UUID: Task<Void, Never>] = [:]
+    private var pendingPublicCheckURLs: [UUID: String] = [:]
 
     private init() {
         configuration = RelayConfigurationStore.load()
@@ -144,6 +254,7 @@ public final class RelayTunnelManager: ObservableObject {
         authenticatedAgents.removeAll()
         addressToAgentId.removeAll()
         pendingNonceHandler = nil
+        cancelAllPublicChecks()
         for id in agentStatuses.keys {
             agentStatuses[id] = .disconnected
         }
@@ -295,7 +406,7 @@ public final class RelayTunnelManager: ObservableObject {
 
             if let agent = findAgent(byAddress: lower) {
                 addressToAgentId[lower] = agent.id
-                agentStatuses[agent.id] = .connected(url: url)
+                beginPublicRouteCheck(for: agent.id, url: url)
             }
         }
     }
@@ -314,6 +425,7 @@ public final class RelayTunnelManager: ObservableObject {
         authenticatedAgents.removeAll()
         addressToAgentId.removeAll()
         pendingNonceHandler = nil
+        cancelAllPublicChecks()
     }
 
     private func handleAgentAdded(_ json: [String: Any]) {
@@ -325,7 +437,7 @@ public final class RelayTunnelManager: ObservableObject {
         authenticatedAgents.insert(lower)
         if let agent = findAgent(byAddress: lower) {
             addressToAgentId[lower] = agent.id
-            agentStatuses[agent.id] = .connected(url: url)
+            beginPublicRouteCheck(for: agent.id, url: url)
         }
     }
 
@@ -334,6 +446,7 @@ public final class RelayTunnelManager: ObservableObject {
         let lower = address.lowercased()
         authenticatedAgents.remove(lower)
         if let agentId = addressToAgentId.removeValue(forKey: lower) {
+            cancelPublicCheck(for: agentId)
             agentStatuses[agentId] = .disconnected
         }
     }
@@ -576,6 +689,7 @@ public final class RelayTunnelManager: ObservableObject {
         let lower = address.lowercased()
         authenticatedAgents.remove(lower)
         addressToAgentId.removeValue(forKey: lower)
+        cancelPublicCheck(for: agentId)
     }
 
     /// Attempt to auto-assign a cryptographic identity if the agent is missing one.
@@ -596,6 +710,7 @@ public final class RelayTunnelManager: ObservableObject {
         authenticatedAgents.removeAll()
         addressToAgentId.removeAll()
         pendingNonceHandler = nil
+        cancelAllPublicChecks()
 
         for id in configuration.enabledAgentIds {
             if agentStatuses[id] != .disconnected {
@@ -654,5 +769,58 @@ public final class RelayTunnelManager: ObservableObject {
         return AgentManager.shared.agents.first { agent in
             agent.agentAddress?.lowercased() == lower
         }
+    }
+
+    private func beginPublicRouteCheck(for agentId: UUID, url: String) {
+        agentStatuses[agentId] = .connecting
+        pendingPublicCheckURLs[agentId] = url
+        publicCheckTasks[agentId]?.cancel()
+
+        let probe = publicURLProbe
+        publicCheckTasks[agentId] = Task { [weak self] in
+            let result = await probe.check(baseURL: url)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                self?.finishPublicRouteCheck(for: agentId, url: url, result: result)
+            }
+        }
+    }
+
+    private func finishPublicRouteCheck(
+        for agentId: UUID,
+        url: String,
+        result: RelayPublicRouteCheckResult
+    ) {
+        publicCheckTasks[agentId] = nil
+
+        guard configuration.isEnabled(for: agentId),
+            pendingPublicCheckURLs[agentId] == url,
+            isConnected,
+            webSocketTask != nil
+        else { return }
+
+        pendingPublicCheckURLs[agentId] = nil
+        if result.reachable {
+            agentStatuses[agentId] = .connected(url: url)
+        } else {
+            let message =
+                result.failureDescription
+                ?? "Public link check failed before the relay could reach the local server."
+            agentStatuses[agentId] = .error(message)
+        }
+    }
+
+    private func cancelPublicCheck(for agentId: UUID) {
+        publicCheckTasks[agentId]?.cancel()
+        publicCheckTasks[agentId] = nil
+        pendingPublicCheckURLs[agentId] = nil
+    }
+
+    private func cancelAllPublicChecks() {
+        for task in publicCheckTasks.values {
+            task.cancel()
+        }
+        publicCheckTasks.removeAll()
+        pendingPublicCheckURLs.removeAll()
     }
 }

--- a/Packages/OsaurusCore/Tests/Networking/RelayPublicURLProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RelayPublicURLProbeTests.swift
@@ -1,0 +1,121 @@
+//
+//  RelayPublicURLProbeTests.swift
+//  OsaurusCoreTests
+//
+//  The relay auth WebSocket can succeed while the public HTTPS hostname still
+//  closes before TLS or fails to proxy. These tests pin the cheap health probe
+//  that prevents the UI from showing a green relay URL until `/health` works
+//  through the public route.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct RelayPublicURLProbeTests {
+    @Test func healthRequestTargetsPublicHealthEndpoint() throws {
+        let request = try #require(
+            RelayPublicURLProbe.makeHealthRequest(baseURL: "https://0xabc.agent.osaurus.ai")
+        )
+
+        #expect(request.url?.absoluteString == "https://0xabc.agent.osaurus.ai/health")
+        #expect(request.httpMethod == "GET")
+        #expect(request.value(forHTTPHeaderField: "Cache-Control") == "no-cache")
+        #expect(request.value(forHTTPHeaderField: "User-Agent") == "OsaurusRelayHealthCheck/1")
+    }
+
+    @Test func healthRequestHandlesTrailingSlash() throws {
+        let request = try #require(
+            RelayPublicURLProbe.makeHealthRequest(baseURL: "https://0xabc.agent.osaurus.ai/")
+        )
+
+        #expect(request.url?.absoluteString == "https://0xabc.agent.osaurus.ai/health")
+    }
+
+    @Test func checkTreatsHTTP200HealthAsReachable() async throws {
+        let probe = RelayPublicURLProbe { request in
+            #expect(request.url?.path == "/health")
+            return (Data(#"{"status":"ok"}"#.utf8), Self.response(for: request, statusCode: 200))
+        }
+
+        let result = await probe.check(
+            baseURL: "https://0xabc.agent.osaurus.ai",
+            attempts: 1,
+            retryDelayNanoseconds: 0
+        )
+
+        #expect(result.reachable)
+        #expect(result.statusCode == 200)
+        #expect(result.failureDescription == nil)
+    }
+
+    @Test func checkReportsHTTPFailureInsteadOfMarkingReachable() async {
+        let probe = RelayPublicURLProbe { request in
+            (Data(#"{"error":"not ready"}"#.utf8), Self.response(for: request, statusCode: 503))
+        }
+
+        let result = await probe.check(
+            baseURL: "https://0xabc.agent.osaurus.ai",
+            attempts: 1,
+            retryDelayNanoseconds: 0
+        )
+
+        #expect(!result.reachable)
+        #expect(result.statusCode == 503)
+        #expect(result.failureDescription == "Public link health check returned HTTP 503.")
+    }
+
+    @Test func checkReportsTransportFailureForClosedTLS() async {
+        let probe = RelayPublicURLProbe { _ in
+            throw NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNetworkConnectionLost,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Client network socket disconnected before secure TLS connection was established"
+                ]
+            )
+        }
+
+        let result = await probe.check(
+            baseURL: "https://0xabc.agent.osaurus.ai",
+            attempts: 1,
+            retryDelayNanoseconds: 0
+        )
+
+        #expect(!result.reachable)
+        #expect(result.statusCode == nil)
+        #expect(
+            result.failureDescription?
+                .contains("Client network socket disconnected before secure TLS connection was established")
+                == true
+        )
+    }
+
+    @Test func malformedBaseURLReturnsActionableFailure() async {
+        let probe = RelayPublicURLProbe { _ in
+            Issue.record("Malformed URLs must not hit the transport")
+            return (Data(), URLResponse())
+        }
+
+        let result = await probe.check(
+            baseURL: "not a url",
+            attempts: 1,
+            retryDelayNanoseconds: 0
+        )
+
+        #expect(!result.reachable)
+        #expect(result.statusCode == nil)
+        #expect(result.failureDescription == "Public link URL is invalid.")
+    }
+
+    private static func response(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: request.url ?? URL(string: "https://0xabc.agent.osaurus.ai/health")!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+    }
+}


### PR DESCRIPTION
## Business rationale

Fixes #1299, where Osaurus could show a relay as connected and publish a public `https://<agent>.agent.osaurus.ai` URL even though that public URL immediately failed with `ERR_CONNECTION_CLOSED` / "Client network socket disconnected before secure TLS connection was established." The visible problem is a false-green relay state: local `127.0.0.1:1337` can work while the public link is unusable. This PR changes the observable success condition so the UI and plugin-exposed tunnel URL only become connected after the public relay URL successfully returns HTTP 200 from `/health`.

## Coding rationale

The fix stays inside the existing relay tunnel boundary instead of adding new default tools, new service dependencies, or changing the relay protocol. Relay WebSocket auth still proves the agent is authorized, but `RelayTunnelManager` now treats auth as only the first step and runs a small ephemeral `GET <public-url>/health` probe before setting `.connected(url:)`. This keeps `DocumentFormatRegistry`, tools, and plugin surfaces untouched; it deliberately does not modify the hosted relay service or create a new recovery workflow. The trust boundary crossed here is the public HTTPS route: local readiness is not enough evidence for a public URL shown to users or exposed to plugins.

## Acceptance criteria

- [x] Relay auth success alone cannot mark an agent connected.
- [x] The public relay URL must return HTTP 200 from `/health` before `.connected(url:)` is published.
- [x] Public-route TLS, network, or HTTP failures surface as `.error(...)` with an actionable diagnostic instead of a false green URL.
- [x] Stale public-route checks are cancelled on disconnect, agent removal, or relay reset.
- [x] The probe request builder and success/failure paths are covered by unit tests.

## Quality gate

- [x] swift-format / swiftlint / shellcheck — exited 0 (`swiftlint`: existing non-serious warnings only, 0 serious)
- [x] swift test --package-path Packages/OsaurusCLI --parallel — green
- [x] make ci-test — green
- [x] swift build --package-path Packages/OsaurusCore -c release — green
- [x] Archive freshness — confirmed by `git fetch --all --prune` after the gate; `origin/main` remained `291cdf84a60f7665389b4037550bae0472815c70`

## Debug evidence

Focused probe coverage:

```text
swift test --package-path Packages/OsaurusCore --filter RelayPublicURLProbeTests
✔ Test run with 6 tests in 1 suite passed after 0.002 seconds.
```

Full local gate after updating onto current `origin/main` with a no-force merge
commit. The merge was clean; the only incoming file was the release appcast.

```text
HEAD c30de17c0f35fee2593eba6cc276007eda159cde
ORIGIN_MAIN 291cdf84a60f7665389b4037550bae0472815c70
...
Build complete! (0.75s)
LANE_GATE_OK 2026-05-30T13:44:46Z
```

## Rollback

Revert this PR to restore the previous relay behavior that marked the public
URL connected immediately after relay WebSocket auth.
