### PR TITLE
Fix Gemma4 reasoning, VL recognition, and tool schema rendering

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1067,45 +1067,108 @@ extension JSONValue {
     /// Convert JSON Schema into the shape expected by local chat templates.
     ///
     /// Some local templates, notably Gemma-4's native tool template, treat
-    /// `type` as a scalar and run string filters over it. OpenAI/MCP schemas
-    /// commonly spell nullable fields as `type: ["string", "null"]`. That is
-    /// valid JSON Schema, but it is not renderable by those templates. The
-    /// transformation below is the lossless OpenAPI spelling of the same
-    /// schema: `type: "string", nullable: true`.
+    /// schema `type` fields as scalars and run string filters over them.
+    /// OpenAI/MCP schemas commonly spell nullable fields as
+    /// `type: ["string", "null"]`. That is valid JSON Schema, but it is not
+    /// renderable by those templates. The transformation below rewrites only
+    /// schema-position dictionaries into template-renderable shapes while
+    /// preserving property maps whose keys may legitimately include "type".
     var chatTemplateSchemaValue: JSONValue {
+        normalizedChatTemplateSchemaValue(inSchemaPosition: true)
+    }
+
+    private func normalizedChatTemplateSchemaValue(inSchemaPosition: Bool) -> JSONValue {
         switch self {
         case .object(let obj):
-            var normalized = obj.mapValues { $0.chatTemplateSchemaValue }
-            Self.normalizeNullableTypeUnion(&normalized)
+            var normalized: [String: JSONValue] = [:]
+            for (key, value) in obj {
+                switch key {
+                case "properties":
+                    if case .object(let properties) = value {
+                        normalized[key] = .object(
+                            properties.mapValues {
+                                $0.normalizedChatTemplateSchemaValue(inSchemaPosition: true)
+                            }
+                        )
+                    } else {
+                        normalized[key] = value.normalizedChatTemplateSchemaValue(
+                            inSchemaPosition: false
+                        )
+                    }
+                case "items", "additionalProperties", "response":
+                    normalized[key] = value.normalizedChatTemplateSchemaValue(
+                        inSchemaPosition: true
+                    )
+                case "oneOf", "anyOf", "allOf":
+                    if case .array(let branches) = value {
+                        normalized[key] = .array(
+                            branches.map {
+                                $0.normalizedChatTemplateSchemaValue(inSchemaPosition: true)
+                            }
+                        )
+                    } else {
+                        normalized[key] = value.normalizedChatTemplateSchemaValue(
+                            inSchemaPosition: false
+                        )
+                    }
+                default:
+                    normalized[key] = value.normalizedChatTemplateSchemaValue(
+                        inSchemaPosition: false
+                    )
+                }
+            }
+            if inSchemaPosition {
+                Self.normalizeTemplateRenderableSchemaType(&normalized)
+            }
             return .object(normalized)
         case .array(let arr):
-            return .array(arr.map { $0.chatTemplateSchemaValue })
+            return .array(
+                arr.map { $0.normalizedChatTemplateSchemaValue(inSchemaPosition: inSchemaPosition) }
+            )
         case .null, .bool, .number, .string:
             return self
         }
     }
 
-    private static func normalizeNullableTypeUnion(_ object: inout [String: JSONValue]) {
-        guard case .array(let entries) = object["type"] else { return }
+    private static func normalizeTemplateRenderableSchemaType(_ object: inout [String: JSONValue]) {
+        switch object["type"] {
+        case .some(.string):
+            return
+        case .some(.array(let entries)):
+            normalizeTypeUnion(entries, in: &object)
+        case .some(.null), .some(.bool), .some(.number), .some(.object):
+            object["type"] = inferredFallbackType(for: object)
+        case nil:
+            object["type"] = inferredFallbackType(for: object)
+        }
+    }
 
+    private static func normalizeTypeUnion(_ entries: [JSONValue], in object: inout [String: JSONValue]) {
+        var typeNames: [String] = []
         var hasNull = false
-        var scalar: String?
+
         for entry in entries {
-            guard case .string(let typeName) = entry else { return }
+            guard case .string(let typeName) = entry else {
+                object["type"] = inferredFallbackType(for: object)
+                return
+            }
             if typeName == "null" {
                 hasNull = true
-            } else if scalar == nil {
-                scalar = typeName
-            } else {
-                return
+            } else if !typeNames.contains(typeName) {
+                typeNames.append(typeName)
             }
         }
 
-        guard let scalar else { return }
-        object["type"] = .string(scalar)
+        object["type"] = .string(typeNames.first ?? "string")
         if hasNull {
             object["nullable"] = .bool(true)
         }
+    }
+
+    private static func inferredFallbackType(for object: [String: JSONValue]) -> JSONValue {
+        if object["properties"] != nil { return .string("object") }
+        if object["items"] != nil { return .string("array") }
+        return .string("string")
     }
 
     /// Convert JSONValue to Sendable-compatible value for Jinja chat templates.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -148,7 +148,15 @@ public enum ModelMediaCapabilities {
             "gemma-3", "gemma3",
             "gemma-4-it",  // VLM Gemma 4 (the dense LLM gemma-4 also exists)
             "gemma-4-12b-it",
+            "gemma-4-26b-it",
+            "gemma-4-26b-a4b-it",
+            "gemma-4-31b-it",
+            "gemma-4-31b-a4b-it",
             "gemma4-12b-it",
+            "gemma4-26b-it",
+            "gemma4-26b-a4b-it",
+            "gemma4-31b-it",
+            "gemma4-31b-a4b-it",
         ]
         if imageOnlyPatterns.contains(where: lower.contains) {
             return .imageOnly

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -431,11 +431,10 @@ struct ZayaThinkingProfile: ModelProfile {
 
 // MARK: - Gemma 4 Runtime Profile
 
-/// Gemma-4 chat templates expose an `enable_thinking` kwarg, but current
-/// Gemma-4 12B live rows show explicit thinking is not production-clean enough
-/// for the chat input Thinking chip. Keep a family profile so Gemma-4 does not
-/// fall through to `AutoThinkingProfile`, while leaving explicit API
-/// `enable_thinking` requests to the lower runtime path.
+/// Gemma-4 chat templates expose an `enable_thinking` kwarg and pipe-wrapped
+/// `<|think|>` markers. Expose the same chat-input Thinking chip as other
+/// local reasoning models, but do not synthesize a hidden request default:
+/// omitted options still let the model bundle/runtime decide.
 struct Gemma4RuntimeProfile: ModelProfile {
     static let displayName = "Gemma 4"
 
@@ -444,9 +443,20 @@ struct Gemma4RuntimeProfile: ModelProfile {
         return lower.contains("gemma-4") || lower.contains("gemma4")
     }
 
-    static let options: [ModelOptionDefinition] = []
+    static let options: [ModelOptionDefinition] = [
+        ModelOptionDefinition(
+            id: "disableThinking",
+            label: "Disable Thinking",
+            icon: "brain.head.profile",
+            kind: .toggle(default: true)
+        )
+    ]
 
-    static let defaults: [String: ModelOptionValue] = [:]
+    static let defaults: [String: ModelOptionValue] = [
+        "disableThinking": .bool(true)
+    ]
+
+    static let thinkingOption: (id: String, inverted: Bool)? = ("disableThinking", true)
 }
 
 // MARK: - Auto Thinking Profile (chat-template driven)

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -91,8 +91,8 @@ struct ModelProfileRegistryTests {
         #expect(profile?.thinkingOption == nil)
     }
 
-    @Test("Gemma 4 does not expose chat Thinking toggle until explicit thinking is production-clean")
-    func gemma4_noChatThinkingToggle() {
+    @Test("Gemma 4 exposes chat Thinking toggle without synthesizing hidden defaults")
+    func gemma4_exposesChatThinkingToggle() {
         for id in [
             "gemma-4-26b-a4b-it-jang_4m-crack",
             "dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK",
@@ -100,12 +100,28 @@ struct ModelProfileRegistryTests {
             "gemma-4-12b-it-jang_4m",
             "gemma-4-12b-it-mxfp4",
             "gemma-4-12b-it-mxfp8",
+            "dealign.ai/Gemma-4-12B-it-MXFP8-CRACK",
         ] {
             let profile = ModelProfileRegistry.profile(for: id)
             #expect(profile?.displayName == Gemma4RuntimeProfile.displayName)
-            #expect(profile?.thinkingOption == nil)
+            #expect(profile?.thinkingOption?.id == "disableThinking")
+            #expect(profile?.thinkingOption?.inverted == true)
             let normalized = ModelProfileRegistry.normalizedOptions(for: id, persisted: nil)
             #expect(normalized["disableThinking"] == nil)
+
+            let explicitOff = ModelProfileRegistry.normalizedOptions(
+                for: id,
+                persisted: ["disableThinking": .bool(true)]
+            )
+            #expect(explicitOff["disableThinking"]?.boolValue == true)
+            #expect(ModelProfileRegistry.thinkingEnabled(for: id, values: explicitOff) == false)
+
+            let explicitOn = ModelProfileRegistry.normalizedOptions(
+                for: id,
+                persisted: ["disableThinking": .bool(false)]
+            )
+            #expect(explicitOn["disableThinking"]?.boolValue == false)
+            #expect(ModelProfileRegistry.thinkingEnabled(for: id, values: explicitOn) == true)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MultiTurnFamilyMatrixTests.swift
@@ -86,6 +86,12 @@ struct CapabilityFromModelIdTests {
         "LiquidAI/LFM2-VL-1.6B",
         "google/gemma-3-12b-it",
         "google/gemma-4-it-mxfp4",
+        "dealign.ai/Gemma-4-12B-it-MXFP4-CRACK",
+        "dealign.ai/Gemma-4-12B-it-MXFP8-CRACK",
+        "dealign.ai/Gemma-4-12B-it-JANG_4M-CRACK",
+        "dealign.ai/Gemma-4-26B-A4B-it-JANG_4M-CRACK",
+        "dealign.ai/Gemma-4-31B-A4B-it-MXFP4-CRACK",
+        "OsaurusAI/Gemma-4-31B-it-JANG_4M",
         "Zyphra/ZAYA1-VL-8B-MXFP4",
         "zaya1-vl-8b-mxfp4",  // flat-layout picker form
     ])

--- a/Packages/OsaurusCore/Tests/Tool/ToolSerializationStabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolSerializationStabilityTests.swift
@@ -80,4 +80,77 @@ struct ToolSerializationStabilityTests {
         #expect(mode["type"] as? String == "string")
         #expect((mode["enum"] as? [String]) == ["fast", "full"])
     }
+
+    @Test
+    func toTokenizerToolSpec_normalizesGemmaSensitiveTypeFieldsOnlyInSchemaPositions() throws {
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "schema_probe",
+                description: "Exercises Gemma4 template-sensitive schema shapes.",
+                parameters: .object([
+                    "type": .array([.string("object"), .string("null")]),
+                    "properties": .object([
+                        "query": .object([
+                            "type": .null,
+                            "description": .string("Malformed external schema still renders."),
+                        ]),
+                        "value": .object([
+                            "type": .array([.string("string"), .string("integer")])
+                        ]),
+                        "payload": .object([
+                            "properties": .object([
+                                "type": .object(["type": .string("string")])
+                            ])
+                        ]),
+                    ]),
+                ])
+            )
+        )
+
+        let spec = tool.toTokenizerToolSpec()
+        let fn = try #require(spec["function"] as? [String: any Sendable])
+        let parameters = try #require(fn["parameters"] as? [String: any Sendable])
+        let properties = try #require(parameters["properties"] as? [String: any Sendable])
+        let query = try #require(properties["query"] as? [String: any Sendable])
+        let value = try #require(properties["value"] as? [String: any Sendable])
+        let payload = try #require(properties["payload"] as? [String: any Sendable])
+        let payloadProperties = try #require(payload["properties"] as? [String: any Sendable])
+        let propertyNamedType = try #require(payloadProperties["type"] as? [String: any Sendable])
+
+        #expect(parameters["type"] as? String == "object")
+        #expect(parameters["nullable"] as? Bool == true)
+        #expect(query["type"] as? String == "string")
+        #expect(value["type"] as? String == "string")
+        #expect(payload["type"] as? String == "object")
+        #expect(propertyNamedType["type"] as? String == "string")
+        try Self.assertSchemaTypesAreTemplateRenderable(parameters)
+    }
+
+    private static func assertSchemaTypesAreTemplateRenderable(
+        _ schema: [String: any Sendable]
+    ) throws {
+        if let typeValue = schema["type"] {
+            #expect(typeValue is String, "schema type must be String, got \(type(of: typeValue))")
+        }
+
+        if let properties = schema["properties"] as? [String: any Sendable] {
+            for value in properties.values {
+                let child = try #require(value as? [String: any Sendable])
+                try assertSchemaTypesAreTemplateRenderable(child)
+            }
+        }
+
+        if let items = schema["items"] as? [String: any Sendable] {
+            try assertSchemaTypesAreTemplateRenderable(items)
+        }
+
+        for key in ["oneOf", "anyOf", "allOf"] {
+            guard let branches = schema[key] as? [Any] else { continue }
+            for branch in branches {
+                guard let child = branch as? [String: any Sendable] else { continue }
+                try assertSchemaTypesAreTemplateRenderable(child)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Summary
- Expose the Gemma 4 chat Thinking control through the existing disableThinking model option.
- Preserve the no-hidden-default contract: omitted persisted/API options still normalize to no modelOptions entry.
- Add explicit Gemma 4 CRACK 12B/26B/31B aliases to image-only media capability detection so image attachments are accepted and video/audio remain rejected.

Validation
- git diff --check
- Focused SwiftPM checks are running locally now; results will be posted when complete.