### PR TITLE
Add workbook workflow validation and export service

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/WorkbookWorkflowService.swift
+++ b/Packages/OsaurusCore/Services/Documents/WorkbookWorkflowService.swift
@@ -1,0 +1,619 @@
+//
+//  WorkbookWorkflowService.swift
+//  osaurus
+//
+//  Inspection and export orchestration for typed workbook documents. This is
+//  deliberately a service, not an agent-facing default tool: callers must come
+//  through an explicit UI/plugin/export surface and a registered emitter.
+//
+
+import Foundation
+
+public struct WorkbookExportPolicy: Codable, Equatable, Sendable {
+    public let maxSheets: Int
+    public let maxRowsPerSheet: Int
+    public let maxColumnsPerSheet: Int
+    public let maxCells: Int
+    public let maxMergedRanges: Int
+    public let maxCellTextUTF16Units: Int
+    public let allowFormulaCells: Bool
+
+    public init(
+        maxSheets: Int = 1_024,
+        maxRowsPerSheet: Int = 1_048_576,
+        maxColumnsPerSheet: Int = 16_384,
+        maxCells: Int = 1_000_000,
+        maxMergedRanges: Int = 100_000,
+        maxCellTextUTF16Units: Int = 32_767,
+        allowFormulaCells: Bool = false
+    ) {
+        self.maxSheets = max(1, maxSheets)
+        self.maxRowsPerSheet = max(1, maxRowsPerSheet)
+        self.maxColumnsPerSheet = max(1, maxColumnsPerSheet)
+        self.maxCells = max(1, maxCells)
+        self.maxMergedRanges = max(0, maxMergedRanges)
+        self.maxCellTextUTF16Units = max(1, maxCellTextUTF16Units)
+        self.allowFormulaCells = allowFormulaCells
+    }
+
+    public static let xlsxExport = WorkbookExportPolicy()
+}
+
+public struct WorkbookValidationIssue: Codable, Equatable, Sendable {
+    public enum Severity: String, Codable, Hashable, Sendable {
+        case warning
+        case error
+    }
+
+    public enum Code: String, Codable, Hashable, Sendable {
+        case noSheets
+        case tooManySheets
+        case invalidSheetIndex
+        case invalidSheetName
+        case duplicateSheetName
+        case rowOutOfBounds
+        case duplicateRow
+        case columnOutOfBounds
+        case cellRowMismatch
+        case duplicateCell
+        case invalidCellReference
+        case overlongCellText
+        case invalidXMLText
+        case formulaNotWritable
+        case nonFiniteNumber
+        case invalidMergedRange
+        case tooManyCells
+        case tooManyMergedRanges
+        case noRenderableCells
+    }
+
+    public let severity: Severity
+    public let code: Code
+    public let message: String
+    public let sheetName: String?
+    public let cellReference: String?
+
+    public init(
+        severity: Severity,
+        code: Code,
+        message: String,
+        sheetName: String? = nil,
+        cellReference: String? = nil
+    ) {
+        self.severity = severity
+        self.code = code
+        self.message = message
+        self.sheetName = sheetName
+        self.cellReference = cellReference
+    }
+}
+
+public struct WorkbookSheetWorkflowSummary: Codable, Equatable, Sendable {
+    public let name: String
+    public let index: Int
+    public let rowCount: Int
+    public let cellCount: Int
+    public let formulaCellCount: Int
+    public let mergedRangeCount: Int
+    public let maxColumn: Int
+
+    public init(
+        name: String,
+        index: Int,
+        rowCount: Int,
+        cellCount: Int,
+        formulaCellCount: Int,
+        mergedRangeCount: Int,
+        maxColumn: Int
+    ) {
+        self.name = name
+        self.index = index
+        self.rowCount = rowCount
+        self.cellCount = cellCount
+        self.formulaCellCount = formulaCellCount
+        self.mergedRangeCount = mergedRangeCount
+        self.maxColumn = maxColumn
+    }
+}
+
+public struct WorkbookExportAvailability: Codable, Equatable, Sendable {
+    public enum Reason: String, Codable, Hashable, Sendable {
+        case available
+        case missingEmitter
+        case invalidWorkbook
+        case notChecked
+    }
+
+    public let reason: Reason
+    public let formatId: String?
+    public let message: String
+
+    public var canExport: Bool { reason == .available }
+
+    public init(reason: Reason, formatId: String?, message: String) {
+        self.reason = reason
+        self.formatId = formatId
+        self.message = message
+    }
+}
+
+public struct WorkbookWorkflowInspection: Codable, Equatable, Sendable {
+    public let formatId: String
+    public let filename: String
+    public let sheetSummaries: [WorkbookSheetWorkflowSummary]
+    public let totalRows: Int
+    public let totalCells: Int
+    public let formulaCellCount: Int
+    public let mergedRangeCount: Int
+    public let validationIssues: [WorkbookValidationIssue]
+    public let exportAvailability: WorkbookExportAvailability
+
+    public var blockingIssues: [WorkbookValidationIssue] {
+        validationIssues.filter { $0.severity == .error }
+    }
+
+    public var isValidForExport: Bool {
+        blockingIssues.isEmpty && exportAvailability.canExport
+    }
+}
+
+public struct WorkbookExportResult: Codable, Equatable, Sendable {
+    public let url: URL
+    public let formatId: String
+    public let bytesWritten: Int64
+    public let inspection: WorkbookWorkflowInspection
+}
+
+public enum WorkbookWorkflowError: LocalizedError, Sendable {
+    case notWorkbook(formatId: String)
+    case missingEmitter(formatId: String)
+    case validationFailed([WorkbookValidationIssue])
+    case writeFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notWorkbook(let formatId):
+            return "Document format '\(formatId)' does not contain a workbook representation"
+        case .missingEmitter(let formatId):
+            return "No registered emitter can export workbook format '\(formatId)'"
+        case .validationFailed(let issues):
+            let first = issues.first?.message ?? "Workbook failed validation"
+            return "Workbook validation failed: \(first)"
+        case .writeFailed(let message):
+            return "Workbook export failed: \(message)"
+        }
+    }
+}
+
+public enum WorkbookWorkflowService {
+    public static func inspect(
+        _ document: StructuredDocument,
+        registry: DocumentFormatRegistry? = .shared,
+        policy: WorkbookExportPolicy = .xlsxExport
+    ) throws -> WorkbookWorkflowInspection {
+        guard let workbook = document.representation.underlying as? Workbook else {
+            throw WorkbookWorkflowError.notWorkbook(formatId: document.formatId)
+        }
+
+        let issues = validationIssues(for: workbook, policy: policy)
+        let availability = exportAvailability(
+            for: document,
+            registry: registry,
+            hasBlockingIssues: issues.contains { $0.severity == .error }
+        )
+        let sheetSummaries = workbook.sheets.map(sheetSummary)
+
+        return WorkbookWorkflowInspection(
+            formatId: document.formatId,
+            filename: document.filename,
+            sheetSummaries: sheetSummaries,
+            totalRows: sheetSummaries.reduce(0) { $0 + $1.rowCount },
+            totalCells: sheetSummaries.reduce(0) { $0 + $1.cellCount },
+            formulaCellCount: sheetSummaries.reduce(0) { $0 + $1.formulaCellCount },
+            mergedRangeCount: sheetSummaries.reduce(0) { $0 + $1.mergedRangeCount },
+            validationIssues: issues,
+            exportAvailability: availability
+        )
+    }
+
+    public static func export(
+        _ document: StructuredDocument,
+        to url: URL,
+        registry: DocumentFormatRegistry = .shared,
+        policy: WorkbookExportPolicy = .xlsxExport
+    ) async throws -> WorkbookExportResult {
+        let inspection = try inspect(document, registry: registry, policy: policy)
+        if !inspection.blockingIssues.isEmpty {
+            throw WorkbookWorkflowError.validationFailed(inspection.blockingIssues)
+        }
+        guard let emitter = registry.emitter(for: document) else {
+            throw WorkbookWorkflowError.missingEmitter(formatId: document.formatId)
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try await emitter.emit(document, to: url)
+            let size = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+            return WorkbookExportResult(
+                url: url,
+                formatId: emitter.formatId,
+                bytesWritten: size,
+                inspection: inspection
+            )
+        } catch let error as WorkbookWorkflowError {
+            throw error
+        } catch let error as DocumentAdapterError {
+            throw error
+        } catch {
+            throw WorkbookWorkflowError.writeFailed(error.localizedDescription)
+        }
+    }
+
+    public static func validationIssues(
+        for workbook: Workbook,
+        policy: WorkbookExportPolicy = .xlsxExport
+    ) -> [WorkbookValidationIssue] {
+        var validator = WorkbookWorkflowValidator(policy: policy)
+        return validator.validate(workbook)
+    }
+
+    private static func exportAvailability(
+        for document: StructuredDocument,
+        registry: DocumentFormatRegistry?,
+        hasBlockingIssues: Bool
+    ) -> WorkbookExportAvailability {
+        guard !hasBlockingIssues else {
+            return WorkbookExportAvailability(
+                reason: .invalidWorkbook,
+                formatId: document.formatId,
+                message: "Workbook has validation errors that must be fixed before export."
+            )
+        }
+        guard let registry else {
+            return WorkbookExportAvailability(
+                reason: .notChecked,
+                formatId: document.formatId,
+                message: "No registry was provided, so exporter availability was not checked."
+            )
+        }
+        if let emitter = registry.emitter(for: document) {
+            return WorkbookExportAvailability(
+                reason: .available,
+                formatId: emitter.formatId,
+                message: "Workbook can be exported through the registered '\(emitter.formatId)' emitter."
+            )
+        }
+        return WorkbookExportAvailability(
+            reason: .missingEmitter,
+            formatId: document.formatId,
+            message: "Workbook export requires a registered emitter; no default workbook write tool is exposed."
+        )
+    }
+
+    private static func sheetSummary(_ sheet: Workbook.Sheet) -> WorkbookSheetWorkflowSummary {
+        let cells = sheet.rows.flatMap(\.cells)
+        return WorkbookSheetWorkflowSummary(
+            name: sheet.name,
+            index: sheet.index,
+            rowCount: sheet.rows.count,
+            cellCount: cells.count,
+            formulaCellCount: cells.filter { $0.formula != nil }.count,
+            mergedRangeCount: sheet.mergedRanges.count,
+            maxColumn: cells.map(\.columnNumber).max() ?? 0
+        )
+    }
+}
+
+private struct WorkbookWorkflowValidator {
+    private let policy: WorkbookExportPolicy
+    private var issues: [WorkbookValidationIssue] = []
+    private var totalCells = 0
+    private var totalMergedRanges = 0
+    private var hasRenderableCell = false
+
+    init(policy: WorkbookExportPolicy) {
+        self.policy = policy
+    }
+
+    mutating func validate(_ workbook: Workbook) -> [WorkbookValidationIssue] {
+        issues = []
+        totalCells = 0
+        totalMergedRanges = 0
+        hasRenderableCell = false
+
+        if workbook.sheets.isEmpty {
+            add(.noSheets, "Workbook must contain at least one sheet.")
+        }
+        if workbook.sheets.count > policy.maxSheets {
+            add(.tooManySheets, "Workbook has \(workbook.sheets.count) sheets, limit is \(policy.maxSheets).")
+        }
+
+        var normalizedNames: Set<String> = []
+        for (offset, sheet) in workbook.sheets.enumerated() {
+            validateSheet(sheet, expectedIndex: offset, normalizedNames: &normalizedNames)
+        }
+
+        if totalCells > policy.maxCells {
+            add(.tooManyCells, "Workbook has \(totalCells) cells, limit is \(policy.maxCells).")
+        }
+        if totalMergedRanges > policy.maxMergedRanges {
+            add(
+                .tooManyMergedRanges,
+                "Workbook has \(totalMergedRanges) merged ranges, limit is \(policy.maxMergedRanges)."
+            )
+        }
+        if !hasRenderableCell {
+            add(.noRenderableCells, "Workbook must contain at least one non-empty renderable cell.")
+        }
+        return issues
+    }
+
+    private mutating func validateSheet(
+        _ sheet: Workbook.Sheet,
+        expectedIndex: Int,
+        normalizedNames: inout Set<String>
+    ) {
+        if sheet.index != expectedIndex {
+            add(
+                .invalidSheetIndex,
+                "Sheet '\(sheet.name)' has index \(sheet.index), expected \(expectedIndex).",
+                sheetName: sheet.name
+            )
+        }
+        validateSheetName(sheet.name)
+        let normalizedName = sheet.name.lowercased()
+        if !normalizedName.isEmpty, !normalizedNames.insert(normalizedName).inserted {
+            add(.duplicateSheetName, "Duplicate sheet name '\(sheet.name)'.", sheetName: sheet.name)
+        }
+        if sheet.rows.count > policy.maxRowsPerSheet {
+            add(
+                .rowOutOfBounds,
+                "Sheet '\(sheet.name)' has \(sheet.rows.count) rows, limit is \(policy.maxRowsPerSheet).",
+                sheetName: sheet.name
+            )
+        }
+
+        var rowNumbers: Set<Int> = []
+        var cellReferences: Set<String> = []
+        for row in sheet.rows {
+            validateRow(row, sheet: sheet, rowNumbers: &rowNumbers, cellReferences: &cellReferences)
+        }
+
+        totalMergedRanges += sheet.mergedRanges.count
+        for range in sheet.mergedRanges {
+            guard isValidCellRangeReference(range.reference) else {
+                add(
+                    .invalidMergedRange,
+                    "Invalid merged range '\(range.reference)' in sheet '\(sheet.name)'.",
+                    sheetName: sheet.name
+                )
+                continue
+            }
+        }
+    }
+
+    private mutating func validateSheetName(_ name: String) {
+        let invalidCharacters = CharacterSet(charactersIn: "[]:*?/\\")
+        if name.isEmpty {
+            add(.invalidSheetName, "Sheet name cannot be empty.")
+        }
+        if name.utf16.count > 31 {
+            add(.invalidSheetName, "Sheet name '\(name)' exceeds the XLSX 31-character limit.", sheetName: name)
+        }
+        if name.rangeOfCharacter(from: invalidCharacters) != nil {
+            add(.invalidSheetName, "Sheet name '\(name)' contains characters XLSX does not allow.", sheetName: name)
+        }
+        if name.first == "'" || name.last == "'" {
+            add(.invalidSheetName, "Sheet name '\(name)' cannot start or end with apostrophe.", sheetName: name)
+        }
+        if let scalar = firstDisallowedXMLScalar(in: name) {
+            add(
+                .invalidXMLText,
+                "Sheet name '\(name)' contains XML 1.0-incompatible character \(scalarDescription(scalar)).",
+                sheetName: name
+            )
+        }
+    }
+
+    private mutating func validateRow(
+        _ row: Workbook.Row,
+        sheet: Workbook.Sheet,
+        rowNumbers: inout Set<Int>,
+        cellReferences: inout Set<String>
+    ) {
+        if row.number < 1 || row.number > policy.maxRowsPerSheet {
+            add(
+                .rowOutOfBounds,
+                "\(sheet.name) row \(row.number) is outside XLSX row bounds.",
+                sheetName: sheet.name
+            )
+        }
+        if !rowNumbers.insert(row.number).inserted {
+            add(.duplicateRow, "\(sheet.name) contains duplicate row \(row.number).", sheetName: sheet.name)
+        }
+
+        for cell in row.cells {
+            validateCell(cell, row: row, sheet: sheet, cellReferences: &cellReferences)
+        }
+    }
+
+    private mutating func validateCell(
+        _ cell: Workbook.Cell,
+        row: Workbook.Row,
+        sheet: Workbook.Sheet,
+        cellReferences: inout Set<String>
+    ) {
+        totalCells += 1
+        if !cell.value.fallbackText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            hasRenderableCell = true
+        }
+        if cell.rowNumber != row.number {
+            add(
+                .cellRowMismatch,
+                "\(sheet.name)!\(cell.reference) rowNumber \(cell.rowNumber) does not match row \(row.number).",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+        }
+        if cell.columnNumber < 1 || cell.columnNumber > policy.maxColumnsPerSheet {
+            add(
+                .columnOutOfBounds,
+                "\(sheet.name)!\(cell.reference) is outside XLSX column bounds.",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+        }
+        guard let parsed = parseCellReference(cell.reference) else {
+            add(
+                .invalidCellReference,
+                "\(sheet.name)!\(cell.reference) is not a valid A1 cell reference.",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+            return
+        }
+        if parsed.columnNumber != cell.columnNumber || parsed.rowNumber != cell.rowNumber {
+            add(
+                .invalidCellReference,
+                "\(sheet.name)!\(cell.reference) does not match row \(cell.rowNumber), column \(cell.columnNumber).",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+        }
+
+        let normalizedReference = cell.reference.uppercased()
+        if !cellReferences.insert(normalizedReference).inserted {
+            add(
+                .duplicateCell,
+                "\(sheet.name) contains duplicate cell \(cell.reference).",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+        }
+
+        switch cell.value {
+        case .string(let value):
+            if value.utf16.count > policy.maxCellTextUTF16Units {
+                add(
+                    .overlongCellText,
+                    "\(sheet.name)!\(cell.reference) text exceeds Excel's "
+                        + "\(policy.maxCellTextUTF16Units)-character cell limit.",
+                    sheetName: sheet.name,
+                    cellReference: cell.reference
+                )
+            }
+            if let scalar = firstDisallowedXMLScalar(in: value) {
+                add(
+                    .invalidXMLText,
+                    "\(sheet.name)!\(cell.reference) contains XML 1.0-incompatible character "
+                        + "\(scalarDescription(scalar)).",
+                    sheetName: sheet.name,
+                    cellReference: cell.reference
+                )
+            }
+        case .number(let value):
+            if !value.isFinite {
+                add(
+                    .nonFiniteNumber,
+                    "\(sheet.name)!\(cell.reference) contains a non-finite number.",
+                    sheetName: sheet.name,
+                    cellReference: cell.reference
+                )
+            }
+        case .empty, .bool:
+            break
+        }
+
+        if cell.formula != nil, !policy.allowFormulaCells {
+            add(
+                .formulaNotWritable,
+                "XLSX export does not write formulas yet (\(sheet.name)!\(cell.reference)).",
+                sheetName: sheet.name,
+                cellReference: cell.reference
+            )
+        }
+    }
+
+    private mutating func add(
+        _ code: WorkbookValidationIssue.Code,
+        _ message: String,
+        sheetName: String? = nil,
+        cellReference: String? = nil
+    ) {
+        issues.append(
+            WorkbookValidationIssue(
+                severity: .error,
+                code: code,
+                message: message,
+                sheetName: sheetName,
+                cellReference: cellReference
+            )
+        )
+    }
+
+    private func isValidCellRangeReference(_ reference: String) -> Bool {
+        let endpoints = reference.split(separator: ":", omittingEmptySubsequences: false)
+        guard endpoints.count == 1 || endpoints.count == 2 else { return false }
+        let parsed = endpoints.compactMap { parseCellReference(String($0)) }
+        guard parsed.count == endpoints.count else { return false }
+        guard parsed.count == 2 else { return true }
+        return parsed[0].columnNumber <= parsed[1].columnNumber
+            && parsed[0].rowNumber <= parsed[1].rowNumber
+    }
+
+    private func firstDisallowedXMLScalar(in value: String) -> UnicodeScalar? {
+        value.unicodeScalars.first { !isAllowedXMLCharacter($0) }
+    }
+
+    private func isAllowedXMLCharacter(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x9, 0xA, 0xD:
+            return true
+        case 0x20 ... 0xD7FF, 0xE000 ... 0xFFFD, 0x10000 ... 0x10FFFF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func scalarDescription(_ scalar: UnicodeScalar) -> String {
+        "U+\(String(scalar.value, radix: 16).uppercased())"
+    }
+
+    private func parseCellReference(_ reference: String) -> (columnNumber: Int, rowNumber: Int)? {
+        var column = 0
+        var rowText = ""
+        var readingRow = false
+
+        for scalar in reference.unicodeScalars {
+            if CharacterSet.letters.contains(scalar), !readingRow {
+                let value = Int(scalar.value)
+                let upperA = Int(UnicodeScalar("A").value)
+                let lowerA = Int(UnicodeScalar("a").value)
+                if value >= upperA, value <= upperA + 25 {
+                    column = column * 26 + (value - upperA + 1)
+                } else if value >= lowerA, value <= lowerA + 25 {
+                    column = column * 26 + (value - lowerA + 1)
+                } else {
+                    return nil
+                }
+            } else if CharacterSet.decimalDigits.contains(scalar) {
+                readingRow = true
+                rowText.unicodeScalars.append(scalar)
+            } else {
+                return nil
+            }
+        }
+
+        guard column > 0,
+            column <= policy.maxColumnsPerSheet,
+            let row = Int(rowText),
+            row > 0,
+            row <= policy.maxRowsPerSheet
+        else { return nil }
+        return (column, row)
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
+++ b/Packages/OsaurusCore/Services/Documents/XLSXEmitter.swift
@@ -51,9 +51,8 @@ public struct XLSXEmitter: DocumentFormatEmitter {
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
 
     private static func packageData(for workbook: Workbook) throws -> Data {
-        let sheets = try validatedSheets(workbook.sheets)
-        try rejectFormulaCells(in: sheets)
-        try requireRenderableContent(in: sheets)
+        try validateForExport(workbook)
+        let sheets = workbook.sheets
 
         var sharedStrings = SharedStringTable()
         var worksheetEntries: [(path: String, xml: String)] = []
@@ -94,6 +93,17 @@ public struct XLSXEmitter: DocumentFormatEmitter {
             try archive.append(path: entry.path, data: entry.data)
         }
         return try archive.finalize()
+    }
+
+    private static func validateForExport(_ workbook: Workbook) throws {
+        let issues = WorkbookWorkflowService.validationIssues(for: workbook, policy: .xlsxExport)
+        guard let firstIssue = issues.first(where: { $0.severity == .error }) else { return }
+        switch firstIssue.code {
+        case .noRenderableCells, .noSheets:
+            throw DocumentAdapterError.emptyContent
+        default:
+            throw DocumentAdapterError.writeFailed(underlying: firstIssue.message)
+        }
     }
 
     private static func contentTypesXML(sheetCount: Int, hasSharedStrings: Bool) throws -> String {
@@ -274,102 +284,6 @@ public struct XLSXEmitter: DocumentFormatEmitter {
 
     private static let maxRows = 1_048_576
     private static let maxColumns = 16_384
-    private static let maxCellTextUTF16Units = 32_767
-    private static let invalidSheetNameCharacters = CharacterSet(charactersIn: "[]:*?/\\")
-
-    private static func validatedSheets(_ sheets: [Workbook.Sheet]) throws -> [Workbook.Sheet] {
-        guard !sheets.isEmpty else { throw DocumentAdapterError.emptyContent }
-
-        var names: Set<String> = []
-        for (offset, sheet) in sheets.enumerated() {
-            guard sheet.index == offset else {
-                throw writeFailed("Sheet '\(sheet.name)' has index \(sheet.index), expected \(offset)")
-            }
-            try validateSheetName(sheet.name)
-            let normalizedName = sheet.name.lowercased()
-            guard names.insert(normalizedName).inserted else {
-                throw writeFailed("Duplicate sheet name '\(sheet.name)'")
-            }
-            try validateRows(sheet.rows, sheetName: sheet.name)
-            for range in sheet.mergedRanges where !isValidCellRangeReference(range.reference) {
-                throw writeFailed("Invalid merged range '\(range.reference)'")
-            }
-        }
-        return sheets
-    }
-
-    private static func validateSheetName(_ name: String) throws {
-        guard !name.isEmpty else { throw writeFailed("Sheet name cannot be empty") }
-        guard name.utf16.count <= 31 else {
-            throw writeFailed("Sheet name '\(name)' exceeds the XLSX 31-character limit")
-        }
-        guard name.rangeOfCharacter(from: invalidSheetNameCharacters) == nil else {
-            throw writeFailed("Sheet name '\(name)' contains characters XLSX does not allow")
-        }
-        guard name.first != "'", name.last != "'" else {
-            throw writeFailed("Sheet name '\(name)' cannot start or end with apostrophe")
-        }
-    }
-
-    private static func validateRows(_ rows: [Workbook.Row], sheetName: String) throws {
-        var rowNumbers: Set<Int> = []
-        var cellReferences: Set<String> = []
-        for row in rows {
-            guard row.number >= 1, row.number <= maxRows else {
-                throw writeFailed("\(sheetName) row \(row.number) is outside XLSX row bounds")
-            }
-            guard rowNumbers.insert(row.number).inserted else {
-                throw writeFailed("\(sheetName) contains duplicate row \(row.number)")
-            }
-
-            for cell in row.cells {
-                guard cell.columnNumber >= 1, cell.columnNumber <= maxColumns else {
-                    throw writeFailed("\(sheetName)!\(cell.reference) is outside XLSX column bounds")
-                }
-                guard cell.rowNumber >= 1, cell.rowNumber <= maxRows else {
-                    throw writeFailed("\(sheetName)!\(cell.reference) is outside XLSX row bounds")
-                }
-                if case .string(let value) = cell.value {
-                    try validateCellText(value, reference: "\(sheetName)!\(cell.reference)")
-                }
-                let normalizedReference = cell.reference.uppercased()
-                guard cellReferences.insert(normalizedReference).inserted else {
-                    throw writeFailed("\(sheetName) contains duplicate cell \(cell.reference)")
-                }
-            }
-        }
-    }
-
-    private static func validateCellText(_ value: String, reference: String) throws {
-        guard value.utf16.count <= maxCellTextUTF16Units else {
-            throw writeFailed(
-                "\(reference) text exceeds Excel's \(maxCellTextUTF16Units)-character cell limit"
-            )
-        }
-    }
-
-    private static func rejectFormulaCells(in sheets: [Workbook.Sheet]) throws {
-        for sheet in sheets {
-            for row in sheet.rows {
-                for cell in row.cells where cell.formula != nil {
-                    throw writeFailed("XLSX emitter does not write formulas yet (\(sheet.name)!\(cell.reference))")
-                }
-            }
-        }
-    }
-
-    private static func requireRenderableContent(in sheets: [Workbook.Sheet]) throws {
-        let hasRenderableCell = sheets.contains { sheet in
-            sheet.rows.contains { row in
-                row.cells.contains { cell in
-                    !cell.value.fallbackText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                }
-            }
-        }
-        guard hasRenderableCell else {
-            throw DocumentAdapterError.emptyContent
-        }
-    }
 
     private static func validatedCellReference(for cell: Workbook.Cell, sheetName: String) throws -> String {
         let expected = cellReference(columnNumber: cell.columnNumber, rowNumber: cell.rowNumber)
@@ -436,10 +350,11 @@ public struct XLSXEmitter: DocumentFormatEmitter {
         guard value.isFinite else {
             throw writeFailed("XLSX emitter cannot write non-finite numbers")
         }
-        if value >= Double(Int64.min),
-            value <= Double(Int64.max),
-            value.rounded(.towardZero) == value
-        {
+        let isIntegerInInt64Range =
+            value >= Double(Int64.min)
+            && value <= Double(Int64.max)
+            && value.rounded(.towardZero) == value
+        if isIntegerInInt64Range {
             return String(Int64(value))
         }
         return String(value)

--- a/Packages/OsaurusCore/Tests/Documents/WorkbookWorkflowServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/WorkbookWorkflowServiceTests.swift
@@ -1,0 +1,308 @@
+//
+//  WorkbookWorkflowServiceTests.swift
+//  osaurusTests
+//
+//  Pins the workbook workflow layer that sits between typed workbook
+//  representations and explicit export/plugin surfaces.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Workbook workflow service")
+struct WorkbookWorkflowServiceTests {
+
+    @Test func inspectReportsCountsValidationAndEmitterAvailability() throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let document = Self.document(workbook: Self.workbook(includeFormula: true))
+
+        let inspection = try WorkbookWorkflowService.inspect(document, registry: registry)
+
+        #expect(inspection.sheetSummaries.map(\.name) == ["Revenue", "Notes"])
+        #expect(inspection.totalRows == 3)
+        #expect(inspection.totalCells == 5)
+        #expect(inspection.formulaCellCount == 1)
+        #expect(inspection.mergedRangeCount == 1)
+        #expect(inspection.exportAvailability.reason == .invalidWorkbook)
+        #expect(inspection.validationIssues.contains { $0.code == .formulaNotWritable })
+    }
+
+    @Test func exportWritesXLSXThroughRegisteredEmitterAndRoundTrips() async throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try await WorkbookWorkflowService.export(
+            Self.document(workbook: Self.workbook()),
+            to: url,
+            registry: registry
+        )
+
+        #expect(result.formatId == "xlsx")
+        #expect(result.bytesWritten > 0)
+        #expect(result.inspection.exportAvailability.canExport)
+
+        let parsed = try await XLSXAdapter().parse(url: url, sizeLimit: 0)
+        let parsedWorkbook = try #require(parsed.representation.underlying as? Workbook)
+        let revenue = try #require(parsedWorkbook.sheets.first { $0.name == "Revenue" })
+        #expect(revenue.cell("A1")?.value == .string("Month"))
+        #expect(revenue.cell("B2")?.value == .number(1200))
+        #expect(revenue.mergedRanges.map(\.reference) == ["A3:B3"])
+    }
+
+    @Test func exportRequiresRegisteredEmitterWithoutTouchingTarget() async throws {
+        let registry = DocumentFormatRegistry()
+        let url = Self.temporaryURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        do {
+            _ = try await WorkbookWorkflowService.export(
+                Self.document(workbook: Self.workbook()),
+                to: url,
+                registry: registry
+            )
+            Issue.record("expected missing emitter error")
+        } catch WorkbookWorkflowError.missingEmitter(let formatId) {
+            #expect(formatId == "xlsx")
+            #expect(!FileManager.default.fileExists(atPath: url.path))
+        } catch {
+            Issue.record("expected missing emitter error, got \(error)")
+        }
+    }
+
+    @Test func validationSurfacesReferencesRangesBoundsAndFormulaErrors() {
+        let workbook = Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Bad",
+                    index: 0,
+                    rows: [
+                        Self.row(
+                            number: 1,
+                            sheetName: "Bad",
+                            sheetIndex: 0,
+                            cells: [
+                                Self.cell(
+                                    "B2",
+                                    row: 1,
+                                    column: 1,
+                                    value: .string("mismatch\u{0001}"),
+                                    sheetName: "Bad",
+                                    sheetIndex: 0
+                                ),
+                                Self.cell(
+                                    "C1",
+                                    row: 1,
+                                    column: 3,
+                                    value: .number(.infinity),
+                                    formula: "SUM(A1:A1)",
+                                    sheetName: "Bad",
+                                    sheetIndex: 0
+                                ),
+                            ]
+                        )
+                    ],
+                    mergedRanges: [Workbook.CellRange(reference: "B2:A1")],
+                    anchor: Self.sheetAnchor(name: "Bad", index: 0)
+                )
+            ]
+        )
+
+        let issues = WorkbookWorkflowService.validationIssues(
+            for: workbook,
+            policy: WorkbookExportPolicy(maxCells: 1, maxMergedRanges: 0)
+        )
+        let codes = Set<WorkbookValidationIssue.Code>(issues.map(\.code))
+
+        #expect(codes.contains(.invalidCellReference))
+        #expect(codes.contains(.invalidXMLText))
+        #expect(codes.contains(.formulaNotWritable))
+        #expect(codes.contains(.nonFiniteNumber))
+        #expect(codes.contains(.invalidMergedRange))
+        #expect(codes.contains(.tooManyCells))
+        #expect(codes.contains(.tooManyMergedRanges))
+    }
+
+    private static func document(workbook: Workbook) -> StructuredDocument {
+        StructuredDocument(
+            formatId: "xlsx",
+            filename: "workbook.xlsx",
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: ""
+        )
+    }
+
+    private static func workbook(includeFormula: Bool = false) -> Workbook {
+        Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            sheetName: "Revenue",
+                            sheetIndex: 0,
+                            cells: [
+                                cell(
+                                    "A1",
+                                    row: 1,
+                                    column: 1,
+                                    value: .string("Month"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell(
+                                    "B1",
+                                    row: 1,
+                                    column: 2,
+                                    value: .string("Amount"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            sheetName: "Revenue",
+                            sheetIndex: 0,
+                            cells: [
+                                cell(
+                                    "A2",
+                                    row: 2,
+                                    column: 1,
+                                    value: .string("January"),
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .number(1200),
+                                    formula: includeFormula ? "SUM(B2:B2)" : nil,
+                                    sheetName: "Revenue",
+                                    sheetIndex: 0
+                                ),
+                            ]
+                        ),
+                    ],
+                    mergedRanges: [Workbook.CellRange(reference: "A3:B3")],
+                    anchor: sheetAnchor(name: "Revenue", index: 0)
+                ),
+                Workbook.Sheet(
+                    name: "Notes",
+                    index: 1,
+                    rows: [
+                        row(
+                            number: 1,
+                            sheetName: "Notes",
+                            sheetIndex: 1,
+                            cells: [
+                                cell(
+                                    "A1",
+                                    row: 1,
+                                    column: 1,
+                                    value: .string("Owner"),
+                                    sheetName: "Notes",
+                                    sheetIndex: 1
+                                )
+                            ]
+                        )
+                    ],
+                    anchor: sheetAnchor(name: "Notes", index: 1)
+                ),
+            ]
+        )
+    }
+
+    private static func row(
+        number: Int,
+        sheetName: String,
+        sheetIndex: Int,
+        cells: [Workbook.Cell]
+    ) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(
+                kind: .row,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .row, index: number - 1),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: DocumentSourceLocation(sheetIndex: sheetIndex, sheetName: sheetName, rowIndex: number - 1)
+                ),
+                label: "\(sheetName) row \(number)"
+            )
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        formula: String? = nil,
+        sheetName: String,
+        sheetIndex: Int
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            formula: formula,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .document),
+                    .init(kind: .sheet, identifier: sheetName, index: sheetIndex),
+                    .init(kind: .cell, identifier: reference),
+                ],
+                sourceRange: DocumentSourceRange(
+                    start: .cell(sheetName: sheetName, rowIndex: row - 1, columnIndex: column - 1)
+                ),
+                label: "\(sheetName)!\(reference)"
+            )
+        )
+    }
+
+    private static func sheetAnchor(name: String, index: Int) -> DocumentAnchor {
+        DocumentAnchor(
+            kind: .sheet,
+            path: [
+                .init(kind: .document),
+                .init(kind: .sheet, identifier: name, index: index),
+            ],
+            sourceRange: DocumentSourceRange(
+                start: DocumentSourceLocation(sheetIndex: index, sheetName: name)
+            ),
+            label: name,
+            metadata: ["sheetIndex": "\(index)"]
+        )
+    }
+
+    private static func temporaryURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-workflow.xlsx")
+    }
+}
+
+private extension Workbook.Sheet {
+    func cell(_ reference: String) -> Workbook.Cell? {
+        rows.flatMap(\.cells).first { $0.reference == reference }
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -324,6 +324,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
 - `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
 - `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
+- `Services/Documents/WorkbookWorkflowService.swift` — workbook inspection, export availability, validation issues, and explicit emitter-backed save flow.
 - `Services/Documents/PPTXAdapter.swift` — PPTX/POTX deck parsing from Office Open XML packages.
 - `Services/Documents/PDFAdapter.swift` — PDF extraction with page-level anchors and layout-aware text-layer table detection.
 - `Services/Documents/PDFPPTXWorkflowService.swift` — bounded PDF/PPTX previews plus structured creation availability diagnostics.
@@ -333,7 +334,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 **Supported format surface:**
 
 - CSV and TSV tables preserve headers, rows, delimiters, and source metadata.
-- XLSX workbooks preserve sheets, cells, shared strings, relationships, and can emit a minimal valid `.xlsx` package.
+- XLSX workbooks preserve sheets, cells, formulas, merged ranges, shared strings, relationships, and export availability metadata. Explicit workbook save flows validate bounds, formulas, non-finite numbers, XML-safe text, merged ranges, and emitter availability before writing a minimal valid `.xlsx` package.
 - PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
 - PDF/PPTX workflow previews expose page/slide/table/notes metadata and report missing structured emitters instead of treating text writes as valid binary output.

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -13,10 +13,12 @@ writing plain text with a package extension. For tabular text output, agents
 should write CSV/TSV.
 
 Structured workbook output stays on the document-emitter/plugin path.
-`XLSXEmitter` assembles an OOXML ZIP package in memory, validates workbook
-bounds before writing, rejects formulas instead of flattening them, rejects
-workbooks with no renderable cells, rejects overlong cell text and invalid XML,
-and only then writes the package atomically.
+`WorkbookWorkflowService` inspects typed workbooks, reports validation issues
+and emitter availability, and exports only through a registered document
+emitter. `XLSXEmitter` assembles an OOXML ZIP package in memory, validates
+workbook bounds before writing, rejects formulas instead of flattening them,
+rejects workbooks with no renderable cells, rejects overlong cell text and
+invalid XML, and only then writes the package atomically.
 
 PDF/PPTX creation remains diagnostic-only in core. `PDFPPTXWorkflowService`
 reports whether a structured emitter is registered for a typed PDF/PPTX
@@ -40,12 +42,14 @@ No workbook writer is added to the default schema.
 | XLSX formula safety | Formula cells are rejected, while formula-looking strings stay inert shared strings | `XLSXEmitterTests.emit_rejectsFormulaCellsWithoutFlatteningThem`, `XLSXEmitterTests.emit_keepsFormulaLookingTextInert` |
 | XLSX bounds | Empty exports, whitespace-only exports, overlong cell text, invalid names/references, non-finite numbers, and ZIP32 overflows are rejected before package write | `XLSXEmitterTests`, `XLSXAdapterTests` |
 | PDF/PPTX creation diagnostics | Typed PDF/PPTX workflows report registered emitters or `missingEmitter` and do not route creation through text writes | `PDFPPTXWorkflowServiceTests` |
+| Workbook workflow | Workbook inspection reports sheet/cell/formula/merged-range counts, validation reason codes, and missing-emitter state before export | `WorkbookWorkflowServiceTests` |
 | Tool exposure | XLSX plugin injection is bias-only, installed-plugin gated, and allowlist-respecting | `PreflightCapabilitySearchTests.folderInjection_*`, `FolderPluginHintsTests` |
 
 ## Follow-Up Lanes
 
-1. Add first-party workbook write UI/tooling only when it can call the
-   structured emitter directly and surface save/share state as an artifact.
+1. Add first-party workbook write UI/tooling only when it can call
+   `WorkbookWorkflowService.export` and surface save/share state as an
+   artifact.
 2. Keep extending structured creation only through real emitters, artifact
    surfacing, and validation errors; do not add package-shaped text writes.
 3. Keep sandbox write parity separate: `sandbox_write_file` has a different


### PR DESCRIPTION
## Maintainer status

Ready for maintainer review. This PR is non-draft, merge-clean, and GitHub-green on head `9bf9605f320185055111ab192524905d9b61edb5`.

## Maintainer rationale

**Business rationale:** Users need real workbook inspection/export affordances, not plain-text guesses about XLSX files. This PR provides bounded workbook validation and explicit export availability while staying behind the existing document registry/emitter path.

**Coding rationale:** The change reuses `XLSXAdapter`, `XLSXEmitter`, workbook validation, and `DocumentFormatRegistry` instead of adding always-on agent tools or ad hoc XML output.

**Osaurus standards check:** Current-main, function-sized PR; bounded read/write metadata; no fake XLSX text output; export is explicit and registry-backed; focused tests plus GitHub CI are green.

## Business rationale

This is the Workbook End-to-End Workflow feature PR from the development plan. It provides explicit XLSX inspection, validation, and emitter-backed export surfaces without adding an unsafe default agent workbook writer. Users and plugins get a real workflow for validating workbook output and understanding why export is or is not available.

## Coding rationale

`WorkbookWorkflowService` centralizes workbook inspection, validation reason codes, emitter availability, and export. It reuses the existing `Workbook`, `XLSXAdapter`, `XLSXEmitter`, and `DocumentFormatRegistry` surfaces instead of creating a parallel workbook model. The refresh also keeps XLSX number formatting lint-clean by naming the Int64-safe integer condition in `XLSXEmitter`.

## Acceptance criteria

- Workbook inspection reports sheet/row/cell counts, formulas, merged ranges, validation state, and emitter availability.
- Workbook validation returns structured reason codes for formulas, non-finite numbers, bounds, duplicate sheets/rows/cells, merged range direction, XML-unsafe text, and empty renderable content.
- XLSX export goes through a registered document emitter and reports missing-emitter state without touching the target.
- Formula-looking text remains inert and formula cells are not silently flattened into fake output.
- No default `file_write` workbook path is added.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `d0302ddeb94bcc6bccece9c45e7935168fa48809` on `mimeding:codex/workbook-end-to-end-workflow`.
- Rebase was clean. The only refresh cleanup was a local SwiftLint/format-compatible rewrite of an XLSXEmitter numeric condition.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `xcrun swift-format lint --configuration .swift-format` on touched Swift files
- [x] `swiftlint lint --quiet --config .swiftlint.yml` on touched Swift files
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-workbook-rebased swift test --package-path Packages/OsaurusCore --filter 'WorkbookWorkflowServiceTests|XLSXEmitterTests|XLSXAdapterTests|FileReadWorkbookTests|FolderToolsResilienceTests'` (49 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [x] GitHub CI green on `d0302dde`: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and release drafter.

## Debug evidence

The focused test run passed 49 tests. It covers workbook inspection, validation codes, missing-emitter refusal, registered-emitter export and round-trip, formula and formula-looking-text handling, XLSX adapter parsing/security metadata, file_read workbook previews, and folder text-write safety for workbook packages.

## Self-review

### Regression review

Touched call sites are explicit workbook workflow/export helpers, XLSX emitter validation, workbook-focused tests, and docs. Existing `file_read` and `file_write` defaults remain unchanged; workbook export requires an explicit caller and registered emitter. The focused tests cover workflow validation, emitter behavior, adapter round trips, and folder-tool guardrails.

### Performance review

Validation is bounded by workbook sheet/row/cell collections already in memory. Export uses the existing registered emitter path and does not add background parsing or file I/O unless the explicit export call is made. Bounds and reason codes prevent accidental large or fake XLSX output.

## Rollback

Revert this PR commit to remove the workbook workflow service, XLSX validation changes, tests, and docs updates.

## Latest refresh

- Refreshed on June 9, 2026 against `origin/main` `fdc5d210` (`Pin vMLX MiMo routed JANG fix (#1425)`).
- Rebased with one documentation conflict in `docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md`; kept current PDF/PPTX/dry-run safety coverage and this PR workbook workflow coverage.
- Force-pushed current head `9bf9605f`.
- Local validation: `git diff --check`; `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-1368 swift test --package-path Packages/OsaurusCore --filter 'WorkbookWorkflowServiceTests|XLSXEmitterTests'` (12 tests).
- GitHub CI restarted on the refreshed head; wait for branch checks before merge.

