### PR TITLE
Pin Nemotron fallback macro runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
+        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
+        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
+            revision: "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
+        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Pin Osaurus to vMLX `f50ab1ac7f1744d91ed46a77c5c87a173d91423b`.
- This is the merged vMLX main fix for the Nemotron HuggingFace macro fallback log escaping issue.
- Keep the Osaurus change scoped to the package manifest and lockfiles only.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift package --package-path Packages/OsaurusCore resolve`
  - resolved `https://github.com/osaurus-ai/vmlx-swift` at `f50ab1ac7f1744d91ed46a77c5c87a173d91423b`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'ModelRuntimeMappingTests|ModelProfileRegistryTests|ServerRuntimeSettingsStoreTests' --jobs 1 --no-parallel`
  - 40 tests passed

## vMLX Source Evidence

- vMLX PR: https://github.com/osaurus-ai/vmlx-swift/pull/23
- vMLX `NemotronHJANGTQDispatchFocusedTests`: 9 tests passed
- vMLX `CacheCoordinatorTopologyFocusedTests`: 31 tests passed
- vMLX `VMLINUXServerRuntimeSettingsTests`: 32 tests passed

## Release Note

The documented Nemotron Ultra speed gate is met at 8.335 tok/s. Long-context coherence/cache/VL proof remains tracked as partial runtime validation rather than being claimed by this pin-only Osaurus PR.
