### PR TITLE
Add CSV table workflow previews and export

### DIFF
--- a/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
+++ b/Packages/OsaurusCore/Managers/Documents/DocumentAdaptersBootstrap.swift
@@ -31,6 +31,8 @@ public enum DocumentAdaptersBootstrap {
         registry.register(adapter: PPTXAdapter())
         registry.register(adapter: RichDocumentAdapter())
         registry.register(adapter: XLSXAdapter())
+        registry.register(emitter: CSVEmitter(delimiter: .comma))
+        registry.register(emitter: CSVEmitter(delimiter: .tab))
         registry.register(emitter: XLSXEmitter())
         if registry === DocumentFormatRegistry.shared {
             didRegisterShared = true

--- a/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVAdapter.swift
@@ -94,7 +94,7 @@ public struct CSVAdapter: DocumentFormatAdapter, FormatAdapter {
             throw DocumentAdapterError.emptyContent
         }
 
-        let parsedRows = Self.parseRows(source: source, delimiter: delimiter)
+        let parsedRows = CSVRowParser.parseRows(source: source, delimiter: delimiter)
         guard !parsedRows.isEmpty else {
             throw DocumentAdapterError.emptyContent
         }
@@ -139,137 +139,12 @@ public struct CSVAdapter: DocumentFormatAdapter, FormatAdapter {
         }
     }
 
-    // MARK: - Parsing
-
-    private static func parseRows(source: String, delimiter: CSVDelimiter) -> [ParsedRow] {
-        let delimiterScalar = scalar(for: delimiter)
-        let quoteScalar = UnicodeScalar("\"")
-        let carriageReturn = UnicodeScalar("\r")
-        let lineFeed = UnicodeScalar("\n")
-        let scalars = source.unicodeScalars
-
-        var rows: [ParsedRow] = []
-        var cells: [ParsedCell] = []
-        var field = ""
-        var fieldStart = 0
-        var rowStart = 0
-        var offset = 0
-        var isQuoted = false
-        var wasQuoted = false
-        var index = scalars.startIndex
-
-        func finishCell(sourceEnd: Int) {
-            let sourceRange = DocumentTextRange(
-                startUTF16Offset: fieldStart,
-                length: sourceEnd - fieldStart
-            )
-            cells.append(
-                ParsedCell(
-                    text: field,
-                    wasQuoted: wasQuoted,
-                    sourceRange: sourceRange
-                )
-            )
-            field = ""
-            wasQuoted = false
-        }
-
-        func finishRow(sourceEnd: Int) {
-            finishCell(sourceEnd: sourceEnd)
-            let rowRange = DocumentTextRange(
-                startUTF16Offset: rowStart,
-                length: sourceEnd - rowStart
-            )
-            rows.append(ParsedRow(cells: cells, sourceRange: rowRange))
-            cells = []
-        }
-
-        while index != scalars.endIndex {
-            let scalar = scalars[index]
-            let scalarLength = utf16Length(of: scalar)
-
-            if isQuoted {
-                if scalar == quoteScalar {
-                    let nextIndex = scalars.index(after: index)
-                    if nextIndex != scalars.endIndex, scalars[nextIndex] == quoteScalar {
-                        field.unicodeScalars.append(quoteScalar)
-                        scalars.formIndex(after: &index)
-                        scalars.formIndex(after: &index)
-                        offset += 2
-                    } else {
-                        isQuoted = false
-                        scalars.formIndex(after: &index)
-                        offset += scalarLength
-                    }
-                } else {
-                    field.unicodeScalars.append(scalar)
-                    scalars.formIndex(after: &index)
-                    offset += scalarLength
-                }
-                continue
-            }
-
-            if scalar == quoteScalar, field.isEmpty, fieldStart == offset {
-                isQuoted = true
-                wasQuoted = true
-                scalars.formIndex(after: &index)
-                offset += scalarLength
-                continue
-            }
-
-            if scalar == delimiterScalar {
-                finishCell(sourceEnd: offset)
-                scalars.formIndex(after: &index)
-                offset += scalarLength
-                fieldStart = offset
-                continue
-            }
-
-            if scalar == carriageReturn || scalar == lineFeed {
-                finishRow(sourceEnd: offset)
-                let nextIndex = scalars.index(after: index)
-                if scalar == carriageReturn, nextIndex != scalars.endIndex, scalars[nextIndex] == lineFeed {
-                    scalars.formIndex(after: &index)
-                    scalars.formIndex(after: &index)
-                    offset += 2
-                } else {
-                    scalars.formIndex(after: &index)
-                    offset += scalarLength
-                }
-                rowStart = offset
-                fieldStart = offset
-                continue
-            }
-
-            field.unicodeScalars.append(scalar)
-            scalars.formIndex(after: &index)
-            offset += scalarLength
-        }
-
-        if !cells.isEmpty || !field.isEmpty || wasQuoted || fieldStart < offset {
-            finishRow(sourceEnd: offset)
-        }
-
-        return rows
-    }
-
-    private static func scalar(for delimiter: CSVDelimiter) -> UnicodeScalar {
-        switch delimiter {
-        case .comma: return UnicodeScalar(",")
-        case .tab: return UnicodeScalar("\t")
-        }
-    }
-
-    private static func utf16Length(of scalar: UnicodeScalar) -> Int {
-        scalar.value <= 0xFFFF ? 1 : 2
-    }
-
     // MARK: - Structure
 
     private static func buildDocument(
         filename: String,
         delimiter: CSVDelimiter,
-        parsedRows: [ParsedRow],
+        parsedRows: [CSVRowParser.Row],
         sourceTextLengthUTF16: Int
     ) -> BuiltCSVDocument {
         let rootAnchor = DocumentAnchor.root(label: filename)
@@ -481,17 +356,6 @@ public struct CSVAdapter: DocumentFormatAdapter, FormatAdapter {
             characterOffset: range.endUTF16Offset
         )
         return DocumentSourceRange(start: start, end: end)
-    }
-
-    private struct ParsedCell {
-        let text: String
-        let wasQuoted: Bool
-        let sourceRange: DocumentTextRange
-    }
-
-    private struct ParsedRow {
-        let cells: [ParsedCell]
-        let sourceRange: DocumentTextRange
     }
 
     private struct BuiltCSVDocument {

--- a/Packages/OsaurusCore/Services/Documents/CSVEmitter.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVEmitter.swift
@@ -1,0 +1,115 @@
+//
+//  CSVEmitter.swift
+//  osaurus
+//
+//  Emits typed CSV/TSV documents back to delimited text. This is an explicit
+//  document-emitter surface; it is not exposed as a default file-write tool.
+//
+
+import Foundation
+
+public struct CSVEmitter: DocumentFormatEmitter {
+    public let delimiter: CSVDelimiter
+    public let allowFormulaLikeText: Bool
+
+    public var formatId: String { delimiter.formatId }
+
+    public init(delimiter: CSVDelimiter = .comma, allowFormulaLikeText: Bool = false) {
+        self.delimiter = delimiter
+        self.allowFormulaLikeText = allowFormulaLikeText
+    }
+
+    public func canEmit(_ document: StructuredDocument) -> Bool {
+        guard let csv = document.representation.underlying as? CSVDocument else { return false }
+        return document.formatId == formatId
+            || document.representation.formatId == formatId
+            || csv.delimiter == delimiter
+    }
+
+    public func emit(_ document: StructuredDocument, to url: URL) async throws {
+        guard let csv = document.representation.underlying as? CSVDocument else {
+            throw DocumentAdapterError.unsupportedFormat(formatId: document.formatId)
+        }
+
+        do {
+            let data = try Self.data(
+                for: csv,
+                delimiter: delimiter,
+                allowFormulaLikeText: allowFormulaLikeText
+            )
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        } catch let error as DocumentAdapterError {
+            throw error
+        } catch {
+            throw DocumentAdapterError.writeFailed(underlying: error.localizedDescription)
+        }
+    }
+
+    static func data(
+        for csv: CSVDocument,
+        delimiter: CSVDelimiter,
+        allowFormulaLikeText: Bool = false
+    ) throws -> Data {
+        let lines = try csv.rows.map { row in
+            try row.cells.map { cell in
+                try encodeField(
+                    cell.text,
+                    delimiter: delimiter,
+                    allowFormulaLikeText: allowFormulaLikeText
+                )
+            }.joined(separator: delimiter.rawValue)
+        }
+        guard let data = lines.joined(separator: "\n").data(using: .utf8) else {
+            throw DocumentAdapterError.writeFailed(underlying: "CSV output could not be encoded as UTF-8")
+        }
+        return data
+    }
+
+    private static func encodeField(
+        _ value: String,
+        delimiter: CSVDelimiter,
+        allowFormulaLikeText: Bool
+    ) throws -> String {
+        try validateText(value)
+        if !allowFormulaLikeText, isFormulaLike(value) {
+            throw DocumentAdapterError.writeFailed(
+                underlying: "CSV output contains a spreadsheet formula-like field"
+            )
+        }
+        let needsQuotes =
+            value.contains(delimiter.rawValue) || value.contains("\"") || value.contains("\n") || value.contains("\r")
+        guard needsQuotes else { return value }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    private static func isFormulaLike(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return false }
+        if first == "=" || first == "@" { return true }
+        if first == "+" || first == "-", Double(trimmed) == nil { return true }
+        return false
+    }
+
+    private static func validateText(_ value: String) throws {
+        for scalar in value.unicodeScalars where !isAllowedTextScalar(scalar) {
+            throw DocumentAdapterError.writeFailed(
+                underlying: "CSV output contains an unsupported control character"
+            )
+        }
+    }
+
+    private static func isAllowedTextScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x9, 0xA, 0xD:
+            return true
+        case 0x20 ... 0xD7FF, 0xE000 ... 0xFFFD, 0x10000 ... 0x10FFFF:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/CSVRowParser.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVRowParser.swift
@@ -1,0 +1,144 @@
+//
+//  CSVRowParser.swift
+//  osaurus
+//
+//  Shared delimited-text parser for CSV/TSV adapters and workflow previews.
+//
+
+import Foundation
+
+enum CSVRowParser {
+    struct Cell: Equatable, Sendable {
+        let text: String
+        let wasQuoted: Bool
+        let sourceRange: DocumentTextRange
+    }
+
+    struct Row: Equatable, Sendable {
+        let cells: [Cell]
+        let sourceRange: DocumentTextRange
+    }
+
+    static func parseRows(source: String, delimiter: CSVDelimiter) -> [Row] {
+        let delimiterScalar = scalar(for: delimiter)
+        let quoteScalar = UnicodeScalar("\"")
+        let carriageReturn = UnicodeScalar("\r")
+        let lineFeed = UnicodeScalar("\n")
+        let scalars = source.unicodeScalars
+
+        var rows: [Row] = []
+        var cells: [Cell] = []
+        var field = ""
+        var fieldStart = 0
+        var rowStart = 0
+        var offset = 0
+        var isQuoted = false
+        var wasQuoted = false
+        var index = scalars.startIndex
+
+        func finishCell(sourceEnd: Int) {
+            let sourceRange = DocumentTextRange(
+                startUTF16Offset: fieldStart,
+                length: sourceEnd - fieldStart
+            )
+            cells.append(
+                Cell(
+                    text: field,
+                    wasQuoted: wasQuoted,
+                    sourceRange: sourceRange
+                )
+            )
+            field = ""
+            wasQuoted = false
+        }
+
+        func finishRow(sourceEnd: Int) {
+            finishCell(sourceEnd: sourceEnd)
+            let rowRange = DocumentTextRange(
+                startUTF16Offset: rowStart,
+                length: sourceEnd - rowStart
+            )
+            rows.append(Row(cells: cells, sourceRange: rowRange))
+            cells = []
+        }
+
+        while index != scalars.endIndex {
+            let scalar = scalars[index]
+            let scalarLength = utf16Length(of: scalar)
+
+            if isQuoted {
+                if scalar == quoteScalar {
+                    let nextIndex = scalars.index(after: index)
+                    if nextIndex != scalars.endIndex, scalars[nextIndex] == quoteScalar {
+                        field.unicodeScalars.append(quoteScalar)
+                        scalars.formIndex(after: &index)
+                        scalars.formIndex(after: &index)
+                        offset += 2
+                    } else {
+                        isQuoted = false
+                        scalars.formIndex(after: &index)
+                        offset += scalarLength
+                    }
+                } else {
+                    field.unicodeScalars.append(scalar)
+                    scalars.formIndex(after: &index)
+                    offset += scalarLength
+                }
+                continue
+            }
+
+            if scalar == quoteScalar, field.isEmpty, fieldStart == offset {
+                isQuoted = true
+                wasQuoted = true
+                scalars.formIndex(after: &index)
+                offset += scalarLength
+                continue
+            }
+
+            if scalar == delimiterScalar {
+                finishCell(sourceEnd: offset)
+                scalars.formIndex(after: &index)
+                offset += scalarLength
+                fieldStart = offset
+                continue
+            }
+
+            if scalar == carriageReturn || scalar == lineFeed {
+                finishRow(sourceEnd: offset)
+                let nextIndex = scalars.index(after: index)
+                if scalar == carriageReturn, nextIndex != scalars.endIndex, scalars[nextIndex] == lineFeed {
+                    scalars.formIndex(after: &index)
+                    scalars.formIndex(after: &index)
+                    offset += 2
+                } else {
+                    scalars.formIndex(after: &index)
+                    offset += scalarLength
+                }
+                rowStart = offset
+                fieldStart = offset
+                continue
+            }
+
+            field.unicodeScalars.append(scalar)
+            scalars.formIndex(after: &index)
+            offset += scalarLength
+        }
+
+        if !cells.isEmpty || !field.isEmpty || wasQuoted || fieldStart < offset {
+            finishRow(sourceEnd: offset)
+        }
+
+        return rows
+    }
+
+    private static func scalar(for delimiter: CSVDelimiter) -> UnicodeScalar {
+        switch delimiter {
+        case .comma: return UnicodeScalar(",")
+        case .tab: return UnicodeScalar("\t")
+        }
+    }
+
+    private static func utf16Length(of scalar: UnicodeScalar) -> Int {
+        scalar.value <= 0xFFFF ? 1 : 2
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/CSVTableWorkflowService.swift
+++ b/Packages/OsaurusCore/Services/Documents/CSVTableWorkflowService.swift
@@ -1,0 +1,550 @@
+//
+//  CSVTableWorkflowService.swift
+//  osaurus
+//
+//  Table workflow helpers for CSV/TSV documents: bounded previews, schema
+//  inference, and explicit delimited-text export.
+//
+
+import Foundation
+
+public struct CSVTablePreviewPolicy: Codable, Equatable, Sendable {
+    public let maxPreviewBytes: Int
+    public let maxRows: Int
+    public let maxColumns: Int
+    public let maxSampleValuesPerColumn: Int
+    public let maxCellPreviewUTF16Units: Int
+
+    public init(
+        maxPreviewBytes: Int = 1 * 1024 * 1024,
+        maxRows: Int = 1_000,
+        maxColumns: Int = 200,
+        maxSampleValuesPerColumn: Int = 5,
+        maxCellPreviewUTF16Units: Int = 512
+    ) {
+        self.maxPreviewBytes = max(1, maxPreviewBytes)
+        self.maxRows = max(1, maxRows)
+        self.maxColumns = max(1, maxColumns)
+        self.maxSampleValuesPerColumn = max(0, maxSampleValuesPerColumn)
+        self.maxCellPreviewUTF16Units = max(1, maxCellPreviewUTF16Units)
+    }
+
+    public static let standard = CSVTablePreviewPolicy()
+}
+
+public enum CSVInferredColumnType: String, Codable, Hashable, Sendable {
+    case empty
+    case integer
+    case decimal
+    case boolean
+    case date
+    case string
+    case mixed
+}
+
+public struct CSVColumnPreview: Codable, Equatable, Sendable {
+    public let index: Int
+    public let name: String
+    public let inferredType: CSVInferredColumnType
+    public let nonEmptyCount: Int
+    public let emptyCount: Int
+    public let distinctSampleCount: Int
+    public let maxUTF16Length: Int
+    public let sampleValues: [String]
+}
+
+public struct CSVSampleRow: Codable, Equatable, Sendable {
+    public let rowIndex: Int
+    public let values: [String]
+    public let sourceRange: DocumentTextRange?
+    public let truncatedCellTextCount: Int
+}
+
+public struct CSVTablePreview: Codable, Equatable, Sendable {
+    public let formatId: String
+    public let filename: String
+    public let fileSize: Int64
+    public let delimiter: CSVDelimiter
+    public let hasHeader: Bool
+    public let sourceBytesRead: Int
+    public let rowsScanned: Int
+    public let sampledRows: [CSVSampleRow]
+    public let columns: [CSVColumnPreview]
+    public let truncatedByByteLimit: Bool
+    public let truncatedByRowLimit: Bool
+    public let truncatedByColumnLimit: Bool
+
+    public var sampledRowCount: Int { sampledRows.count }
+    public var columnCount: Int { columns.count }
+}
+
+public struct CSVTableExportPolicy: Codable, Equatable, Sendable {
+    public let maxRows: Int
+    public let maxColumns: Int
+    public let maxCells: Int
+    public let maxCellTextUTF16Units: Int
+    public let allowFormulaLikeText: Bool
+
+    public init(
+        maxRows: Int = 1_000_000,
+        maxColumns: Int = 16_384,
+        maxCells: Int = 2_000_000,
+        maxCellTextUTF16Units: Int = 32_767,
+        allowFormulaLikeText: Bool = false
+    ) {
+        self.maxRows = max(1, maxRows)
+        self.maxColumns = max(1, maxColumns)
+        self.maxCells = max(1, maxCells)
+        self.maxCellTextUTF16Units = max(1, maxCellTextUTF16Units)
+        self.allowFormulaLikeText = allowFormulaLikeText
+    }
+
+    public static let standard = CSVTableExportPolicy()
+}
+
+public struct CSVTableExportIssue: Codable, Equatable, Sendable {
+    public enum Code: String, Codable, Hashable, Sendable {
+        case noRows
+        case tooManyRows
+        case tooManyColumns
+        case tooManyCells
+        case overlongCellText
+        case formulaLikeText
+        case invalidText
+    }
+
+    public let code: Code
+    public let message: String
+    public let rowIndex: Int?
+    public let columnIndex: Int?
+}
+
+public struct CSVTableExportResult: Codable, Equatable, Sendable {
+    public let url: URL
+    public let formatId: String
+    public let delimiter: CSVDelimiter
+    public let rowCount: Int
+    public let columnCount: Int
+    public let bytesWritten: Int64
+}
+
+public enum CSVTableWorkflowError: LocalizedError, Sendable {
+    case notCSV(formatId: String)
+    case emptyPreview
+    case validationFailed([CSVTableExportIssue])
+    case writeFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notCSV(let formatId):
+            return "Document format '\(formatId)' does not contain a CSV/TSV table representation"
+        case .emptyPreview:
+            return "CSV/TSV preview contains no complete rows"
+        case .validationFailed(let issues):
+            let first = issues.first?.message ?? "CSV/TSV export failed validation"
+            return "CSV/TSV export validation failed: \(first)"
+        case .writeFailed(let message):
+            return "CSV/TSV export failed: \(message)"
+        }
+    }
+}
+
+public enum CSVTableWorkflowService {
+    public static func preview(
+        _ document: StructuredDocument,
+        policy: CSVTablePreviewPolicy = .standard
+    ) throws -> CSVTablePreview {
+        guard let csv = document.representation.underlying as? CSVDocument else {
+            throw CSVTableWorkflowError.notCSV(formatId: document.formatId)
+        }
+        let rows = csv.rows.map { row in
+            SourceRow(
+                rowIndex: row.rowIndex,
+                values: row.cells.map(\.text),
+                sourceRange: row.sourceRange
+            )
+        }
+        return try buildPreview(
+            filename: document.filename,
+            fileSize: document.fileSize,
+            delimiter: csv.delimiter,
+            rows: rows,
+            sourceBytesRead: Int(min(document.fileSize, Int64(Int.max))),
+            truncatedByByteLimit: false,
+            policy: policy
+        )
+    }
+
+    public static func preview(
+        url: URL,
+        delimiter: CSVDelimiter,
+        policy: CSVTablePreviewPolicy = .standard
+    ) async throws -> CSVTablePreview {
+        let fileSize = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+        let prefix = try readPreviewPrefix(url: url, policy: policy)
+        let parsedRows = CSVRowParser.parseRows(source: prefix.source, delimiter: delimiter)
+        let rows = parsedRows.enumerated().map { index, row in
+            SourceRow(rowIndex: index, values: row.cells.map(\.text), sourceRange: row.sourceRange)
+        }
+        return try buildPreview(
+            filename: url.lastPathComponent,
+            fileSize: fileSize,
+            delimiter: delimiter,
+            rows: rows,
+            sourceBytesRead: prefix.bytesRead,
+            truncatedByByteLimit: prefix.truncatedByByteLimit,
+            policy: policy
+        )
+    }
+
+    public static func export(
+        _ document: StructuredDocument,
+        to url: URL,
+        delimiter: CSVDelimiter,
+        policy: CSVTableExportPolicy = .standard
+    ) async throws -> CSVTableExportResult {
+        guard let csv = document.representation.underlying as? CSVDocument else {
+            throw CSVTableWorkflowError.notCSV(formatId: document.formatId)
+        }
+        let issues = validationIssues(for: csv, policy: policy)
+        guard issues.isEmpty else {
+            throw CSVTableWorkflowError.validationFailed(issues)
+        }
+
+        do {
+            try await CSVEmitter(
+                delimiter: delimiter,
+                allowFormulaLikeText: policy.allowFormulaLikeText
+            ).emit(document, to: url)
+            let bytesWritten = Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+            return CSVTableExportResult(
+                url: url,
+                formatId: delimiter.formatId,
+                delimiter: delimiter,
+                rowCount: csv.rowCount,
+                columnCount: csv.columnCount,
+                bytesWritten: bytesWritten
+            )
+        } catch let error as CSVTableWorkflowError {
+            throw error
+        } catch let error as DocumentAdapterError {
+            throw CSVTableWorkflowError.writeFailed(error.localizedDescription)
+        } catch {
+            throw CSVTableWorkflowError.writeFailed(error.localizedDescription)
+        }
+    }
+
+    public static func validationIssues(
+        for csv: CSVDocument,
+        policy: CSVTableExportPolicy = .standard
+    ) -> [CSVTableExportIssue] {
+        var validator = CSVTableExportValidator(policy: policy)
+        return validator.validate(csv)
+    }
+
+    private static func buildPreview(
+        filename: String,
+        fileSize: Int64,
+        delimiter: CSVDelimiter,
+        rows: [SourceRow],
+        sourceBytesRead: Int,
+        truncatedByByteLimit: Bool,
+        policy: CSVTablePreviewPolicy
+    ) throws -> CSVTablePreview {
+        guard !rows.isEmpty else { throw CSVTableWorkflowError.emptyPreview }
+
+        let truncatedByRowLimit = rows.count > policy.maxRows
+        let sampledSourceRows = Array(rows.prefix(policy.maxRows))
+        let maxObservedColumns = sampledSourceRows.map(\.values.count).max() ?? 0
+        let visibleColumnCount = min(maxObservedColumns, policy.maxColumns)
+        let truncatedByColumnLimit = maxObservedColumns > policy.maxColumns
+        let hasHeader = inferHasHeader(rows: sampledSourceRows, columnCount: visibleColumnCount)
+        let dataRows = hasHeader ? Array(sampledSourceRows.dropFirst()) : sampledSourceRows
+        let columns = buildColumns(
+            rows: dataRows.isEmpty ? sampledSourceRows : dataRows,
+            headerRow: hasHeader ? sampledSourceRows.first : nil,
+            columnCount: visibleColumnCount,
+            policy: policy
+        )
+        let sampledRows = sampledSourceRows.map { row in
+            let values = row.values.prefix(visibleColumnCount).map {
+                truncate($0, maxUTF16Units: policy.maxCellPreviewUTF16Units).value
+            }
+            let truncatedCellTextCount = row.values.prefix(visibleColumnCount).filter {
+                truncate($0, maxUTF16Units: policy.maxCellPreviewUTF16Units).wasTruncated
+            }.count
+            return CSVSampleRow(
+                rowIndex: row.rowIndex,
+                values: Array(values),
+                sourceRange: row.sourceRange,
+                truncatedCellTextCount: truncatedCellTextCount
+            )
+        }
+
+        return CSVTablePreview(
+            formatId: delimiter.formatId,
+            filename: filename,
+            fileSize: fileSize,
+            delimiter: delimiter,
+            hasHeader: hasHeader,
+            sourceBytesRead: sourceBytesRead,
+            rowsScanned: sampledSourceRows.count,
+            sampledRows: sampledRows,
+            columns: columns,
+            truncatedByByteLimit: truncatedByByteLimit,
+            truncatedByRowLimit: truncatedByRowLimit,
+            truncatedByColumnLimit: truncatedByColumnLimit
+        )
+    }
+
+    private static func readPreviewPrefix(
+        url: URL,
+        policy: CSVTablePreviewPolicy
+    ) throws -> (source: String, bytesRead: Int, truncatedByByteLimit: Bool) {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: policy.maxPreviewBytes + 1) ?? Data()
+        let truncated = data.count > policy.maxPreviewBytes
+        let prefixData = truncated ? data.prefix(policy.maxPreviewBytes) : data[...]
+        let prefixBytes = Array(prefixData)
+        var source =
+            String(bytes: prefixBytes, encoding: .utf8)
+            ?? String(bytes: prefixBytes, encoding: .isoLatin1)
+            ?? ""
+        if truncated {
+            source = trimTrailingPartialRow(source)
+        }
+        return (source, prefixData.count, truncated)
+    }
+
+    private static func trimTrailingPartialRow(_ source: String) -> String {
+        guard let lastNewline = source.lastIndex(where: { $0 == "\n" || $0 == "\r" }) else {
+            return source
+        }
+        return String(source[...lastNewline])
+    }
+
+    private static func inferHasHeader(rows: [SourceRow], columnCount: Int) -> Bool {
+        guard rows.count >= 2, columnCount > 0 else { return false }
+        let first = rows[0].values
+        let names = first.prefix(columnCount).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard names.contains(where: { !$0.isEmpty }) else { return false }
+        guard Set(names.filter { !$0.isEmpty }.map { $0.lowercased() }).count == names.filter({ !$0.isEmpty }).count
+        else { return false }
+
+        let dataRows = Array(rows.dropFirst())
+        for columnIndex in 0 ..< columnCount {
+            let headerType = classify(names[safe: columnIndex] ?? "")
+            let dataTypes = dataRows.compactMap { row -> CSVInferredColumnType? in
+                let value = row.values[safe: columnIndex]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !value.isEmpty else { return nil }
+                return classify(value)
+            }
+            if headerType == .string, dataTypes.contains(where: { $0 != .string && $0 != .mixed }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func buildColumns(
+        rows: [SourceRow],
+        headerRow: SourceRow?,
+        columnCount: Int,
+        policy: CSVTablePreviewPolicy
+    ) -> [CSVColumnPreview] {
+        var usedNames: [String: Int] = [:]
+        return (0 ..< columnCount).map { columnIndex in
+            let rawName = headerRow?.values[safe: columnIndex]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let baseName = rawName?.isEmpty == false ? rawName! : "Column \(columnIndex + 1)"
+            let name = uniqueName(baseName, usedNames: &usedNames)
+            let values = rows.map { $0.values[safe: columnIndex] ?? "" }
+            let nonEmptyValues = values.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            var sampleValues: [String] = []
+            var seenSamples: Set<String> = []
+            for value in nonEmptyValues where sampleValues.count < policy.maxSampleValuesPerColumn {
+                let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard seenSamples.insert(normalized).inserted else { continue }
+                sampleValues.append(truncate(normalized, maxUTF16Units: policy.maxCellPreviewUTF16Units).value)
+            }
+            return CSVColumnPreview(
+                index: columnIndex,
+                name: name,
+                inferredType: inferType(values: nonEmptyValues),
+                nonEmptyCount: nonEmptyValues.count,
+                emptyCount: values.count - nonEmptyValues.count,
+                distinctSampleCount: Set(nonEmptyValues).count,
+                maxUTF16Length: values.map { $0.utf16.count }.max() ?? 0,
+                sampleValues: sampleValues
+            )
+        }
+    }
+
+    private static func uniqueName(_ value: String, usedNames: inout [String: Int]) -> String {
+        let normalized = value.lowercased()
+        let next = (usedNames[normalized] ?? 0) + 1
+        usedNames[normalized] = next
+        return next == 1 ? value : "\(value) (\(next))"
+    }
+
+    private static func inferType(values: [String]) -> CSVInferredColumnType {
+        let types = Set(values.map { classify($0.trimmingCharacters(in: .whitespacesAndNewlines)) })
+        guard !types.isEmpty else { return .empty }
+        if types.count == 1 { return types.first! }
+        if types.isSubset(of: [.integer, .decimal]) { return .decimal }
+        return .mixed
+    }
+
+    private static func classify(_ value: String) -> CSVInferredColumnType {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return .empty }
+        if isBoolean(trimmed) { return .boolean }
+        if Int64(trimmed) != nil { return .integer }
+        if Double(trimmed) != nil { return .decimal }
+        if isISODate(trimmed) { return .date }
+        return .string
+    }
+
+    private static func isBoolean(_ value: String) -> Bool {
+        switch value.lowercased() {
+        case "true", "false":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isISODate(_ value: String) -> Bool {
+        let pattern = #"^\d{4}-\d{2}-\d{2}([T ][0-9:.+-Zz]+)?$"#
+        return value.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private static func truncate(_ value: String, maxUTF16Units: Int) -> (value: String, wasTruncated: Bool) {
+        guard value.utf16.count > maxUTF16Units else { return (value, false) }
+        var result = ""
+        result.reserveCapacity(maxUTF16Units)
+        for character in value {
+            if result.utf16.count + String(character).utf16.count > maxUTF16Units { break }
+            result.append(character)
+        }
+        return (result, true)
+    }
+
+    private struct SourceRow {
+        let rowIndex: Int
+        let values: [String]
+        let sourceRange: DocumentTextRange?
+    }
+}
+
+private struct CSVTableExportValidator {
+    private let policy: CSVTableExportPolicy
+    private var issues: [CSVTableExportIssue] = []
+    private var totalCells = 0
+
+    init(policy: CSVTableExportPolicy) {
+        self.policy = policy
+    }
+
+    mutating func validate(_ csv: CSVDocument) -> [CSVTableExportIssue] {
+        issues = []
+        totalCells = 0
+
+        if csv.rows.isEmpty {
+            add(.noRows, "CSV/TSV export requires at least one row.")
+        }
+        if csv.rows.count > policy.maxRows {
+            add(.tooManyRows, "CSV/TSV export has \(csv.rows.count) rows, limit is \(policy.maxRows).")
+        }
+        for row in csv.rows {
+            validate(row)
+        }
+        if totalCells > policy.maxCells {
+            add(.tooManyCells, "CSV/TSV export has \(totalCells) cells, limit is \(policy.maxCells).")
+        }
+        return issues
+    }
+
+    private mutating func validate(_ row: CSVRow) {
+        if row.cells.count > policy.maxColumns {
+            add(
+                .tooManyColumns,
+                "Row \(row.rowIndex + 1) has \(row.cells.count) cells, limit is \(policy.maxColumns).",
+                rowIndex: row.rowIndex
+            )
+        }
+        for cell in row.cells {
+            validate(cell)
+        }
+    }
+
+    private mutating func validate(_ cell: CSVCell) {
+        totalCells += 1
+        if cell.text.utf16.count > policy.maxCellTextUTF16Units {
+            add(
+                .overlongCellText,
+                "R\(cell.rowIndex + 1)C\(cell.columnIndex + 1) exceeds "
+                    + "\(policy.maxCellTextUTF16Units) UTF-16 units.",
+                rowIndex: cell.rowIndex,
+                columnIndex: cell.columnIndex
+            )
+        }
+        if !policy.allowFormulaLikeText, Self.isFormulaLike(cell.text) {
+            add(
+                .formulaLikeText,
+                "R\(cell.rowIndex + 1)C\(cell.columnIndex + 1) starts with a spreadsheet formula prefix.",
+                rowIndex: cell.rowIndex,
+                columnIndex: cell.columnIndex
+            )
+        }
+        if cell.text.unicodeScalars.contains(where: { !Self.isAllowedTextScalar($0) }) {
+            add(
+                .invalidText,
+                "R\(cell.rowIndex + 1)C\(cell.columnIndex + 1) contains an unsupported control character.",
+                rowIndex: cell.rowIndex,
+                columnIndex: cell.columnIndex
+            )
+        }
+    }
+
+    private static func isFormulaLike(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first else { return false }
+        if first == "=" || first == "@" { return true }
+        if first == "+" || first == "-", Double(trimmed) == nil { return true }
+        return false
+    }
+
+    private static func isAllowedTextScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x9, 0xA, 0xD:
+            return true
+        case 0x20 ... 0xD7FF, 0xE000 ... 0xFFFD, 0x10000 ... 0x10FFFF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private mutating func add(
+        _ code: CSVTableExportIssue.Code,
+        _ message: String,
+        rowIndex: Int? = nil,
+        columnIndex: Int? = nil
+    ) {
+        issues.append(
+            CSVTableExportIssue(
+                code: code,
+                message: message,
+                rowIndex: rowIndex,
+                columnIndex: columnIndex
+            )
+        )
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/CSVAdapterTests.swift
@@ -145,6 +145,17 @@ struct CSVAdapterTests {
         #expect(records[1].metadata["documentId"] == reference.id.uuidString)
     }
 
+    @Test func bootstrap_registersCSVEmitters() async throws {
+        let url = try Self.write("name,age\nAda,37\n", filename: "people.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let document = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+        let registry = DocumentFormatRegistry()
+
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+
+        #expect(registry.emitter(for: document)?.formatId == "csv")
+    }
+
     private static func write(_ content: String, filename: String) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-\(filename)")

--- a/Packages/OsaurusCore/Tests/Documents/CSVTableWorkflowServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/CSVTableWorkflowServiceTests.swift
@@ -1,0 +1,133 @@
+//
+//  CSVTableWorkflowServiceTests.swift
+//  osaurusTests
+//
+//  Covers CSV/TSV workflow previews and explicit delimited-text export.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("CSV table workflow service")
+struct CSVTableWorkflowServiceTests {
+    @Test func previewInfersHeaderSchemaAndSamples() async throws {
+        let url = try Self.write(
+            """
+            name,age,active,joined
+            Ada,37,true,2026-06-05
+            Ben,41,false,2026-06-06
+            """,
+            filename: "people.csv"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        let document = try await CSVAdapter(delimiter: .comma).parse(url: url, sizeLimit: 0)
+
+        let preview = try CSVTableWorkflowService.preview(document)
+
+        #expect(preview.hasHeader)
+        #expect(preview.columnCount == 4)
+        #expect(preview.sampledRowCount == 3)
+        #expect(preview.columns.map(\.name) == ["name", "age", "active", "joined"])
+        #expect(preview.columns.map(\.inferredType) == [.string, .integer, .boolean, .date])
+        #expect(preview.columns[1].nonEmptyCount == 2)
+        #expect(preview.columns[1].sampleValues == ["37", "41"])
+    }
+
+    @Test func previewFromLargeFileRespectsByteRowAndColumnCaps() async throws {
+        let rows = (0 ..< 200).map { "row\($0),\($0),\($0 * 2)" }.joined(separator: "\n")
+        let url = try Self.write("name,value,extra\n\(rows)", filename: "large.csv")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let preview = try await CSVTableWorkflowService.preview(
+            url: url,
+            delimiter: .comma,
+            policy: CSVTablePreviewPolicy(
+                maxPreviewBytes: 128,
+                maxRows: 3,
+                maxColumns: 2,
+                maxSampleValuesPerColumn: 2,
+                maxCellPreviewUTF16Units: 16
+            )
+        )
+
+        #expect(preview.truncatedByByteLimit)
+        #expect(preview.truncatedByRowLimit)
+        #expect(preview.truncatedByColumnLimit)
+        #expect(preview.rowsScanned == 3)
+        #expect(preview.columnCount == 2)
+        #expect(preview.columns.map(\.name) == ["name", "value"])
+    }
+
+    @Test func exportConvertsCSVToTSVAndRoundTrips() async throws {
+        let source = try Self.write("name,note\nAda,\"Hello, world\"\n", filename: "notes.csv")
+        let target = Self.temporaryURL(extension: "tsv")
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: target)
+        }
+        let document = try await CSVAdapter(delimiter: .comma).parse(url: source, sizeLimit: 0)
+
+        let result = try await CSVTableWorkflowService.export(
+            document,
+            to: target,
+            delimiter: .tab
+        )
+
+        #expect(result.formatId == "tsv")
+        #expect(result.bytesWritten > 0)
+        let parsed = try await CSVAdapter(delimiter: .tab).parse(url: target, sizeLimit: 0)
+        let table = try #require(parsed.representation.underlying as? CSVDocument)
+        #expect(table.delimiter == .tab)
+        #expect(table.rows[1].cells.map(\.text) == ["Ada", "Hello, world"])
+    }
+
+    @Test func exportRejectsFormulaLikeCellsWithoutTouchingTarget() async throws {
+        let source = try Self.write("name,value\nAda,=2+2\n", filename: "formula.csv")
+        let target = Self.temporaryURL(extension: "csv")
+        try "existing".write(to: target, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: target)
+        }
+        let document = try await CSVAdapter(delimiter: .comma).parse(url: source, sizeLimit: 0)
+
+        do {
+            _ = try await CSVTableWorkflowService.export(document, to: target, delimiter: .comma)
+            Issue.record("expected formula-like export validation failure")
+        } catch CSVTableWorkflowError.validationFailed(let issues) {
+            #expect(issues.map(\.code).contains(.formulaLikeText))
+            #expect(try String(contentsOf: target, encoding: .utf8) == "existing")
+        } catch {
+            Issue.record("expected formula-like export validation failure, got \(error)")
+        }
+    }
+
+    @Test func emitterRejectsFormulaLikeCellsByDefault() async throws {
+        let source = try Self.write("name,value\nAda,@cmd\n", filename: "formula.csv")
+        let target = Self.temporaryURL(extension: "csv")
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: target)
+        }
+        let document = try await CSVAdapter(delimiter: .comma).parse(url: source, sizeLimit: 0)
+
+        await #expect(throws: DocumentAdapterError.self) {
+            try await CSVEmitter(delimiter: .comma).emit(document, to: target)
+        }
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
+    private static func write(_ content: String, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func temporaryURL(extension ext: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-table-workflow.\(ext)")
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -323,6 +323,8 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - `Models/Documents/PresentationDocument.swift` — typed deck, slide, note, table, and relationship representation.
 - `Models/Documents/RichDocumentRepresentation.swift` — sections, headings, links, and metadata for rich text sources.
 - `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
+- `Services/Documents/CSVEmitter.swift` — explicit CSV/TSV delimited-text export.
+- `Services/Documents/CSVTableWorkflowService.swift` — schema previews, bounded samples, and safe CSV/TSV conversion/export validation.
 - `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
 - `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
 - `Services/Documents/WorkbookWorkflowService.swift` — workbook inspection, export availability, validation issues, and explicit emitter-backed save flow.
@@ -334,7 +336,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 
 **Supported format surface:**
 
-- CSV and TSV tables preserve headers, rows, delimiters, and source metadata.
+- CSV and TSV tables preserve headers, rows, delimiters, and source metadata. Explicit table workflow previews infer schema types from bounded samples, cap large-file reads, and validate CSV/TSV conversion/export before writing.
 - XLSX workbooks preserve sheets, cells, formulas, merged ranges, shared strings, relationships, and export availability metadata. Explicit workbook save flows validate bounds, formulas, non-finite numbers, XML-safe text, merged ranges, and emitter availability before writing a minimal valid `.xlsx` package.
 - PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -9,8 +9,14 @@ fidelity lanes moved workbook reading into core `file_read`.
 risk warnings before applying, creates parent directories when explicitly
 applied, writes atomically, and refuses structured package targets (`.xlsx`,
 `.pdf`, `.pptx` families) so an agent cannot create invalid office/PDF output by
-writing plain text with a package extension. For tabular text output, agents
-should write CSV/TSV.
+writing plain text with a package extension. For simple tabular text output,
+agents can still write CSV/TSV text; structured CSV/TSV conversion/export uses
+the explicit document workflow path below.
+
+Structured table output stays on the document-emitter/plugin path.
+`CSVTableWorkflowService` previews bounded samples, reports schema/type
+metadata, validates export bounds and formula-like spreadsheet prefixes, then
+emits CSV/TSV through `CSVEmitter`.
 
 Structured workbook output stays on the document-emitter/plugin path.
 `WorkbookWorkflowService` inspects typed workbooks, reports validation issues
@@ -38,6 +44,7 @@ No workbook writer is added to the default schema.
 | Dry-run write/edit | `dry_run: true` returns a bounded diff/risk preview, does not mutate files, and does not log fake operations | `FolderToolsResilienceTests.fileWrite_dryRunPreviewsDiffWithoutWritingOrLogging`, `FolderToolsResilienceTests.fileEdit_dryRunPreviewsDiffWithoutMutatingOrLogging` |
 | Operation history | Applied file writes/edits are visible through a session-scoped history tool | `FolderToolsResilienceTests.fileWrite_applyLogsInspectableOperationHistory` |
 | CSV output | Text tabular output remains allowed through `file_write` | `FolderToolsResilienceTests.fileWrite_allowsCSVTextOutput` |
+| CSV/TSV workflow | Explicit table export validates row/cell bounds and formula-like spreadsheet prefixes before writing CSV/TSV through an emitter | `CSVTableWorkflowServiceTests` |
 | XLSX emitter | Valid scalar workbooks round-trip through the XLSX adapter | `XLSXEmitterTests.emit_roundTripsScalarWorkbookThroughXLSXAdapter` |
 | XLSX formula safety | Formula cells are rejected, while formula-looking strings stay inert shared strings | `XLSXEmitterTests.emit_rejectsFormulaCellsWithoutFlatteningThem`, `XLSXEmitterTests.emit_keepsFormulaLookingTextInert` |
 | XLSX bounds | Empty exports, whitespace-only exports, overlong cell text, invalid names/references, non-finite numbers, and ZIP32 overflows are rejected before package write | `XLSXEmitterTests`, `XLSXAdapterTests` |

--- a/docs/HIGH_FIDELITY_READ_FILE_AUDIT.md
+++ b/docs/HIGH_FIDELITY_READ_FILE_AUDIT.md
@@ -26,7 +26,7 @@ weight because core `file_read` already owns their read path.
 
 | Format | Current surface | Proof |
 | --- | --- | --- |
-| CSV/TSV | Raw line-numbered `file_read`; structured adapter remains available for document parsing | `FileReadDocumentFormatsTests.fileReadCSVStaysRawLineNumbered`, `CSVAdapterTests` |
+| CSV/TSV | Raw line-numbered `file_read`; structured adapter and table workflow previews remain available for explicit document parsing/export paths | `FileReadDocumentFormatsTests.fileReadCSVStaysRawLineNumbered`, `CSVAdapterTests`, `CSVTableWorkflowServiceTests` |
 | XLSX | Bounded workbook preview through `file_read`, with sheet, row, row-cap, column-cap, formula, merged-range, and security summary controls | `FileReadWorkbookTests`, `XLSXAdapterTests` |
 | PPTX | Text extraction through `file_read` and the in-tree PPTX adapter; typed workflow previews expose slide, hidden-slide, notes, and table metadata | `FileReadDocumentFormatsTests.fileReadExtractsPPTXSlideText`, `PPTXAdapterTests`, `PDFPPTXWorkflowServiceTests` |
 | PDF | Text-layer extraction through `file_read` and the in-tree PDF adapter; typed workflow previews expose page, text-layer table, cell, and bounding-box metadata | `FileReadDocumentFormatsTests.fileReadExtractsPDFTextLayerPages`, `PDFAdapterTests`, `PDFPPTXWorkflowServiceTests` |


### PR DESCRIPTION
## Maintainer status

Ready for maintainer review. This PR is non-draft, rebased on current main, and the local focused gate plus release build passed on the refreshed head.

## Maintainer rationale

**Business rationale:** CSV and TSV files are common business inputs, but large or formula-like table data needs safe previews and clear export paths. This PR gives users bounded schema previews, sampling, and explicit conversion/export without changing default file-tool behavior.

**Coding rationale:** The implementation reuses the existing CSV adapter surface, extracts shared row parsing, registers CSV/TSV emitters through `DocumentFormatRegistry`, and keeps parsing/export bounded with spreadsheet-prefix guards.

## Acceptance criteria

- CSV and TSV previews are bounded by byte, row, and column policy.
- Header detection, schema/type inference, row counts, sample values, and truncation flags are reported.
- CSV adapter parsing and table previews share row parser semantics.
- Explicit CSV/TSV export supports delimiter conversion through a registered emitter.
- Formula-like cell prefixes are refused by default in workflow validation and emitter output.
- Raw `file_read` behavior and default file-writer exposure remain unchanged.

## Latest refresh

- Refreshed on June 12, 2026 against `origin/main` `f1b069debc9a` (`fixed main thread app hangs (#1472)`).
- Current head is `a7fc701c1f6b` with the same file diff as the prior refreshed head.
- Rebase was clean.
- The previous GitHub `test-core` run failed in `AgentToolLoopParallelBatchTests`, which is outside this PR's document/CSV diff. I do not have permission to rerun failed jobs directly, so this same-diff branch refresh restarts CI without adding unrelated code.

## Quality gate

LANE_GATE_OK 2026-06-12T11:05:38Z

- [x] `git fetch --all --prune` before push.
- [x] `git rebase origin/main`.
- [x] `git diff --check origin/main`.
- [x] `swift-format lint --configuration .swift-format --strict --recursive` on touched document/test paths.
- [x] `swiftlint lint --config .swiftlint.yml --force-exclude` on touched Swift files: 0 violations.
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-table-* swift test --package-path Packages/OsaurusCore --filter 'CSVTableWorkflowServiceTests|CSVAdapterTests|FileReadDocumentFormatsTests|FolderToolsResilienceTests'`.
- [x] `swift build --package-path Packages/OsaurusCore -c release` succeeded; existing repo warnings only.
- [ ] GitHub CI on refreshed head.

## Debug evidence

The focused tests cover CSV adapter parsing, TSV detection, malformed/truncated preview behavior, schema inference, row/column/byte bounds, formula-prefix export refusal, registered emitter output, raw file-read compatibility, and folder write-safety regressions.

## Self-review

### Regression review

Touched call sites are CSV adapter parsing, explicit table workflow/export helpers, document adapter bootstrap registration, tests, and docs. Existing raw text file reads and default writer exposure remain unchanged, so the table workflow remains opt-in for callers that deliberately use the structured CSV/TSV path.

### Performance review

Preview reads are byte-capped before decoding and row/column-capped while parsing, so large files do not require full in-memory table materialization. Export validation walks explicit structured rows supplied by the caller and refuses unsafe spreadsheet prefixes before writing output.

## Rollback

Revert this PR commit to remove the shared CSV row parser, table workflow service, CSV emitter registration, tests, and docs updates.
