### PR TITLE
Pin vMLX MiniMax parser runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
+        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
+        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
+            revision: "87ad12a14cf4e9b467d3723507aabf203d3574a2"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -464,7 +464,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
+        let expectedRuntimeHardenedRevision = "87ad12a14cf4e9b467d3723507aabf203d3574a2"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d3e57e32c91f57ef8455021ef03eaa8c8b3b1169"
+        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX 87ad12a14cf4e9b467d3723507aabf203d3574a2.
- Pull in the merged MiniMax reasoning/tool routing fix while retaining the Gemma4 boolean schema and Nemotron Ultra runtime/cache contract fixes already on vMLX main.
- Keep all Osaurus SwiftPM lockfiles synchronized with the package manifest guard.

Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel
- git diff --check
