### PR TITLE
Fix Sentry pasteboard and keychain hangs

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -60,13 +60,9 @@ enum ChatSessionStore {
     /// rotation is in flight. Normally a no-op fast path.
     private static func ensureOpen() {
         guard !didOpen else { return }
-        // Close the prewarm race: a session-touching call can arrive before
-        // the launch key prewarm lands. Load the key now (this is not the
-        // launch-critical path) so chat history isn't reported unavailable
-        // purely because the cache is still cold.
-        if !StorageKeyManager.shared.hasCachedKey {
-            try? StorageKeyManager.shared.prewarmCurrentKey()
-        }
+        // Do not synchronously prewarm here. This runs on MainActor, and
+        // Sentry APPLE-MACOS-40/41/42 showed Keychain decrypt/read can hang
+        // the UI when a cold cache reaches this path.
         guard StorageKeyManager.shared.hasCachedKey else {
             print("[ChatSessionStore] Chat history unavailable: storage key is not already unlocked")
             return

--- a/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
@@ -46,4 +46,29 @@ struct ClipboardContentDiagnosticsTests {
         #expect(source.contains("string(forType: type)"))
         #expect(source.contains("Sentry APPLE-MACOS-2N"))
     }
+
+    @Test func pasteMonitorAvoidsPasteboardTypeAndObjectConversionEnumeration() throws {
+        let here = URL(fileURLWithPath: #filePath)
+        let packageRoot = here.deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = packageRoot.appendingPathComponent(
+            "Views/Chat/FloatingInputCard.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let methodStart = try #require(source.range(of: "private func handlePasteIfImage() -> Bool"))
+        let methodEnd = try #require(
+            source.range(
+                of: "\n    }\n}\n\n// MARK: - NSImage PNG Conversion",
+                range: methodStart.upperBound ..< source.endIndex
+            )
+        )
+        let methodBody = String(source[methodStart.lowerBound ..< methodEnd.lowerBound])
+
+        #expect(!methodBody.contains("pasteboard.types"))
+        #expect(!methodBody.contains("readObjects(forClasses:"))
+        #expect(methodBody.contains("string(forType: type)"))
+        #expect(methodBody.contains("Sentry APPLE-MACOS-43"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -131,6 +131,8 @@ struct RuntimePolicySourceTests {
         let store = try Self.source("Models/Chat/ChatSessionStore.swift")
         #expect(store.contains("StorageKeyManager.shared.hasCachedKey"))
         #expect(store.contains("Chat history unavailable: storage key is not already unlocked"))
+        #expect(!store.contains("prewarmCurrentKey()"))
+        #expect(store.contains("Sentry APPLE-MACOS-40/41/42"))
     }
 
     @Test("chat history writer skips persistence unless storage key is already unlocked")

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3252,14 +3252,9 @@ class PasteMonitorView: NSView {
 
         let pasteboard = NSPasteboard.general
 
-        // Check if pasteboard contains an image
-        guard let types = pasteboard.types,
-            types.contains(where: { $0 == .png || $0 == .tiff || $0 == .fileURL })
-        else {
-            return false
-        }
-
-        // Try to get image data directly
+        // Avoid pasteboard type enumeration and object-conversion APIs here.
+        // Sentry APPLE-MACOS-43 showed AppKit pasteboard conversion can race
+        // paste monitoring on Cmd+V.
         if let imageData = pasteboard.data(forType: .png) {
             onImagePaste?(imageData)
             return true
@@ -3273,18 +3268,23 @@ class PasteMonitorView: NSView {
             return true
         }
 
-        // Try file URL (for copied files)
-        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] {
-            for url in urls {
-                if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
-                    UTType(uti)?.conforms(to: .image) == true,
-                    let data = try? Data(contentsOf: url),
-                    let nsImage = NSImage(data: data),
-                    let pngData = nsImage.pngData()
-                {
-                    onImagePaste?(pngData)
-                    return true
-                }
+        let fileURLTypes: [NSPasteboard.PasteboardType] = [
+            .fileURL,
+            NSPasteboard.PasteboardType("public.file-url"),
+        ]
+        for type in fileURLTypes {
+            guard let raw = pasteboard.string(forType: type),
+                let url = URL(string: raw),
+                url.isFileURL
+            else { continue }
+            if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
+                UTType(uti)?.conforms(to: .image) == true,
+                let data = try? Data(contentsOf: url),
+                let nsImage = NSImage(data: data),
+                let pngData = nsImage.pngData()
+            {
+                onImagePaste?(pngData)
+                return true
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid AppKit pasteboard type enumeration and object-conversion APIs in the chat paste monitor after Sentry `APPLE-MACOS-43` showed crashes inside NSPasteboard conversion on Cmd+V
- keep chat session opening from synchronously prewarming the storage key on MainActor after Sentry `APPLE-MACOS-40/41/42` showed Keychain hangs through `ChatSessionStore.ensureOpen`
- add source guards so these two crash/hang paths do not regress

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ClipboardContentDiagnosticsTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/chatSessionListDoesNotUnlockStorageKeyOnInit --jobs 1 --no-parallel`

## Sentry Scope
- This fixes the app-side pasteboard crash and Keychain/UI hang groups found in today's Sentry triage.
- The highest-volume fatal groups are still MLX/Metal runtime crashes (`APPLE-MACOS-10`, `APPLE-MACOS-14`, `APPLE-MACOS-17`, `APPLE-MACOS-3T`, `APPLE-MACOS-13`) and remain a separate runtime follow-up, not hidden by this PR.