### PR TITLE
[codex] Reject workbook targets in file_write

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1331,9 +1331,11 @@ struct FileReadTool: OsaurusTool {
 struct FileWriteTool: OsaurusTool, PermissionedTool {
     let name = "file_write"
     let description =
-        "Create a new file or overwrite an existing file with the provided content. **Use this "
-        + "instead of `echo` / `cat` heredoc in `shell_run`.** Parent directories will be created "
-        + "if they don't exist. You MUST provide the file contents in the `content` parameter."
+        "Create a new UTF-8 text file or overwrite an existing text file with the provided content. "
+        + "**Use this instead of `echo` / `cat` heredoc in `shell_run`.** Parent directories will "
+        + "be created if they don't exist. You MUST provide the file contents in the `content` "
+        + "parameter. Do not use this for `.xlsx` workbooks; use a spreadsheet/XLSX tool or write "
+        + "CSV text instead."
     let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -1356,6 +1358,9 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
     var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
 
     private let rootPath: URL
+    private static let structuredWorkbookExtensions: Set<String> = [
+        "xlsx", "xlsm", "xltx", "xltm", "xlsb", "xls",
+    ]
 
     init(rootPath: URL) {
         self.rootPath = rootPath
@@ -1388,6 +1393,13 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
         }
 
         let fileURL = try FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        if let rejected = Self.structuredWorkbookWriteRejection(
+            path: relativePath,
+            fileExtension: fileURL.pathExtension.lowercased(),
+            toolName: name
+        ) {
+            return rejected
+        }
 
         // Capture previous state for undo
         let existed = FileManager.default.fileExists(atPath: fileURL.path)
@@ -1422,6 +1434,26 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
         return ToolEnvelope.success(
             tool: name,
             text: "\(action) \(relativePath) (\(lineCount) lines, \(content.count) characters)"
+        )
+    }
+
+    private static func structuredWorkbookWriteRejection(
+        path: String,
+        fileExtension ext: String,
+        toolName: String
+    ) -> String? {
+        guard structuredWorkbookExtensions.contains(ext) else { return nil }
+        return ToolEnvelope.failure(
+            kind: .rejected,
+            message:
+                "Refused to write '\(path)' with file_write: .\(ext) is a structured workbook "
+                + "package, but file_write only writes UTF-8 text. Use a spreadsheet/XLSX "
+                + "tool for workbook output, or write CSV/TSV text instead.",
+            field: "path",
+            expected: "path for a UTF-8 text file; for .\(ext), use a workbook writer or CSV/TSV",
+            tool: toolName,
+            retryable: false,
+            metadata: ["extension": ext]
         )
     }
 }

--- a/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
@@ -250,6 +250,41 @@ struct FolderToolsResilienceTests {
         #expect(FileManager.default.fileExists(atPath: path))
     }
 
+    @Test func fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile() async throws {
+        let root = tmpRoot()
+        let existing = root.appendingPathComponent("report.xlsx")
+        let original = Data([0x50, 0x4B, 0x03, 0x04, 0x00])
+        try original.write(to: existing)
+
+        let tool = FileWriteTool(rootPath: root)
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path": "report.xlsx", "content": "not a workbook"}"#
+        )
+
+        #expect(ToolEnvelope.isError(result))
+        #expect(failureKind(result) == "rejected")
+        #expect(failureField(result) == "path")
+        #expect(result.contains("structured workbook"))
+        let after = try Data(contentsOf: existing)
+        #expect(after == original)
+    }
+
+    @Test func fileWrite_allowsCSVTextOutput() async throws {
+        let root = tmpRoot()
+        let tool = FileWriteTool(rootPath: root)
+
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path": "report.csv", "content": "month,total\nJan,1200\n"}"#
+        )
+
+        #expect(ToolEnvelope.isSuccess(result))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("report.csv"),
+            encoding: .utf8
+        )
+        #expect(written == "month,total\nJan,1200\n")
+    }
+
     @Test @MainActor func fileWrite_unknownKeyIsRejected() {
         // `additionalProperties: false` kicks in during preflight
         // validation; the model gets a structured envelope pointing at

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -107,7 +107,7 @@ Built by [`FolderToolFactory`](../Packages/OsaurusCore/Folder/FolderTools.swift)
 | Tool            | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
 | `file_read`     | Read a file (line ranges, `tail_lines`/`max_chars`, bounded XLSX sheet previews) **or** list a directory (with `max_depth`, project-aware ignore patterns) — the path decides. Use this instead of `cat`/`head`/`tail`/`ls`/`tree`. |
-| `file_write`    | Create or overwrite files. Use this instead of `echo`/`cat` heredoc. |
+| `file_write`    | Create or overwrite UTF-8 text files. Use this instead of `echo`/`cat` heredoc. Refuses `.xlsx`-family workbook targets; write CSV/TSV text or use a spreadsheet/XLSX tool for workbook output. |
 | `file_edit`     | Surgical exact-string replacement. Use this instead of `sed`/`awk`. |
 | `file_search`   | ripgrep-style content search, or `target="files"` filename-glob find. Use this instead of `grep`/`rg`/`find`. |
 | `shell_run`     | Execute a shell command (requires approval). Reserve for `mv`/`cp`/`rm`/`mkdir`, builds, tests, git, installs, and any work that can't be expressed via the dedicated `file_*` tools. |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -647,7 +647,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 | Tool              | Category | Description                                                       |
 | ----------------- | -------- | ----------------------------------------------------------------- |
 | `file_read`       | Core     | Read a file (text ranges, `tail_lines`/`max_chars`, bounded XLSX sheet previews) **or** list a directory (with `max_depth`, project-aware ignore patterns) — the path decides. A directory returns a structured `kind: "listing"` with `entries[]` (each a ready-to-use `path`), not an ASCII tree |
-| `file_write`      | Core     | Create or overwrite                                               |
+| `file_write`      | Core     | Create or overwrite UTF-8 text files; refuses `.xlsx`-family workbook targets so structured workbook output goes through the XLSX/spreadsheet path |
 | `file_edit`       | Core     | Surgical exact-string replacement                                 |
 | `file_search`     | Core     | ripgrep-style content search, or `target="files"` filename-glob find |
 | `shell_run`       | Core     | Run a shell command (requires approval). Reserve for `mv`/`cp`/`rm`/`mkdir`, builds, tests, git, installs. |

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -1,0 +1,43 @@
+# High-Fidelity Output Safety Audit
+
+This audit records the current write path for generated files after the input
+fidelity lanes moved workbook reading into core `file_read`.
+
+## Current Write Path
+
+`file_write` remains a UTF-8 text/code tool. It creates parent directories and
+writes atomically, but it now refuses `.xlsx`-family workbook targets so an
+agent cannot create an invalid OOXML package by writing plain text with a
+workbook extension. For tabular text output, agents should write CSV/TSV.
+
+Structured workbook output stays on the document-emitter/plugin path.
+`XLSXEmitter` assembles an OOXML ZIP package in memory, validates workbook
+bounds before writing, rejects formulas instead of flattening them, rejects
+workbooks with no renderable cells, rejects overlong cell text and invalid XML,
+and only then writes the package atomically.
+
+Tool exposure stays narrow. Folder plugin hints only bias installed spreadsheet
+plugins, preflight injection respects installed plugin ids and per-agent
+allowlists, and default-agent `capabilities_load` cannot load plugin tools.
+No workbook writer is added to the default schema.
+
+## Coverage Matrix
+
+| Surface | Safety contract | Proof |
+| --- | --- | --- |
+| `file_write` | Text-only writes; rejects `.xlsx`-family targets before logging or touching the existing file | `FolderToolsResilienceTests.fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile` |
+| CSV output | Text tabular output remains allowed through `file_write` | `FolderToolsResilienceTests.fileWrite_allowsCSVTextOutput` |
+| XLSX emitter | Valid scalar workbooks round-trip through the XLSX adapter | `XLSXEmitterTests.emit_roundTripsScalarWorkbookThroughXLSXAdapter` |
+| XLSX formula safety | Formula cells are rejected, while formula-looking strings stay inert shared strings | `XLSXEmitterTests.emit_rejectsFormulaCellsWithoutFlatteningThem`, `XLSXEmitterTests.emit_keepsFormulaLookingTextInert` |
+| XLSX bounds | Empty exports, whitespace-only exports, overlong cell text, invalid names/references, non-finite numbers, and ZIP32 overflows are rejected before package write | `XLSXEmitterTests`, `XLSXAdapterTests` |
+| Tool exposure | XLSX plugin injection is bias-only, installed-plugin gated, and allowlist-respecting | `PreflightCapabilitySearchTests.folderInjection_*`, `FolderPluginHintsTests` |
+
+## Follow-Up Lanes
+
+1. Add first-party workbook write UI/tooling only when it can call the
+   structured emitter directly and surface save/share state as an artifact.
+2. Extend the same text-only `file_write` refusal pattern to other structured
+   binary families if their output emitters become production-ready.
+3. Keep sandbox write parity separate: `sandbox_write_file` has a different
+   filesystem boundary and should be audited in its own lane before changing
+   behavior.


### PR DESCRIPTION
## Business rationale

`file_write` is the folder-context text/code writer, but before this change an agent could point it at `report.xlsx` and produce a plain UTF-8 text file with a workbook extension. That creates a misleading artifact and works against the current high-fidelity document direction: workbook output should be produced by the structured XLSX emitter or spreadsheet/plugin path, not by a text write masquerading as OOXML. This PR closes that safety gap without adding a new default tool.

## Coding rationale

The change keeps the default tool surface narrow. Instead of adding `write_workbook` or a new first-turn XLSX writer, `FileWriteTool` now resolves the requested path under the existing folder root, then rejects `.xlsx`-family workbook extensions before operation logging, parent-directory creation, or any filesystem mutation. CSV/TSV remains the text fallback for tabular output. The audit doc records the current emitter guarantees and the plugin/tool exposure guardrails so future output lanes can reuse the same pattern.

## Acceptance criteria

- [x] `file_write` rejects `.xlsx`-family workbook targets with a structured non-retryable failure.
- [x] Rejected workbook writes do not touch an existing file.
- [x] CSV text output through `file_write` remains allowed.
- [x] XLSX output/tool-surface safety is documented without adding a default workbook writer.

## Quality gate

- [x] `xcrun swift-format lint --recursive Packages/OsaurusCore/Folder/FolderTools.swift Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift`
- [x] `git diff --check`
- [x] `swift test --package-path Packages/OsaurusCore --filter FolderToolsResilienceTests`
- [x] `swift test --package-path Packages/OsaurusCore --filter XLSXEmitterTests`
- [x] `swift test --package-path Packages/OsaurusCore --filter PreflightCapabilitySearchTests`
- [x] `swift test --package-path Packages/OsaurusCore --filter FolderPluginHintsTests`
- [x] `swift test --package-path Packages/OsaurusCore --filter AgentManagerLifecycleNotificationTests/deleteSweepsPerAgentKeychainSecrets`
- [x] GitHub CI on head `e8cce276`: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and release drafter are green.
- [ ] Full local `make test`: attempted. `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1` fails the real-Keychain lifecycle test by design; no-disabled `make test` was interrupted after unrelated Keychain-backed tests blocked inside macOS `SecItemCopyMatching` / `SecItemUpdate`.
- [ ] Local release build: not run.
- [x] Archive freshness: branch based on `origin/main` `e6bbcc345a6dd1a0f39e0606ba674e155f4c67f7`.
- [x] Gate head SHA: `e8cce276`

## Debug evidence

Focused proof from `FolderToolsResilienceTests`:

- `fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile` passed and asserts the existing `report.xlsx` bytes are unchanged after rejection.
- `fileWrite_allowsCSVTextOutput` passed and asserts CSV text is written normally.

`XLSXEmitterTests`, `PreflightCapabilitySearchTests`, and `FolderPluginHintsTests` also passed, covering structured emitter behavior and the installed-plugin/allowlist-gated XLSX tool surface.

## Self-review

### Regression review

Changed call site: `FileWriteTool.execute` in `Packages/OsaurusCore/Folder/FolderTools.swift`. Existing path containment still runs before the new extension refusal, so outside-root behavior is unchanged. The new branch returns a standard `ToolEnvelope.failure(kind: .rejected, field: "path")` for workbook-package extensions before logging or mutation. Covered by new `FolderToolsResilienceTests.fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile`.

Adjacent behavior: ordinary text writes still create parent directories and write atomically; covered by existing `fileWrite_emptyContentIsAllowed` and new CSV text proof. XLSX structured output remains in `XLSXEmitter`; covered by existing `XLSXEmitterTests`. Plugin/tool exposure remains bias-only and allowlist-respecting; covered by `PreflightCapabilitySearchTests` and `FolderPluginHintsTests`.

### Performance review

The hot path adds one lowercased path-extension lookup plus a constant-size set membership check after path resolution and before any filesystem mutation. Complexity remains O(1) relative to content size and avoids unnecessary operation logging/directory creation for rejected workbook targets. No new unbounded I/O, parsing, allocations, or default tool-schema expansion.

## Rebase notes

None.

## Rollback

`git revert e8cce276`
