### PR TITLE
Pin Nemotron Ultra vMLX runtime contract

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
+        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
+        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
+            revision: "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -464,7 +464,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
+        let expectedRuntimeHardenedRevision = "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "27f5806eaacba051b12b06c1f6c9bb6de9f1ebaa"
+        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX d3e57e32 with the Nemotron Ultra runtime cache contract.
- Keep package, workspace, and app SwiftPM lockfiles aligned.
- Update the runtime pin source guard.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel

Notes
- vMLX PR #16 is merged to main as d3e57e32.
- This pin includes tpae's Gemma4 boolean additionalProperties hardening via vMLX 27f5806 and the follow-up Nemotron Ultra cache-contract tests.
- The vMLX update pins the JANG source-contract Ultra layer/cache topology and test metallib harness; it does not claim full live production proof for the 98G Nemo Ultra bundle.