### PR TITLE
Pin vMLX cold-tier opt-in runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
+        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/OsaurusServer.swift
+++ b/Packages/OsaurusCore/Networking/OsaurusServer.swift
@@ -74,16 +74,13 @@ public actor OsaurusServer: Sendable {
                         // Connection cap (first handler): a flood of idle-held
                         // sockets can't exhaust file descriptors / pin memory.
                         ConnectionLimitHandler(),
-                        // Slow-loris / idle-hold defense: drop a connection that
-                        // accepts no writes or sits fully idle past the budget.
-                        // Do not enforce a post-request read timeout here:
-                        // long SSE streams can spend minutes in cold model load
-                        // or prefill while only writing keepalive comments.
-                        IdleStateHandler(
-                            readTimeout: nil,
-                            writeTimeout: .seconds(150),
-                            allTimeout: .seconds(300)
-                        ),
+                        // Slow-loris / idle-hold defense cannot use NIO idle
+                        // timeouts on this pipeline: long local non-streaming
+                        // model calls intentionally produce no response bytes
+                        // until generation completes, and slow cold loads can
+                        // exceed several minutes. ConnectionLimitHandler keeps
+                        // idle-held sockets bounded without closing legitimate
+                        // in-flight inference requests.
                         HTTPHandler(
                             configuration: serverConfiguration,
                             apiKeyValidatorProvider: { validatorSnapshot.value() },

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
+        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
+            revision: "8619ab110a37cd62547994ed9f7cb625a044b508"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -524,7 +524,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
+        let expectedRuntimeHardenedRevision = "8619ab110a37cd62547994ed9f7cb625a044b508"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -532,7 +532,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, and Ultra no-load speed-gate boundary; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, Ultra no-load speed-gate boundary, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -473,6 +473,26 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("HTTP server does not close long local inference for NIO idle timeout")
+    func osaurusServerDoesNotInstallNIOIdleTimeoutForInferenceChannels() throws {
+        let source = try Self.source("Networking/OsaurusServer.swift")
+        let initializerStart = try #require(source.range(of: ".childChannelInitializer { channel in"))
+        let initializerEnd = try #require(
+            source.range(of: ".childChannelOption", range: initializerStart.upperBound ..< source.endIndex)
+        )
+        let initializer = String(source[initializerStart.lowerBound ..< initializerEnd.lowerBound])
+
+        #expect(initializer.contains("ConnectionLimitHandler()"))
+        #expect(initializer.contains("HTTPHandler("))
+        #expect(!initializer.contains("IdleStateHandler("))
+        #expect(!initializer.contains("writeTimeout:"))
+        #expect(!initializer.contains("allTimeout:"))
+        #expect(
+            initializer.contains("long local non-streaming"),
+            "source comment should preserve why NIO idle timeouts break slow local /v1/chat/completions"
+        )
+    }
+
     @Test("vmlx pin uses consolidated package with runtime hardening")
     func vmlxPinIncludesRuntimeHardening() throws {
         let manifest = try Self.source("Package.swift")

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6fc0a55d3ac10e032aa12e6a7431983cad0d645d"
+        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus to vMLX `8619ab110a37cd62547994ed9f7cb625a044b508`.
- Keep all Osaurus SwiftPM lockfiles synchronized with the same vMLX revision.
- Update the runtime source guard so future pins must include the Osaurus MLXPress cold-tier opt-in policy.

## Why
vMLX main now keeps `LoadConfiguration.osaurusProduction` on the proven default mmap/cap path and leaves MLXPress/JangPress cold-tier as explicit opt-in. This prevents Osaurus production loads from silently taking the experimental cold-tier path for large routed bundles while preserving the separate explicit opt-in configuration for diagnostics.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`

## Runtime Boundary
This is a pin-only Osaurus PR. It does not add sampler overrides, prompt coercion, forced reasoning tags, or model-family behavior guards. Full no-sign app live proof against the new pin is still a separate validation step before claiming the broader Nemotron Ultra release row complete.
