### PR TITLE
Fix Gemma4 chat image attachment routing

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
+        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
+        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24d5ac5251c24006cf209942441cf9ce9e25642e"
+        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -147,6 +147,8 @@ public enum ModelMediaCapabilities {
             "lfm2-vl", "lfm2_vl",
             "gemma-3", "gemma3",
             "gemma-4-it",  // VLM Gemma 4 (the dense LLM gemma-4 also exists)
+            "gemma-4-12b-it",
+            "gemma4-12b-it",
         ]
         if imageOnlyPatterns.contains(where: lower.contains) {
             return .imageOnly

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24d5ac5251c24006cf209942441cf9ce9e25642e"
+        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
+        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
+        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "95c9f9e1d12d900be9e10911939cb160994526aa"
+            revision: "454f16efe6b867bc33cb74d6d5cb554227949445"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
+            revision: "95c9f9e1d12d900be9e10911939cb160994526aa"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "24d5ac5251c24006cf209942441cf9ce9e25642e"
+            revision: "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -115,6 +115,23 @@ struct ChatAttachmentSecurityTests {
         #expect(forwarded.imageUrls[0].hasPrefix("data:image/png;base64,"))
     }
 
+    @Test func buildUserChatMessage_hydratesSpilledImagesWhenSupported() throws {
+        let imageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+        let hash = try AttachmentBlobStore.write(imageData)
+        let imageRef = Attachment(kind: .imageRef(hash: hash, byteCount: imageData.count))
+
+        let message = ChatSession.buildUserChatMessage(
+            content: "look",
+            attachments: [imageRef],
+            supportsImages: true,
+            supportsAudio: false,
+            supportsVideo: false
+        )
+
+        #expect(message.imageUrls.count == 1)
+        #expect(message.imageDataFromParts == [imageData])
+    }
+
     @Test func buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs() {
         let droppedAudio = Attachment.audio(Data([0x01]), format: "wav", filename: "dropped.wav")
         let liveAudio = Attachment.audio(Data([0x02, 0x03]), format: "wav", filename: "voice.wav")

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -191,6 +191,9 @@ struct ModelMediaCapabilitiesMCDCTests {
     func d6_gemmaVLM() {
         #expect(ModelMediaCapabilities.from(modelId: "google/gemma-3-27b-it") == .imageOnly)
         #expect(ModelMediaCapabilities.from(modelId: "OsaurusAI/Gemma-4-it-26B-A4B") == .imageOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-jang_4m") == .imageOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-mxfp4") == .imageOnly)
+        #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-mxfp8") == .imageOnly)
     }
 
     // MARK: - D7: Mistral 3 / 3.5 (image only via Pixtral wrap)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -859,7 +859,7 @@ final class ChatSession: ObservableObject {
         supportsVideo: Bool
     ) -> ChatMessage {
         let messageText = buildUserMessageText(content: content, attachments: attachments)
-        let imageData = supportsImages ? attachments.images : []
+        let imageData = supportsImages ? attachments.loadImages() : []
         let audioPayloads =
             supportsAudio
             ? attachments.compactMap(audioPayload)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
+        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "95c9f9e1d12d900be9e10911939cb160994526aa"
+        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8ed5eda8cd4efdfbeb03eb738e6ef81dbc0e1ad329863a55a2bbc04c3cf62d92",
+  "originHash" : "8cb2a13e15ef48f079ec7bf3a837a7c85954b9dc6de71ca659747a31405db7c5",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "24d5ac5251c24006cf209942441cf9ce9e25642e"
+        "revision" : "b7e30695efc5308c4cd04ba06dcb8fbe90145680"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Fix Gemma4 local chat image routing so `gemma-4-12b-it-*` IDs are treated as image-capable and spilled image attachments are hydrated before local inference.
- Pin Osaurus to vMLX main `95c9f9e1d12d900be9e10911939cb160994526aa`, which includes Gemma4 proportional RoPE plus harmony/empty-thought reasoning parser fixes.
- Add source coverage for Gemma4 local media capability detection and spilled-image chat attachment hydration.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ChatAttachmentSecurityTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ModelMediaCapabilitiesMCDCTests/d6_gemmaVLM --jobs 1 --no-parallel`
- Keychain-free Release build: `build/DerivedData-gemma4-vlm-dev-proof-nosign-95c9f9e/Build/Products/Release/osaurus.app`
- Verified built vMLX checkout: `95c9f9e1d12d900be9e10911939cb160994526aa`
- Live rebuilt-app rows for `gemma-4-12b-it-jang_4m`, `gemma-4-12b-it-mxfp4`, `gemma-4-12b-it-mxfp8`: exact text, blind no-image, forced tool call, image payload, and multi-turn follow-up. No `reasoning_content` or harmony/think marker leakage observed.

## Notes
- Visual payload routing is proven live. OCR/text-label precision remains approximate in the current Gemma4 rows, so this PR claims attachment routing/runtime parser correctness, not OCR-quality perfection.
- Merge is gated on the current GitHub `test-core` check for commit `851db4f3`.