### PR TITLE
Pin vMLX Ultra no-load speed gate

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b611922ccfeaf6fdc6f2d0a26a8f2a6b5f4c6089"
+        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b611922ccfeaf6fdc6f2d0a26a8f2a6b5f4c6089"
+        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b611922ccfeaf6fdc6f2d0a26a8f2a6b5f4c6089"
+            revision: "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -524,7 +524,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "b611922ccfeaf6fdc6f2d0a26a8f2a6b5f4c6089"
+        let expectedRuntimeHardenedRevision = "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -532,7 +532,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, and hybrid SSM rederive boundary clarification; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, and Ultra no-load speed-gate boundary; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b611922ccfeaf6fdc6f2d0a26a8f2a6b5f4c6089"
+        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX `6fc0a55d3ac10e032aa12e6a7431983cad0d645d`.
- Pull in the Nemotron Ultra no-load speed-gate docs/guard from vMLX main.
- Keep release wording honest: resident Swift decode has a saved live `8.335 tok/s` row; low-footprint mmap/JangPress remains `3.8-4.5 tok/s` class and is not presented as the 8-10 tok/s path.

Validation
- `PYTHONPATH=/Users/eric/jang/jang-tools /Users/eric/jang/jang-tools/.venv/bin/python /Users/eric/jang/jang-tools/examples/nemotron_ultra/runtime_status_report.py --log-dir /Users/eric/jang/docs/runtime/logs`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- `git diff --check`

Notes
- This is a pin/documentation guard PR only. It does not change Osaurus runtime behavior beyond consuming the updated vMLX revision.
- The remaining low-footprint speed work belongs to future vMLX MoE/Mamba graph/kernel reduction, not Osaurus prompt/parser/tool wiring.
