### PR TITLE
Gate local model loads on available memory

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
+        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
+        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
+        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
+        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
       }
     },
     {

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -277,16 +277,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             PluginRepositoryService.shared.startBackgroundRefresh()
         }
 
-        // Pre-warm caches immediately for instant first window (no async deps).
-        // The unified prewarm builds the picker with whatever is currently
-        // available; once remote providers finish connecting below they post
-        // .remoteProviderModelsChanged and the cache rebuilds automatically.
+        // Pre-warm cheap caches immediately for instant first window.
         _ = SpeechConfigurationStore.load()
-        ModelPickerItemCache.shared.prewarm()
 
         // Bind the local HTTP server before heavier optional startup work such
-        // as provider connection, scheduler DB polling, sandbox registration,
-        // or Parakeet/CoreML auto-load can occupy the main actor or accelerator.
+        // as provider connection, model-picker bundle metadata scans,
+        // scheduler DB polling, sandbox registration, or Parakeet/CoreML
+        // auto-load can occupy the main actor or accelerator.
         let serverStartupTask = Task { @MainActor in
             await serverController.startServer()
         }
@@ -297,6 +294,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         Task { @MainActor in
             await serverStartupTask.value
             serverController.markLaunchComplete()
+            // The unified prewarm builds the picker with whatever is currently
+            // available; once remote providers finish connecting below they post
+            // .remoteProviderModelsChanged and the cache rebuilds automatically.
+            // Keep this after server bind so very large local bundles cannot
+            // block `/health` and API startup while their config is inspected.
+            ModelPickerItemCache.shared.prewarm()
         }
 
         Task.detached(priority: .utility) {

--- a/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
@@ -162,7 +162,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
             maxTokens: nil,
             contextLength: 128000,
             topPOverride: nil,
-            maxToolAttempts: 15,
+            maxToolAttempts: 30,
             // Out-of-box core model: Apple Foundation when this Mac can
             // actually run it (macOS 26+ with Apple Intelligence). On
             // older systems / Intel, leave the core model unset and let

--- a/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatSessionStore.swift
@@ -60,13 +60,9 @@ enum ChatSessionStore {
     /// rotation is in flight. Normally a no-op fast path.
     private static func ensureOpen() {
         guard !didOpen else { return }
-        // Close the prewarm race: a session-touching call can arrive before
-        // the launch key prewarm lands. Load the key now (this is not the
-        // launch-critical path) so chat history isn't reported unavailable
-        // purely because the cache is still cold.
-        if !StorageKeyManager.shared.hasCachedKey {
-            try? StorageKeyManager.shared.prewarmCurrentKey()
-        }
+        // Do not synchronously prewarm here. This runs on MainActor, and
+        // Sentry APPLE-MACOS-40/41/42 showed Keychain decrypt/read can hang
+        // the UI when a cold cache reaches this path.
         guard StorageKeyManager.shared.hasCachedKey else {
             print("[ChatSessionStore] Chat history unavailable: storage key is not already unlocked")
             return

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -240,12 +240,25 @@ struct MLXModel: Identifiable, Codable {
         let hasTokenizerAssets = hasTokenizerJSON || hasBPE || hasSentencePiece
         guard hasTokenizerAssets else { return false }
 
-        if let items = try? fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: nil
-        ) {
-            let hasWeights = items.contains { $0.pathExtension == "safetensors" }
-            return hasWeights
+        let directWeightSentinels = [
+            "model.safetensors",
+            "weights.safetensors",
+            "model-00001-of-00001.safetensors",
+            "weights-00001-of-00001.safetensors",
+        ]
+        if directWeightSentinels.contains(where: exists) {
+            return true
+        }
+        if exists("model.safetensors.index.json")
+            || exists("pytorch_model.safetensors.index.json")
+        {
+            return true
+        }
+        for shardCount in 2 ... 256 {
+            let candidate = String(format: "model-00001-of-%05d.safetensors", shardCount)
+            if exists(candidate) {
+                return true
+            }
         }
         return false
     }
@@ -275,6 +288,13 @@ struct MLXModel: Identifiable, Codable {
             // capability detection text-only until Step VLM is wired and
             // proven, and avoid blocking picker rebuilds on large external
             // bundle metadata reads.
+            return false
+        }
+        if (ModelFamilyNames.isNemotronThinkingFamily(id)
+            || ModelFamilyNames.isNemotronThinkingFamily(name))
+            && !(ModelFamilyNames.isNemotronOmniFamily(id)
+                || ModelFamilyNames.isNemotronOmniFamily(name))
+        {
             return false
         }
         if isDownloaded { return VLMDetection.isVLM(at: localDirectory) }

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -216,16 +216,18 @@ public enum ModelMediaCapabilities {
             return .omni
         }
 
-        if ModelFamilyNames.isNemotronThinkingFamily(modelId) {
-            return .textOnly
-        }
-
         // Read config.json for vision_config presence.
         let configURL = directory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
             return from(modelId: modelId)
+        }
+
+        if ModelFamilyNames.isNemotronThinkingFamily(modelId)
+            && !ModelFamilyNames.isNemotronOmniFamily(modelId)
+        {
+            return .textOnly
         }
 
         let modelType = (json["model_type"] as? String)?.lowercased() ?? ""

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -216,6 +216,10 @@ public enum ModelMediaCapabilities {
             return .omni
         }
 
+        if ModelFamilyNames.isNemotronThinkingFamily(modelId) {
+            return .textOnly
+        }
+
         // Read config.json for vision_config presence.
         let configURL = directory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -32,6 +32,11 @@ enum VLMDetection {
     /// Best-effort check for a model by its Hugging Face repo ID.
     /// Returns false if the model is not downloaded locally.
     static func isVLM(modelId: String) -> Bool {
+        if ModelFamilyNames.isNemotronThinkingFamily(modelId)
+            && !ModelFamilyNames.isNemotronOmniFamily(modelId)
+        {
+            return false
+        }
         guard let dir = findLocalModelDirectory(forModelId: modelId) else { return false }
         return isVLM(at: dir)
     }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3303,7 +3303,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return req.tool_choice ?? .auto
             }()
 
-            let maxIterations = 30
+            let configuredMaxToolAttempts = await MainActor.run {
+                ChatConfigurationStore.load().maxToolAttempts ?? 30
+            }
+            let maxIterations = max(1, min(configuredMaxToolAttempts, 120))
             var iteration = 0
             let requestId = UUID().uuidString
             // Per-request harness state. The agent-run endpoint is stateless
@@ -6185,6 +6188,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "kv_headroom_bytes": f.kvHeadroomBytes,
                         "projected_bytes": f.projectedBytes,
                         "physical_memory_bytes": f.physicalMemoryBytes,
+                        "available_memory_bytes": f.availableMemoryBytes,
+                        "required_available_bytes": f.requiredAvailableBytes,
                         "soft_limit_bytes": f.softLimitBytes,
                         "hard_limit_bytes": f.hardLimitBytes,
                     ] as [String: Any]

--- a/Packages/OsaurusCore/Networking/OsaurusServer.swift
+++ b/Packages/OsaurusCore/Networking/OsaurusServer.swift
@@ -75,12 +75,12 @@ public actor OsaurusServer: Sendable {
                         // sockets can't exhaust file descriptors / pin memory.
                         ConnectionLimitHandler(),
                         // Slow-loris / idle-hold defense: drop a connection that
-                        // sends no bytes, accepts no writes, or sits fully idle
-                        // past the budget. Long SSE streams emit periodic
-                        // keepalive comments well inside the write window, so
-                        // legitimate streaming is unaffected.
+                        // accepts no writes or sits fully idle past the budget.
+                        // Do not enforce a post-request read timeout here:
+                        // long SSE streams can spend minutes in cold model load
+                        // or prefill while only writing keepalive comments.
                         IdleStateHandler(
-                            readTimeout: .seconds(60),
+                            readTimeout: nil,
                             writeTimeout: .seconds(150),
                             allTimeout: .seconds(300)
                         ),

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b3fa98af5681678bb95936a128e7faeeb2858d1a42148845bd0fa35e4257f41",
+  "originHash" : "f542b12b997346c98c4659e88c6bba4ee1d0a03afffca3802f8ada7929dcc20f",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
+        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
+        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
+        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
+        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
+            revision: "45a1560d96a10899a7c20f4797b2769d26e3294d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "525fc6dc17650efd420e7f9adfc1c37e40650a73"
+            revision: "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "45a1560d96a10899a7c20f4797b2769d26e3294d"
+            revision: "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
+            revision: "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -10,6 +10,7 @@
 
 import CoreImage
 import CryptoKit
+import Darwin
 import Foundation
 import MLX
 import MLXLLM
@@ -627,6 +628,8 @@ public actor ModelRuntime {
         public let kvHeadroomBytes: Int64
         public let projectedBytes: Int64
         public let physicalMemoryBytes: Int64
+        public let availableMemoryBytes: Int64
+        public let requiredAvailableBytes: Int64
         public let softLimitBytes: Int64
         public let hardLimitBytes: Int64
         public let timestamp: Date
@@ -638,14 +641,134 @@ public actor ModelRuntime {
     private static let ramHardThreshold = 0.90
 
     /// Estimated KV-cache + activation headroom an incoming load needs beyond
-    /// its static weights. We don't know the exact context length up front, so
-    /// scale modestly with weight size and floor it so even a small model
-    /// reserves something. Intentionally conservative — the goal is to catch
-    /// "this clearly won't fit" before the OS jetsams us, not to be exact.
-    private static func estimatedKVHeadroomBytes(forWeights weights: Int64) -> Int64 {
+    /// its static weights.
+    ///
+    /// Prefer config-derived KV sizing when the bundle exposes enough
+    /// architecture metadata. Hybrid JANGTQ rows such as NemotronH carry a
+    /// small number of attention layers but very large routed-expert weight
+    /// shards, so a flat percentage of safetensors bytes can overestimate KV
+    /// by tens of GB and refuse a load before vMLX's mmap-backed loader can
+    /// prove the real footprint. If the config is missing or unfamiliar,
+    /// fall back to the existing conservative percentage estimate.
+    static func estimatedKVHeadroomBytes(
+        forWeights weights: Int64,
+        modelDirectory: URL? = nil,
+        modelName: String? = nil
+    ) -> Int64 {
+        if let modelDirectory,
+            let architectureHeadroom = estimatedArchitectureKVHeadroomBytes(at: modelDirectory)
+        {
+            return architectureHeadroom
+        }
+        if let modelName, ModelFamilyNames.isNemotronThinkingFamily(modelName) {
+            // Nemotron 3 Ultra JANGTQ is a hybrid model with only a small
+            // attention KV footprint relative to routed-expert weights. Keep
+            // the fallback architecture-scoped so a slow external volume
+            // cannot force the generic 20% disk-size estimate and reject load.
+            return 4 * 1024 * 1024 * 1024
+        }
         let scaled = Int64(Double(weights) * 0.20)
         let floor: Int64 = 512 * 1024 * 1024
         return max(scaled, floor)
+    }
+
+    private static func estimatedArchitectureKVHeadroomBytes(at directory: URL) -> Int64? {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        let attentionLayers = attentionLayerCount(in: config)
+        let hiddenLayers = intValue(config["num_hidden_layers"]) ?? 0
+        guard attentionLayers > 0, hiddenLayers > 0 else { return nil }
+
+        let kvHeads = intValue(config["num_key_value_heads"])
+            ?? intValue(config["num_kv_heads"])
+            ?? intValue(config["n_kv_heads"])
+            ?? intValue(config["num_attention_heads"])
+            ?? intValue(config["n_heads"])
+        let headDim = intValue(config["head_dim"])
+            ?? intValue(config["kv_channels"])
+            ?? {
+                guard let hidden = intValue(config["hidden_size"]),
+                    let heads = intValue(config["num_attention_heads"]) ?? intValue(config["n_heads"]),
+                    heads > 0
+                else { return nil }
+                return hidden / heads
+            }()
+        let maxPositions = intValue(config["max_position_embeddings"])
+            ?? intValue(config["max_sequence_length"])
+            ?? intValue(config["seq_length"])
+            ?? intValue(config["sliding_window"])
+            ?? 32768
+        guard let kvHeads, let headDim, kvHeads > 0, headDim > 0, maxPositions > 0 else {
+            return nil
+        }
+
+        let dtypeBytes = cacheElementByteWidth(config: config)
+        let kvBytes = Int64(attentionLayers)
+            * 2
+            * Int64(kvHeads)
+            * Int64(headDim)
+            * Int64(maxPositions)
+            * Int64(dtypeBytes)
+
+        // SSM companion state is much smaller than full KV but still real.
+        // Count it from the same config so hybrid families have an explicit
+        // budget instead of hiding under the percentage fallback.
+        let mambaLayers = mambaLayerCount(in: config)
+        let mambaHeads = intValue(config["mamba_num_heads"]) ?? 0
+        let ssmState = intValue(config["ssm_state_size"]) ?? intValue(config["mamba_d_state"]) ?? 0
+        let convKernel = intValue(config["conv_kernel"]) ?? intValue(config["mamba_d_conv"]) ?? 0
+        let mambaHeadDim = intValue(config["mamba_head_dim"]) ?? 0
+        let ssmBytes = Int64(max(0, mambaLayers))
+            * Int64(max(0, mambaHeads))
+            * Int64(max(0, ssmState + convKernel * max(1, mambaHeadDim)))
+            * Int64(dtypeBytes)
+
+        // Leave room for masks, logits, transient activation slices, and
+        // allocator slack without scaling by total routed-expert disk size.
+        let floor: Int64 = 512 * 1024 * 1024
+        let slack = Int64(Double(kvBytes + ssmBytes) * 0.25)
+        return max(floor, kvBytes + ssmBytes + slack)
+    }
+
+    private static func attentionLayerCount(in config: [String: Any]) -> Int {
+        if let blocks = config["layers_block_type"] as? [Any] {
+            return blocks.compactMap { stringValue($0)?.lowercased() }
+                .filter { $0 == "attention" || $0 == "attn" || $0 == "*" }
+                .count
+        }
+        if let pattern = stringValue(config["hybrid_override_pattern"]), !pattern.isEmpty {
+            return pattern.filter { $0 == "*" || $0 == "A" || $0 == "a" }.count
+        }
+        return intValue(config["num_hidden_layers"]) ?? 0
+    }
+
+    private static func mambaLayerCount(in config: [String: Any]) -> Int {
+        if let blocks = config["layers_block_type"] as? [Any] {
+            return blocks.compactMap { stringValue($0)?.lowercased() }
+                .filter { $0 == "mamba" || $0 == "linear_attention" || $0 == "ssm" }
+                .count
+        }
+        if let pattern = stringValue(config["hybrid_override_pattern"]), !pattern.isEmpty {
+            return pattern.filter { $0 == "M" || $0 == "m" }.count
+        }
+        return 0
+    }
+
+    private static func cacheElementByteWidth(config: [String: Any]) -> Int {
+        let raw =
+            stringValue(config["kv_cache_dtype"])
+            ?? stringValue(config["mamba_ssm_cache_dtype"])
+            ?? stringValue(config["torch_dtype"])
+            ?? stringValue(config["dtype"])
+            ?? "bfloat16"
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "float32", "fp32", "f32": return 4
+        case "float8", "fp8", "e4m3", "e5m2": return 1
+        default: return 2
+        }
     }
 
     /// Public read of the last feasibility assessment for `/health` + UI.
@@ -659,7 +782,8 @@ public actor ModelRuntime {
     private func checkRAMFeasibility(
         modelName: String,
         incomingWeightsBytes: Int64,
-        excludingResident excludedName: String?
+        excludingResident excludedName: String?,
+        modelDirectory: URL? = nil
     ) throws {
         let physical = Int64(ProcessInfo.processInfo.physicalMemory)
         guard physical > 0, incomingWeightsBytes > 0 else { return }
@@ -669,13 +793,19 @@ public actor ModelRuntime {
         // this, two concurrent loads of different models each see only the
         // (empty) cache and both pass, doubling the real footprint.
         let inflightOther = inflightLoadWeightBytes(excluding: excludedName)
-        let kvHeadroom = Self.estimatedKVHeadroomBytes(forWeights: incomingWeightsBytes)
+        let kvHeadroom = Self.estimatedKVHeadroomBytes(
+            forWeights: incomingWeightsBytes,
+            modelDirectory: modelDirectory,
+            modelName: modelName
+        )
+        let available = Self.availableMemoryBytes()
+        let requiredAvailable = incomingWeightsBytes + kvHeadroom
         let projected = resident + inflightOther + incomingWeightsBytes + kvHeadroom
         let softLimit = Int64(Double(physical) * Self.ramSoftThreshold)
         let hardLimit = Int64(Double(physical) * Self.ramHardThreshold)
 
         let verdict: RAMFeasibility.Verdict
-        if projected > hardLimit {
+        if projected > hardLimit || (available > 0 && requiredAvailable > available) {
             verdict = .refused
         } else if projected > softLimit {
             verdict = .tight
@@ -691,6 +821,8 @@ public actor ModelRuntime {
             kvHeadroomBytes: kvHeadroom,
             projectedBytes: projected,
             physicalMemoryBytes: physical,
+            availableMemoryBytes: available,
+            requiredAvailableBytes: requiredAvailable,
             softLimitBytes: softLimit,
             hardLimitBytes: hardLimit,
             timestamp: Date()
@@ -705,19 +837,50 @@ public actor ModelRuntime {
             )
         case .refused:
             genLog.error(
-                "loadContainer: refusing \(modelName, privacy: .public) — projected footprint \(projected, privacy: .public)B exceeds hard limit \(hardLimit, privacy: .public)B (physical \(physical, privacy: .public)B)"
+                "loadContainer: refusing \(modelName, privacy: .public) — projected footprint \(projected, privacy: .public)B hard limit \(hardLimit, privacy: .public)B available \(available, privacy: .public)B requiredAvailable \(requiredAvailable, privacy: .public)B physical \(physical, privacy: .public)B"
+            )
+            CrashReportingService.recordBreadcrumb(
+                category: "model.load",
+                message:
+                    "refused model=\(modelName) weightsBytes=\(incomingWeightsBytes) kvHeadroomBytes=\(kvHeadroom) availableBytes=\(available) requiredAvailableBytes=\(requiredAvailable) physicalBytes=\(physical)"
             )
             let projGB = String(format: "%.1f", Double(projected) / 1_073_741_824)
             let physGB = String(format: "%.1f", Double(physical) / 1_073_741_824)
+            let availGB = String(format: "%.1f", Double(max(available, 0)) / 1_073_741_824)
+            let requiredGB = String(format: "%.1f", Double(requiredAvailable) / 1_073_741_824)
             throw NSError(
                 domain: "ModelRuntime",
                 code: 2,
                 userInfo: [
                     NSLocalizedDescriptionKey:
-                        "Not enough memory to load \(modelName): needs ~\(projGB) GB (weights + KV headroom) but this Mac has \(physGB) GB. Free up RAM, choose a smaller/more-quantized model, or close other models."
+                        "Not enough memory to load \(modelName): needs ~\(requiredGB) GB available now (~\(projGB) GB projected with resident models), but this Mac has \(availGB) GB currently available out of \(physGB) GB. Clear memory, unload other models, or choose a smaller/more-quantized model."
                 ]
             )
         }
+    }
+
+    private static func availableMemoryBytes() -> Int64 {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size
+        )
+        let host = mach_host_self()
+        defer { mach_port_deallocate(mach_task_self_, host) }
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(host, HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        var rawPageSize: vm_size_t = 0
+        host_page_size(host, &rawPageSize)
+        let pageSize = Int64(rawPageSize)
+        let pages =
+            Int64(stats.free_count)
+            + Int64(stats.inactive_count)
+            + Int64(stats.speculative_count)
+            + Int64(stats.purgeable_count)
+        return max(0, pages * pageSize)
     }
 
     private func residentWeightBytes(excluding excludedName: String? = nil) -> Int64 {
@@ -930,7 +1093,8 @@ public actor ModelRuntime {
         try checkRAMFeasibility(
             modelName: name,
             incomingWeightsBytes: weightsBytes,
-            excludingResident: name
+            excludingResident: name,
+            modelDirectory: localURL
         )
 
         // Tool-call format + reasoning parser are stamped automatically by
@@ -2498,19 +2662,54 @@ public actor ModelRuntime {
 
     private static func computeWeightsSizeBytes(at url: URL) -> Int64 {
         let fm = FileManager.default
-        let fileURLs: [URL]
-        if let entries = try? fm.contentsOfDirectory(
-            at: url,
-            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) {
-            fileURLs = entries
-        } else {
-            return 0
+
+        let directWeightNames = [
+            "model.safetensors",
+            "weights.safetensors",
+            "model-00001-of-00001.safetensors",
+            "weights-00001-of-00001.safetensors",
+        ]
+        for name in directWeightNames {
+            let path = url.appendingPathComponent(name).path
+            guard fm.fileExists(atPath: path) else { continue }
+            if let attrs = try? fm.attributesOfItem(atPath: path),
+                let size = attrs[.size] as? NSNumber
+            {
+                return size.int64Value
+            }
         }
+
         var total: Int64 = 0
-        for fileURL in fileURLs {
-            if fileURL.pathExtension.lowercased() == "safetensors" {
+        for shardCount in 2 ... 256 {
+            var foundAny = false
+            var candidateTotal: Int64 = 0
+            for index in 1 ... shardCount {
+                let name = String(format: "model-%05d-of-%05d.safetensors", index, shardCount)
+                let path = url.appendingPathComponent(name).path
+                guard fm.fileExists(atPath: path) else {
+                    candidateTotal = 0
+                    break
+                }
+                foundAny = true
+                if let attrs = try? fm.attributesOfItem(atPath: path),
+                    let size = attrs[.size] as? NSNumber
+                {
+                    candidateTotal += size.int64Value
+                }
+            }
+            if foundAny, candidateTotal > 0 {
+                total = candidateTotal
+                break
+            }
+        }
+        if total == 0,
+            let entries = try? fm.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles]
+            )
+        {
+            for fileURL in entries where fileURL.pathExtension.lowercased() == "safetensors" {
                 if let attrs = try? fm.attributesOfItem(atPath: fileURL.path),
                     let size = attrs[.size] as? NSNumber
                 {
@@ -2529,19 +2728,25 @@ public actor ModelRuntime {
     /// `isDownloaded` check already covers them.
     static func verifyShardManifest(at directory: URL, name: String) throws {
         let fm = FileManager.default
-        guard
-            let entries = try? fm.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
-            )
-        else { return }
-
-        let indexFiles = entries.filter {
-            $0.lastPathComponent.hasSuffix(".safetensors.index.json")
+        let commonIndexNames = [
+            "model.safetensors.index.json",
+            "pytorch_model.safetensors.index.json",
+        ]
+        let knownIndexURL = commonIndexNames
+            .map { directory.appendingPathComponent($0) }
+            .first { fm.fileExists(atPath: $0.path) }
+        if knownIndexURL != nil {
+            // Do not read or enumerate the manifest in the launch preflight:
+            // large external APFS model volumes can block reads here before
+            // vMLX gets a chance to memory-map the real weights.
+            return
         }
+        guard let names = try? fm.contentsOfDirectory(atPath: directory.path) else { return }
+        let scannedIndexURL = names.first {
+            !$0.hasPrefix(".") && $0.hasSuffix(".safetensors.index.json")
+        }.map { directory.appendingPathComponent($0) }
         // No manifest → not a sharded bundle; nothing to cross-check.
-        guard let indexURL = indexFiles.first else { return }
+        guard let indexURL = scannedIndexURL else { return }
 
         guard
             let data = try? Data(contentsOf: indexURL),

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -674,8 +674,8 @@ final class PluginHostContext: @unchecked Sendable {
     // default turns any omitted `max_iterations` into "stop before executing
     // the first model-emitted tool call", which is especially visible on
     // Qwen-family local models that rely on multi-turn tool/result loops.
-    private static let defaultMaxIterations = 8
-    private static let maxIterationsCap = 30
+    private static let defaultMaxIterations = 30
+    private static let maxIterationsCap = 120
 
     // MARK: Inference Types
 

--- a/Packages/OsaurusCore/Services/SystemMonitorService.swift
+++ b/Packages/OsaurusCore/Services/SystemMonitorService.swift
@@ -189,13 +189,10 @@ class SystemMonitorService: ObservableObject {
 
     /// Query storage capacity off the main actor and publish the result back.
     ///
-    /// `OsaurusPaths.volumeFreeBytes` uses the modern URL-keyed
-    /// `.volumeAvailableCapacityForImportantUsageKey` (the value Finder shows; the
-    /// legacy `attributesOfFileSystem(.systemFreeSize)` returns 0 for sandboxed
-    /// container paths). It's the same helper as `ModelDownloadService.freeBytesOnVolume`
-    /// so the two read-outs can't silently drift. That key routes through macOS's
-    /// CacheDelete/purgeable-space machinery and can block the caller for seconds,
-    /// so it must not run on the main thread.
+    /// `OsaurusPaths.volumeFreeBytes` prefers the cheap filesystem free-space
+    /// query and falls back to the URL-keyed important-usage capacity only when
+    /// needed. This avoids CacheDelete stalls on external model volumes while
+    /// still covering sandbox/container zero-free-space reports from bug #964.
     private func refreshStorageUsage() {
         guard !isRefreshingStorage else { return }
         isRefreshingStorage = true

--- a/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/ClipboardContentDiagnosticsTests.swift
@@ -46,4 +46,29 @@ struct ClipboardContentDiagnosticsTests {
         #expect(source.contains("string(forType: type)"))
         #expect(source.contains("Sentry APPLE-MACOS-2N"))
     }
+
+    @Test func pasteMonitorAvoidsPasteboardTypeAndObjectConversionEnumeration() throws {
+        let here = URL(fileURLWithPath: #filePath)
+        let packageRoot = here.deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = packageRoot.appendingPathComponent(
+            "Views/Chat/FloatingInputCard.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let methodStart = try #require(source.range(of: "private func handlePasteIfImage() -> Bool"))
+        let methodEnd = try #require(
+            source.range(
+                of: "\n    }\n}\n\n// MARK: - NSImage PNG Conversion",
+                range: methodStart.upperBound ..< source.endIndex
+            )
+        )
+        let methodBody = String(source[methodStart.lowerBound ..< methodEnd.lowerBound])
+
+        #expect(!methodBody.contains("pasteboard.types"))
+        #expect(!methodBody.contains("readObjects(forClasses:"))
+        #expect(methodBody.contains("string(forType: type)"))
+        #expect(methodBody.contains("Sentry APPLE-MACOS-43"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -64,6 +64,23 @@ struct ModelMediaCapabilitiesMCDCTests {
         )
     }
 
+    @Test("D1 boundary: Nemotron 3 Ultra is text-only unless it is Omni")
+    func d1_nemotronUltraTextOnly() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try #"{"model_type":"nemotron_h","vision_config":{"hidden_size":1280}}"#
+            .write(to: tmp.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        let cap = ModelMediaCapabilities.from(
+            directory: tmp,
+            modelId: "nvidia-nemotron-3-ultra-550b-a55b-jangtq_1l"
+        )
+
+        #expect(cap == .textOnly)
+    }
+
     @Test("Step 3.7 text runtime does not advertise media")
     func step37TextRuntimeDoesNotAdvertiseMedia() {
         #expect(ModelMediaCapabilities.from(modelId: "JANGQ-AI/Step-3.7-Flash-JANG_2L") == .textOnly)

--- a/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelDownloadServiceStorageTests.swift
@@ -122,4 +122,14 @@ struct ModelDownloadServiceStorageTests {
         }
         #expect(bytes == expected)
     }
+
+    @Test func positiveLegacyFreeSpaceAvoidsImportantCapacityOverride() {
+        let legacy: Int64 = 512 * 1024 * 1024 * 1024
+        let important: Int64 = 700 * 1024 * 1024 * 1024
+        let bytes = OsaurusPaths.resolvedVolumeFreeBytes(
+            importantCapacity: important,
+            legacyFree: legacy
+        )
+        #expect(bytes == legacy)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -116,6 +116,40 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(resolved == nil)
     }
 
+    @Test("Hybrid JANGTQ RAM headroom is derived from attention topology, not disk bytes")
+    func hybridJANGTQHeadroomUsesConfigTopology() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "nemotron_h",
+              "num_hidden_layers": 8,
+              "layers_block_type": ["mamba", "moe", "mamba", "attention", "moe", "mamba", "moe", "attention"],
+              "num_attention_heads": 64,
+              "num_key_value_heads": 2,
+              "head_dim": 128,
+              "max_position_embeddings": 262144,
+              "mamba_num_heads": 128,
+              "mamba_head_dim": 128,
+              "ssm_state_size": 128,
+              "conv_kernel": 4,
+              "mamba_ssm_cache_dtype": "float32",
+              "weight_format": "mxtq"
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let weights: Int64 = 100 * 1024 * 1024 * 1024
+        let fallback = ModelRuntime.estimatedKVHeadroomBytes(forWeights: weights)
+        let topology = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir
+        )
+
+        #expect(fallback == 20 * 1024 * 1024 * 1024)
+        #expect(topology < 2 * 1024 * 1024 * 1024)
+        #expect(topology >= 512 * 1024 * 1024)
+    }
+
     // MARK: - JANGTQ sidecar preflight
     //
     // vmlx's LLMModelFactory dispatches to the JANGTQ class purely on

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -131,6 +131,8 @@ struct RuntimePolicySourceTests {
         let store = try Self.source("Models/Chat/ChatSessionStore.swift")
         #expect(store.contains("StorageKeyManager.shared.hasCachedKey"))
         #expect(store.contains("Chat history unavailable: storage key is not already unlocked"))
+        #expect(!store.contains("prewarmCurrentKey()"))
+        #expect(store.contains("Sentry APPLE-MACOS-40/41/42"))
     }
 
     @Test("chat history writer skips persistence unless storage key is already unlocked")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -259,13 +259,23 @@ struct RuntimePolicySourceTests {
         let source = try Self.source("Services/Plugin/PluginHostAPI.swift")
 
         #expect(
-            source.contains("private static let defaultMaxIterations = 8"),
-            "Plugin complete/complete_stream callers that omit max_iterations must still be able to execute a model-emitted tool call, feed back the tool result, and continue. A default of 1 makes Qwen-style multi-turn tool use stop before the first tool/result loop."
+            source.contains("private static let defaultMaxIterations = 30"),
+            "Plugin complete/complete_stream callers that omit max_iterations must get the same real multi-step budget as HTTP chat; Qwen-style tool/result loops can exceed a tiny default."
         )
         #expect(
-            !source.contains("private static let defaultMaxIterations = 1"),
-            "One-shot plugin inference is the Qwen 35B tool-call stop regression."
+            source.contains("private static let maxIterationsCap = 120"),
+            "Plugin callers that explicitly request a deeper tool loop need headroom above the default without making the loop unbounded."
         )
+        #expect(!source.contains("private static let defaultMaxIterations = 1"))
+        #expect(!source.contains("private static let defaultMaxIterations = 8"))
+
+        let chatConfig = try Self.source("Models/Chat/ChatConfiguration.swift")
+        #expect(chatConfig.contains("maxToolAttempts: 30"))
+
+        let http = try Self.source("Networking/HTTPHandler.swift")
+        #expect(http.contains("await MainActor.run"))
+        #expect(http.contains("ChatConfigurationStore.load().maxToolAttempts ?? 30"))
+        #expect(http.contains("let maxIterations = max(1, min(configuredMaxToolAttempts, 120))"))
     }
 
     @Test("HTTP chat persistence runs after response path")
@@ -1676,6 +1686,11 @@ struct RuntimePolicySourceTests {
             !body.contains("enumerator("),
             "Weight-size preflight must not recursively walk huge model bundles or symlinked cache folders on the request path."
         )
+        #expect(
+            body.contains("model-%05d-of-%05d.safetensors")
+                && body.contains("fileURL.pathExtension.lowercased() == \"safetensors\""),
+            "Weight-size preflight must count known numbered shards and fall back to a shallow safetensors sum so unknown layouts cannot report 0 bytes."
+        )
 
         let loadStart = try #require(runtime.range(of: "func loadContainer(id: String, name: String)"))
         let loadEnd = try #require(
@@ -1699,6 +1714,17 @@ struct RuntimePolicySourceTests {
             loadPreflight.contains("checkRAMFeasibility("),
             "All policies must pass the pre-load RAM feasibility gate before vmlx starts loading."
         )
+        #expect(
+            runtime.contains("availableMemoryBytes()")
+                && runtime.contains("requiredAvailable > available")
+                && runtime.contains("availableBytes=")
+                && runtime.contains("Clear memory, unload other models, or choose a smaller/more-quantized model."),
+            "The load gate must stop low-available-memory launches before Metal OOMs and expose a user-actionable resource message, not a fatal C++ exception."
+        )
+
+        let health = try Self.source("Networking/HTTPHandler.swift")
+        #expect(health.contains("\"available_memory_bytes\": f.availableMemoryBytes"))
+        #expect(health.contains("\"required_available_bytes\": f.requiredAvailableBytes"))
     }
 
     @Test("MTP bundles auto-resolve vmlx tuning into load and generation")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -494,7 +494,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "45a1560d96a10899a7c20f4797b2769d26e3294d"
+        let expectedRuntimeHardenedRevision = "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -483,12 +483,14 @@ struct RuntimePolicySourceTests {
         // envelopes, plus Gemma4 unified 12B config dispatch, processor
         // tool-schema preservation, quoted native call:value parsing, the
         // explicit unsupported boundary for unproven unified image/audio/video,
-        // and Gemma4 proportional RoPE support needed by full-attention layers.
+        // and Gemma4 proportional RoPE support needed by full-attention layers,
+        // plus safe auto-enabled Nemotron Ultra JANGTQ streaming dispatch that
+        // avoids full expert materialization for 512-expert stacked-only models.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "525fc6dc17650efd420e7f9adfc1c37e40650a73"
+        let expectedRuntimeHardenedRevision = "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -496,7 +498,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, and Gemma4 quoted tool-key parser coverage; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming dispatch guard; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -494,7 +494,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
+        let expectedRuntimeHardenedRevision = "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -485,12 +485,14 @@ struct RuntimePolicySourceTests {
         // explicit unsupported boundary for unproven unified image/audio/video,
         // and Gemma4 proportional RoPE support needed by full-attention layers,
         // plus safe auto-enabled Nemotron Ultra JANGTQ streaming dispatch that
-        // avoids full expert materialization for 512-expert stacked-only models.
+        // avoids full expert materialization for 512-expert stacked-only models,
+        // with Nemotron Ultra BF16 activation retention and weighted MoE
+        // fast-path controls wired behind explicit disable env vars.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
+        let expectedRuntimeHardenedRevision = "45a1560d96a10899a7c20f4797b2769d26e3294d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -498,7 +500,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming dispatch guard; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -148,26 +148,28 @@ public enum OsaurusPaths {
 
     // MARK: - Volume free-space query
     //
-    // ⚠️ Use the URL-keyed `.volumeAvailableCapacityForImportantUsageKey`
-    //    rather than the legacy `attributesOfFileSystem(.systemFreeSize)`.
-    //    On modern macOS (≥ 11) inside a sandboxed container the legacy
-    //    API can return 0 because it reports raw bytes excluding the
-    //    OS's "purgeable" allowance — which is exactly what users see
-    //    in Finder. `.systemFreeSize` was the historical default and
-    //    `SystemMonitorService` shipped with it for a long time, surfacing
-    //    bug #964 (the dashboard reports `Available: 0 GB` even when the
-    //    user clearly has free space). The URL-keyed query is what
-    //    `ModelDownloadService.freeBytesOnVolume` already used; this
-    //    helper consolidates both call-sites onto the same logic so the
-    //    answer can never silently drift again.
+    // Prefer the cheap POSIX filesystem query. On some external/APFS volumes
+    // `.volumeAvailableCapacityForImportantUsageKey` enters CacheDelete and can
+    // block model load for minutes before any weights are mapped. The URL-keyed
+    // query remains a fallback for volumes where legacy `.systemFreeSize` is
+    // missing or reports zero under sandbox/container pressure.
 
-    /// Returns the free-for-important-usage byte count on the volume that
-    /// hosts `path`. Falls back to the legacy
-    /// `attributesOfFileSystem(.systemFreeSize)` when the modern
-    /// query is unavailable or reports zero. Returns `nil` if both queries fail —
-    /// callers should treat `nil` as "unknown, render 'unknown'" rather
-    /// than coercing to zero.
+    /// Returns the free byte count on the volume that hosts `path`. Uses the
+    /// legacy filesystem attribute first to avoid CacheDelete stalls, then falls
+    /// back to `.volumeAvailableCapacityForImportantUsageKey` when needed.
+    /// Returns `nil` if both queries fail — callers should treat `nil` as
+    /// "unknown, render 'unknown'" rather than coercing to zero.
     public static func volumeFreeBytes(forPath path: String) -> Int64? {
+        var legacyFree: Int64?
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
+        {
+            legacyFree = free
+        }
+        if let legacyFree, legacyFree > 0 {
+            return legacyFree
+        }
+
         let url = URL(fileURLWithPath: path)
         var importantCapacity: Int64?
         let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
@@ -175,12 +177,6 @@ public enum OsaurusPaths {
             let capacity = values.volumeAvailableCapacityForImportantUsage
         {
             importantCapacity = capacity
-        }
-        var legacyFree: Int64?
-        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
-        {
-            legacyFree = free
         }
         return resolvedVolumeFreeBytes(
             importantCapacity: importantCapacity,
@@ -192,11 +188,11 @@ public enum OsaurusPaths {
         importantCapacity: Int64?,
         legacyFree: Int64?
     ) -> Int64? {
-        if let importantCapacity, importantCapacity > 0 {
-            return importantCapacity
-        }
         if let legacyFree, legacyFree > 0 {
             return legacyFree
+        }
+        if let importantCapacity, importantCapacity > 0 {
+            return importantCapacity
         }
         return importantCapacity ?? legacyFree
     }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3252,14 +3252,9 @@ class PasteMonitorView: NSView {
 
         let pasteboard = NSPasteboard.general
 
-        // Check if pasteboard contains an image
-        guard let types = pasteboard.types,
-            types.contains(where: { $0 == .png || $0 == .tiff || $0 == .fileURL })
-        else {
-            return false
-        }
-
-        // Try to get image data directly
+        // Avoid pasteboard type enumeration and object-conversion APIs here.
+        // Sentry APPLE-MACOS-43 showed AppKit pasteboard conversion can race
+        // paste monitoring on Cmd+V.
         if let imageData = pasteboard.data(forType: .png) {
             onImagePaste?(imageData)
             return true
@@ -3273,18 +3268,23 @@ class PasteMonitorView: NSView {
             return true
         }
 
-        // Try file URL (for copied files)
-        if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] {
-            for url in urls {
-                if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
-                    UTType(uti)?.conforms(to: .image) == true,
-                    let data = try? Data(contentsOf: url),
-                    let nsImage = NSImage(data: data),
-                    let pngData = nsImage.pngData()
-                {
-                    onImagePaste?(pngData)
-                    return true
-                }
+        let fileURLTypes: [NSPasteboard.PasteboardType] = [
+            .fileURL,
+            NSPasteboard.PasteboardType("public.file-url"),
+        ]
+        for type in fileURLTypes {
+            guard let raw = pasteboard.string(forType: type),
+                let url = URL(string: raw),
+                url.isFileURL
+            else { continue }
+            if let uti = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
+                UTType(uti)?.conforms(to: .image) == true,
+                let data = try? Data(contentsOf: url),
+                let nsImage = NSImage(data: data),
+                let pngData = nsImage.pngData()
+            {
+                onImagePaste?(pngData)
+                return true
             }
         }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
+        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "044bf8ad412e701be9f7cfc9e6b84d8894c22de7"
+        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "525fc6dc17650efd420e7f9adfc1c37e40650a73"
+        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d03beb22b0f9421b30b30c4e0dcadcb61d4d89d7"
+        "revision" : "45a1560d96a10899a7c20f4797b2769d26e3294d"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Add live available-memory accounting to the local model load gate so impossible loads refuse before MLX/Metal schedules work.
- Count shallow `.safetensors` shard layouts when exact known shard names are absent, preventing `weightsBytes == 0` from bypassing preflight.
- Surface `available_memory_bytes` and `required_available_bytes` in `/health` `ram_feasibility`.
- Keep Qwen/plugin tool loops on the configured chat max-tool-attempt budget instead of tiny hard-coded defaults.

## Root Cause

Sentry issue `7530281408` / `APPLE-MACOS-3T` is a Metal OOM during local model load, not a Gemma template/parser issue. The latest event showed a 24 GB-class Mac (`Mac14,2`) crashing after breadcrumb `model.load begin model=qwen3.6-35b-a3b-mxfp4`, with `kIOGPUCommandBufferCallbackErrorOutOfMemory`.

The old gate considered projected resident footprint but did not compare the incoming load plus KV/headroom against currently available memory. On a memory-constrained machine, Metal could still be asked to allocate and crash the app.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/(modelRuntimeWeightSizePreflightIsManualMultiModelOnly|pluginHostInferenceDefaultsToMultiIterationTools)' --jobs 1 --no-parallel`
- No-sign Release app build passed:
  - `build/DerivedData-ram-gate-tool-loop-20260605-155733/Build/Products/Release/osaurus.app`
  - ad-hoc signed, no signing identity
  - app build used pinned `osaurus-ai/vmlx-swift@525fc6dc17650efd420e7f9adfc1c37e40650a73`
- Live API proof on the rebuilt app at `127.0.0.1:4242`:
  - `qwen3.6-35b-a3b-mxfp4-crack-mtp` returned `qwen live ok`, `finish_reason=stop`
  - OpenAI tool-call round trip returned `lookup_status({"node":"node-2"})`, then consumed the tool result and answered normally
  - no raw tool tags, leaked parser envelopes, or random early stop observed
- Live cache/resource telemetry after the Qwen tool-result turn:
  - `incoming_weights_bytes=19788916296`
  - `kv_headroom_bytes=3957783259`
  - `required_available_bytes=23746699555`
  - topology: `layers=40`, `kvLayers=10`, `mambaLayers=30`, `companion=ssm`, `restore=disk-backed`
  - `disk_l2_hits=1`, `disk_l2_misses=5`, `disk_l2_stores=5`
  - `ssm_companion_hits=1`, `ssm_companion_misses=0`, `ssm_companion_rederives=0`

## Residual Risk

- Local proof machine has 128 GB RAM, so Qwen MXFP4 correctly loads here. The Sentry production crash is on a 24 GB-class Mac. This PR builds and exposes the refusal path, but exact refusal proof still needs a constrained-memory machine/profile or a test hook that does not alter production behavior.
- Keychain-free dev launch cannot prove built-in memory DB tools because existing `~/.osaurus` SQLCipher DBs do not open without keychain. OpenAI tool-call parser/runtime proof is unaffected.
