### PR TITLE
Pin Gemma4 tool parser vMLX runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
+        "revision" : "44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
+        "revision" : "44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "454f16efe6b867bc33cb74d6d5cb554227949445"
+            revision: "44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -476,7 +476,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "454f16efe6b867bc33cb74d6d5cb554227949445"
+        let expectedRuntimeHardenedRevision = "44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -484,7 +484,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix and Gemma4 proportional RoPE live rows; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, and Gemma4 quoted tool-key parser coverage; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "454f16efe6b867bc33cb74d6d5cb554227949445"
+        "revision" : "44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed"
       }
     },
     {


### PR DESCRIPTION
## Summary
- pin Osaurus to `osaurus-ai/vmlx-swift` main commit `44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed`
- keep Package.swift, OsaurusCore Package.resolved, workspace Package.resolved, and app project Package.resolved synchronized
- update the runtime source guard expectation to include the Gemma4 quoted tool-key parser coverage

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`

## Upstream vMLX
- osaurus-ai/vmlx-swift#11 merged as `44e99eb51babd7a47e4d9a5f20b92bedd2d7d0ed`
- vMLX local validation passed for `MLXLMCommonToolParserFocusedTests.Gemma4ToolCallParserFocusedTests`
