### PR TITLE
[codex] Add provider/auth/network diagnostics

### DIFF
--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -497,7 +497,7 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         // Create temporary transport
-        let configuration = URLSessionConfiguration.default
+        let configuration = GlobalProxySettings.makeConfiguration(base: .default)
         var allHeaders: [String: String] = headers
         if let token = token, !token.isEmpty {
             allHeaders["Authorization"] = "Bearer \(token)"
@@ -672,7 +672,7 @@ public final class MCPProviderManager: ObservableObject {
             throw MCPProviderError.invalidURL
         }
 
-        let urlConfig = URLSessionConfiguration.default
+        let urlConfig = GlobalProxySettings.makeConfiguration(base: .default)
 
         // Build headers
         var headers = provider.resolvedHeaders()
@@ -769,7 +769,7 @@ public final class MCPProviderManager: ObservableObject {
         request.timeoutInterval = 10
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await GlobalProxySettings.sharedSession().data(for: request)
             guard let http = response as? HTTPURLResponse else { return nil }
             guard http.statusCode == 401 || http.statusCode == 403 else { return nil }
             let header =

--- a/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
+++ b/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
@@ -54,6 +54,13 @@ public enum GlobalProxySettings {
         configuration(from: diskBackedServerConfiguration())
     }
 
+    /// Human-readable state for settings and provider diagnostics. Unlike
+    /// `currentConfiguration()`, this distinguishes "not configured" from
+    /// "configured but invalid and therefore ignored."
+    public static func currentDiagnostic() -> GlobalProxyDiagnosticState {
+        diagnostic(from: diskBackedServerConfiguration())
+    }
+
     /// Shape a copied session configuration with the current proxy endpoint.
     public static func makeConfiguration(
         base: URLSessionConfiguration = .default
@@ -92,6 +99,26 @@ public enum GlobalProxySettings {
         return try? GlobalProxyConfiguration(urlString: rawURL)
     }
 
+    /// Testable adapter from persisted settings to a copyable diagnostic row.
+    public static func diagnostic(from serverConfiguration: ServerConfiguration?) -> GlobalProxyDiagnosticState {
+        guard
+            let rawURL = serverConfiguration?.globalProxyURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawURL.isEmpty
+        else {
+            return .disabled
+        }
+
+        do {
+            let proxy = try GlobalProxyConfiguration(urlString: rawURL)
+            return .active(proxy.redactedDescription)
+        } catch {
+            let reason =
+                (error as? LocalizedError)?.errorDescription
+                ?? "Proxy URL could not be validated."
+            return .invalid(reason)
+        }
+    }
+
     /// Network services are frequently initialized off the main actor, while
     /// `ServerConfigurationStore` is main-actor isolated because it is also
     /// used by SwiftUI state. Reading the same JSON file directly keeps
@@ -104,4 +131,11 @@ public enum GlobalProxySettings {
         guard let data = try? Data(contentsOf: url) else { return nil }
         return try? JSONDecoder().decode(ServerConfiguration.self, from: data)
     }
+}
+
+/// Safe, display-oriented summary of the persisted global proxy setting.
+public enum GlobalProxyDiagnosticState: Equatable, Sendable {
+    case disabled
+    case active(String)
+    case invalid(String)
 }

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -1,0 +1,625 @@
+//
+//  ProviderNetworkDiagnostics.swift
+//  osaurus
+//
+//  Human-readable diagnostics for inference providers, MCP providers, and the
+//  shared network policy they depend on.
+//
+
+import Foundation
+
+/// Severity used by provider diagnostics rows. The raw values are stable so
+/// tests and copied reports can reason about status without parsing UI text.
+public enum ProviderDiagnosticSeverity: String, Codable, Sendable, Equatable {
+    case ok
+    case info
+    case warning
+    case blocked
+}
+
+/// One safe-to-display provider diagnostic row.
+public struct ProviderDiagnosticRow: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let value: String
+    public let detail: String?
+    public let action: String?
+    public let severity: ProviderDiagnosticSeverity
+
+    public init(
+        id: String,
+        title: String,
+        value: String,
+        severity: ProviderDiagnosticSeverity,
+        detail: String? = nil,
+        action: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.value = value
+        self.detail = detail
+        self.action = action
+        self.severity = severity
+    }
+}
+
+/// A copyable diagnostics snapshot for one provider row.
+public struct ProviderDiagnosticReport: Sendable, Equatable {
+    public let title: String
+    public let subtitle: String
+    public let rows: [ProviderDiagnosticRow]
+
+    public init(title: String, subtitle: String, rows: [ProviderDiagnosticRow]) {
+        self.title = title
+        self.subtitle = subtitle
+        self.rows = rows
+    }
+
+    /// Pasteboard text intentionally contains status and hints, but never raw
+    /// credential values, request bodies, callback URLs, or provider headers.
+    public var pasteboardText: String {
+        var lines = [
+            title,
+            subtitle,
+        ]
+        lines.append(
+            contentsOf: rows.map { row in
+                var line = "[\(row.severity.rawValue)] \(row.title): \(row.value)"
+                if let detail = row.detail, !detail.isEmpty {
+                    line += " - \(detail)"
+                }
+                if let action = row.action, !action.isEmpty {
+                    line += " Action: \(action)"
+                }
+                return line
+            }
+        )
+        return lines.joined(separator: "\n")
+    }
+}
+
+/// Builds provider diagnostics from existing configuration/state so UI, tests,
+/// and support docs all describe the same behavior.
+public enum ProviderNetworkDiagnostics {
+    public static func remoteProviderReport(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        apiKeyPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticReport {
+        ProviderDiagnosticReport(
+            title: "Remote provider diagnostics",
+            subtitle: "\(provider.name) | \(provider.displayEndpoint)",
+            rows: [
+                remoteStateRow(provider: provider, state: state),
+                remoteAuthRow(
+                    provider: provider,
+                    state: state,
+                    apiKeyPresent: apiKeyPresent,
+                    oauthTokensPresent: oauthTokensPresent
+                ),
+                remoteModelDiscoveryRow(provider: provider),
+                remoteRequestFormatRow(provider: provider),
+                proxyRow(proxy, appliesTo: "Remote provider requests"),
+            ]
+        )
+    }
+
+    public static func mcpProviderReport(
+        provider: MCPProvider,
+        state: MCPProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        bearerTokenPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticReport {
+        ProviderDiagnosticReport(
+            title: "MCP provider diagnostics",
+            subtitle: "\(provider.name) | \(mcpEndpointSubtitle(for: provider))",
+            rows: [
+                mcpStateRow(provider: provider, state: state),
+                mcpAuthRow(
+                    provider: provider,
+                    state: state,
+                    bearerTokenPresent: bearerTokenPresent,
+                    oauthTokensPresent: oauthTokensPresent
+                ),
+                mcpTransportRow(provider: provider),
+                mcpProxyRow(provider: provider, proxy: proxy),
+                mcpFailureReproRow(provider: provider, state: state),
+            ]
+        )
+    }
+
+    // MARK: - Remote Providers
+
+    private static func remoteStateRow(
+        provider: RemoteProvider,
+        state: RemoteProviderState?
+    ) -> ProviderDiagnosticRow {
+        guard provider.enabled else {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Disabled",
+                severity: .warning,
+                detail: "Osaurus will not auto-connect this provider while the row toggle is off.",
+                action: "Enable the provider before testing or selecting its models."
+            )
+        }
+
+        if state?.isConnecting == true {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Connecting",
+                severity: .info,
+                detail: "A bounded model-discovery request is in flight."
+            )
+        }
+
+        if state?.isConnected == true {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Connected",
+                severity: .ok,
+                detail: "\(state?.modelCount ?? 0) model(s) currently available."
+            )
+        }
+
+        if let error = state?.lastError, !error.isEmpty {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Failed",
+                severity: .blocked,
+                detail: safeDiagnostic(error),
+                action: "Use the Test button or copy diagnostics when reporting the issue."
+            )
+        }
+
+        return ProviderDiagnosticRow(
+            id: "connection",
+            title: "Connection",
+            value: "Not connected",
+            severity: .info,
+            detail: "The provider is configured but has not completed model discovery yet."
+        )
+    }
+
+    private static func remoteAuthRow(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        apiKeyPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticRow {
+        switch provider.authType {
+        case .none:
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "None",
+                severity: .info,
+                detail: "No Authorization header is added by Osaurus."
+            )
+        case .apiKey:
+            if apiKeyPresent {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "API key in Keychain",
+                    severity: .ok,
+                    detail: "The saved key is injected using the provider-specific header."
+                )
+            }
+            if hasCredentialHeader(provider) {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "Credential header configured",
+                    severity: .ok,
+                    detail: "A regular or secret credential header is configured for this provider."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "Missing API key",
+                severity: .blocked,
+                detail: state?.lastError.map(safeDiagnostic),
+                action: "Edit the provider and save an API key or secret Authorization header."
+            )
+        case .openAICodexOAuth:
+            if oauthTokensPresent {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "ChatGPT signed in",
+                    severity: .ok,
+                    detail: "Codex OAuth tokens are present and refreshed before model discovery."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "ChatGPT sign-in required",
+                severity: .blocked,
+                detail: state?.lastError.map(safeDiagnostic)
+                    ?? "No Codex OAuth tokens are saved for this provider.",
+                action: "Sign in with the ChatGPT account that has Codex access."
+            )
+        case .xaiOAuth:
+            if oauthTokensPresent {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "xAI signed in",
+                    severity: .ok,
+                    detail: "xAI OAuth tokens are present and refreshed before model discovery."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "xAI sign-in required",
+                severity: .blocked,
+                detail: state?.lastError.map(safeDiagnostic)
+                    ?? "No xAI OAuth tokens are saved for this provider.",
+                action: "Sign in with the xAI account that has Grok API access."
+            )
+        }
+    }
+
+    private static func remoteModelDiscoveryRow(provider: RemoteProvider) -> ProviderDiagnosticRow {
+        guard let modelsURL = provider.url(for: provider.providerType.modelsEndpoint) else {
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: "Invalid URL",
+                severity: .blocked,
+                detail: "Host, port, or base path could not be converted into a /models URL.",
+                action: "Edit the endpoint fields and test again."
+            )
+        }
+
+        switch provider.providerType {
+        case .openAICodex:
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: "ChatGPT/Codex catalog",
+                severity: .info,
+                detail:
+                    "Uses the live ChatGPT model catalog after sign-in, with the static Codex fallback before sign-in."
+            )
+        case .azureOpenAI:
+            let hasManual = !provider.mergedModelIds(discovered: []).isEmpty
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: hasManual ? "Manual deployments" : "/models probe",
+                severity: hasManual ? .ok : .warning,
+                detail: hasManual
+                    ? "Azure deployment IDs are configured, so connect can proceed even when /models is unavailable."
+                    : "Azure often requires manual deployment IDs because /models may be unavailable.",
+                action: hasManual ? nil : "Add at least one deployment/model ID in Advanced."
+            )
+        case .openaiLegacy, .openResponses:
+            let manual = provider.mergedModelIds(discovered: [])
+            let detail =
+                manual.isEmpty
+                ? "Requires \(modelsURL.absoluteString) to return an OpenAI-shaped model list."
+                : "Manual IDs are used if /models is missing or returns a non-OpenAI schema."
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: manual.isEmpty ? "/models required" : "Fallback available",
+                severity: manual.isEmpty ? .info : .ok,
+                detail: detail
+            )
+        case .anthropic:
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: "Anthropic /models",
+                severity: .info,
+                detail: "Uses Anthropic's paginated model catalog endpoint."
+            )
+        case .gemini:
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: "Gemini model list",
+                severity: .info,
+                detail: "Filters the Gemini catalog to models that support generateContent."
+            )
+        case .osaurus:
+            return ProviderDiagnosticRow(
+                id: "models",
+                title: "Model discovery",
+                value: "Remote Osaurus",
+                severity: .info,
+                detail: "Tries the remote /models endpoint, then falls back to the agent default model."
+            )
+        }
+    }
+
+    private static func remoteRequestFormatRow(provider: RemoteProvider) -> ProviderDiagnosticRow {
+        ProviderDiagnosticRow(
+            id: "format",
+            title: "Request format",
+            value: "\(provider.providerType.displayName) \(provider.providerType.chatEndpoint)",
+            severity: .info,
+            detail:
+                "Local OpenAI-compatible validation returns typed 400 errors for unsupported sampler fields such as n > 1 or response_format=json_schema."
+        )
+    }
+
+    // MARK: - MCP Providers
+
+    private static func mcpStateRow(provider: MCPProvider, state: MCPProviderState?) -> ProviderDiagnosticRow {
+        guard provider.enabled else {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Disabled",
+                severity: .warning,
+                detail: "Osaurus will not auto-connect this MCP provider while the row toggle is off."
+            )
+        }
+        if state?.isConnecting == true {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Connecting",
+                severity: .info,
+                detail: "Tool discovery is running with a \(Int(provider.discoveryTimeout))s timeout."
+            )
+        }
+        if state?.isConnected == true {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Connected",
+                severity: .ok,
+                detail: "\(state?.discoveredToolCount ?? 0) tool(s) discovered."
+            )
+        }
+        if state?.requiresAuth == true {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Auth required",
+                severity: .blocked,
+                detail: state?.lastError.map(safeDiagnostic),
+                action: "Use the inline Sign In or token prompt."
+            )
+        }
+        if let error = state?.lastError, !error.isEmpty {
+            return ProviderDiagnosticRow(
+                id: "connection",
+                title: "Connection",
+                value: "Failed",
+                severity: .blocked,
+                detail: safeDiagnostic(error),
+                action: "Use the Test button in Edit to reproduce the failure."
+            )
+        }
+        return ProviderDiagnosticRow(
+            id: "connection",
+            title: "Connection",
+            value: "Not connected",
+            severity: .info,
+            detail: "The provider is configured but no tools are registered yet."
+        )
+    }
+
+    private static func mcpAuthRow(
+        provider: MCPProvider,
+        state: MCPProviderState?,
+        bearerTokenPresent: Bool,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticRow {
+        switch provider.authType {
+        case .none:
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "None",
+                severity: .info,
+                detail: "No Authorization header is added by Osaurus."
+            )
+        case .bearerToken:
+            if bearerTokenPresent || hasMCPHeaderCredential(provider) {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "Bearer credential configured",
+                    severity: .ok,
+                    detail: "The token or secret header is stored outside plain provider config."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: state?.requiresAuth == true ? "Token required" : "No token saved",
+                severity: state?.requiresAuth == true ? .blocked : .warning,
+                detail: state?.lastError.map(safeDiagnostic),
+                action: "Paste an API token in the inline prompt or edit the provider."
+            )
+        case .oauth:
+            if oauthTokensPresent {
+                return ProviderDiagnosticRow(
+                    id: "auth",
+                    title: "Authentication",
+                    value: "OAuth tokens saved",
+                    severity: .ok,
+                    detail: "Tokens are refreshed before HTTP MCP discovery."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "auth",
+                title: "Authentication",
+                value: "OAuth sign-in required",
+                severity: state?.requiresAuth == true ? .blocked : .warning,
+                detail: state?.lastError.map(safeDiagnostic)
+                    ?? "No OAuth tokens are saved for this provider.",
+                action: "Sign in from the provider row."
+            )
+        }
+    }
+
+    private static func mcpTransportRow(provider: MCPProvider) -> ProviderDiagnosticRow {
+        switch provider.transport {
+        case .http:
+            return ProviderDiagnosticRow(
+                id: "transport",
+                title: "Transport",
+                value: provider.streamingEnabled ? "HTTP/SSE" : "HTTP",
+                severity: .info,
+                detail: "Discovery and tool calls use URLSession with the global proxy policy applied."
+            )
+        case .stdio:
+            let command = provider.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            if command.isEmpty {
+                return ProviderDiagnosticRow(
+                    id: "transport",
+                    title: "Transport",
+                    value: "Stdio command missing",
+                    severity: .blocked,
+                    detail: "A stdio MCP provider needs a command before it can launch.",
+                    action: "Edit the provider and enter the executable."
+                )
+            }
+            return ProviderDiagnosticRow(
+                id: "transport",
+                title: "Transport",
+                value: "Stdio \(provider.executionHost.rawValue)",
+                severity: provider.executionHost == .host ? .warning : .ok,
+                detail: provider.executionHost == .host
+                    ? "Runs directly on the macOS host. Prefer full executable paths for GUI-launched apps."
+                    : "Runs inside the Osaurus sandbox and is torn down on disconnect."
+            )
+        }
+    }
+
+    private static func mcpProxyRow(
+        provider: MCPProvider,
+        proxy: GlobalProxyDiagnosticState
+    ) -> ProviderDiagnosticRow {
+        switch provider.transport {
+        case .http:
+            return proxyRow(proxy, appliesTo: "MCP HTTP/SSE requests")
+        case .stdio:
+            return ProviderDiagnosticRow(
+                id: "proxy",
+                title: "Global proxy",
+                value: "Not used for stdio",
+                severity: .info,
+                detail: "Stdio providers launch a local subprocess instead of sending HTTP traffic through URLSession."
+            )
+        }
+    }
+
+    private static func mcpFailureReproRow(
+        provider: MCPProvider,
+        state: MCPProviderState?
+    ) -> ProviderDiagnosticRow {
+        if let error = state?.lastError, !error.isEmpty {
+            let commandMissing = MCPStdioTransportError.isCommandNotFoundMessage(error)
+            return ProviderDiagnosticRow(
+                id: "repro",
+                title: "Repro path",
+                value: commandMissing ? "PATH issue" : "Copyable error",
+                severity: .warning,
+                detail: safeDiagnostic(error),
+                action: commandMissing
+                    ? "Use a full path such as /opt/homebrew/bin/npx or switch execution host."
+                    : "Open Edit and press Test to reproduce discovery without saving."
+            )
+        }
+        if provider.transport == .stdio {
+            return ProviderDiagnosticRow(
+                id: "repro",
+                title: "Repro path",
+                value: "Short-lived stdio probe",
+                severity: .info,
+                detail: "The Test button launches the subprocess, runs initialize/listTools, and tears it down."
+            )
+        }
+        return ProviderDiagnosticRow(
+            id: "repro",
+            title: "Repro path",
+            value: "HTTP discovery probe",
+            severity: .info,
+            detail: "401 challenges surface as inline sign-in or token prompts with the last error preserved."
+        )
+    }
+
+    // MARK: - Shared
+
+    private static func proxyRow(_ proxy: GlobalProxyDiagnosticState, appliesTo: String) -> ProviderDiagnosticRow {
+        switch proxy {
+        case .disabled:
+            return ProviderDiagnosticRow(
+                id: "proxy",
+                title: "Global proxy",
+                value: "Off",
+                severity: .info,
+                detail: "\(appliesTo) use direct networking."
+            )
+        case .active(let description):
+            return ProviderDiagnosticRow(
+                id: "proxy",
+                title: "Global proxy",
+                value: description,
+                severity: .ok,
+                detail: "\(appliesTo) use this validated proxy endpoint."
+            )
+        case .invalid(let reason):
+            return ProviderDiagnosticRow(
+                id: "proxy",
+                title: "Global proxy",
+                value: "Ignored",
+                severity: .warning,
+                detail: reason,
+                action: "Fix or clear the proxy URL in Server settings."
+            )
+        }
+    }
+
+    private static func hasCredentialHeader(_ provider: RemoteProvider) -> Bool {
+        let names = Array(provider.customHeaders.keys) + provider.secretHeaderKeys
+        return names.contains {
+            RemoteProviderHeaderRedactor.isSensitiveHeader(
+                $0,
+                configuredSecretHeaderKeys: provider.secretHeaderKeys
+            )
+        }
+    }
+
+    private static func hasMCPHeaderCredential(_ provider: MCPProvider) -> Bool {
+        let names = Array(provider.customHeaders.keys) + provider.secretHeaderKeys
+        return names.contains {
+            RemoteProviderHeaderRedactor.isSensitiveHeader(
+                $0,
+                configuredSecretHeaderKeys: provider.secretHeaderKeys
+            )
+        }
+    }
+
+    private static func mcpEndpointSubtitle(for provider: MCPProvider) -> String {
+        switch provider.transport {
+        case .http:
+            return provider.url
+        case .stdio:
+            let args = ShellArgs.join(provider.args)
+            return args.isEmpty ? provider.command : "\(provider.command) \(args)"
+        }
+    }
+
+    private static func safeDiagnostic(_ raw: String) -> String {
+        OpenAICodexOAuthService.safeDiagnosticFragment(raw, maxLength: 280)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
@@ -1,0 +1,160 @@
+//
+//  ProviderNetworkDiagnosticsTests.swift
+//  osaurusTests
+//
+//  Regression coverage for copyable provider/auth/network diagnostics.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Provider network diagnostics")
+struct ProviderNetworkDiagnosticsTests {
+    @Test func codexOAuthReportFlagsMissingTokensWithoutLeakingSecrets() {
+        let provider = OpenAICodexOAuthService.makeProvider(id: UUID())
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = #"HTTP 401: {"access_token":"secret-token"}"#
+
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+
+        let auth = row("auth", in: report)
+        #expect(auth.severity == .blocked)
+        #expect(auth.value == "ChatGPT sign-in required")
+        #expect(report.pasteboardText.contains("ChatGPT sign-in required"))
+        #expect(!report.pasteboardText.contains("secret-token"))
+    }
+
+    @Test func xaiOAuthReportFlagsMissingTokensWithoutLeakingSecrets() {
+        let provider = XAIOAuthService.makeProvider(id: UUID())
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = #"HTTP 401: {"access_token":"secret-token"}"#
+
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+
+        let auth = row("auth", in: report)
+        #expect(auth.severity == .blocked)
+        #expect(auth.value == "xAI sign-in required")
+        #expect(report.pasteboardText.contains("xAI sign-in required"))
+        #expect(!report.pasteboardText.contains("secret-token"))
+    }
+
+    @Test func openAICompatibleReportExplainsManualModelFallbackAndRequestValidation() {
+        let provider = RemoteProvider(
+            name: "Lemonade",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 8000,
+            basePath: "/api/v1",
+            authType: .none,
+            providerType: .openaiLegacy,
+            manualModelIds: ["local-chat"]
+        )
+
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: nil,
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+
+        #expect(row("models", in: report).value == "Fallback available")
+        #expect(row("models", in: report).detail?.contains("Manual IDs") == true)
+        #expect(row("format", in: report).detail?.contains("response_format=json_schema") == true)
+    }
+
+    @Test func proxyDiagnosticDistinguishesInvalidConfiguredProxy() {
+        var configuration = ServerConfiguration.default
+        configuration.globalProxyURL = "http://localhost:8080"
+
+        let diagnostic = GlobalProxySettings.diagnostic(from: configuration)
+
+        #expect(diagnostic == .invalid("Proxy host 'localhost' is reserved for local networking."))
+
+        let provider = RemoteProvider(
+            name: "Remote",
+            host: "api.example.com",
+            authType: .none
+        )
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: nil,
+            proxy: diagnostic,
+            apiKeyPresent: false,
+            oauthTokensPresent: false
+        )
+
+        #expect(row("proxy", in: report).value == "Ignored")
+        #expect(row("proxy", in: report).severity == .warning)
+    }
+
+    @Test func mcpStdioReportShowsExecutionHostAndProbeGuidance() {
+        let provider = MCPProvider(
+            name: "Local MCP",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem"]
+        )
+
+        let report = ProviderNetworkDiagnostics.mcpProviderReport(
+            provider: provider,
+            state: nil,
+            proxy: .active("socks://proxy.example.com:1080"),
+            bearerTokenPresent: false,
+            oauthTokensPresent: false
+        )
+
+        #expect(row("transport", in: report).value == "Stdio host")
+        #expect(row("transport", in: report).severity == .warning)
+        #expect(row("proxy", in: report).value == "Not used for stdio")
+        #expect(row("repro", in: report).detail?.contains("listTools") == true)
+    }
+
+    @Test func mcpHTTPReportShowsProxyAppliesToDiscovery() {
+        let provider = MCPProvider(
+            name: "Linear",
+            url: "https://mcp.linear.app/mcp",
+            streamingEnabled: true,
+            authType: .oauth,
+            transport: .http
+        )
+
+        let report = ProviderNetworkDiagnostics.mcpProviderReport(
+            provider: provider,
+            state: nil,
+            proxy: .active("https://proxy.example.com:8443"),
+            bearerTokenPresent: false,
+            oauthTokensPresent: true
+        )
+
+        #expect(row("transport", in: report).value == "HTTP/SSE")
+        #expect(row("proxy", in: report).value == "https://proxy.example.com:8443")
+        #expect(row("proxy", in: report).detail?.contains("MCP HTTP/SSE") == true)
+        #expect(row("auth", in: report).severity == .ok)
+    }
+
+    private func row(_ id: String, in report: ProviderDiagnosticReport) -> ProviderDiagnosticRow {
+        guard let found = report.rows.first(where: { $0.id == id }) else {
+            Issue.record("Missing diagnostics row \(id)")
+            return ProviderDiagnosticRow(id: id, title: "missing", value: "missing", severity: .blocked)
+        }
+        return found
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
@@ -1,0 +1,128 @@
+//
+//  ProviderDiagnosticsRowsView.swift
+//  osaurus
+//
+//  Shared compact diagnostics renderer for provider settings rows.
+//
+
+import AppKit
+import SwiftUI
+
+struct ProviderDiagnosticsRowsView: View {
+    @Environment(\.theme) private var theme
+
+    let report: ProviderDiagnosticReport
+    var maxRows: Int?
+
+    private var visibleRows: [ProviderDiagnosticRow] {
+        guard let maxRows else { return report.rows }
+        return Array(report.rows.prefix(maxRows))
+    }
+
+    private var hiddenCount: Int {
+        max(0, report.rows.count - visibleRows.count)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "stethoscope")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                Text("Diagnostics", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                Spacer()
+                Button(action: copyReport) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.tertiaryText)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .localizedHelp("Copy")
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(visibleRows) { row in
+                    diagnosticRow(row)
+                }
+                if hiddenCount > 0 {
+                    Text("+\(hiddenCount) more in copied report", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func diagnosticRow(_ row: ProviderDiagnosticRow) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: icon(for: row.severity))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(color(for: row.severity))
+                .frame(width: 14, height: 14)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(row.title)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                    Text(row.value)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                if let detail = row.detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(2)
+                }
+
+                if let action = row.action, !action.isEmpty {
+                    Text(action)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(color(for: row.severity))
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+
+    private func copyReport() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(report.pasteboardText, forType: .string)
+    }
+
+    private func color(for severity: ProviderDiagnosticSeverity) -> Color {
+        switch severity {
+        case .ok:
+            return theme.successColor
+        case .info:
+            return theme.infoColor
+        case .warning:
+            return theme.warningColor
+        case .blocked:
+            return theme.errorColor
+        }
+    }
+
+    private func icon(for severity: ProviderDiagnosticSeverity) -> String {
+        switch severity {
+        case .ok:
+            return "checkmark.circle.fill"
+        case .info:
+            return "info.circle.fill"
+        case .warning:
+            return "exclamationmark.triangle.fill"
+        case .blocked:
+            return "xmark.octagon.fill"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -203,6 +203,8 @@ private struct ProviderCard: View {
     @State private var showDeleteConfirm = false
     /// Inline secure-field text for the bearer-token 401 banner. Cleared on submit.
     @State private var inlineBearerToken: String = ""
+    @State private var bearerTokenPresent = false
+    @State private var oauthTokensPresent = false
 
     private var isConnected: Bool {
         state?.isConnected ?? false
@@ -214,6 +216,29 @@ private struct ProviderCard: View {
 
     private var requiresAuth: Bool {
         state?.requiresAuth ?? false
+    }
+
+    private var diagnosticsReport: ProviderDiagnosticReport {
+        ProviderNetworkDiagnostics.mcpProviderReport(
+            provider: provider,
+            state: state,
+            proxy: GlobalProxySettings.currentDiagnostic(),
+            bearerTokenPresent: bearerTokenPresent,
+            oauthTokensPresent: oauthTokensPresent
+        )
+    }
+
+    @MainActor
+    private func refreshCredentialState() async {
+        let providerID = provider.id
+        let credentials = await Task.detached(priority: .utility) {
+            (
+                MCPProviderKeychain.hasToken(for: providerID),
+                MCPProviderKeychain.hasOAuthTokens(for: providerID)
+            )
+        }.value
+        bearerTokenPresent = credentials.0
+        oauthTokensPresent = credentials.1
     }
 
     var body: some View {
@@ -420,6 +445,12 @@ private struct ProviderCard: View {
         .background(cardBackground)
         .animation(.easeOut(duration: 0.15), value: isHovering)
         .onHover { hovering in isHovering = hovering }
+        .task(id: provider.id) {
+            await refreshCredentialState()
+        }
+        .onChange(of: provider.authType) { _, _ in
+            Task { await refreshCredentialState() }
+        }
         .opacity(hasAppeared ? 1 : 0)
         .onAppear {
             let delay = Double(animationIndex) * 0.03
@@ -697,6 +728,9 @@ private struct ProviderCard: View {
                     value: provider.autoConnect ? "Yes" : "No"
                 )
             }
+
+            ProviderDiagnosticsRowsView(report: diagnosticsReport, maxRows: nil)
+                .padding(.horizontal, -16)
 
             // Custom headers summary
             if !provider.customHeaders.isEmpty || !provider.secretHeaderKeys.isEmpty {

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -196,9 +196,33 @@ private struct ProviderCardView: View {
 
     @State private var showDeleteConfirm = false
     @State private var isHovered = false
+    @State private var apiKeyPresent = false
+    @State private var oauthTokensPresent = false
 
     private var isConnected: Bool { state?.isConnected ?? false }
     private var isConnecting: Bool { state?.isConnecting ?? false }
+    private var diagnosticsReport: ProviderDiagnosticReport {
+        ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: GlobalProxySettings.currentDiagnostic(),
+            apiKeyPresent: apiKeyPresent,
+            oauthTokensPresent: oauthTokensPresent
+        )
+    }
+
+    @MainActor
+    private func refreshCredentialState() async {
+        let providerID = provider.id
+        let credentials = await RemoteProviderKeychain.runOffCooperativeExecutor {
+            (
+                RemoteProviderKeychain.hasAPIKey(for: providerID),
+                RemoteProviderKeychain.hasOAuthTokens(for: providerID)
+            )
+        }
+        apiKeyPresent = credentials.0
+        oauthTokensPresent = credentials.1
+    }
 
     /// Match to a known preset for icon/color
     private var matchedPreset: ProviderPreset? {
@@ -317,6 +341,11 @@ private struct ProviderCardView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(theme.errorColor.opacity(0.05))
             }
+
+            Divider()
+                .background(theme.primaryBorder.opacity(0.5))
+
+            ProviderDiagnosticsRowsView(report: diagnosticsReport, maxRows: 4)
         }
         .background(
             RoundedRectangle(cornerRadius: 14)
@@ -333,6 +362,12 @@ private struct ProviderCardView: View {
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isHovered)
         .onHover { hovering in
             isHovered = hovering
+        }
+        .task(id: provider.id) {
+            await refreshCredentialState()
+        }
+        .onChange(of: provider.authType) { _, _ in
+            Task { await refreshCredentialState() }
         }
         .themedAlert(
             "Delete Provider?",

--- a/docs/GLOBAL_PROXY.md
+++ b/docs/GLOBAL_PROXY.md
@@ -10,11 +10,17 @@ boundaries.
 ## Status
 
 The current rollout adds the validated URL format, URLSession factory, settings
-persistence, and first call-site wiring for remote provider traffic plus model
-and Hugging Face downloads. Plugin HTTP, MCP OAuth, relay, theme sharing, GitHub
-skill import, sandbox provisioning, local health checks, and per-provider
-overrides remain follow-up work so the shared network policy can be reviewed in
-bounded steps.
+persistence, and call-site wiring for remote provider traffic, HTTP/SSE MCP
+provider discovery, MCP auth-challenge probes, model downloads, and Hugging Face
+lookups. Plugin HTTP, relay, theme sharing, GitHub skill import, sandbox
+provisioning, local health checks, and per-provider overrides remain follow-up
+work so the shared network policy can be reviewed in bounded steps.
+
+Provider and MCP provider cards now expose a copyable **Global proxy**
+diagnostic row. A valid proxy row shows the redacted endpoint. A missing proxy
+row says requests use direct networking. An invalid saved proxy URL is shown as
+ignored with the validation reason, instead of silently looking like a network
+failure.
 
 ## Proxy Policy
 
@@ -57,9 +63,9 @@ store boundary.
 ## Rollout Plan
 
 1. Migrate the remaining URLSession call sites in small PRs. Known affected
-   paths include plugin fetch/search traffic, MCP HTTP/SSE and OAuth traffic,
-   GitHub skill requests, relay traffic, theme sharing, sandbox provisioning,
-   and remote agent HTTP traffic.
+   paths include plugin fetch/search traffic, GitHub skill requests, relay
+   traffic, theme sharing, sandbox provisioning, local health checks, and
+   per-provider override flows.
 2. Add smoke coverage with a stub proxy that records CONNECT/HTTP/SOCKS attempts
    for provider and model-download flows. Include a DNS-leak check before
    marking #1091 complete.

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -4,7 +4,11 @@ Remote MCP Providers connect Osaurus to external MCP (Model Context Protocol) se
 
 This is different from [Remote Providers](REMOTE_PROVIDERS.md) (which provide _inference_ endpoints). Remote MCP Providers provide **tools**.
 
-Remote MCP Providers are URL-based client connections. The current app connects to HTTP/SSE MCP endpoints and does not launch local `command`/`args` stdio provider processes. Command-based stdio is supported in the opposite direction: external MCP clients can launch Osaurus with `osaurus mcp` to use Osaurus as their MCP server.
+Remote MCP Providers are client connections to MCP tool servers. Osaurus can
+connect to HTTP/SSE MCP endpoints and can also launch configured stdio MCP
+subprocesses. Command-based stdio is supported in the opposite direction too:
+external MCP clients can launch Osaurus with `osaurus mcp` to use Osaurus as
+their MCP server.
 
 ---
 
@@ -16,9 +20,14 @@ Remote MCP Providers are URL-based client connections. The current app connects 
 | External MCP client -> Osaurus | HTTP endpoints | Supported | Use `GET /mcp/tools` and `POST /mcp/call` on the local Osaurus server. |
 | Osaurus -> remote MCP provider | HTTP endpoint | Supported | Add a provider URL in **Custom Server** or choose a catalog template. |
 | Osaurus -> remote MCP provider | HTTP streaming / SSE | Supported when the server supports it | Enable **Streaming Enabled** in Advanced. |
-| Osaurus -> third-party local MCP provider | Stdio command | Not supported in Remote MCP Providers | The provider config has no `command`, `args`, `env`, or working-directory fields. |
+| Osaurus -> third-party local MCP provider | Stdio command | Supported | Choose **Stdio** in Custom Server and configure command, args, env, execution host, and working directory. |
 
-If a vendor only publishes a stdio config such as `{"command": "npx", "args": [...]}`, it is not directly usable in Remote MCP Providers today. Use an HTTP/SSE deployment of that MCP server, a bridge that exposes it over HTTP, or implement the integration as an Osaurus plugin.
+If a vendor publishes a stdio config such as `{"command": "npx", "args": [...]}`,
+enter that command in the Stdio editor. The **Test** button launches the
+subprocess, runs the MCP initialize/listTools flow, reports the tool count or
+spawn/protocol error, and tears the subprocess down. For host-executed stdio
+providers, GUI apps may not inherit your shell `PATH`; use a full executable
+path such as `/opt/homebrew/bin/npx` when a command-not-found diagnostic appears.
 
 ---
 
@@ -88,7 +97,9 @@ Google Workspace doesn't ship a hosted remote MCP. Tapping the card opens the [c
 
 The freeform editor — Name, URL, Auth picker (None / Bearer Token / OAuth), Custom Headers, Advanced (timeouts, streaming, auto-connect). Use this for any URL-reachable MCP server not in the catalog, or to override fine-grained settings on one that is.
 
-Custom Server is still HTTP/SSE only. It does not accept stdio `command`, `args`, environment variables, or working-directory settings.
+Custom Server supports both HTTP/SSE and stdio. HTTP/SSE providers use the
+global proxy policy when one is configured. Stdio providers run a local
+subprocess and therefore do not send traffic through URLSession's proxy path.
 
 ---
 
@@ -143,6 +154,19 @@ Providers requiring multi-step manual OAuth-app registration with no PAT fallbac
 ## Editing an Existing Provider
 
 Click the row's edit menu. Edit-mode skips the catalog and opens the freeform editor directly so you can change anything (name, URL, auth, headers, timeouts) regardless of whether the provider was originally added from a template.
+
+## Provider Diagnostics
+
+Each provider row has a copyable diagnostics section in the expanded details.
+It reports connection state, auth mode, transport, proxy policy, and the best
+repro path. The copied text is safe to paste in an issue or Discord thread; it
+does not include bearer tokens, OAuth tokens, request bodies, env values, or raw
+headers.
+
+For stdio providers, diagnostics distinguish sandbox vs host execution and point
+command-not-found failures at the executable path/PATH fix. For HTTP/SSE
+providers, diagnostics show whether the global proxy is active, disabled, or
+ignored because the saved URL failed validation.
 
 ---
 
@@ -298,7 +322,12 @@ When connected, the provider card shows tool count, last connected timestamp, an
 
 ## Testing Connections
 
-The freeform Custom Server form has a **Test** button that runs `tools/list` against the configured URL and reports the tool count. The OAuth and API-key catalog screens skip this — saving and connecting is the test. The test path only validates HTTP/SSE providers; it does not start or validate stdio command providers.
+The freeform Custom Server form has a **Test** button. For HTTP/SSE providers it
+runs `tools/list` against the configured URL and reports the tool count. For
+stdio providers it launches the configured command, completes the MCP
+initialize/listTools flow, reports the tool count or spawn/protocol error, and
+then tears the subprocess down. The OAuth and API-key catalog screens skip this
+button — saving and connecting is the test.
 
 ---
 
@@ -312,7 +341,10 @@ The freeform Custom Server form has a **Test** button that runs `tools/list` aga
 
 ### "My provider config has `command` and `args`"
 
-That is a stdio MCP provider config. Remote MCP Providers currently require a URL and do not spawn local commands. `command: "osaurus"` with `args: ["mcp"]` is for external MCP clients that want to use Osaurus as a server, not for adding third-party providers inside Osaurus.
+That is a stdio MCP provider config. Choose **Custom Server**, switch the
+transport to **Stdio**, and enter the command/args there. `command: "osaurus"`
+with `args: ["mcp"]` is still the opposite direction: external MCP clients use
+that to launch Osaurus as their MCP server.
 
 ### "Authentication failed" / `401 Unauthorized`
 
@@ -369,7 +401,12 @@ Non-secret configuration is stored at:
 ~/.osaurus/providers/mcp.json
 ```
 
-Each provider record carries its `name`, `url`, `enabled`, headers (non-secret only), timeouts, `authType` (`none` | `bearerToken` | `oauth`), and — for OAuth — non-secret discovery metadata (`oauth.clientId`, `oauth.scopes`, `oauth.authorizationEndpoint`, etc.). Provider records do not carry stdio `command`, `args`, `env`, or working-directory fields.
+Each provider record carries its `name`, `url`, `enabled`, headers (non-secret
+only), timeouts, `authType` (`none` | `bearerToken` | `oauth`), `transport`
+(`http` | `stdio`), and — for OAuth — non-secret discovery metadata
+(`oauth.clientId`, `oauth.scopes`, `oauth.authorizationEndpoint`, etc.). Stdio
+records also carry non-secret `command`, `args`, `env`, execution host, and
+working-directory fields. Secret stdio env values live in Keychain.
 
 Existing pre-OAuth `mcp.json` files keep working unchanged; missing fields default to `bearerToken` for backwards compatibility.
 

--- a/docs/REMOTE_PROVIDERS.md
+++ b/docs/REMOTE_PROVIDERS.md
@@ -150,6 +150,28 @@ Providers can be in the following states:
 4. **Check network** — Ensure no firewall is blocking the connection
 5. **Review error message** — The provider card shows detailed error info
 
+### Provider Diagnostics
+
+Each provider card includes a compact diagnostics section with a copy button.
+The copied report is safe to paste in GitHub or Discord: it lists connection
+state, authentication state, model-discovery path, request format, and global
+proxy state without including API keys, OAuth tokens, request bodies, callback
+URLs, or raw headers.
+
+Useful rows:
+
+- **Authentication** shows whether the provider has a Keychain API key, a
+  custom/secret credential header, ChatGPT/Codex OAuth tokens, or a missing
+  sign-in/key.
+- **Model discovery** shows whether Osaurus requires `/models`, can use manual
+  model IDs as a fallback, uses Azure deployment IDs, or reads the
+  ChatGPT/Codex catalog.
+- **Request format** shows the outbound API format and endpoint family. Local
+  OpenAI-compatible API validation returns typed 400 errors for unsupported
+  sampler settings such as `n > 1` or `response_format=json_schema`.
+- **Global proxy** shows whether provider requests use a validated proxy, use
+  direct networking, or ignore an invalid saved proxy URL.
+
 ---
 
 ## Provider-Specific Notes


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Auth, provider, MCP, and proxy bugs are expensive to triage when users can only report that a provider failed. This PR makes failures copyable, redacted, and provider-specific so maintainers can tell auth, request-shape, proxy, and MCP transport issues apart.

**Coding rationale:** The implementation keeps diagnostics near existing provider/MCP/auth paths and validates requests without changing provider defaults or credential storage behavior.

**Osaurus standards check:** Current-main, function-sized PR; secrets are redacted; diagnostics are additive; no auth bypass; proxy handling is explicit; focused tests plus GitHub CI are green.

## Business rationale

This is the Provider/Auth/Network Reliability feature PR from the development plan. It gives users and maintainers copyable diagnostics for remote provider setup, auth state, proxy routing, and MCP provider startup failures without exposing saved secrets. The user-visible outcome is fewer vague “provider failed” reports and clearer next actions for Codex subscription auth, OpenAI-compatible request shape problems, local provider compatibility, and MCP stdio/proxy issues.

## Coding rationale

The implementation keeps diagnostics read-only and redacted. It extends the existing provider/MCP configuration surfaces instead of adding a new network subsystem, and it treats trust boundaries explicitly: credential state is summarized, request/proxy configuration is validated without leaking tokens, and MCP reproduction guidance is copyable but does not execute hidden commands. During the current-main refresh, upstream added xAI OAuth provider auth, so this PR now handles `.xaiOAuth` explicitly with signed-in vs sign-in-required diagnostic rows and a regression test that proves secrets are not copied into diagnostics.

## Acceptance criteria

- Copyable remote-provider diagnostics summarize auth, request shape, model-discovery, and proxy state.
- MCP provider diagnostics include stdio crash/repro guidance and proxy-aware HTTP/SSE validation paths.
- Codex/OpenAI-compatible/local-provider failures report actionable, redacted next steps.
- xAI OAuth providers report missing tokens without leaking token-like error text.
- Existing provider connection behavior remains unchanged unless the diagnostic path is requested.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `2d27463b95c87d703a802d908fecc54aca74ad53` on `mimeding:codex/provider-auth-network-reliability`.
- The only current-main adjustment was adding the new `.xaiOAuth` diagnostic branch plus regression coverage.

## Quality gate

- [x] `git diff --check`
- [x] `xcrun swift-format lint` on touched Swift files
- [x] `swiftlint lint --quiet` on touched Swift files (existing warnings only)
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-provider-auth-network-rebased swift test --package-path Packages/OsaurusCore --filter 'ProviderNetworkDiagnosticsTests|GlobalProxyConfigurationTests|RemoteProviderModelDiscoveryTests|RequestValidationTests'` (33 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release`
- [x] GitHub CI green on `2d27463b`: `test-core` passed in 11m03s, `test-cli` passed, `swiftlint` passed, `shellcheck` passed, and release drafter passed.

## Debug evidence

`ProviderNetworkDiagnosticsTests.xaiOAuthReportFlagsMissingTokensWithoutLeakingSecrets` now covers the refresh fix: a provider with `.xaiOAuth` and an error containing `secret-token` reports `xAI sign-in required`, marks the row blocked, and keeps the copied diagnostic text redacted.

## Self-review

### Regression review

Call sites touched are diagnostic/report builders and tests; provider connection, token refresh, and model-discovery execution paths still use the existing managers. The xAI addition is a switch-exhaustiveness fix for the new auth type on current `main` and is covered by the focused diagnostic test.

### Performance review

Diagnostics remain bounded string/report construction and do not add network I/O unless an existing explicit probe path is invoked. The xAI row is O(1), redacts through existing helpers, and adds no runtime allocations beyond the diagnostic strings.

## Rollback

Revert this PR commit to remove the diagnostic surface and return to the previous provider/MCP reporting behavior.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `13a55a39c140`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
