### PR TITLE
Pin Step and LFM vMLX runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
+        "revision" : "258d20770cfb3d2c07a756caac14c768ed7f9a24"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -58,6 +58,18 @@ enum ModelFamilyNames {
         ) != nil
     }
 
+    /// StepFun Step 3.5 / 3.7 bundles. Step 3.7 VLM-wrapped local
+    /// JANG/JANGTQ models expose the Step 3.5-compatible text runtime and
+    /// native template, but explicit required-tool calls need the corrected
+    /// Step fallback template instead of the native always-open thinking rail.
+    static func isStepFamily(_ modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return lower.range(
+            of: #"(^|/|[\-_])step($|[\-_/\.0-9])"#,
+            options: .regularExpression
+        ) != nil
+    }
+
     /// DeepSeek-V4 / DSV4 Flash bundles (`model_type=deepseek_v4`).
     /// Match both public repo forms (`DeepSeek-V4-...`) and shorthand
     /// runtime names (`DSV4-...`, `deepseekv4-...`) while avoiding

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
+        "revision" : "258d20770cfb3d2c07a756caac14c768ed7f9a24"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+            revision: "72d97209b37f12646ff4d84d5900a4eec2b9d041"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "72d97209b37f12646ff4d84d5900a4eec2b9d041"
+            revision: "258d20770cfb3d2c07a756caac14c768ed7f9a24"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2269,10 +2269,11 @@ public actor ModelRuntime {
         // Non-JANG models have no jang_config.json — nothing to validate.
         guard FileManager.default.fileExists(atPath: jangConfigURL.path) else { return }
 
-        // Only read the `weight_format` field; ignore anything else so format
-        // drift (new fields, missing optionals) doesn't break the preflight.
+        // Read only routing stamps; ignore all other fields so format drift
+        // (new fields, missing optionals) doesn't break the preflight.
         struct JangConfigProbe: Decodable {
             let weight_format: String?
+            let format: String?
         }
         guard let data = try? Data(contentsOf: jangConfigURL),
             let probe = try? JSONDecoder().decode(JangConfigProbe.self, from: data)
@@ -2291,6 +2292,10 @@ public actor ModelRuntime {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         let isMxtq = normalizedStamp == "mxtq"
+        let normalizedFormat = (probe.format ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let declaresJANGTQFormat = normalizedFormat == "jangtq"
 
         // Forward mismatch: declared JANGTQ, sidecar missing.
         if isMxtq && !sidecarPresent {
@@ -2309,7 +2314,7 @@ public actor ModelRuntime {
         // Inverse mismatch: sidecar present but stamp says non-JANGTQ. The
         // safetensors carry `tq_norms` / `tq_packed` keys vmlx's base class
         // can't decode → "Unhandled keys" runtime error. Catch it here.
-        if sidecarPresent && !isMxtq {
+        if sidecarPresent && !isMxtq && !declaresJANGTQFormat {
             let actualStamp = (probe.weight_format?.isEmpty == false) ? probe.weight_format! : "absent"
             throw NSError(
                 domain: "ModelRuntime",

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -811,6 +811,16 @@ struct MLXBatchAdapter {
             }
             return context
         }
+        if ModelFamilyNames.isStepFamily(modelName) {
+            if toolChoiceRequiresLocalCall(toolChoice) {
+                context["enable_thinking"] = false
+            } else if let disableThinking {
+                context["enable_thinking"] = !disableThinking
+            } else if normalizedReasoningEffort != nil {
+                context["enable_thinking"] = hasPositiveReasoningEffort
+            }
+            return context
+        }
         if ModelFamilyNames.isGemmaFamily(modelName) {
             if directRailReasoningEffort {
                 context["enable_thinking"] = false

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -51,6 +51,12 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         + String(UnicodeScalar(0x2581)!) + "sentence"
         + String(UnicodeScalar(0xFF5C)!) + ">"
 
+    private static let step37Bos =
+        "<" + String(UnicodeScalar(0xFF5C)!)
+        + "begin" + String(UnicodeScalar(0x2581)!) + "of"
+        + String(UnicodeScalar(0x2581)!) + "sentence"
+        + String(UnicodeScalar(0xFF5C)!) + ">"
+
     private static let gemma3FunctionToolMinimal = #"""
 {{ bos_token }}
 {%- set loop_messages = messages -%}
@@ -255,6 +261,12 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         let hasDSV4Sentinel =
             !hasZayaVLVisionSentinel
             && upstream.bosToken == Self.dsv4Bos
+        let hasStep37Sentinels =
+            upstream.bosToken == Self.step37Bos
+            && upstream.eosToken == "<|im_end|>"
+            && upstream.convertTokenToId("<|im_start|>") != nil
+            && upstream.convertTokenToId("<tool_call>") != nil
+            && upstream.convertTokenToId("<im_patch>") != nil
         if hasLagunaSentinel
             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {
@@ -297,6 +309,20 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             return try fallback(
                 label: "LFM2ToolMinimal",
                 template: MLXLMCommon.ChatTemplateFallbacks.lfm2ToolMinimal,
+                messages: messages,
+                tools: chatTemplateTools,
+                additionalContext: adjustedContext,
+                addGenerationPrompt: addGenerationPrompt
+            )
+        }
+        if hasStep37Sentinels,
+            (!(chatTemplateTools?.isEmpty ?? true)
+                || (adjustedContext?["enable_thinking"] as? Bool) == false),
+            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
+        {
+            return try fallback(
+                label: "Step37Minimal",
+                template: MLXLMCommon.ChatTemplateFallbacks.step37Minimal,
                 messages: messages,
                 tools: chatTemplateTools,
                 additionalContext: adjustedContext,

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -651,6 +651,42 @@ struct MLXBatchAdapterTests {
                 modelName: "Gemma-4-26B-A4B-it-JANG_4M-CRACK"
             ) == "fp16"
         )
+        #expect(
+            ModelRuntime.cacheKVModeTag(
+                for: settings.cache,
+                modelName: "JANGQ-AI/Step-3.7-Flash-JANG_2L",
+                cacheTopology: ModelCacheTopologySnapshot(
+                    layerCount: 45,
+                    kvLayerCount: 12,
+                    turboQuantKVLayerCount: 0,
+                    rotatingKVLayerCount: 33
+                )
+            ) == "fp16"
+        )
+        #expect(
+            ModelRuntime.cacheKVModeTag(
+                for: settings.cache,
+                modelName: "JANGQ-AI/Step-3.7-Flash-JANGTQ_K",
+                cacheTopology: ModelCacheTopologySnapshot(
+                    layerCount: 45,
+                    kvLayerCount: 12,
+                    turboQuantKVLayerCount: 0,
+                    rotatingKVLayerCount: 33
+                )
+            ) == "fp16"
+        )
+        #expect(
+            ModelRuntime.cacheKVModeTag(
+                for: settings.cache,
+                modelName: "MiniMax-M2.7-JANG_K-CRACK",
+                cacheTopology: ModelCacheTopologySnapshot(
+                    layerCount: 62,
+                    kvLayerCount: 62,
+                    turboQuantKVLayerCount: 0,
+                    rotatingKVLayerCount: 0
+                )
+            ) == "turbo(3,3)"
+        )
 
         settings.cache.liveKVCodec = .native
         #expect(

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1192,6 +1192,14 @@ struct MLXBatchAdapterTests {
             modelName: modelName
         )
         #expect(omitted["tool_choice"] == nil)
+
+        let stepRequired = MLXBatchAdapter.additionalContext(
+            for: generation,
+            modelName: "JANGQ-AI/Step-3.7-Flash-JANGTQ_K",
+            toolChoice: .required
+        )
+        #expect(stepRequired["tool_choice"] as? String == "required")
+        #expect(stepRequired["enable_thinking"] as? Bool == false)
     }
 
     @Test func additionalContext_defaultsLingThinkingOffButHonorsExplicitOptIn() {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -138,6 +138,20 @@ struct ModelRuntimeFindDirectoryTests {
         }
     }
 
+    @Test("JANGTQ format stamp with sidecar passes even when weight_format is absent")
+    func jangtq_formatStampWithSidecar_passes() throws {
+        let dir = try makeIsolatedDir()
+        // Step 3.7 JANGTQ_K bundles can declare the runtime via
+        // `format: "jangtq"` while omitting the older top-level
+        // `weight_format` key. vmlx infers the JANGTQ route from the
+        // sidecar/codebook; Osaurus preflight must not block that valid
+        // bundle shape.
+        let json = #"{"format":"jangtq"}"#
+        try Data(json.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+        try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "Step-3.7-JANGTQ_K")
+    }
+
     /// Genuine bf16 dense bundle: stamp says bf16 AND no sidecar. This is
     /// the common case for non-quantized JANG bundles (DSV4-Flash-JANG_2L,
     /// Mistral-Small-4-JANG_2L, etc.) — must pass through cleanly.

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -472,7 +472,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        let expectedRuntimeHardenedRevision = "72d97209b37f12646ff4d84d5900a4eec2b9d041"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -480,7 +480,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4 matrix; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -472,7 +472,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "72d97209b37f12646ff4d84d5900a4eec2b9d041"
+        let expectedRuntimeHardenedRevision = "258d20770cfb3d2c07a756caac14c768ed7f9a24"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -1150,6 +1150,56 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(!decoded.contains("Today's date:"), "Decoded: \(decoded)")
         #expect(!decoded.contains("<think>"), "Decoded: \(decoded)")
     }
+
+    @Test func step37LocalTokenizerUsesRequiredToolFallbackAndClosesThinkingRail() async throws {
+        let defaultPath = "/Volumes/EricsLLMDrive/jangq-ai/Step-3.7-Flash-JANGTQ_K"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_STEP37_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                ["role": "user", "content": "Use the line_count tool on this exact text: red\ngreen\nblue"]
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(decoded.contains("# Tools"), "Decoded: \(decoded)")
+        #expect(decoded.contains("The active API tool_choice is required"), "Decoded: \(decoded)")
+        #expect(decoded.contains("Use the `line_count` function."), "Decoded: \(decoded)")
+        #expect(decoded.contains("Required parameters for `line_count`: text."), "Decoded: \(decoded)")
+        #expect(decoded.contains("<tool_call>\n<function=FUNCTION_NAME>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<parameter=ARGUMENT_NAME>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<|im_start|>assistant\n<think>\n</think>\n\n"), "Decoded: \(decoded)")
+        #expect(!decoded.hasSuffix("<|im_start|>assistant\n<think>\n"), "Decoded: \(decoded)")
+    }
 }
 
 private struct LocalTokenizerRow {

--- a/docs/STEP37_LFM_OSAURUS_E2E_EVIDENCE_2026_05_30.md
+++ b/docs/STEP37_LFM_OSAURUS_E2E_EVIDENCE_2026_05_30.md
@@ -1,0 +1,127 @@
+# Step 3.7 / LFM Osaurus E2E Evidence - 2026-05-30
+
+This document records the current no-sign Osaurus app proof for the Step/LFM
+vMLX pin. It deliberately separates proven rows from partial rows.
+
+## Code State
+
+- vMLX pin: `72d97209b37f12646ff4d84d5900a4eec2b9d041`.
+- vMLX fix: Step tool-call parser support for Step XML and narrow
+  schema-gated bare `name({"arg": ...})` calls on reasoning/content rails.
+- Osaurus fix: local JANGTQ sidecar preflight accepts bundles that declare
+  `format: "jangtq"` with `jangtq_runtime.safetensors` even when
+  `weight_format` is absent.
+- Osaurus cache policy: engine-selected TurboQuant KV remains topology-gated.
+  Full simple-KV models can use TurboQuant KV; Step hybrid rotating/sliding
+  cache and LFM SSM/Mamba hybrid cache use native KV plus disk-backed restore
+  and companion state.
+
+## No-Sign / No-Keychain Boundary
+
+- App build:
+  `/tmp/osaurus-step37-pr/build/DerivedData-step37-nosign-7c9b14e0-72d9720-formatfix/Build/Products/Release/osaurus.app`.
+- Build path used `scripts/live-proof/build-keychain-free-osaurus.sh`.
+- Xcode build settings included `CODE_SIGNING_ALLOWED=NO`,
+  `CODE_SIGNING_REQUIRED=NO`, empty `CODE_SIGN_IDENTITY`, and
+  `AD_HOC_CODE_SIGNING_ALLOWED=NO`.
+- The only seal was the script's local ad-hoc seal with no signing identity,
+  no notary, no `security` command, and no password/keychain prompt.
+- Live app launches used `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, isolated
+  `OSAURUS_TEST_ROOT`, and explicit `OSU_MODELS_DIR`.
+
+## Proven Live Row: LFM2.5 MXFP4
+
+- Model id: `lfm2.5-8b-a1b-mxfp4`.
+- Model root: `/tmp/osaurus-e2e-lfm-one`.
+- Final warm artifact:
+  `/tmp/osaurus-lfm-finalapp-warm-2048-20260530-145426`.
+- Harness:
+  `scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py`.
+- Required evidence: `cache_topology`, `requires_disk_backed_restore`,
+  `ssm_companion_cache`, `companion_cache`, and `disk_l2_hits`.
+- Result: `passed: true`, `failed_checks: []`.
+
+Behavior proven:
+
+- Turn 1 required tool call finished as `tool_calls`.
+- Turn 1 exact tool args: `{"text":"red\ngreen\nblue"}`.
+- Turn 2 produced visible answer: `Three lines were counted.`
+- Turn 2 had no tool call, no protocol leak, and no length-stop fake pass.
+- Turn 3 required tool call after history finished as `tool_calls`.
+- Turn 3 exact tool args: `{"text":"one\ntwo"}`.
+- No visible content leaked on tool-call turns.
+- App `/health` after the row was healthy with no in-flight request.
+- Visible generation throughput was recorded: 118 completion tokens in
+  1.598719583 seconds, about 73.81 tok/s.
+
+Cache/topology proven:
+
+- 24 total layers.
+- 6 KV layers.
+- 18 Mamba/SSM companion layers.
+- `companion=ssm`.
+- `requires_disk_backed_restore=true`.
+- `requires_ssm_companion_state=true`.
+- Paged cache incompatible for this hybrid row.
+- `turbo_quant_kv_layer_count=0`.
+- Warm row delta: `disk_l2_hits +1`, `ssm_companion_hits +1`,
+  `companion_hits +1`, and `block_disk_stores +4`.
+
+Boundary:
+
+- The same LFM row can fail with too-small explicit max-token caps. A cold
+  run using `--max-tokens 256` failed with `finish=length` before a tool call.
+  The green row used explicit `--max-tokens 2048`; this is recorded as a
+  request budget requirement, not hidden runtime behavior.
+- This row proves LFM2.5 MXFP4. It does not prove LFM MXFP8 or LFM JANG_2L.
+
+## Partial / Blocked Rows
+
+Step JANG_2L:
+
+- Earlier app attempts under current machine load did not produce a clean live
+  Osaurus pass. The app entered generation and timed out before returning
+  output. Sampling showed real generation work, not keychain/signing.
+- A separate Step CRACK process was consuming about 82 GB RSS and high CPU/GPU
+  during these attempts, so this row remains blocked/partial until rerun on a
+  less contended machine.
+
+Step JANGTQ_K:
+
+- The Osaurus preflight blocker for `format: "jangtq"` without
+  `weight_format` is fixed and has focused test coverage.
+- The final no-sign app served `/health`, but `/v1/models` and a direct chat
+  request hung for the one-model Step JANGTQ_K root before runtime proof.
+- Do not call Step JANGTQ_K live-proven from this PR evidence.
+
+Step JANGTQ2:
+
+- No local Step JANGTQ2 bundle was found. Do not claim Step JANGTQ2 proof.
+
+VL/media:
+
+- No fresh real media row was run for this PR evidence. Do not claim VL proof
+  from the Step/LFM rows.
+
+## Source And Guard Verification
+
+Focused Swift tests passed:
+
+- `ModelRuntimeFindDirectoryTests/jangtq_formatStampWithSidecar_passes`
+- `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`
+- `MLXBatchAdapterTests/cacheKVModeTagTracksEffectiveCoordinatorPolicy`
+
+Guard scripts passed:
+
+- `scripts/live-proof/assert-tool-choice-required-routing.sh`
+- `scripts/live-proof/assert-keychain-free-proof-path.sh`
+- `scripts/live-proof/assert-server-settings-runtime-wiring.sh`
+- `scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh`
+- `scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh`
+- `scripts/live-proof/assert-osaurus-pr-hygiene.sh`
+
+No fake-fix boundary:
+
+- No hidden sampler defaults, forced repetition penalty, close-token bias,
+  forced thinking/reasoning behavior, or broad parser repair was used for the
+  live proof.

--- a/docs/STEP37_LFM_OSAURUS_E2E_EVIDENCE_2026_05_30.md
+++ b/docs/STEP37_LFM_OSAURUS_E2E_EVIDENCE_2026_05_30.md
@@ -5,12 +5,19 @@ vMLX pin. It deliberately separates proven rows from partial rows.
 
 ## Code State
 
-- vMLX pin: `72d97209b37f12646ff4d84d5900a4eec2b9d041`.
-- vMLX fix: Step tool-call parser support for Step XML and narrow
-  schema-gated bare `name({"arg": ...})` calls on reasoning/content rails.
+- vMLX pin: `258d20770cfb3d2c07a756caac14c768ed7f9a24`.
+- vMLX fixes:
+  - Step tool-call parser support for Step XML and narrow schema-gated bare
+    `name({"arg": ...})` calls on reasoning/content rails.
+  - Step required-tool fallback closes the native thinking rail before the
+    explicit function-call contract so `tool_choice: required` does not remain
+    trapped in hidden reasoning.
 - Osaurus fix: local JANGTQ sidecar preflight accepts bundles that declare
   `format: "jangtq"` with `jangtq_runtime.safetensors` even when
   `weight_format` is absent.
+- Osaurus fix: SwiftTransformers local-tokenizer loading routes Step sentinel
+  templates through the Step fallback, disables Step thinking only for explicit
+  required tool choice, and preserves normal optional-tool behavior otherwise.
 - Osaurus cache policy: engine-selected TurboQuant KV remains topology-gated.
   Full simple-KV models can use TurboQuant KV; Step hybrid rotating/sliding
   cache and LFM SSM/Mamba hybrid cache use native KV plus disk-backed restore
@@ -19,7 +26,7 @@ vMLX pin. It deliberately separates proven rows from partial rows.
 ## No-Sign / No-Keychain Boundary
 
 - App build:
-  `/tmp/osaurus-step37-pr/build/DerivedData-step37-nosign-7c9b14e0-72d9720-formatfix/Build/Products/Release/osaurus.app`.
+  `/tmp/osaurus-step37-pr/build/DerivedData-step37-nosign-623fffc3-258d207/Build/Products/Release/osaurus.app`.
 - Build path used `scripts/live-proof/build-keychain-free-osaurus.sh`.
 - Xcode build settings included `CODE_SIGNING_ALLOWED=NO`,
   `CODE_SIGNING_REQUIRED=NO`, empty `CODE_SIGN_IDENTITY`, and
@@ -75,6 +82,62 @@ Boundary:
   request budget requirement, not hidden runtime behavior.
 - This row proves LFM2.5 MXFP4. It does not prove LFM MXFP8 or LFM JANG_2L.
 
+## Proven Live Row: Step 3.7 JANGTQ_K
+
+- Model id: `step-3.7-flash-jangtq_k`.
+- Model root: `/tmp/osaurus-step37-jangtqk-final-modelroot`.
+- Final artifact:
+  `/tmp/osaurus-step37-jangtqk-final-proof-20260530-154948`.
+- Summary:
+  `/tmp/osaurus-step37-jangtqk-final-proof-20260530-154948/step-3.7-flash-jangtq_k_summary.json`.
+- Harness:
+  `scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py`.
+- Required evidence: `cache_topology`, `requires_disk_backed_restore`, and
+  `rotating_kv_layer_count`.
+- Result: `passed: true`, `failed_checks: []`.
+
+Behavior proven:
+
+- Turn 1 required tool call finished as `tool_calls`.
+- Turn 1 exact tool args: `{"text":"red\ngreen\nblue"}`.
+- Turn 1 had `content=null`, no reasoning leak, and no visible protocol leak.
+- Turn 2 produced visible answer: `The line count tool counted 3 lines.`
+- Turn 2 had no tool call, no reasoning leak, no protocol leak, and no
+  length-stop fake pass.
+- Turn 3 required tool call after assistant/tool history finished as
+  `tool_calls`.
+- Turn 3 exact tool args: `{"text":"one\ntwo"}`.
+- Turn 3 had no visible content leak and no protocol leak.
+- App `/health` after the row was healthy, resident on
+  `step-3.7-flash-jangtq_k`, and had no in-flight request.
+- Token/s was recorded. This row is extremely slow on the current machine under
+  the concurrent Step CRACK load: visible turn 2 produced 10 completion tokens
+  in 326.031645042 seconds, about 0.0307 tok/s. Required tool-call turns emitted
+  zero completion tokens by design.
+
+Cache/topology proven:
+
+- 45 total layers.
+- 12 full KV layers.
+- 33 rotating/sliding KV layers.
+- `requires_disk_backed_restore=true`.
+- Paged cache incompatible for this rotating hybrid row.
+- `turbo_quant_kv_layer_count=0`.
+- Cold row delta: `block_disk_misses +2`, `block_disk_stores +4`,
+  `block_disk_hits +0`.
+
+Boundary:
+
+- This row proves Step JANGTQ_K required-tool parsing, reasoning separation,
+  multi-turn tool-result history, no visible loop, no length-stop fake pass,
+  and rotating/topology detection through the real no-sign Osaurus app.
+- This row does not prove warm disk-L2 hit reuse for Step JANGTQ_K. The cache
+  topology and disk-backed store path are proven, but `block_disk_hits` stayed
+  `0`. Do not claim Step JANGTQ_K warm cache-hit readiness until a repeat row
+  records `disk_l2_hits > 0` or `block_disk_hits > 0`.
+- Step remains native/fp16 by default in Osaurus because it is a rotating hybrid
+  topology. TurboQuant KV is not enabled by default for this row.
+
 ## Partial / Blocked Rows
 
 Step JANG_2L:
@@ -88,11 +151,11 @@ Step JANG_2L:
 
 Step JANGTQ_K:
 
-- The Osaurus preflight blocker for `format: "jangtq"` without
-  `weight_format` is fixed and has focused test coverage.
-- The final no-sign app served `/health`, but `/v1/models` and a direct chat
-  request hung for the one-model Step JANGTQ_K root before runtime proof.
-- Do not call Step JANGTQ_K live-proven from this PR evidence.
+- The earlier red row
+  `/tmp/osaurus-step37-jangtqk-open-proof-20260530-151428` failed because the
+  native Step template kept the required-tool contract inside hidden thinking.
+- The final row above supersedes that red artifact for required-tool behavior.
+- Warm disk-L2 hit reuse remains partial as described above.
 
 Step JANGTQ2:
 
@@ -109,6 +172,8 @@ Focused Swift tests passed:
 
 - `ModelRuntimeFindDirectoryTests/jangtq_formatStampWithSidecar_passes`
 - `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`
+- `SwiftTransformersTokenizerLoaderTests/step37LocalTokenizerUsesRequiredToolFallbackAndClosesThinkingRail`
+- `MLXBatchAdapterTests/additionalContext_threadsRequiredToolChoiceToLocalTemplates`
 - `MLXBatchAdapterTests/cacheKVModeTagTracksEffectiveCoordinatorPolicy`
 
 Guard scripts passed:
@@ -119,6 +184,10 @@ Guard scripts passed:
 - `scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh`
 - `scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh`
 - `scripts/live-proof/assert-osaurus-pr-hygiene.sh`
+- `scripts/live-proof/assert-chat-reasoning-delta-routing.sh`
+- `scripts/live-proof/assert-chat-ui-reasoning-routing.sh`
+- `scripts/live-proof/assert-http-channel-load-cancellation.sh`
+- `scripts/live-proof/assert-model-tool-capability-surfaces.sh`
 
 No fake-fix boundary:
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "84c8bb653a50cd48b4af7f5cdce04d3f16e6ed95"
+        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "72d97209b37f12646ff4d84d5900a4eec2b9d041"
+        "revision" : "258d20770cfb3d2c07a756caac14c768ed7f9a24"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Pins Osaurus to vMLX `72d97209b37f12646ff4d84d5900a4eec2b9d041` with Step tool-call parser/runtime hardening.
- Accepts valid JANGTQ bundles that declare `format: \"jangtq\"` plus `jangtq_runtime.safetensors` even when `weight_format` is absent.
- Adds source coverage for topology-gated KV policy: full simple-KV models can use TurboQuant KV, while Step hybrid rotating/sliding and LFM SSM/Mamba hybrid rows stay native/fp16 with disk-backed restore/companion cache.
- Adds a dated E2E evidence document with proven/partial boundaries.

## Verified

- No-sign Release app build succeeded with signing disabled and keychain-free env.
- Focused Swift tests passed:
  - `ModelRuntimeFindDirectoryTests/jangtq_formatStampWithSidecar_passes`
  - `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`
  - `MLXBatchAdapterTests/cacheKVModeTagTracksEffectiveCoordinatorPolicy`
- Guard scripts passed:
  - `assert-tool-choice-required-routing.sh`
  - `assert-keychain-free-proof-path.sh`
  - `assert-server-settings-runtime-wiring.sh`
  - `assert-osaurus-no-forced-behavior-pr.sh`
  - `assert-osaurus-vmlx-pr-readiness.sh`
  - `assert-osaurus-pr-hygiene.sh`
- Live final-app LFM2.5 MXFP4 warm E2E passed:
  - artifact `/tmp/osaurus-lfm-finalapp-warm-2048-20260530-145426`
  - strict required / none / required tool flow
  - exact `line_count` args on turns 1 and 3
  - no protocol leak, no visible tool-turn content, no length-stop fake pass
  - healthy app after run
  - warm `disk_l2_hits +1`, `ssm_companion_hits +1`, `companion_hits +1`
  - visible generation throughput recorded at about 73.81 tok/s

## Honest Boundaries

- Step JANGTQ_K preflight is fixed and tested, but the local final-app live proof is not green: `/v1/models`/direct chat hung before runtime proof for the one-model root.
- Step JANG_2L app live proof is partial under current machine contention; a separate Step CRACK process was using about 82 GB RSS/high CPU during attempts.
- No Step JANGTQ2 bundle was present locally.
- No fresh VL/media row is claimed in this PR evidence.
- No hidden sampler defaults, repetition penalties, close-token biasing, forced thinking tags, or broad parser repair were used.