### PR TITLE
Pin vMLX Nemotron auto BF16 runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
+        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
+        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3fb5944c13f915ef097f945d52a1ad1a831b5977"
+            revision: "9717a4562cd52a3b91156fb627389fdbc1911013"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -539,12 +539,14 @@ struct RuntimePolicySourceTests {
         // disk-backed hybrid SSM companion hits, plus the Nemotron Ultra
         // mamba_projection role alias so Osaurus auto-settings consume the
         // same 8-bit affine Mamba projection metadata as mamba_proj-stamped
-        // bundles.
+        // bundles, plus the Nemotron-H JANGTQ mmap auto-BF16 load path that
+        // keeps TQ tensors raw while promoting non-TQ tensors out of fp16
+        // AsType-heavy decode.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "3fb5944c13f915ef097f945d52a1ad1a831b5977"
+        let expectedRuntimeHardenedRevision = "9717a4562cd52a3b91156fb627389fdbc1911013"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -552,7 +554,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, Ultra no-load speed-gate boundary, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fb5944c13f915ef097f945d52a1ad1a831b5977"
+        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus to vMLX `9717a4562cd52a3b91156fb627389fdbc1911013` from merged vMLX PR #28.
- Bring in the Nemotron-H JANGTQ mmap auto-BF16 load default: non-TQ tensors promote out of fp16 AsType-heavy decode while `.tq_packed` / `.tq_norms` stay raw.
- Keep this Osaurus diff pin-only plus the RuntimePolicy source guard.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- vMLX focused source checks passed before merge: `LoadConfigurationTests/jangtqLoadDoesNotSkipWholeModelBFloat16Conversion`, `NemotronHJANGTQDispatchFocusedTests`.
- vMLX live low-footprint mmap row without BF16 env flags: `tokps_median=5.3`, `peak_footprint_mib=1926`, coherent output, no reasoning leak/loop.

## Boundary
- This improves the low-footprint Nemotron-H JANGTQ mmap default and keeps Osaurus pinned to the merged runtime.
- It does not complete the separate 8-10 tok/s target; the rejected explicit streaming-expert control remains diagnostic only (`tokps_median=0.3`).