### PR TITLE
Pin vMLX Nemotron graph evidence runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
+        "revision" : "698190feab4add2190e0058dd81f39735db82653"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
+        "revision" : "698190feab4add2190e0058dd81f39735db82653"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
+            revision: "698190feab4add2190e0058dd81f39735db82653"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -515,7 +515,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
+        let expectedRuntimeHardenedRevision = "698190feab4add2190e0058dd81f39735db82653"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -523,7 +523,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, and the Nemotron Ultra resident/mmap cache-proof harness; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, and the mmap graph-breakdown documentation; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4ccceed2b4ad9a5fbab3f1481a6df34b16b7c943"
+        "revision" : "698190feab4add2190e0058dd81f39735db82653"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus to vmlx-swift `698190feab4add2190e0058dd81f39735db82653`.
- Align all SwiftPM lockfiles and the runtime source policy guard with the pushed vMLX main commit.
- The pinned vMLX docs prove Nemotron Ultra JANGTQ_1L resident Swift decode at the 8 tok/s class (`8.1 tok/s`) while keeping low-footprint mmap/JangPress scoped as coherent/cache-correct but speed-open.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`

## Notes
- This is a pin/readiness PR only. It does not claim new Osaurus live UI proof beyond prior app rows; follow-up no-sign app/live chat rows should be run before broad release language if runtime behavior, tool calls, or cache behavior changes beyond the pin are suspected.
