### PR TITLE
Pin vMLX Nemotron parser alias runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
+        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
+        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
+            revision: "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f50ab1ac7f1744d91ed46a77c5c87a173d91423b"
+        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
       }
     },
     {


### PR DESCRIPTION
## Summary
- pin Osaurus to vMLX `8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9`
- picks up vMLX PR #24 parser/settings alias coverage for Nemotron/Qwen XML tool parser dispatch
- keeps the Osaurus diff pin-only across Package.swift and resolved locks

## Validation
- `git diff --check`
- `xcrun swift package --package-path Packages/OsaurusCore resolve` resolved vMLX at `8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9`
- `xcrun swift test --package-path Packages/OsaurusCore --filter 'ModelRuntimeMappingTests|ModelProfileRegistryTests|ServerRuntimeSettingsStoreTests' --jobs 1 --no-parallel` passed 40 tests in 3 suites\n\n## Notes\n- This PR does not alter generation defaults, sampler behavior, or reasoning/tool prompt policy.\n- The documented Nemotron Ultra speed row remains confirmed at 8.335 tok/s against the 8.000 tok/s release floor; broader long-row coherence/cache proof remains tracked separately as partial.