### PR TITLE
Pin vMLX ZAYA CCA cache runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
+        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
+        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "87ad12a14cf4e9b467d3723507aabf203d3574a2"
+            revision: "525fc6dc17650efd420e7f9adfc1c37e40650a73"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -464,7 +464,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "87ad12a14cf4e9b467d3723507aabf203d3574a2"
+        let expectedRuntimeHardenedRevision = "525fc6dc17650efd420e7f9adfc1c37e40650a73"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "87ad12a14cf4e9b467d3723507aabf203d3574a2"
+        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX `525fc6dc17650efd420e7f9adfc1c37e40650a73`.
- Consume the ZAYA CCA format-v2 disk cache hit fix from vMLX PR #18.
- Keep `RuntimePolicySourceTests` aligned with the active runtime hardening pin.

Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- `git diff --check`

vMLX source validation for the pinned commit
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CacheCoordinator --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CacheCoordinatorTopologyFocusedTests/hybridDiskMediaSaltPromptBoundaryReturnsExactHit --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CacheCoordinatorTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter ReasoningParserTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter MultiTurnFamilyMatrixTests --jobs 1 --no-parallel`
