### PR TITLE
Preserve PPTX slide table structure

### DIFF
--- a/Packages/OsaurusCore/Models/Documents/PresentationDocument.swift
+++ b/Packages/OsaurusCore/Models/Documents/PresentationDocument.swift
@@ -44,6 +44,7 @@ public struct PresentationSlide: Codable, Equatable, Sendable {
     public let label: String
     public let isHidden: Bool
     public let textRuns: [PresentationTextRun]
+    public let tables: [PresentationTable]
     public let speakerNotes: PresentationSpeakerNotes?
 
     public var text: String {
@@ -57,6 +58,7 @@ public struct PresentationSlide: Codable, Equatable, Sendable {
         label: String,
         isHidden: Bool = false,
         textRuns: [PresentationTextRun],
+        tables: [PresentationTable] = [],
         speakerNotes: PresentationSpeakerNotes? = nil
     ) {
         precondition(index >= 0, "Presentation slide index must be non-negative")
@@ -67,6 +69,7 @@ public struct PresentationSlide: Codable, Equatable, Sendable {
         self.label = label
         self.isHidden = isHidden
         self.textRuns = textRuns
+        self.tables = tables
         self.speakerNotes = speakerNotes
     }
 
@@ -79,6 +82,7 @@ public struct PresentationSlide: Codable, Equatable, Sendable {
             label: container.decode(String.self, forKey: .label),
             isHidden: container.decodeIfPresent(Bool.self, forKey: .isHidden) ?? false,
             textRuns: container.decode([PresentationTextRun].self, forKey: .textRuns),
+            tables: container.decodeIfPresent([PresentationTable].self, forKey: .tables) ?? [],
             speakerNotes: container.decodeIfPresent(PresentationSpeakerNotes.self, forKey: .speakerNotes)
         )
     }
@@ -90,6 +94,7 @@ public struct PresentationSlide: Codable, Equatable, Sendable {
         case label
         case isHidden
         case textRuns
+        case tables
         case speakerNotes
     }
 }
@@ -150,5 +155,79 @@ public struct PresentationSpeakerNotes: Codable, Equatable, Sendable {
         self.sourcePart = sourcePart
         self.anchorId = anchorId
         self.textRuns = textRuns
+    }
+}
+
+/// Table structure recovered from a slide's DrawingML table markup. Cell text
+/// is also present in `textRuns`; this typed view preserves row/column
+/// provenance so downstream callers do not need to infer tables from lines.
+public struct PresentationTable: Codable, Equatable, Sendable {
+    public let index: Int
+    public let sourcePart: String
+    public let anchorId: String
+    public let rows: [PresentationTableRow]
+
+    public var text: String {
+        rows.map(\.text)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    public var columnCount: Int {
+        rows.map(\.cells.count).max() ?? 0
+    }
+
+    public init(
+        index: Int,
+        sourcePart: String,
+        anchorId: String,
+        rows: [PresentationTableRow]
+    ) {
+        precondition(index >= 0, "Presentation table index must be non-negative")
+        self.index = index
+        self.sourcePart = sourcePart
+        self.anchorId = anchorId
+        self.rows = rows
+    }
+}
+
+public struct PresentationTableRow: Codable, Equatable, Sendable {
+    public let index: Int
+    public let anchorId: String
+    public let cells: [PresentationTableCell]
+
+    public var text: String {
+        cells.map(\.text).joined(separator: "\t")
+    }
+
+    public init(index: Int, anchorId: String, cells: [PresentationTableCell]) {
+        precondition(index >= 0, "Presentation table row index must be non-negative")
+        self.index = index
+        self.anchorId = anchorId
+        self.cells = cells
+    }
+}
+
+public struct PresentationTableCell: Codable, Equatable, Sendable {
+    public let rowIndex: Int
+    public let columnIndex: Int
+    public let text: String
+    public let paragraphIndexes: [Int]
+    public let anchorId: String
+
+    public init(
+        rowIndex: Int,
+        columnIndex: Int,
+        text: String,
+        paragraphIndexes: [Int],
+        anchorId: String
+    ) {
+        precondition(rowIndex >= 0, "Presentation table cell row index must be non-negative")
+        precondition(columnIndex >= 0, "Presentation table cell column index must be non-negative")
+        self.rowIndex = rowIndex
+        self.columnIndex = columnIndex
+        self.text = text
+        self.paragraphIndexes = paragraphIndexes
+        self.anchorId = anchorId
     }
 }

--- a/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/PPTXAdapter.swift
@@ -132,6 +132,7 @@ public struct PPTXAdapter: DocumentFormatAdapter {
                     label: "Slide \(index + 1)",
                     isHidden: slideExtraction.isHiddenSlide,
                     textRuns: slideExtraction.textRuns,
+                    tables: slideExtraction.tables,
                     speakerNotes: speakerNotes?.text.isEmpty == false ? speakerNotes : nil
                 )
             )
@@ -281,6 +282,37 @@ public struct PPTXAdapter: DocumentFormatAdapter {
                     )
                 )
             },
+            tables: collector.tables.enumerated().map { tableIndex, table in
+                PresentationTable(
+                    index: tableIndex,
+                    sourcePart: part,
+                    anchorId: tableAnchorId(slideIndex: slideIndex, tableIndex: tableIndex),
+                    rows: table.rows.enumerated().map { rowIndex, row in
+                        PresentationTableRow(
+                            index: rowIndex,
+                            anchorId: tableRowAnchorId(
+                                slideIndex: slideIndex,
+                                tableIndex: tableIndex,
+                                rowIndex: rowIndex
+                            ),
+                            cells: row.cells.enumerated().map { columnIndex, cell in
+                                PresentationTableCell(
+                                    rowIndex: rowIndex,
+                                    columnIndex: columnIndex,
+                                    text: cell.text,
+                                    paragraphIndexes: cell.paragraphIndexes,
+                                    anchorId: tableCellAnchorId(
+                                        slideIndex: slideIndex,
+                                        tableIndex: tableIndex,
+                                        rowIndex: rowIndex,
+                                        columnIndex: columnIndex
+                                    )
+                                )
+                            }
+                        )
+                    }
+                )
+            },
             isHiddenSlide: collector.isHiddenSlide
         )
     }
@@ -336,12 +368,20 @@ public struct PPTXAdapter: DocumentFormatAdapter {
             let slideStart = text.utf16.count
             text.append(slide.label)
 
-            var children = appendParagraphElements(
+            let slideTextAppend = appendParagraphElements(
                 runs: slide.textRuns,
                 slide: slide,
                 region: .slideText,
                 text: &text
-            ).elements
+            )
+            var children = slideTextAppend.elements
+            children.append(
+                contentsOf: tableElements(
+                    tables: slide.tables,
+                    slide: slide,
+                    paragraphRanges: slideTextAppend.paragraphRanges
+                )
+            )
 
             if let notes = slide.speakerNotes, !notes.text.isEmpty {
                 text.append("\nSpeaker notes:")
@@ -519,8 +559,130 @@ public struct PPTXAdapter: DocumentFormatAdapter {
         return ParagraphAppendResult(
             elements: elements,
             textStart: firstStart ?? textEnd,
-            textEnd: textEnd
+            textEnd: textEnd,
+            paragraphRanges: Dictionary(
+                uniqueKeysWithValues: elements.compactMap { element in
+                    guard let range = element.anchor.textRange,
+                        let paragraphIndex = element.anchor.sourceRange?.start.paragraphIndex
+                    else {
+                        return nil
+                    }
+                    return (paragraphIndex, range)
+                }
+            )
         )
+    }
+
+    private static func tableElements(
+        tables: [PresentationTable],
+        slide: PresentationSlide,
+        paragraphRanges: [Int: DocumentTextRange]
+    ) -> [DocumentElement] {
+        tables.compactMap { table in
+            let rowElements = table.rows.map { row in
+                let cellElements = row.cells.map { cell in
+                    let range = spanningRange(
+                        cell.paragraphIndexes.compactMap { paragraphRanges[$0] }
+                    )
+                    let anchor = DocumentAnchor(
+                        id: cell.anchorId,
+                        kind: .cell,
+                        path: tableAnchorPath(
+                            slideIndex: slide.index,
+                            tableIndex: table.index,
+                            rowIndex: row.index,
+                            columnIndex: cell.columnIndex
+                        ),
+                        textRange: range,
+                        sourceRange: .init(
+                            start: DocumentSourceLocation(
+                                slideIndex: slide.index,
+                                rowIndex: row.index,
+                                columnIndex: cell.columnIndex,
+                                namedRegion: "table"
+                            )
+                        ),
+                        label:
+                            "\(slide.label) table \(table.index + 1) cell \(row.index + 1).\(cell.columnIndex + 1)",
+                        metadata: [
+                            "sourcePart": table.sourcePart,
+                            "tableIndex": "\(table.index)",
+                            "rowIndex": "\(row.index)",
+                            "columnIndex": "\(cell.columnIndex)",
+                        ]
+                    )
+                    return DocumentElement(
+                        kind: .tableCell,
+                        anchor: anchor,
+                        text: cell.text,
+                        attributes: .init(role: "tableCell")
+                    )
+                }
+                let rowRange = spanningRange(cellElements.compactMap { $0.anchor.textRange })
+                let rowAnchor = DocumentAnchor(
+                    id: row.anchorId,
+                    kind: .row,
+                    path: tableAnchorPath(slideIndex: slide.index, tableIndex: table.index, rowIndex: row.index),
+                    textRange: rowRange,
+                    sourceRange: .init(
+                        start: DocumentSourceLocation(
+                            slideIndex: slide.index,
+                            rowIndex: row.index,
+                            namedRegion: "table"
+                        )
+                    ),
+                    label: "\(slide.label) table \(table.index + 1) row \(row.index + 1)",
+                    metadata: [
+                        "sourcePart": table.sourcePart,
+                        "tableIndex": "\(table.index)",
+                        "rowIndex": "\(row.index)",
+                        "columnCount": "\(row.cells.count)",
+                    ]
+                )
+                return DocumentElement(
+                    kind: .tableRow,
+                    anchor: rowAnchor,
+                    text: row.text,
+                    attributes: .init(role: "tableRow"),
+                    children: cellElements
+                )
+            }
+            guard rowElements.contains(where: { !$0.children.isEmpty }) else { return nil }
+
+            let tableRange = spanningRange(rowElements.compactMap { $0.anchor.textRange })
+            let tableAnchor = DocumentAnchor(
+                id: table.anchorId,
+                kind: .table,
+                path: tableAnchorPath(slideIndex: slide.index, tableIndex: table.index),
+                textRange: tableRange,
+                sourceRange: .init(
+                    start: DocumentSourceLocation(slideIndex: slide.index, namedRegion: "table")
+                ),
+                label: "\(slide.label) table \(table.index + 1)",
+                metadata: [
+                    "sourcePart": table.sourcePart,
+                    "tableIndex": "\(table.index)",
+                    "rowCount": "\(table.rows.count)",
+                    "columnCount": "\(table.columnCount)",
+                ]
+            )
+            return DocumentElement(
+                kind: .table,
+                anchor: tableAnchor,
+                text: table.text,
+                attributes: .init(role: "table"),
+                children: rowElements
+            )
+        }
+    }
+
+    private static func spanningRange(_ ranges: [DocumentTextRange]) -> DocumentTextRange? {
+        guard let start = ranges.map(\.startUTF16Offset).min(),
+            let end = ranges.map(\.endUTF16Offset).max()
+        else {
+            return nil
+        }
+        return DocumentTextRange(startUTF16Offset: start, length: end - start)
     }
 
     private static func groupedParagraphs(
@@ -766,6 +928,23 @@ public struct PPTXAdapter: DocumentFormatAdapter {
         "\(paragraphAnchorId(slideIndex: slideIndex, region: region, paragraphIndex: paragraphIndex))/r-\(runIndex + 1)"
     }
 
+    private static func tableAnchorId(slideIndex: Int, tableIndex: Int) -> String {
+        "\(slideAnchorId(slideIndex: slideIndex))/table-\(tableIndex + 1)"
+    }
+
+    private static func tableRowAnchorId(slideIndex: Int, tableIndex: Int, rowIndex: Int) -> String {
+        "\(tableAnchorId(slideIndex: slideIndex, tableIndex: tableIndex))/row-\(rowIndex + 1)"
+    }
+
+    private static func tableCellAnchorId(
+        slideIndex: Int,
+        tableIndex: Int,
+        rowIndex: Int,
+        columnIndex: Int
+    ) -> String {
+        "\(tableRowAnchorId(slideIndex: slideIndex, tableIndex: tableIndex, rowIndex: rowIndex))/cell-\(columnIndex + 1)"
+    }
+
     private static func anchorPath(
         slideIndex: Int,
         region: PresentationTextRegion,
@@ -780,6 +959,26 @@ public struct PPTXAdapter: DocumentFormatAdapter {
         ]
         if let runIndex {
             path.append(.init(kind: .run, index: runIndex))
+        }
+        return path
+    }
+
+    private static func tableAnchorPath(
+        slideIndex: Int,
+        tableIndex: Int,
+        rowIndex: Int? = nil,
+        columnIndex: Int? = nil
+    ) -> [DocumentAnchor.PathComponent] {
+        var path: [DocumentAnchor.PathComponent] = [
+            .init(kind: .document),
+            .init(kind: .slide, index: slideIndex),
+            .init(kind: .table, index: tableIndex),
+        ]
+        if let rowIndex {
+            path.append(.init(kind: .row, index: rowIndex))
+        }
+        if let columnIndex {
+            path.append(.init(kind: .cell, index: columnIndex))
         }
         return path
     }
@@ -809,6 +1008,7 @@ private struct SlidePart: Sendable {
 
 private struct PresentationPartTextExtraction {
     let textRuns: [PresentationTextRun]
+    let tables: [PresentationTable]
     let isHiddenSlide: Bool
 }
 
@@ -821,6 +1021,7 @@ private struct ParagraphAppendResult {
     let elements: [DocumentElement]
     let textStart: Int
     let textEnd: Int
+    let paragraphRanges: [Int: DocumentTextRange]
 }
 
 private enum PresentationTextRegion: String {
@@ -930,9 +1131,18 @@ private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
     private var inText = false
     private var currentRun = ""
     private var currentParagraphRuns: [String] = []
+    private var nextParagraphIndex = 0
     private var totalUTF16Length = 0
+    private var tableDepth = 0
+    private var inTableRow = false
+    private var inTableCell = false
+    private var currentTableRows: [CollectedTable.Row] = []
+    private var currentRowCells: [CollectedTable.Cell] = []
+    private var currentCellParagraphIndexes: [Int] = []
+    private var currentCellParagraphTexts: [String] = []
 
     private(set) var runs: [CollectedRun] = []
+    private(set) var tables: [CollectedTable] = []
     private(set) var didOverflow = false
     private(set) var didExceedDepth = false
     private(set) var isHiddenSlide = false
@@ -961,6 +1171,22 @@ private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
         }
 
         switch localName {
+        case "tbl":
+            tableDepth += 1
+            if tableDepth == 1 {
+                currentTableRows = []
+            }
+        case "tr":
+            if tableDepth > 0, !inTableRow {
+                inTableRow = true
+                currentRowCells = []
+            }
+        case "tc":
+            if tableDepth > 0, inTableRow, !inTableCell {
+                inTableCell = true
+                currentCellParagraphIndexes = []
+                currentCellParagraphTexts = []
+            }
         case "p":
             inParagraph = true
             currentParagraphRuns = []
@@ -985,16 +1211,48 @@ private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
             if !currentRun.isEmpty {
                 if inParagraph {
                     currentParagraphRuns.append(currentRun)
-                } else {
-                    appendParagraphRuns([currentRun], parser: parser)
+                } else if let paragraph = appendParagraphRuns([currentRun], parser: parser),
+                    inTableCell
+                {
+                    currentCellParagraphIndexes.append(paragraph.index)
+                    currentCellParagraphTexts.append(paragraph.text)
                 }
             }
             currentRun = ""
             inText = false
         case "p":
-            appendParagraphRuns(currentParagraphRuns, parser: parser)
+            if let paragraph = appendParagraphRuns(currentParagraphRuns, parser: parser),
+                inTableCell
+            {
+                currentCellParagraphIndexes.append(paragraph.index)
+                currentCellParagraphTexts.append(paragraph.text)
+            }
             currentParagraphRuns = []
             inParagraph = false
+        case "tc":
+            if inTableCell {
+                currentRowCells.append(
+                    CollectedTable.Cell(
+                        text: currentCellParagraphTexts.joined(separator: "\n"),
+                        paragraphIndexes: currentCellParagraphIndexes
+                    )
+                )
+                currentCellParagraphIndexes = []
+                currentCellParagraphTexts = []
+                inTableCell = false
+            }
+        case "tr":
+            if inTableRow {
+                currentTableRows.append(CollectedTable.Row(cells: currentRowCells))
+                currentRowCells = []
+                inTableRow = false
+            }
+        case "tbl":
+            if tableDepth == 1 {
+                tables.append(CollectedTable(rows: currentTableRows))
+                currentTableRows = []
+            }
+            tableDepth = max(0, tableDepth - 1)
         default:
             break
         }
@@ -1013,21 +1271,23 @@ private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
         nil
     }
 
-    private func appendParagraphRuns(_ rawRuns: [String], parser: XMLParser) {
+    private func appendParagraphRuns(_ rawRuns: [String], parser: XMLParser) -> CollectedParagraph? {
         let paragraphText = rawRuns.joined().trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !paragraphText.isEmpty else { return }
+        guard !paragraphText.isEmpty else { return nil }
 
-        let paragraphIndex = Set(runs.map(\.paragraphIndex)).count
+        let paragraphIndex = nextParagraphIndex
         var runIndex = 0
+        var collectedRuns: [CollectedRun] = []
         for rawRun in rawRuns {
             guard !rawRun.isEmpty else { continue }
-            totalUTF16Length += rawRun.utf16.count
-            if totalUTF16Length > maxUTF16Length {
+            let nextTotal = totalUTF16Length + rawRun.utf16.count
+            if nextTotal > maxUTF16Length {
                 didOverflow = true
                 parser.abortParsing()
-                return
+                return nil
             }
-            runs.append(
+            totalUTF16Length = nextTotal
+            collectedRuns.append(
                 CollectedRun(
                     text: rawRun,
                     paragraphIndex: paragraphIndex,
@@ -1036,12 +1296,34 @@ private final class OpenXMLTextRunCollector: NSObject, XMLParserDelegate {
             )
             runIndex += 1
         }
+        guard !collectedRuns.isEmpty else { return nil }
+        runs.append(contentsOf: collectedRuns)
+        nextParagraphIndex += 1
+        return CollectedParagraph(index: paragraphIndex, text: paragraphText)
+    }
+
+    struct CollectedParagraph {
+        let index: Int
+        let text: String
     }
 
     struct CollectedRun {
         let text: String
         let paragraphIndex: Int
         let runIndex: Int
+    }
+
+    struct CollectedTable {
+        let rows: [Row]
+
+        struct Row {
+            let cells: [Cell]
+        }
+
+        struct Cell {
+            let text: String
+            let paragraphIndexes: [Int]
+        }
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PPTXAdapterTests.swift
@@ -69,6 +69,54 @@ struct PPTXAdapterTests {
         #expect(document.security.externalReferences.first?.urlString == "https://example.com/deck-context")
     }
 
+    @Test func parse_preservesSlideTableCellsAndStructureAnchors() async throws {
+        let fixture = try makePresentationFixture(
+            fileExtension: "pptx",
+            slides: [1: ["Regional forecast"]],
+            slideOrder: [1],
+            tables: [
+                1: [
+                    [
+                        ["Region", "Revenue"],
+                        ["North", "1200"],
+                        ["South", "900"],
+                        ["West", ""],
+                    ]
+                ]
+            ],
+            compression: .stored
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let document = try await PPTXAdapter().parse(url: fixture.url, sizeLimit: 100_000)
+        let presentation = try #require(document.representation.underlying as? PresentationDocument)
+        let table = try #require(presentation.slides.first?.tables.first)
+
+        #expect(table.rows.count == 4)
+        #expect(table.columnCount == 2)
+        #expect(table.rows[0].cells.map(\.text) == ["Region", "Revenue"])
+        #expect(table.rows[2].cells.map(\.text) == ["South", "900"])
+        #expect(table.rows[3].cells.map(\.text) == ["West", ""])
+        #expect(table.rows[1].cells[0].paragraphIndexes.isEmpty == false)
+        #expect(table.rows[3].cells[1].paragraphIndexes.isEmpty)
+        #expect(document.textFallback.contains("Regional forecast"))
+        #expect(document.textFallback.contains("Region"))
+        #expect(document.textFallback.contains("1200"))
+
+        let tableElement = try #require(document.structure.elements(kind: .table).first)
+        let cells = document.structure.elements(kind: .tableCell)
+        #expect(document.structure.elements(kind: .tableRow).count == 4)
+        #expect(cells.count == 8)
+        #expect(tableElement.anchor.metadata["rowCount"] == "4")
+        #expect(tableElement.anchor.metadata["columnCount"] == "2")
+        #expect(cells.map(\.text).contains("Revenue"))
+        let north = try #require(cells.first { $0.text == "North" })
+        #expect(north.anchor.sourceRange?.start.slideIndex == 0)
+        #expect(north.anchor.sourceRange?.start.rowIndex == 1)
+        #expect(north.anchor.sourceRange?.start.columnIndex == 0)
+        #expect(north.anchor.textRange?.endUTF16Offset ?? 0 <= document.textFallback.utf16.count)
+    }
+
     @Test func parse_marksPOTXAsTemplate() async throws {
         let fixture = try makePresentationFixture(
             fileExtension: "potx",
@@ -269,6 +317,7 @@ struct PPTXAdapterTests {
         slides: [Int: [String]],
         slideOrder: [Int],
         notes: [Int: [String]] = [:],
+        tables: [Int: [[[String]]]] = [:],
         hiddenSlides: Set<Int> = [],
         externalTargets: [String] = [],
         externalRelationships: [RelationshipFixture] = [],
@@ -288,7 +337,13 @@ struct PPTXAdapterTests {
             entries.append(
                 (
                     "ppt/slides/slide\(number).xml",
-                    Data(slideXML(paragraphs, isHidden: hiddenSlides.contains(number)).utf8)
+                    Data(
+                        slideXML(
+                            paragraphs,
+                            tables: tables[number] ?? [],
+                            isHidden: hiddenSlides.contains(number)
+                        ).utf8
+                    )
                 )
             )
             let slideRelationships = slideRelationshipsXML(
@@ -387,7 +442,7 @@ struct PPTXAdapterTests {
         """
     }
 
-    private func slideXML(_ paragraphs: [String], isHidden: Bool = false) -> String {
+    private func slideXML(_ paragraphs: [String], tables: [[[String]]] = [], isHidden: Bool = false) -> String {
         let showAttribute = isHidden ? #" show="0""# : ""
         return """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -395,6 +450,7 @@ struct PPTXAdapterTests {
               <p:cSld>
                 <p:spTree>
                   \(paragraphs.map(textShapeXML).joined(separator: "\n"))
+                  \(tables.map(tableXML).joined(separator: "\n"))
                 </p:spTree>
               </p:cSld>
             </p:sld>
@@ -423,6 +479,44 @@ struct PPTXAdapterTests {
             </a:p>
           </p:txBody>
         </p:sp>
+        """
+    }
+
+    private func tableXML(_ rows: [[String]]) -> String {
+        """
+        <p:graphicFrame>
+          <a:graphic>
+            <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+              <a:tbl>
+                <a:tblPr/>
+                <a:tblGrid>
+                  \((0 ..< (rows.map(\.count).max() ?? 0)).map { _ in #"<a:gridCol w="2000000"/>"# }.joined(separator: "\n        "))
+                </a:tblGrid>
+                \(rows.map(tableRowXML).joined(separator: "\n        "))
+              </a:tbl>
+            </a:graphicData>
+          </a:graphic>
+        </p:graphicFrame>
+        """
+    }
+
+    private func tableRowXML(_ cells: [String]) -> String {
+        """
+        <a:tr h="370840">
+          \(cells.map(tableCellXML).joined(separator: "\n  "))
+        </a:tr>
+        """
+    }
+
+    private func tableCellXML(_ text: String) -> String {
+        """
+        <a:tc>
+          <a:txBody>
+            <a:p>
+              <a:r><a:t>\(escapeXML(text))</a:t></a:r>
+            </a:p>
+          </a:txBody>
+        </a:tc>
         """
     }
 

--- a/docs/DEVELOPER_TOOLS.md
+++ b/docs/DEVELOPER_TOOLS.md
@@ -297,9 +297,10 @@ Currently env-gated:
 ### Document runtime discovery
 
 Structured document parsing runs in-process for the built-in CSV/TSV, XLSX,
-PPTX/POTX, PDF, and rich-document adapters. PDF table extraction uses the
-text-layer glyph geometry already exposed by PDFKit; it does not add OCR or a
-third-party PDF engine. The optional office runtime
+PPTX/POTX, PDF, and rich-document adapters. PPTX/POTX slide tables are
+preserved from DrawingML table markup; PDF table extraction uses the text-layer
+glyph geometry already exposed by PDFKit. Neither path adds OCR or a third-party
+PDF engine. The optional office runtime
 detector exists only to discover a local LibreOffice/OpenOffice-compatible
 `soffice` binary for future conversion flows; it probes version metadata and
 never sends document bytes to the runtime.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -317,7 +317,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - `Managers/Documents/DocumentAdaptersBootstrap.swift` — registers built-in document adapters.
 - `Models/Documents/Workbook.swift` — typed workbook, sheet, row, and cell representation.
 - `Models/Documents/PDFDocumentRepresentation.swift` — typed PDF pages and heuristic table detections with source anchors.
-- `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, and relationship representation.
+- `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, table, and relationship representation.
 - `Models/Documents/RichDocumentRepresentation.swift` — sections, headings, links, and metadata for rich text sources.
 - `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
 - `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
@@ -331,7 +331,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 
 - CSV and TSV tables preserve headers, rows, delimiters, and source metadata.
 - XLSX workbooks preserve sheets, cells, shared strings, relationships, and can emit a minimal valid `.xlsx` package.
-- PPTX/POTX decks preserve slide grouping, text runs, notes, and relationships.
+- PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
 - Rich documents preserve section boundaries, headings, links, and metadata.
 


### PR DESCRIPTION
## Business rationale

PPTX/POTX file reads now preserve native slide table structure instead of requiring downstream callers to infer rows and cells from flattened lines. This advances the high-fidelity document input lane while keeping PDF table handling on the existing text-layer path.

## Coding rationale

- Add typed `PresentationTable`, row, and cell models on `PresentationSlide`, with backward-compatible decoding for older serialized presentations.
- Extend the existing bounded OpenXML text collector to record DrawingML `a:tbl` / `a:tr` / `a:tc` structure while still emitting the same slide text runs.
- Add `table`, `tableRow`, and `tableCell` structure elements with stable anchors and row/column metadata that point back to existing fallback paragraph ranges, avoiding duplicated fallback text.
- Update document feature/runtime docs to describe PPTX/POTX slide table preservation.

## Acceptance criteria

- PPTX slide tables are exposed as typed rows and cells with stable anchor IDs.
- Table structure elements include row/column metadata and text ranges when cell text exists.
- Empty table cells remain represented as cells without inventing fallback text.
- Existing PPTX slide text, speaker notes, relationships, and PDF table tests continue to pass.

## Quality gate

Passed locally on 2026-05-30. Evidence log: `.osaurus-plan/evidence/T-P1-HF-PPTX-PDF-INPUT-FIDELITY/gate-20260530T175625Z.log`.

Commands run:

```sh
swift-format lint --strict --recursive Packages App
swiftlint lint --reporter github-actions-logging
find scripts -name "*.sh" -print0 | xargs -0 shellcheck --severity=warning
swift test --package-path Packages/OsaurusCLI --parallel
make ci-test
swift build --package-path Packages/OsaurusCore -c release
```

## Debug evidence

Focused checks also passed before the full gate:

```sh
swift test --package-path Packages/OsaurusCore --filter PPTXAdapterTests
swift test --package-path Packages/OsaurusCore --filter PDFAdapterTests
swift test --package-path Packages/OsaurusCore --filter FileReadDocumentFormatsTests
swift test --package-path Packages/OsaurusCore --filter Document
git diff --check
```

## Self-review

Regression: The table structure reuses the paragraph text ranges generated from the existing slide text runs, so this does not duplicate or reorder `textFallback`. `PresentationSlide` decoding defaults missing `tables` to an empty array. Speaker-note table structure is not promoted into `PresentationSlide.tables`; note text extraction remains unchanged.

Performance: The implementation adds bookkeeping to the existing XML parser pass. Memory growth is proportional to recovered table rows/cells and remains bounded by the existing XML part and text extraction limits.

## Rebase notes

Final `git fetch --all --prune` and `git rebase origin/main` completed cleanly. Branch head: `60f94fe5554f9ab8b57412cf0418e85e9a0be779`; base: `291cdf84a60f7665389b4037550bae0472815c70`.

## Rollback

Revert commit `60f94fe5554f9ab8b57412cf0418e85e9a0be779`.