### PR TITLE
Pin vMLX Nemotron live proof runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
+        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -333,8 +333,7 @@ public enum ServerRuntimeSettingsStore {
         let projectedOrigins = settings.network.corsOrigins
             .filter { $0 != "*" }
         updated.allowedOrigins = projectedOrigins
-        updated.genTopP =
-            settings.generation.topP.map(Float.init)
+        updated.genTopP = settings.generation.topP.map(Float.init)
             ?? ServerConfiguration.default.genTopP
         return updated
     }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
+        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
+            revision: "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -508,12 +508,14 @@ struct RuntimePolicySourceTests {
         // with Nemotron Ultra BF16 activation retention, weighted MoE
         // fast-path controls wired behind explicit disable env vars, and the
         // native Nemotron XML tool fallback preserving required parameter
-        // metadata for strict tool choice.
+        // metadata for strict tool choice, plus the Nemotron Ultra resident
+        // perf harness load split and mmap growing-cache proof for
+        // disk-backed hybrid SSM companion hits.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "9e28ccdf3f0bf07f7e867ce3b4925fc547adbdd7"
+        let expectedRuntimeHardenedRevision = "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -521,7 +523,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, and Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, and the Nemotron Ultra resident/mmap cache-proof harness; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8ba63f93e0b25302303b6b8b3573a2f97cf4f8f9"
+        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus to vmlx-swift `4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943`, the merged Nemotron live-proof runtime commit.
- Keep the OsaurusCore manifest and both SwiftPM lockfiles synchronized on that vMLX revision.
- Update the source policy guard so future pin drift catches the Nemotron resident/mmap cache-proof runtime lineage.
- Normalize the legacy `genTopP` projection assignment so the runtime-settings source guard verifies blank runtime top-p clears stale legacy top-p.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
  - artifact: `/tmp/osaurus-vmlx-4cc-pin-runtime-policy-20260606-041807.log`
  - result: passed, 1 Swift Testing test
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ServerRuntimeSettingsStoreTests/projectIntoLegacy_clearsLegacyTopPWhenRuntimeTopPIsModelDefault --jobs 1 --no-parallel`
  - artifact: `/tmp/osaurus-server-runtime-top-p-focused-20260606-042337.log`
  - result: passed, 1 Swift Testing test
- `scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh`
  - artifact: `/tmp/osaurus-vmlx-4cc-pr-readiness-clean-20260606-042620.log`
  - result: passed
- No-sign Release app build from this branch
  - app: `/tmp/osaurus-vmlx-4cc-nosign-derived-20260606-043051/Build/Products/Release/osaurus.app`
  - log: `/tmp/osaurus-vmlx-4cc-nosign-build-20260606-043051.log`
  - result: `** BUILD SUCCEEDED **`, ad-hoc signed, no keychain prompt
- Live app/API proof against the no-sign app on `127.0.0.1:4242`
  - simple chat artifact: `/tmp/osaurus-vmlx-4cc-live-20260606-043825/ultra-simple-20260606-044040`
  - strict warm tool/cache artifact: `/tmp/osaurus-vmlx-4cc-live-20260606-043825/ultra-tool-cache-warm-20260606-044503`
  - result: passed required tool-call parser turns, no protocol leaks, no length-stop fake pass, disk L2 hits, and SSM companion cache hits

## Upstream vMLX evidence
- vmlx-swift PR #25 merged to main as `4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943`.
- Resident Nemo Ultra row: `/tmp/vmlx-nemotron-resident-original-load-20260606-040225.log` -> `tokps_median=8.1`, `peak_footprint_mib=102736`, bundle defaults, coherent/no leak/no loop.
- mmap Nemo Ultra row: `/tmp/vmlx-nemotron-mmap-explicit-load-20260606-040324.log` -> `tokps_median=3.9`, `peak_footprint_mib=1353`, low footprint, coherent/no leak/no loop.
- mmap hybrid SSM cache row: `/tmp/vmlx-nemotron-mmap-cache-hybrid-ssm-20260606-040758.log` -> `tokps_median=4.5`, `peak_footprint_mib=2131`, coherent/no leak/no loop.
- Warm Osaurus API proof showed `disk_l2_hits=3`, `ssm_companion_hits=3`, `companion_hits=3`, and all required parser/cache checks passed.

## Status
Ready to merge. The documented Swift `8.1 tok/s` number is the resident runtime row. The low-footprint Osaurus/mmap path is intentionally lower throughput in the current proof, but it keeps physical footprint low and passed the required tool/parser/cache gate.
