### PR TITLE
Pin Nemotron Ultra vMLX runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2144e1dc39bb33e9ed08ee21e66b0fafb314c3a"
+        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -96,6 +96,22 @@ enum ModelFamilyNames {
             ) != nil
     }
 
+    /// Nemotron bundles whose native template exposes an `enable_thinking`
+    /// switch. Keep this broader than Omni media support but narrower than all
+    /// historical Nemotron lineages.
+    static func isNemotronThinkingFamily(_ modelId: String) -> Bool {
+        let lower = modelId.lowercased()
+        return isNemotronOmniFamily(modelId)
+            || lower.range(
+                of: #"(^|/)nvidia[\-_]?nemotron[\-_]3[\-_]ultra($|[\-_/\.0-9])"#,
+                options: .regularExpression
+            ) != nil
+            || lower.range(
+                of: #"(^|/)nemotron[\-_]3[\-_]ultra($|[\-_/\.0-9])"#,
+                options: .regularExpression
+            ) != nil
+    }
+
     /// Match Zyphra ZAYA bundles (`model_type=zaya`). Matches the bare
     /// repo form (`Zaya1-…`, `Zaya2-…`, `Zaya-S-…`) and any
     /// `<owner>/Zaya…` path. The required digit-or-dash boundary after

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -252,7 +252,7 @@ struct QwenThinkingProfile: ModelProfile {
 
 // MARK: - Nemotron-3 Thinking Profile
 
-/// Nemotron-3-Nano-Omni Reasoning models — `model_type=nemotron_h` hybrid
+/// Nemotron-3 reasoning models — `model_type=nemotron_h` hybrid
 /// Mamba+Attn+MoE bundles whose chat template reads an `enable_thinking`
 /// kwarg. Osaurus exposes the toggle but does not synthesize a reasoning mode:
 /// absent values must let the model bundle/runtime decide.
@@ -264,7 +264,7 @@ struct NemotronThinkingProfile: ModelProfile {
 
     static func matches(modelId: String) -> Bool {
         let lower = modelId.lowercased()
-        return ModelFamilyNames.isNemotronOmniFamily(modelId) && !lower.contains("coder")
+        return ModelFamilyNames.isNemotronThinkingFamily(modelId) && !lower.contains("coder")
     }
 
     static let options: [ModelOptionDefinition] = [

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2144e1dc39bb33e9ed08ee21e66b0fafb314c3a"
+        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f2144e1dc39bb33e9ed08ee21e66b0fafb314c3a"
+            revision: "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -761,7 +761,7 @@ struct MLXBatchAdapter {
             }
             return context
         }
-        if ModelFamilyNames.isNemotronOmniFamily(modelName) {
+        if ModelFamilyNames.isNemotronThinkingFamily(modelName) {
             if directRailReasoningEffort {
                 context["enable_thinking"] = false
                 return context

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -139,6 +139,9 @@ struct ModelProfileRegistryTests {
             "dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK",
             "nemotron-omni-nano-jangtq-crack",
             "nemotron-3-nano-omni-30b-a3b-mxfp4",  // case-folded picker form
+            "jangq-ai/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "nemotron-3-ultra-550b-a55b-jangtq-1l",
         ] {
             let profile = ModelProfileRegistry.profile(for: id)
             #expect(
@@ -166,7 +169,7 @@ struct ModelProfileRegistryTests {
             // profile.
             let isNemotron3 = profile?.displayName == NemotronThinkingProfile.displayName
             #expect(
-                !isNemotron3 || id.lowercased().contains("nemotron-3"),
+                !isNemotron3,
                 "matcher must be specific to nemotron-3, not generic nemotron"
             )
         }

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1552,12 +1552,12 @@ struct MLXBatchAdapterTests {
         }
     }
 
-    /// Nemotron Omni call/audio workloads default to the closed/no-thinking
+    /// Nemotron reasoning workloads default to the closed/no-thinking
     /// rail for ordinary chat. Live JANGTQ rows otherwise stream only hidden
     /// reasoning_content and length-stop with empty visible content. Explicit
     /// user/API opt-in still enables thinking and explicit direct/off efforts
     /// still disable it.
-    @Test func additionalContext_defaultsNemotronOmniThinkingOffButHonorsExplicitOptIn() {
+    @Test func additionalContext_defaultsNemotronThinkingOffButHonorsExplicitOptIn() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(
             temperature: nil,
@@ -1569,20 +1569,22 @@ struct MLXBatchAdapterTests {
             "dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK",
             "nemotron-omni-nano-jangtq-crack",
             "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4",
+            "jangq-ai/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
         ] {
             #expect(
                 MLXBatchAdapter.additionalContext(
                     for: unspecified,
                     modelName: modelName
                 )["enable_thinking"] as? Bool == false,
-                "Nemotron Omni should default to the closed/no-thinking rail: \(modelName)"
+                "Nemotron should default to the closed/no-thinking rail: \(modelName)"
             )
             #expect(
                 MLXBatchAdapter.additionalContext(
                     for: userEnabled,
                     modelName: modelName
                 )["enable_thinking"] as? Bool == true,
-                "Nemotron Omni must honor explicit thinking opt-in: \(modelName)"
+                "Nemotron must honor explicit thinking opt-in: \(modelName)"
             )
 
             let directOff = MLXBatchAdapter.additionalContext(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -464,7 +464,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "f2144e1dc39bb33e9ed08ee21e66b0fafb314c3a"
+        let expectedRuntimeHardenedRevision = "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -2124,9 +2124,9 @@ struct RuntimePolicySourceTests {
             "Qwen local chat is an explicit exception: live tool-history rows must default to the closed/no-thinking rail instead of hidden reasoning-only length stops."
         )
         #expect(
-            adapter.contains("if ModelFamilyNames.isNemotronOmniFamily(modelName)")
+            adapter.contains("if ModelFamilyNames.isNemotronThinkingFamily(modelName)")
                 && adapter.contains("context[\"enable_thinking\"] = false"),
-            "Nemotron Omni bundles are the explicit multimodal exception: live ordinary chat must default to the closed/no-thinking rail instead of hidden reasoning-only output."
+            "Nemotron reasoning bundles are the explicit hybrid exception: live ordinary chat must default to the closed/no-thinking rail instead of hidden reasoning-only output."
         )
         #expect(
             adapter.contains("if ModelFamilyNames.isGemmaFamily(modelName)")

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f2144e1dc39bb33e9ed08ee21e66b0fafb314c3a"
+        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Pin OsaurusCore and workspace resolved files to `osaurus-ai/vmlx-swift` commit `6d4661897b8a0fca3d9eaf93c9f11db5cbab3f1b`.
- Add Osaurus recognition for `Nemotron-3-Ultra` reasoning bundles without broadening Omni audio/video media support.
- Keep ordinary local chat on the closed/no-thinking rail for Nemotron reasoning bundles while preserving explicit user/API thinking opt-in.

## Scope

This PR depends on vMLX PR osaurus-ai/vmlx-swift#14. It does not include the separate Gemma tool-schema `additionalProperties` fix; that is being handled separately.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-nemotron-ultra-source-tests xcrun swift test --package-path Packages/OsaurusCore --filter ModelProfileRegistryTests/nemotron3_matchesNemotronProfile --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-nemotron-ultra-source-tests xcrun swift test --package-path Packages/OsaurusCore --filter MLXBatchAdapterTests/additionalContext_defaultsNemotronThinkingOffButHonorsExplicitOptIn --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-nemotron-ultra-source-tests xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-nemotron-ultra-source-tests xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/mlxBatchAdapterDoesNotForceHiddenReasoningDefaults --jobs 1 --no-parallel`
