### PR TITLE
fixed hangs

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -166,9 +166,15 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     private var didPrewarmChatView = false
     func prewarmChatView() {
         guard !didPrewarmChatView else { return }
-        didPrewarmChatView = true
         // A live chat window already paid (and warmed) this cost.
         guard windowCount == 0 else { return }
+        // Constructing ChatWindowState pulls up ChatSessionsManager, which opens the
+        // chat store and needs the storage key. If the launch-time key prewarm is still
+        // stuck inside a slow Keychain read, that lookup would park the main thread
+        // behind it, so only prewarm once the key is already resident. Skipping is
+        // safe: the first real window pays the realization cost on demand instead.
+        guard StorageKeyManager.shared.hasCachedKey else { return }
+        didPrewarmChatView = true
 
         let windowState = ChatWindowState(
             windowId: UUID(),

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -11,13 +11,62 @@ import Foundation
 import MLXVLM
 
 enum VLMDetection {
+    // MARK: - Memoization
+
+    // `isVLM(at:)` / `isVLM(modelId:)` are read from view bodies (e.g.
+    // `ModelRowView.modelTypeBadge` via `MLXModel.isVLM`) on every SwiftUI body
+    // evaluation, and each call reads + parses config.json from disk — synchronous
+    // I/O that hangs the UI when it runs per row per body eval. Verdicts are pure
+    // functions of the on-disk model, so they're cached and dropped on
+    // `.localModelsChanged` to stay in sync with downloads and deletions.
+    private static let cacheLock = NSLock()
+    private nonisolated(unsafe) static var verdictCache: [String: Bool] = [:]
+    private nonisolated(unsafe) static var didInstallObserver = false
+
+    private static func cachedVerdict(_ key: String, compute: () -> Bool) -> Bool {
+        ensureCacheObserverInstalled()
+        cacheLock.lock()
+        if let cached = verdictCache[key] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let result = compute()
+
+        cacheLock.lock()
+        verdictCache[key] = result
+        cacheLock.unlock()
+        return result
+    }
+
+    private static func ensureCacheObserverInstalled() {
+        cacheLock.lock()
+        let already = didInstallObserver
+        didInstallObserver = true
+        cacheLock.unlock()
+        if already { return }
+
+        NotificationCenter.default.addObserver(
+            forName: .localModelsChanged,
+            object: nil,
+            queue: nil
+        ) { _ in
+            VLMDetection.cacheLock.lock()
+            VLMDetection.verdictCache.removeAll(keepingCapacity: true)
+            VLMDetection.cacheLock.unlock()
+        }
+    }
+
     /// Check if a downloaded model at the given directory is a VLM.
     /// Uses vision_config key presence in config.json as the definitive signal,
     /// disambiguating model types registered in both LLM and VLM factories
     /// (e.g. gemma4 has both text-only and vision variants).
     static func isVLM(at directory: URL) -> Bool {
-        guard let json = readConfigJSON(at: directory) else { return false }
-        return json["vision_config"] != nil
+        cachedVerdict("dir:\(directory.path)") {
+            guard let json = readConfigJSON(at: directory) else { return false }
+            return json["vision_config"] != nil
+        }
     }
 
     /// Check if a model_type string is a known VLM architecture.
@@ -32,8 +81,10 @@ enum VLMDetection {
     /// Best-effort check for a model by its Hugging Face repo ID.
     /// Returns false if the model is not downloaded locally.
     static func isVLM(modelId: String) -> Bool {
-        guard let dir = findLocalModelDirectory(forModelId: modelId) else { return false }
-        return isVLM(at: dir)
+        cachedVerdict("id:\(modelId)") {
+            guard let dir = findLocalModelDirectory(forModelId: modelId) else { return false }
+            return isVLM(at: dir)
+        }
     }
 
     /// Read model_type from a model's local config.json.

--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -205,13 +205,15 @@ final class SystemPermissionService: NSObject, ObservableObject, CLLocationManag
                 }
             }
 
-            // Automation states use the last known cached value and location reads the
-            // main-actor CLLocationManager, so both must be resolved on the MainActor.
+            // Automation states and location use the last known cached value: automation
+            // probes run AppleScript, and reading the location authorization makes a
+            // synchronous XPC call to locationd that can block the main thread for seconds.
+            // Location stays fresh via the CLLocationManager delegate callback.
             await MainActor.run {
                 for permission in SystemPermission.allCases where permission.isAutomationBased {
                     newStates[permission] = self.permissionStates[permission]
                 }
-                newStates[.location] = self.checkLocationPermission()
+                newStates[.location] = self.permissionStates[.location]
                 self.setPermissions(newStates)
             }
         }
@@ -247,8 +249,9 @@ final class SystemPermissionService: NSObject, ObservableObject, CLLocationManag
             }
 
             await MainActor.run {
-                // Location reads the main-actor CLLocationManager.
-                results[.location] = self.checkLocationPermission()
+                // Location is intentionally not probed here: the authorization read makes a
+                // synchronous XPC call to locationd, and the delegate callback already keeps
+                // the cached state fresh.
                 // Only update if changed to avoid unnecessary saves.
                 for (permission, granted) in results where self.permissionStates[permission] != granted {
                     self.setPermission(permission, isGranted: granted)

--- a/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
@@ -1714,11 +1714,29 @@ final class NativeToolCallRowView: NSView {
             && TTSService.shared.activeSpeakCallId == item.call.id
     }
 
+    /// Memoized `ToolEnvelope.isError` verdict. The sniff scans the whole result
+    /// string, which gets expensive for large tool results, and the status color is
+    /// recomputed on every cell (re)configure tick while a response streams. Results
+    /// are write-once per call, so the verdict is keyed by (call id, byte length).
+    private var cachedErrorVerdict: (callId: String, resultBytes: Int, isError: Bool)?
+
+    private func isErrorResult(_ result: String, callId: String) -> Bool {
+        let bytes = result.utf8.count
+        if let cached = cachedErrorVerdict,
+            cached.callId == callId, cached.resultBytes == bytes
+        {
+            return cached.isError
+        }
+        let verdict = ToolEnvelope.isError(result)
+        cachedErrorVerdict = (callId, bytes, verdict)
+        return verdict
+    }
+
     /// Color of the node (icon + fill tint + ring), driven by run status:
     /// running = accent, error = red, success = green.
     private func nodeStatusColor(item: ToolCallItem, theme: any ThemeProtocol) -> NSColor {
         if isRunning(item) { return NSColor(theme.accentColor) }
-        if let r = item.result, ToolEnvelope.isError(r) {
+        if let r = item.result, isErrorResult(r, callId: item.call.id) {
             return NSColor(theme.errorColor)
         }
         return NSColor(theme.successColor)


### PR DESCRIPTION
## Summary

  - cached vision model detection so the model list no longer reads and parses files from disk every time a row refreshes
  - the chat view prewarm at launch now waits until the encryption key is already in memory so startup no longer stalls behind a slow keychain
  - permission refreshes now reuse the last known location authorization instead of making a blocking system call on the main thread
  - tool call rows now remember whether a result was an error so large results are no longer rescanned every time the row updates

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
