### PR TITLE
Bound raw file_read previews

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -520,11 +520,33 @@ struct FileReadTool: OsaurusTool {
     /// Consistent with truncation limits on shell_run (10k) and git_diff (20k).
     private static let maxOutputChars = 15_000
 
+    /// Maximum raw bytes read for plain text / source / CSV before
+    /// decoding. Rich documents and XLSX previews have their own adapter
+    /// limits; this cap protects the raw path from loading a huge file
+    /// just to emit a 15K-character preview.
+    private static let rawReadByteLimit = 5 * 1024 * 1024
+
+    /// Chunk size for bounded raw reads. Keeps peak transient allocation
+    /// modest while avoiding tiny syscall loops.
+    private static let rawReadChunkBytes = 64 * 1024
+
     /// First-chunk byte budget for the NUL-byte binary sniff. Catches
     /// off-extension binaries whose UTF-8 decode happens to succeed by
     /// luck. Matches the size most editors / `file(1)` use for the same
     /// heuristic.
     private static let binarySniffBytes = 4096
+
+    private struct LoadedFileContent {
+        let text: String
+        let rawRead: RawReadMetadata?
+    }
+
+    private struct RawReadMetadata {
+        let bytesRead: Int
+        let byteLimit: Int
+        let fileSize: Int64?
+        let truncatedByByteLimit: Bool
+    }
 
     func execute(argumentsJSON: String) async throws -> String {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
@@ -590,7 +612,7 @@ struct FileReadTool: OsaurusTool {
             relativePath: relativePath,
             ext: ext
         )
-        let lines = content.components(separatedBy: .newlines)
+        let lines = content.text.components(separatedBy: .newlines)
 
         let startLine = coerceInt(args["start_line"]) ?? 1
         let endLine = coerceInt(args["end_line"]) ?? lines.count
@@ -599,9 +621,16 @@ struct FileReadTool: OsaurusTool {
 
         var output = ""
         var lastLineIncluded = validStart - 1
+        var outputTruncated = false
         for i in (validStart - 1) ..< validEnd {
             let line = String(format: "%6d| %@\n", i + 1, lines[i])
             if output.count + line.count > Self.maxOutputChars {
+                let remaining = Self.maxOutputChars - output.count
+                if remaining > 0 {
+                    output += String(line.prefix(remaining))
+                    lastLineIncluded = i + 1
+                }
+                outputTruncated = true
                 break
             }
             output += line
@@ -613,27 +642,45 @@ struct FileReadTool: OsaurusTool {
         }
 
         // If truncated, inform the model and suggest using line ranges
-        if lastLineIncluded < validEnd {
+        if outputTruncated || lastLineIncluded < validEnd {
             output +=
-                "\n... (truncated at \(lastLineIncluded) of \(lines.count) lines — use start_line/end_line for specific ranges)"
+                "\n... (truncated at \(lastLineIncluded) of \(Self.lineCountLabel(lines.count, rawRead: content.rawRead)) lines — use start_line/end_line for specific ranges)"
+        }
+        if let rawRead = content.rawRead, rawRead.truncatedByByteLimit {
+            output +=
+                "\n... (raw read capped at \(Self.formatByteCount(Int64(rawRead.bytesRead)))"
+                + " of \(Self.formatByteCount(rawRead.fileSize ?? Int64(rawRead.bytesRead)))"
+                + " before full-file load; split the file or use a format-specific reader for later content)"
         }
 
         let text: String
-        if validStart > 1 || validEnd < lines.count {
-            text = "Lines \(validStart)-\(validEnd) of \(lines.count):\n" + output
+        if validStart > 1 || validEnd < lines.count || content.rawRead?.truncatedByByteLimit == true {
+            let totalLines = Self.lineCountLabel(lines.count, rawRead: content.rawRead)
+            text = "Lines \(validStart)-\(lastLineIncluded) of \(totalLines):\n" + output
         } else {
             text = output
         }
+        var result: [String: Any] = [
+            "text": text,
+            "path": relativePath,
+            "start_line": validStart,
+            "end_line": lastLineIncluded,
+            "total_lines": lines.count,
+            "total_lines_exact": content.rawRead?.truncatedByByteLimit != true,
+            "truncated": outputTruncated || lastLineIncluded < validEnd
+                || content.rawRead?.truncatedByByteLimit == true,
+        ]
+        if let rawRead = content.rawRead {
+            result["bytes_read"] = rawRead.bytesRead
+            result["byte_limit"] = rawRead.byteLimit
+            result["raw_bytes_truncated"] = rawRead.truncatedByByteLimit
+            if let fileSize = rawRead.fileSize {
+                result["file_size"] = fileSize
+            }
+        }
         return ToolEnvelope.success(
             tool: name,
-            result: [
-                "text": text,
-                "path": relativePath,
-                "start_line": validStart,
-                "end_line": lastLineIncluded,
-                "total_lines": lines.count,
-                "truncated": lastLineIncluded < validEnd,
-            ]
+            result: result
         )
     }
 
@@ -652,28 +699,30 @@ struct FileReadTool: OsaurusTool {
         url: URL,
         relativePath: String,
         ext: String
-    ) async throws -> String {
+    ) async throws -> LoadedFileContent {
         // Text-only tool: never try to surface image pixels.
         if DocumentParser.isImageFile(url: url) {
-            throw binaryError(path: relativePath, ext: ext, detail: .image)
+            throw Self.binaryError(path: relativePath, ext: ext, detail: .image)
         }
 
         if Self.shouldExtractViaParser(url: url, ext: ext) {
-            return try await extractRichDocumentText(
+            return LoadedFileContent(
+                text: try await extractRichDocumentText(
+                    url: url,
+                    relativePath: relativePath,
+                    ext: ext
+                ),
+                rawRead: nil
+            )
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            try Self.loadBoundedRawText(
                 url: url,
                 relativePath: relativePath,
                 ext: ext
             )
-        }
-
-        let data = try Data(contentsOf: url)
-        if data.prefix(Self.binarySniffBytes).contains(0) {
-            throw binaryError(path: relativePath, ext: ext, detail: .nulByte)
-        }
-        if let text = String(data: data, encoding: .utf8) {
-            return text
-        }
-        throw binaryError(path: relativePath, ext: ext, detail: .decodeFailed)
+        }.value
     }
 
     /// Whether `url` should be routed through `DocumentParser` for text
@@ -712,7 +761,7 @@ struct FileReadTool: OsaurusTool {
                 // text path would for a zero-byte `.txt`.
                 return ""
             case .unsupportedFormat, .readFailed, .fileTooLarge:
-                throw binaryError(path: relativePath, ext: ext, detail: .parseFailed)
+                throw Self.binaryError(path: relativePath, ext: ext, detail: .parseFailed)
             }
         }
         if case .document(_, let text, _) = attachment.kind {
@@ -721,12 +770,105 @@ struct FileReadTool: OsaurusTool {
         // Image-only PDF (DocumentParser falls back to per-page image
         // attachments). We can't surface those through file_read — emit
         // the binary envelope so the model pivots instead of retrying.
-        throw binaryError(path: relativePath, ext: ext, detail: .imageOnlyPdf)
+        throw Self.binaryError(path: relativePath, ext: ext, detail: .imageOnlyPdf)
+    }
+
+    private static func loadBoundedRawText(
+        url: URL,
+        relativePath: String,
+        ext: String
+    ) throws -> LoadedFileContent {
+        let fileSize: Int64? = {
+            guard let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize else {
+                return nil
+            }
+            return Int64(size)
+        }()
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: url)
+        } catch {
+            throw FolderToolError.operationFailed(
+                "Could not read '\(relativePath)': \(error.localizedDescription)"
+            )
+        }
+        defer { try? handle.close() }
+
+        var data = Data()
+        let reserve = min(Self.rawReadByteLimit, Int(fileSize ?? Int64(Self.rawReadByteLimit)))
+        data.reserveCapacity(max(0, reserve))
+
+        var bytesRead = 0
+        do {
+            while bytesRead < Self.rawReadByteLimit {
+                try Task.checkCancellation()
+                let remaining = Self.rawReadByteLimit - bytesRead
+                let count = min(Self.rawReadChunkBytes, remaining)
+                guard let chunk = try handle.read(upToCount: count), !chunk.isEmpty else { break }
+                data.append(chunk)
+                bytesRead += chunk.count
+                if chunk.count < count { break }
+            }
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            throw FolderToolError.operationFailed(
+                "Could not read '\(relativePath)': \(error.localizedDescription)"
+            )
+        }
+
+        if data.prefix(Self.binarySniffBytes).contains(0) {
+            throw binaryError(path: relativePath, ext: ext, detail: .nulByte)
+        }
+
+        let truncatedByByteLimit: Bool
+        if let fileSize {
+            truncatedByByteLimit = Int64(data.count) < fileSize
+        } else {
+            truncatedByByteLimit = data.count >= Self.rawReadByteLimit
+        }
+        let decoded = try decodeUTF8(
+            data,
+            allowTrailingScalarTrim: truncatedByByteLimit,
+            relativePath: relativePath,
+            ext: ext
+        )
+
+        return LoadedFileContent(
+            text: decoded.text,
+            rawRead: RawReadMetadata(
+                bytesRead: decoded.bytesUsed,
+                byteLimit: Self.rawReadByteLimit,
+                fileSize: fileSize,
+                truncatedByByteLimit: truncatedByByteLimit
+            )
+        )
+    }
+
+    private static func decodeUTF8(
+        _ data: Data,
+        allowTrailingScalarTrim: Bool,
+        relativePath: String,
+        ext: String
+    ) throws -> (text: String, bytesUsed: Int) {
+        let maxTrim = allowTrailingScalarTrim ? min(3, data.count) : 0
+        for trim in 0 ... maxTrim {
+            let candidate: Data
+            if trim == 0 {
+                candidate = data
+            } else {
+                candidate = Data(data.dropLast(trim))
+            }
+            if let text = String(data: candidate, encoding: .utf8) {
+                return (text, candidate.count)
+            }
+        }
+        throw binaryError(path: relativePath, ext: ext, detail: .decodeFailed)
     }
 
     /// Construct a `binaryContent` error, normalising an empty extension
     /// to `nil` so the envelope mapper doesn't emit a bare `(.)` label.
-    private func binaryError(
+    private static func binaryError(
         path: String,
         ext: String,
         detail: FolderToolError.BinaryDetail
@@ -736,6 +878,19 @@ struct FileReadTool: OsaurusTool {
             ext: ext.isEmpty ? nil : ext,
             detail: detail
         )
+    }
+
+    private static func lineCountLabel(_ count: Int, rawRead: RawReadMetadata?) -> String {
+        guard rawRead?.truncatedByByteLimit == true else { return "\(count)" }
+        return "at least \(count) scanned"
+    }
+
+    private static func formatByteCount(_ bytes: Int64) -> String {
+        let mib = 1024 * 1024
+        if bytes >= Int64(mib), bytes % Int64(mib) == 0 {
+            return "\(bytes / Int64(mib)) MiB (\(bytes) bytes)"
+        }
+        return "\(bytes) bytes"
     }
 
     private func workbookPreviewIfAvailable(

--- a/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
@@ -140,12 +140,10 @@ struct FolderToolsResilienceTests {
         )
     }
 
-    /// Regression for the `(empty file)` raw-string leak at the bottom
-    /// of `FileReadTool.execute`. The branch is reachable when the
-    /// first line alone exceeds `maxOutputChars` — output stays empty
-    /// after the truncation break and the tool returned the bare
-    /// `"(empty file)"` string instead of an envelope. Pinned via a
-    /// 16k-character line so the truncation fires deterministically.
+    /// Regression for the old `(empty file)` lie at the bottom of
+    /// `FileReadTool.execute`. A single oversized line now returns the
+    /// leading slice inside the success envelope plus a truncation note,
+    /// instead of pretending the file had no content.
     @Test func fileRead_oversizedFirstLineWrappedInEnvelope() async throws {
         let root = tmpRoot()
         let path = root.appendingPathComponent("wide.txt")
@@ -157,8 +155,43 @@ struct FolderToolsResilienceTests {
             argumentsJSON: #"{"path": "wide.txt"}"#
         )
         #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(EnvelopeAssertions.successPayload(result))
         let text = EnvelopeAssertions.successText(result) ?? ""
-        #expect(text == "(empty file)", "got: \(text)")
+        #expect(text.hasPrefix("     1| "), "got: \(text.prefix(40))")
+        #expect(text.contains("(empty file)") == false)
+        #expect(text.contains("truncated at 1 of 1 lines"))
+        #expect(payload["truncated"] as? Bool == true)
+        #expect(payload["raw_bytes_truncated"] as? Bool == false)
+    }
+
+    /// Raw text / CSV reads are part of the prompt-building hot path. A
+    /// huge file should be capped before full-file loading, with explicit
+    /// envelope metadata so the model understands it only saw a prefix.
+    @Test func fileRead_largeRawFileCapsBytesBeforeDecode() async throws {
+        let root = tmpRoot()
+        let path = root.appendingPathComponent("huge.csv")
+        let size = 6 * 1024 * 1024
+        try Data(repeating: 0x61, count: size).write(to: path)
+
+        let tool = FileReadTool(rootPath: root)
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path": "huge.csv"}"#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let payload = try #require(EnvelopeAssertions.successPayload(result))
+        let text = try #require(payload["text"] as? String)
+        let bytesRead = try #require(payload["bytes_read"] as? Int)
+        let byteLimit = try #require(payload["byte_limit"] as? Int)
+        let fileSize = try #require(payload["file_size"] as? Int)
+
+        #expect(byteLimit == 5 * 1024 * 1024)
+        #expect(bytesRead <= byteLimit)
+        #expect(fileSize == size)
+        #expect(payload["raw_bytes_truncated"] as? Bool == true)
+        #expect(payload["total_lines_exact"] as? Bool == false)
+        #expect(payload["truncated"] as? Bool == true)
+        #expect(text.contains("raw read capped at 5 MiB"))
     }
 
     /// The success payload carries a single line-numbered `text` field — no
@@ -187,7 +220,9 @@ struct FolderToolsResilienceTests {
         #expect(payload["start_line"] as? Int == 1)
         #expect(payload["end_line"] as? Int == 1)
         #expect(payload["total_lines"] as? Int == 3)
+        #expect(payload["total_lines_exact"] as? Bool == true)
         #expect(payload["truncated"] as? Bool == false)
+        #expect(payload["raw_bytes_truncated"] as? Bool == false)
         let text = try #require(payload["text"] as? String)
         #expect(text.contains("1| #!/usr/bin/env python3"))
         #expect(text.contains(#"\/"#) == false)

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -181,6 +181,13 @@ Reserve `sandbox_exec` for builds, installs, git, processes, network calls, pack
 | `sandbox_read_file` | Read a file's contents from the sandbox (supports line ranges, tail, char cap) |
 | `sandbox_search_files` | Search file contents (`target="content"`, ripgrep) **or** find files by name (`target="files"`, glob). Folded the previously-separate `sandbox_find_files` and `sandbox_list_directory` here. |
 
+Folder-mode `file_read` uses a bounded raw path for plain text, source, and
+CSV/TSV: it reads at most 5 MiB before UTF-8 decoding and returns explicit
+metadata when that cap truncates the preview. Rich documents and XLSX previews
+use the document-adapter limits instead. `sandbox_read_file` remains a raw
+sandbox utility with its own character/range controls; it does not currently
+share the folder `file_read` document-adapter path.
+
 ### Requires Autonomous Exec
 
 | Tool | Description |


### PR DESCRIPTION
## Business rationale
Folder-mode agents are instructed to prefer `file_read` for project files, but the raw plain/source/CSV path loaded the entire file before emitting a 15K-character preview. A large CSV or log could therefore spend memory and time on content the tool would never return. This bounds that hot path before UTF-8 decoding and makes prefix-only previews explicit to the agent.

## Coding rationale
- Add a 5 MiB raw-byte cap with 64 KiB chunked reads for plain text, source, CSV, TSV, and unknown raw-text files.
- Preserve first-4 KiB NUL-byte binary sniffing and UTF-8 validation, including trimming a split trailing scalar only when the byte cap truncates the raw read.
- Keep rich document extraction and XLSX workbook previews on their existing adapter limits.
- Surface raw-read metadata in the success envelope: `bytes_read`, `byte_limit`, `file_size`, `raw_bytes_truncated`, and `total_lines_exact`.
- Fix oversized first-line output so the envelope contains the leading slice plus truncation metadata instead of reporting `(empty file)`.

## Acceptance criteria
- Raw file previews are bounded before full-file load.
- Byte-capped previews clearly tell the agent that only a prefix was scanned.
- Existing line-range behavior and the single `text` success payload remain intact.
- Folder-mode and sandbox read-tool docs describe the limit boundary.

## Quality gate
- Archive freshness: fetched `origin/main` on 2026-05-30; branch is based on `291cdf84a60f7665389b4037550bae0472815c70` and is `0 1` ahead.
- Gate head SHA: `3b0616e86ed64b9dc18a809c016463485c4ca959`.
- `swift-format lint --strict --recursive Packages/OsaurusCore/Folder/FolderTools.swift Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift`
- `swift test --package-path Packages/OsaurusCore --filter FolderToolsResilienceTests` — 21 tests, 0 failures.
- `swift test --package-path Packages/OsaurusCore --filter FileRead` — 9 tests, 0 failures.
- `git diff --check`
- Full gate: `swift-format lint --strict --recursive Packages App`; `swiftlint lint --reporter github-actions-logging`; `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning`; `swift test --package-path Packages/OsaurusCLI --parallel`; `make ci-test`; `swift build --package-path Packages/OsaurusCore -c release`.
- Full gate marker: `LANE_GATE_OK 2026-05-30T17:11:20Z`.

## Debug evidence
- `fileRead_largeRawFileCapsBytesBeforeDecode` writes a 6 MiB `huge.csv` and asserts a 5 MiB byte limit, `raw_bytes_truncated == true`, `total_lines_exact == false`, and the user-visible raw-cap note.
- `fileRead_oversizedFirstLineWrappedInEnvelope` asserts a 16K single-line file returns a line-numbered prefix instead of `(empty file)` and reports truncation.
- Existing binary sniff, successful single-line payload, rich document, workbook, and image-refusal coverage still pass through the focused `FileRead` filter.
- Local evidence log: `.osaurus-plan/evidence/T-P1-HF-FILE-READ-RAW-BOUNDS/gate-2026-05-30T170049Z.log`.

## Self-review
### Regression review
Non-test code changes are limited to `FileReadTool` and the sandbox docs. The runtime surface is the folder tool registration path via `FolderToolFactory.buildCoreTools`, where the model-visible success payload and text preview now include raw-read metadata for raw files only. Rich documents still route through `DocumentParser`; XLSX still routes through the workbook adapter. Existing tests cover binary refusal, image refusal, PPTX extraction, workbook previews, raw CSV/text reads, and the updated payload fields.

### Performance review
The previous raw path was O(file size) memory/time because it used `Data(contentsOf:)` and decoded the full file before applying the 15K output cap. The new raw path is O(min(file size, 5 MiB)) before decode, reads in 64 KiB chunks, checks cancellation per chunk, and runs the synchronous file work on a detached task. The existing 15K output cap remains unchanged. No new dependencies or background services were added.

## Rollback
`git revert 3b0616e86ed64b9dc18a809c016463485c4ca959`
