### PR TITLE
Budget routed JANGTQ load footprint

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
+        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
+        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
+        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -6184,6 +6184,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "model": f.modelName,
                         "verdict": f.verdict.rawValue,
                         "incoming_weights_bytes": f.incomingWeightsBytes,
+                        "incoming_load_footprint_bytes": f.incomingLoadFootprintBytes,
                         "resident_weights_bytes": f.residentWeightsBytes,
                         "kv_headroom_bytes": f.kvHeadroomBytes,
                         "projected_bytes": f.projectedBytes,

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
+        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
+        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
+        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
+            revision: "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "fb72783969d4dc30ccde78e8fd7d322b1438db85"
+            revision: "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
+            revision: "fb72783969d4dc30ccde78e8fd7d322b1438db85"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -624,6 +624,7 @@ public actor ModelRuntime {
         public let modelName: String
         public let verdict: Verdict
         public let incomingWeightsBytes: Int64
+        public let incomingLoadFootprintBytes: Int64
         public let residentWeightsBytes: Int64
         public let kvHeadroomBytes: Int64
         public let projectedBytes: Int64
@@ -782,6 +783,7 @@ public actor ModelRuntime {
     private func checkRAMFeasibility(
         modelName: String,
         incomingWeightsBytes: Int64,
+        incomingLoadFootprintBytes: Int64,
         excludingResident excludedName: String?,
         modelDirectory: URL? = nil
     ) throws {
@@ -794,13 +796,13 @@ public actor ModelRuntime {
         // (empty) cache and both pass, doubling the real footprint.
         let inflightOther = inflightLoadWeightBytes(excluding: excludedName)
         let kvHeadroom = Self.estimatedKVHeadroomBytes(
-            forWeights: incomingWeightsBytes,
+            forWeights: incomingLoadFootprintBytes,
             modelDirectory: modelDirectory,
             modelName: modelName
         )
         let available = Self.availableMemoryBytes()
-        let requiredAvailable = incomingWeightsBytes + kvHeadroom
-        let projected = resident + inflightOther + incomingWeightsBytes + kvHeadroom
+        let requiredAvailable = incomingLoadFootprintBytes + kvHeadroom
+        let projected = resident + inflightOther + incomingLoadFootprintBytes + kvHeadroom
         let softLimit = Int64(Double(physical) * Self.ramSoftThreshold)
         let hardLimit = Int64(Double(physical) * Self.ramHardThreshold)
 
@@ -817,6 +819,7 @@ public actor ModelRuntime {
             modelName: modelName,
             verdict: verdict,
             incomingWeightsBytes: incomingWeightsBytes,
+            incomingLoadFootprintBytes: incomingLoadFootprintBytes,
             residentWeightsBytes: resident,
             kvHeadroomBytes: kvHeadroom,
             projectedBytes: projected,
@@ -842,7 +845,7 @@ public actor ModelRuntime {
             CrashReportingService.recordBreadcrumb(
                 category: "model.load",
                 message:
-                    "refused model=\(modelName) weightsBytes=\(incomingWeightsBytes) kvHeadroomBytes=\(kvHeadroom) availableBytes=\(available) requiredAvailableBytes=\(requiredAvailable) physicalBytes=\(physical)"
+                    "refused model=\(modelName) weightsBytes=\(incomingWeightsBytes) loadFootprintBytes=\(incomingLoadFootprintBytes) kvHeadroomBytes=\(kvHeadroom) availableBytes=\(available) requiredAvailableBytes=\(requiredAvailable) physicalBytes=\(physical)"
             )
             let projGB = String(format: "%.1f", Double(projected) / 1_073_741_824)
             let physGB = String(format: "%.1f", Double(physical) / 1_073_741_824)
@@ -1061,8 +1064,13 @@ public actor ModelRuntime {
         // below — were blind under the default strict policy. The value also
         // feeds `mlxCacheLimit()` and the `/health` + model-picker surfaces.
         let weightsBytes = Self.computeWeightsSizeBytes(at: localURL)
+        let loadFootprintBytes = Self.effectiveLoadFootprintBytes(
+            rawWeightsBytes: weightsBytes,
+            modelDirectory: localURL,
+            modelName: name
+        )
         genLog.info(
-            "loadContainer: pre-load checks done model=\(name, privacy: .public) weightsBytes=\(weightsBytes, privacy: .public)"
+            "loadContainer: pre-load checks done model=\(name, privacy: .public) weightsBytes=\(weightsBytes, privacy: .public) loadFootprintBytes=\(loadFootprintBytes, privacy: .public)"
         )
 
         // Reserve this load's footprint the instant it's known, BEFORE the
@@ -1072,7 +1080,7 @@ public actor ModelRuntime {
         // — by the time the success path returns, the model is already
         // resident in `modelCache`, so dropping the reservation can't
         // momentarily under-count.
-        inflightLoadWeights[name] = weightsBytes
+        inflightLoadWeights[name] = loadFootprintBytes
         defer { inflightLoadWeights.removeValue(forKey: name) }
 
         try Task.checkCancellation()
@@ -1080,7 +1088,7 @@ public actor ModelRuntime {
         if policy == .manualMultiModel {
             await unloadForFlexibleResidentBudget(
                 targetName: name,
-                incomingWeightsSizeBytes: weightsBytes
+                incomingWeightsSizeBytes: loadFootprintBytes
             )
         }
         try Task.checkCancellation()
@@ -1093,6 +1101,7 @@ public actor ModelRuntime {
         try checkRAMFeasibility(
             modelName: name,
             incomingWeightsBytes: weightsBytes,
+            incomingLoadFootprintBytes: loadFootprintBytes,
             excludingResident: name,
             modelDirectory: localURL
         )
@@ -1144,7 +1153,7 @@ public actor ModelRuntime {
             return SessionHolder(
                 name: name,
                 container: container,
-                weightsSizeBytes: weightsBytes,
+                weightsSizeBytes: loadFootprintBytes,
                 isVLM: isVLM,
                 draftStrategy: mtpPlan.draftStrategy
             )
@@ -2718,6 +2727,70 @@ public actor ModelRuntime {
             }
         }
         return total
+    }
+
+    static func effectiveLoadFootprintBytes(
+        rawWeightsBytes: Int64,
+        modelDirectory: URL?,
+        modelName: String? = nil
+    ) -> Int64 {
+        guard rawWeightsBytes > 0, let modelDirectory else { return rawWeightsBytes }
+        guard isRoutedJANGTQCompressionLoad(at: modelDirectory, modelName: modelName) else {
+            return rawWeightsBytes
+        }
+
+        // vMLX `.osaurusProduction` loads routed JANGTQ through mmap-backed
+        // safetensors and MLXPress compression-first residency. The default
+        // compression policy advises 70% of routed weights cold, so the
+        // pre-load crash-prevention gate should budget the hot working set,
+        // not require the entire routed shard total to be immediately free.
+        let hotFraction = 0.30
+        let floor: Int64 = 4 * 1024 * 1024 * 1024
+        let estimated = Int64(Double(rawWeightsBytes) * hotFraction)
+        return min(rawWeightsBytes, max(floor, estimated))
+    }
+
+    private static func isRoutedJANGTQCompressionLoad(at directory: URL, modelName: String?) -> Bool {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: directory.appendingPathComponent("jangtq_runtime.safetensors").path)
+        else { return false }
+
+        let config = Self.readJSONObject(at: directory.appendingPathComponent("config.json"))
+        let jang = Self.readJSONObject(at: directory.appendingPathComponent("jang_config.json"))
+        guard !config.isEmpty || !jang.isEmpty else { return false }
+
+        let weightFormat =
+            Self.stringValue(jang["weight_format"])
+            ?? Self.stringValue(config["weight_format"])
+            ?? ""
+        let profile =
+            ((jang["quantization"] as? [String: Any]).flatMap { Self.stringValue($0["profile"]) }
+                ?? Self.stringValue(jang["profile"])
+                ?? "")
+        let declaresJANGTQ =
+            weightFormat.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "mxtq"
+            || profile.lowercased().contains("jangtq")
+            || (modelName?.lowercased().contains("jangtq") ?? false)
+        guard declaresJANGTQ else { return false }
+
+        let routedExperts =
+            Self.intValue(config["n_routed_experts"])
+            ?? Self.intValue(config["num_routed_experts"])
+            ?? Self.intValue(config["num_experts"])
+            ?? Self.intValue(config["num_local_experts"])
+        if (routedExperts ?? 0) > 0 { return true }
+
+        if let actions = (jang["quantization"] as? [String: Any])?["actions"] as? [String: Any],
+            (Self.intValue(actions["routed_tq"]) ?? 0) > 0
+        {
+            return true
+        }
+        if let mxtqBits = jang["mxtq_bits"] as? [String: Any],
+            mxtqBits["routed_expert"] != nil
+        {
+            return true
+        }
+        return false
     }
 
     /// Verify every weight shard referenced by a `*.safetensors.index.json`

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -242,6 +242,9 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             || normalizedModelType == "lfm2_moe"
             || normalizedModelType == "lfm2-vl"
             || normalizedModelType == "lfm2_vl"
+        let modelTypeIsNemotron =
+            normalizedModelType == "nemotron"
+            || normalizedModelType == "nemotron_h"
         let hasZayaChatTokens =
             upstream.bosToken == "<bos>"
             && upstream.convertTokenToId("<|im_start|>") != nil
@@ -372,7 +375,20 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                 addGenerationPrompt: addGenerationPrompt
             )
         }
-        if (modelTypeIsGemma4 || upstream.bosToken == "<bos>" || hasGemma4NativeToolSentinels),
+        if modelTypeIsNemotron,
+            !(chatTemplateTools?.isEmpty ?? true),
+            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
+        {
+            return try fallback(
+                label: "NemotronMinimal",
+                template: MLXLMCommon.ChatTemplateFallbacks.nemotronMinimal,
+                messages: messages,
+                tools: chatTemplateTools,
+                additionalContext: adjustedContext,
+                addGenerationPrompt: addGenerationPrompt
+            )
+        }
+        if (modelTypeIsGemma4 || (!modelTypeIsNemotron && upstream.bosToken == "<bos>") || (!modelTypeIsNemotron && hasGemma4NativeToolSentinels)),
             !(chatTemplateTools?.isEmpty ?? true),
             !modelTypeIsGemma3n,
             Self.requiresToolChoice(adjustedContext),

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -379,10 +379,14 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             !(chatTemplateTools?.isEmpty ?? true),
             (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
         {
+            let fallbackMessages =
+                Self.requiresToolChoice(adjustedContext)
+                ? Self.compactCompletedToolHistoryForRequiredChoice(messages)
+                : messages
             return try fallback(
                 label: "NemotronMinimal",
                 template: MLXLMCommon.ChatTemplateFallbacks.nemotronMinimal,
-                messages: messages,
+                messages: fallbackMessages,
                 tools: chatTemplateTools,
                 additionalContext: adjustedContext,
                 addGenerationPrompt: addGenerationPrompt
@@ -397,7 +401,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             return try fallback(
                 label: "Gemma4RequiredTool",
                 template: MLXLMCommon.ChatTemplateFallbacks.gemma4WithTools,
-                messages: Self.compactGemma4CompletedToolHistoryForRequiredChoice(messages),
+                messages: Self.compactCompletedToolHistoryForRequiredChoice(messages),
                 tools: chatTemplateTools,
                 additionalContext: adjustedContext,
                 addGenerationPrompt: addGenerationPrompt
@@ -497,7 +501,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                     : MLXLMCommon.ChatTemplateFallbacks.gemma4WithTools
                 let fallbackMessages =
                     Self.requiresToolChoice(adjustedContext)
-                    ? Self.compactGemma4CompletedToolHistoryForRequiredChoice(messages)
+                    ? Self.compactCompletedToolHistoryForRequiredChoice(messages)
                     : messages
                 let fallbackTools = modelTypeIsGemma3n ? nil : chatTemplateTools
                 return try fallback(
@@ -589,7 +593,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         return false
     }
 
-    private static func compactGemma4CompletedToolHistoryForRequiredChoice(
+    private static func compactCompletedToolHistoryForRequiredChoice(
         _ messages: [[String: any Sendable]]
     ) -> [[String: any Sendable]] {
         guard

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -150,6 +150,73 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(topology >= 512 * 1024 * 1024)
     }
 
+    @Test("Routed JANGTQ pre-load RAM gate uses MLXPress hot working set")
+    func routedJANGTQLoadFootprintUsesCompressionHotSet() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "nemotron_h",
+              "weight_format": "mxtq",
+              "n_routed_experts": 512,
+              "num_experts_per_tok": 22
+            }
+            """
+        let jang = """
+            {
+              "weight_format": "mxtq",
+              "quantization": {
+                "profile": "JANGTQ_1L",
+                "actions": { "routed_tq": 49152 }
+              },
+              "mxtq_bits": {
+                "routed_expert": { "up_proj": 1, "down_proj": 1 }
+              }
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        try Data(jang.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+        try Data([0]).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+
+        let raw: Int64 = 100 * 1024 * 1024 * 1024
+        let effective = ModelRuntime.effectiveLoadFootprintBytes(
+            rawWeightsBytes: raw,
+            modelDirectory: dir,
+            modelName: "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L"
+        )
+
+        #expect(effective == 30 * 1024 * 1024 * 1024)
+    }
+
+    @Test("Non-JANGTQ and missing-sidecar models keep raw pre-load RAM budget")
+    func nonJANGTQLoadFootprintKeepsRawBudget() throws {
+        let plain = try makeIsolatedDir()
+        try Data(#"{"model_type":"gemma4","num_hidden_layers":48}"#.utf8)
+            .write(to: plain.appendingPathComponent("config.json"))
+
+        let missingSidecar = try makeIsolatedDir()
+        try Data(#"{"model_type":"nemotron_h","weight_format":"mxtq","n_routed_experts":512}"#.utf8)
+            .write(to: missingSidecar.appendingPathComponent("config.json"))
+        try Data(#"{"weight_format":"mxtq","quantization":{"profile":"JANGTQ_1L"}}"#.utf8)
+            .write(to: missingSidecar.appendingPathComponent("jang_config.json"))
+
+        let raw: Int64 = 100 * 1024 * 1024 * 1024
+
+        #expect(
+            ModelRuntime.effectiveLoadFootprintBytes(
+                rawWeightsBytes: raw,
+                modelDirectory: plain,
+                modelName: "gemma-4-12b-it-mxfp8"
+            ) == raw
+        )
+        #expect(
+            ModelRuntime.effectiveLoadFootprintBytes(
+                rawWeightsBytes: raw,
+                modelDirectory: missingSidecar,
+                modelName: "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L"
+            ) == raw
+        )
+    }
+
     // MARK: - JANGTQ sidecar preflight
     //
     // vmlx's LLMModelFactory dispatches to the JANGTQ class purely on

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1731,10 +1731,14 @@ struct RuntimePolicySourceTests {
         // reservation both need the incoming bundle's footprint up front.
         #expect(loadPreflight.contains("if policy == .manualMultiModel"))
         #expect(loadPreflight.contains("let weightsBytes = Self.computeWeightsSizeBytes(at: localURL)"))
+        #expect(
+            loadPreflight.contains("let loadFootprintBytes = Self.effectiveLoadFootprintBytes("),
+            "Routed mmap/JANGTQ loads must feed the RAM gate with vMLX's effective hot working set, not the whole safetensors shard total."
+        )
         // Feasibility gate + concurrent-load reservation must run before the
         // load task is allocated, so a cold load can't bypass RAM accounting.
         #expect(
-            loadPreflight.contains("inflightLoadWeights[name] = weightsBytes"),
+            loadPreflight.contains("inflightLoadWeights[name] = loadFootprintBytes"),
             "Cold loads must reserve their footprint before the feasibility gate so a parallel load of another model can't double-book unified memory."
         )
         #expect(
@@ -1744,6 +1748,7 @@ struct RuntimePolicySourceTests {
         #expect(
             runtime.contains("availableMemoryBytes()")
                 && runtime.contains("requiredAvailable > available")
+                && runtime.contains("incomingLoadFootprintBytes")
                 && runtime.contains("availableBytes=")
                 && runtime.contains("Clear memory, unload other models, or choose a smaller/more-quantized model."),
             "The load gate must stop low-available-memory launches before Metal OOMs and expose a user-actionable resource message, not a fatal C++ exception."
@@ -1752,6 +1757,7 @@ struct RuntimePolicySourceTests {
         let health = try Self.source("Networking/HTTPHandler.swift")
         #expect(health.contains("\"available_memory_bytes\": f.availableMemoryBytes"))
         #expect(health.contains("\"required_available_bytes\": f.requiredAvailableBytes"))
+        #expect(health.contains("\"incoming_load_footprint_bytes\": f.incomingLoadFootprintBytes"))
     }
 
     @Test("MTP bundles auto-resolve vmlx tuning into load and generation")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -513,7 +513,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "fb72783969d4dc30ccde78e8fd7d322b1438db85"
+        let expectedRuntimeHardenedRevision = "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -513,7 +513,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
+        let expectedRuntimeHardenedRevision = "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -505,13 +505,15 @@ struct RuntimePolicySourceTests {
         // and Gemma4 proportional RoPE support needed by full-attention layers,
         // plus safe auto-enabled Nemotron Ultra JANGTQ streaming dispatch that
         // avoids full expert materialization for 512-expert stacked-only models,
-        // with Nemotron Ultra BF16 activation retention and weighted MoE
-        // fast-path controls wired behind explicit disable env vars.
+        // with Nemotron Ultra BF16 activation retention, weighted MoE
+        // fast-path controls wired behind explicit disable env vars, and the
+        // native Nemotron XML tool fallback preserving required parameter
+        // metadata for strict tool choice.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
+        let expectedRuntimeHardenedRevision = "fb72783969d4dc30ccde78e8fd7d322b1438db85"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -519,7 +521,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -505,6 +505,85 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(!decoded.contains("For multiline string values, represent each line break"), "Decoded: \(decoded)")
     }
 
+    @Test func nemotronRequiredToolChoiceCompactsClosedToolHistoryForLaterRequiredToolTurn() async throws {
+        let defaultPath = "/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_NEMOTRON_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+        let finalUser = "Now use line_count on exactly this new text, preserving newlines:\none\ntwo"
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                [
+                    "role": "user",
+                    "content": "Use the line_count tool on exactly this text, preserving newlines:\nalpha\nbeta\ngamma",
+                ],
+                [
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        [
+                            "id": "call_line_count_1",
+                            "type": "function",
+                            "function": [
+                                "name": "line_count",
+                                "arguments": ["text": "alpha\nbeta\ngamma"],
+                            ] as [String: any Sendable],
+                        ] as [String: any Sendable]
+                    ],
+                ] as [String: any Sendable],
+                ["role": "tool", "content": "{\"lines\":3}", "tool_call_id": "call_line_count_1"],
+                [
+                    "role": "user",
+                    "content": "Answer visibly in one short sentence: how many lines were counted? Do not call a tool.",
+                ],
+                ["role": "assistant", "content": "The line_count tool counted 3 lines."],
+                ["role": "user", "content": finalUser],
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(decoded.contains(finalUser), "Decoded: \(decoded)")
+        #expect(decoded.contains("<tools>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<name>line_count</name>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<required>[\"text\"]</required>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("MUST be a tool call"), "Decoded: \(decoded)")
+        #expect(decoded.contains("Use the `line_count` function."), "Decoded: \(decoded)")
+        #expect(decoded.contains("<function=line_count>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<parameter=text>"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("alpha\nbeta\ngamma"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("call_line_count_1"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("The line_count tool counted 3 lines."), "Decoded: \(decoded)")
+        #expect(!decoded.contains("{\"lines\":3}"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("<|tool_call>call:line_count"), "Decoded: \(decoded)")
+    }
+
     @Test func gemma3nLocalTokenizerDoesNotInventRequiredToolContractFromFallback() async throws {
         let defaultPath = "/Users/eric/models/mlx-community/gemma-3n-E2B-it-4bit"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_GEMMA3N_TEST_MODEL"] ?? defaultPath

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -451,6 +451,60 @@ struct SwiftTransformersTokenizerLoaderTests {
         #expect(!decoded.contains("<zyphra_tool_call>"), "Decoded: \(decoded)")
     }
 
+    @Test func nemotronRequiredToolChoiceUsesNemotronFallbackNotGemmaFallback() async throws {
+        let defaultPath = "/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_NEMOTRON_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "line_count",
+                description: "Count newline-separated text lines.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "text": .object(["type": .string("string")])
+                    ]),
+                    "required": .array([.string("text")]),
+                ])
+            )
+        )
+
+        let tokenIds = try tokenizer.applyChatTemplate(
+            messages: [
+                [
+                    "role": "user",
+                    "content": "Use the line_count tool on exactly this text, preserving newlines:\nalpha\nbeta\ngamma",
+                ]
+            ],
+            tools: [tool.toTokenizerToolSpec()],
+            additionalContext: [
+                "tool_choice": "required",
+                "tool_choice_name": "line_count",
+            ]
+        )
+        let decoded = tokenizer.decode(tokenIds: tokenIds, skipSpecialTokens: false)
+
+        #expect(decoded.contains("<tools>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<name>line_count</name>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<required>[\"text\"]</required>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("MUST be a tool call"), "Decoded: \(decoded)")
+        #expect(decoded.contains("Use the `line_count` function."), "Decoded: \(decoded)")
+        #expect(decoded.contains("<function=line_count>"), "Decoded: \(decoded)")
+        #expect(decoded.contains("<parameter=text>"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("<|tool_call>call:line_count"), "Decoded: \(decoded)")
+        #expect(!decoded.contains("For multiline string values, represent each line break"), "Decoded: \(decoded)")
+    }
+
     @Test func gemma3nLocalTokenizerDoesNotInventRequiredToolContractFromFallback() async throws {
         let defaultPath = "/Users/eric/models/mlx-community/gemma-3n-E2B-it-4bit"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_GEMMA3N_TEST_MODEL"] ?? defaultPath

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a7481f9793d253cb2dacff31cb0b3f18a307ef6"
+        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "fb72783969d4dc30ccde78e8fd7d322b1438db85"
+        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c761d6cba5e5b46b4f3f9d5940141a88a5ad4879"
+        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Budget routed JANGTQ pre-load RAM using the MLXPress hot working set instead of raw safetensors bytes.
- Keep raw `incoming_weights_bytes` visible while adding `incoming_load_footprint_bytes` to `/health`.
- Preserve strict raw-budget behavior for non-JANGTQ bundles and JANGTQ-like bundles missing the runtime sidecar.

## Root Cause
Nemo Ultra JANGTQ_1L was refused before vMLX could load it because Osaurus treated the raw safetensors total (`105603112752` bytes) as the immediate resident load footprint. The production vMLX path uses mmap-backed JANGTQ plus MLXPress cold routed pages, so the crash-prevention gate needed to budget the effective hot working set while still reporting the raw model size.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'ModelRuntimeFindDirectoryTests|RuntimePolicySourceTests' --jobs 1 --no-parallel`
  - Result: 100 tests in 2 suites passed.
- No-sign Release app build from `a213f3ce...` against pinned `vmlx-swift@7a7481f...` succeeded.
- Live artifact: `/tmp/osaurus-vmlx-effective-ram-nemo-ultra-jangtq1l-tool-cache-20260605-235911`
  - Load gate fixed: `/health` reported `incoming_weights_bytes=105603112752`, `incoming_load_footprint_bytes=31680933825`, `projected_bytes=39757590465`, `verdict=ok`, and the model loaded.
  - Hybrid cache topology surfaced: `kv_layer_count=12`, `mamba_layer_count=48`, `requires_ssm_companion_state=true`, `requires_disk_backed_restore=true`.
  - MLXPress surfaced: mmap enabled, `cold_fraction=0.7`, `total_routed_bytes=64776830976`.
  - App did not crash during the bounded row.

## Known Remaining Partial Items
- Nemo Ultra strict tool argument exactness is still partial: turns 1 and 3 emitted `line_count` without required `text`, so Osaurus returned the invalid-arguments fallback. No protocol/reasoning tag leak was observed.
- Nemo Ultra speed is still partial: the only visible decode row was 5 completion tokens in 18.58s, about `0.27 tok/s`. This PR fixes the Osaurus load gate and telemetry, not the vMLX speed target.
