### PR TITLE
added guards to prevent sentry from flagging false hangings

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "sentry": {
+      "enabled": true
+    }
+  }
+}

--- a/Packages/OsaurusCore/Folder/FolderContextService.swift
+++ b/Packages/OsaurusCore/Folder/FolderContextService.swift
@@ -56,7 +56,7 @@ public final class FolderContextService: ObservableObject {
         panel.message = L("Choose a folder for the AI to work with")
         panel.prompt = L("Select")
 
-        guard panel.runModal() == .OK, let url = panel.url else {
+        guard await panel.beginModal() == .OK, let url = panel.url else {
             return nil
         }
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExportCoordinator.swift
@@ -36,37 +36,36 @@ enum ChatSessionExportCoordinator {
         panel.allowedContentTypes = [contentType(for: format)]
         panel.title = panelTitle(format)
 
-        let response = panel.runModal()
-        guard response == .OK, let url = panel.url else { return }
-
-        let progressId = UUID()
-
-        // Only surface the progress alert if the export hasn't finished
-        // within the threshold, so quick markdown writes don't flash a
-        // dialog the user can't read.
-        let progressThreshold: Duration = .seconds(2.5)
-        let displayTask = Task { @MainActor in
-            do {
-                try await Task.sleep(for: progressThreshold)
-            } catch {
-                return  // cancelled before the threshold elapsed
-            }
-            ThemedAlertCenter.shared.present(
-                ThemedAlertRequest(
-                    id: progressId,
-                    title: progressTitle(format),
-                    message: "Working on \"\(full.title)\". This may take a moment for larger chats.",
-                    accessory: AnyView(ExportProgressIndicator()),
-                    buttons: [.cancel("Hide")],
-                    onDismiss: {
-                        ThemedAlertCenter.shared.dismiss(scope: scope, id: progressId)
-                    }
-                ),
-                scope: scope
-            )
-        }
-
         Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+
+            let progressId = UUID()
+
+            // Only surface the progress alert if the export hasn't finished
+            // within the threshold, so quick markdown writes don't flash a
+            // dialog the user can't read.
+            let progressThreshold: Duration = .seconds(2.5)
+            let displayTask = Task { @MainActor in
+                do {
+                    try await Task.sleep(for: progressThreshold)
+                } catch {
+                    return  // cancelled before the threshold elapsed
+                }
+                ThemedAlertCenter.shared.present(
+                    ThemedAlertRequest(
+                        id: progressId,
+                        title: progressTitle(format),
+                        message: "Working on \"\(full.title)\". This may take a moment for larger chats.",
+                        accessory: AnyView(ExportProgressIndicator()),
+                        buttons: [.cancel("Hide")],
+                        onDismiss: {
+                            ThemedAlertCenter.shared.dismiss(scope: scope, id: progressId)
+                        }
+                    ),
+                    scope: scope
+                )
+            }
+
             let result: Result<Void, Error>
             do {
                 switch format {

--- a/Packages/OsaurusCore/Services/DirectoryPickerService.swift
+++ b/Packages/OsaurusCore/Services/DirectoryPickerService.swift
@@ -168,11 +168,13 @@ final class DirectoryPickerService: ObservableObject {
         panel.title = L("Choose Models Directory")
         panel.message = L("Select a directory where MLX models will be stored")
 
-        guard panel.runModal() == .OK, let url = panel.url else {
-            return
-        }
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else {
+                return
+            }
 
-        saveDirectory(url)
+            saveDirectory(url)
+        }
     }
 
     /// Save directory selection from SwiftUI file picker

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -476,7 +476,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "24d5ac5251c24006cf209942441cf9ce9e25642e"
+        let expectedRuntimeHardenedRevision = "454f16efe6b867bc33cb74d6d5cb554227949445"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Utils/UIWorkarounds.swift
+++ b/Packages/OsaurusCore/Utils/UIWorkarounds.swift
@@ -5,6 +5,7 @@
 //  Centralized workarounds for SwiftUI bugs and platform-specific UI quirks.
 //
 
+import AppKit
 import Foundation
 
 extension Task where Success == Never, Failure == Never {
@@ -16,5 +17,21 @@ extension Task where Success == Never, Failure == Never {
     @MainActor
     static func sleepForPopoverDismiss() async throws {
         try await Task.sleep(nanoseconds: 300_000_000)
+    }
+}
+
+extension NSSavePanel {
+    /// Presents the panel without spinning a nested modal run loop on the
+    /// main thread. `runModal()` blocks the run loop for as long as the user
+    /// browses, which Sentry's app-hang watchdog reports as a false 2000ms+
+    /// "App Hang". `begin` is non-blocking and resumes on the main thread once
+    /// the user dismisses the panel.
+    ///
+    /// Covers `NSOpenPanel` too, since it subclasses `NSSavePanel`.
+    @MainActor
+    func beginModal() async -> NSApplication.ModalResponse {
+        await withCheckedContinuation { continuation in
+            begin { continuation.resume(returning: $0) }
+        }
     }
 }

--- a/Packages/OsaurusCore/Views/Agent/AgentDBTabViews.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentDBTabViews.swift
@@ -949,12 +949,14 @@ public struct DataTabView: View {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.commaSeparatedText]
         panel.nameFieldStringValue = "\(selectedTable ?? "rows").csv"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        let csv = renderCSV(columns: columns.map(\.name), rows: rows)
-        do {
-            try csv.write(to: url, atomically: true, encoding: .utf8)
-        } catch {
-            loadError = "CSV write failed: \(error.localizedDescription)"
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            let csv = renderCSV(columns: columns.map(\.name), rows: rows)
+            do {
+                try csv.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                loadError = "CSV write failed: \(error.localizedDescription)"
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -2362,16 +2362,18 @@ struct AgentDetailView: View {
         panel.canChooseFiles = true
         panel.allowedContentTypes = [.png, .jpeg, .heic, .tiff, .gif, .image]
         panel.prompt = L("Choose")
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
 
-        guard let original = NSImage(contentsOf: url) else { return }
-        let downscaled = downscaleAvatar(original, maxDimension: 256)
-        guard let pngData = pngData(from: downscaled) else { return }
-        agentManager.setCustomAvatar(pngData, ext: "png", for: agent.id)
-        // Bust the cache for this agent's avatar URL so the new bytes show
-        // up immediately in inline chat + sidebar without an mtime race.
-        if let updated = agentManager.agent(for: agent.id), let newURL = updated.customAvatarURL {
-            AvatarImageCache.shared.invalidate(url: newURL)
+            guard let original = NSImage(contentsOf: url) else { return }
+            let downscaled = downscaleAvatar(original, maxDimension: 256)
+            guard let pngData = pngData(from: downscaled) else { return }
+            agentManager.setCustomAvatar(pngData, ext: "png", for: agent.id)
+            // Bust the cache for this agent's avatar URL so the new bytes show
+            // up immediately in inline chat + sidebar without an mtime race.
+            if let updated = agentManager.agent(for: agent.id), let newURL = updated.customAvatarURL {
+                AvatarImageCache.shared.invalidate(url: newURL)
+            }
         }
     }
 
@@ -3120,10 +3122,12 @@ struct AgentDetailView: View {
             localized: "Pick a folder for the .osaurus-agent bundle.",
             bundle: .module
         )
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        bundleExportDestination = url.deletingLastPathComponent()
-        bundlePassphraseInput = ""
-        bundleConfirmPassphraseInput = ""
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            bundleExportDestination = url.deletingLastPathComponent()
+            bundlePassphraseInput = ""
+            bundleConfirmPassphraseInput = ""
+        }
     }
 
     private func beginBundleImport() {
@@ -3133,9 +3137,11 @@ struct AgentDetailView: View {
         panel.canChooseFiles = true
         panel.allowedContentTypes = []
         panel.title = L("Import Bundle")
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        bundleImportSource = url
-        bundlePassphraseInput = ""
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            bundleImportSource = url
+            bundlePassphraseInput = ""
+        }
     }
 
     private func performBundleExport() {

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2680,7 +2680,8 @@ extension FloatingInputCard {
             ? "Select files to attach (\(mediaCapabilities.summary) supported)"
             : "Select files to attach"
 
-        if panel.runModal() == .OK {
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK else { return }
             for url in panel.urls {
                 attachIfAllowed(url: url)
             }

--- a/Packages/OsaurusCore/Views/Identity/MasterMnemonicCard.swift
+++ b/Packages/OsaurusCore/Views/Identity/MasterMnemonicCard.swift
@@ -157,9 +157,11 @@ struct MasterMnemonicCard: View {
         panel.allowedContentTypes = [.plainText]
         panel.canCreateDirectories = true
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        let content = renderPlainText()
-        try? content.data(using: .utf8)?.write(to: url, options: .atomic)
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            let content = renderPlainText()
+            try? content.data(using: .utf8)?.write(to: url, options: .atomic)
+        }
     }
 
     private func printPhrase() {

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -585,7 +585,8 @@ private struct SandboxPluginsTabContent: View {
         panel.allowedContentTypes = [.json]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        if panel.runModal() == .OK, let url = panel.url {
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
             do {
                 let plugin = try pluginLibrary.importFromFile(url)
                 ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
@@ -608,7 +609,8 @@ private struct SandboxPluginsTabContent: View {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.json]
         panel.nameFieldStringValue = "\(plugin.id).json"
-        if panel.runModal() == .OK, let url = panel.url {
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
             try? data.write(to: url, options: .atomic)
         }
     }

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -1903,20 +1903,22 @@ struct ScheduleEditorSheet: View {
         panel.title = L("Select Working Directory")
         panel.prompt = L("Select")
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
 
-        do {
-            let bookmark = try url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            withAnimation(.easeOut(duration: 0.2)) {
-                selectedFolderPath = url.path
-                selectedFolderBookmark = bookmark
+            do {
+                let bookmark = try url.bookmarkData(
+                    options: .withSecurityScope,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                withAnimation(.easeOut(duration: 0.2)) {
+                    selectedFolderPath = url.path
+                    selectedFolderBookmark = bookmark
+                }
+            } catch {
+                print("[ScheduleEditor] Failed to create bookmark: \(error)")
             }
-        } catch {
-            print("[ScheduleEditor] Failed to create bookmark: \(error)")
         }
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -2148,7 +2148,8 @@ private struct TranscriptionTestRow: View {
         panel.message = L("Select an audio file to transcribe")
         panel.prompt = L("Select")
 
-        if panel.runModal() == .OK, let url = panel.url {
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
             loadFile(from: url)
         }
     }

--- a/Packages/OsaurusCore/Views/Settings/StorageSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/StorageSettingsView.swift
@@ -401,33 +401,29 @@ public struct StorageSettingsView: View {
                     "Pick a folder to write the plaintext backup to. We'll re-prompt for rotation after the backup completes."
                 )
         }
-        guard panel.runModal() == .OK, let dest = panel.url else { return }
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let dest = panel.url else { return }
 
-        let backupDir = dest.appendingPathComponent("osaurus-plaintext-backup", isDirectory: true)
-        isWorking = true
-        errorMessage = nil
-        Task {
+            let backupDir = dest.appendingPathComponent("osaurus-plaintext-backup", isDirectory: true)
+            isWorking = true
+            errorMessage = nil
             do {
                 let summary = try await StorageExportService.shared.exportPlaintextBackup(to: backupDir)
-                await MainActor.run {
-                    self.isWorking = false
-                    self.hasExportedBackupThisSession = true
-                    switch reason {
-                    case .userInitiated:
-                        self.lastSummary =
-                            "Wrote \(summary.databasesExported) databases, \(summary.jsonFilesDecrypted) config files, and \(summary.blobsDecrypted) attachments to \(summary.destination.lastPathComponent)."
-                        NSWorkspace.shared.activateFileViewerSelecting([backupDir])
-                    case .beforeRotate:
-                        self.lastSummary =
-                            "Backup written to \(summary.destination.lastPathComponent). You can now rotate the key safely."
-                        self.showRotateConfirm = true
-                    }
+                self.isWorking = false
+                self.hasExportedBackupThisSession = true
+                switch reason {
+                case .userInitiated:
+                    self.lastSummary =
+                        "Wrote \(summary.databasesExported) databases, \(summary.jsonFilesDecrypted) config files, and \(summary.blobsDecrypted) attachments to \(summary.destination.lastPathComponent)."
+                    NSWorkspace.shared.activateFileViewerSelecting([backupDir])
+                case .beforeRotate:
+                    self.lastSummary =
+                        "Backup written to \(summary.destination.lastPathComponent). You can now rotate the key safely."
+                    self.showRotateConfirm = true
                 }
             } catch {
-                await MainActor.run {
-                    self.isWorking = false
-                    self.errorMessage = error.localizedDescription
-                }
+                self.isWorking = false
+                self.errorMessage = error.localizedDescription
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
+++ b/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
@@ -750,20 +750,22 @@ struct WatcherEditorSheet: View {
         panel.title = L("Select Folder to Watch")
         panel.prompt = L("Select")
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
 
-        do {
-            let bookmark = try url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            withAnimation(.easeOut(duration: 0.2)) {
-                selectedWatchPath = url.path
-                selectedWatchBookmark = bookmark
+            do {
+                let bookmark = try url.bookmarkData(
+                    options: .withSecurityScope,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                withAnimation(.easeOut(duration: 0.2)) {
+                    selectedWatchPath = url.path
+                    selectedWatchBookmark = bookmark
+                }
+            } catch {
+                print("[WatcherEditor] Failed to create watch bookmark: \(error)")
             }
-        } catch {
-            print("[WatcherEditor] Failed to create watch bookmark: \(error)")
         }
     }
 


### PR DESCRIPTION
## Summary

Root cause addressed: Blocking NSOpenPanel/NSSavePanel.runModal() calls spun a nested modal run loop on the main thread, starving Sentry's app-hang watchdog and producing false 2000ms+ hang reports while users browsed file dialogs.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
