### PR TITLE
Pin vMLX Nemotron decode conv runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
+        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "acfccefec59775e87e5a8f039663468eb3b66285c0bb07030a7f4b6e3acd5866",
+  "originHash" : "03f6c66fd5d6227c46f3d3b706e72a0e283a9008ce29e74cba10a2694437b15d",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
+        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8619ab110a37cd62547994ed9f7cb625a044b508"
+            revision: "3fb5944c13f915ef097f945d52a1ad1a831b5977"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -544,7 +544,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "8619ab110a37cd62547994ed9f7cb625a044b508"
+        let expectedRuntimeHardenedRevision = "3fb5944c13f915ef097f945d52a1ad1a831b5977"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8619ab110a37cd62547994ed9f7cb625a044b508"
+        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus/OsaurusCore to vMLX `3fb5944c13f915ef097f945d52a1ad1a831b5977` from osaurus-ai/vmlx-swift#27.
- Update the runtime source guard to require the same merged vMLX revision.
- No Osaurus runtime behavior changes in this PR; this is the propagation pin for the merged vMLX Nemotron-H decode conv fast path.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
  - log: `/tmp/osaurus-vmlx-3fb5944-pin-source-test-20260606-150051.log`
  - confirmed resolver line: `vmlx-swift resolved at 3fb5944c13f915ef097f945d52a1ad1a831b5977`
  - passed: `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`

## Notes
- vMLX #27 focused test passed before merge: `/tmp/vmlx-nemotron-depthwise-conv-focused-rerun2-20260606-144944.log`.
- vMLX #27 live rows showed a real decode graph reduction but only a small mmap speed delta; low-footprint Nemo Ultra remains partial, while resident decode was already around 9 tok/s.
