### PR TITLE
Pin vMLX Nemotron Ultra loader hardening

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "698190feab4add2190e0058dd81f39735db82653"
+        "revision" : "4f9e2d176ceeac24886751e816ce3054579c3b19"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "698190feab4add2190e0058dd81f39735db82653"
+        "revision" : "4f9e2d176ceeac24886751e816ce3054579c3b19"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "698190feab4add2190e0058dd81f39735db82653"
+            revision: "4f9e2d176ceeac24886751e816ce3054579c3b19"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -515,7 +515,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "698190feab4add2190e0058dd81f39735db82653"
+        let expectedRuntimeHardenedRevision = "4f9e2d176ceeac24886751e816ce3054579c3b19"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "698190feab4add2190e0058dd81f39735db82653"
+        "revision" : "4f9e2d176ceeac24886751e816ce3054579c3b19"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vmlx-swift 4f9e2d176ceeac24886751e816ce3054579c3b19.
- Update the runtime source-policy guard to require the same vMLX revision.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'ModelRuntimeIsHybridTests|MLXBatchAdapterTests/cacheCoordinatorModelKey_alignsWithKnownHybridFamilies|LocalGenerationDefaultsTests|LocalReasoningCapabilityTests|ModelMediaCapabilitiesMCDCTests/d1_boundaryNemotron3UltraIsTextOnly|ModelMediaCapabilitiesMCDCTests/d1_boundaryNemotron3UltraComposerFallbackStaysTextOnly|RuntimePolicySourceTests' --jobs 1 --no-parallel\n  - passed: 137 tests in 5 suites\n\nRuntime note\n- vMLX resident Nemotron Ultra JANGTQ_1L row is confirmed at 8.1 tok/s with bundle defaults and no loop/reasoning leak in the captured row.\n- Low-footprint mmap/JangPress rows remain slower, around 3.9-5.0 tok/s, so this pin should not be described as an 8 tok/s low-footprint mmap fix.