### PR TITLE
[codex] Add workspace write previews and history

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -147,10 +147,9 @@ enum FolderToolHelpers {
     static func detectProjectType(_ url: URL) -> ProjectType {
         let fm = FileManager.default
         for projectType in ProjectType.allCases where projectType != .unknown {
-            for manifestFile in projectType.manifestFiles {
-                if fm.fileExists(atPath: url.appendingPathComponent(manifestFile).path) {
-                    return projectType
-                }
+            for manifestFile in projectType.manifestFiles
+            where fm.fileExists(atPath: url.appendingPathComponent(manifestFile).path) {
+                return projectType
             }
         }
         return .unknown
@@ -1334,8 +1333,9 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
         "Create a new UTF-8 text file or overwrite an existing text file with the provided content. "
         + "**Use this instead of `echo` / `cat` heredoc in `shell_run`.** Parent directories will "
         + "be created if they don't exist. You MUST provide the file contents in the `content` "
-        + "parameter. Do not use this for `.xlsx` workbooks; use a spreadsheet/XLSX tool or write "
-        + "CSV text instead."
+        + "parameter. Pass `dry_run: true` to preview the diff and risk warnings without writing. "
+        + "Do not use this for structured `.xlsx`, `.pdf`, or `.pptx` outputs; use a document "
+        + "creation tool or write text formats such as CSV/TSV/Markdown instead."
     let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -1350,6 +1350,12 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
                     "Content to write to the file"
                 ),
             ]),
+            "dry_run": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Preview the write, diff, and risk warnings without modifying the filesystem (default: false)"
+                ),
+            ]),
         ]),
         "required": .array([.string("path"), .string("content")]),
     ])
@@ -1358,9 +1364,6 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
     var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
 
     private let rootPath: URL
-    private static let structuredWorkbookExtensions: Set<String> = [
-        "xlsx", "xlsm", "xltx", "xltm", "xlsb", "xls",
-    ]
 
     init(rootPath: URL) {
         self.rootPath = rootPath
@@ -1391,9 +1394,10 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
         guard case .value(let content) = contentReq else {
             return contentReq.failureEnvelope ?? ""
         }
+        let dryRun = coerceBool(args["dry_run"]) ?? false
 
         let fileURL = try FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
-        if let rejected = Self.structuredWorkbookWriteRejection(
+        if let rejected = WorkspaceWriteSafety.structuredTextWriteRejection(
             path: relativePath,
             fileExtension: fileURL.pathExtension.lowercased(),
             toolName: name
@@ -1401,25 +1405,38 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
             return rejected
         }
 
-        // Capture previous state for undo
-        let existed = FileManager.default.fileExists(atPath: fileURL.path)
-        let previousContent = existed ? try? String(contentsOf: fileURL, encoding: .utf8) : nil
+        let previousContent: String?
+        switch WorkspaceWriteSafety.existingText(
+            at: fileURL,
+            relativePath: relativePath,
+            toolName: name
+        ) {
+        case .success(let content):
+            previousContent = content
+        case .failureEnvelope(let envelope):
+            return envelope
+        }
 
-        // Log operation before executing
-        if let sessionId = ChatExecutionContext.currentSessionId {
-            await FileOperationLog.shared.log(
-                FileOperation(
-                    type: existed ? .write : .create,
-                    path: relativePath,
-                    previousContent: previousContent,
-                    sessionId: sessionId,
-                    batchId: ChatExecutionContext.currentBatchId
-                )
+        let parentDir = fileURL.deletingLastPathComponent()
+        let createsParentDirectories = !FileManager.default.fileExists(atPath: parentDir.path)
+        var preview = WorkspaceWriteSafety.preview(
+            path: relativePath,
+            previousContent: previousContent,
+            proposedContent: content,
+            operation: name,
+            dryRun: dryRun,
+            createsParentDirectories: createsParentDirectories,
+            fileURL: fileURL
+        )
+        if dryRun {
+            return ToolEnvelope.success(
+                tool: name,
+                result: preview.payload,
+                warnings: preview.warnings
             )
         }
 
         // Create parent directories if needed
-        let parentDir = fileURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(
             at: parentDir,
             withIntermediateDirectories: true,
@@ -1429,31 +1446,21 @@ struct FileWriteTool: OsaurusTool, PermissionedTool {
         // Write content
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
 
-        let lineCount = content.components(separatedBy: .newlines).count
-        let action = existed ? "Updated" : "Created"
+        if let sessionId = ChatExecutionContext.currentSessionId {
+            let operation = FileOperation(
+                type: previousContent == nil ? .create : .write,
+                path: relativePath,
+                previousContent: previousContent,
+                sessionId: sessionId,
+                batchId: ChatExecutionContext.currentBatchId
+            )
+            await FileOperationLog.shared.log(operation)
+            preview.payload["operation_id"] = operation.id.uuidString
+        }
         return ToolEnvelope.success(
             tool: name,
-            text: "\(action) \(relativePath) (\(lineCount) lines, \(content.count) characters)"
-        )
-    }
-
-    private static func structuredWorkbookWriteRejection(
-        path: String,
-        fileExtension ext: String,
-        toolName: String
-    ) -> String? {
-        guard structuredWorkbookExtensions.contains(ext) else { return nil }
-        return ToolEnvelope.failure(
-            kind: .rejected,
-            message:
-                "Refused to write '\(path)' with file_write: .\(ext) is a structured workbook "
-                + "package, but file_write only writes UTF-8 text. Use a spreadsheet/XLSX "
-                + "tool for workbook output, or write CSV/TSV text instead.",
-            field: "path",
-            expected: "path for a UTF-8 text file; for .\(ext), use a workbook writer or CSV/TSV",
-            tool: toolName,
-            retryable: false,
-            metadata: ["extension": ext]
+            result: preview.payload,
+            warnings: preview.warnings
         )
     }
 }
@@ -1473,7 +1480,8 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
         "Edit a file by replacing specific text. **Use this instead of `sed` / `awk` in "
         + "`shell_run`.** `old_string` must uniquely match exactly one location in the file — "
         + "include surrounding context lines if needed to ensure uniqueness. Fails if `old_string` "
-        + "is not found or matches multiple locations. You MUST provide the strings in the parameters."
+        + "is not found or matches multiple locations. Pass `dry_run: true` to preview the diff "
+        + "without modifying the file. You MUST provide the strings in the parameters."
     let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -1492,6 +1500,12 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
                 "type": .string("string"),
                 "description": .string(
                     "The replacement text"
+                ),
+            ]),
+            "dry_run": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Preview the edit and diff without modifying the filesystem (default: false)"
                 ),
             ]),
         ]),
@@ -1545,53 +1559,184 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
         guard case .value(let newString) = newReq else {
             return newReq.failureEnvelope ?? ""
         }
+        let dryRun = coerceBool(args["dry_run"]) ?? false
 
         let fileURL = try FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        if let rejected = WorkspaceWriteSafety.structuredTextWriteRejection(
+            path: relativePath,
+            fileExtension: fileURL.pathExtension.lowercased(),
+            toolName: name
+        ) {
+            return rejected
+        }
 
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             throw FolderToolError.fileNotFound(relativePath)
         }
 
         // Capture pre-edit contents for the operation log (undo support).
-        let originalContent = try String(contentsOf: fileURL, encoding: .utf8)
+        let originalContent: String
+        switch WorkspaceWriteSafety.existingText(
+            at: fileURL,
+            relativePath: relativePath,
+            toolName: name
+        ) {
+        case .success(let content):
+            originalContent = content ?? ""
+        case .failureEnvelope(let envelope):
+            return envelope
+        }
         var content = originalContent
 
         guard let range = content.range(of: oldString) else {
-            throw FolderToolError.operationFailed(
-                "Could not find the specified text in the file. Make sure old_string exactly matches the file content."
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "Could not find `old_string` in \(relativePath). Make sure it exactly matches the file content.",
+                field: "old_string",
+                expected: "exact non-empty text present once in the target file",
+                tool: name
             )
         }
 
         let matches = content.ranges(of: oldString)
         if matches.count > 1 {
-            throw FolderToolError.operationFailed(
-                "Found \(matches.count) matches for old_string — include more context to uniquely identify the location."
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "Found \(matches.count) matches for `old_string` in \(relativePath); include more surrounding context to identify one location.",
+                field: "old_string",
+                expected: "exact text that matches exactly one location",
+                tool: name
             )
         }
 
         content.replaceSubrange(range, with: newString)
+        var preview = WorkspaceWriteSafety.preview(
+            path: relativePath,
+            previousContent: originalContent,
+            proposedContent: content,
+            operation: name,
+            dryRun: dryRun,
+            createsParentDirectories: false,
+            fileURL: fileURL
+        )
+        if dryRun {
+            return ToolEnvelope.success(
+                tool: name,
+                result: preview.payload,
+                warnings: preview.warnings
+            )
+        }
         try content.write(to: fileURL, atomically: true, encoding: .utf8)
 
         // Log for undo parity with `file_write`. Skipped when no session.
         if let sid = ChatExecutionContext.currentSessionId {
-            await FileOperationLog.shared.log(
-                FileOperation(
-                    type: .fileEdit,
-                    path: relativePath,
-                    previousContent: originalContent,
-                    sessionId: sid,
-                    batchId: ChatExecutionContext.currentBatchId
-                )
+            let operation = FileOperation(
+                type: .fileEdit,
+                path: relativePath,
+                previousContent: originalContent,
+                sessionId: sid,
+                batchId: ChatExecutionContext.currentBatchId
             )
+            await FileOperationLog.shared.log(operation)
+            preview.payload["operation_id"] = operation.id.uuidString
         }
-
-        let beforeLines = oldString.components(separatedBy: .newlines).count
-        let afterLines = newString.components(separatedBy: .newlines).count
 
         return ToolEnvelope.success(
             tool: name,
-            text: "Edited \(relativePath): replaced \(beforeLines) line(s) with \(afterLines) line(s)"
+            result: preview.payload,
+            warnings: preview.warnings
         )
+    }
+}
+
+// MARK: File Operation History Tool
+
+struct FileOperationHistoryTool: OsaurusTool {
+    let name = "file_operation_history"
+    let description =
+        "Show recent file writes/edits made by this chat session. Use this before undo/review "
+        + "or after multi-file work to inspect what changed. Optional `path` filters to one file."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Optional relative file path to filter history"),
+            ]),
+            "limit": .object([
+                "type": .string("integer"),
+                "description": .string("Maximum entries to return (default: 20, max: 100)"),
+            ]),
+        ]),
+        "required": .array([]),
+    ])
+
+    private let rootPath: URL
+
+    init(rootPath: URL) {
+        self.rootPath = rootPath
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        guard let sessionId = ChatExecutionContext.currentSessionId, !sessionId.isEmpty else {
+            return ToolEnvelope.failure(
+                kind: .unavailable,
+                message: "`file_operation_history` requires an active chat session.",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let rawPath = args["path"] as? String
+        let pathFilter: String?
+        if let rawPath {
+            let resolvedURL = try FolderToolHelpers.resolvePath(rawPath, rootPath: rootPath)
+            pathFilter = Self.relativePath(for: resolvedURL, rootPath: rootPath)
+        } else {
+            pathFilter = nil
+        }
+
+        let limit = min(max(coerceInt(args["limit"]) ?? 20, 1), 100)
+        let operations = await FileOperationLog.shared.operations(for: sessionId)
+        let filtered =
+            pathFilter.map { path in
+                operations.filter { $0.path == path || $0.destinationPath == path }
+            } ?? operations
+        let recent = Array(filtered.suffix(limit).reversed())
+        let entries = recent.map(WorkspaceWriteSafety.operationHistoryEntry)
+        var payload: [String: Any] = [
+            "kind": "file_operation_history",
+            "session_id": sessionId,
+            "entries": entries,
+            "operation_count": filtered.count,
+            "returned_count": entries.count,
+            "limit": limit,
+        ]
+        if let pathFilter {
+            payload["path"] = pathFilter
+        }
+
+        let warnings =
+            filtered.count > limit
+            ? ["History truncated to the \(limit) most recent matching operations."]
+            : nil
+        return ToolEnvelope.success(tool: name, result: payload, warnings: warnings)
+    }
+
+    private static func relativePath(for url: URL, rootPath: URL) -> String {
+        let root = rootPath.standardized.path
+        let path = url.standardized.path
+        if path == root { return "." }
+        if path.hasPrefix(root + "/") {
+            return String(path.dropFirst(root.count + 1))
+        }
+        return url.lastPathComponent
     }
 }
 
@@ -2596,6 +2741,7 @@ enum FolderToolFactory {
             FileReadTool(rootPath: rootPath),
             FileWriteTool(rootPath: rootPath),
             FileEditTool(rootPath: rootPath),
+            FileOperationHistoryTool(rootPath: rootPath),
             FileSearchTool(rootPath: rootPath),
             ShellRunTool(rootPath: rootPath),
         ]

--- a/Packages/OsaurusCore/Folder/WorkspaceWriteSafety.swift
+++ b/Packages/OsaurusCore/Folder/WorkspaceWriteSafety.swift
@@ -1,0 +1,349 @@
+//
+//  WorkspaceWriteSafety.swift
+//  osaurus
+//
+//  Shared guardrails for host-folder write tools.
+//
+
+import Foundation
+
+/// Shared preview, diff, and output-safety helpers for host workspace writes.
+///
+/// The folder write tools stay small and consistent by routing their
+/// extension refusals, risk warnings, and preview payloads through this type.
+enum WorkspaceWriteSafety {
+    struct Preview {
+        var payload: [String: Any]
+        let warnings: [String]
+        let text: String
+    }
+
+    enum ExistingTextResult {
+        case success(String?)
+        case failureEnvelope(String)
+    }
+
+    private struct StructuredTarget {
+        let label: String
+        let pivot: String
+    }
+
+    private static let maxDiffLines = 80
+    private static let maxDiffCharacters = 12_000
+    private static let maxDiffMatrixCells = 200_000
+    private static let largeWriteCharacters = 1_000_000
+
+    private static let structuredTargets: [String: StructuredTarget] = [
+        "xlsx": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "xlsm": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "xltx": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "xltm": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "xlsb": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "xls": StructuredTarget(
+            label: "structured workbook package",
+            pivot: "Use a spreadsheet/XLSX tool for workbook output, or write CSV/TSV text instead."
+        ),
+        "pdf": StructuredTarget(
+            label: "PDF document",
+            pivot: "Use a PDF/document creation path that emits a real PDF package."
+        ),
+        "pptx": StructuredTarget(
+            label: "presentation package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "pptm": StructuredTarget(
+            label: "presentation package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "potx": StructuredTarget(
+            label: "presentation template package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "potm": StructuredTarget(
+            label: "presentation template package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "ppsx": StructuredTarget(
+            label: "presentation slideshow package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "ppsm": StructuredTarget(
+            label: "presentation slideshow package",
+            pivot: "Use a presentation/PPTX creation path that emits a real OpenXML presentation."
+        ),
+        "ppt": StructuredTarget(
+            label: "presentation document",
+            pivot: "Use a presentation/PPTX creation path instead of writing plain text to a presentation extension."
+        ),
+    ]
+
+    static func structuredTextWriteRejection(
+        path: String,
+        fileExtension ext: String,
+        toolName: String
+    ) -> String? {
+        guard let target = structuredTargets[ext] else { return nil }
+        return ToolEnvelope.failure(
+            kind: .rejected,
+            message:
+                "Refused to write '\(path)' with \(toolName): .\(ext) is a \(target.label), "
+                + "but \(toolName) only writes UTF-8 text. \(target.pivot)",
+            field: "path",
+            expected: "path for a UTF-8 text file; for .\(ext), use a structured document writer",
+            tool: toolName,
+            retryable: false,
+            metadata: ["extension": ext]
+        )
+    }
+
+    static func existingText(
+        at fileURL: URL,
+        relativePath: String,
+        toolName: String
+    ) -> ExistingTextResult {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .success(nil)
+        }
+        do {
+            return .success(try String(contentsOf: fileURL, encoding: .utf8))
+        } catch {
+            return .failureEnvelope(
+                ToolEnvelope.failure(
+                    kind: .rejected,
+                    message:
+                        "Refused to modify '\(relativePath)' with \(toolName): the existing file is not valid UTF-8 text, so a text write could destroy binary or structured content.",
+                    field: "path",
+                    expected: "existing UTF-8 text file, or choose a structured/binary-safe writer",
+                    tool: toolName,
+                    retryable: false
+                )
+            )
+        }
+    }
+
+    static func preview(
+        path: String,
+        previousContent: String?,
+        proposedContent: String,
+        operation: String,
+        dryRun: Bool,
+        createsParentDirectories: Bool,
+        fileURL: URL
+    ) -> Preview {
+        let existed = previousContent != nil
+        let action = existed ? "update" : "create"
+        let diff = unifiedDiff(
+            old: previousContent ?? "",
+            new: proposedContent,
+            path: path,
+            oldLabel: existed ? "before" : "before (new file)",
+            newLabel: dryRun ? "after (preview)" : "after"
+        )
+        let warnings = riskWarnings(
+            path: path,
+            fileURL: fileURL,
+            existed: existed,
+            createsParentDirectories: createsParentDirectories,
+            proposedContent: proposedContent
+        )
+        let lineCount = proposedContent.components(separatedBy: .newlines).count
+        let resultKind = dryRun ? "workspace_write_preview" : "workspace_write_result"
+        let riskLevel = warnings.isEmpty ? "low" : "needs_review"
+        var payload: [String: Any] = [
+            "kind": resultKind,
+            "path": path,
+            "operation": operation,
+            "action": action,
+            "dry_run": dryRun,
+            "would_write": dryRun,
+            "applied": !dryRun,
+            "line_count": lineCount,
+            "character_count": proposedContent.count,
+            "creates_parent_directories": createsParentDirectories,
+            "risk_level": riskLevel,
+            "diff": diff.text,
+            "diff_truncated": diff.truncated,
+        ]
+        let text =
+            dryRun
+            ? "Dry run for \(operation) \(path): \(action), \(lineCount) lines, \(proposedContent.count) characters.\n\(diff.text)"
+            : "\(action == "create" ? "Created" : "Updated") \(path) (\(lineCount) lines, \(proposedContent.count) characters)"
+        payload["text"] = text
+        return Preview(payload: payload, warnings: warnings, text: text)
+    }
+
+    static func operationHistoryEntry(_ operation: FileOperation) -> [String: Any] {
+        var entry: [String: Any] = [
+            "id": operation.id.uuidString,
+            "type": operation.type.rawValue,
+            "display_name": operation.type.displayName,
+            "path": operation.path,
+            "timestamp": ISO8601DateFormatter().string(from: operation.timestamp),
+            "can_undo": true,
+        ]
+        if let destinationPath = operation.destinationPath {
+            entry["destination_path"] = destinationPath
+        }
+        if let batchId = operation.batchId {
+            entry["batch_id"] = batchId.uuidString
+        }
+        return entry
+    }
+
+    private static func riskWarnings(
+        path: String,
+        fileURL: URL,
+        existed: Bool,
+        createsParentDirectories: Bool,
+        proposedContent: String
+    ) -> [String] {
+        var warnings: [String] = []
+        if existed {
+            warnings.append(
+                "This will overwrite an existing file; use dry_run first when replacing more than a small edit."
+            )
+        }
+        if createsParentDirectories {
+            warnings.append("Parent directories do not exist and will be created.")
+        }
+        if proposedContent.count > largeWriteCharacters {
+            warnings.append("Large text write over 1 MB; confirm this is intentional before applying.")
+        }
+        if pathComponents(path).contains(where: { $0.hasPrefix(".") }) {
+            warnings.append("This targets a hidden or configuration path.")
+        }
+        if FolderToolHelpers.isSecretPath(fileURL: fileURL) {
+            warnings.append(
+                "This path looks like secret or credential material; avoid writing real secrets unless the user explicitly requested it."
+            )
+        }
+        return warnings
+    }
+
+    private static func pathComponents(_ path: String) -> [String] {
+        path.split(separator: "/").map(String.init)
+    }
+
+    private static func unifiedDiff(
+        old: String,
+        new: String,
+        path: String,
+        oldLabel: String,
+        newLabel: String
+    ) -> (text: String, truncated: Bool) {
+        let oldLines = old.components(separatedBy: .newlines)
+        let newLines = new.components(separatedBy: .newlines)
+        var lines: [String] = [
+            "--- \(path) (\(oldLabel))",
+            "+++ \(path) (\(newLabel))",
+        ]
+
+        if oldLines == newLines {
+            lines.append(" no text changes")
+            return (lines.joined(separator: "\n"), false)
+        }
+
+        let matrixCells = oldLines.count * newLines.count
+        if matrixCells > maxDiffMatrixCells {
+            return boundedPrefixDiff(
+                oldLines: oldLines,
+                newLines: newLines,
+                path: path,
+                oldLabel: oldLabel,
+                newLabel: newLabel
+            )
+        }
+
+        let table = lcsTable(oldLines, newLines)
+        var oldIndex = 0
+        var newIndex = 0
+        while oldIndex < oldLines.count || newIndex < newLines.count {
+            if oldIndex < oldLines.count,
+                newIndex < newLines.count,
+                oldLines[oldIndex] == newLines[newIndex]
+            {
+                lines.append(" \(oldLines[oldIndex])")
+                oldIndex += 1
+                newIndex += 1
+            } else if newIndex < newLines.count,
+                oldIndex == oldLines.count || table[oldIndex][newIndex + 1] >= table[oldIndex + 1][newIndex]
+            {
+                lines.append("+\(newLines[newIndex])")
+                newIndex += 1
+            } else if oldIndex < oldLines.count {
+                lines.append("-\(oldLines[oldIndex])")
+                oldIndex += 1
+            }
+            if lines.count >= maxDiffLines {
+                let joined = lines.joined(separator: "\n")
+                return (truncate(joined) + "\n... (diff truncated)", true)
+            }
+        }
+
+        let joined = lines.joined(separator: "\n")
+        let truncated = joined.count > maxDiffCharacters
+        return (truncate(joined), truncated)
+    }
+
+    private static func boundedPrefixDiff(
+        oldLines: [String],
+        newLines: [String],
+        path: String,
+        oldLabel: String,
+        newLabel: String
+    ) -> (text: String, truncated: Bool) {
+        var lines = [
+            "--- \(path) (\(oldLabel))",
+            "+++ \(path) (\(newLabel))",
+            "... large diff preview uses bounded prefixes",
+        ]
+        for line in oldLines.prefix(maxDiffLines / 2) {
+            lines.append("-\(line)")
+        }
+        for line in newLines.prefix(maxDiffLines / 2) {
+            lines.append("+\(line)")
+        }
+        return (truncate(lines.joined(separator: "\n")) + "\n... (diff truncated)", true)
+    }
+
+    private static func truncate(_ text: String) -> String {
+        guard text.count > maxDiffCharacters else { return text }
+        return String(text.prefix(maxDiffCharacters)) + "\n... (diff truncated)"
+    }
+
+    private static func lcsTable(_ oldLines: [String], _ newLines: [String]) -> [[Int]] {
+        var table = Array(
+            repeating: Array(repeating: 0, count: newLines.count + 1),
+            count: oldLines.count + 1
+        )
+        if oldLines.isEmpty || newLines.isEmpty { return table }
+        for oldIndex in stride(from: oldLines.count - 1, through: 0, by: -1) {
+            for newIndex in stride(from: newLines.count - 1, through: 0, by: -1) {
+                if oldLines[oldIndex] == newLines[newIndex] {
+                    table[oldIndex][newIndex] = table[oldIndex + 1][newIndex + 1] + 1
+                } else {
+                    table[oldIndex][newIndex] = max(
+                        table[oldIndex + 1][newIndex],
+                        table[oldIndex][newIndex + 1]
+                    )
+                }
+            }
+        }
+        return table
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
@@ -45,6 +45,15 @@ struct FolderToolsResilienceTests {
         EnvelopeAssertions.failureKind(result)
     }
 
+    private func withSession<T>(
+        _ sessionId: String = "folder-tools-\(UUID().uuidString)",
+        body: (String) async throws -> T
+    ) async throws -> T {
+        try await ChatExecutionContext.$currentSessionId.withValue(sessionId) {
+            try await body(sessionId)
+        }
+    }
+
     // MARK: - file_read
 
     @Test func fileRead_missingPath() async throws {
@@ -285,6 +294,104 @@ struct FolderToolsResilienceTests {
         #expect(written == "month,total\nJan,1200\n")
     }
 
+    @Test func fileWrite_rejectsPDFAndPresentationPackagesWithoutTouchingExistingFile() async throws {
+        let root = tmpRoot()
+        let cases: [(name: String, bytes: [UInt8])] = [
+            ("report.pdf", [0x25, 0x50, 0x44, 0x46]),
+            ("deck.pptx", [0x50, 0x4B, 0x03, 0x04]),
+        ]
+
+        let tool = FileWriteTool(rootPath: root)
+        for item in cases {
+            let target = root.appendingPathComponent(item.name)
+            let original = Data(item.bytes)
+            try original.write(to: target)
+
+            let result = try await tool.execute(
+                argumentsJSON: #"{"path": "\#(item.name)", "content": "fake structured output"}"#
+            )
+
+            #expect(ToolEnvelope.isError(result))
+            #expect(failureKind(result) == "rejected")
+            #expect(failureField(result) == "path")
+            let after = try Data(contentsOf: target)
+            #expect(after == original)
+        }
+    }
+
+    @Test func fileWrite_dryRunPreviewsDiffWithoutWritingOrLogging() async throws {
+        await FileOperationLog.shared.clearAll()
+        let root = tmpRoot()
+        let path = root.appendingPathComponent("note.txt")
+        try "alpha\nbeta\n".write(to: path, atomically: true, encoding: .utf8)
+
+        try await withSession { sessionId in
+            let tool = FileWriteTool(rootPath: root)
+            let result = try await tool.execute(
+                argumentsJSON: #"{"path": "note.txt", "content": "alpha\ngamma\n", "dry_run": true}"#
+            )
+
+            #expect(ToolEnvelope.isSuccess(result))
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["kind"] as? String == "workspace_write_preview")
+            #expect(payload["dry_run"] as? Bool == true)
+            #expect(payload["applied"] as? Bool == false)
+            let diff = try #require(payload["diff"] as? String)
+            #expect(diff.contains("-beta"))
+            #expect(diff.contains("+gamma"))
+
+            let after = try String(contentsOf: path, encoding: .utf8)
+            #expect(after == "alpha\nbeta\n")
+            let operations = await FileOperationLog.shared.operations(for: sessionId)
+            #expect(operations.isEmpty)
+        }
+    }
+
+    @Test func fileWrite_applyLogsInspectableOperationHistory() async throws {
+        await FileOperationLog.shared.clearAll()
+        let root = tmpRoot()
+
+        try await withSession { _ in
+            let write = FileWriteTool(rootPath: root)
+            let writeResult = try await write.execute(
+                argumentsJSON: "{\"path\": \"nested/report.md\", \"content\": \"# Report\\n\"}"
+            )
+            #expect(ToolEnvelope.isSuccess(writeResult))
+            let writePayload = try #require(EnvelopeAssertions.successPayload(writeResult))
+            #expect(writePayload["kind"] as? String == "workspace_write_result")
+            #expect(writePayload["operation_id"] as? String != nil)
+            #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent("nested/report.md").path))
+
+            let history = FileOperationHistoryTool(rootPath: root)
+            let historyResult = try await history.execute(argumentsJSON: #"{"limit": 5}"#)
+            #expect(ToolEnvelope.isSuccess(historyResult))
+            let historyPayload = try #require(EnvelopeAssertions.successPayload(historyResult))
+            #expect(historyPayload["kind"] as? String == "file_operation_history")
+            let entries = try #require(historyPayload["entries"] as? [[String: Any]])
+            #expect(entries.count == 1)
+            #expect(entries.first?["type"] as? String == "create")
+            #expect(entries.first?["path"] as? String == "nested/report.md")
+        }
+    }
+
+    @Test func fileWrite_rejectsExistingNonUTF8TextTarget() async throws {
+        let root = tmpRoot()
+        let path = root.appendingPathComponent("blob.txt")
+        let original = Data([0xFF, 0x00, 0xAB])
+        try original.write(to: path)
+
+        let tool = FileWriteTool(rootPath: root)
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path": "blob.txt", "content": "replacement"}"#
+        )
+
+        #expect(ToolEnvelope.isError(result))
+        #expect(failureKind(result) == "rejected")
+        #expect(failureField(result) == "path")
+        let after = try Data(contentsOf: path)
+        #expect(after == original)
+    }
+
     @Test @MainActor func fileWrite_unknownKeyIsRejected() {
         // `additionalProperties: false` kicks in during preflight
         // validation; the model gets a structured envelope pointing at
@@ -329,6 +436,57 @@ struct FolderToolsResilienceTests {
         #expect(ToolEnvelope.isSuccess(result))
         let after = try String(contentsOf: path, encoding: .utf8)
         #expect(after == "hello ")
+    }
+
+    @Test func fileEdit_dryRunPreviewsDiffWithoutMutatingOrLogging() async throws {
+        await FileOperationLog.shared.clearAll()
+        let root = tmpRoot()
+        let path = root.appendingPathComponent("f.txt")
+        try "hello world\n".write(to: path, atomically: true, encoding: .utf8)
+
+        try await withSession { sessionId in
+            let tool = FileEditTool(rootPath: root)
+            let result = try await tool.execute(
+                argumentsJSON: #"{"path": "f.txt", "old_string": "world", "new_string": "mars", "dry_run": true}"#
+            )
+
+            #expect(ToolEnvelope.isSuccess(result))
+            let payload = try #require(EnvelopeAssertions.successPayload(result))
+            #expect(payload["kind"] as? String == "workspace_write_preview")
+            #expect(payload["operation"] as? String == "file_edit")
+            let diff = try #require(payload["diff"] as? String)
+            #expect(diff.contains("-hello world"))
+            #expect(diff.contains("+hello mars"))
+
+            let after = try String(contentsOf: path, encoding: .utf8)
+            #expect(after == "hello world\n")
+            let operations = await FileOperationLog.shared.operations(for: sessionId)
+            #expect(operations.isEmpty)
+        }
+    }
+
+    @Test func fileEdit_duplicateMatchReturnsStructuredArgumentError() async throws {
+        let root = tmpRoot()
+        let path = root.appendingPathComponent("f.txt")
+        try "same\nsame\n".write(to: path, atomically: true, encoding: .utf8)
+
+        let tool = FileEditTool(rootPath: root)
+        let result = try await tool.execute(
+            argumentsJSON: #"{"path": "f.txt", "old_string": "same", "new_string": "other"}"#
+        )
+
+        #expect(ToolEnvelope.isError(result))
+        #expect(failureKind(result) == "invalid_args")
+        #expect(failureField(result) == "old_string")
+        let after = try String(contentsOf: path, encoding: .utf8)
+        #expect(after == "same\nsame\n")
+    }
+
+    @Test func fileOperationHistory_requiresSessionContext() async throws {
+        let tool = FileOperationHistoryTool(rootPath: tmpRoot())
+        let result = try await tool.execute(argumentsJSON: "{}")
+        #expect(ToolEnvelope.isError(result))
+        #expect(failureKind(result) == "unavailable")
     }
 
     // MARK: - file_tree

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -107,8 +107,9 @@ Built by [`FolderToolFactory`](../Packages/OsaurusCore/Folder/FolderTools.swift)
 | Tool            | Description                                                  |
 | --------------- | ------------------------------------------------------------ |
 | `file_read`     | Read a file (line ranges, `tail_lines`/`max_chars`, bounded XLSX sheet previews) **or** list a directory (with `max_depth`, project-aware ignore patterns) — the path decides. Use this instead of `cat`/`head`/`tail`/`ls`/`tree`. |
-| `file_write`    | Create or overwrite UTF-8 text files. Use this instead of `echo`/`cat` heredoc. Refuses `.xlsx`-family workbook targets; write CSV/TSV text or use a spreadsheet/XLSX tool for workbook output. |
-| `file_edit`     | Surgical exact-string replacement. Use this instead of `sed`/`awk`. |
+| `file_write`    | Create or overwrite UTF-8 text files. Use this instead of `echo`/`cat` heredoc. Pass `dry_run: true` to preview the diff and risk warnings without writing. Refuses `.xlsx`, `.pdf`, and `.pptx`-family structured targets; write CSV/TSV/Markdown text or use a structured document tool. |
+| `file_edit`     | Surgical exact-string replacement. Use this instead of `sed`/`awk`. Pass `dry_run: true` to preview the diff without mutating. |
+| `file_operation_history` | Show recent file writes/edits made by the current chat session, optionally filtered to one path. |
 | `file_search`   | ripgrep-style content search, or `target="files"` filename-glob find. Use this instead of `grep`/`rg`/`find`. |
 | `shell_run`     | Execute a shell command (requires approval). Reserve for `mv`/`cp`/`rm`/`mkdir`, builds, tests, git, installs, and any work that can't be expressed via the dedicated `file_*` tools. |
 
@@ -124,7 +125,7 @@ The previously-discrete `file_move`, `file_copy`, `file_delete`, `dir_create`, a
 | `git_diff`   | Show diffs                                        |
 | `git_commit` | Stage and commit (requires approval)              |
 
-Every write/exec/git-mutating call is logged in [`FileOperationLog`](../Packages/OsaurusCore/Folder/FileOperationLog.swift) so the user can review or undo individual operations.
+Every applied `file_write` / `file_edit` call is logged in [`FileOperationLog`](../Packages/OsaurusCore/Folder/FileOperationLog.swift) so the user can review or undo individual file operations. Dry-run write/edit previews do not log because they do not change the filesystem.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -647,8 +647,9 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 | Tool              | Category | Description                                                       |
 | ----------------- | -------- | ----------------------------------------------------------------- |
 | `file_read`       | Core     | Read a file (text ranges, `tail_lines`/`max_chars`, bounded XLSX sheet previews) **or** list a directory (with `max_depth`, project-aware ignore patterns) — the path decides. A directory returns a structured `kind: "listing"` with `entries[]` (each a ready-to-use `path`), not an ASCII tree |
-| `file_write`      | Core     | Create or overwrite UTF-8 text files; refuses `.xlsx`-family workbook targets so structured workbook output goes through the XLSX/spreadsheet path |
-| `file_edit`       | Core     | Surgical exact-string replacement                                 |
+| `file_write`      | Core     | Create or overwrite UTF-8 text files with `dry_run` diff/risk previews; refuses `.xlsx`, `.pdf`, and `.pptx`-family structured targets so package output goes through a structured writer |
+| `file_edit`       | Core     | Surgical exact-string replacement with optional `dry_run` diff preview |
+| `file_operation_history` | Core | Recent applied file writes/edits for the current chat session |
 | `file_search`     | Core     | ripgrep-style content search, or `target="files"` filename-glob find |
 | `shell_run`       | Core     | Run a shell command (requires approval). Reserve for `mv`/`cp`/`rm`/`mkdir`, builds, tests, git, installs. |
 | `git_status`      | Git      | Repository status. Registered when `.git` present.                |

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -5,10 +5,12 @@ fidelity lanes moved workbook reading into core `file_read`.
 
 ## Current Write Path
 
-`file_write` remains a UTF-8 text/code tool. It creates parent directories and
-writes atomically, but it now refuses `.xlsx`-family workbook targets so an
-agent cannot create an invalid OOXML package by writing plain text with a
-workbook extension. For tabular text output, agents should write CSV/TSV.
+`file_write` remains a UTF-8 text/code tool. It can return a dry-run diff and
+risk warnings before applying, creates parent directories when explicitly
+applied, writes atomically, and refuses structured package targets (`.xlsx`,
+`.pdf`, `.pptx` families) so an agent cannot create invalid office/PDF output by
+writing plain text with a package extension. For tabular text output, agents
+should write CSV/TSV.
 
 Structured workbook output stays on the document-emitter/plugin path.
 `XLSXEmitter` assembles an OOXML ZIP package in memory, validates workbook
@@ -25,7 +27,9 @@ No workbook writer is added to the default schema.
 
 | Surface | Safety contract | Proof |
 | --- | --- | --- |
-| `file_write` | Text-only writes; rejects `.xlsx`-family targets before logging or touching the existing file | `FolderToolsResilienceTests.fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile` |
+| `file_write` | Text-only writes; rejects `.xlsx`, `.pdf`, and `.pptx`-family targets before logging or touching the existing file | `FolderToolsResilienceTests.fileWrite_rejectsWorkbookPackagesWithoutTouchingExistingFile`, `FolderToolsResilienceTests.fileWrite_rejectsPDFAndPresentationPackagesWithoutTouchingExistingFile` |
+| Dry-run write/edit | `dry_run: true` returns a bounded diff/risk preview, does not mutate files, and does not log fake operations | `FolderToolsResilienceTests.fileWrite_dryRunPreviewsDiffWithoutWritingOrLogging`, `FolderToolsResilienceTests.fileEdit_dryRunPreviewsDiffWithoutMutatingOrLogging` |
+| Operation history | Applied file writes/edits are visible through a session-scoped history tool | `FolderToolsResilienceTests.fileWrite_applyLogsInspectableOperationHistory` |
 | CSV output | Text tabular output remains allowed through `file_write` | `FolderToolsResilienceTests.fileWrite_allowsCSVTextOutput` |
 | XLSX emitter | Valid scalar workbooks round-trip through the XLSX adapter | `XLSXEmitterTests.emit_roundTripsScalarWorkbookThroughXLSXAdapter` |
 | XLSX formula safety | Formula cells are rejected, while formula-looking strings stay inert shared strings | `XLSXEmitterTests.emit_rejectsFormulaCellsWithoutFlatteningThem`, `XLSXEmitterTests.emit_keepsFormulaLookingTextInert` |
@@ -36,8 +40,8 @@ No workbook writer is added to the default schema.
 
 1. Add first-party workbook write UI/tooling only when it can call the
    structured emitter directly and surface save/share state as an artifact.
-2. Extend the same text-only `file_write` refusal pattern to other structured
-   binary families if their output emitters become production-ready.
+2. Keep extending structured creation only through real emitters, artifact
+   surfacing, and validation errors; do not add package-shaped text writes.
 3. Keep sandbox write parity separate: `sandbox_write_file` has a different
    filesystem boundary and should be audited in its own lane before changing
    behavior.


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Agent workspace writes need a safer review path before broad document/workspace features grow. This PR gives users and maintainers dry-run/diff/history/risky-write context and blocks fake binary document output through text writes.

**Coding rationale:** The change extends existing folder-tool and agent-state surfaces with structured preview/history/errors rather than replacing the workspace tool model.

**Osaurus standards check:** Current-main, function-sized PR; narrow write exposure preserved; fake XLSX/PDF/PPTX output is refused; no broad refactor; focused tests plus GitHub CI are green.

## Business rationale

This is the Agent Workspace Safety feature PR from the development plan. It gives agents safer host-folder mutation workflows: preview first, apply second, and inspect what changed afterward. That reduces accidental overwrites and gives maintainers one coherent workspace-safety feature to review instead of several small slices.

## Coding rationale

`WorkspaceWriteSafety` is the shared guardrail layer for host-folder writes. `file_write` and `file_edit` now support dry-run previews with bounded diffs, risk warnings, line/character counts, structured errors, and session operation history after successful apply. Structured binary/package targets (`.xlsx`, `.pdf`, `.pptx`) are refused through one text-write safety path, existing non-UTF-8 targets are protected before mutation, and the implementation stays dependency-free with bounded LCS diff work.

## Acceptance criteria

- `file_write` can preview a create/update without writing or logging.
- `file_edit` can preview a replacement without mutating or logging.
- Applied writes/edits return structured payloads and add inspectable operation IDs when a session exists.
- Existing `.xlsx`, `.pdf`, and `.pptx` style targets are refused by text write/edit paths with structured envelopes.
- Existing non-UTF-8 targets are refused before mutation.
- Duplicate/missing `old_string` edit errors are structured argument errors.
- Recent session operations are visible through `file_operation_history`.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `73e12c1318b8bafee34c2ef51748d37674754837` on `mimeding:codex/agent-workspace-safety`.
- Rebase was clean. The refresh also folds in a small SwiftLint cleanup in touched helper code; Swift-format keeps a few multiline brace shapes that SwiftLint reports as warnings but does not fail.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `xcrun swift-format lint --configuration .swift-format` on touched Swift files
- [x] `swiftlint lint --quiet --config .swiftlint.yml` on touched Swift files (exit 0; formatter/linter brace-style warnings remain)
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-agent-workspace-safety-rebased swift test --package-path Packages/OsaurusCore --filter 'FolderToolsResilienceTests|FolderToolRegistrationTests|FolderContextRenderTests|SystemPromptComposerToolResolutionTests|AgentTaskStateTests'` (92 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [x] GitHub CI green on `73e12c13`: `test-core` passed in 11m04s, `test-cli` passed, `swiftlint` passed, `shellcheck` passed, and release drafter passed.

## Debug evidence

The focused test run passed 92 tests and exercises dry-run no-op behavior, applied operation history, structured package refusal, existing binary/non-UTF-8 refusal, duplicate edit-match errors, missing session behavior for history, folder tool registration, folder context rendering, prompt tool resolution, and agent task-state behavior.

## Self-review

### Regression review

Call sites touched are host-folder mutation tools, folder tool registration, session operation history, and docs. `file_write` and `file_edit` still use the same root path resolution and write mechanics, but now validate existing targets before writing and log only after successful apply. `file_operation_history` is read-only and session-scoped. The new and existing focused tests cover the touched folder-tool behaviors.

### Performance review

Preview reads only the target file already needed for safe overwrite/edit. Diff generation caps LCS work at 200,000 matrix cells, output is truncated, and history reads the in-memory session operation log with a max result limit of 100. No network I/O, new dependency, or unbounded hot-path work was added.

## Rollback

Revert this PR commit to restore the previous direct write/edit behavior and remove the new history tool. The docs updates are confined to the same feature surface.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `8b266e970a14`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
