### PR TITLE
[codex] Add business document attachment summaries

### DIFF
--- a/Packages/OsaurusCore/Managers/Documents/DocumentFormatRegistry.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentFormatRegistry.swift
@@ -17,6 +17,22 @@
 
 import Foundation
 
+public enum DocumentFormatRegistrationRole: String, Codable, CaseIterable, Hashable, Sendable {
+    case adapter
+    case emitter
+    case streamer
+}
+
+public struct DocumentFormatRegistrationSnapshot: Codable, Equatable, Hashable, Sendable {
+    public let formatId: String
+    public let roles: Set<DocumentFormatRegistrationRole>
+
+    public init(formatId: String, roles: Set<DocumentFormatRegistrationRole>) {
+        self.formatId = formatId
+        self.roles = roles
+    }
+}
+
 public final class DocumentFormatRegistry: @unchecked Sendable {
     public static let shared = DocumentFormatRegistry()
 
@@ -104,5 +120,38 @@ public final class DocumentFormatRegistry: @unchecked Sendable {
         for emitter in emitters { ids.insert(emitter.formatId) }
         for id in streamersByFormatId.keys { ids.insert(id) }
         return ids
+    }
+
+    public func registrationSnapshot() -> [DocumentFormatRegistrationSnapshot] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var rolesByFormat: [String: Set<DocumentFormatRegistrationRole>] = [:]
+        for adapter in adapters {
+            rolesByFormat[adapter.formatId, default: []].insert(.adapter)
+        }
+        for emitter in emitters {
+            rolesByFormat[emitter.formatId, default: []].insert(.emitter)
+        }
+        for formatId in streamersByFormatId.keys {
+            rolesByFormat[formatId, default: []].insert(.streamer)
+        }
+
+        return rolesByFormat.keys.sorted().map { formatId in
+            DocumentFormatRegistrationSnapshot(
+                formatId: formatId,
+                roles: rolesByFormat[formatId] ?? []
+            )
+        }
+    }
+
+    public func registrationRoles(forFormatId formatId: String) -> Set<DocumentFormatRegistrationRole> {
+        lock.lock()
+        defer { lock.unlock() }
+        var roles: Set<DocumentFormatRegistrationRole> = []
+        if adapters.contains(where: { $0.formatId == formatId }) { roles.insert(.adapter) }
+        if emitters.contains(where: { $0.formatId == formatId }) { roles.insert(.emitter) }
+        if streamersByFormatId[formatId] != nil { roles.insert(.streamer) }
+        return roles
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -375,8 +375,9 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
         switch ext {
         case "pdf": return "doc.richtext"
         case "docx", "doc": return "doc.text"
+        case "xlsx", "xlsm", "xltx", "xltm", "xlsb", "xls", "csv", "tsv": return "tablecells"
+        case "pptx", "pptm", "potx", "potm", "ppsx", "ppsm", "ppt": return "rectangle.on.rectangle"
         case "md", "markdown": return "text.document"
-        case "csv": return "tablecells"
         case "json": return "curlybraces"
         case "xml", "html", "htm": return "chevron.left.forwardslash.chevron.right"
         case "rtf": return "doc.richtext"
@@ -445,28 +446,61 @@ public struct StructuredDocumentAttachmentMetadata: Codable, Sendable, Equatable
     public let filename: String
     public let fileSize: Int64
     public let createdAt: Date
+    public let fileExtension: String?
+    public let documentKind: BusinessDocumentKind?
+    public let structureSummary: DocumentStructureSummary?
+    public let inspectionStatus: DocumentSecurityMetadata.InspectionStatus?
+    public let maximumSeverity: DocumentSecurityFinding.Severity?
+    // Optional preserves metadata decoded from attachments saved before this field existed.
+    // swiftlint:disable:next discouraged_optional_boolean
+    public let hasActiveContent: Bool?
 
     public init(
         formatId: String,
         representationFormatId: String,
         filename: String,
         fileSize: Int64,
-        createdAt: Date
+        createdAt: Date,
+        fileExtension: String? = nil,
+        documentKind: BusinessDocumentKind? = nil,
+        structureSummary: DocumentStructureSummary? = nil,
+        inspectionStatus: DocumentSecurityMetadata.InspectionStatus? = nil,
+        maximumSeverity: DocumentSecurityFinding.Severity? = nil,
+        // swiftlint:disable:next discouraged_optional_boolean
+        hasActiveContent: Bool? = nil
     ) {
         self.formatId = formatId
         self.representationFormatId = representationFormatId
         self.filename = filename
         self.fileSize = fileSize
         self.createdAt = createdAt
+        self.fileExtension = fileExtension
+        self.documentKind = documentKind
+        self.structureSummary = structureSummary
+        self.inspectionStatus = inspectionStatus
+        self.maximumSeverity = maximumSeverity
+        self.hasActiveContent = hasActiveContent
     }
 
     public init(_ document: StructuredDocument) {
+        let fileExtension =
+            document.security.fileExtension
+            ?? URL(fileURLWithPath: document.filename).pathExtension.lowercasedNonEmpty
         self.init(
             formatId: document.formatId,
             representationFormatId: document.representation.formatId,
             filename: document.filename,
             fileSize: document.fileSize,
-            createdAt: document.createdAt
+            createdAt: document.createdAt,
+            fileExtension: fileExtension,
+            documentKind: BusinessDocumentKind.infer(
+                formatId: document.formatId,
+                fileExtension: fileExtension
+            ),
+            structureSummary: document.structure.businessSummary,
+            inspectionStatus: document.security.inspectionStatus,
+            maximumSeverity: document.security.maximumSeverity,
+            hasActiveContent: document.security.hasActiveContent
         )
     }
 }
@@ -476,6 +510,13 @@ extension StructuredDocument {
         if fileSize < 0 { return 0 }
         if fileSize > Int64(Int.max) { return Int.max }
         return Int(fileSize)
+    }
+}
+
+private extension String {
+    var lowercasedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return value.isEmpty ? nil : value
     }
 }
 

--- a/Packages/OsaurusCore/Models/Documents/BusinessDocumentSummary.swift
+++ b/Packages/OsaurusCore/Models/Documents/BusinessDocumentSummary.swift
@@ -1,0 +1,227 @@
+//
+//  BusinessDocumentSummary.swift
+//  osaurus
+//
+//  Cheap, stable metadata for presenting parsed business files in chat
+//  without requiring every UI surface to know each adapter's representation.
+//
+
+import Foundation
+
+public enum BusinessDocumentKind: String, Codable, CaseIterable, Sendable {
+    case workbook
+    case table
+    case presentation
+    case pdf
+    case richText
+    case plainText
+    case document
+    case unknown
+
+    public var displayName: String {
+        switch self {
+        case .workbook: return "Workbook"
+        case .table: return "Table"
+        case .presentation: return "Slides"
+        case .pdf: return "PDF"
+        case .richText: return "Document"
+        case .plainText: return "Text"
+        case .document: return "Document"
+        case .unknown: return "File"
+        }
+    }
+
+    public var systemImageName: String {
+        switch self {
+        case .workbook, .table: return "tablecells"
+        case .presentation: return "rectangle.on.rectangle"
+        case .pdf: return "doc.richtext"
+        case .richText: return "doc.text"
+        case .plainText: return "text.document"
+        case .document, .unknown: return "doc.plaintext"
+        }
+    }
+
+    public static func infer(formatId: String?, fileExtension: String?) -> BusinessDocumentKind {
+        let normalizedFormat = normalize(formatId)
+        let ext = normalize(fileExtension)
+        let token = normalizedFormat ?? ext ?? ""
+
+        switch token {
+        case "xlsx", "xlsm", "xltx", "xltm", "xlsb", "xls", "workbook":
+            return .workbook
+        case "csv", "tsv", "table":
+            return .table
+        case "pptx", "pptm", "potx", "potm", "ppsx", "ppsm", "ppt", "presentation":
+            return .presentation
+        case "pdf":
+            return .pdf
+        case "docx", "doc", "rtf", "rtfd", "html", "htm", "richtext":
+            return .richText
+        case "txt", "md", "markdown", "plain-text", "plaintext":
+            return .plainText
+        case "":
+            return .unknown
+        default:
+            return .document
+        }
+    }
+
+    private static func normalize(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+public struct DocumentStructureSummary: Codable, Equatable, Hashable, Sendable {
+    public let pageCount: Int
+    public let slideCount: Int
+    public let sheetCount: Int
+    public let tableCount: Int
+    public let imageCount: Int
+    public let chartCount: Int
+    public let textLengthUTF16: Int
+
+    public init(
+        pageCount: Int = 0,
+        slideCount: Int = 0,
+        sheetCount: Int = 0,
+        tableCount: Int = 0,
+        imageCount: Int = 0,
+        chartCount: Int = 0,
+        textLengthUTF16: Int = 0
+    ) {
+        self.pageCount = max(0, pageCount)
+        self.slideCount = max(0, slideCount)
+        self.sheetCount = max(0, sheetCount)
+        self.tableCount = max(0, tableCount)
+        self.imageCount = max(0, imageCount)
+        self.chartCount = max(0, chartCount)
+        self.textLengthUTF16 = max(0, textLengthUTF16)
+    }
+
+    public var primaryCountLabel: String? {
+        if sheetCount > 0 { return Self.countLabel(sheetCount, singular: "sheet", plural: "sheets") }
+        if slideCount > 0 { return Self.countLabel(slideCount, singular: "slide", plural: "slides") }
+        if pageCount > 0 { return Self.countLabel(pageCount, singular: "page", plural: "pages") }
+        if tableCount > 0 { return Self.countLabel(tableCount, singular: "table", plural: "tables") }
+        return nil
+    }
+
+    private static func countLabel(_ count: Int, singular: String, plural: String) -> String {
+        "\(count) \(count == 1 ? singular : plural)"
+    }
+}
+
+public struct BusinessDocumentSummary: Equatable, Sendable {
+    public let filename: String
+    public let formatId: String?
+    public let representationFormatId: String?
+    public let fileExtension: String?
+    public let kind: BusinessDocumentKind
+    public let fileSize: Int64?
+    public let isStructured: Bool
+    public let structureSummary: DocumentStructureSummary?
+    public let inspectionStatus: DocumentSecurityMetadata.InspectionStatus?
+    public let maximumSeverity: DocumentSecurityFinding.Severity?
+    public let hasActiveContent: Bool
+
+    public var displayName: String { kind.displayName }
+    public var systemImageName: String { kind.systemImageName }
+
+    public var chipDetailLabel: String {
+        var pieces: [String] = [displayName]
+        if let primary = structureSummary?.primaryCountLabel {
+            pieces.append(primary)
+        }
+        if hasActiveContent {
+            pieces.append("Review")
+        } else if let maximumSeverity, maximumSeverity >= .medium {
+            pieces.append("Review")
+        }
+        if let formatted = formattedFileSize {
+            pieces.append(formatted)
+        }
+        return pieces.joined(separator: " - ")
+    }
+
+    public var contextAttributes: [(name: String, value: String)] {
+        var attributes: [(String, String)] = [
+            ("type", kind.rawValue),
+            ("format", formatId ?? fileExtension ?? "unknown"),
+            ("structured", isStructured ? "true" : "false"),
+        ]
+        if let inspectionStatus {
+            attributes.append(("security", inspectionStatus.rawValue))
+        }
+        if hasActiveContent {
+            attributes.append(("active_content", "true"))
+        }
+        if let primary = structureSummary?.primaryCountLabel {
+            attributes.append(("structure", primary))
+        }
+        return attributes
+    }
+
+    private var formattedFileSize: String? {
+        guard let fileSize else { return nil }
+        return ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+    }
+
+    public init?(_ attachment: Attachment) {
+        guard attachment.isDocument else { return nil }
+
+        let metadata = attachment.structuredDocumentMetadata
+        let filename = attachment.filename ?? metadata?.filename ?? "Document"
+        let extensionFromName = (filename as NSString).pathExtension.lowercased()
+        let fileExtension = metadata?.fileExtension ?? (extensionFromName.isEmpty ? nil : extensionFromName)
+        let formatId = metadata?.formatId ?? fileExtension
+        let kind =
+            metadata?.documentKind
+            ?? BusinessDocumentKind.infer(
+                formatId: formatId,
+                fileExtension: fileExtension
+            )
+
+        self.filename = filename
+        self.formatId = formatId
+        self.representationFormatId = metadata?.representationFormatId
+        self.fileExtension = fileExtension
+        self.kind = kind
+        self.fileSize = metadata?.fileSize ?? attachment.documentFileSize
+        self.isStructured = metadata != nil
+        self.structureSummary = metadata?.structureSummary
+        self.inspectionStatus = metadata?.inspectionStatus
+        self.maximumSeverity = metadata?.maximumSeverity
+        self.hasActiveContent = metadata?.hasActiveContent ?? false
+    }
+}
+
+extension DocumentStructure {
+    public var businessSummary: DocumentStructureSummary {
+        DocumentStructureSummary(
+            pageCount: elements(kind: .page).count,
+            slideCount: elements(kind: .slide).count,
+            sheetCount: elements(kind: .sheet).count,
+            tableCount: elements(kind: .table).count,
+            imageCount: elements(kind: .image).count,
+            chartCount: elements(kind: .chart).count,
+            textLengthUTF16: textLengthUTF16
+        )
+    }
+}
+
+extension Attachment {
+    public var businessDocumentSummary: BusinessDocumentSummary? {
+        BusinessDocumentSummary(self)
+    }
+
+    fileprivate var documentFileSize: Int64? {
+        switch kind {
+        case .document(_, _, let fileSize), .documentRef(_, _, let fileSize):
+            return Int64(fileSize)
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatAttachmentSecurityTests.swift
@@ -9,6 +9,7 @@
 //  the model should only ever see neutral, entity-escaped content.
 //
 
+import CryptoKit
 import Foundation
 import Testing
 
@@ -50,6 +51,30 @@ struct ChatAttachmentSecurityTests {
         let attachment = Attachment.document(filename: "", content: "data", fileSize: 4)
         let message = ChatSession.buildUserMessageText(content: "", attachments: [attachment])
         #expect(message.contains(#"<attached_document name="attachment">"#))
+    }
+
+    @Test func buildUserMessageText_addsStructuredDocumentAttributes() {
+        let document = StructuredDocument(
+            formatId: "xlsx",
+            filename: "budget.xlsx",
+            fileSize: 1024,
+            representation: AnyStructuredRepresentation(
+                formatId: "xlsx",
+                underlying: PlainTextRepresentation(text: "A,B\n1,2")
+            ),
+            textFallback: "A,B\n1,2"
+        )
+        let attachment = Attachment.structuredDocument(document)
+
+        let message = ChatSession.buildUserMessageText(content: "Summarize", attachments: [attachment])
+
+        #expect(
+            message.contains(
+                #"<attached_document name="budget.xlsx" type="workbook" format="xlsx" structured="true" security="notInspected">"#
+            )
+        )
+        #expect(message.contains("A,B\n1,2"))
+        #expect(message.contains("Summarize"))
     }
 
     @Test func buildUserChatMessage_forwardsAudioAndVideoWhenSupported() {
@@ -115,21 +140,39 @@ struct ChatAttachmentSecurityTests {
         #expect(forwarded.imageUrls[0].hasPrefix("data:image/png;base64,"))
     }
 
-    @Test func buildUserChatMessage_hydratesSpilledImagesWhenSupported() throws {
-        let imageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
-        let hash = try AttachmentBlobStore.write(imageData)
-        let imageRef = Attachment(kind: .imageRef(hash: hash, byteCount: imageData.count))
+    @Test func buildUserChatMessage_hydratesSpilledImagesWhenSupported() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-chat-attachment-tests-\(UUID().uuidString)"
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+            StorageKeyManager.shared._setKeyForTesting(
+                SymmetricKey(data: Data(repeating: 0x44, count: 32))
+            )
+            defer {
+                OsaurusPaths.overrideRoot = nil
+                try? FileManager.default.removeItem(at: root)
+                StorageKeyManager.shared.wipeCache()
+            }
 
-        let message = ChatSession.buildUserChatMessage(
-            content: "look",
-            attachments: [imageRef],
-            supportsImages: true,
-            supportsAudio: false,
-            supportsVideo: false
-        )
+            let imageData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+            let hash = try AttachmentBlobStore.write(imageData)
+            let imageRef = Attachment(kind: .imageRef(hash: hash, byteCount: imageData.count))
 
-        #expect(message.imageUrls.count == 1)
-        #expect(message.imageDataFromParts == [imageData])
+            let message = await MainActor.run {
+                ChatSession.buildUserChatMessage(
+                    content: "look",
+                    attachments: [imageRef],
+                    supportsImages: true,
+                    supportsAudio: false,
+                    supportsVideo: false
+                )
+            }
+
+            #expect(message.imageUrls.count == 1)
+            #expect(message.imageDataFromParts == [imageData])
+        }
     }
 
     @Test func buildUserChatMessage_alignsLocalLiveAudioSamplesWithAudioInputs() {

--- a/Packages/OsaurusCore/Tests/Chat/StructuredDocumentAttachmentMetadataTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/StructuredDocumentAttachmentMetadataTests.swift
@@ -36,6 +36,8 @@ struct StructuredDocumentAttachmentMetadataTests {
         #expect(fileSize == Int(document.fileSize))
         #expect(attachment.structuredDocumentMetadata?.formatId == "csv")
         #expect(attachment.structuredDocumentMetadata?.representationFormatId == "csv")
+        #expect(attachment.businessDocumentSummary?.kind == .table)
+        #expect(attachment.businessDocumentSummary?.chipDetailLabel == "Table - 42 bytes")
     }
 
     @Test func metadataSurvivesCodableRoundTrip() throws {
@@ -51,6 +53,7 @@ struct StructuredDocumentAttachmentMetadataTests {
         #expect(kind["type"] as? String == "document")
         #expect(kind["content"] as? String == "debit,credit")
         #expect(metadata["formatId"] as? String == "csv")
+        #expect(metadata["documentKind"] as? String == "table")
 
         let decoded = try JSONDecoder().decode(Attachment.self, from: encoded)
         #expect(decoded.documentContent == "debit,credit")
@@ -73,6 +76,55 @@ struct StructuredDocumentAttachmentMetadataTests {
         let decoded = try JSONDecoder().decode(Attachment.self, from: Data(json.utf8))
         #expect(decoded.documentContent == "plain fallback")
         #expect(decoded.structuredDocumentMetadata == nil)
+    }
+
+    @Test func legacyDocumentStillGetsDisplaySummaryFromExtension() {
+        let attachment = Attachment.document(
+            filename: "Budget.Q4.xlsx",
+            content: "fallback",
+            fileSize: 2_048
+        )
+
+        let summary = attachment.businessDocumentSummary
+        #expect(summary?.kind == .workbook)
+        #expect(summary?.isStructured == false)
+        #expect(summary?.chipDetailLabel == "Workbook - 2 KB")
+        #expect(attachment.fileIcon == "tablecells")
+    }
+
+    @Test func metadataCapturesStructureAndSecurityFacts() {
+        let security = DocumentSecurityMetadata(
+            inspectionStatus: .partiallyInspected,
+            formatId: "xlsx",
+            fileExtension: "xlsx",
+            activeContentTypes: [.formula],
+            findings: [
+                DocumentSecurityFinding(
+                    kind: .formula,
+                    severity: .medium,
+                    message: "Workbook contains formulas."
+                )
+            ]
+        )
+        let document = Self.sampleStructuredDocument(
+            formatId: "xlsx",
+            filename: "budget.xlsx",
+            text: "A1,B1",
+            fileSize: 4096,
+            structure: Self.workbookStructure(),
+            security: security
+        )
+        let attachment = Attachment.structuredDocument(document)
+
+        let metadata = attachment.structuredDocumentMetadata
+        #expect(metadata?.fileExtension == "xlsx")
+        #expect(metadata?.documentKind == .workbook)
+        #expect(metadata?.inspectionStatus == .partiallyInspected)
+        #expect(metadata?.maximumSeverity == .medium)
+        #expect(metadata?.hasActiveContent == true)
+        #expect(metadata?.structureSummary?.sheetCount == 1)
+        #expect(metadata?.structureSummary?.tableCount == 1)
+        #expect(attachment.businessDocumentSummary?.chipDetailLabel == "Workbook - 1 sheet - Review - 4 KB")
     }
 
     @Test func parseAllAttachesMetadataFromRegistryAdapter() throws {
@@ -106,21 +158,46 @@ struct StructuredDocumentAttachmentMetadataTests {
     }
 
     private static func sampleStructuredDocument(
+        formatId: String = "csv",
         filename: String = "sample.csv",
         text: String = "sample text",
-        fileSize: Int64 = 42
+        fileSize: Int64 = 42,
+        structure: DocumentStructure? = nil,
+        security: DocumentSecurityMetadata? = nil
     ) -> StructuredDocument {
         StructuredDocument(
-            formatId: "csv",
+            formatId: formatId,
             filename: filename,
             fileSize: fileSize,
             representation: AnyStructuredRepresentation(
-                formatId: "csv",
+                formatId: formatId,
                 underlying: PlainTextRepresentation(text: text)
             ),
+            structure: structure,
+            security: security,
             textFallback: text,
             createdAt: createdAt
         )
+    }
+
+    private static func workbookStructure() -> DocumentStructure {
+        let rootAnchor = DocumentAnchor.root(label: "budget.xlsx")
+        let sheetAnchor = DocumentAnchor(
+            kind: .sheet,
+            path: [.init(kind: .document), .init(kind: .sheet, identifier: "Sheet1")]
+        )
+        let tableAnchor = DocumentAnchor(
+            kind: .table,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: "Sheet1"),
+                .init(kind: .table, identifier: "A1:B2"),
+            ]
+        )
+        let table = DocumentElement(kind: .table, anchor: tableAnchor)
+        let sheet = DocumentElement(kind: .sheet, anchor: sheetAnchor, children: [table])
+        let root = DocumentElement(kind: .document, anchor: rootAnchor, children: [sheet])
+        return DocumentStructure(root: root, textLengthUTF16: 5)
     }
 
     private struct FixtureAdapter: DocumentFormatAdapter {

--- a/Packages/OsaurusCore/Tests/Documents/DocumentFormatRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentFormatRegistryTests.swift
@@ -76,6 +76,23 @@ struct DocumentFormatRegistryTests {
         #expect(registry.unregisterAll(formatId: "xlsx") == false)
     }
 
+    @Test func registrationSnapshotReportsAdapterEmitterAndStreamerRoles() {
+        let registry = DocumentFormatRegistry()
+        registry.register(adapter: FakeAdapter(formatId: "xlsx", extensions: ["xlsx"]))
+        registry.register(emitter: FakeEmitter(formatId: "xlsx"))
+        registry.register(adapter: FakeAdapter(formatId: "csv", extensions: ["csv"]))
+        registry.register(streamer: FakeStreamer(formatId: "csv"))
+
+        let snapshot = registry.registrationSnapshot()
+        #expect(
+            snapshot.first { $0.formatId == "xlsx" }?.roles == [.adapter, .emitter]
+        )
+        #expect(
+            snapshot.first { $0.formatId == "csv" }?.roles == [.adapter, .streamer]
+        )
+        #expect(registry.registrationRoles(forFormatId: "missing").isEmpty)
+    }
+
     // MARK: - Thread safety
 
     @Test func register_isThreadSafe() async {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -831,9 +831,9 @@ final class ChatSession: ObservableObject {
         var parts: [String] = []
         for doc in docs {
             if let name = doc.filename, let text = doc.documentContent {
-                let safeName = escapeAttachmentName(name)
+                let attributes = attachedDocumentAttributes(for: doc, rawName: name)
                 let safeText = xmlEscape(text)
-                parts.append("<attached_document name=\"\(safeName)\">\n\(safeText)\n</attached_document>")
+                parts.append("<attached_document \(attributes)>\n\(safeText)\n</attached_document>")
             }
         }
 
@@ -916,9 +916,28 @@ final class ChatSession: ObservableObject {
     }
 
     private static func escapeAttachmentName(_ raw: String) -> String {
+        xmlEscape(normalizedAttachmentName(raw))
+    }
+
+    private static func normalizedAttachmentName(_ raw: String) -> String {
         let basename = (raw as NSString).lastPathComponent
         let trimmed = basename.trimmingCharacters(in: .whitespacesAndNewlines)
-        return xmlEscape(trimmed.isEmpty ? "attachment" : trimmed)
+        return trimmed.isEmpty ? "attachment" : trimmed
+    }
+
+    private static func attachedDocumentAttributes(for attachment: Attachment, rawName: String) -> String {
+        var attributes: [(name: String, value: String)] = [
+            ("name", normalizedAttachmentName(rawName))
+        ]
+        if attachment.structuredDocumentMetadata != nil {
+            if let summary = attachment.businessDocumentSummary {
+                attributes.append(contentsOf: summary.contextAttributes)
+            }
+        }
+        return
+            attributes
+            .map { "\($0.name)=\"\(xmlEscape($0.value))\"" }
+            .joined(separator: " ")
     }
 
     private static func xmlEscape(_ s: String) -> String {

--- a/Packages/OsaurusCore/Views/Chat/DocumentChip.swift
+++ b/Packages/OsaurusCore/Views/Chat/DocumentChip.swift
@@ -22,6 +22,7 @@ struct DocumentChip: View {
     @State private var isHovered = false
 
     private var isPasted: Bool { attachment.isPastedContent }
+    private var businessSummary: BusinessDocumentSummary? { attachment.businessDocumentSummary }
 
     var body: some View {
         HStack(spacing: 6) {
@@ -71,7 +72,7 @@ struct DocumentChip: View {
 
     private var labelStack: some View {
         HStack(spacing: 5) {
-            Image(systemName: isPasted ? "doc.on.clipboard" : attachment.fileIcon)
+            Image(systemName: isPasted ? "doc.on.clipboard" : businessSummary?.systemImageName ?? attachment.fileIcon)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(theme.accentColor)
 
@@ -90,10 +91,11 @@ struct DocumentChip: View {
                         .font(theme.font(size: 9, weight: .regular))
                         .foregroundColor(onRemove != nil ? theme.secondaryText : theme.tertiaryText)
                 }
-            } else if let size = attachment.fileSizeFormatted {
-                Text(size)
+            } else if let detail = businessSummary?.chipDetailLabel ?? attachment.fileSizeFormatted {
+                Text(detail)
                     .font(theme.font(size: 9, weight: .regular))
                     .foregroundColor(onRemove != nil ? theme.secondaryText : theme.tertiaryText)
+                    .lineLimit(1)
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -2394,7 +2394,8 @@ private final class UserDocumentChipView: NSView {
     func configure(attachment: Attachment, theme: any ThemeProtocol) {
         layer?.backgroundColor = NSColor(theme.secondaryBackground).withAlphaComponent(0.7).cgColor
 
-        let symbolName = attachment.fileIcon
+        let summary = attachment.businessDocumentSummary
+        let symbolName = summary?.systemImageName ?? attachment.fileIcon
         let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
         iconView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
             .withSymbolConfiguration(config)
@@ -2403,7 +2404,7 @@ private final class UserDocumentChipView: NSView {
         nameField.stringValue = attachment.filename ?? "Document"
         nameField.textColor = NSColor(theme.primaryText)
 
-        sizeField.stringValue = attachment.fileSizeFormatted ?? ""
+        sizeField.stringValue = summary?.chipDetailLabel ?? attachment.fileSizeFormatted ?? ""
         sizeField.textColor = NSColor(theme.tertiaryText)
 
         invalidateIntrinsicContentSize()

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -315,6 +315,8 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 **Components:**
 
 - `Managers/Documents/DocumentAdaptersBootstrap.swift` — registers built-in document adapters.
+- `Managers/Documents/DocumentFormatRegistry.swift` — routes read/write/stream registrations and exposes role snapshots for adapter compatibility checks.
+- `Models/Documents/BusinessDocumentSummary.swift` — stable workbook/table/PDF/slides summary metadata for chat chips and prompt context.
 - `Models/Documents/Workbook.swift` — typed workbook, sheet, row, and cell representation.
 - `Models/Documents/PDFDocumentRepresentation.swift` — typed PDF pages and heuristic table detections with source anchors.
 - `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, table, and relationship representation.
@@ -334,6 +336,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
 - Rich documents preserve section boundaries, headings, links, and metadata.
+- Structured attachments keep legacy text fallback compatibility while carrying format kind, structure counts, and security inspection facts into chat chips and `<attached_document>` context attributes.
 
 ---
 

--- a/docs/PLUGIN_ADAPTER_ABI.md
+++ b/docs/PLUGIN_ADAPTER_ABI.md
@@ -18,6 +18,17 @@ the registry that matches the data path they need, and code that supports both
 structured documents and plugin records should query both explicitly at its
 own boundary.
 
+Core `DocumentFormatRegistry` also exposes a registration snapshot that reports
+whether a format currently has an adapter, emitter, or streamer. UI and tests
+use that snapshot as compatibility proof; plugin adapters should not infer
+write support from read support alone.
+
+Structured chat attachments remain backwards-compatible `Attachment.document`
+values, but include a structured sidecar when a `DocumentFormatRegistry`
+adapter produced the fallback. That sidecar feeds `BusinessDocumentSummary`,
+so chips and model-facing `<attached_document>` wrappers can label workbooks,
+tables, PDFs, and slide decks without depending on the concrete representation.
+
 ## Adapter Contract
 
 Plugin packs register adapter factories at startup:


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Business files need a first-class attachment/metadata foundation before workbook, table, PDF, and slide workflows can be reviewed coherently. This PR gives users readable document chips and gives later PRs a stable registry-backed surface.

**Coding rationale:** The implementation extends `StructuredDocument`, attachment metadata, and `DocumentFormatRegistry` instead of creating a parallel document model.

**Osaurus standards check:** Current-main, function-sized PR; additive metadata; no unsafe file creation path; no new dependency; stale document-foundation drafts are treated as reference only; focused tests plus GitHub CI are green.

## Business rationale

This is the Business Files Foundation feature PR from the development plan. It makes structured business documents first-class in chat: attachments can carry workbook/table/PDF/slides metadata, chips can show meaningful document facts, and future workbook/table/PDF/PPTX PRs have a stable registry proof surface for gating affordances.

## Coding rationale

The implementation extends the existing `StructuredDocument`, attachment, and `DocumentFormatRegistry` surfaces instead of introducing a parallel document model. Metadata remains optional for Codable compatibility, legacy `Attachment.document` behavior keeps its existing fallback, and the chat prompt wrapper only adds structured attributes when sidecar metadata exists. Registry role snapshots expose adapter/emitter/streamer support so later feature PRs can ask what is possible rather than guessing.

## Acceptance criteria

- Structured document attachments preserve format kind, structure counts, security status, severity, and active-content state.
- Legacy document attachments still decode and render with the existing fallback path.
- Chat document chips surface business-file summaries without triggering new parsing or I/O on render.
- Prompt context emits escaped structured document attributes while preserving the legacy wrapper shape.
- `DocumentFormatRegistry` exposes adapter/emitter/streamer role snapshots for compatibility checks.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `c987afade8950f8fbdc9cce20d541bc97d628ecd` on `mimeding:codex/business-files-foundation`.
- Rebase was clean; no code conflicts or current-main functional adjustments were required.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `xcrun swift-format lint --configuration .swift-format` on touched Swift files
- [x] `swiftlint lint --quiet --config .swiftlint.yml` on touched Swift files (exit 0; existing baseline warnings in large chat UI files)
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-business-files-rebased swift test --package-path Packages/OsaurusCore --filter 'StructuredDocumentAttachmentMetadataTests|DocumentFormatRegistryTests|ChatAttachmentSecurityTests|DocumentParserShimTests|AttachmentSpilloverTests'` (35 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [x] GitHub CI green on `c987afad`: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and release drafter.

## Debug evidence

The focused test run passed 35 tests. It covers metadata Codable round trips, legacy document decode/fallback, registry adapter/emitter/streamer snapshots, registry parser shims, XML escaping for structured document context, model media gating, and encrypted spillover preservation for structured metadata.

## Self-review

### Regression review

Touched call sites are attachment metadata construction/encoding, registry snapshots, chat document chips, user-message attachment wrappers, and docs. Optional metadata preserves saved attachment compatibility, and legacy document wrappers still use the old fallback when no structured sidecar exists. The focused tests cover the changed attachment, registry, parser, and chat-wrapper behavior.

### Performance review

The new summaries are metadata assembly and UI string/icon selection only. No parser work, file I/O, or network I/O is added on chip render. Registry snapshots are bounded over registered handlers and remain small for the built-in document set.

## Rollback

Revert this PR commit to remove the structured business-document sidecar, registry role snapshots, chip summaries, and docs updates.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `e22ee52cce0d`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
