### PR TITLE
[codex] Add runtime proof validation model

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
@@ -1,0 +1,374 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+
+/// Verdict vocabulary for runtime evidence rows.
+///
+/// The names intentionally mirror the project proof standard: a row is not
+/// "green" just because a model loaded or one prompt returned text. Runtime
+/// promotion has to distinguish proven behavior from partial, failed, and
+/// still-unproven coverage.
+public enum RuntimeProofVerdict: String, Codable, Sendable, Equatable, CaseIterable {
+    case proven
+    case partial
+    case failed
+    case unproven
+}
+
+/// Evidence dimensions that a runtime row may claim.
+public enum RuntimeProofRequirement: String, Codable, Sendable, Equatable, Hashable, CaseIterable {
+    case visibleOutput
+    case tokensPerSecond
+    case noParserMarkerLeak
+    case multiTurnCoherency
+    case systemPromptInjection
+    case ramFootprint
+    case cancellation
+    case cacheHit
+    case mediaPayload
+}
+
+/// Cache topology determines what counts as real cache proof.
+public enum RuntimeProofCacheTopology: String, Codable, Sendable, Equatable {
+    case fullAttention
+    case hybridSSM
+    case zayaCCA
+    case deepSeekHybridPool
+    case rotating
+    case unknown
+}
+
+/// Cache evidence captured from one runtime proof row.
+public struct RuntimeProofCacheEvidence: Codable, Sendable, Equatable {
+    public var topology: RuntimeProofCacheTopology
+    public var kvLayerCount: Int?
+    public var prefixHits: Int
+    public var diskL2Hits: Int
+    public var diskL2Stores: Int
+    public var ssmCompanionHits: Int
+    public var zayaCompanionHits: Int
+    public var poolRestoreHits: Int
+    public var turboQuantKVLayerCount: Int?
+
+    public init(
+        topology: RuntimeProofCacheTopology,
+        kvLayerCount: Int? = nil,
+        prefixHits: Int = 0,
+        diskL2Hits: Int = 0,
+        diskL2Stores: Int = 0,
+        ssmCompanionHits: Int = 0,
+        zayaCompanionHits: Int = 0,
+        poolRestoreHits: Int = 0,
+        turboQuantKVLayerCount: Int? = nil
+    ) {
+        self.topology = topology
+        self.kvLayerCount = kvLayerCount
+        self.prefixHits = prefixHits
+        self.diskL2Hits = diskL2Hits
+        self.diskL2Stores = diskL2Stores
+        self.ssmCompanionHits = ssmCompanionHits
+        self.zayaCompanionHits = zayaCompanionHits
+        self.poolRestoreHits = poolRestoreHits
+        self.turboQuantKVLayerCount = turboQuantKVLayerCount
+    }
+
+    var provesRequiredHit: Bool {
+        switch topology {
+        case .fullAttention:
+            return (kvLayerCount ?? 0) > 0 && prefixHits > 0 && diskL2Hits > 0
+        case .hybridSSM:
+            return (kvLayerCount ?? 0) > 0 && diskL2Hits > 0 && ssmCompanionHits > 0
+        case .zayaCCA:
+            return diskL2Hits > 0 && zayaCompanionHits > 0
+        case .deepSeekHybridPool:
+            return diskL2Hits > 0 && poolRestoreHits > 0
+        case .rotating:
+            return diskL2Hits > 0 || diskL2Stores > 0
+        case .unknown:
+            return false
+        }
+    }
+}
+
+/// Media evidence for VLM/audio/video rows.
+public struct RuntimeProofMediaEvidence: Codable, Sendable, Equatable {
+    public var payloadKind: String
+    public var payloadBytes: Int
+    public var cacheSaltRecorded: Bool
+    public var mediaCacheHitValidated: Bool
+    public var routedThroughMediaPath: Bool
+
+    public init(
+        payloadKind: String,
+        payloadBytes: Int,
+        cacheSaltRecorded: Bool,
+        mediaCacheHitValidated: Bool,
+        routedThroughMediaPath: Bool
+    ) {
+        self.payloadKind = payloadKind
+        self.payloadBytes = payloadBytes
+        self.cacheSaltRecorded = cacheSaltRecorded
+        self.mediaCacheHitValidated = mediaCacheHitValidated
+        self.routedThroughMediaPath = routedThroughMediaPath
+    }
+
+    var provesMediaPath: Bool {
+        !payloadKind.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && payloadBytes > 0
+            && cacheSaltRecorded
+            && mediaCacheHitValidated
+            && routedThroughMediaPath
+    }
+}
+
+/// One row of runtime proof evidence.
+public struct RuntimeProofRow: Codable, Sendable, Equatable {
+    public var modelId: String
+    public var scenario: String
+    public var verdict: RuntimeProofVerdict
+    public var requirements: Set<RuntimeProofRequirement>
+    public var artifactPaths: [String]
+    public var visibleOutput: String?
+    public var reasoningOutput: String?
+    public var tokensPerSecond: Double?
+    public var generationTokenCount: Int?
+    public var finishReason: String?
+    public var ramWithinLimit: Bool
+    public var cancellationCleanedUp: Bool
+    public var cacheEvidence: RuntimeProofCacheEvidence?
+    public var mediaEvidence: RuntimeProofMediaEvidence?
+    public var systemPromptProbePassed: Bool
+    public var multiTurnCoherent: Bool
+    public var parserMarkerLeaks: [String]
+
+    public init(
+        modelId: String,
+        scenario: String,
+        verdict: RuntimeProofVerdict,
+        requirements: Set<RuntimeProofRequirement>,
+        artifactPaths: [String] = [],
+        visibleOutput: String? = nil,
+        reasoningOutput: String? = nil,
+        tokensPerSecond: Double? = nil,
+        generationTokenCount: Int? = nil,
+        finishReason: String? = nil,
+        ramWithinLimit: Bool = false,
+        cancellationCleanedUp: Bool = false,
+        cacheEvidence: RuntimeProofCacheEvidence? = nil,
+        mediaEvidence: RuntimeProofMediaEvidence? = nil,
+        systemPromptProbePassed: Bool = false,
+        multiTurnCoherent: Bool = false,
+        parserMarkerLeaks: [String] = []
+    ) {
+        self.modelId = modelId
+        self.scenario = scenario
+        self.verdict = verdict
+        self.requirements = requirements
+        self.artifactPaths = artifactPaths
+        self.visibleOutput = visibleOutput
+        self.reasoningOutput = reasoningOutput
+        self.tokensPerSecond = tokensPerSecond
+        self.generationTokenCount = generationTokenCount
+        self.finishReason = finishReason
+        self.ramWithinLimit = ramWithinLimit
+        self.cancellationCleanedUp = cancellationCleanedUp
+        self.cacheEvidence = cacheEvidence
+        self.mediaEvidence = mediaEvidence
+        self.systemPromptProbePassed = systemPromptProbePassed
+        self.multiTurnCoherent = multiTurnCoherent
+        self.parserMarkerLeaks = parserMarkerLeaks
+    }
+}
+
+public enum RuntimeProofIssueSeverity: String, Codable, Sendable, Equatable {
+    case blocker
+    case warning
+}
+
+public struct RuntimeProofValidationIssue: Codable, Sendable, Equatable {
+    public var severity: RuntimeProofIssueSeverity
+    public var requirement: RuntimeProofRequirement?
+    public var message: String
+
+    public init(
+        severity: RuntimeProofIssueSeverity,
+        requirement: RuntimeProofRequirement?,
+        message: String
+    ) {
+        self.severity = severity
+        self.requirement = requirement
+        self.message = message
+    }
+}
+
+public struct RuntimeProofValidationResult: Codable, Sendable, Equatable {
+    public var row: RuntimeProofRow
+    public var issues: [RuntimeProofValidationIssue]
+
+    public init(row: RuntimeProofRow, issues: [RuntimeProofValidationIssue]) {
+        self.row = row
+        self.issues = issues
+    }
+
+    public var blockers: [RuntimeProofValidationIssue] {
+        issues.filter { $0.severity == .blocker }
+    }
+
+    public var isAcceptableForProvenClaim: Bool {
+        row.verdict == .proven && blockers.isEmpty
+    }
+}
+
+public enum RuntimeProofValidator {
+    private static let knownParserMarkers = [
+        "<|tool", "</|",
+        "<tool_call", "</tool_call",
+        "<think>", "</think>",
+        "DSML", "xml_function",
+        "\u{FFFE}tool:", "\u{FFFE}args:", "\u{FFFE}reasoning:",
+    ]
+
+    public static func validate(_ row: RuntimeProofRow) -> RuntimeProofValidationResult {
+        var issues: [RuntimeProofValidationIssue] = []
+
+        if row.verdict == .proven {
+            appendProvenClaimIssues(row, into: &issues)
+        }
+
+        if row.requirements.contains(.noParserMarkerLeak) {
+            let leaks = detectedParserLeaks(in: row)
+            if !leaks.isEmpty {
+                issues.append(
+                    .init(
+                        severity: .blocker,
+                        requirement: .noParserMarkerLeak,
+                        message:
+                            "visible/runtime output contains parser marker leaks: \(leaks.sorted().joined(separator: ", "))"
+                    )
+                )
+            }
+        }
+
+        if row.verdict == .failed, row.artifactPaths.isEmpty {
+            issues.append(
+                .init(
+                    severity: .warning,
+                    requirement: nil,
+                    message: "failed rows should keep an artifact path so the failure remains inspectable"
+                )
+            )
+        }
+
+        return RuntimeProofValidationResult(row: row, issues: issues)
+    }
+
+    private static func appendProvenClaimIssues(
+        _ row: RuntimeProofRow,
+        into issues: inout [RuntimeProofValidationIssue]
+    ) {
+        if row.artifactPaths.isEmpty {
+            issues.append(
+                .init(
+                    severity: .blocker,
+                    requirement: nil,
+                    message: "proven runtime rows require at least one artifact path"
+                )
+            )
+        }
+
+        for requirement in row.requirements {
+            switch requirement {
+            case .visibleOutput:
+                if row.visibleOutput?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+                    issues.append(
+                        blocker(.visibleOutput, "proven visible-output rows require non-empty visible output")
+                    )
+                }
+            case .tokensPerSecond:
+                if row.generationTokenCount ?? 1 > 0 {
+                    guard let tps = row.tokensPerSecond, tps > 0 else {
+                        issues.append(
+                            blocker(.tokensPerSecond, "proven generation rows require token/s greater than zero")
+                        )
+                        break
+                    }
+                } else if row.tokensPerSecond == nil {
+                    issues.append(
+                        blocker(
+                            .tokensPerSecond,
+                            "zero-token tool rows must still record token/s as unavailable/zero, not leave it missing"
+                        )
+                    )
+                }
+            case .noParserMarkerLeak:
+                break
+            case .multiTurnCoherency:
+                if !row.multiTurnCoherent {
+                    issues.append(
+                        blocker(.multiTurnCoherency, "proven multi-turn rows require coherent follow-up behavior")
+                    )
+                }
+            case .systemPromptInjection:
+                if !row.systemPromptProbePassed {
+                    issues.append(
+                        blocker(
+                            .systemPromptInjection,
+                            "proven system-prompt rows require a positive prompt-injection probe"
+                        )
+                    )
+                }
+            case .ramFootprint:
+                if !row.ramWithinLimit {
+                    issues.append(
+                        blocker(
+                            .ramFootprint,
+                            "proven RAM rows require physical-footprint evidence within the intended gate"
+                        )
+                    )
+                }
+            case .cancellation:
+                if !row.cancellationCleanedUp {
+                    issues.append(
+                        blocker(.cancellation, "proven cancellation rows require cleanup/no-zombie-load evidence")
+                    )
+                }
+            case .cacheHit:
+                if row.cacheEvidence?.provesRequiredHit != true {
+                    issues.append(blocker(.cacheHit, "proven cache rows require topology-specific hit evidence"))
+                }
+            case .mediaPayload:
+                if row.mediaEvidence?.provesMediaPath != true {
+                    issues.append(
+                        blocker(
+                            .mediaPayload,
+                            "proven media rows require real payload, cache salt, media-path routing, and cache-hit validation"
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private static func detectedParserLeaks(in row: RuntimeProofRow) -> Set<String> {
+        let explicit = Set(row.parserMarkerLeaks.filter { !$0.isEmpty })
+        let combined = [row.visibleOutput, row.reasoningOutput]
+            .compactMap { $0 }
+            .joined(separator: "\n")
+        guard !combined.isEmpty else { return explicit }
+        let implicit = knownParserMarkers.filter { marker in
+            combined.localizedCaseInsensitiveContains(marker)
+        }
+        return explicit.union(implicit)
+    }
+
+    private static func blocker(
+        _ requirement: RuntimeProofRequirement,
+        _ message: String
+    ) -> RuntimeProofValidationIssue {
+        RuntimeProofValidationIssue(
+            severity: .blocker,
+            requirement: requirement,
+            message: message
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
@@ -1,0 +1,140 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Runtime proof validation")
+struct RuntimeProofValidationTests {
+    @Test("complete visible text row can be marked proven")
+    func completeVisibleRowIsAcceptable() {
+        let row = RuntimeProofRow(
+            modelId: "OsaurusAI/Qwen3.6-35B-A3B-JANGTQ4",
+            scenario: "system prompt plus visible answer",
+            verdict: .proven,
+            requirements: [
+                .visibleOutput,
+                .tokensPerSecond,
+                .noParserMarkerLeak,
+                .multiTurnCoherency,
+                .systemPromptInjection,
+            ],
+            artifactPaths: ["/tmp/osaurus-proof/summary.json"],
+            visibleOutput: "Gerald answers with the requested name.",
+            tokensPerSecond: 18.4,
+            generationTokenCount: 42,
+            finishReason: "stop",
+            systemPromptProbePassed: true,
+            multiTurnCoherent: true
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(result.isAcceptableForProvenClaim)
+        #expect(result.blockers.isEmpty)
+    }
+
+    @Test("proven generation row without token/s is blocked")
+    func missingTokenRateBlocksProvenRow() {
+        let row = RuntimeProofRow(
+            modelId: "local-model",
+            scenario: "visible output without stats",
+            verdict: .proven,
+            requirements: [.visibleOutput, .tokensPerSecond],
+            artifactPaths: ["/tmp/osaurus-proof/summary.json"],
+            visibleOutput: "hello",
+            generationTokenCount: 5
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.tokensPerSecond))
+    }
+
+    @Test("parser markers in visible output block proof")
+    func parserLeakBlocksProof() {
+        let row = RuntimeProofRow(
+            modelId: "Gemma4",
+            scenario: "tool marker leakage",
+            verdict: .proven,
+            requirements: [.visibleOutput, .tokensPerSecond, .noParserMarkerLeak],
+            artifactPaths: ["/tmp/osaurus-proof/summary.json"],
+            visibleOutput: "Here is the answer <tool_call>{}</tool_call>",
+            tokensPerSecond: 9.1,
+            generationTokenCount: 12
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.noParserMarkerLeak))
+    }
+
+    @Test("hybrid SSM cache proof requires companion hits")
+    func hybridCacheRequiresCompanionHit() {
+        let row = RuntimeProofRow(
+            modelId: "Ling-2.6-flash-JANGTQ2",
+            scenario: "warm cache row",
+            verdict: .proven,
+            requirements: [.tokensPerSecond, .cacheHit],
+            artifactPaths: ["/tmp/osaurus-proof/cache.json"],
+            tokensPerSecond: 12.7,
+            generationTokenCount: 15,
+            cacheEvidence: RuntimeProofCacheEvidence(
+                topology: .hybridSSM,
+                kvLayerCount: 4,
+                diskL2Hits: 2,
+                ssmCompanionHits: 0
+            )
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.cacheHit))
+    }
+
+    @Test("media rows require real media path evidence")
+    func mediaRowsRequireMediaProof() {
+        let row = RuntimeProofRow(
+            modelId: "Gemma4-audio",
+            scenario: "audio attachment",
+            verdict: .proven,
+            requirements: [.tokensPerSecond, .visibleOutput, .mediaPayload],
+            artifactPaths: ["/tmp/osaurus-proof/audio.json"],
+            visibleOutput: "The clip contains spoken words.",
+            tokensPerSecond: 5.2,
+            generationTokenCount: 17,
+            mediaEvidence: RuntimeProofMediaEvidence(
+                payloadKind: "audio/wav",
+                payloadBytes: 48_000,
+                cacheSaltRecorded: true,
+                mediaCacheHitValidated: false,
+                routedThroughMediaPath: true
+            )
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.mediaPayload))
+    }
+
+    @Test("failed rows may be preserved with warnings instead of blockers")
+    func failedRowsKeepEvidenceWithoutBlockingClassification() {
+        let row = RuntimeProofRow(
+            modelId: "Qwen",
+            scenario: "crash repro",
+            verdict: .failed,
+            requirements: [.tokensPerSecond, .visibleOutput],
+            artifactPaths: []
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(result.blockers.isEmpty)
+        #expect(result.issues.contains { $0.severity == .warning })
+    }
+}

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -85,6 +85,38 @@ It requires real Osaurus chat-app and HTTP rows for VLM/omni media, reasoning
 settings, saved-setting isolation, generation defaults, parser leak checks, and
 cache stats before the consolidated package can be called production-clear.
 
+## Runtime proof validation
+
+Open runtime issues such as #1228, #1161, #1162, #1163, #903, and #1183 need
+evidence rows that separate `proven`, `partial`, `failed`, and `unproven`
+states. Source inspection or a load-only check is not enough to promote a
+model family, cache path, system-prompt path, cancellation path, or media route.
+
+[`RuntimeProofValidation.swift`](../Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift)
+contains the source-level validator used to keep that language precise. A row
+marked `proven` is blocked unless the requirements it claims have matching
+evidence:
+
+- `tokensPerSecond` requires a recorded token/s value for generation rows.
+- `visibleOutput` requires non-empty visible assistant text.
+- `noParserMarkerLeak` rejects visible/runtime marker leaks such as tool-call,
+  reasoning, DSML, or streaming sentinel fragments.
+- `multiTurnCoherency` and `systemPromptInjection` require explicit positive
+  probes rather than a single happy-path answer.
+- `ramFootprint` and `cancellation` require physical-footprint and cleanup
+  evidence before a RAM or cancel row can be called proven.
+- `cacheHit` applies topology-specific checks: full-attention rows need KV,
+  prefix, and disk-L2 evidence; hybrid SSM rows need companion hits; ZAYA/CCA
+  and DeepSeek pool rows need their companion/pool evidence instead of generic
+  KV-only proof.
+- `mediaPayload` requires a real media payload, cache salt, media-path routing,
+  and cache-hit validation. Text-path evidence cannot prove an audio, image, or
+  video route.
+
+Rows marked `failed` remain valid evidence even when they lack the positive
+fields above, but they should still carry an artifact path so the failure can be
+replayed or inspected.
+
 osaurus deliberately does not pass `GenerateParameters.maxKVSize` -- a
 global rotating cache window forced from the app layer conflicted with
 sliding-window attention layers (e.g. Gemma-4 with a fixed per-layer
@@ -225,6 +257,7 @@ reasoning gets dropped together with the other sentinels.
 | `Events.swift` | `ModelRuntimeEvent` enum (`tokens` / `reasoning` / `toolInvocation` / `completionInfo`). |
 | `RuntimeConfig.swift` | Server-side default `topP`. |
 | `InferenceFeatureFlags.swift` | Single user-tunable: `mlxBatchEngineMaxBatchSize`. |
+| `RuntimeProofValidation.swift` | Source-level validation for runtime proof rows and issue-closure evidence. |
 | `MetalGate.swift` | Embedding-only counter (kept as the canonical hook for any future MLX-vs-CoreML interlock). |
 | `ModelLease.swift` | Per-model refcount; `unload(name)` waits for `count == 0` before freeing buffers. |
 | `ModelResidencyManager.swift` | Per-model idle timers and health snapshots for the Settings residency policy. |
@@ -238,6 +271,7 @@ reasoning gets dropped together with the other sentinels.
 | `ModelResidencyManagerTests` | Timer scheduling, cancellation on new use, never policy, and active-lease protection. |
 | `TaskCoalescerTests` | Single-flight engine-creation discipline and teardown-during-creation races. |
 | `RuntimePolicySourceTests` | Source-level guardrails for DSV4 cache ownership, vmlx pin, SSM re-derive opt-out, idle residency wiring, and max-batch docs. |
+| `RuntimeProofValidationTests` | Proven/partial/failed/unproven proof-row validation; token/s, parser leak, cache, media, and artifact checks. |
 | `GenerationEventMapperTests` | `chunk` -> `tokens`; `toolCall` -> `toolInvocation` JSON serialization (happy path + failure envelope); `info` -> `completionInfo`; cross-chunk stop-sequence cut. |
 | `StreamingReasoningHintTests` | Sentinel encode/decode round-trip; co-existence with the tool sentinel filter. |
 | `MetalGateTests` | Embedding gate happy paths. |

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -117,6 +117,29 @@ Rows marked `failed` remain valid evidence even when they lack the positive
 fields above, but they should still carry an artifact path so the failure can be
 replayed or inspected.
 
+The live family runner also emits a machine-readable classification report:
+
+```bash
+scripts/live-proof/run-family-runtime-chat-matrix.sh FAMILY_FILTER=gemma
+```
+
+After the row summaries are collected, the runner writes
+`PROOF_CLASSIFICATION.json` next to `SUMMARY.json`. The classifier reads the
+existing `family-runtime-chat-matrix.json` manifest and each row summary, then
+records:
+
+- per-row verdicts using `proven`, `partial`, `failed`, or `unproven`
+- the claimed proof requirements for that row
+- blocker messages for missing token/s, visible output, parser-leak checks,
+  multi-turn coherency, topology-specific cache evidence, or media-path proof
+- issue-coverage notes for #1228, #1161, #1162, #1163, #903, and #1183
+
+This report is intentionally stricter than the harness pass/fail bit. A row can
+complete the tool/cache harness and still remain `partial` if, for example, a
+VL model was tested through a text/tool path without a real media payload and
+media cache salt. Those rows stay useful as evidence, but they must not close a
+runtime/media issue as proven.
+
 osaurus deliberately does not pass `GenerateParameters.maxKVSize` -- a
 global rotating cache window forced from the app layer conflicted with
 sliding-window attention layers (e.g. Gemma-4 with a fixed per-layer

--- a/scripts/live-proof/classify-runtime-proof-summary.py
+++ b/scripts/live-proof/classify-runtime-proof-summary.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Classify live runtime proof summaries against Osaurus proof rules.
+
+The family runtime matrix already records model responses, token rates, cache
+telemetry, and failed checks. This script converts those artifacts into the
+project proof vocabulary: proven, partial, failed, or unproven. It is designed
+to run after ``run-family-runtime-chat-matrix.sh`` and to keep live runtime
+issue closure honest when a row lacks token/s, topology-specific cache proof,
+media-path proof, or other required evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+
+PROTOCOL_MARKERS = (
+    "<|tool",
+    "</|",
+    "<tool_call",
+    "</tool_call",
+    "<think>",
+    "</think>",
+    "DSML",
+    "xml_function",
+    "\ufffetool:",
+    "\ufffeargs:",
+    "\ufffereasoning:",
+)
+
+REQUIRED_PRIORITIES = {"required", "required-local"}
+
+
+def load_json(path: pathlib.Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: pathlib.Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def manifest_by_id(manifest_path: pathlib.Path) -> dict[str, dict[str, Any]]:
+    rows = load_json(manifest_path)
+    if not isinstance(rows, list):
+        raise ValueError(f"manifest must be a list: {manifest_path}")
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if isinstance(row, dict) and row.get("id"):
+            out[str(row["id"])] = row
+    return out
+
+
+def first_summary_payload(row: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    for raw_path in row.get("summary_files") or []:
+        path = pathlib.Path(str(raw_path))
+        if not path.exists():
+            continue
+        try:
+            payload = load_json(path)
+        except Exception as exc:  # noqa: BLE001 - artifact parser should preserve error text
+            return None, f"summary parse error for {path}: {exc!r}"
+        if isinstance(payload, dict):
+            return payload, str(path)
+    return None, None
+
+
+def row_requirements(manifest_row: dict[str, Any]) -> list[str]:
+    requirements = [
+        "visible_output",
+        "tokens_per_second",
+        "no_parser_marker_leak",
+        "multi_turn_coherency",
+    ]
+    if manifest_row.get("required_cache_evidence"):
+        requirements.append("cache_hit")
+    topology = str(manifest_row.get("topology", "")).lower()
+    model = str(manifest_row.get("model", "")).lower()
+    row_id = str(manifest_row.get("id", "")).lower()
+    if "vl" in topology or "-vl" in model or "-vl" in row_id or row_id.endswith("-vl"):
+        requirements.append("media_payload")
+    return requirements
+
+
+def has_token_rate(payload: dict[str, Any]) -> bool:
+    token_rates = payload.get("token_rates")
+    if not isinstance(token_rates, dict):
+        return False
+    for value in token_rates.values():
+        if not isinstance(value, dict):
+            continue
+        tokens = value.get("completion_tokens")
+        rate = value.get("tokens_per_second")
+        if isinstance(tokens, int) and tokens > 0 and isinstance(rate, (int, float)) and rate > 0:
+            return True
+    return False
+
+
+def parser_leaks(payload: dict[str, Any]) -> list[str]:
+    text = json.dumps(payload, ensure_ascii=False)
+    return sorted(marker for marker in PROTOCOL_MARKERS if marker.lower() in text.lower())
+
+
+def checks(payload: dict[str, Any]) -> dict[str, bool]:
+    raw = payload.get("checks")
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): bool(value) for key, value in raw.items()}
+
+
+def failed_checks(payload: dict[str, Any]) -> list[str]:
+    raw = payload.get("failed_checks")
+    if not isinstance(raw, list):
+        return []
+    return [str(value) for value in raw]
+
+
+def visible_output_present(payload: dict[str, Any]) -> bool:
+    turns = payload.get("turns")
+    if isinstance(turns, dict):
+        text = turns.get("turn2_content")
+        if isinstance(text, str) and text.strip():
+            return True
+    for key in ("first", "repeat"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            text = value.get("text") or value.get("answer")
+            if isinstance(text, str) and text.strip():
+                return True
+    return False
+
+
+def multi_turn_coherent(payload: dict[str, Any]) -> bool:
+    row_checks = checks(payload)
+    required = [
+        "history_valid_after_turn1",
+        "turn2_no_tool_calls",
+        "turn2_visible_mentions_3",
+        "turn2_not_length_stop",
+        "turn3_finish_tool_calls",
+        "turn3_has_one_tool_call",
+        "turn3_name_line_count",
+        "turn3_args_exact",
+    ]
+    return all(row_checks.get(name) is True for name in required)
+
+
+def cache_hit_proven(payload: dict[str, Any], manifest_row: dict[str, Any]) -> bool:
+    required = manifest_row.get("required_cache_evidence") or []
+    if not required:
+        return True
+    row_checks = checks(payload)
+    failures = set(failed_checks(payload))
+    for name in required:
+        check_name = f"cache_evidence_{name}"
+        if check_name in failures or row_checks.get(check_name) is not True:
+            return False
+    return True
+
+
+def media_payload_proven(payload: dict[str, Any]) -> bool:
+    row_checks = checks(payload)
+    media_checks = [
+        "first_mentions_red",
+        "repeat_mentions_red",
+        "stable_prefix_hash",
+        "repeat_disk_l2_hit",
+    ]
+    has_real_payload = bool(payload.get("image") or payload.get("media") or payload.get("payload"))
+    if has_real_payload and all(row_checks.get(name) is True for name in media_checks):
+        return True
+    return False
+
+
+def requirement_blockers(payload: dict[str, Any], manifest_row: dict[str, Any]) -> list[dict[str, str]]:
+    blockers: list[dict[str, str]] = []
+    requirements = row_requirements(manifest_row)
+
+    if "visible_output" in requirements and not visible_output_present(payload):
+        blockers.append(
+            {
+                "requirement": "visible_output",
+                "message": "row lacks non-empty visible assistant output",
+            }
+        )
+    if "tokens_per_second" in requirements and not has_token_rate(payload):
+        blockers.append(
+            {
+                "requirement": "tokens_per_second",
+                "message": "row lacks token/s for a generation turn",
+            }
+        )
+    if "no_parser_marker_leak" in requirements:
+        leaks = parser_leaks(payload)
+        if leaks:
+            blockers.append(
+                {
+                    "requirement": "no_parser_marker_leak",
+                    "message": "row contains parser marker leaks: " + ", ".join(leaks),
+                }
+            )
+    if "multi_turn_coherency" in requirements and not multi_turn_coherent(payload):
+        blockers.append(
+            {
+                "requirement": "multi_turn_coherency",
+                "message": "row lacks complete multi-turn tool/follow-up coherence",
+            }
+        )
+    if "cache_hit" in requirements and not cache_hit_proven(payload, manifest_row):
+        blockers.append(
+            {
+                "requirement": "cache_hit",
+                "message": "row lacks required topology-specific cache evidence",
+            }
+        )
+    if "media_payload" in requirements and not media_payload_proven(payload):
+        blockers.append(
+            {
+                "requirement": "media_payload",
+                "message": "VL/media row lacks real media payload, media routing, or media cache-hit proof",
+            }
+        )
+    return blockers
+
+
+def classify_row(row: dict[str, Any], manifest_rows: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    row_id = str(row.get("id", ""))
+    manifest_row = manifest_rows.get(row_id, {"id": row_id})
+    payload, payload_path = first_summary_payload(row)
+    artifact_paths = [str(path) for path in row.get("summary_files") or []]
+
+    result: dict[str, Any] = {
+        "id": row_id,
+        "model": manifest_row.get("model") or row.get("model"),
+        "family": manifest_row.get("family"),
+        "priority": manifest_row.get("priority"),
+        "requirements": row_requirements(manifest_row),
+        "artifact_paths": artifact_paths,
+        "summary_path": payload_path,
+    }
+
+    if payload is None:
+        result.update(
+            {
+                "verdict": "unproven",
+                "acceptable_for_proven_claim": False,
+                "blockers": [
+                    {
+                        "requirement": "artifact",
+                        "message": "row has no readable summary payload",
+                    }
+                ],
+                "warnings": [],
+            }
+        )
+        return result
+
+    blockers = requirement_blockers(payload, manifest_row)
+    failed = failed_checks(payload)
+    passed = payload.get("passed") is True and row.get("passed") is True
+
+    if passed and not blockers:
+        verdict = "proven"
+    elif payload.get("passed") is False or str(row.get("status", "")).startswith("FAIL"):
+        verdict = "failed"
+    else:
+        verdict = "partial"
+
+    if passed and blockers:
+        verdict = "partial"
+
+    result.update(
+        {
+            "verdict": verdict,
+            "acceptable_for_proven_claim": verdict == "proven",
+            "blockers": blockers,
+            "warnings": []
+            if artifact_paths
+            else [
+                {
+                    "requirement": "artifact",
+                    "message": "row should keep at least one artifact path",
+                }
+            ],
+            "failed_checks": failed,
+            "cache_delta": payload.get("cache_delta", {}),
+            "token_rates": payload.get("token_rates", {}),
+        }
+    )
+    return result
+
+
+def verdict_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts = Counter(str(row.get("verdict", "unproven")) for row in rows)
+    return {key: counts.get(key, 0) for key in ("proven", "partial", "failed", "unproven")}
+
+
+def required_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [row for row in rows if str(row.get("priority")) in REQUIRED_PRIORITIES]
+
+
+def issue_coverage(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    required = required_rows(rows)
+    required_not_proven = [
+        row["id"] for row in required if row.get("verdict") != "proven"
+    ]
+    hy3_rows = [row for row in rows if str(row.get("family")) == "hy3"]
+    media_rows = [
+        row for row in rows if "media_payload" in row.get("requirements", [])
+    ]
+
+    runtime_matrix_verdict = "proven" if not required_not_proven and required else "partial"
+    if not required:
+        runtime_matrix_verdict = "unproven"
+
+    return {
+        "#1161": {
+            "verdict": runtime_matrix_verdict,
+            "note": "local-model corruption closure requires all required family rows to be proven",
+            "required_rows_not_proven": required_not_proven,
+        },
+        "#1162": {
+            "verdict": runtime_matrix_verdict,
+            "note": "systematic runtime verification tracks the full required matrix",
+            "required_rows_not_proven": required_not_proven,
+        },
+        "#1163": {
+            "verdict": "proven"
+            if any(row.get("verdict") == "proven" for row in hy3_rows)
+            else "unproven",
+            "note": "Hy3/harmony parser closure needs a local Hy3 row, not sibling inference",
+            "rows": [row["id"] for row in hy3_rows],
+        },
+        "#903": {
+            "verdict": "unproven",
+            "note": "this tool/cache matrix does not claim system-prompt injection proof",
+        },
+        "#1228": {
+            "verdict": "partial" if any(row.get("verdict") == "failed" for row in rows) else "unproven",
+            "note": "crash closure needs a reporter-aligned crash/cancellation artifact",
+        },
+        "#1183": {
+            "verdict": "proven"
+            if media_rows and all(row.get("verdict") == "proven" for row in media_rows)
+            else "unproven",
+            "note": "native media closure needs real media-path rows with cache-salt and cache-hit proof",
+            "rows": [row["id"] for row in media_rows],
+        },
+    }
+
+
+def classify(summary_path: pathlib.Path, manifest_path: pathlib.Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    if not isinstance(summary, dict):
+        raise ValueError(f"summary must be an object: {summary_path}")
+    manifest_rows = manifest_by_id(manifest_path)
+    rows = [
+        classify_row(row, manifest_rows)
+        for row in summary.get("rows", [])
+        if isinstance(row, dict)
+    ]
+    required_not_proven = [
+        row["id"] for row in required_rows(rows) if row.get("verdict") != "proven"
+    ]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "summary_path": str(summary_path),
+        "manifest_path": str(manifest_path),
+        "artifact_root": summary.get("artifact_root"),
+        "verdict_counts": verdict_counts(rows),
+        "required_rows_not_proven": required_not_proven,
+        "passed": not required_not_proven,
+        "rows": rows,
+        "issue_coverage": issue_coverage(rows),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("summary", type=pathlib.Path, help="matrix SUMMARY.json")
+    parser.add_argument(
+        "--manifest",
+        type=pathlib.Path,
+        default=pathlib.Path(__file__).with_name("family-runtime-chat-matrix.json"),
+    )
+    parser.add_argument("--output", type=pathlib.Path)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero when any required row is not proven",
+    )
+    args = parser.parse_args()
+
+    output = args.output or args.summary.with_name("PROOF_CLASSIFICATION.json")
+    report = classify(args.summary, args.manifest)
+    save_json(output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 2 if args.strict and not report["passed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live-proof/run-family-runtime-chat-matrix.sh
+++ b/scripts/live-proof/run-family-runtime-chat-matrix.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MANIFEST="$ROOT/scripts/live-proof/family-runtime-chat-matrix.json"
 HARNESS="$ROOT/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py"
+CLASSIFIER="$ROOT/scripts/live-proof/classify-runtime-proof-summary.py"
 
 BASE_URL="${OSAURUS_BASE_URL:-http://127.0.0.1:1337}"
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-/tmp/osaurus-family-runtime-chat-matrix-$(date +%Y%m%d-%H%M%S)}"
@@ -181,4 +182,8 @@ print(json.dumps({"artifact_root": str(root), "passed": all(r.get("passed") is T
 PY
 
 cat "$ARTIFACT_ROOT/SUMMARY.json"
+"$CLASSIFIER" "$ARTIFACT_ROOT/SUMMARY.json" \
+  --manifest "$MANIFEST" \
+  --output "$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json"
+echo "proof_classification=$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json"
 exit "$fail"

--- a/scripts/live-proof/test-classify-runtime-proof-summary.py
+++ b/scripts/live-proof/test-classify-runtime-proof-summary.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CLASSIFIER = ROOT / "scripts/live-proof/classify-runtime-proof-summary.py"
+
+
+def write(path: pathlib.Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def run_classifier(root: pathlib.Path, manifest: list[dict[str, object]], summary: dict[str, object]) -> dict[str, object]:
+    manifest_path = root / "manifest.json"
+    summary_path = root / "SUMMARY.json"
+    output_path = root / "PROOF_CLASSIFICATION.json"
+    write(manifest_path, manifest)
+    write(summary_path, summary)
+    subprocess.run(
+        [
+            sys.executable,
+            str(CLASSIFIER),
+            str(summary_path),
+            "--manifest",
+            str(manifest_path),
+            "--output",
+            str(output_path),
+        ],
+        check=True,
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+    )
+    return json.loads(output_path.read_text(encoding="utf-8"))
+
+
+def matrix_summary(root: pathlib.Path, row_id: str, payload: dict[str, object]) -> dict[str, object]:
+    row_dir = root / row_id
+    row_dir.mkdir()
+    payload_path = row_dir / "model_summary.json"
+    write(payload_path, payload)
+    return {
+        "artifact_root": str(root),
+        "rows": [
+            {
+                "id": row_id,
+                "passed": payload.get("passed"),
+                "status": f"PASS {row_id}" if payload.get("passed") else f"FAIL {row_id}",
+                "summary_files": [str(payload_path)],
+            }
+        ],
+    }
+
+
+def base_payload() -> dict[str, object]:
+    checks = {
+        "history_valid_after_turn1": True,
+        "turn2_no_tool_calls": True,
+        "turn2_visible_mentions_3": True,
+        "turn2_not_length_stop": True,
+        "turn3_finish_tool_calls": True,
+        "turn3_has_one_tool_call": True,
+        "turn3_name_line_count": True,
+        "turn3_args_exact": True,
+        "turn1_no_protocol_leak": True,
+        "turn2_no_protocol_leak": True,
+        "turn3_no_protocol_leak": True,
+        "cache_evidence_cache_topology": True,
+        "cache_evidence_disk_l2_hits": True,
+    }
+    return {
+        "passed": True,
+        "checks": checks,
+        "failed_checks": [],
+        "turns": {"turn2_content": "The text has 3 lines."},
+        "token_rates": {
+            "turn2": {
+                "completion_tokens": 8,
+                "elapsed_seconds": 0.5,
+                "tokens_per_second": 16.0,
+            }
+        },
+        "cache_delta": {"block_disk_hits": 1},
+    }
+
+
+def test_proven_row() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        manifest = [
+            {
+                "id": "full-kv",
+                "model": "model",
+                "family": "minimax",
+                "priority": "required",
+                "topology": "full-kv",
+                "required_cache_evidence": ["cache_topology", "disk_l2_hits"],
+            }
+        ]
+        report = run_classifier(root, manifest, matrix_summary(root, "full-kv", base_payload()))
+        row = report["rows"][0]
+        assert row["verdict"] == "proven", row
+        assert report["passed"] is True
+
+
+def test_missing_token_rate_is_partial() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        payload = base_payload()
+        payload["token_rates"] = {}
+        manifest = [
+            {
+                "id": "missing-tps",
+                "model": "model",
+                "family": "qwen",
+                "priority": "required",
+                "topology": "hybrid-ssm",
+                "required_cache_evidence": ["cache_topology", "disk_l2_hits"],
+            }
+        ]
+        report = run_classifier(root, manifest, matrix_summary(root, "missing-tps", payload))
+        row = report["rows"][0]
+        assert row["verdict"] == "partial", row
+        assert any(issue["requirement"] == "tokens_per_second" for issue in row["blockers"])
+        assert report["passed"] is False
+
+
+def test_vl_row_without_media_payload_is_not_proven() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        manifest = [
+            {
+                "id": "zaya-vl",
+                "model": "zaya1-vl-8b-jangtq4",
+                "family": "zaya",
+                "priority": "required",
+                "topology": "zaya-cca-vl",
+                "required_cache_evidence": ["cache_topology", "disk_l2_hits"],
+            }
+        ]
+        report = run_classifier(root, manifest, matrix_summary(root, "zaya-vl", base_payload()))
+        row = report["rows"][0]
+        assert row["verdict"] == "partial", row
+        assert any(issue["requirement"] == "media_payload" for issue in row["blockers"])
+
+
+def test_unreadable_row_is_unproven() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        manifest = [{"id": "missing", "priority": "required"}]
+        summary = {
+            "artifact_root": str(root),
+            "rows": [{"id": "missing", "passed": None, "summary_files": [str(root / "missing.json")]}],
+        }
+        report = run_classifier(root, manifest, summary)
+        row = report["rows"][0]
+        assert row["verdict"] == "unproven", row
+        assert report["passed"] is False
+
+
+def main() -> int:
+    test_proven_row()
+    test_missing_token_rate_is_partial()
+    test_vl_row_without_media_payload_is_not_proven()
+    test_unreadable_row_is_unproven()
+    print("runtime proof classifier tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Maintainer rationale

**Business rationale:** Runtime bug closure needs a shared proof standard so load-only, single-prompt, missing token/s, missing cache, or text-only media evidence cannot be mislabeled as production proof. This PR gives maintainers a source-level validator and live-proof classification report for that standard.

**Coding rationale:** The implementation is a pure value-type validator plus a JSON-artifact classifier for the existing live-proof harness. It does not touch model loading, generation, prompts, cache behavior, media routing, or runtime defaults.

**Osaurus standards check:** Current-main, function-sized PR; no forced thinking tags, parser repair, prompt coercion, hidden sampler defaults, or fake proof promotion; proven/partial/failed/unproven stay distinct; focused Swift/script tests and local gates passed. GitHub CI is green.

## Business rationale

Open runtime issues (#1228, #1161, #1162, #1163, #903, #1183) need a shared evidence standard before we call a model family, cache path, system-prompt path, cancellation path, RAM row, or media path fixed. Today that standard exists across docs and live-proof notes, but it is easy for a future row to overstate a load-only or single-prompt result. This PR turns the proof language into a small source-level validator so incomplete rows stay partial/failed/unproven instead of being accidentally promoted to proven.

## Coding rationale

This adds pure Swift value types under `Services/ModelRuntime` rather than coupling proof validation to `MLXBatchAdapter` or live model loading, and it adds a small Python classifier beside the existing live-proof runner so generated artifacts receive the same conservative verdicts. That keeps the validator usable by tests, future live-proof scripts, and UI/reporting code without introducing a new runtime dependency or changing generation behavior. The validator is intentionally conservative: it blocks only `verdict == .proven` rows that claim missing evidence, while preserving failed rows as inspectable evidence.

## Acceptance criteria

- [x] Runtime proof rows have explicit `proven`, `partial`, `failed`, and `unproven` verdicts.
- [x] Proven rows are blocked when required token/s, visible output, parser-leak, multi-turn, system-prompt, RAM, cancellation, cache, or media evidence is missing.
- [x] Cache proof is topology-aware: hybrid/CCA/pool rows cannot pass with generic KV-only evidence.
- [x] Media proof requires real payload, media-path routing, cache salt, and cache-hit validation.
- [x] Failed rows remain valid evidence and can carry artifact-path warnings without being treated as proven.
- [x] Live matrix runs emit `PROOF_CLASSIFICATION.json` with per-row blockers and issue-coverage notes.

## Quality gate

- [x] `git diff --check origin/main`
- [x] `xcrun swift-format lint Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift`
- [x] `swiftlint lint --quiet Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift`
- [x] `bash scripts/i18n/check.sh` (existing stale-key warning only)
- [x] `swift test --package-path Packages/OsaurusCore --filter RuntimeProofValidationTests`
- [x] `python3 scripts/live-proof/test-classify-runtime-proof-summary.py`
- [x] `python3 -m py_compile scripts/live-proof/classify-runtime-proof-summary.py scripts/live-proof/test-classify-runtime-proof-summary.py`
- [x] `shellcheck scripts/live-proof/run-family-runtime-chat-matrix.sh`
- [x] `scripts/live-proof/run-family-runtime-chat-matrix.sh --dry-run FAMILY_FILTER=gemma ARTIFACT_ROOT=/tmp/osaurus-runtime-proof-classifier-dry-run`
- [x] `swift build --package-path Packages/OsaurusCore -c release` (existing repo warnings only)
- [ ] `make test` local full-suite: `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test make test` compiled and ran 3,232 tests, then failed in existing `AgentManagerLifecycleNotificationTests.deleteSweepsPerAgentKeychainSecrets` because keychain-disabled reads return nil where that test expects a bystander secret to survive. This is unrelated to this diff, but documents current no-prompt test-lane debt.
- [x] Gate head SHA: `1a3fd053`

## Debug evidence

Focused proof-validator tests passed 6/6 and cover: complete proven visible row, missing token/s blocker, parser marker leak blocker, hybrid SSM cache companion-hit blocker, media-path blocker, and failed-row artifact warning behavior. Classifier tests also pass and cover proven rows, missing token/s partial rows, VL rows without media payload proof, and unreadable summary artifacts.

## Self-review

### Regression review

`RuntimeProofValidation.swift` is a new pure value-type validator. The live-proof classifier reads existing JSON artifacts after a run and writes a sibling report; it does not change generation, model loading, cache behavior, prompt composition, or media routing. `docs/INFERENCE_RUNTIME.md` only documents the proof contract, source map, and classifier output. New tests cover every validator branch and classifier verdict introduced in this PR.

### Performance review

The validator is not on the request/generation hot path. Validation cost is O(number of claimed requirements + output marker scan length) for an offline proof row. The classifier is also offline and bounded by the number of executed matrix rows plus JSON artifact size. No model loading, network access, or large allocation is added. Cache/media checks are bounded scalar checks over captured counters/metadata.

## Rebase notes

No conflicts across refreshes to current `origin/main` `dae15a92403216210d54f2d763b6e4ddb5c9b38a`.

## Rollback

`git revert 1a3fd053 c9a8c817` removes the validator, classifier, tests, and docs sections. No runtime behavior or persisted schema is changed.

Refs #1228, #1161, #1162, #1163, #903, #1183.

## Latest refresh

- Refreshed on June 7, 2026 against `origin/main` `e361e78b` (`Improve Claude plugin marketplace install outcomes (#1363)`).
- Rebased cleanly and force-pushed current head `e6aa1ff5eee3`.
- GitHub CI is green: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and `update_release_draft`.
- Merge state is `CLEAN` with no conflicts detected after the refresh.
