### PR TITLE
Harden Nemotron Ultra media and cache wiring

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -194,6 +194,12 @@ public enum ModelMediaCapabilities {
         }
 
         let detected = from(modelId: modelId)
+        if detected == .textOnly,
+            ModelFamilyNames.isNemotronThinkingFamily(modelId),
+            !ModelFamilyNames.isNemotronOmniFamily(modelId)
+        {
+            return .textOnly
+        }
         guard fallbackSupportsImages, !detected.supportsImage else {
             return detected
         }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -81,6 +81,24 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(cap == .textOnly)
     }
 
+    @Test("D1 boundary: Nemotron 3 Ultra composer fallback stays text-only")
+    func d1_nemotronUltraComposerFallbackTextOnly() {
+        for modelId in [
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "nemotron-3-ultra-550b-a55b-jangtq-1l",
+        ] {
+            let cap = ModelMediaCapabilities.composerCapabilities(
+                modelId: modelId,
+                fallbackSupportsImages: true
+            )
+            #expect(
+                cap == .textOnly,
+                "explicit text-only Nemotron Ultra must not inherit stale image fallback: \(modelId)"
+            )
+        }
+    }
+
     @Test("Step 3.7 text runtime does not advertise media")
     func step37TextRuntimeDoesNotAdvertiseMedia() {
         #expect(ModelMediaCapabilities.from(modelId: "JANGQ-AI/Step-3.7-Flash-JANG_2L") == .textOnly)

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -735,6 +735,8 @@ struct MLXBatchAdapterTests {
             "qwen3_6_moe",
             "qwen36_moe",
             "qwen3-next-80b-jangtq",
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
             "ibm-granite/granite-3.0-moe-hybrid-7b",
             "tiiuae/falcon-h1-34b",
             "baichuan-m1-14b",

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -33,6 +33,8 @@ struct ModelRuntimeIsHybridTests {
             "dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK",
             "dealign.ai/Nemotron-Omni-Nano-MXFP4-CRACK",
             "nemotron_omni_nano_jangtq",
+            "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
+            "NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L",
             "JANGQ-AI/Nemotron-3-Reasoning-Future-Variant",  // forward-compat
         ] {
             #expect(

--- a/docs/NEMOTRON_ULTRA_OSAURUS_WIRING_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_OSAURUS_WIRING_2026_06_06.md
@@ -1,0 +1,53 @@
+# Nemotron Ultra Osaurus Wiring - 2026-06-06
+
+## Scope
+
+Model family: Nemotron 3 Ultra text reasoning bundles, including
+`NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L`.
+
+This note tracks the Osaurus-side wiring that sits above the vMLX runtime pin.
+It does not claim new decode speed. Current vMLX evidence keeps the resident
+Swift row separate from the low-footprint mmap row:
+
+- resident Swift decode: `8.1 tok/s`, bundle generation defaults, no loop, no
+  parser leak, about 100 GB physical footprint.
+- low-footprint mmap decode: `3.9-4.5 tok/s`, coherent and hybrid-cache
+  correct, but still below the 8-10 tok/s target.
+
+## Osaurus Fix
+
+The chat composer previously allowed a generic `fallbackSupportsImages` bit to
+promote an explicit text-only model id to image support. Nemotron Ultra is a
+text reasoning model even when a bundle config contains generic vision-shaped
+metadata. The composer now keeps non-Omni Nemotron reasoning ids text-only.
+
+This keeps media routing aligned with the vMLX contract:
+
+- Nemotron Omni remains image + video + audio.
+- Nemotron Ultra remains text-only unless a future real Omni/VL bundle declares
+  the correct family.
+- Hybrid cache keys include the real Ultra ids so prefix-cache salt includes
+  SSM companion topology for the production names.
+
+## Validation
+
+Focused source test:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --package-path Packages/OsaurusCore \
+  --filter 'ModelMediaCapabilitiesMCDCTests|ModelRuntimeIsHybridTests|MLXBatchAdapterTests/cacheCoordinatorModelKey_alignsWithKnownHybridFamilies|MLXBatchAdapterTests/additionalContext_defaultsNemotronThinkingOffButHonorsExplicitOptIn' \
+  --jobs 1 --no-parallel
+```
+
+Result: 53 tests passed.
+
+Covered surfaces:
+
+- Nemotron Ultra directory detection stays text-only even with `vision_config`.
+- Nemotron Ultra composer fallback stays text-only when `fallbackSupportsImages`
+  is true.
+- Nemotron Ultra ids match the SSM hybrid cache-key path.
+- Nemotron reasoning ids default local API context to `enable_thinking=false`
+  while preserving explicit thinking opt-in.
+


### PR DESCRIPTION
## Summary
- Keep explicit text-only Nemotron Ultra reasoning ids from inheriting stale image fallback in the chat composer.
- Add production Ultra ids to hybrid cache-key coverage so the SSM companion topology is locked for the real model names.
- Document the Osaurus wiring boundary and the resident-vs-mmap vMLX runtime evidence.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'ModelMediaCapabilitiesMCDCTests|ModelRuntimeIsHybridTests|MLXBatchAdapterTests/cacheCoordinatorModelKey_alignsWithKnownHybridFamilies|MLXBatchAdapterTests/additionalContext_defaultsNemotronThinkingOffButHonorsExplicitOptIn' --jobs 1 --no-parallel`\n  - 53 tests passed\n- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path /tmp/vmlx-nemotron-b0e-main --filter CacheCoordinatorTopologyFocusedTests --jobs 1 --no-parallel`\n  - 31 tests passed\n\n## Notes\n- This does not change sampler defaults, prompt behavior, parser behavior, or decode speed.\n- Current vMLX evidence remains split: resident Swift decode is 8.1 tok/s, while low-footprint mmap is 3.9-4.5 tok/s and still speed-open.\n