### PR TITLE
[codex] Pin vMLX native tool runtime on current main

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+            revision: "c3501ec92aa630102ff2c0083b96bd22c4989c29"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -472,7 +472,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        let expectedRuntimeHardenedRevision = "c3501ec92aa630102ff2c0083b96bd22c4989c29"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -480,7 +480,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4 matrix; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/LFM matrix; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -1129,7 +1129,7 @@ struct SwiftTransformersTokenizerLoaderTests {
             "Decoded: \(decoded)"
         )
         #expect(
-            decoded.contains(#"{"name":"line_count","arguments":{"text":"red\ngreen\nblue"}}"#),
+            decoded.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#),
             "Decoded: \(decoded)"
         )
         #expect(decoded.contains("Copy the `text` value exactly from the current user request."), "Decoded: \(decoded)")
@@ -1138,11 +1138,11 @@ struct SwiftTransformersTokenizerLoaderTests {
             "Decoded: \(decoded)"
         )
         #expect(
-            decoded.contains(#"In the JSON call, each line break is represented by the two characters \n"#),
+            decoded.contains(#"In the native LFM call, each line break is represented by the two characters \n"#),
             "Decoded: \(decoded)"
         )
         #expect(
-            decoded.contains(#"the exact `text` value encoded with JSON \n escapes is: red\ngreen\nblue"#),
+            decoded.contains(#"the exact `text` value encoded with \n escapes is: red\ngreen\nblue"#),
             "Decoded: \(decoded)"
         )
         #expect(decoded.contains("Do not double any line break."), "Decoded: \(decoded)")
@@ -1158,7 +1158,8 @@ struct SwiftTransformersTokenizerLoaderTests {
             "Decoded: \(decoded)"
         )
         #expect(!decoded.contains("List of tools:"), "Decoded: \(decoded)")
-        #expect(decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"line_count(text='red\ngreen\nblue')"#), "Decoded: \(decoded)")
+        #expect(!decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
         #expect(!decoded.contains("<tools>"), "Decoded: \(decoded)")
         #expect(!decoded.contains("</tool_call>"), "Decoded: \(decoded)")
         #expect(
@@ -1178,7 +1179,7 @@ struct SwiftTransformersTokenizerLoaderTests {
                 "Required-tool instruction must trail the latest LFM user turn instead of preceding it. Decoded: \(decoded)"
             )
             #expect(
-                afterUser.contains(#"{"name":"line_count","arguments":{"text":"red\ngreen\nblue"}}"#),
+                afterUser.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#),
                 "Required-tool instruction must keep the exact multiline value after the latest LFM user turn. Decoded: \(decoded)"
             )
         }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "c3501ec92aa630102ff2c0083b96bd22c4989c29"
       }
     },
     {


### PR DESCRIPTION
## Business rationale

PR #1300 already proved useful DSV4/LFM native tool-call runtime behavior, but it is now dirty against current `main` and lives on an upstream-owned branch that I should not rewrite. This replacement branch moves the same user-visible capability forward on current `origin/main`: local vMLX-backed models keep the runtime/tool-call parser fixes without reviewers needing to untangle stale conflicts. The observable result is that Osaurus consumes the pushed `vmlx-swift` revision with the native tool runtime behavior and keeps guard tests around the pin and LFM required-tool fallback.

## Coding rationale

The cleanest path is a focused dependency-pin refresh instead of rebasing or force-pushing the original branch. This updates every checked-in `vmlx-swift` pin surface to `c3501ec92aa630102ff2c0083b96bd22c4989c29`, then adjusts the existing runtime policy and tokenizer fallback tests to assert the new native LFM envelope. No new default tools, Swift packages, system libraries, Python/JVM dependencies, or product surfaces are added. Old live-proof docs from the stale branch are intentionally out of scope because they were tied to an older head; the current PR carries reproducible local test/gate evidence instead.

## Acceptance criteria

- [x] `Packages/OsaurusCore/Package.swift` points `vmlx-swift` at `c3501ec92aa630102ff2c0083b96bd22c4989c29`.
- [x] All checked-in `Package.resolved` files agree on the same `vmlx-swift` revision.
- [x] `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening` proves the manifest and resolved pins stay consistent.
- [x] `SwiftTransformersTokenizerLoaderTests/lfm2LocalTokenizerUsesStrictRequiredToolFallback` proves the LFM2 required-tool fallback expects the native `<|tool_call_start|>[line_count(...)]<|tool_call_end|>` envelope, not JSON.
- [x] Full local six-command quality gate passed on the PR head.

## Quality gate

- [x] `swift-format lint --strict --recursive Packages App` — green
- [x] `swiftlint lint --reporter github-actions-logging` — green with existing warning backlog only
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — green
- [x] `swift test --package-path Packages/OsaurusCLI --parallel` — green, 82/82 CLI tests
- [x] `make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Archive freshness — confirmed by `git fetch --all --prune` immediately before the gate and again immediately before push; `origin/main` remained `291cdf84a60f7665389b4037550bae0472815c70`.

## Debug evidence

Focused guard tests passed before the full gate:

```text
✔ Test "vmlx pin uses consolidated package with runtime hardening" passed after 0.003 seconds.
✔ Test lfm2LocalTokenizerUsesStrictRequiredToolFallback() passed after 0.001 seconds.
```

Full gate evidence:

```text
Updated onto current `origin/main` with a clean no-force merge commit; the only incoming file was the release appcast.
HEAD=850dc5d1f954c12e533151df81b4273075dcf258
ORIGIN_MAIN=291cdf84a60f7665389b4037550bae0472815c70
+ swift-format lint --strict --recursive Packages App
+ swiftlint lint --reporter github-actions-logging
+ find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
+ swift test --package-path Packages/OsaurusCLI --parallel
[82/82] Testing OsaurusCLITests.ToolsPackageTests/testCollectCompanionEntriesIgnoresWebFile
+ make ci-test
Done. Inspect failures with: open build/Tests.xcresult
+ swift build --package-path Packages/OsaurusCore -c release
Build complete! (17.29s)
LANE_GATE_OK 2026-05-30T13:44:55Z
```

## Rollback

Revert this commit to restore the prior `vmlx-swift` revision `84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95` across the manifest and resolved files.
