### PR TITLE
Pin Gemma4 boolean schema vMLX runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
+        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
+        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
+            revision: "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -464,7 +464,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
+        let expectedRuntimeHardenedRevision = "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "58a4eee17da66f041a6fdd69fc3ab5ca3c24c4c7"
+        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX 27f5806 with Gemma4 boolean additionalProperties hardening.
- Keep workspace and app SwiftPM lockfiles aligned with the package manifest.
- Update the runtime pin source guard.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ToolSerializationStabilityTests --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter SwiftTransformersTokenizerLoaderTests/gemma4LocalTokenizerRendersFirstTurnChatUIToolSurface --jobs 1 --no-parallel

Notes
- vMLX PR #15 is already merged to main as 27f5806.
- This PR only advances Osaurus to that runtime SHA; Osaurus already had the app-side schema normalizer from the prior Gemma4 fix.