### PR TITLE
Add tool capability availability diagnostics

### DIFF
--- a/Packages/OsaurusCore/Models/Tool/ToolAvailability.swift
+++ b/Packages/OsaurusCore/Models/Tool/ToolAvailability.swift
@@ -1,0 +1,82 @@
+//
+//  ToolAvailability.swift
+//  osaurus
+//
+//  Human- and model-readable reason codes for tool availability.
+//
+
+import Foundation
+
+enum ToolAvailabilityReasonCode: String, Codable, CaseIterable, Sendable {
+    case available
+    case alreadyLoaded = "already_loaded"
+    case loadableViaCapabilitiesLoad = "loadable_via_capabilities_load"
+    case disabled
+    case hiddenByAgentScope = "hidden_by_agent_scope"
+    case hiddenByExecutionMode = "hidden_by_execution_mode"
+    case permissionBlocked = "permission_blocked"
+    case missingPermission = "missing_permission"
+    case notInstalled = "not_installed"
+    case notRegistered = "not_registered"
+    case pluginConfigRequired = "plugin_config_required"
+    case notSelectedByPreflight = "not_selected_by_preflight"
+}
+
+struct ToolAvailability: Equatable, Sendable {
+    let toolName: String
+    let runtime: String?
+    let groupName: String?
+    let reasonCodes: [ToolAvailabilityReasonCode]
+    let detail: String
+
+    var primaryReason: ToolAvailabilityReasonCode {
+        reasonCodes.first ?? .available
+    }
+
+    var isLoadableViaCapabilitiesLoad: Bool {
+        reasonCodes.contains(.loadableViaCapabilitiesLoad)
+    }
+
+    var isCallableNow: Bool {
+        reasonCodes.contains(.available) || reasonCodes.contains(.alreadyLoaded)
+    }
+
+    var compactSummary: String {
+        let codes = reasonCodes.map(\.rawValue).joined(separator: ",")
+        guard !detail.isEmpty else { return codes }
+        return "\(codes) - \(detail)"
+    }
+
+    var displayLabel: String {
+        switch primaryReason {
+        case .available:
+            return "Available"
+        case .alreadyLoaded:
+            return "Loaded"
+        case .loadableViaCapabilitiesLoad:
+            return "Loadable"
+        case .disabled:
+            return "Disabled"
+        case .hiddenByAgentScope:
+            return "Agent off"
+        case .hiddenByExecutionMode:
+            return "Mode hidden"
+        case .permissionBlocked:
+            return "Blocked"
+        case .missingPermission:
+            return "Needs permission"
+        case .notInstalled:
+            return "Not installed"
+        case .notRegistered:
+            return "Not registered"
+        case .pluginConfigRequired:
+            return "Config needed"
+        case .notSelectedByPreflight:
+            return "Not selected"
+        }
+    }
+
+    var displayDetail: String {
+        detail.isEmpty ? displayLabel : detail
+    }
+}

--- a/Packages/OsaurusCore/Tests/Agent/AgentCapabilityRowBuilderTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentCapabilityRowBuilderTests.swift
@@ -111,6 +111,7 @@ struct AgentCapabilityRowBuilderTests {
             plugins: [],
             enabledToolNames: [],
             enabledSkillNames: [],
+            toolMode: .auto,
             searchQuery: "",
             filter: .all,
             // Force every group to expand so build emits child rows we can
@@ -165,6 +166,7 @@ struct AgentCapabilityRowBuilderTests {
             plugins: [],
             enabledToolNames: [],
             enabledSkillNames: [],
+            toolMode: .auto,
             searchQuery: "",
             filter: .all,
             expandedGroups: []
@@ -204,6 +206,7 @@ struct AgentCapabilityRowBuilderTests {
             plugins: [],
             enabledToolNames: [],
             enabledSkillNames: [],
+            toolMode: .auto,
             searchQuery: "",
             filter: .all,
             // Even with the group force-expanded, the row builder must
@@ -218,7 +221,7 @@ struct AgentCapabilityRowBuilderTests {
             switch row {
             case .groupHeader(let id, _, _, _, _, _, _, _, _):
                 #expect(id != "src:builtin", "Informational built-in group leaked into rows")
-            case .tool(let id, _, _, _, _, _, _):
+            case .tool(let id, _, _, _, _, _, _, _):
                 #expect(
                     !id.hasPrefix("src:builtin::"),
                     "Tool \(id) under the hidden built-in group leaked into rows"

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -207,6 +207,7 @@ struct CapabilitiesDiscoverToolTests {
                 )
                 #expect(result.contains(allowed.name))
                 #expect(!result.contains(denied.name))
+                #expect(result.contains("availability: loadable_via_capabilities_load"))
 
                 AgentManager.shared.setActiveAgent(agent.id)
                 defer { AgentManager.shared.setActiveAgent(Agent.defaultId) }
@@ -269,10 +270,13 @@ struct CapabilitiesLoadToolTests {
 
     @Test func toolNotFoundReturnsError() async throws {
         let tool = CapabilitiesLoadTool()
-        let result = try await tool.execute(
-            argumentsJSON: "{\"ids\": [\"tool/zzz_nonexistent_tool\"]}"
-        )
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await tool.execute(
+                argumentsJSON: "{\"ids\": [\"tool/zzz_nonexistent_tool\"]}"
+            )
+        }
         #expect(result.contains("Error") || result.contains("not found"))
+        #expect(result.contains("availability: not_registered"))
     }
 
     @Test func skillNotFoundReturnsError() async throws {
@@ -361,6 +365,7 @@ struct CapabilitiesLoadToolTests {
                     )
                 }
                 #expect(result.contains("not enabled for this agent"))
+                #expect(result.contains("availability: hidden_by_agent_scope"))
                 let buffered = await CapabilityLoadBuffer.shared.drain()
                 #expect(!buffered.contains(where: { $0.function.name == denied.name }))
 
@@ -445,6 +450,44 @@ struct CapabilitiesLoadToolTests {
                 await SkillManager.shared.unregisterPluginSkills(pluginId: plugin.id)
                 _ = await AgentManager.shared.delete(id: agent.id)
             }
+        }
+    }
+
+    @Test @MainActor
+    func toolLoadReportsDisabledAvailability() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-load-disabled-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let toolName = "lane_b_disabled_search_tool_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+            let disabled = CapabilityPolicyFixtureTool(
+                name: toolName,
+                description: "Search the web for current headlines and online results"
+            )
+            ToolRegistry.shared.registerPluginTool(disabled)
+            ToolRegistry.shared.setEnabled(false, for: disabled.name)
+            defer { ToolRegistry.shared.unregister(names: [disabled.name]) }
+
+            let tool = CapabilitiesLoadTool()
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await tool.execute(
+                    argumentsJSON: "{\"ids\": [\"tool/\(disabled.name)\"]}"
+                )
+            }
+
+            #expect(result.contains("disabled"))
+            #expect(result.contains("availability: disabled"))
+            let buffered = await CapabilityLoadBuffer.shared.drain()
+            #expect(!buffered.contains(where: { $0.function.name == disabled.name }))
         }
     }
 }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -169,6 +169,17 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         }
 
         let hits = Self.mergeHits(perQueryResults)
+        let toolAvailabilityByName: [String: ToolAvailability] = await MainActor.run {
+            var result: [String: ToolAvailability] = [:]
+            result.reserveCapacity(hits.tools.count)
+            for hit in hits.tools {
+                result[hit.entry.id] = ToolRegistry.shared.availability(
+                    forTool: hit.entry.id,
+                    agentAllowedNames: effectiveAllowedToolNames
+                )
+            }
+            return result
+        }
 
         if hits.isEmpty {
             let queryList = queries.map { "'\($0)'" }.joined(separator: ", ")
@@ -192,7 +203,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
             let type: String
             let description: String
             let score: Double
-            let extra: String?
+            let extraLines: [String]
         }
 
         let results: [ScoredResult] =
@@ -202,16 +213,23 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
                     type: "method",
                     description: "\($0.method.name): \($0.method.description)",
                     score: $0.score,
-                    extra: "tools_used: \($0.method.toolsUsed.joined(separator: ", "))"
+                    extraLines: ["tools_used: \($0.method.toolsUsed.joined(separator: ", "))"]
                 )
             }
             + hits.tools.map {
-                ScoredResult(
+                var extraLines = ["runtime: \($0.entry.runtime.rawValue)"]
+                if let availability = toolAvailabilityByName[$0.entry.id] {
+                    extraLines.append("availability: \(availability.compactSummary)")
+                    if let groupName = availability.groupName {
+                        extraLines.append("provider: \(groupName)")
+                    }
+                }
+                return ScoredResult(
                     id: "tool/\($0.entry.id)",
                     type: "tool",
                     description: "\($0.entry.name): \($0.entry.description)",
                     score: Double($0.searchScore),
-                    extra: "runtime: \($0.entry.runtime.rawValue)"
+                    extraLines: extraLines
                 )
             }
             + hits.skills.map {
@@ -220,7 +238,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
                     type: "skill",
                     description: "\($0.skill.name): \($0.skill.description)",
                     score: Double($0.searchScore),
-                    extra: nil
+                    extraLines: []
                 )
             }).sorted { $0.score > $1.score }
 
@@ -228,7 +246,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         for r in results {
             output += "- **\(r.id)** [\(r.type)]\n"
             output += "  \(r.description)\n"
-            if let extra = r.extra {
+            for extra in r.extraLines {
                 output += "  \(extra)\n"
             }
             output += "\n"
@@ -553,23 +571,31 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             }
         }
         let allowedNames = await grantedToolNamesForCurrentAgent()
-        let (isEnabled, isBuiltIn, toolSpec) = await MainActor.run {
+        let (availability, isEnabled, isBuiltIn, toolSpec) = await MainActor.run {
             (
+                ToolRegistry.shared.availability(
+                    forTool: toolId,
+                    agentAllowedNames: allowedNames
+                ),
                 ToolRegistry.shared.isGlobalEnabled(toolId),
                 ToolRegistry.shared.builtInToolNames.contains(toolId),
                 ToolRegistry.shared.specs(forTools: [toolId])
             )
         }
+        guard !availability.reasonCodes.contains(.notRegistered) else {
+            return "Error: Tool '\(toolId)' not found or not registered. availability: \(availability.compactSummary)\n"
+        }
         guard isBuiltIn || (allowedNames?.contains(toolId) ?? true) else {
-            return "Error: Tool '\(toolId)' is not enabled for this agent.\n"
+            return
+                "Error: Tool '\(toolId)' is not enabled for this agent. availability: \(availability.compactSummary)\n"
         }
         // Built-in tools are always loaded via alwaysLoadedSpecs, so skip the
         // enabled check — rejecting them here is misleading since they're callable.
         guard isEnabled || isBuiltIn else {
-            return "Error: Tool '\(toolId)' is disabled.\n"
+            return "Error: Tool '\(toolId)' is disabled. availability: \(availability.compactSummary)\n"
         }
         guard let spec = toolSpec.first else {
-            return "Error: Tool '\(toolId)' not found or not registered.\n"
+            return "Error: Tool '\(toolId)' not found or not registered. availability: \(availability.compactSummary)\n"
         }
         await CapabilityLoadBuffer.shared.add(spec)
         return "Tool '\(toolId)' loaded and available.\n"

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -71,7 +71,7 @@ private final class ToolBodyRaceState: @unchecked Sendable {
 /// must price the spec that will be sent this turn, not the registry's
 /// canonical full schema, because the prompt composer can now ship compact
 /// bootstrap schemas and hot-load full ones later.
-fileprivate enum ToolSpecTokenEstimator {
+private enum ToolSpecTokenEstimator {
     static func estimate(name: String, description: String?, parameters: JSONValue?) -> Int {
         var total = name.count + (description?.count ?? 0)
         if let parameters {
@@ -560,7 +560,7 @@ final class ToolRegistry: ObservableObject {
     /// wall-clock race. Cancellation still propagates: when the calling
     /// task is cancelled, the body's own `Task.isCancelled` checks (or
     /// the underlying process signals) tear it down.
-    internal nonisolated static func runToolBodyUntimed(
+    nonisolated internal static func runToolBodyUntimed(
         _ tool: OsaurusTool,
         argumentsJSON: String
     ) async throws -> String {
@@ -603,7 +603,7 @@ final class ToolRegistry: ObservableObject {
     /// fall through unchanged: parsing is best-effort, and tool bodies
     /// keep their richer `requireXxx` helpers as the second line of
     /// defence.
-    private nonisolated static func preflight(
+    nonisolated private static func preflight(
         argumentsJSON: String,
         schema: JSONValue?,
         toolName: String
@@ -663,7 +663,7 @@ final class ToolRegistry: ObservableObject {
     /// The timeout branch also uses a dedicated GCD timer queue rather than
     /// `Task.sleep`, because a saturated Swift executor can otherwise delay
     /// the "wall-clock" timeout behind unrelated async work.
-    internal nonisolated static func runToolBody(
+    nonisolated internal static func runToolBody(
         _ tool: OsaurusTool,
         argumentsJSON: String,
         timeoutSeconds: TimeInterval
@@ -1165,6 +1165,94 @@ final class ToolRegistry: ObservableObject {
         listDynamicTools().isEmpty
     }
 
+    /// Explain why a tool is callable now, loadable through
+    /// `capabilities_load`, or unavailable. This is read-only diagnostic
+    /// state: callers still enforce visibility/loading through the existing
+    /// toolset and `capabilities_load` gates.
+    func availability(
+        forTool toolName: String,
+        agentAllowedNames: Set<String>? = nil,
+        executionMode: ExecutionMode? = nil,
+        selectedPreflightNames: Set<String>? = nil
+    ) -> ToolAvailability {
+        guard let entry = listTools().first(where: { $0.name == toolName }) else {
+            return ToolAvailability(
+                toolName: toolName,
+                runtime: nil,
+                groupName: nil,
+                reasonCodes: [.notRegistered],
+                detail: "tool is not registered; install or enable the plugin/provider that owns it"
+            )
+        }
+
+        let builtIn = builtInToolNames.contains(toolName)
+        let runtimeManaged = runtimeManagedToolNames.contains(toolName)
+        let dynamic = !builtIn && !runtimeManaged
+        let runtime = availabilityRuntimeLabel(for: toolName, builtIn: builtIn)
+        let group = groupName(for: toolName)
+        var reasons: [ToolAvailabilityReasonCode] = []
+        var details: [String] = []
+
+        func appendReason(_ reason: ToolAvailabilityReasonCode) {
+            if !reasons.contains(reason) {
+                reasons.append(reason)
+            }
+        }
+
+        if dynamic, !entry.enabled {
+            appendReason(.disabled)
+            details.append("globally disabled")
+        }
+
+        if dynamic, let agentAllowedNames, !agentAllowedNames.contains(toolName) {
+            appendReason(.hiddenByAgentScope)
+            details.append("not enabled for this agent")
+        }
+
+        if let executionMode, excludedToolNames(for: executionMode).contains(toolName) {
+            appendReason(.hiddenByExecutionMode)
+            details.append("hidden in \(String(describing: executionMode)) mode")
+        }
+
+        if let policy = policyInfo(for: toolName) {
+            if policy.effectivePolicy == .deny {
+                appendReason(.permissionBlocked)
+                details.append("permission policy is deny")
+            }
+            let missingPermissions = policy.systemPermissionStates
+                .filter { !$0.value }
+                .map { $0.key.displayName }
+                .sorted()
+            if !missingPermissions.isEmpty {
+                appendReason(.missingPermission)
+                details.append("missing system permission(s): \(missingPermissions.joined(separator: ", "))")
+            }
+        }
+
+        if dynamic, let selectedPreflightNames, !selectedPreflightNames.contains(toolName) {
+            appendReason(.notSelectedByPreflight)
+            details.append("not selected by preflight for this turn")
+        }
+
+        if reasons.isEmpty {
+            if dynamic {
+                appendReason(.loadableViaCapabilitiesLoad)
+                details.append("registered \(runtime) tool; load with capabilities_load")
+            } else {
+                appendReason(.alreadyLoaded)
+                details.append("registered \(runtime) tool; already in the active baseline")
+            }
+        }
+
+        return ToolAvailability(
+            toolName: toolName,
+            runtime: runtime,
+            groupName: group,
+            reasonCodes: reasons,
+            detail: details.joined(separator: "; ")
+        )
+    }
+
     /// Returns the plugin or provider name that a tool belongs to, if any.
     func groupName(for toolName: String) -> String? {
         guard let tool = toolsByName[toolName] else { return nil }
@@ -1172,6 +1260,14 @@ final class ToolRegistry: ObservableObject {
         if let mcp = tool as? MCPProviderTool { return mcp.providerName }
         if let sandbox = tool as? SandboxPluginTool { return sandbox.plugin.id }
         return nil
+    }
+
+    private func availabilityRuntimeLabel(for toolName: String, builtIn: Bool) -> String {
+        if isSandboxTool(toolName) { return "sandbox" }
+        if isMCPTool(toolName) { return "mcp" }
+        if isPluginTool(toolName) { return "plugin" }
+        if builtIn { return "builtin" }
+        return "native"
     }
 
     static let capabilityToolNames: Set<String> = [

--- a/Packages/OsaurusCore/Views/Agent/AgentCapabilityManagerView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentCapabilityManagerView.swift
@@ -114,6 +114,7 @@ enum CapabilityRowBuilder {
         let plugins: [PluginManager.LoadedPlugin]
         let enabledToolNames: Set<String>
         let enabledSkillNames: Set<String>
+        let toolMode: ToolSelectionMode
         let searchQuery: String
         let filter: CapabilityFilter
         let expandedGroups: Set<String>
@@ -264,12 +265,14 @@ enum CapabilityRowBuilder {
             guard isExpanded else { continue }
 
             for tool in toolsForRows {
+                let availability = availability(forTool: tool, input: input)
                 rows.append(
                     .tool(
                         id: "\(groupId)::tool::\(tool.name)",
                         name: tool.name,
                         description: tool.description,
                         enabled: input.enabledToolNames.contains(tool.name),
+                        availability: availability,
                         // Informational sources were filtered above; every
                         // tool that reaches this point is freely toggleable.
                         isAgentRestricted: false,
@@ -293,6 +296,25 @@ enum CapabilityRowBuilder {
             }
         }
         return rows
+    }
+
+    private static func availability(forTool tool: ToolRegistry.ToolEntry, input: Input) -> ToolAvailability {
+        let base = ToolRegistry.shared.availability(
+            forTool: tool.name,
+            agentAllowedNames: input.enabledToolNames
+        )
+        guard input.toolMode == .manual,
+            input.enabledToolNames.contains(tool.name),
+            base.reasonCodes == [.loadableViaCapabilitiesLoad]
+        else { return base }
+
+        return ToolAvailability(
+            toolName: tool.name,
+            runtime: base.runtime,
+            groupName: base.groupName,
+            reasonCodes: [.available],
+            detail: "enabled for this agent; sent every turn in manual mode"
+        )
     }
 
     private static func sortRank(_ source: CapabilitySource) -> Int {
@@ -699,6 +721,7 @@ struct AgentCapabilityManagerView: View {
                 plugins: plugins,
                 enabledToolNames: enabledToolNames,
                 enabledSkillNames: enabledSkillNames,
+                toolMode: toolMode,
                 searchQuery: searchText,
                 filter: filter,
                 expandedGroups: expandedGroups

--- a/Packages/OsaurusCore/Views/Agent/CapabilitiesTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Agent/CapabilitiesTableRepresentable.swift
@@ -47,6 +47,7 @@ enum CapabilityRow: Equatable, Identifiable {
         name: String,
         description: String,
         enabled: Bool,
+        availability: ToolAvailability,
         isAgentRestricted: Bool,
         catalogTokens: Int,
         estimatedTokens: Int
@@ -64,7 +65,7 @@ enum CapabilityRow: Equatable, Identifiable {
     var id: String {
         switch self {
         case .groupHeader(let id, _, _, _, _, _, _, _, _): return "gh-\(id)"
-        case .tool(let id, _, _, _, _, _, _): return "tool-\(id)"
+        case .tool(let id, _, _, _, _, _, _, _): return "tool-\(id)"
         case .skill(let id, _, _, _, _, _, _): return "skill-\(id)"
         }
     }
@@ -263,8 +264,8 @@ extension CapabilitiesTableRepresentable {
         // MARK: - Update Paths (Private)
 
         private func hasContentChanges(newLookup: [String: CapabilityRow]) -> Bool {
-            for id in rowIds {
-                if newLookup[id] != rowLookup[id] { return true }
+            for id in rowIds where newLookup[id] != rowLookup[id] {
+                return true
             }
             return false
         }
@@ -417,6 +418,7 @@ extension CapabilitiesTableRepresentable {
                     let name,
                     let description,
                     let enabled,
+                    let availability,
                     let isAgentRestricted,
                     let catalogTokens,
                     let estimatedTokens
@@ -428,6 +430,7 @@ extension CapabilitiesTableRepresentable {
                     name: name,
                     description: description,
                     enabled: enabled,
+                    availability: availability,
                     isAgentRestricted: isAgentRestricted,
                     catalogTokens: catalogTokens,
                     estimatedTokens: estimatedTokens,
@@ -541,7 +544,7 @@ extension CapabilitiesTableRepresentable {
         private static func estimatedHeight(for row: CapabilityRow) -> CGFloat {
             switch row {
             case .groupHeader: return 44
-            case .tool: return 56
+            case .tool: return 70
             case .skill: return 56
             }
         }
@@ -697,6 +700,7 @@ struct ToolRowCell: View {
     let name: String
     let description: String
     let enabled: Bool
+    let availability: ToolAvailability
     let isAgentRestricted: Bool
     let catalogTokens: Int
     let estimatedTokens: Int
@@ -729,11 +733,17 @@ struct ToolRowCell: View {
                     if isAgentRestricted {
                         SmallCapsuleBadge(text: "Chat Mode only")
                     }
+
+                    ToolAvailabilityBadge(availability: availability)
                 }
                 Text(description)
                     .font(.system(size: 10))
                     .foregroundColor(theme.tertiaryText)
                     .lineLimit(2)
+                Text(availability.displayDetail)
+                    .font(.system(size: 9))
+                    .foregroundColor(theme.tertiaryText)
+                    .lineLimit(1)
             }
 
             Spacer()
@@ -758,7 +768,7 @@ struct ToolRowCell: View {
         .help(
             isAgentRestricted
                 ? "Restricted for this agent."
-                : ""
+                : availability.compactSummary
         )
     }
 }

--- a/Packages/OsaurusCore/Views/Common/ToolAvailabilityBadge.swift
+++ b/Packages/OsaurusCore/Views/Common/ToolAvailabilityBadge.swift
@@ -1,0 +1,39 @@
+//
+//  ToolAvailabilityBadge.swift
+//  osaurus
+//
+//  Compact availability status marker shared by tool diagnostics surfaces.
+//
+
+import SwiftUI
+
+struct ToolAvailabilityBadge: View {
+    let availability: ToolAvailability
+
+    @Environment(\.theme) private var theme
+
+    private var tint: Color {
+        switch availability.primaryReason {
+        case .available, .alreadyLoaded, .loadableViaCapabilitiesLoad:
+            return theme.accentColor
+        case .disabled, .hiddenByAgentScope, .hiddenByExecutionMode, .notSelectedByPreflight:
+            return theme.secondaryText
+        case .permissionBlocked, .missingPermission, .notInstalled, .notRegistered, .pluginConfigRequired:
+            return theme.warningColor
+        }
+    }
+
+    var body: some View {
+        Text(availability.displayLabel)
+            .font(.system(size: 8, weight: .medium))
+            .foregroundColor(tint)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(tint.opacity(0.12))
+                    .overlay(Capsule().strokeBorder(tint.opacity(0.18), lineWidth: 1))
+            )
+            .help(availability.compactSummary)
+    }
+}

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -82,8 +82,9 @@ struct ToolsManagerView: View {
         .onReceive(NotificationCenter.default.publisher(for: .toolsListChanged)) { _ in
             reload()
         }
-        .onReceive(NotificationCenter.default.publisher(for: Foundation.Notification.Name.mcpProviderStatusChanged)) {
-            _ in
+        .onReceive(
+            NotificationCenter.default.publisher(for: Foundation.Notification.Name.mcpProviderStatusChanged)
+        ) { _ in
             remoteProviderCount = providerManager.configuration.providers.count
             reload()
         }
@@ -1338,6 +1339,10 @@ private struct RuntimeManagedToolEntryRow: View {
         return info.systemPermissionStates.values.contains(false)
     }
 
+    private var availability: ToolAvailability {
+        ToolRegistry.shared.availability(forTool: entry.name)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             toolIcon
@@ -1352,11 +1357,17 @@ private struct RuntimeManagedToolEntryRow: View {
                             .font(.system(size: 9))
                             .foregroundColor(theme.warningColor)
                     }
+
+                    ToolAvailabilityBadge(availability: availability)
                 }
 
                 Text(entry.description)
                     .font(.system(size: 11))
                     .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+                Text(availability.displayDetail)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
                     .lineLimit(1)
             }
 
@@ -1419,6 +1430,10 @@ struct ToolEntryRow: View {
         return info.systemPermissionStates.values.contains(false)
     }
 
+    private var availability: ToolAvailability {
+        ToolRegistry.shared.availability(forTool: entry.name)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             toolIcon
@@ -1470,20 +1485,14 @@ struct ToolEntryRow: View {
                     .font(.system(size: 13, weight: .medium, design: .rounded))
                     .foregroundColor(theme.primaryText)
 
-                if hasMissingSystemPermissions {
-                    Text("Needs Permission", bundle: .module)
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(theme.warningColor)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(theme.warningColor.opacity(0.12))
-                        )
-                }
+                ToolAvailabilityBadge(availability: availability)
             }
             Text(entry.description)
                 .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .lineLimit(1)
+            Text(availability.displayDetail)
+                .font(.system(size: 10))
                 .foregroundColor(theme.tertiaryText)
                 .lineLimit(1)
         }
@@ -1513,6 +1522,10 @@ private struct RemoteToolRow: View {
         return entry.name
     }
 
+    private var availability: ToolAvailability {
+        ToolRegistry.shared.availability(forTool: entry.name)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             ZStack {
@@ -1525,11 +1538,19 @@ private struct RemoteToolRow: View {
             .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(displayName)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundColor(theme.primaryText)
+                HStack(spacing: 4) {
+                    Text(displayName)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+
+                    ToolAvailabilityBadge(availability: availability)
+                }
                 Text(entry.description)
                     .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+                    .lineLimit(1)
+                Text(availability.displayDetail)
+                    .font(.system(size: 10))
                     .foregroundColor(theme.tertiaryText)
                     .lineLimit(1)
             }


### PR DESCRIPTION
## Maintainer status

Ready for maintainer review. This PR is non-draft, merge-clean, and GitHub-green on head `38f3bf65e066844820371be6ac20850658a96fa0`.

## Maintainer rationale

**Business rationale:** Users report tools as unavailable or invisible even when permissions are granted. This PR makes tool and plugin availability understandable, so support can distinguish disabled, permission-blocked, scoped, gated, and loadable states without asking maintainers to inspect internals.

**Coding rationale:** The implementation uses shared reason codes across capability search/load and the existing UI surfaces. It improves diagnostics without bypassing preflight selection or widening default tool exposure.

**Osaurus standards check:** Current-main, function-sized PR; additive diagnostics; no new dependency; no secret-bearing output; narrow default exposure preserved; focused tests plus GitHub CI are green.

## Summary
- add a shared ToolAvailability reason-code model for registered, disabled, scoped, permission-blocked, and loadable tool states
- surface availability diagnostics in capabilities_search and capabilities_load error paths
- show compact availability badges/details in the agent capability picker and tool management rows

## Rebase notes
- cleanly rebased onto origin/main 4dc06e064e0e6497e8667a1b9dd19fadb5f918c8 (Fix Gemma4 chat-template schema normalization (#1357))
- refreshed head: 13fea3baf463f293bd44820bedadffa01229db9a

## Tests
- git diff --check
- bash scripts/i18n/check.sh (passes; existing stale-key warning only)
- xcrun swift-format lint on touched Swift files
- swiftlint lint --quiet on touched Swift files (passes with existing warnings in touched UI files)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-capability-center-rebased-1357 swift test --package-path Packages/OsaurusCore --filter 'CapabilityToolsTests|AgentCapabilityRowBuilderTests|PreflightCapabilitySearchTests|PreflightCompanionsTests|ToolSearchServiceTests|SkillSearchServiceTests|ConfigureToolExposureTests|ContextBudgetPreviewTests|ChatViewSandboxTests' (154 tests)
- swift build --package-path Packages/OsaurusCore -c release
- GitHub CI green on 13fea3ba: test-core, test-cli, swiftlint, shellcheck, release drafter

Refs #647, #789, #823.

## Latest refresh

- Refreshed on June 9, 2026 against `origin/main` `fdc5d210` (`Pin vMLX MiMo routed JANG fix (#1425)`).
- Rebased with one test-file conflict between upstream skill auto-load coverage and this PR disabled-tool availability coverage; kept both tests.
- Force-pushed current head `38f3bf65`.
- Local validation: `git diff --check`; `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-1358 swift test --package-path Packages/OsaurusCore --filter CapabilityToolsTests` (21 tests).
- GitHub CI restarted on the refreshed head; wait for branch checks before merge.