### PR TITLE
added insights button to assistant responses

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -519,6 +519,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // first chat session of the launch.
             if !keychainDisabledTestMode {
                 prewarmGreetingPoolIfEnabled()
+                // Build the Settings/management window graph while idle so the
+                // first open is instant
+                // instead of stalling on a synchronous SwiftUI construct+layout.
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .seconds(1.5))
+                    self?.prewarmManagementWindow()
+                }
             }
         }
     }
@@ -1973,5 +1980,36 @@ extension AppDelegate {
             windowManager.show(.management, center: false)
             NSLog("[Management] Created new window and presented")
         }
+    }
+
+    /// Builds the management window's SwiftUI graph + `NSHostingController`
+    /// once, while idle, WITHOUT showing it. The construction + initial layout
+    /// of `ManagementView` (sidebar, badge stores, tab shell) is the dominant
+    /// cost of opening Settings; doing it here means the first user-initiated
+    /// open (e.g. the chat "Insights" button) hits the cheap reuse path in
+    /// `showManagementWindow` instead of stalling the click. No-op if the
+    /// window already exists.
+    @MainActor public func prewarmManagementWindow() {
+        let windowManager = WindowManager.shared
+        guard windowManager.window(for: .management) == nil else { return }
+
+        let themeManager = ThemeManager.shared
+        let root = ManagementView()
+            .environmentObject(self.serverController)
+            .environmentObject(self.updater)
+            .environment(\.theme, themeManager.currentTheme)
+
+        let window = windowManager.createWindow(config: .management) { root }
+        window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: themeManager.currentTheme.isDark ? .darkAqua : .aqua)
+        themeManager.$currentTheme
+            .receive(on: DispatchQueue.main)
+            .sink { [weak window] theme in
+                window?.appearance = NSAppearance(named: theme.isDark ? .darkAqua : .aqua)
+            }
+            .store(in: &self.cancellables)
+        // Intentionally not shown — it stays registered and hidden until the
+        // user opens Settings, at which point `showManagementWindow` reuses it.
+        NSLog("[Management] Prewarmed hidden window")
     }
 }

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -306,6 +306,14 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         nsWindows[id]
     }
 
+    /// Reverse lookup: the window id that owns a given NSWindow, if it's a
+    /// chat window. Lets AppKit views deep inside the chat hierarchy resolve
+    /// their own window id (e.g. to scope a ThemedAlert to this chat window)
+    /// without threading it down through the view tree.
+    public func windowId(for window: NSWindow) -> UUID? {
+        nsWindows.first(where: { $0.value === window })?.key
+    }
+
     /// Get window info by ID
     public func windowInfo(id: UUID) -> ChatWindowInfo? {
         windows[id]

--- a/Packages/OsaurusCore/Managers/InsightsService.swift
+++ b/Packages/OsaurusCore/Managers/InsightsService.swift
@@ -52,6 +52,12 @@ final class InsightsService: ObservableObject {
     /// Summary statistics. Recomputed alongside `filteredLogs`.
     @Published public private(set) var stats: InsightsStats = .empty
 
+    /// Log entry that another part of the app asked the Insights tab to
+    /// reveal (e.g. the per-message "Insights" button in chat). `InsightsView`
+    /// observes this, pushes the matching log into its detail pane, then
+    /// clears it back to nil. Nil means no pending request.
+    @Published var pendingFocusLogId: UUID?
+
     private var pipelineCancellable: AnyCancellable?
 
     // MARK: - Initialization
@@ -185,6 +191,23 @@ final class InsightsService: ObservableObject {
     func clear() {
         logs.removeAll()
         totalRequestCount = 0
+        pendingFocusLogId = nil
+    }
+
+    /// Ask the Insights tab to reveal the most recent log produced by the
+    /// given chat assistant turn. Returns false when no matching log exists
+    /// (e.g. it was evicted from the ring buffer or cleared), in which case
+    /// the caller may still open the tab to show the full list.
+    @discardableResult
+    func focus(turnId: UUID) -> Bool {
+        guard let match = logs.first(where: { $0.turnId == turnId }) else {
+            return false
+        }
+        // Reassign even if it already equals the target id so a second tap
+        // re-pushes the detail pane after the user backed out of it.
+        pendingFocusLogId = nil
+        pendingFocusLogId = match.id
+        return true
     }
 
     /// Clear filters
@@ -343,6 +366,7 @@ extension InsightsService {
     /// Thread-safe logging from non-main-actor contexts
     nonisolated static func logRequest(
         source: RequestSource,
+        turnId: UUID? = nil,
         method: String,
         path: String,
         statusCode: Int,
@@ -379,6 +403,7 @@ extension InsightsService {
         Task { @MainActor in
             let log = RequestLog(
                 source: source,
+                turnId: turnId,
                 method: method,
                 path: path,
                 statusCode: statusCode,
@@ -409,6 +434,7 @@ extension InsightsService {
     /// text). Defaults are nil to preserve existing call-site ergonomics.
     nonisolated static func logInference(
         source: RequestSource,
+        turnId: UUID? = nil,
         model: String,
         inputTokens: Int,
         outputTokens: Int,
@@ -425,6 +451,7 @@ extension InsightsService {
     ) {
         logRequest(
             source: source,
+            turnId: turnId,
             method: "POST",
             path: "/chat/completions",
             statusCode: errorMessage != nil ? 500 : 200,

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -676,6 +676,11 @@ struct ChatCompletionRequest: Codable, Sendable {
     var modelOptions: [String: ModelOptionValue]? = nil
     /// Optional TTFT trace for diagnostic timing (not serialized to JSON).
     var ttftTrace: TTFTTrace? = nil
+    /// Local-only correlation id tying this request to the chat assistant
+    /// turn that produced it, so the Insights tab can be opened focused on a
+    /// specific response. Not decoded from OpenAI JSON, not forwarded to
+    /// remote providers.
+    var turnId: UUID? = nil
     /// Per-request thinking toggle. Translated to `modelOptions["disableThinking"]`
     /// at request entry; absent preserves server defaults.
     var enable_thinking: Bool? = nil
@@ -721,6 +726,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.max_completion_tokens = max_completion_tokens
         copy.modelOptions = modelOptions
         copy.ttftTrace = ttftTrace
+        copy.turnId = turnId
         copy.enable_thinking = enable_thinking
         copy.reasoning_effort = reasoning_effort
         copy.samplingParametersAreImplicit = samplingParametersAreImplicit
@@ -753,6 +759,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.max_completion_tokens = max_completion_tokens
         copy.modelOptions = modelOptions
         copy.ttftTrace = ttftTrace
+        copy.turnId = turnId
         copy.enable_thinking = enable_thinking
         copy.reasoning_effort = reasoning_effort
         copy.samplingParametersAreImplicit = samplingParametersAreImplicit

--- a/Packages/OsaurusCore/Models/Chat/RequestLog.swift
+++ b/Packages/OsaurusCore/Models/Chat/RequestLog.swift
@@ -54,6 +54,11 @@ struct RequestLog: Identifiable, Sendable {
     let timestamp: Date
     let source: RequestSource
 
+    /// Local-only correlation back to the chat assistant turn that produced
+    /// this log (chatUI source only). Lets the per-message "Insights" button
+    /// open this exact entry. Nil for HTTP/plugin requests.
+    let turnId: UUID?
+
     // HTTP request/response fields
     let method: String
     let path: String
@@ -97,6 +102,7 @@ struct RequestLog: Identifiable, Sendable {
         id: UUID = UUID(),
         timestamp: Date = Date(),
         source: RequestSource,
+        turnId: UUID? = nil,
         method: String,
         path: String,
         statusCode: Int,
@@ -119,6 +125,7 @@ struct RequestLog: Identifiable, Sendable {
         self.id = id
         self.timestamp = timestamp
         self.source = source
+        self.turnId = turnId
         self.method = method
         self.path = path
         self.statusCode = statusCode

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -38327,6 +38327,9 @@
         }
       }
     },
+    "View in Insights" : {
+
+    },
     "View on GitHub" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -10121,6 +10121,9 @@
         }
       }
     },
+    "Detailed request logs are kept only for a short duration to save storage, so there's nothing to show for this response." : {
+
+    },
     "Detected: %@" : {
       "localizations" : {
         "de" : {
@@ -15895,6 +15898,9 @@
           }
         }
       }
+    },
+    "Insights Unavailable" : {
+
     },
     "insights.body.caption.local.request" : {
       "comment" : "Caption under the Request tab's Local sub-toggle in Insights, describing the body as the unscrubbed payload your local app handed to Osaurus.",

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -535,10 +535,15 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // Capture the request body up-front so the producer task does not
             // need to retain `request` (a non-Sendable in Swift 6 strict mode).
             let requestBodyJSON = source == .chatUI ? Self.serializeRequestForLog(request) : nil
+            // `turnId` is a Sendable UUID, so capturing it (unlike `request`)
+            // is safe for the detached producer — correlates the log back to
+            // the chat assistant turn for the per-message Insights button.
+            let turnId = request.turnId
 
             return wrapStreamWithLogging(
                 innerStream,
                 source: source,
+                turnId: turnId,
                 model: model,
                 inputTokens: inputTokens,
                 temperature: temp,
@@ -557,6 +562,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
     private func wrapStreamWithLogging(
         _ inner: AsyncThrowingStream<String, Error>,
         source: InferenceSource,
+        turnId: UUID? = nil,
         model: String,
         inputTokens: Int,
         temperature: Float?,
@@ -785,6 +791,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
                 InsightsService.logInference(
                     source: source,
+                    turnId: turnId,
                     model: model,
                     inputTokens: inputTokens,
                     outputTokens: outputTokenCount,
@@ -929,6 +936,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         let durationMs = Date().timeIntervalSince(startTime) * 1000
                         InsightsService.logInference(
                             source: inferenceSource,
+                            turnId: request.turnId,
                             model: effectiveModel,
                             inputTokens: inputTokens,
                             outputTokens: outputTokens,
@@ -1041,6 +1049,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
                 InsightsService.logInference(
                     source: inferenceSource,
+                    turnId: request.turnId,
                     model: effectiveModel,
                     inputTokens: inputTokens,
                     outputTokens: outputTokens,

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2650,6 +2650,10 @@ final class ChatSession: ObservableObject {
                         req.samplingParametersAreImplicit = true
                         req.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
                         req.ttftTrace = ttftTrace
+                        // Correlate the Insights log this send produces back to the
+                        // assistant turn, so the per-message "Insights" button can
+                        // open this exact response.
+                        req.turnId = assistantTurn.id
                         debugLog(
                             "send: attempt=\(attempts) model=\(req.model) tools=\(req.tools?.count ?? 0) sessionId=\(req.session_id ?? "nil")"
                         )
@@ -3074,6 +3078,7 @@ final class ChatSession: ObservableObject {
                             )
                             finalReq.samplingParametersAreImplicit = true
                             finalReq.modelOptions = activeModelOptions.isEmpty ? nil : activeModelOptions
+                            finalReq.turnId = assistantTurn.id
 
                             let processor = StreamingDeltaProcessor(
                                 turn: assistantTurn

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -537,8 +537,10 @@ final class NativeAssistantActionsView: NSView {
         }
 
         let size: CGFloat = 28
+        // Speaker is last; its leading hangs off Insights and collapses to 0
+        // (along with its width) when TTS is disabled so the row tightens up.
         let speakLeading = speakButton.leadingAnchor.constraint(
-            equalTo: regenerateButton.trailingAnchor,
+            equalTo: insightsButton.trailingAnchor,
             constant: 4
         )
         let speakWidth = speakButton.widthAnchor.constraint(equalToConstant: size)
@@ -556,19 +558,19 @@ final class NativeAssistantActionsView: NSView {
             regenerateButton.widthAnchor.constraint(equalToConstant: size),
             regenerateButton.heightAnchor.constraint(equalToConstant: size),
 
+            insightsButton.leadingAnchor.constraint(equalTo: regenerateButton.trailingAnchor, constant: 4),
+            insightsButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            insightsButton.widthAnchor.constraint(equalToConstant: size),
+            insightsButton.heightAnchor.constraint(equalToConstant: size),
+
+            // Speaker follows Insights and carries the trailing pin. When it's
+            // hidden its width/leading collapse to 0, so Insights becomes the
+            // effective last button.
             speakLeading,
             speakButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             speakWidth,
             speakButton.heightAnchor.constraint(equalToConstant: size),
-
-            // Insights follows the speaker button. When the speaker is hidden
-            // its width/leading collapse to 0, so insights sits flush after
-            // Regenerate instead. Insights carries the trailing pin.
-            insightsButton.leadingAnchor.constraint(equalTo: speakButton.trailingAnchor, constant: 4),
-            insightsButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            insightsButton.widthAnchor.constraint(equalToConstant: size),
-            insightsButton.heightAnchor.constraint(equalToConstant: size),
-            insightsButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            speakButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
         ])
 
         ttsObservation = NotificationCenter.default.addObserver(
@@ -633,7 +635,7 @@ final class NativeAssistantActionsView: NSView {
             iconTint: nil
         )
         insightsButton.setSymbol(
-            NSImage(systemSymbolName: "chart.bar.doc.horizontal", accessibilityDescription: L("Insights"))?
+            NSImage(systemSymbolName: "waveform.path.ecg.magnifyingglass", accessibilityDescription: L("Insights"))?
                 .withSymbolConfiguration(cfg),
             toolTip: L("View in Insights"),
             theme: theme,
@@ -644,14 +646,43 @@ final class NativeAssistantActionsView: NSView {
     }
 
     /// Opens the Settings → Insights tab, focused on the request/response log
-    /// this assistant turn produced. Falls back to the full Insights list when
-    /// no matching log survives in the ring buffer (e.g. it was evicted or the
-    /// logs were cleared).
+    /// this assistant turn produced. Request logs live only in memory for the
+    /// current app session (and are capped at a ring-buffer limit), so turns
+    /// from a previous launch or evicted entries have nothing to show — in
+    /// that case we surface a themed alert instead of opening an unrelated
+    /// (or empty) Insights list.
     private func openInsights() {
         MainActor.assumeIsolated {
-            InsightsService.shared.focus(turnId: turnId)
-            AppDelegate.shared?.showManagementWindow(initialTab: .insights)
+            if InsightsService.shared.focus(turnId: turnId) {
+                AppDelegate.shared?.showManagementWindow(initialTab: .insights)
+            } else {
+                presentLogUnavailableAlert()
+            }
         }
+    }
+
+    @MainActor
+    private func presentLogUnavailableAlert() {
+        // Scope the alert to this chat window when we can resolve it, so it
+        // dims and centers over the chat rather than another surface.
+        let scope: ThemedAlertScope =
+            window.flatMap { ChatWindowManager.shared.windowId(for: $0) }
+            .map { .chat($0) } ?? .content
+        let requestId = UUID()
+        ThemedAlertCenter.shared.present(
+            ThemedAlertRequest(
+                id: requestId,
+                title: L("Insights Unavailable"),
+                message: L(
+                    "Detailed request logs are kept only for a short duration to save storage, so there's nothing to show for this response."
+                ),
+                buttons: [.primary(L("OK")) {}],
+                onDismiss: {
+                    ThemedAlertCenter.shared.dismiss(scope: scope, id: requestId)
+                }
+            ),
+            scope: scope
+        )
     }
 
     private func refreshSpeakIcon() {

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -484,6 +484,8 @@ final class NativeAssistantActionsView: NSView {
     private let copyButton: HeaderCircleActionControl
     private let regenerateButton: HeaderCircleActionControl
     let speakButton: HeaderCircleActionControl
+    /// Opens the Insights tab focused on this turn's request/response log.
+    let insightsButton: HeaderCircleActionControl
 
     private var turnId: UUID = UUID()
     private var onCopy: ((UUID) -> Void)?
@@ -500,18 +502,22 @@ final class NativeAssistantActionsView: NSView {
         let copyControl = HeaderCircleActionControl(action: {})
         let regenControl = HeaderCircleActionControl(action: {})
         let speakControl = HeaderCircleActionControl(action: {})
+        let insightsControl = HeaderCircleActionControl(action: {})
         self.copyButton = copyControl
         self.regenerateButton = regenControl
         self.speakButton = speakControl
+        self.insightsButton = insightsControl
         super.init(frame: frame)
         translatesAutoresizingMaskIntoConstraints = false
 
         copyButton.translatesAutoresizingMaskIntoConstraints = false
         regenerateButton.translatesAutoresizingMaskIntoConstraints = false
         speakButton.translatesAutoresizingMaskIntoConstraints = false
+        insightsButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(copyButton)
         addSubview(regenerateButton)
         addSubview(speakButton)
+        addSubview(insightsButton)
 
         copyButton.setAction { [weak self] in
             guard let self else { return }
@@ -524,6 +530,10 @@ final class NativeAssistantActionsView: NSView {
         speakButton.setAction { [weak self] in
             guard let self else { return }
             self.onSpeak?(self.turnId)
+        }
+        insightsButton.setAction { [weak self] in
+            guard let self else { return }
+            self.openInsights()
         }
 
         let size: CGFloat = 28
@@ -550,7 +560,15 @@ final class NativeAssistantActionsView: NSView {
             speakButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             speakWidth,
             speakButton.heightAnchor.constraint(equalToConstant: size),
-            speakButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+
+            // Insights follows the speaker button. When the speaker is hidden
+            // its width/leading collapse to 0, so insights sits flush after
+            // Regenerate instead. Insights carries the trailing pin.
+            insightsButton.leadingAnchor.constraint(equalTo: speakButton.trailingAnchor, constant: 4),
+            insightsButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            insightsButton.widthAnchor.constraint(equalToConstant: size),
+            insightsButton.heightAnchor.constraint(equalToConstant: size),
+            insightsButton.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
         ])
 
         ttsObservation = NotificationCenter.default.addObserver(
@@ -614,8 +632,26 @@ final class NativeAssistantActionsView: NSView {
             theme: theme,
             iconTint: nil
         )
+        insightsButton.setSymbol(
+            NSImage(systemSymbolName: "chart.bar.doc.horizontal", accessibilityDescription: L("Insights"))?
+                .withSymbolConfiguration(cfg),
+            toolTip: L("View in Insights"),
+            theme: theme,
+            iconTint: nil
+        )
         applyTTSVisibility()
         refreshSpeakIcon()
+    }
+
+    /// Opens the Settings → Insights tab, focused on the request/response log
+    /// this assistant turn produced. Falls back to the full Insights list when
+    /// no matching log survives in the ring buffer (e.g. it was evicted or the
+    /// logs were cleared).
+    private func openInsights() {
+        MainActor.assumeIsolated {
+            InsightsService.shared.focus(turnId: turnId)
+            AppDelegate.shared?.showManagementWindow(initialTab: .insights)
+        }
     }
 
     private func refreshSpeakIcon() {

--- a/Packages/OsaurusCore/Views/Insights/InsightsView.swift
+++ b/Packages/OsaurusCore/Views/Insights/InsightsView.swift
@@ -62,6 +62,12 @@ struct InsightsView: View {
             withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
                 hasAppeared = true
             }
+            // Honor a focus request that landed before this view existed
+            // (e.g. the chat "Insights" button opened the window on this tab).
+            applyPendingFocus(insightsService.pendingFocusLogId)
+        }
+        .onChange(of: insightsService.pendingFocusLogId) { _, newValue in
+            applyPendingFocus(newValue)
         }
         .themedAlert(
             "Clear All Logs",
@@ -103,6 +109,17 @@ struct InsightsView: View {
         withAnimation(.easeInOut(duration: 0.25)) {
             selectedLog = log
         }
+    }
+
+    /// Resolves a pending focus request (a log id set by another part of the
+    /// app) to the matching log and pushes it into the detail pane, then clears
+    /// the request so it isn't re-applied. No-op when the id is nil or the log
+    /// has already been evicted from the ring buffer.
+    private func applyPendingFocus(_ logId: UUID?) {
+        guard let logId else { return }
+        defer { insightsService.pendingFocusLogId = nil }
+        guard let log = insightsService.logs.first(where: { $0.id == logId }) else { return }
+        push(log)
     }
 
     // MARK: - Header View


### PR DESCRIPTION
## Summary

added a button under each assistant message that opens the Insights tab focused on that response's request and details (when a response is too old to have a saved log, an alert with a brief explanation is shown)


https://github.com/user-attachments/assets/5b5744f9-5ef2-47b5-989c-ee130d8fbdc8

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
