### PR TITLE
Improve Claude plugin marketplace install outcomes

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/InstalledClaudePluginsAggregator.swift
+++ b/Packages/OsaurusCore/Services/Plugin/InstalledClaudePluginsAggregator.swift
@@ -363,6 +363,36 @@ public struct ClaudePluginInstalled: Identifiable, Equatable, Sendable {
 
     public var version: String? { snapshot?.version }
 
+    public var declaredCounts: ClaudePluginArtifactCounts {
+        guard let declared = snapshot?.declaredCounts else { return counts }
+        return ClaudePluginArtifactCounts(
+            skill: declared.skills,
+            schedule: declared.agents,
+            command: declared.commands,
+            mcp: declared.mcp
+        )
+    }
+
+    public var missingDeclaredCounts: ClaudePluginArtifactCounts {
+        let declared = declaredCounts
+        return ClaudePluginArtifactCounts(
+            skill: max(declared.skill - counts.skill, 0),
+            schedule: max(declared.schedule - counts.schedule, 0),
+            command: max(declared.command - counts.command, 0),
+            mcp: max(declared.mcp - counts.mcp, 0)
+        )
+    }
+
+    public var hasPartialImport: Bool { missingDeclaredCounts.total > 0 }
+
+    public var needsPostInstallAttention: Bool {
+        snapshot?.installOutcome?.requiresAttention == true || hasPartialImport
+    }
+
+    public func declaredCount(for kind: ClaudePluginArtifactKind) -> Int {
+        declaredCounts[kind]
+    }
+
     public var hasUpdate: Bool {
         GitHubSkillService.ClaudePluginVersionResolver.hasUpdate(
             installed: snapshot?.version,

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -102,6 +102,9 @@ public struct ClaudePluginInstallReport: Sendable {
         public var importedAgentCount: Int = 0
         public var importedCommandCount: Int = 0
         public var importedMCPProviderCount: Int = 0
+        /// Components declared by the resolved manifest. Kept separate from
+        /// imported counts so the UI can explain skipped or blocked artifacts.
+        public var declaredCounts = ClaudePluginArtifactCounts()
         /// Total co-located asset files (Python helpers, references, etc.)
         /// attached to imported skills.
         public var importedSkillAssetCount: Int = 0
@@ -134,6 +137,16 @@ public struct ClaudePluginInstallReport: Sendable {
         /// UI can deep-link to the editor.
         public var schedulesNeedingCron: [PendingSchedule] = []
         public var errors: [String] = []
+
+        public var attentionItemCount: Int {
+            schedulesNeedingCron.count
+                + skippedStdioMCPServers.count
+                + stdioProvidersNeedingConfiguration.count
+                + stdioProvidersBlockedNoSandbox.count
+                + placeholderTokensSkipped.count
+                + oauthProvidersNeedingSignIn.count
+                + errors.count
+        }
     }
 
     public var perPlugin: [PluginSummary] = []
@@ -172,6 +185,10 @@ public struct ClaudePluginInstallReport: Sendable {
     public var allErrors: [String] {
         perPlugin.flatMap { $0.errors }
     }
+    public var totalAttentionItems: Int {
+        perPlugin.reduce(0) { $0 + $1.attentionItemCount }
+    }
+    public var requiresAttention: Bool { totalAttentionItems > 0 }
 }
 
 // MARK: - Installer
@@ -223,6 +240,12 @@ public final class ClaudePluginInstaller {
             var summary = ClaudePluginInstallReport.PluginSummary(
                 pluginId: pluginId,
                 pluginName: manifest.name
+            )
+            summary.declaredCounts = ClaudePluginArtifactCounts(
+                skill: manifest.skills.count,
+                schedule: manifest.agents.count,
+                command: manifest.commands.count,
+                mcp: manifest.mcpJsonPath == nil ? 0 : 1
             )
 
             // Load any previously persisted user_config so substitutions
@@ -475,6 +498,10 @@ public final class ClaudePluginInstaller {
                 defer { tick() }
                 if let content = fetched.mcpJson {
                     let parsed = MCPJSONParser.parse(content)
+                    summary.declaredCounts.mcp = max(
+                        parsed.servers.count,
+                        summary.declaredCounts.mcp
+                    )
                     // Precompute sandbox availability once per install run so a
                     // batch of stdio servers in the same plugin doesn't kick
                     // off the macOS-version probe N times.
@@ -706,11 +733,12 @@ public final class ClaudePluginInstaller {
                 declaresHooks: manifest.declaresHooks,
                 declaresUnsupportedComponents: manifest.declaresUnsupportedComponents,
                 declaredCounts: ClaudePluginManifestSnapshot.DeclaredCounts(
-                    skills: summary.importedSkillCount,
-                    agents: summary.importedAgentCount,
-                    commands: summary.importedCommandCount,
-                    mcp: summary.importedMCPProviderCount
-                )
+                    skills: summary.declaredCounts.skill,
+                    agents: summary.declaredCounts.schedule,
+                    commands: summary.declaredCounts.command,
+                    mcp: summary.declaredCounts.mcp
+                ),
+                installOutcome: ClaudePluginManifestSnapshot.InstallOutcome(summary: summary)
             )
             ClaudePluginManifestStore.save(snapshot)
 

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginManifestStore.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginManifestStore.swift
@@ -38,6 +38,9 @@ public struct ClaudePluginManifestSnapshot: Codable, Sendable, Hashable {
     public let userConfigSpec: [ClaudePluginUserConfigField]
     public let declaresHooks: Bool
     public let declaresUnsupportedComponents: [String]
+    /// Follow-up state captured from the install report. Optional so snapshots
+    /// written by older Osaurus builds still decode.
+    public let installOutcome: InstallOutcome?
 
     /// Declared artifact counts captured at install. Used to seed the card
     /// before the manager-side counts settle (e.g. on cold launch right
@@ -56,6 +59,75 @@ public struct ClaudePluginManifestSnapshot: Codable, Sendable, Hashable {
             self.commands = commands
             self.mcp = mcp
         }
+    }
+
+    public struct PendingProvider: Codable, Sendable, Hashable {
+        public let name: String
+        public let missingKeys: [String]
+
+        public init(name: String, missingKeys: [String] = []) {
+            self.name = name
+            self.missingKeys = missingKeys
+        }
+    }
+
+    /// Compact install outcome persisted with the manifest snapshot so the
+    /// installed-plugin detail can explain partial imports after app restart.
+    public struct InstallOutcome: Codable, Sendable, Hashable {
+        public let schedulesNeedingCron: [String]
+        public let skippedStdioMCPServers: [String]
+        public let stdioProvidersNeedingConfiguration: [PendingProvider]
+        public let stdioProvidersBlockedNoSandbox: [String]
+        public let placeholderTokensSkipped: [PendingProvider]
+        public let oauthProvidersNeedingSignIn: [String]
+        public let errors: [String]
+
+        public init(
+            schedulesNeedingCron: [String] = [],
+            skippedStdioMCPServers: [String] = [],
+            stdioProvidersNeedingConfiguration: [PendingProvider] = [],
+            stdioProvidersBlockedNoSandbox: [String] = [],
+            placeholderTokensSkipped: [PendingProvider] = [],
+            oauthProvidersNeedingSignIn: [String] = [],
+            errors: [String] = []
+        ) {
+            self.schedulesNeedingCron = schedulesNeedingCron
+            self.skippedStdioMCPServers = skippedStdioMCPServers
+            self.stdioProvidersNeedingConfiguration = stdioProvidersNeedingConfiguration
+            self.stdioProvidersBlockedNoSandbox = stdioProvidersBlockedNoSandbox
+            self.placeholderTokensSkipped = placeholderTokensSkipped
+            self.oauthProvidersNeedingSignIn = oauthProvidersNeedingSignIn
+            self.errors = errors
+        }
+
+        public init(summary: ClaudePluginInstallReport.PluginSummary) {
+            self.init(
+                schedulesNeedingCron: summary.schedulesNeedingCron.map(\.name),
+                skippedStdioMCPServers: summary.skippedStdioMCPServers,
+                stdioProvidersNeedingConfiguration: summary.stdioProvidersNeedingConfiguration
+                    .map {
+                        PendingProvider(name: $0.name, missingKeys: $0.missingKeys)
+                    },
+                stdioProvidersBlockedNoSandbox: summary.stdioProvidersBlockedNoSandbox,
+                placeholderTokensSkipped: summary.placeholderTokensSkipped.map {
+                    PendingProvider(name: $0.name, missingKeys: $0.missingKeys)
+                },
+                oauthProvidersNeedingSignIn: summary.oauthProvidersNeedingSignIn.map(\.name),
+                errors: summary.errors
+            )
+        }
+
+        public var attentionCount: Int {
+            schedulesNeedingCron.count
+                + skippedStdioMCPServers.count
+                + stdioProvidersNeedingConfiguration.count
+                + stdioProvidersBlockedNoSandbox.count
+                + placeholderTokensSkipped.count
+                + oauthProvidersNeedingSignIn.count
+                + errors.count
+        }
+
+        public var requiresAttention: Bool { attentionCount > 0 }
     }
 
     public init(
@@ -79,7 +151,8 @@ public struct ClaudePluginManifestSnapshot: Codable, Sendable, Hashable {
         userConfigSpec: [ClaudePluginUserConfigField] = [],
         declaresHooks: Bool = false,
         declaresUnsupportedComponents: [String] = [],
-        declaredCounts: DeclaredCounts
+        declaredCounts: DeclaredCounts,
+        installOutcome: InstallOutcome? = nil
     ) {
         self.pluginId = pluginId
         self.name = name
@@ -102,6 +175,7 @@ public struct ClaudePluginManifestSnapshot: Codable, Sendable, Hashable {
         self.declaresHooks = declaresHooks
         self.declaresUnsupportedComponents = declaresUnsupportedComponents
         self.declaredCounts = declaredCounts
+        self.installOutcome = installOutcome
     }
 
     /// Convenience GitHub URL pointing at the plugin's source tree. Used

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
@@ -650,7 +650,18 @@ struct ClaudePluginSpecTests {
                 ],
                 declaresHooks: true,
                 declaresUnsupportedComponents: ["channels"],
-                declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1)
+                declaredCounts: .init(skills: 2, agents: 1, commands: 0, mcp: 1),
+                installOutcome: .init(
+                    schedulesNeedingCron: ["Renewals:Weekly Review"],
+                    stdioProvidersNeedingConfiguration: [
+                        .init(name: "local-crm", missingKeys: ["CRM_TOKEN"])
+                    ],
+                    placeholderTokensSkipped: [
+                        .init(name: "vault", missingKeys: ["Authorization"])
+                    ],
+                    oauthProvidersNeedingSignIn: ["notion"],
+                    errors: ["skill renewals/skills/audit: missing SKILL.md"]
+                )
             )
 
             #expect(ClaudePluginManifestStore.save(snap) == true)
@@ -658,6 +669,81 @@ struct ClaudePluginSpecTests {
             #expect(loaded != nil)
             #expect(loaded == snap)
         }
+    }
+
+    /// Snapshots written before install outcome persistence did not contain the
+    /// optional `installOutcome` key. They must keep loading so existing users
+    /// don't lose installed Claude plugin cards after upgrade.
+    @Test func manifestStoreLoadsLegacySnapshotWithoutInstallOutcome() async {
+        await Self.withIsolatedRoot(label: "manifest-store-legacy-outcome") { _ in
+            let pluginId = "github:o/r/legacy"
+            let json = #"""
+                {
+                  "pluginId" : "github:o/r/legacy",
+                  "name" : "legacy",
+                  "displayName" : "Legacy",
+                  "sourceOwner" : "o",
+                  "sourceRepo" : "r",
+                  "installedAt" : "2023-11-14T22:13:20Z",
+                  "keywords" : [],
+                  "userConfigSpec" : [],
+                  "declaresHooks" : false,
+                  "declaresUnsupportedComponents" : [],
+                  "declaredCounts" : {
+                    "skills" : 1,
+                    "agents" : 0,
+                    "commands" : 0,
+                    "mcp" : 0
+                  }
+                }
+                """#
+            let file = OsaurusPaths.claudePluginManifestFile(for: pluginId)
+            OsaurusPaths.ensureExistsSilent(file.deletingLastPathComponent())
+            try? Data(json.utf8).write(to: file)
+
+            let loaded = ClaudePluginManifestStore.load(pluginId: pluginId)
+            #expect(loaded?.displayName == "Legacy")
+            #expect(loaded?.installOutcome == nil)
+            #expect(loaded?.declaredCounts.skills == 1)
+        }
+    }
+
+    /// The install outcome snapshot keeps names and missing-key hints from the
+    /// live install report without persisting provider ids that can change
+    /// across restarts.
+    @Test func installOutcomeCapturesReportFollowUps() {
+        var summary = ClaudePluginInstallReport.PluginSummary(
+            pluginId: "github:o/r/p",
+            pluginName: "p"
+        )
+        summary.schedulesNeedingCron = [
+            .init(id: UUID(), name: "p:Daily Agent")
+        ]
+        summary.skippedStdioMCPServers = ["broken"]
+        summary.stdioProvidersNeedingConfiguration = [
+            .init(id: UUID(), name: "stdio", missingKeys: ["API_KEY"])
+        ]
+        summary.stdioProvidersBlockedNoSandbox = ["local-shell"]
+        summary.placeholderTokensSkipped = [
+            .init(id: UUID(), name: "remote", missingKeys: ["Authorization"])
+        ]
+        summary.oauthProvidersNeedingSignIn = [
+            .init(id: UUID(), name: "notion")
+        ]
+        summary.errors = ["command p/commands/run.md: 404"]
+
+        let outcome = ClaudePluginManifestSnapshot.InstallOutcome(summary: summary)
+
+        #expect(outcome.requiresAttention)
+        #expect(outcome.attentionCount == 7)
+        #expect(outcome.schedulesNeedingCron == ["p:Daily Agent"])
+        #expect(outcome.skippedStdioMCPServers == ["broken"])
+        #expect(outcome.stdioProvidersNeedingConfiguration.first?.name == "stdio")
+        #expect(
+            outcome.stdioProvidersNeedingConfiguration.first?.missingKeys == ["API_KEY"]
+        )
+        #expect(outcome.oauthProvidersNeedingSignIn == ["notion"])
+        #expect(outcome.errors == ["command p/commands/run.md: 404"])
     }
 
     /// `all()` should sort by displayName and tolerate corrupt files —
@@ -977,6 +1063,46 @@ struct ClaudePluginSpecTests {
         #expect(p.commands == [])
         #expect(p.mcps == [])
         #expect(p.counts.total == 0)
+    }
+
+    /// Declared counts from the manifest snapshot are separate from live
+    /// imported counts. This lets the installed detail flag partial imports
+    /// such as MCP providers skipped because they need OAuth, env vars, or a
+    /// sandbox that is unavailable on the current machine.
+    @Test func aggregatorFlagsPartialImportFromDeclaredCounts() {
+        let pluginId = "github:owner/repo/partial"
+        let snapshot = ClaudePluginManifestSnapshot(
+            pluginId: pluginId,
+            name: "partial",
+            displayName: "Partial",
+            description: nil,
+            version: nil,
+            sourceOwner: "owner",
+            sourceRepo: "repo",
+            installedAt: Date(),
+            declaredCounts: .init(skills: 1, agents: 0, commands: 0, mcp: 2),
+            installOutcome: .init(
+                skippedStdioMCPServers: ["broken"],
+                oauthProvidersNeedingSignIn: ["notion"]
+            )
+        )
+
+        let result = InstalledClaudePluginsAggregator.buildPlugins(
+            snapshots: [snapshot],
+            skills: [Skill(name: "Imported", pluginId: pluginId)],
+            schedules: [],
+            commands: [],
+            providers: []
+        )
+
+        #expect(result.count == 1)
+        let plugin = result[0]
+        #expect(plugin.counts.skill == 1)
+        #expect(plugin.counts.mcp == 0)
+        #expect(plugin.declaredCounts.mcp == 2)
+        #expect(plugin.missingDeclaredCounts.mcp == 2)
+        #expect(plugin.hasPartialImport)
+        #expect(plugin.needsPostInstallAttention)
     }
 
     // MARK: - Helpers

--- a/Packages/OsaurusCore/Views/Plugin/ClaudePluginCard.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudePluginCard.swift
@@ -133,6 +133,12 @@ struct ClaudePluginCard: View {
     private var statusBadge: some View {
         if plugin.hasUpdate {
             StatusCapsuleBadge(icon: "arrow.up.circle.fill", text: "Update", color: .orange)
+        } else if plugin.needsPostInstallAttention {
+            StatusCapsuleBadge(
+                icon: "exclamationmark.circle.fill",
+                text: "Needs setup",
+                color: .orange
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Views/Plugin/ClaudePluginDetailView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudePluginDetailView.swift
@@ -61,6 +61,10 @@ struct ClaudePluginDetailView: View {
                         userConfigBanner(onConfigure: onConfigure)
                     }
 
+                    if plugin.needsPostInstallAttention {
+                        installOutcomeNotice
+                    }
+
                     if let snap = snapshot, !snap.keywords.isEmpty {
                         keywordsSection(snap.keywords)
                     }
@@ -327,6 +331,120 @@ struct ClaudePluginDetailView: View {
         )
     }
 
+    private var installOutcomeNotice: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.circle")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.warningColor)
+                Text("Import needs attention", bundle: .module)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+            }
+            Text(
+                "Some declared components require setup, sign-in, or were skipped during import.",
+                bundle: .module
+            )
+            .font(.system(size: 11.5))
+            .foregroundColor(theme.secondaryText)
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(installOutcomeMessages, id: \.self) { message in
+                    Text("• \(message)")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.warningColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.warningColor.opacity(0.2), lineWidth: 1)
+                )
+        )
+    }
+
+    private var installOutcomeMessages: [String] {
+        var messages: [String] = []
+        if let outcome = snapshot?.installOutcome {
+            messages.append(
+                contentsOf: outcome.schedulesNeedingCron.map {
+                    "Schedule needs review: \($0)"
+                }
+            )
+            messages.append(
+                contentsOf: outcome.stdioProvidersNeedingConfiguration.map {
+                    providerMessage(
+                        prefix: "Stdio MCP needs env vars",
+                        provider: $0
+                    )
+                }
+            )
+            messages.append(
+                contentsOf: outcome.placeholderTokensSkipped.map {
+                    providerMessage(
+                        prefix: "MCP needs token",
+                        provider: $0
+                    )
+                }
+            )
+            messages.append(
+                contentsOf: outcome.oauthProvidersNeedingSignIn.map {
+                    "OAuth sign-in required: \($0)"
+                }
+            )
+            messages.append(
+                contentsOf: outcome.stdioProvidersBlockedNoSandbox.map {
+                    "Stdio MCP skipped, sandbox unavailable: \($0)"
+                }
+            )
+            messages.append(
+                contentsOf: outcome.skippedStdioMCPServers.map {
+                    "MCP entry skipped: \($0)"
+                }
+            )
+            messages.append(contentsOf: outcome.errors.map { "Install error: \($0)" })
+        }
+
+        if messages.isEmpty, plugin.hasPartialImport {
+            let missing = plugin.missingDeclaredCounts
+            if missing.skill > 0 {
+                messages.append("\(missing.skill) skill\(missing.skill == 1 ? "" : "s") declared but not imported")
+            }
+            if missing.schedule > 0 {
+                messages.append(
+                    "\(missing.schedule) schedule\(missing.schedule == 1 ? "" : "s") declared but not imported"
+                )
+            }
+            if missing.command > 0 {
+                messages.append(
+                    "\(missing.command) command\(missing.command == 1 ? "" : "s") declared but not imported"
+                )
+            }
+            if missing.mcp > 0 {
+                messages.append("\(missing.mcp) MCP provider\(missing.mcp == 1 ? "" : "s") declared but not imported")
+            }
+        }
+
+        return messages.isEmpty
+            ? ["Declared components differ from imported artifacts."]
+            : messages
+    }
+
+    private func providerMessage(
+        prefix: String,
+        provider: ClaudePluginManifestSnapshot.PendingProvider
+    ) -> String {
+        guard !provider.missingKeys.isEmpty else {
+            return "\(prefix): \(provider.name)"
+        }
+        return "\(prefix): \(provider.name) (\(provider.missingKeys.joined(separator: ", ")))"
+    }
+
     private func keywordsSection(_ keywords: [String]) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             sectionHeader(title: "Keywords", icon: "tag")
@@ -442,15 +560,29 @@ struct ClaudePluginDetailView: View {
     /// have none.
     @ViewBuilder
     private func groupEmptyPlaceholder(kind: ClaudePluginArtifactKind) -> some View {
-        let message: LocalizedStringKey = {
-            switch kind {
-            case .skill: return "No skills shipped with this plugin."
-            case .schedule: return "No schedules shipped with this plugin."
-            case .command: return "No slash commands shipped with this plugin."
-            case .mcp: return "No MCP providers shipped with this plugin."
+        let message: String = {
+            let declared = plugin.declaredCount(for: kind)
+            if declared > 0 {
+                switch kind {
+                case .skill:
+                    return "No skills imported; \(declared) declared."
+                case .schedule:
+                    return "No schedules imported; \(declared) declared."
+                case .command:
+                    return "No slash commands imported; \(declared) declared."
+                case .mcp:
+                    return "No MCP providers imported; \(declared) declared."
+                }
+            } else {
+                switch kind {
+                case .skill: return "No skills shipped with this plugin."
+                case .schedule: return "No schedules shipped with this plugin."
+                case .command: return "No slash commands shipped with this plugin."
+                case .mcp: return "No MCP providers shipped with this plugin."
+                }
             }
         }()
-        Text(message, bundle: .module)
+        Text(message)
             .font(.system(size: 11).italic())
             .foregroundColor(theme.tertiaryText)
             .padding(.leading, 4)

--- a/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/PluginsView.swift
@@ -372,11 +372,15 @@ struct PluginsView: View {
             let total =
                 report.totalImportedSkills + report.totalImportedAgents
                 + report.totalImportedCommands + report.totalImportedMCPProviders
-            showSuccess(
+            let baseMessage =
                 total > 0
-                    ? L("Installed \(total) items from \(entry.name)")
-                    : L("Installed \(entry.name)")
-            )
+                ? L("Installed \(total) items from \(entry.name)")
+                : L("Installed \(entry.name)")
+            let message =
+                report.requiresAttention
+                ? "\(baseMessage); \(report.totalAttentionItems) need review"
+                : baseMessage
+            showSuccess(message)
         }
     }
 

--- a/docs/CLAUDE_PLUGINS.md
+++ b/docs/CLAUDE_PLUGINS.md
@@ -52,7 +52,7 @@ All fetches are gated through a shared concurrency limiter (8 in-flight at a tim
 
 ### Not Imported
 
-- **Stdio MCP servers** — Osaurus's remote MCP transport is HTTP/SSE only. Stdio entries in `.mcp.json` are listed in the install summary as "skipped"; configure them manually if needed.
+- **Stdio MCP servers without sandbox support** — stdio entries are imported disabled into the Osaurus sandbox when available. If the sandbox is unavailable, they are listed in the install summary as skipped.
 - **Skill-local scripts at run time** — Python helpers and similar are attached so the operator can read or re-use them, but Osaurus does not execute them; the agent reads the source text only.
 - **Hooks** — Claude Code-style hook scripts are ignored.
 
@@ -178,7 +178,7 @@ After install, the sheet shows a per-plugin summary including:
 - **Schedules needing cron** — agent markdown files where no recurrence could be inferred. Click a row to deep-link into the schedule editor with the cron field focused.
 - **MCP providers with placeholder tokens** — when `.mcp.json` uses `${VAR}`, `$VAR`, or `<token>` style env references, the provider is created without a token. Paste a real one in Management → Providers before enabling.
 - **MCP servers needing OAuth sign-in** — `.mcp.json` entries with an `oauth` block (e.g. Slack, Notion in `anthropics/knowledge-work-plugins`) are imported with `authType: .oauth` and the declared `clientId` + `callbackPort` pre-populated. Open Management → Providers and click "Sign in" on each one before enabling.
-- **Skipped stdio MCP servers** — listed for manual configuration.
+- **Skipped stdio / malformed MCP entries** — listed with names so the user can tell which components did not land.
 - **Errors** — any per-artifact failures (one bad skill does not abort the import).
 
 ---
@@ -214,11 +214,13 @@ Imported Claude plugins render as cards in the **Plugins → Installed** grid al
 - Display name, optional version pill, and an `Imported` badge
 - Per-artifact chips for skill / schedule / command / MCP counts (live from the underlying managers)
 - An `Update` capsule when the source's `plugin.json.version` (or marketplace entry / source SHA) is newer than what's installed
+- A `Needs setup` capsule when the last install recorded follow-up work or declared component counts exceed the live imported artifacts
 - Ellipsis menu: **View Details**, **Open on GitHub**, **Configure Settings…** (when `userConfig` is declared), **Update** (when newer), **Uninstall**
 
 Tapping a card opens **Claude Plugin Detail** with the full hero (icon, displayName, version, license, author/homepage/repository badges, description), keyword chips, per-artifact list (skills, schedules, slash commands, MCP servers with inline Restart for stdio servers), a **CHANGELOG** section fetched lazily from `<source>/CHANGELOG.md`, and external link badges. The same view exposes:
 
 - A **Configure plugin settings** action that re-opens the userConfig sheet.
+- An **Import needs attention** banner persisted from the last install report, including skipped MCP names, OAuth sign-in needs, placeholder-token/env-var setup, install errors, and declared-but-not-imported component counts.
 - A "components declared but not yet honored" notice for unsupported manifest sections (hooks, output styles, monitors, themes, channels, LSP servers).
 
 Uninstalling a plugin removes the corresponding skills, schedules, slash commands, and MCP providers in one shot, including any Keychain-stored MCP tokens, the persisted manifest snapshot, the per-plugin userConfig file, the cache directory, and the per-plugin `${CLAUDE_PLUGIN_DATA}` directory.
@@ -280,7 +282,7 @@ The installer reads `.mcp.json` and classifies each server entry:
 | `{ url, env: { API_KEY: "${VAR}" } }`                    | No-auth provider, flagged as needing token   |
 | `{ url, oauth: { clientId, callbackPort } }`             | OAuth provider (`authType: .oauth`), disabled, flagged as needing sign-in |
 | `{ url: "" }` (placeholder)                              | Skipped (manual setup)                       |
-| `{ command, args }` (stdio)                              | Skipped (manual setup)                       |
+| `{ command, args }` (stdio)                              | Disabled sandbox stdio provider when sandbox is available; otherwise skipped |
 
 For OAuth providers, the declared `clientId` and a `http://127.0.0.1:<callbackPort>/callback` `redirectURI` are stashed on the provider so the existing MCP OAuth service can complete the discovery + Dynamic Client Registration + PKCE handshake when the user clicks "Sign in". The provider stays disabled until that completes.
 


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Claude plugin import failures are hard to explain to users because skipped artifacts, config-required pieces, and installed status are not obvious. This PR turns marketplace/import outcomes into visible state so maintainers can support plugin installs without guesswork.

**Coding rationale:** The change builds on `ClaudeMarketplaceService`, `ClaudePluginInstaller`, and `InstalledClaudePluginsAggregator`, persisting installer outcomes instead of inventing a parallel plugin model.

**Osaurus standards check:** Current-main, function-sized PR; additive state/reporting; no default tool exposure expansion; OAuth/config-required components stay explicit; focused tests plus GitHub CI are green.

## Summary

Improves Claude plugin marketplace reliability by making partial imports and post-install setup durable and visible after restart.

The installer persists a compact install outcome snapshot with each Claude plugin manifest, separates declared component counts from imported counts, and lets the Installed Plugins UI explain why a plugin needs follow-up setup instead of silently showing missing components.

Related: #793

## What changed

- Persisted install outcomes for schedules needing review, skipped stdio/malformed MCP entries, stdio env-var setup, OAuth sign-in, placeholder-token setup, sandbox-unavailable stdio providers, and install errors.
- Separated declared manifest counts from live imported counts so partial imports can be diagnosed after app restart.
- Added `Needs setup` card status and an `Import needs attention` detail banner for imported Claude plugins.
- Updated empty component copy to distinguish `not shipped` from `declared but not imported`.
- Updated Claude plugin docs for current stdio MCP and marketplace outcome behavior.

## Rebase notes

- Cleanly rebased onto origin/main 4dc06e064e0e6497e8667a1b9dd19fadb5f918c8.
- Refreshed head: 5fb6db95fbc5fa571bcbfdbf662979301372ca02.

## Validation

- git diff --check
- bash scripts/i18n/check.sh (passes; existing stale-key warning only)
- xcrun swift-format lint on touched Swift files
- swiftlint lint --quiet on touched Swift files (passes with existing warnings in touched plugin files)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-claude-marketplace-rebased swift test --package-path Packages/OsaurusCore --filter 'ClaudePluginSpecTests|ClaudePluginInstallerTests' (82 tests)
- swift build --package-path Packages/OsaurusCore -c release
- GitHub CI green on 5fb6db95: test-core, test-cli, swiftlint, shellcheck, release drafter

## Regression and performance notes

- Legacy snapshots without `installOutcome` still decode.
- No new network calls or dependencies.
- Snapshot writes still happen through the existing manifest-store path.
- UI work is derived from already-loaded snapshot arrays and simple counts.
- Persisted follow-up data contains names and missing key labels, not secret values.

## Rollback

Revert this PR. Snapshots written with the optional `installOutcome` field remain backward-compatible with older decoders that ignore unknown JSON fields.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `95c55bed` (`Pin vMLX runtime cache parser fixes (#1405)`).
- Rebased cleanly and force-pushed current head `3a68b16a1dfc`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
