### PR TITLE
[codex] Add PDF/PPTX workflow previews

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/PDFPPTXWorkflowService.swift
+++ b/Packages/OsaurusCore/Services/Documents/PDFPPTXWorkflowService.swift
@@ -1,0 +1,418 @@
+//
+//  PDFPPTXWorkflowService.swift
+//  osaurus
+//
+//  Workflow summaries for typed PDF and presentation reads. This layer keeps
+//  PDF/PPTX creation honest: it can report a registered structured emitter,
+//  but it does not treat text file writes as a valid binary package output.
+//
+
+import Foundation
+
+public struct PDFPPTXWorkflowService: Sendable {
+    private let registry: DocumentFormatRegistry
+
+    public init(registry: DocumentFormatRegistry = .shared) {
+        self.registry = registry
+    }
+
+    public func preview(
+        _ document: StructuredDocument,
+        policy: PDFPPTXPreviewPolicy = .standard
+    ) throws -> PDFPPTXWorkflowPreview {
+        if let pdf = document.representation.underlying as? PDFDocumentRepresentation {
+            return .pdf(pdfPreview(pdf, document: document, policy: policy))
+        }
+
+        if let presentation = document.representation.underlying as? PresentationDocument {
+            return .presentation(presentationPreview(presentation, document: document, policy: policy))
+        }
+
+        throw PDFPPTXWorkflowError.unsupportedRepresentation(formatId: document.formatId)
+    }
+
+    public func creationAvailability(for document: StructuredDocument) -> PDFPPTXCreationAvailability {
+        guard
+            document.representation.underlying is PDFDocumentRepresentation
+                || document.representation.underlying is PresentationDocument
+        else {
+            return PDFPPTXCreationAvailability(
+                formatId: document.formatId,
+                reasonCode: .unsupportedFormat,
+                emitterFormatId: nil,
+                message: "Only typed PDF and PPTX/POTX documents are covered by this workflow."
+            )
+        }
+
+        if let emitter = registry.emitter(for: document) {
+            return PDFPPTXCreationAvailability(
+                formatId: document.formatId,
+                reasonCode: .available,
+                emitterFormatId: emitter.formatId,
+                message: "A structured emitter is registered for this document."
+            )
+        }
+
+        return PDFPPTXCreationAvailability(
+            formatId: document.formatId,
+            reasonCode: .missingEmitter,
+            emitterFormatId: nil,
+            message:
+                "No structured PDF/PPTX emitter is registered; file_write remains text-only and must not fake a binary package."
+        )
+    }
+
+    // MARK: - PDF
+
+    private func pdfPreview(
+        _ pdf: PDFDocumentRepresentation,
+        document: StructuredDocument,
+        policy: PDFPPTXPreviewPolicy
+    ) -> PDFWorkflowPreview {
+        let sampledPages = pdf.pages.prefix(policy.maxSections).map { page in
+            PDFPageWorkflowPreview(
+                pageIndex: page.pageIndex,
+                anchorId: page.anchor.id,
+                bounds: page.bounds,
+                text: Self.textPreview(page.text, maxUTF16Units: policy.maxTextPreviewUTF16Units),
+                tableCount: page.tables.count,
+                tables: page.tables.prefix(policy.maxTablesPerSection).map {
+                    Self.pdfTablePreview($0, policy: policy)
+                },
+                isTableSampleTruncated: page.tables.count > policy.maxTablesPerSection
+            )
+        }
+
+        let tables = pdf.pages.flatMap(\.tables)
+        let tableCellCount = tables.reduce(0) { count, table in
+            count + table.rows.reduce(0) { $0 + $1.cells.count }
+        }
+
+        return PDFWorkflowPreview(
+            filename: document.filename,
+            pageCount: pdf.pages.count,
+            sampledPageCount: sampledPages.count,
+            totalTextUTF16Units: pdf.pages.reduce(0) { $0 + $1.text.utf16.count },
+            tableCount: tables.count,
+            tableCellCount: tableCellCount,
+            pages: Array(sampledPages),
+            isPageSampleTruncated: pdf.pages.count > policy.maxSections,
+            creationAvailability: creationAvailability(for: document)
+        )
+    }
+
+    private static func pdfTablePreview(
+        _ table: PDFTable,
+        policy: PDFPPTXPreviewPolicy
+    ) -> PDFPPTXTablePreview {
+        tablePreview(
+            sourceKind: .pdfPage,
+            sourceIndex: table.pageIndex,
+            index: table.index,
+            anchorId: table.anchor.id,
+            bounds: table.bounds,
+            rows: table.rows,
+            columnCount: table.columnCount,
+            policy: policy,
+            cells: { $0.cells },
+            rowIndex: { $0.index },
+            cellRowIndex: { $0.rowIndex },
+            cellColumnIndex: { $0.columnIndex },
+            cellText: { $0.text },
+            cellAnchorId: { $0.anchor.id }
+        )
+    }
+
+    // MARK: - Presentation
+
+    private func presentationPreview(
+        _ presentation: PresentationDocument,
+        document: StructuredDocument,
+        policy: PDFPPTXPreviewPolicy
+    ) -> PresentationWorkflowPreview {
+        let sampledSlides = presentation.slides.prefix(policy.maxSections).map { slide in
+            PresentationSlideWorkflowPreview(
+                slideIndex: slide.index,
+                slideNumber: slide.number,
+                label: slide.label,
+                sourcePart: slide.sourcePart,
+                isHidden: slide.isHidden,
+                text: Self.textPreview(slide.text, maxUTF16Units: policy.maxTextPreviewUTF16Units),
+                speakerNotes: slide.speakerNotes.map {
+                    Self.textPreview($0.text, maxUTF16Units: policy.maxTextPreviewUTF16Units)
+                },
+                tableCount: slide.tables.count,
+                tables: slide.tables.prefix(policy.maxTablesPerSection).map {
+                    Self.presentationTablePreview($0, slideIndex: slide.index, policy: policy)
+                },
+                isTableSampleTruncated: slide.tables.count > policy.maxTablesPerSection
+            )
+        }
+
+        let tables = presentation.slides.flatMap(\.tables)
+        let tableCellCount = tables.reduce(0) { count, table in
+            count + table.rows.reduce(0) { $0 + $1.cells.count }
+        }
+
+        return PresentationWorkflowPreview(
+            filename: document.filename,
+            kind: presentation.kind,
+            slideCount: presentation.slides.count,
+            sampledSlideCount: sampledSlides.count,
+            hiddenSlideCount: presentation.slides.filter(\.isHidden).count,
+            speakerNotesCount: presentation.slides.filter { $0.speakerNotes != nil }.count,
+            totalTextUTF16Units: presentation.slides.reduce(0) {
+                $0 + $1.text.utf16.count + ($1.speakerNotes?.text.utf16.count ?? 0)
+            },
+            tableCount: tables.count,
+            tableCellCount: tableCellCount,
+            slides: Array(sampledSlides),
+            isSlideSampleTruncated: presentation.slides.count > policy.maxSections,
+            creationAvailability: creationAvailability(for: document)
+        )
+    }
+
+    private static func presentationTablePreview(
+        _ table: PresentationTable,
+        slideIndex: Int,
+        policy: PDFPPTXPreviewPolicy
+    ) -> PDFPPTXTablePreview {
+        tablePreview(
+            sourceKind: .presentationSlide,
+            sourceIndex: slideIndex,
+            index: table.index,
+            anchorId: table.anchorId,
+            bounds: nil,
+            rows: table.rows,
+            columnCount: table.columnCount,
+            policy: policy,
+            cells: { $0.cells },
+            rowIndex: { $0.index },
+            cellRowIndex: { $0.rowIndex },
+            cellColumnIndex: { $0.columnIndex },
+            cellText: { $0.text },
+            cellAnchorId: { $0.anchorId }
+        )
+    }
+
+    // MARK: - Shared table helpers
+
+    private static func tablePreview<Row, Cell>(
+        sourceKind: PDFPPTXTableSourceKind,
+        sourceIndex: Int,
+        index: Int,
+        anchorId: String,
+        bounds: DocumentBoundingBox?,
+        rows: [Row],
+        columnCount: Int,
+        policy: PDFPPTXPreviewPolicy,
+        cells: (Row) -> [Cell],
+        rowIndex: (Row) -> Int,
+        cellRowIndex: (Cell) -> Int,
+        cellColumnIndex: (Cell) -> Int,
+        cellText: (Cell) -> String,
+        cellAnchorId: (Cell) -> String
+    ) -> PDFPPTXTablePreview {
+        let sampledRows = rows.prefix(policy.maxRowsPerTable).map { row in
+            let rowCells = cells(row)
+            return PDFPPTXTableRowPreview(
+                index: rowIndex(row),
+                cells: rowCells.prefix(policy.maxColumnsPerTable).map { cell in
+                    PDFPPTXTableCellPreview(
+                        rowIndex: cellRowIndex(cell),
+                        columnIndex: cellColumnIndex(cell),
+                        text: textPreview(cellText(cell), maxUTF16Units: policy.maxCellTextUTF16Units),
+                        anchorId: cellAnchorId(cell)
+                    )
+                },
+                isCellSampleTruncated: rowCells.count > policy.maxColumnsPerTable
+            )
+        }
+
+        return PDFPPTXTablePreview(
+            sourceKind: sourceKind,
+            sourceIndex: sourceIndex,
+            index: index,
+            anchorId: anchorId,
+            rowCount: rows.count,
+            columnCount: columnCount,
+            cellCount: rows.reduce(0) { $0 + cells($1).count },
+            bounds: bounds,
+            sampleRows: Array(sampledRows),
+            isRowSampleTruncated: rows.count > policy.maxRowsPerTable,
+            isColumnSampleTruncated: rows.contains { cells($0).count > policy.maxColumnsPerTable }
+        )
+    }
+
+    private static func textPreview(_ text: String, maxUTF16Units: Int) -> PDFPPTXTextPreview {
+        let fullLength = text.utf16.count
+        guard fullLength > maxUTF16Units else {
+            return PDFPPTXTextPreview(
+                text: text,
+                fullUTF16Length: fullLength,
+                isTruncated: false
+            )
+        }
+
+        var clipped = ""
+        var units = 0
+        for character in text {
+            let nextUnits = String(character).utf16.count
+            guard units + nextUnits <= maxUTF16Units else { break }
+            clipped.append(character)
+            units += nextUnits
+        }
+
+        return PDFPPTXTextPreview(
+            text: clipped,
+            fullUTF16Length: fullLength,
+            isTruncated: true
+        )
+    }
+}
+
+public struct PDFPPTXPreviewPolicy: Equatable, Sendable {
+    public static let standard = PDFPPTXPreviewPolicy()
+
+    public let maxSections: Int
+    public let maxTablesPerSection: Int
+    public let maxRowsPerTable: Int
+    public let maxColumnsPerTable: Int
+    public let maxTextPreviewUTF16Units: Int
+    public let maxCellTextUTF16Units: Int
+
+    public init(
+        maxSections: Int = 20,
+        maxTablesPerSection: Int = 10,
+        maxRowsPerTable: Int = 20,
+        maxColumnsPerTable: Int = 12,
+        maxTextPreviewUTF16Units: Int = 1_000,
+        maxCellTextUTF16Units: Int = 256
+    ) {
+        precondition(maxSections > 0, "maxSections must be positive")
+        precondition(maxTablesPerSection > 0, "maxTablesPerSection must be positive")
+        precondition(maxRowsPerTable > 0, "maxRowsPerTable must be positive")
+        precondition(maxColumnsPerTable > 0, "maxColumnsPerTable must be positive")
+        precondition(maxTextPreviewUTF16Units > 0, "maxTextPreviewUTF16Units must be positive")
+        precondition(maxCellTextUTF16Units > 0, "maxCellTextUTF16Units must be positive")
+
+        self.maxSections = maxSections
+        self.maxTablesPerSection = maxTablesPerSection
+        self.maxRowsPerTable = maxRowsPerTable
+        self.maxColumnsPerTable = maxColumnsPerTable
+        self.maxTextPreviewUTF16Units = maxTextPreviewUTF16Units
+        self.maxCellTextUTF16Units = maxCellTextUTF16Units
+    }
+}
+
+public enum PDFPPTXWorkflowPreview: Equatable, Sendable {
+    case pdf(PDFWorkflowPreview)
+    case presentation(PresentationWorkflowPreview)
+}
+
+public struct PDFWorkflowPreview: Equatable, Sendable {
+    public let filename: String
+    public let pageCount: Int
+    public let sampledPageCount: Int
+    public let totalTextUTF16Units: Int
+    public let tableCount: Int
+    public let tableCellCount: Int
+    public let pages: [PDFPageWorkflowPreview]
+    public let isPageSampleTruncated: Bool
+    public let creationAvailability: PDFPPTXCreationAvailability
+}
+
+public struct PDFPageWorkflowPreview: Equatable, Sendable {
+    public let pageIndex: Int
+    public let anchorId: String
+    public let bounds: DocumentBoundingBox?
+    public let text: PDFPPTXTextPreview
+    public let tableCount: Int
+    public let tables: [PDFPPTXTablePreview]
+    public let isTableSampleTruncated: Bool
+}
+
+public struct PresentationWorkflowPreview: Equatable, Sendable {
+    public let filename: String
+    public let kind: PresentationDocumentKind
+    public let slideCount: Int
+    public let sampledSlideCount: Int
+    public let hiddenSlideCount: Int
+    public let speakerNotesCount: Int
+    public let totalTextUTF16Units: Int
+    public let tableCount: Int
+    public let tableCellCount: Int
+    public let slides: [PresentationSlideWorkflowPreview]
+    public let isSlideSampleTruncated: Bool
+    public let creationAvailability: PDFPPTXCreationAvailability
+}
+
+public struct PresentationSlideWorkflowPreview: Equatable, Sendable {
+    public let slideIndex: Int
+    public let slideNumber: Int
+    public let label: String
+    public let sourcePart: String
+    public let isHidden: Bool
+    public let text: PDFPPTXTextPreview
+    public let speakerNotes: PDFPPTXTextPreview?
+    public let tableCount: Int
+    public let tables: [PDFPPTXTablePreview]
+    public let isTableSampleTruncated: Bool
+}
+
+public struct PDFPPTXTablePreview: Equatable, Sendable {
+    public let sourceKind: PDFPPTXTableSourceKind
+    public let sourceIndex: Int
+    public let index: Int
+    public let anchorId: String
+    public let rowCount: Int
+    public let columnCount: Int
+    public let cellCount: Int
+    public let bounds: DocumentBoundingBox?
+    public let sampleRows: [PDFPPTXTableRowPreview]
+    public let isRowSampleTruncated: Bool
+    public let isColumnSampleTruncated: Bool
+}
+
+public enum PDFPPTXTableSourceKind: String, Equatable, Sendable {
+    case pdfPage
+    case presentationSlide
+}
+
+public struct PDFPPTXTableRowPreview: Equatable, Sendable {
+    public let index: Int
+    public let cells: [PDFPPTXTableCellPreview]
+    public let isCellSampleTruncated: Bool
+}
+
+public struct PDFPPTXTableCellPreview: Equatable, Sendable {
+    public let rowIndex: Int
+    public let columnIndex: Int
+    public let text: PDFPPTXTextPreview
+    public let anchorId: String
+}
+
+public struct PDFPPTXTextPreview: Equatable, Sendable {
+    public let text: String
+    public let fullUTF16Length: Int
+    public let isTruncated: Bool
+}
+
+public struct PDFPPTXCreationAvailability: Equatable, Sendable {
+    public let formatId: String
+    public let reasonCode: PDFPPTXCreationReasonCode
+    public let emitterFormatId: String?
+    public let message: String
+
+    public var isAvailable: Bool { reasonCode == .available }
+}
+
+public enum PDFPPTXCreationReasonCode: String, Equatable, Sendable {
+    case available
+    case missingEmitter
+    case unsupportedFormat
+}
+
+public enum PDFPPTXWorkflowError: Error, Equatable, Sendable {
+    case unsupportedRepresentation(formatId: String)
+}

--- a/Packages/OsaurusCore/Tests/Documents/PDFPPTXWorkflowServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/PDFPPTXWorkflowServiceTests.swift
@@ -1,0 +1,411 @@
+//
+//  PDFPPTXWorkflowServiceTests.swift
+//  osaurusTests
+//
+//  Exercises the workflow layer that turns typed PDF/PPTX reads into bounded
+//  previews and explicit creation availability diagnostics.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("PDFPPTXWorkflowService")
+struct PDFPPTXWorkflowServiceTests {
+
+    @Test func pdfPreviewSummarizesPagesTablesAndMissingEmitter() throws {
+        let document = Self.pdfDocument()
+        let service = PDFPPTXWorkflowService(registry: DocumentFormatRegistry())
+
+        let preview = try service.preview(document)
+        guard case let .pdf(pdf) = preview else {
+            Issue.record("Expected PDF preview")
+            return
+        }
+
+        #expect(pdf.filename == "report.pdf")
+        #expect(pdf.pageCount == 2)
+        #expect(pdf.sampledPageCount == 2)
+        #expect(pdf.tableCount == 1)
+        #expect(pdf.tableCellCount == 4)
+        #expect(pdf.creationAvailability.reasonCode == .missingEmitter)
+        #expect(pdf.creationAvailability.isAvailable == false)
+
+        let page = try #require(pdf.pages.first)
+        #expect(page.pageIndex == 0)
+        #expect(page.text.text.contains("Revenue by region"))
+        #expect(page.tableCount == 1)
+        #expect(page.tables.first?.sourceKind == .pdfPage)
+        #expect(page.tables.first?.rowCount == 2)
+        #expect(page.tables.first?.columnCount == 2)
+        #expect(page.tables.first?.sampleRows.first?.cells.map(\.text.text) == ["Region", "Revenue"])
+    }
+
+    @Test func presentationPreviewSummarizesSlidesNotesTablesAndHiddenState() throws {
+        let document = Self.presentationDocument()
+        let service = PDFPPTXWorkflowService(registry: DocumentFormatRegistry())
+
+        let preview = try service.preview(document)
+        guard case let .presentation(presentation) = preview else {
+            Issue.record("Expected presentation preview")
+            return
+        }
+
+        #expect(presentation.filename == "roadmap.pptx")
+        #expect(presentation.kind == .presentation)
+        #expect(presentation.slideCount == 2)
+        #expect(presentation.hiddenSlideCount == 1)
+        #expect(presentation.speakerNotesCount == 1)
+        #expect(presentation.tableCount == 1)
+        #expect(presentation.tableCellCount == 4)
+        #expect(presentation.creationAvailability.reasonCode == .missingEmitter)
+
+        let firstSlide = try #require(presentation.slides.first)
+        #expect(firstSlide.slideNumber == 1)
+        #expect(firstSlide.text.text == "Roadmap\nNext steps")
+        #expect(firstSlide.speakerNotes?.text == "Mention pilot feedback")
+        #expect(firstSlide.tables.first?.sourceKind == .presentationSlide)
+        #expect(firstSlide.tables.first?.sampleRows.last?.cells.map(\.text.text) == ["Q2", "Workbook workflow"])
+
+        let hiddenSlide = try #require(presentation.slides.last)
+        #expect(hiddenSlide.isHidden)
+    }
+
+    @Test func previewPolicyCapsPagesSlidesRowsColumnsAndText() throws {
+        let document = Self.pdfDocument(
+            firstPageText: "Long page text that should be truncated",
+            cellText: "oversized-cell-value"
+        )
+        let service = PDFPPTXWorkflowService(registry: DocumentFormatRegistry())
+        let policy = PDFPPTXPreviewPolicy(
+            maxSections: 1,
+            maxTablesPerSection: 1,
+            maxRowsPerTable: 1,
+            maxColumnsPerTable: 1,
+            maxTextPreviewUTF16Units: 9,
+            maxCellTextUTF16Units: 8
+        )
+
+        let preview = try service.preview(document, policy: policy)
+        guard case let .pdf(pdf) = preview else {
+            Issue.record("Expected PDF preview")
+            return
+        }
+
+        #expect(pdf.sampledPageCount == 1)
+        #expect(pdf.isPageSampleTruncated)
+        let page = try #require(pdf.pages.first)
+        #expect(page.text.text == "Long page")
+        #expect(page.text.isTruncated)
+        let table = try #require(page.tables.first)
+        #expect(table.sampleRows.count == 1)
+        #expect(table.isRowSampleTruncated)
+        #expect(table.isColumnSampleTruncated)
+        let cell = try #require(table.sampleRows.first?.cells.first)
+        #expect(cell.text.text == "oversize")
+        #expect(cell.text.isTruncated)
+    }
+
+    @Test func creationAvailabilityUsesRegisteredStructuredEmitter() {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: FakePDFEmitter())
+        let service = PDFPPTXWorkflowService(registry: registry)
+
+        let availability = service.creationAvailability(for: Self.pdfDocument())
+
+        #expect(availability.reasonCode == .available)
+        #expect(availability.emitterFormatId == "pdf")
+        #expect(availability.isAvailable)
+    }
+
+    @Test func unsupportedDocumentReportsUnsupportedAvailabilityAndPreviewError() throws {
+        let service = PDFPPTXWorkflowService(registry: DocumentFormatRegistry())
+        let document = StructuredDocument(
+            formatId: "plaintext",
+            filename: "note.txt",
+            fileSize: 0,
+            representation: AnyStructuredRepresentation(
+                formatId: "plaintext",
+                underlying: PlainTextRepresentation(text: "hello")
+            ),
+            textFallback: "hello"
+        )
+
+        #expect(service.creationAvailability(for: document).reasonCode == .unsupportedFormat)
+
+        do {
+            _ = try service.preview(document)
+            Issue.record("Expected unsupported representation error")
+        } catch let error as PDFPPTXWorkflowError {
+            #expect(error == .unsupportedRepresentation(formatId: "plaintext"))
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func pdfDocument(
+        firstPageText: String = "Revenue by region\nNorth 120\nSouth 90",
+        cellText: String = "Region"
+    ) -> StructuredDocument {
+        let pageBounds = box(width: 612, height: 792, space: .page)
+        let tableBounds = box(x: 32, y: 120, width: 400, height: 80, space: .page)
+        let rowBounds = box(x: 32, y: 120, width: 400, height: 40, space: .page)
+        let cellBounds = box(x: 32, y: 120, width: 200, height: 40, space: .page)
+        let table = PDFTable(
+            pageIndex: 0,
+            index: 0,
+            rows: [
+                PDFTableRow(
+                    index: 0,
+                    cells: [
+                        PDFTableCell(
+                            rowIndex: 0,
+                            columnIndex: 0,
+                            text: cellText,
+                            bounds: cellBounds,
+                            anchor: anchor(kind: .cell, components: [.page(0), .table(0), .row(0), .cell(0)])
+                        ),
+                        PDFTableCell(
+                            rowIndex: 0,
+                            columnIndex: 1,
+                            text: "Revenue",
+                            bounds: cellBounds,
+                            anchor: anchor(kind: .cell, components: [.page(0), .table(0), .row(0), .cell(1)])
+                        ),
+                    ],
+                    bounds: rowBounds,
+                    anchor: anchor(kind: .row, components: [.page(0), .table(0), .row(0)])
+                ),
+                PDFTableRow(
+                    index: 1,
+                    cells: [
+                        PDFTableCell(
+                            rowIndex: 1,
+                            columnIndex: 0,
+                            text: "North",
+                            bounds: cellBounds,
+                            anchor: anchor(kind: .cell, components: [.page(0), .table(0), .row(1), .cell(0)])
+                        ),
+                        PDFTableCell(
+                            rowIndex: 1,
+                            columnIndex: 1,
+                            text: "120",
+                            bounds: cellBounds,
+                            anchor: anchor(kind: .cell, components: [.page(0), .table(0), .row(1), .cell(1)])
+                        ),
+                    ],
+                    bounds: rowBounds,
+                    anchor: anchor(kind: .row, components: [.page(0), .table(0), .row(1)])
+                ),
+            ],
+            bounds: tableBounds,
+            anchor: anchor(kind: .table, components: [.page(0), .table(0)])
+        )
+        let pages = [
+            PDFPageRepresentation(
+                pageIndex: 0,
+                text: firstPageText,
+                bounds: pageBounds,
+                tables: [table],
+                anchor: anchor(kind: .page, components: [.page(0)])
+            ),
+            PDFPageRepresentation(
+                pageIndex: 1,
+                text: "Appendix",
+                bounds: pageBounds,
+                anchor: anchor(kind: .page, components: [.page(1)])
+            ),
+        ]
+
+        return StructuredDocument(
+            formatId: "pdf",
+            filename: "report.pdf",
+            fileSize: 100,
+            representation: AnyStructuredRepresentation(
+                formatId: "pdf",
+                underlying: PDFDocumentRepresentation(pages: pages)
+            ),
+            textFallback: pages.map(\.text).joined(separator: "\n\n")
+        )
+    }
+
+    private static func presentationDocument() -> StructuredDocument {
+        let table = PresentationTable(
+            index: 0,
+            sourcePart: "ppt/slides/slide1.xml",
+            anchorId: "slide1/table0",
+            rows: [
+                PresentationTableRow(
+                    index: 0,
+                    anchorId: "slide1/table0/row0",
+                    cells: [
+                        PresentationTableCell(
+                            rowIndex: 0,
+                            columnIndex: 0,
+                            text: "Quarter",
+                            paragraphIndexes: [0],
+                            anchorId: "slide1/table0/cell0"
+                        ),
+                        PresentationTableCell(
+                            rowIndex: 0,
+                            columnIndex: 1,
+                            text: "Feature",
+                            paragraphIndexes: [1],
+                            anchorId: "slide1/table0/cell1"
+                        ),
+                    ]
+                ),
+                PresentationTableRow(
+                    index: 1,
+                    anchorId: "slide1/table0/row1",
+                    cells: [
+                        PresentationTableCell(
+                            rowIndex: 1,
+                            columnIndex: 0,
+                            text: "Q2",
+                            paragraphIndexes: [2],
+                            anchorId: "slide1/table0/cell2"
+                        ),
+                        PresentationTableCell(
+                            rowIndex: 1,
+                            columnIndex: 1,
+                            text: "Workbook workflow",
+                            paragraphIndexes: [3],
+                            anchorId: "slide1/table0/cell3"
+                        ),
+                    ]
+                ),
+            ]
+        )
+        let slides = [
+            PresentationSlide(
+                index: 0,
+                number: 1,
+                sourcePart: "ppt/slides/slide1.xml",
+                label: "Slide 1",
+                textRuns: [
+                    run("Roadmap", paragraphIndex: 0, runIndex: 0, sourcePart: "ppt/slides/slide1.xml"),
+                    run("Next steps", paragraphIndex: 1, runIndex: 0, sourcePart: "ppt/slides/slide1.xml"),
+                ],
+                tables: [table],
+                speakerNotes: PresentationSpeakerNotes(
+                    sourcePart: "ppt/notesSlides/notesSlide1.xml",
+                    anchorId: "slide1/notes",
+                    textRuns: [
+                        run(
+                            "Mention pilot feedback",
+                            paragraphIndex: 0,
+                            runIndex: 0,
+                            sourcePart: "ppt/notesSlides/notesSlide1.xml"
+                        )
+                    ]
+                )
+            ),
+            PresentationSlide(
+                index: 1,
+                number: 2,
+                sourcePart: "ppt/slides/slide2.xml",
+                label: "Slide 2",
+                isHidden: true,
+                textRuns: [
+                    run("Hidden appendix", paragraphIndex: 0, runIndex: 0, sourcePart: "ppt/slides/slide2.xml")
+                ]
+            ),
+        ]
+        let presentation = PresentationDocument(
+            kind: .presentation,
+            sourceName: "roadmap.pptx",
+            slides: slides
+        )
+
+        return StructuredDocument(
+            formatId: "pptx",
+            filename: "roadmap.pptx",
+            fileSize: 200,
+            representation: AnyStructuredRepresentation(
+                formatId: "pptx",
+                underlying: presentation
+            ),
+            textFallback: slides.map(\.text).joined(separator: "\n\n")
+        )
+    }
+
+    private static func run(
+        _ text: String,
+        paragraphIndex: Int,
+        runIndex: Int,
+        sourcePart: String
+    ) -> PresentationTextRun {
+        PresentationTextRun(
+            text: text,
+            paragraphIndex: paragraphIndex,
+            runIndex: runIndex,
+            sourcePart: sourcePart,
+            anchorId: "\(sourcePart)#p\(paragraphIndex)-r\(runIndex)"
+        )
+    }
+
+    private static func box(
+        x: Double = 0,
+        y: Double = 0,
+        width: Double,
+        height: Double,
+        space: DocumentBoundingBox.CoordinateSpace
+    ) -> DocumentBoundingBox {
+        DocumentBoundingBox(x: x, y: y, width: width, height: height, coordinateSpace: space)
+    }
+
+    private static func anchor(kind: DocumentAnchor.Kind, components: [AnchorComponent]) -> DocumentAnchor {
+        var path: [DocumentAnchor.PathComponent] = [.init(kind: .document)]
+        for component in components {
+            path.append(component.pathComponent)
+        }
+        return DocumentAnchor(
+            kind: kind,
+            path: path,
+            sourceRange: sourceRange(for: components),
+            label: kind.rawValue
+        )
+    }
+
+    private static func sourceRange(for components: [AnchorComponent]) -> DocumentSourceRange? {
+        guard let page = components.compactMap(\.pageIndex).first else { return nil }
+        return DocumentSourceRange(start: .page(page))
+    }
+
+    private enum AnchorComponent {
+        case page(Int)
+        case table(Int)
+        case row(Int)
+        case cell(Int)
+
+        var pageIndex: Int? {
+            if case let .page(index) = self { return index }
+            return nil
+        }
+
+        var pathComponent: DocumentAnchor.PathComponent {
+            switch self {
+            case let .page(index):
+                return .init(kind: .page, index: index)
+            case let .table(index):
+                return .init(kind: .table, index: index)
+            case let .row(index):
+                return .init(kind: .row, index: index)
+            case let .cell(index):
+                return .init(kind: .cell, index: index)
+            }
+        }
+    }
+
+    private struct FakePDFEmitter: DocumentFormatEmitter {
+        let formatId = "pdf"
+
+        func canEmit(_ document: StructuredDocument) -> Bool {
+            document.representation.underlying is PDFDocumentRepresentation
+        }
+
+        func emit(_ document: StructuredDocument, to url: URL) async throws {}
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -324,6 +324,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
 - `Services/Documents/PPTXAdapter.swift` — PPTX/POTX deck parsing from Office Open XML packages.
 - `Services/Documents/PDFAdapter.swift` — PDF extraction with page-level anchors and layout-aware text-layer table detection.
+- `Services/Documents/PDFPPTXWorkflowService.swift` — bounded PDF/PPTX previews plus structured creation availability diagnostics.
 - `Services/Documents/RichDocumentAdapter.swift` — DOCX/RTF/HTML-style rich document structure extraction.
 - `Services/Documents/ExternalOfficeRuntimeDetector.swift` — optional LibreOffice/OpenOffice discovery for future conversion flows; detection reads version metadata only and does not send document bytes to a runtime.
 
@@ -333,6 +334,7 @@ This command bridge is for external clients connecting to Osaurus. It is separat
 - XLSX workbooks preserve sheets, cells, shared strings, relationships, and can emit a minimal valid `.xlsx` package.
 - PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
+- PDF/PPTX workflow previews expose page/slide/table/notes metadata and report missing structured emitters instead of treating text writes as valid binary output.
 - Rich documents preserve section boundaries, headings, links, and metadata.
 
 ---

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -16,6 +16,11 @@ bounds before writing, rejects formulas instead of flattening them, rejects
 workbooks with no renderable cells, rejects overlong cell text and invalid XML,
 and only then writes the package atomically.
 
+PDF/PPTX creation remains diagnostic-only in core. `PDFPPTXWorkflowService`
+reports whether a structured emitter is registered for a typed PDF/PPTX
+document; on current main it returns `missingEmitter`, keeping fake binary
+packages off the text-only `file_write` path.
+
 Tool exposure stays narrow. Folder plugin hints only bias installed spreadsheet
 plugins, preflight injection respects installed plugin ids and per-agent
 allowlists, and default-agent `capabilities_load` cannot load plugin tools.
@@ -30,6 +35,7 @@ No workbook writer is added to the default schema.
 | XLSX emitter | Valid scalar workbooks round-trip through the XLSX adapter | `XLSXEmitterTests.emit_roundTripsScalarWorkbookThroughXLSXAdapter` |
 | XLSX formula safety | Formula cells are rejected, while formula-looking strings stay inert shared strings | `XLSXEmitterTests.emit_rejectsFormulaCellsWithoutFlatteningThem`, `XLSXEmitterTests.emit_keepsFormulaLookingTextInert` |
 | XLSX bounds | Empty exports, whitespace-only exports, overlong cell text, invalid names/references, non-finite numbers, and ZIP32 overflows are rejected before package write | `XLSXEmitterTests`, `XLSXAdapterTests` |
+| PDF/PPTX creation diagnostics | Typed PDF/PPTX workflows report registered emitters or `missingEmitter` and do not route creation through text writes | `PDFPPTXWorkflowServiceTests` |
 | Tool exposure | XLSX plugin injection is bias-only, installed-plugin gated, and allowlist-respecting | `PreflightCapabilitySearchTests.folderInjection_*`, `FolderPluginHintsTests` |
 
 ## Follow-Up Lanes

--- a/docs/HIGH_FIDELITY_READ_FILE_AUDIT.md
+++ b/docs/HIGH_FIDELITY_READ_FILE_AUDIT.md
@@ -28,8 +28,8 @@ weight because core `file_read` already owns their read path.
 | --- | --- | --- |
 | CSV/TSV | Raw line-numbered `file_read`; structured adapter remains available for document parsing | `FileReadDocumentFormatsTests.fileReadCSVStaysRawLineNumbered`, `CSVAdapterTests` |
 | XLSX | Bounded workbook preview through `file_read`, with sheet, row, row-cap, column-cap, formula, merged-range, and security summary controls | `FileReadWorkbookTests`, `XLSXAdapterTests` |
-| PPTX | Text extraction through `file_read` and the in-tree PPTX adapter | `FileReadDocumentFormatsTests.fileReadExtractsPPTXSlideText`, `PPTXAdapterTests` |
-| PDF | Text-layer extraction through `file_read` and the in-tree PDF adapter | `FileReadDocumentFormatsTests.fileReadExtractsPDFTextLayerPages`, `PDFAdapterTests` |
+| PPTX | Text extraction through `file_read` and the in-tree PPTX adapter; typed workflow previews expose slide, hidden-slide, notes, and table metadata | `FileReadDocumentFormatsTests.fileReadExtractsPPTXSlideText`, `PPTXAdapterTests`, `PDFPPTXWorkflowServiceTests` |
+| PDF | Text-layer extraction through `file_read` and the in-tree PDF adapter; typed workflow previews expose page, text-layer table, cell, and bounding-box metadata | `FileReadDocumentFormatsTests.fileReadExtractsPDFTextLayerPages`, `PDFAdapterTests`, `PDFPPTXWorkflowServiceTests` |
 | Images / scanned PDF | Refused by `file_read` with a pivot to attachment, OCR, or vision workflow | `FileReadDocumentFormatsTests.fileReadRefusesImagesWithImagePivot`, `PDFAdapterTests.parse_throwsEmptyContentForPDFWithNoTextLayer` |
 
 ## Follow-Up Lanes


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** PDF and PPTX workflows need trustworthy previews and metadata before users can rely on document understanding or creation availability. This PR surfaces page/slide/table/notes facts and reports missing emitters instead of pretending binary output exists.

**Coding rationale:** The implementation adds a bounded workflow service on top of existing PDF/PPTX adapters and document services while preserving existing parser and registry behavior.

**Osaurus standards check:** Current-main, function-sized PR; bounded previews; no fake PDF/PPTX text output; creation availability is diagnostic only; focused tests plus GitHub CI are green.

## Business rationale

PDF and PPTX parsing now preserves typed pages, slides, notes, and tables, but downstream workflows still had to inspect the raw representation or fall back to flattened text. This PR adds a bounded workflow preview surface so a user-facing document view can show page/slide/table metadata, hidden-slide and notes counts, table cell samples, and source anchors without adding another default tool. It also makes the current creation state explicit: core can say whether a structured PDF/PPTX emitter is registered, and on current main it returns `missingEmitter` instead of letting a text write pretend to create a binary package.

## Coding rationale

The implementation stays on top of the existing `StructuredDocument`, `PDFDocumentRepresentation`, `PresentationDocument`, and `DocumentFormatRegistry` model rather than introducing a parallel document abstraction or a new dependency. `PDFPPTXWorkflowService` is read-summary plus creation-availability diagnostics only; actual PDF/PPTX emission, atomic save UI, and plugin-gated artifact creation are deliberately out of scope until a real structured emitter exists. The trust boundary is the write path: `file_write` remains text-only, while binary output must come from a registered emitter.

## Acceptance criteria

- PDF previews report page counts, sampled pages, text lengths, table counts, cell counts, anchors, and bounding boxes.
- PPTX/POTX previews report slide counts, hidden slides, speaker notes, slide tables, sampled cells, source parts, and anchors.
- Preview policies bound sampled sections, tables, rows, columns, and UTF-16 text size.
- Creation availability reports `available`, `missingEmitter`, or `unsupportedFormat` through the document registry.
- Core does not add a fake PDF/PPTX emitter or route binary creation through text writes.
- Docs record the read-preview and output-safety behavior.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `e19d66adde0510ce6cd09a53f019f32f40c5328e` on `mimeding:codex/pdf-pptx-understanding-creation`.
- Rebase was clean; no code conflicts or current-main functional adjustments were required.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `xcrun swift-format lint --configuration .swift-format Packages/OsaurusCore/Services/Documents/PDFPPTXWorkflowService.swift Packages/OsaurusCore/Tests/Documents/PDFPPTXWorkflowServiceTests.swift`
- [x] `swiftlint lint --quiet --config .swiftlint.yml Packages/OsaurusCore/Services/Documents/PDFPPTXWorkflowService.swift Packages/OsaurusCore/Tests/Documents/PDFPPTXWorkflowServiceTests.swift`
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-pdf-pptx-rebased swift test --package-path Packages/OsaurusCore --filter 'PDFPPTXWorkflowServiceTests|PDFAdapterTests|PPTXAdapterTests|FileReadDocumentFormatsTests|FolderToolsResilienceTests'` (51 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [ ] GitHub CI pending on `e19d66ad`: `test-core`. `test-cli`, `swiftlint`, `shellcheck`, and release drafter are green.

## Debug evidence

The focused test run passed 51 tests. It covers PDF page/table/cell preview metadata, PPTX slide/hidden-slide/speaker-notes/table metadata, bounded preview sampling, `missingEmitter` creation state, registered-emitter availability, unsupported-document refusal, existing PDF/PPTX parsing behavior, file_read document extraction, and folder text-write safety guardrails.

## Self-review

### Regression review

Changed call surface is additive. `PDFPPTXWorkflowService` is a new service and no existing parser, registry lookup, file-read path, or default tool dispatch was changed. Existing PDF/PPTX behavior remains covered by `PDFAdapterTests`, `PPTXAdapterTests`, and `FileReadDocumentFormatsTests`; new preview behavior is covered by `PDFPPTXWorkflowServiceTests`. Docs were updated in `docs/FEATURES.md`, `docs/HIGH_FIDELITY_READ_FILE_AUDIT.md`, and `docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md` only.

### Performance review

The new service walks already-parsed typed documents and samples with explicit caps: 20 pages/slides, 10 tables per section, 20 rows per table, 12 columns per table, 1,000 UTF-16 units per page/slide/notes preview, and 256 UTF-16 units per cell preview by default. Complexity is linear in the parsed representation for summary counts and bounded for returned previews. It does not add file I/O, archive parsing, PDFKit work, network access, or synchronous writes.

## Rollback

Revert this PR commit to remove the PDF/PPTX workflow service, tests, and docs updates.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `4a1cd9bdc615`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
