### PR TITLE
[codex] Add model compatibility diagnostics

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -6379,6 +6379,22 @@
         }
       }
     },
+    "Benchmark proof" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benchmark-Nachweis"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基准验证"
+          }
+        }
+      }
+    },
     "Bearer Token" : {
       "localizations" : {
         "de" : {
@@ -7057,6 +7073,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内置的确定性检测器与设备端模型一同运行。关闭某个类别后，Osaurus 将不再标记它，也不再在其绕过脱敏泄露时阻止发送。"
+          }
+        }
+      }
+    },
+    "Bundle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bundle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -39,6 +39,66 @@ enum ExternalModelLocator {
         let source: String
     }
 
+    /// Validation or scan reason for a bundle that was not registered.
+    enum SkipReason: String, Equatable {
+        case unreadableRoot
+        case malformedCacheFolder
+        case missingSnapshot
+        case snapshotEscapesRoot
+        case missingConfig
+        case missingTokenizer
+        case missingSafetensors
+        case ggufOnly
+        case symlinkEscapesRoot
+
+        var title: String {
+            switch self {
+            case .unreadableRoot: return "Root unreadable"
+            case .malformedCacheFolder: return "Malformed cache folder"
+            case .missingSnapshot: return "Snapshot missing"
+            case .snapshotEscapesRoot: return "Snapshot outside root"
+            case .missingConfig: return "config.json missing"
+            case .missingTokenizer: return "Tokenizer missing"
+            case .missingSafetensors: return "Safetensors missing"
+            case .ggufOnly: return "GGUF-only bundle"
+            case .symlinkEscapesRoot: return "Symlink escapes root"
+            }
+        }
+    }
+
+    struct BundleDiagnostic: Equatable {
+        let isValid: Bool
+        let reason: SkipReason?
+        let detail: String?
+        let isCandidate: Bool
+    }
+
+    struct Skipped: Equatable {
+        let repoId: String?
+        let path: String
+        let reason: SkipReason
+        let detail: String
+    }
+
+    struct SourceScanReport: Equatable {
+        let source: Source
+        let rootPath: String
+        let discovered: [Discovered]
+        let skipped: [Skipped]
+    }
+
+    struct ScanReport: Equatable {
+        let sources: [SourceScanReport]
+
+        var discovered: [Discovered] {
+            sources.flatMap(\.discovered)
+        }
+
+        var skipped: [Skipped] {
+            sources.flatMap(\.skipped)
+        }
+    }
+
     /// On-disk envelope. Versioned so format changes reject cleanly.
     private struct Persisted: Codable {
         static let currentSchemaVersion: Int = 1
@@ -64,7 +124,8 @@ enum ExternalModelLocator {
     // MARK: - Registry state
 
     private static let lock = NSLock()
-    private static nonisolated(unsafe) var registry: [String: Discovered]?
+    nonisolated(unsafe) private static var registry: [String: Discovered]?
+    nonisolated(unsafe) private static var lastReport: ScanReport?
 
     /// Test hook: override the scan roots so unit tests don't depend on a
     /// developer's real `~/.cache/huggingface`. When set, only these roots
@@ -110,6 +171,16 @@ enum ExternalModelLocator {
         }
     }
 
+    /// Most recent external-model scan report, including skipped candidates.
+    /// This is a UI/diagnostic surface only; runtime path resolution continues
+    /// to use the validated registry above.
+    static func lastScanReport() -> ScanReport? {
+        lock.lock()
+        let report = lastReport
+        lock.unlock()
+        return report
+    }
+
     /// Forget a single external model so it no longer appears in the
     /// catalog. Never touches the source files — this only removes the
     /// registry/manifest entry. A later `rescan()` will rediscover it if
@@ -133,37 +204,16 @@ enum ExternalModelLocator {
     /// call from a background task; performs filesystem I/O.
     @discardableResult
     static func rescan() -> [MLXModel] {
+        let report = scanEnabledSources()
         var discovered: [String: Discovered] = [:]
-
-        if let overrides = testRootsOverride {
-            for (root, source) in overrides {
-                let found: [Discovered]
-                switch source {
-                case .huggingFaceCache: found = scanHuggingFaceCache(root: root)
-                case .lmStudio: found = scan(root: root, source: .lmStudio)
-                }
-                for d in found { discovered[d.id.lowercased()] = d }
-            }
-        } else {
-            if isHFCacheImportEnabled {
-                for root in huggingFaceCacheRoots() {
-                    for d in scanHuggingFaceCache(root: root) {
-                        discovered[d.id.lowercased()] = d
-                    }
-                }
-            }
-            if isLMStudioImportEnabled {
-                for root in lmStudioRoots() {
-                    for d in scan(root: root, source: .lmStudio) {
-                        discovered[d.id.lowercased()] = d
-                    }
-                }
-            }
+        for entry in report.discovered {
+            discovered[entry.id.lowercased()] = entry
         }
 
         lock.lock()
         let changed = registry == nil || registry! != discovered
         registry = discovered
+        lastReport = report
         lock.unlock()
 
         if changed {
@@ -171,6 +221,29 @@ enum ExternalModelLocator {
             NotificationCenter.default.post(name: .localModelsChanged, object: nil)
         }
         return models()
+    }
+
+    static func scanEnabledSources() -> ScanReport {
+        var reports: [SourceScanReport] = []
+        if let overrides = testRootsOverride {
+            for (root, source) in overrides {
+                switch source {
+                case .huggingFaceCache:
+                    reports.append(scanHuggingFaceCacheReport(root: root))
+                case .lmStudio:
+                    reports.append(scanReport(root: root, source: .lmStudio))
+                }
+            }
+            return ScanReport(sources: reports)
+        }
+
+        if isHFCacheImportEnabled {
+            reports.append(contentsOf: huggingFaceCacheRoots().map(scanHuggingFaceCacheReport(root:)))
+        }
+        if isLMStudioImportEnabled {
+            reports.append(contentsOf: lmStudioRoots().map { scanReport(root: $0, source: .lmStudio) })
+        }
+        return ScanReport(sources: reports)
     }
 
     // MARK: - Roots
@@ -211,7 +284,7 @@ enum ExternalModelLocator {
     // MARK: - Hugging Face cache scanner
 
     /// Scan a single HF hub root for `models--org--repo` snapshots.
-    private static func scanHuggingFaceCache(root: URL) -> [Discovered] {
+    private static func scanHuggingFaceCacheReport(root: URL) -> SourceScanReport {
         let fm = FileManager.default
         guard
             let entries = try? fm.contentsOfDirectory(
@@ -219,20 +292,75 @@ enum ExternalModelLocator {
                 includingPropertiesForKeys: [.isDirectoryKey],
                 options: [.skipsHiddenFiles]
             )
-        else { return [] }
+        else {
+            return SourceScanReport(
+                source: .huggingFaceCache,
+                rootPath: root.path,
+                discovered: [],
+                skipped: [
+                    Skipped(
+                        repoId: nil,
+                        path: root.path,
+                        reason: .unreadableRoot,
+                        detail: "The Hugging Face cache root could not be read."
+                    )
+                ]
+            )
+        }
 
         var results: [Discovered] = []
+        var skipped: [Skipped] = []
         for entry in entries {
             let folder = entry.lastPathComponent
             guard folder.hasPrefix("models--") else { continue }
-            guard let repoId = Self.repoId(fromCacheFolder: folder) else { continue }
+            guard let repoId = Self.repoId(fromCacheFolder: folder) else {
+                skipped.append(
+                    Skipped(
+                        repoId: nil,
+                        path: entry.path,
+                        reason: .malformedCacheFolder,
+                        detail: "Expected a cache folder named models--<org>--<repo>."
+                    )
+                )
+                continue
+            }
 
             // Resolve refs/main -> commit hash -> snapshots/<hash>.
             let (snapshotDir, revision) = resolveSnapshot(in: entry)
-            guard let snapshotDir,
-                isContained(snapshotDir, in: root),
-                isMLXBundle(snapshotDir, root: root)
-            else { continue }
+            guard let snapshotDir else {
+                skipped.append(
+                    Skipped(
+                        repoId: repoId,
+                        path: entry.path,
+                        reason: .missingSnapshot,
+                        detail: "No readable snapshots directory or refs/main target was found."
+                    )
+                )
+                continue
+            }
+            guard isContained(snapshotDir, in: root) else {
+                skipped.append(
+                    Skipped(
+                        repoId: repoId,
+                        path: snapshotDir.path,
+                        reason: .snapshotEscapesRoot,
+                        detail: "The resolved snapshot points outside the configured cache root."
+                    )
+                )
+                continue
+            }
+            let diagnostic = bundleDiagnostic(at: snapshotDir, root: root)
+            guard diagnostic.isValid else {
+                skipped.append(
+                    Skipped(
+                        repoId: repoId,
+                        path: snapshotDir.path,
+                        reason: diagnostic.reason ?? .missingSafetensors,
+                        detail: diagnostic.detail ?? "The snapshot does not look like an MLX safetensors bundle."
+                    )
+                )
+                continue
+            }
 
             results.append(
                 Discovered(
@@ -243,7 +371,12 @@ enum ExternalModelLocator {
                 )
             )
         }
-        return results
+        return SourceScanReport(
+            source: .huggingFaceCache,
+            rootPath: root.path,
+            discovered: results,
+            skipped: skipped
+        )
     }
 
     /// `models--<org>--<repo>` -> `org/repo`. Returns nil for non-model
@@ -266,11 +399,10 @@ enum ExternalModelLocator {
         let snapshotsDir = modelDir.appendingPathComponent("snapshots", isDirectory: true)
 
         let refsMain = modelDir.appendingPathComponent("refs/main")
-        if let revData = try? Data(contentsOf: refsMain),
-            let rev = String(data: revData, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-            !rev.isEmpty
-        {
+        let mainRevision = (try? Data(contentsOf: refsMain))
+            .flatMap { String(data: $0, encoding: .utf8) }?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let rev = mainRevision, !rev.isEmpty {
             let candidate = snapshotsDir.appendingPathComponent(rev, isDirectory: true)
             if fm.fileExists(atPath: candidate.path) { return (candidate, rev) }
         }
@@ -300,8 +432,13 @@ enum ExternalModelLocator {
     /// directory that validates as an MLX bundle. Bounded depth keeps the
     /// scan cheap on large model libraries.
     static func scan(root: URL, source: Source) -> [Discovered] {
+        scanReport(root: root, source: source).discovered
+    }
+
+    static func scanReport(root: URL, source: Source) -> SourceScanReport {
         let fm = FileManager.default
         var results: [Discovered] = []
+        var skipped: [Skipped] = []
 
         func walk(_ dir: URL, prefix: [String], depth: Int) {
             guard depth > 0,
@@ -317,7 +454,8 @@ enum ExternalModelLocator {
                 guard fm.fileExists(atPath: resolved.path, isDirectory: &isDir), isDir.boolValue
                 else { continue }
                 let components = prefix + [entry.lastPathComponent]
-                if isMLXBundle(resolved, root: root) {
+                let diagnostic = bundleDiagnostic(at: resolved, root: root)
+                if diagnostic.isValid {
                     let id = components.joined(separator: "/")
                     results.append(
                         Discovered(
@@ -329,13 +467,28 @@ enum ExternalModelLocator {
                     )
                     continue  // a bundle dir doesn't itself contain bundles
                 }
+                if diagnostic.isCandidate {
+                    skipped.append(
+                        Skipped(
+                            repoId: components.count >= 2 ? components.joined(separator: "/") : nil,
+                            path: resolved.path,
+                            reason: diagnostic.reason ?? .missingSafetensors,
+                            detail: diagnostic.detail ?? "The directory is not a complete MLX safetensors bundle."
+                        )
+                    )
+                }
                 if depth > 1 {
                     walk(resolved, prefix: components, depth: depth - 1)
                 }
             }
         }
         walk(root, prefix: [], depth: 3)
-        return results
+        return SourceScanReport(
+            source: source,
+            rootPath: root.path,
+            discovered: results,
+            skipped: skipped
+        )
     }
 
     // MARK: - Validation
@@ -345,35 +498,137 @@ enum ExternalModelLocator {
     /// directories (no safetensors) fail this check and are skipped. Any
     /// symlinked file must resolve to a target under `root`.
     static func isMLXBundle(_ dir: URL, root: URL) -> Bool {
+        bundleDiagnostic(at: dir, root: root).isValid
+    }
+
+    static func bundleDiagnostic(
+        at dir: URL,
+        root: URL,
+        enforceSymlinkContainment: Bool = true
+    ) -> BundleDiagnostic {
         let fm = FileManager.default
-        func exists(_ name: String) -> Bool {
+
+        enum Probe {
+            case present
+            case missing
+            case escapesRoot
+        }
+
+        func probe(_ name: String) -> Probe {
             let url = dir.appendingPathComponent(name)
-            guard fm.fileExists(atPath: url.path) else { return false }
+            guard fm.fileExists(atPath: url.path) else { return .missing }
             // Reject symlinks that escape the scan root.
             let resolved = url.resolvingSymlinksInPath().standardizedFileURL
-            return isContained(resolved, in: root)
+            guard enforceSymlinkContainment else { return .present }
+            return isContained(resolved, in: root) ? .present : .escapesRoot
         }
 
-        guard exists("config.json") else { return false }
+        func hasAny(_ probes: [Probe]) -> Bool {
+            probes.contains { $0 == .present || $0 == .escapesRoot }
+        }
 
+        let config = probe("config.json")
+        let tokenizerJSON = probe("tokenizer.json")
+        let merges = probe("merges.txt")
+        let vocabJSON = probe("vocab.json")
+        let vocabTXT = probe("vocab.txt")
+        let tokenizerModel = probe("tokenizer.model")
+        let spieceModel = probe("spiece.model")
+        let tokenizerProbes = [
+            tokenizerJSON, merges, vocabJSON, vocabTXT, tokenizerModel, spieceModel,
+        ]
+
+        var sawSafetensors = false
+        var sawGGUF = false
+        var weightEscapesRoot = false
+        if let items = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) {
+            for item in items {
+                if item.pathExtension == "gguf" {
+                    sawGGUF = true
+                    continue
+                }
+                guard item.pathExtension == "safetensors" else { continue }
+                let resolved = item.resolvingSymlinksInPath().standardizedFileURL
+                if !enforceSymlinkContainment || isContained(resolved, in: root) {
+                    sawSafetensors = true
+                } else {
+                    weightEscapesRoot = true
+                }
+            }
+        }
+
+        let isCandidate =
+            hasAny([config])
+            || hasAny(tokenizerProbes)
+            || sawSafetensors
+            || sawGGUF
+            || weightEscapesRoot
+
+        if config == .escapesRoot {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .symlinkEscapesRoot,
+                detail: "config.json resolves outside the scan root.",
+                isCandidate: true
+            )
+        }
+        guard config == .present else {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .missingConfig,
+                detail: "config.json is required for MLX bundle discovery.",
+                isCandidate: isCandidate
+            )
+        }
+
+        if tokenizerProbes.contains(.escapesRoot) {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .symlinkEscapesRoot,
+                detail: "A tokenizer file resolves outside the scan root.",
+                isCandidate: true
+            )
+        }
         let hasTokenizer =
-            exists("tokenizer.json")
-            || (exists("merges.txt") && (exists("vocab.json") || exists("vocab.txt")))
-            || exists("tokenizer.model")
-            || exists("spiece.model")
-        guard hasTokenizer else { return false }
-
-        // Weights: a single/sharded safetensors. Cheap sentinel first, then
-        // fall back to scanning the directory for any `*.safetensors` (covers
-        // arbitrary shard counts and HF's symlinked blob names).
-        if exists("model.safetensors") || exists("model.safetensors.index.json") { return true }
-        guard let items = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
-        else { return false }
-        return items.contains { item in
-            guard item.pathExtension == "safetensors" else { return false }
-            let resolved = item.resolvingSymlinksInPath().standardizedFileURL
-            return isContained(resolved, in: root)
+            tokenizerJSON == .present
+            || (merges == .present && (vocabJSON == .present || vocabTXT == .present))
+            || tokenizerModel == .present
+            || spieceModel == .present
+        guard hasTokenizer else {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .missingTokenizer,
+                detail:
+                    "Expected tokenizer.json, BPE merges/vocab files, tokenizer.model, or spiece.model.",
+                isCandidate: true
+            )
         }
+
+        if weightEscapesRoot {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .symlinkEscapesRoot,
+                detail: "A safetensors file resolves outside the scan root.",
+                isCandidate: true
+            )
+        }
+        if sawSafetensors {
+            return BundleDiagnostic(isValid: true, reason: nil, detail: nil, isCandidate: true)
+        }
+        if sawGGUF {
+            return BundleDiagnostic(
+                isValid: false,
+                reason: .ggufOnly,
+                detail: "GGUF files are present, but the MLX runtime requires safetensors weights.",
+                isCandidate: true
+            )
+        }
+        return BundleDiagnostic(
+            isValid: false,
+            reason: .missingSafetensors,
+            detail: "Expected at least one .safetensors weight file.",
+            isCandidate: true
+        )
     }
 
     /// True when `url` is the same as, or nested under, `directory` after
@@ -423,6 +678,7 @@ enum ExternalModelLocator {
     static func invalidateInMemory() {
         lock.lock()
         registry = nil
+        lastReport = nil
         lock.unlock()
     }
 }

--- a/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
@@ -1,0 +1,392 @@
+//
+//  ModelCompatibilityDiagnostics.swift
+//  osaurus
+//
+//  User-visible diagnostics for local model discovery and runtime readiness.
+//  This is intentionally host-side only: it explains what Osaurus can prove
+//  from catalog metadata and local bundle files without rewriting model_type
+//  values or pretending vmlx supports an architecture it does not.
+//
+
+import Foundation
+
+enum ModelCompatibilityDiagnostics {
+    struct Report: Equatable {
+        let modelId: String
+        let source: SourceStatus
+        let localBundle: LocalBundleStatus
+        let runtime: RuntimeStatus
+        let benchmark: BenchmarkStatus
+        let featureHooks: [FeatureHook]
+
+        var primaryTitle: String { runtime.title }
+        var primaryDetail: String { runtime.detail }
+    }
+
+    struct SourceStatus: Equatable {
+        enum Kind: String {
+            case catalog
+            case osaurusLocal
+            case external
+        }
+
+        let kind: Kind
+        let title: String
+        let detail: String?
+    }
+
+    struct LocalBundleStatus: Equatable {
+        enum Kind: String {
+            case notDownloaded
+            case available
+            case incomplete
+        }
+
+        let kind: Kind
+        let title: String
+        let detail: String?
+        let path: String?
+        let config: ConfigSummary?
+    }
+
+    struct ConfigSummary: Equatable {
+        let modelType: String?
+        let textModelType: String?
+        let architectures: [String]
+        let hasVisionConfig: Bool
+        let hasJANGConfig: Bool
+        let hasJANGTQSidecar: Bool
+
+        var displayModelType: String? {
+            modelType ?? textModelType
+        }
+    }
+
+    struct RuntimeStatus: Equatable {
+        enum Kind: String {
+            case ready
+            case blocked
+            case needsDownload
+            case unproven
+        }
+
+        enum ReasonCode: String {
+            case catalogReady
+            case localBundleReady
+            case externalBundleUnproven
+            case needsDownload
+            case incompleteBundle
+            case unsupportedHunyuanDense
+            case unsupportedLongCat
+        }
+
+        let kind: Kind
+        let reason: ReasonCode
+        let title: String
+        let detail: String
+    }
+
+    struct BenchmarkStatus: Equatable {
+        enum Kind: String {
+            case notApplicable
+            case missingProof
+        }
+
+        let kind: Kind
+        let title: String
+        let detail: String
+    }
+
+    struct FeatureHook: Equatable, Identifiable {
+        enum Code: String {
+            case dflashSpeculativeDecoding
+            case tensorParallelism
+        }
+
+        let code: Code
+        let title: String
+        let detail: String
+        let issue: Int
+
+        var id: String { code.rawValue }
+    }
+
+    static func report(for model: MLXModel) -> Report {
+        report(
+            modelId: model.id,
+            modelName: model.name,
+            modelTypeHint: model.modelType,
+            bundleURL: model.isDownloaded ? model.localDirectory : nil,
+            externalSource: model.externalSource
+        )
+    }
+
+    static func report(
+        modelId: String,
+        modelName: String,
+        modelTypeHint: String?,
+        bundleURL: URL?,
+        externalSource: String?
+    ) -> Report {
+        let source = sourceStatus(
+            isLocal: bundleURL != nil,
+            externalSource: externalSource
+        )
+        let localBundle = localBundleStatus(bundleURL: bundleURL)
+        let config = localBundle.config
+        let runtime = runtimeStatus(
+            modelId: modelId,
+            modelName: modelName,
+            modelTypeHint: modelTypeHint,
+            source: source,
+            localBundle: localBundle,
+            config: config
+        )
+        let benchmark = benchmarkStatus(runtime: runtime, localBundle: localBundle)
+        return Report(
+            modelId: modelId,
+            source: source,
+            localBundle: localBundle,
+            runtime: runtime,
+            benchmark: benchmark,
+            featureHooks: runtime.kind == .blocked ? [] : futureHooks(for: localBundle)
+        )
+    }
+
+    private static func sourceStatus(isLocal: Bool, externalSource: String?) -> SourceStatus {
+        if let externalSource {
+            return SourceStatus(
+                kind: .external,
+                title: externalSource,
+                detail: "Referenced in place; Osaurus does not copy or mutate this bundle."
+            )
+        }
+        if isLocal {
+            return SourceStatus(
+                kind: .osaurusLocal,
+                title: "Osaurus local models",
+                detail: "Stored under the configured Osaurus model directory."
+            )
+        }
+        return SourceStatus(
+            kind: .catalog,
+            title: "Catalog",
+            detail: "Download or import the bundle before local runtime proof is possible."
+        )
+    }
+
+    private static func localBundleStatus(bundleURL: URL?) -> LocalBundleStatus {
+        guard let bundleURL else {
+            return LocalBundleStatus(
+                kind: .notDownloaded,
+                title: "Not local",
+                detail: "No local bundle is selected for this catalog entry.",
+                path: nil,
+                config: nil
+            )
+        }
+
+        let config = readConfigSummary(at: bundleURL)
+        let validation = ExternalModelLocator.bundleDiagnostic(
+            at: bundleURL,
+            root: bundleURL,
+            enforceSymlinkContainment: false
+        )
+        if validation.isValid {
+            return LocalBundleStatus(
+                kind: .available,
+                title: "Bundle complete",
+                detail: "config.json, tokenizer assets, and safetensors weights are present.",
+                path: bundleURL.path,
+                config: config
+            )
+        }
+
+        return LocalBundleStatus(
+            kind: .incomplete,
+            title: validation.reason?.title ?? "Bundle incomplete",
+            detail: validation.detail,
+            path: bundleURL.path,
+            config: config
+        )
+    }
+
+    private static func runtimeStatus(
+        modelId: String,
+        modelName: String,
+        modelTypeHint: String?,
+        source: SourceStatus,
+        localBundle: LocalBundleStatus,
+        config: ConfigSummary?
+    ) -> RuntimeStatus {
+        if let blocker = unsupportedFamilyStatus(
+            modelId: modelId,
+            modelName: modelName,
+            modelTypeHint: modelTypeHint,
+            config: config
+        ) {
+            return blocker
+        }
+
+        switch localBundle.kind {
+        case .notDownloaded:
+            return RuntimeStatus(
+                kind: .needsDownload,
+                reason: .needsDownload,
+                title: "Download required",
+                detail: "Osaurus cannot prove runtime behavior until the model bundle is local."
+            )
+        case .incomplete:
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .incompleteBundle,
+                title: "Bundle is incomplete",
+                detail: localBundle.detail ?? "The local directory does not have the required MLX files."
+            )
+        case .available:
+            if source.kind == .external {
+                return RuntimeStatus(
+                    kind: .unproven,
+                    reason: .externalBundleUnproven,
+                    title: "External bundle discovered",
+                    detail:
+                        "The files look loadable, but this specific cache-backed bundle still needs a real generation proof before it should be called validated."
+                )
+            }
+            return RuntimeStatus(
+                kind: .ready,
+                reason: .localBundleReady,
+                title: "Local bundle ready",
+                detail:
+                    "The bundle has the required local files. Runtime quality still depends on model-family support and live generation proof."
+            )
+        }
+    }
+
+    private static func unsupportedFamilyStatus(
+        modelId: String,
+        modelName: String,
+        modelTypeHint: String?,
+        config: ConfigSummary?
+    ) -> RuntimeStatus? {
+        let modelTypes = [
+            modelTypeHint,
+            config?.modelType,
+            config?.textModelType,
+        ].compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+
+        let architectures = config?.architectures.map { $0.lowercased() } ?? []
+        let names = [modelId, modelName].map { $0.lowercased() }
+
+        let isHunyuanDense =
+            modelTypes.contains("hunyuan_v1_dense")
+            || architectures.contains(where: { $0.contains("hunyuan_dense") })
+            || architectures.contains(where: { $0.contains("hunyuan") && $0.contains("dense") })
+        if isHunyuanDense {
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .unsupportedHunyuanDense,
+                title: "Unsupported Hunyuan Dense",
+                detail:
+                    "Unsupported local model type: hunyuan_v1_dense. Osaurus needs vmlx Hunyuan Dense support before this model can run locally."
+            )
+        }
+
+        let isLongCat =
+            modelTypes.contains(where: { $0.contains("longcat") })
+            || architectures.contains(where: { $0.contains("longcat") })
+            || names.contains(where: { $0.contains("longcat") })
+        if isLongCat {
+            return RuntimeStatus(
+                kind: .blocked,
+                reason: .unsupportedLongCat,
+                title: "Unsupported LongCat family",
+                detail:
+                    "LongCat local bundles require native vmlx architecture, processor, cache, and media-path support before Osaurus should offer them as runnable."
+            )
+        }
+
+        return nil
+    }
+
+    private static func benchmarkStatus(
+        runtime: RuntimeStatus,
+        localBundle: LocalBundleStatus
+    ) -> BenchmarkStatus {
+        guard localBundle.kind != .notDownloaded else {
+            return BenchmarkStatus(
+                kind: .notApplicable,
+                title: "No local proof",
+                detail: "Download or import first, then run a generation proof with token/s."
+            )
+        }
+
+        switch runtime.kind {
+        case .blocked:
+            return BenchmarkStatus(
+                kind: .notApplicable,
+                title: "Blocked",
+                detail: "Benchmark proof is not meaningful until the runtime blocker is resolved."
+            )
+        case .ready, .unproven, .needsDownload:
+            return BenchmarkStatus(
+                kind: .missingProof,
+                title: "Proof missing",
+                detail:
+                    "No local benchmark proof is recorded here yet. A passing row needs visible output, token/s, RAM status, cancellation, and cache evidence."
+            )
+        }
+    }
+
+    private static func futureHooks(for localBundle: LocalBundleStatus) -> [FeatureHook] {
+        guard localBundle.kind != .notDownloaded else { return [] }
+        return [
+            FeatureHook(
+                code: .dflashSpeculativeDecoding,
+                title: "DFlash speculative decoding",
+                detail:
+                    "Not enabled for local generation yet; needs target/draft validation and benchmark evidence.",
+                issue: 1065
+            ),
+            FeatureHook(
+                code: .tensorParallelism,
+                title: "Tensor parallelism",
+                detail:
+                    "Not enabled in the local runtime; requires an explicit distributed-runtime design and artifact integrity checks.",
+                issue: 833
+            ),
+        ]
+    }
+
+    private static func readConfigSummary(at bundleURL: URL) -> ConfigSummary? {
+        let configURL = bundleURL.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let textConfig = object["text_config"] as? [String: Any]
+        let architectures =
+            (object["architectures"] as? [Any])?
+            .compactMap { $0 as? String } ?? []
+        return ConfigSummary(
+            modelType: stringValue(object["model_type"]),
+            textModelType: stringValue(textConfig?["model_type"]),
+            architectures: architectures,
+            hasVisionConfig: object["vision_config"] != nil,
+            hasJANGConfig: FileManager.default.fileExists(
+                atPath: bundleURL.appendingPathComponent("jang_config.json").path
+            ),
+            hasJANGTQSidecar: FileManager.default.fileExists(
+                atPath: bundleURL.appendingPathComponent("jangtq_runtime.safetensors").path
+            )
+        )
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -132,6 +132,29 @@ struct ExternalModelLocatorTests {
         #expect(found.isEmpty)
     }
 
+    @Test func scanReport_explainsSkippedCandidates() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let missingTokenizer = root.appendingPathComponent("publisher/repo", isDirectory: true)
+        writeBundle(at: missingTokenizer, tokenizer: false)
+        let ggufOnly = root.appendingPathComponent("publisher/gguf", isDirectory: true)
+        writeBundle(at: ggufOnly, ggufOnly: true)
+
+        let report = ExternalModelLocator.scanReport(root: root, source: .lmStudio)
+
+        #expect(report.discovered.isEmpty)
+        #expect(
+            report.skipped.contains {
+                $0.repoId == "publisher/repo" && $0.reason == .missingTokenizer
+            }
+        )
+        #expect(
+            report.skipped.contains {
+                $0.repoId == "publisher/gguf" && $0.reason == .ggufOnly
+            }
+        )
+    }
+
     // MARK: - HF cache scan + resolution (via test override)
 
     @Test func rescan_resolvesHFCacheSnapshotAndPath() {
@@ -182,5 +205,46 @@ struct ExternalModelLocatorTests {
         let entry = models.first { $0.id == "org/repo" }
         #expect(entry?.bundleDirectory?.standardizedFileURL.path == snapshot.standardizedFileURL.path)
         #expect(entry?.isDownloaded == true)
+
+        let report = ExternalModelLocator.lastScanReport()
+        #expect(report?.discovered.contains { $0.id == "org/repo" } == true)
+        #expect(report?.skipped.isEmpty == true)
+    }
+
+    @Test func rescan_reportsHFCacheSnapshotSkipReason() {
+        OsaurusTestGlobals.withPathsLock {
+            rescan_reportsHFCacheSnapshotSkipReason_body()
+        }
+    }
+
+    private func rescan_reportsHFCacheSnapshotSkipReason_body() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        let previousOverride = ExternalModelLocator.testRootsOverride
+        let manifestRoot = makeTempDir()
+        let hfRoot = makeTempDir()
+        OsaurusPaths.overrideRoot = manifestRoot
+        ExternalModelLocator.invalidateInMemory()
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            ExternalModelLocator.testRootsOverride = previousOverride
+            ExternalModelLocator.invalidateInMemory()
+            try? FileManager.default.removeItem(at: manifestRoot)
+            try? FileManager.default.removeItem(at: hfRoot)
+        }
+
+        let fm = FileManager.default
+        let modelDir = hfRoot.appendingPathComponent("models--org--repo", isDirectory: true)
+        try? fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+
+        ExternalModelLocator.testRootsOverride = [(root: hfRoot, source: .huggingFaceCache)]
+        ExternalModelLocator.rescan()
+
+        let report = ExternalModelLocator.lastScanReport()
+        #expect(report?.discovered.isEmpty == true)
+        #expect(
+            report?.skipped.contains {
+                $0.repoId == "org/repo" && $0.reason == .missingSnapshot
+            } == true
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
@@ -1,0 +1,192 @@
+//
+//  ModelCompatibilityDiagnosticsTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ModelCompatibilityDiagnosticsTests {
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-compat-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeBundle(
+        at dir: URL,
+        config: String = #"{"model_type":"qwen3"}"#,
+        tokenizer: Bool = true,
+        weights: Bool = true
+    ) {
+        let fm = FileManager.default
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        if tokenizer {
+            try? Data("{}".utf8).write(to: dir.appendingPathComponent("tokenizer.json"))
+        }
+        if weights {
+            try? Data("w".utf8).write(to: dir.appendingPathComponent("model.safetensors"))
+        }
+    }
+
+    @Test func externalBundle_reportsUnprovenRuntimeAndMissingProof() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(at: root)
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/repo",
+            modelName: "Repo",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+
+        #expect(report.source.kind == .external)
+        #expect(report.localBundle.kind == .available)
+        #expect(report.runtime.reason == .externalBundleUnproven)
+        #expect(report.benchmark.kind == .missingProof)
+        #expect(report.featureHooks.map(\.code) == [.dflashSpeculativeDecoding, .tensorParallelism])
+    }
+
+    @Test func externalBundleDiagnostic_acceptsHFCacheBlobSymlinks() {
+        let cacheRoot = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+
+        let fm = FileManager.default
+        let blobs = cacheRoot.appendingPathComponent("blobs", isDirectory: true)
+        let snapshot = cacheRoot.appendingPathComponent("models--org--repo/snapshots/rev", isDirectory: true)
+        try? fm.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: snapshot, withIntermediateDirectories: true)
+
+        let configBlob = blobs.appendingPathComponent("config")
+        let tokenizerBlob = blobs.appendingPathComponent("tokenizer")
+        let weightsBlob = blobs.appendingPathComponent("weights")
+        try? Data(#"{"model_type":"qwen3"}"#.utf8).write(to: configBlob)
+        try? Data("{}".utf8).write(to: tokenizerBlob)
+        try? Data("w".utf8).write(to: weightsBlob)
+        try? fm.createSymbolicLink(
+            at: snapshot.appendingPathComponent("config.json"),
+            withDestinationURL: configBlob
+        )
+        try? fm.createSymbolicLink(
+            at: snapshot.appendingPathComponent("tokenizer.json"),
+            withDestinationURL: tokenizerBlob
+        )
+        try? fm.createSymbolicLink(
+            at: snapshot.appendingPathComponent("model.safetensors"),
+            withDestinationURL: weightsBlob
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/repo",
+            modelName: "Repo",
+            modelTypeHint: nil,
+            bundleURL: snapshot,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+
+        #expect(report.localBundle.kind == .available)
+        #expect(report.runtime.reason == .externalBundleUnproven)
+    }
+
+    @Test func hunyuanDenseConfig_reportsUnsupportedFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config:
+                #"{"model_type":"hunyuan_v1_dense","architectures":["HunYuanDenseV1ForCausalLM"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "mlx-community/HY-MT1.5-7B-bf16",
+            modelName: "HY-MT1.5",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedHunyuanDense)
+        #expect(report.benchmark.kind == .notApplicable)
+    }
+
+    @Test func hunyuanDenseArchitecture_reportsUnsupportedFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"architectures":["HunYuanDenseV1ForCausalLM"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "mlx-community/HY-MT1.5-7B-bf16",
+            modelName: "HY-MT1.5",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: ExternalModelLocator.Source.huggingFaceCache.rawValue
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedHunyuanDense)
+    }
+
+    @Test func longCatConfig_reportsUnsupportedFamily() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"longcat_next","architectures":["LongCatFlashForConditionalGeneration"]}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "meituan-longcat/LongCat-Next",
+            modelName: "LongCat Next",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .blocked)
+        #expect(report.runtime.reason == .unsupportedLongCat)
+    }
+
+    @Test func catalogEntryWithoutBundle_reportsDownloadRequired() {
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/repo",
+            modelName: "Repo",
+            modelTypeHint: "qwen3",
+            bundleURL: nil,
+            externalSource: nil
+        )
+
+        #expect(report.source.kind == .catalog)
+        #expect(report.localBundle.kind == .notDownloaded)
+        #expect(report.runtime.reason == .needsDownload)
+        #expect(report.benchmark.kind == .notApplicable)
+        #expect(report.featureHooks.isEmpty)
+    }
+
+    @Test func incompleteBundle_reportsRuntimeBlocker() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(at: root, weights: false)
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/repo",
+            modelName: "Repo",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.localBundle.kind == .incomplete)
+        #expect(report.localBundle.title == "Safetensors missing")
+        #expect(report.runtime.reason == .incompleteBundle)
+    }
+}

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -93,6 +93,8 @@ struct ModelDetailView: View, Identifiable {
                 VStack(spacing: 14) {
                     compatibilityLine
 
+                    runtimeDiagnosticsCard
+
                     modelCardSection
 
                     detailsCard
@@ -266,6 +268,98 @@ struct ModelDetailView: View, Identifiable {
             return VLMDetection.isVLM(modelType: mt)
         }
         return model.isVLM
+    }
+
+    private var diagnosticsReport: ModelCompatibilityDiagnostics.Report {
+        ModelCompatibilityDiagnostics.report(for: model)
+    }
+
+    private var runtimeDiagnosticsCard: some View {
+        let report = diagnosticsReport
+        let tint = runtimeDiagnosticTint(report.runtime.kind)
+
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: runtimeDiagnosticIcon(report.runtime.kind))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(tint)
+                    .frame(width: 18, height: 18)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(report.primaryTitle)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+
+                    Text(report.primaryDetail)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 14, alignment: .topLeading),
+                    GridItem(.flexible(), spacing: 14, alignment: .topLeading),
+                ],
+                alignment: .leading,
+                spacing: 10
+            ) {
+                DiagnosticFact(label: L("Source"), value: report.source.title)
+                DiagnosticFact(label: L("Bundle"), value: report.localBundle.title)
+                if let modelType = report.localBundle.config?.displayModelType {
+                    DiagnosticFact(label: L("Model Type"), value: modelType)
+                }
+                DiagnosticFact(label: L("Benchmark proof"), value: report.benchmark.title)
+            }
+
+            if !report.featureHooks.isEmpty {
+                Divider()
+                    .background(theme.cardBorder)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(report.featureHooks) { hook in
+                        HStack(spacing: 6) {
+                            Image(systemName: "circle.dashed")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundColor(theme.tertiaryText)
+                            Text(hook.title)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundColor(theme.secondaryText)
+                            Text("#\(hook.issue)")
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .foregroundColor(theme.tertiaryText)
+                        }
+                        Text(hook.detail)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.tertiaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .detailCardSurface()
+    }
+
+    private func runtimeDiagnosticTint(_ kind: ModelCompatibilityDiagnostics.RuntimeStatus.Kind) -> Color {
+        switch kind {
+        case .ready: return theme.successColor
+        case .blocked: return theme.errorColor
+        case .needsDownload, .unproven: return theme.warningColor
+        }
+    }
+
+    private func runtimeDiagnosticIcon(_ kind: ModelCompatibilityDiagnostics.RuntimeStatus.Kind) -> String {
+        switch kind {
+        case .ready: return "checkmark.shield.fill"
+        case .blocked: return "xmark.octagon.fill"
+        case .needsDownload: return "arrow.down.circle.fill"
+        case .unproven: return "exclamationmark.triangle.fill"
+        }
     }
 
     // MARK: - Details Card
@@ -894,6 +988,29 @@ private struct MetaItem: View {
 
             Text(value)
                 .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct DiagnosticFact: View {
+    @Environment(\.theme) private var theme
+
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundColor(theme.tertiaryText)
+                .lineLimit(1)
+
+            Text(value)
+                .font(.system(size: 12, weight: .medium))
                 .foregroundColor(theme.primaryText)
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
@@ -21,6 +21,7 @@ struct ExternalModelsSettingsView: View {
 
     @State private var hfCount: Int = 0
     @State private var lmStudioCount: Int = 0
+    @State private var scanReport: ExternalModelLocator.ScanReport?
     @State private var isScanning: Bool = false
 
     var body: some View {
@@ -65,16 +66,41 @@ struct ExternalModelsSettingsView: View {
 
                 Spacer()
 
-                Button(action: { rescan() }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 11, weight: .semibold))
-                        Text("Rescan", bundle: .module)
-                            .font(.system(size: 12, weight: .semibold))
+                Button(
+                    action: { rescan() },
+                    label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 11, weight: .semibold))
+                            Text("Rescan", bundle: .module)
+                                .font(.system(size: 12, weight: .semibold))
+                        }
                     }
-                }
+                )
                 .buttonStyle(PlainButtonStyle())
                 .disabled(isScanning)
+            }
+
+            if let scanReport, !scanReport.skipped.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(theme.warningColor)
+                        Text("\(scanReport.skipped.count) external candidate(s) skipped", bundle: .module)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(theme.secondaryText)
+                    }
+
+                    ForEach(Array(scanReport.skipped.prefix(3).enumerated()), id: \.offset) { _, item in
+                        Text(skippedSummary(item))
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.tertiaryText)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(.top, 2)
             }
         }
         .onAppear { refreshCounts() }
@@ -87,6 +113,7 @@ struct ExternalModelsSettingsView: View {
 
     private func refreshCounts() {
         let models = ExternalModelLocator.models()
+        scanReport = ExternalModelLocator.lastScanReport()
         hfCount =
             models.filter {
                 $0.externalSource == ExternalModelLocator.Source.huggingFaceCache.rawValue
@@ -107,5 +134,10 @@ struct ExternalModelsSettingsView: View {
                 self.refreshCounts()
             }
         }
+    }
+
+    private func skippedSummary(_ item: ExternalModelLocator.Skipped) -> String {
+        let name = item.repoId ?? URL(fileURLWithPath: item.path).lastPathComponent
+        return "\(name): \(item.reason.title)"
     }
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -208,11 +208,11 @@ Research notes for the next local-runtime compatibility wave live in
 
 | Request | User-visible status | Next implementation step | Runtime owner |
 | --- | --- | --- | --- |
-| Hugging Face cache import | Planned: pre-downloaded MLX snapshots are not listed automatically yet. | Add a read-only HF cache scanner with per-file SHA-256 manifests before load. | Osaurus host discovery/storage. |
-| Hunyuan `hunyuan_v1_dense` | Unsupported until vmlx has a native Hunyuan Dense factory. | Add an unsupported-family diagnostic, then enable only after real-model validation. | vmlx model factory and Osaurus diagnostics. |
+| Hugging Face cache import | Implemented as read-only discovery for verified MLX snapshots; Settings now shows skipped candidate reasons. | Add manifest/digest verification before load if cache mutation protection becomes required. | Osaurus host discovery/storage. |
+| Hunyuan `hunyuan_v1_dense` | Blocked with an explicit unsupported-family diagnostic until vmlx has a native Hunyuan Dense factory. | Enable only after real-model validation lands upstream. | vmlx model factory and Osaurus diagnostics. |
 | DFlash speculative decoding | Research-only; no draft/target local generation contract exists today. | Define a feature-flagged draft-model API and benchmark harness. | vmlx or dedicated MLX speculative adapter. |
-| LongCat Flash/Next | Unsupported locally; current public repos require custom LongCat code paths and large multimodal runtimes. | Track exact unsupported reasons and wait for native runtime support. | vmlx model family support. |
-| Tensor parallelism | Research-only; local runtime remains single-host. | Design authenticated cluster policy before any peer execution code. | Distributed runtime plus Osaurus identity/network policy. |
+| LongCat Flash/Next | Blocked with an explicit unsupported-family diagnostic; current public repos require custom LongCat code paths and large multimodal runtimes. | Wait for native runtime support and multimodal proof before local picker enablement. | vmlx model family support. |
+| Tensor parallelism | Future hook only; local runtime remains single-host. | Design authenticated cluster policy before any peer execution code. | Distributed runtime plus Osaurus identity/network policy. |
 
 ---
 

--- a/docs/MODEL_COMPATIBILITY_RESEARCH.md
+++ b/docs/MODEL_COMPATIBILITY_RESEARCH.md
@@ -14,9 +14,9 @@ requests:
 - [#833](https://github.com/osaurus-ai/osaurus/issues/833) - tensor
   parallelism
 
-The immediate deliverable is design and review material only. Runtime
-changes should land later in smaller implementation PRs after the boundaries
-below are accepted.
+The current deliverable is host-side discovery and diagnostics only. Runtime
+family enablement still belongs in vmlx-backed PRs with live proof; Osaurus
+surfaces unsupported or unproven states instead of coercing model configs.
 
 ## Current Boundary
 
@@ -33,10 +33,14 @@ that prove the right boundary is being crossed.
 
 Current source map:
 
-- `ModelManager` and `HuggingFaceService` discover Hugging Face repos and
-  local Osaurus model folders.
+- `ModelManager`, `HuggingFaceService`, and `ExternalModelLocator` discover
+  Hugging Face repos, local Osaurus model folders, Hugging Face cache
+  snapshots, and LM Studio-style external bundles.
 - `MLXModel.isDownloaded` accepts a directory with `config.json`, tokenizer
   assets, and at least one `*.safetensors` file.
+- `ModelCompatibilityDiagnostics` reports local source, bundle completeness,
+  unsupported Hunyuan/LongCat families, benchmark proof status, and future
+  DFlash/tensor-parallel hooks without attempting a model load.
 - `ModelRuntime` loads the selected directory into a vmlx `ModelContainer`
   and submits through `MLXBatchAdapter`.
 - `docs/INFERENCE_RUNTIME.md` documents that vmlx owns KV topology,
@@ -46,10 +50,10 @@ Current source map:
 
 | Request | Current status | First shippable step | Runtime boundary |
 | --- | --- | --- | --- |
-| Hugging Face local cache (#443) | Not surfaced in the model picker; users can manually copy files into the Osaurus model directory. | Add a read-only HF cache scanner that registers verified snapshot directories as local models. | Host-only discovery/storage work; no vmlx change if the snapshot already loads as MLX. |
-| Hunyuan `hunyuan_v1_dense` (#358) | `mlx-community/HY-MT1.5-7B-bf16` advertises `model_type: hunyuan_v1_dense`; Osaurus should treat it as unsupported until vmlx has a native factory. | Add an unsupported-family diagnostic and a no-load fixture test; enable catalog entry only after vmlx support lands. | vmlx must own config mapping, weights, tokenizer/template behavior, and generation tests. |
+| Hugging Face local cache (#443) | Read-only HF cache and LM Studio discovery are implemented for verified MLX safetensors bundles; skipped candidates now have Settings diagnostics. | Add optional manifest/digest verification before load if mutation protection is required. | Host-only discovery/storage work; no vmlx change if the snapshot already loads as MLX. |
+| Hunyuan `hunyuan_v1_dense` (#358) | `mlx-community/HY-MT1.5-7B-bf16` advertises `model_type: hunyuan_v1_dense`; Osaurus now reports it as unsupported until vmlx has a native factory. | Enable catalog/runtime only after vmlx support and live validation land. | vmlx must own config mapping, weights, tokenizer/template behavior, and generation tests. |
 | DFlash speculative decoding (#1065) | Osaurus has one target model per local generation request and no draft-model contract. | Design a feature-flagged draft/target request shape plus benchmark evidence requirements. | vmlx or a dedicated MLX adapter must own the speculative loop and acceptance verification. |
-| LongCat Flash/Next (#886) | LongCat repos use custom code and new LongCat config shapes; LongCat-Next is a 74B any-to-any model that documents at least three 80GB GPUs for Transformers usage. | Track as unsupported locally with exact reason strings and keep remote-provider usage out of this lane. | Native LongCat model classes, multimodal processors, lazy decoder paths, and cache geometry belong upstream. |
+| LongCat Flash/Next (#886) | LongCat repos use custom code and new LongCat config shapes; LongCat-Next is a 74B any-to-any model that documents at least three 80GB GPUs for Transformers usage. Osaurus now reports LongCat local bundles as unsupported. | Keep local catalog entries hidden or blocked until native support and multimodal proof exist. | Native LongCat model classes, multimodal processors, lazy decoder paths, and cache geometry belong upstream. |
 | Tensor parallelism (#833) | Osaurus runs one local MLX process and one local `BatchEngine` per resident model. | Produce a cluster design behind explicit auth and network policy; do not auto-discover or auto-join peers. | Distributed execution belongs in vmlx/external cluster runtime; host owns identity, policy, and UI only. |
 
 ## Hugging Face Cache Import
@@ -204,14 +208,12 @@ Security checks for the later implementation:
 
 ## Implementation Order
 
-1. HF cache scanner, because it is host-side and benefits existing MLX users
-   without new model-family risk.
-2. Unsupported-family diagnostics for Hunyuan and LongCat, because this turns
-   current load failures into actionable messages.
-3. Hunyuan vmlx support, if upstream scope is accepted and real-model evidence
+1. Optional manifest/digest verification for external cache entries, if the
+   project wants stronger mutation detection before load.
+2. Hunyuan vmlx support, if upstream scope is accepted and real-model evidence
    is available.
-4. DFlash API boundary and benchmark harness, still feature-flagged.
-5. Tensor-parallel cluster design after model artifact integrity and network
+3. DFlash API boundary and benchmark harness, still feature-flagged.
+4. Tensor-parallel cluster design after model artifact integrity and network
    identity are reviewed together.
 
 ## Validation Standard


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Model-management issues often look like broken runtime support when the real problem is cache location, unsupported architecture, incomplete bundle, or missing proof. This PR makes those states visible without claiming new model families work.

**Coding rationale:** The change adds compatibility/proof diagnostics around existing model discovery and detail surfaces, keeping runtime support decisions explicit and evidence-backed.

**Osaurus standards check:** Current-main, function-sized PR; diagnostics only; no synthetic runtime enablement; no hidden sampler/template defaults; no new dependency; focused tests plus GitHub CI are green.

## Business rationale

Users can already point Osaurus at local model libraries, but when a Hugging Face cache or LM Studio candidate is skipped the UI only shows the success count. This PR makes model management legible: Settings now reports skipped external candidates with reason codes, and the model detail modal shows whether a selected bundle is local, external, incomplete, blocked by unsupported runtime family, unproven, or missing benchmark proof. This targets #443, #358, #886, #1065, #833, and #22 without pretending new runtime support exists.

## Coding rationale

The implementation keeps runtime validation strict in `ExternalModelLocator` while adding report-only scan metadata beside the existing registry. `ModelCompatibilityDiagnostics` reads lightweight local config and bundle metadata and reports host-side statuses; it does not rewrite `model_type`, add dependencies, load models, or widen vMLX support. Scanner symlink containment remains enforced for registration, while the display-only detail diagnostic does not falsely reject valid Hugging Face snapshot symlinks into the cache blob store.

## Acceptance criteria

- External scans preserve validated model registration while exposing skipped candidate reasons.
- Model detail explains source, bundle completeness, unsupported Hunyuan/LongCat, missing benchmark proof, and future DFlash/tensor-parallel hooks.
- Unsupported model-family diagnostics are no-load and do not alias `model_type`.
- Docs reflect current Hugging Face cache discovery state and remaining runtime boundaries.

## Rebase notes

- Refreshed onto current `origin/main` `4dc06e064e0e6497e8667a1b9dd19fadb5f918c8` (`Fix Gemma4 chat-template schema normalization (#1357)`).
- Current head is `24ddec3aa3885d28d835fd33f3c1ba04b913dfa6` on `mimeding:codex/model-management-performance`.
- Rebase was clean; no code conflicts or current-main functional adjustments were required.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `xcrun swift-format lint --configuration .swift-format` on touched Swift files
- [x] `swiftlint lint --quiet --config .swiftlint.yml` on touched Swift files (exit 0; existing `ModelDetailView` warnings only)
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-model-management-rebased swift test --package-path Packages/OsaurusCore --filter 'ExternalModelLocatorTests|ModelCompatibilityDiagnosticsTests'` (19 tests)
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [ ] GitHub CI pending on `24ddec3a`: `test-core`. `test-cli`, `swiftlint`, `shellcheck`, and release drafter are green.

## Debug evidence

The focused test run passed 19 tests. `ModelCompatibilityDiagnosticsTests` covers external unproven bundles, Hugging Face cache blob symlinks, Hunyuan Dense via `model_type` and architecture, LongCat, catalog needs-download, and incomplete bundles. `ExternalModelLocatorTests` covers skipped LM Studio candidates, Hugging Face missing snapshot reasons, cache snapshot resolution, containment, and GGUF/missing-tokenizer rejection.

## Self-review

### Regression review

`ExternalModelLocator` registration still only uses validated discovered bundles; new report data is sidecar metadata. Existing `models()`, `path(forId:)`, and `forget(id:)` behavior is preserved. `ModelDetailView` and `ExternalModelsSettingsView` are read-only diagnostic display changes; no model load, delete, import, or runtime path changed.

### Performance review

External scanning remains bounded to existing roots and depth; diagnostics reuse the same file probes, adding constant-time reason classification per candidate. Model detail reads `config.json` and sentinel file presence only for the selected local bundle; no model weights are opened or loaded. No new dependencies, no network I/O, no unbounded parsing.

## Rollback

Revert this PR commit to remove the compatibility diagnostics, scan reports, UI surfacing, tests, localizations, and docs updates.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `e967d561279e`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
