### PR TITLE
bug fixes

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -15160,6 +15160,9 @@
         }
       }
     },
+    "Outbound network disabled" : {
+
+    },
     "Override added" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
@@ -317,12 +317,24 @@
         /// config. `SandboxConfiguration.network` is the single VM-wide
         /// switch (the VM is shared across agents); it mirrors the
         /// provisioning agent's `AutonomousExecConfig.sandboxNetworkEnabled`
-        /// via `AgentManager.updateAutonomousExec`. Anything other than the
-        /// explicit "none" sentinel keeps egress on (default "outbound"),
-        /// so existing installs are unaffected. `nonisolated` + pure so the
-        /// regression test can exercise it without booting a VM.
+        /// both when the UI toggle flips (`AgentManager.updateAutonomousExec`)
+        /// and at every boot (`reconcileNetworkFromActiveAgent`, which keeps
+        /// the agent toggle authoritative and heals a stale `sandbox.json`).
+        /// Anything other than the explicit "none" sentinel keeps egress on
+        /// (default "outbound"), so existing installs are unaffected.
+        /// `nonisolated` + pure so the regression test can exercise it
+        /// without booting a VM.
         nonisolated static func networkEnabled(from config: SandboxConfiguration) -> Bool {
             config.network != "none"
+        }
+
+        /// Pure mapping from a provisioning agent's `sandboxNetworkEnabled`
+        /// to the VM-wide `network` string. Factored out of
+        /// `reconcileNetworkFromActiveAgent` so the boot-time reconcile policy
+        /// is testable without a VM, `AgentManager`, or disk. Inverse of
+        /// `networkEnabled(from:)`.
+        nonisolated static func reconciledNetwork(agentNetworkEnabled enabled: Bool) -> String {
+            enabled ? "outbound" : "none"
         }
 
         /// Build the `LinuxContainer.Configuration` closure that's shared
@@ -457,11 +469,44 @@
             }
         }
 
+        /// Mirror the active (provisioning) agent's `sandboxNetworkEnabled`
+        /// onto the VM-wide `SandboxConfiguration.network` so the value the VM
+        /// boots from matches the toggle the user controls. Writes through
+        /// `SandboxConfigurationStore.save` (cache-coherent) only when the two
+        /// actually differ, so steady-state boots pay just a load + compare.
+        /// Defaults to egress-on when the agent has no autonomous-exec config,
+        /// matching `AutonomousExecConfig.sandboxNetworkEnabled`'s default.
+        private func reconcileNetworkFromActiveAgent() async {
+            let enabled: Bool = await MainActor.run {
+                let id = AgentManager.shared.activeAgent.id
+                return AgentManager.shared.effectiveAutonomousExec(for: id)?
+                    .sandboxNetworkEnabled ?? true
+            }
+            let desired = Self.reconciledNetwork(agentNetworkEnabled: enabled)
+            var config = SandboxConfigurationStore.load()
+            if config.network != desired {
+                config.network = desired
+                SandboxConfigurationStore.save(config)
+            }
+        }
+
         public func provision() async throws {
             guard _availability?.isAvailable == true else {
                 throw SandboxError.unavailable
             }
             _removedByUser = false
+
+            // Self-heal a desynced egress switch before reading it. The VM
+            // boots from the shared `SandboxConfiguration.network`, but the
+            // toggle users actually see + edit is the per-agent
+            // `sandboxNetworkEnabled`. Those two stores only sync at the
+            // instant the toggle is flipped, so a `sandbox.json` left at
+            // "none" (early-build provisioning, the container-level toggle, or
+            // another agent's flip) keeps egress off forever while the active
+            // agent's own setting says on — with no way to fix it from the
+            // agent UI. Mirroring the provisioning agent's preference here
+            // makes that toggle authoritative on every boot.
+            await reconcileNetworkFromActiveAgent()
 
             let config = SandboxConfigurationStore.load()
             let isRestart = hasRequiredAssets

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxNetworkPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxNetworkPolicyTests.swift
@@ -71,6 +71,39 @@
             #expect(decoded.allowHostSecretReads == true)
             #expect(decoded.sandboxNetworkEnabled == false)
         }
+
+        // MARK: - Boot-time reconcile (self-heal desynced installs)
+
+        @Test func agentNetworkOnMapsToOutbound() {
+            #expect(SandboxManager.reconciledNetwork(agentNetworkEnabled: true) == "outbound")
+        }
+
+        @Test func agentNetworkOffMapsToNone() {
+            #expect(SandboxManager.reconciledNetwork(agentNetworkEnabled: false) == "none")
+        }
+
+        /// The regression that motivated the reconcile: the per-agent toggle
+        /// says egress-on, but `sandbox.json` was left at "none" (early-build
+        /// provisioning, the container-level toggle, or another agent's flip).
+        /// Reconciling the active agent's preference at boot must override the
+        /// stale value so the VM comes up with network.
+        @Test func agentNetworkOnHealsStaleNoneConfig() {
+            var stale = SandboxConfiguration(network: "none")
+            #expect(!SandboxManager.networkEnabled(from: stale))  // pre-heal: egress cut
+
+            stale.network = SandboxManager.reconciledNetwork(agentNetworkEnabled: true)
+            #expect(SandboxManager.networkEnabled(from: stale))  // post-heal: egress on
+        }
+
+        /// Symmetric guarantee: a user who turned the agent toggle OFF still
+        /// gets egress cut even if `sandbox.json` is stale at "outbound".
+        @Test func agentNetworkOffHealsStaleOutboundConfig() {
+            var stale = SandboxConfiguration(network: "outbound")
+            #expect(SandboxManager.networkEnabled(from: stale))
+
+            stale.network = SandboxManager.reconciledNetwork(agentNetworkEnabled: false)
+            #expect(!SandboxManager.networkEnabled(from: stale))
+        }
     }
 
 #endif

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1797,6 +1797,18 @@ extension FloatingInputCard {
         isSandboxEnabled && sandboxFailure != nil
     }
 
+    /// True when the sandbox is on but outbound network is turned off for
+    /// this agent. Egress is the per-agent `sandboxNetworkEnabled` toggle,
+    /// reconciled onto the VM at boot — so this reflects what the sandbox
+    /// will actually permit. Surfaced on the chip so a network-less sandbox
+    /// is visible up front, instead of the model discovering it only when a
+    /// `curl`/`urllib` call fails mid-task.
+    private var isSandboxNetworkDisabled: Bool {
+        isSandboxEnabled
+            && agentManager.effectiveAutonomousExec(for: effectiveAgentId)?
+                .sandboxNetworkEnabled == false
+    }
+
     private func retrySandbox() {
         let agentId = effectiveAgentId
         Task {
@@ -1878,20 +1890,29 @@ extension FloatingInputCard {
     }
 
     private var sandboxHelpText: String {
+        let base: String
         if let failure = sandboxFailure, isSandboxEnabled {
             return "Sandbox unavailable: \(failure.message)\nClick to open Sandbox settings."
         } else if isSandboxLoading {
             return "Sandbox is starting up — click to view progress."
         } else if isCombinedMode {
-            return
+            base =
                 "Combined mode: the selected folder is read-only and all code runs in the sandbox. Click to disable."
         } else if isSandboxEnabled && isSandboxRunning {
-            return "Sandbox is active — click to disable. Right-click for settings."
+            base = "Sandbox is active — click to disable. Right-click for settings."
         } else if isSandboxEnabled {
-            return "Sandbox enabled — container not running"
+            base = "Sandbox enabled — container not running"
         } else {
-            return "Enable Sandbox for autonomous code execution"
+            base = "Enable Sandbox for autonomous code execution"
         }
+        // Spell out the egress restriction so the user understands the
+        // wifi.slash badge — and why the model can't fetch URLs. Takes
+        // effect on the next sandbox start.
+        if isSandboxNetworkDisabled {
+            return base
+                + "\nOutbound network is off — enable it in Sandbox settings (applies on next sandbox start)."
+        }
+        return base
     }
 
     /// Foreground tint for the chip's icon + dot. Failure beats running so a
@@ -1938,6 +1959,16 @@ extension FloatingInputCard {
                     )
                     .lineLimit(1)
                     .opacity(isSandboxLoading ? sandboxPulseAmount : 1.0)
+
+                // Network-off badge: only meaningful once the sandbox is
+                // settled, so suppress it while loading or failed (those
+                // states own the leading indicator + accent color).
+                if isSandboxNetworkDisabled && !isSandboxLoading && !isSandboxFailed {
+                    Image(systemName: "wifi.slash")
+                        .font(.system(size: CGFloat(theme.captionSize) - 3, weight: .semibold))
+                        .foregroundColor(.orange)
+                        .accessibilityLabel(Text("Outbound network disabled", bundle: .module))
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -368,11 +368,18 @@ final class NativeMarkdownView: NSView {
         let textChanged = blocks != lastBlocks
         let widthChanged = abs(width - lastWidth) > 0.5
         let themeChanged = themeFingerprint != lastThemeFingerprint
+        // A demoted text segment (was the last/streaming segment, now followed
+        // by newer text after a code block) keeps the same blocks but flips to
+        // `isStreaming: false`. Without tracking this we'd early-return and skip
+        // the `exitStreamingMode()` below, leaving its cursor + idle timer alive
+        // — the "two blinking cursors at once" bug.
+        let streamingChanged = isStreaming != lastIsStreaming
 
-        guard textChanged || widthChanged || themeChanged else { return }
+        guard textChanged || widthChanged || themeChanged || streamingChanged else { return }
 
         lastWidth = width
         lastThemeFingerprint = themeFingerprint
+        lastIsStreaming = isStreaming
 
         removeSegmentViews()
         let tv = ensureTextView(width: width, theme: theme)
@@ -646,14 +653,15 @@ final class NativeMarkdownView: NSView {
         var prevAnchor: NSLayoutYAxisAnchor = topAnchor
         var prevOffset: CGFloat = 4
 
-        // The streaming cursor lives on exactly one nested text segment —
-        // the last one in document order. Other text segments configure
-        // with `isStreaming: false` so they don't blink alongside it.
+        // The streaming cursor is a text-view overlay, so it can only live on a
+        // `.textGroup` segment — and only on the *trailing* one. If the document
+        // currently ends in a non-text segment (a code block / table / image /
+        // math that is still streaming), the preceding text is already settled;
+        // parking the cursor there would put it ahead of the segment that's
+        // actually growing. In that case no text segment blinks.
         let lastTextSegmentId: String? = {
-            for seg in segments.reversed() {
-                if case .textGroup = seg.kind { return seg.id }
-            }
-            return nil
+            guard case .textGroup = segments.last?.kind else { return nil }
+            return segments.last?.id
         }()
 
         for seg in segments {


### PR DESCRIPTION
## Summary

  - fixed a second blinking cursor lingering on earlier text while a later paragraph
  streams
  - fixed the cursor showing before a code block or table that's still streaming
  - sandbox now syncs its network setting from the active agent on every start so the toggle users control is authoritative. this also auto restores internet access for sandboxes that had silently lost it, with no manual fixes needed
  - added a chip indicator in the chat input when sandbox outbound network is off
  - added tests for the network reconcile behavior

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
