### PR TITLE
Pin vMLX hybrid SSM cache fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
+        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
+        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9717a4562cd52a3b91156fb627389fdbc1911013"
+            revision: "3fe488bd78497999ed385190fc3639eec0d02a38"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -546,7 +546,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "9717a4562cd52a3b91156fb627389fdbc1911013"
+        let expectedRuntimeHardenedRevision = "3fe488bd78497999ed385190fc3639eec0d02a38"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9717a4562cd52a3b91156fb627389fdbc1911013"
+        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin OsaurusCore's vMLX dependency from `9717a4562cd52a3b91156fb627389fdbc1911013` to `3fe488bd78497999ed385190fc3639eec0d02a38`.
- Pulls in vMLX PR #30, which avoids redundant hybrid SSM rederive when an exact boundary snapshot is already sufficient.
- Keeps Osaurus changes scoped to the package pin only.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ModelProfileRegistryTests/gemma4_exposesChatThinkingToggle --jobs 1 --no-parallel`
  - passed: 1 test in 1 suite
- Dependency resolve/build confirmed vMLX checkout at `3fe488bd78497999ed385190fc3639eec0d02a38`.

## Notes
- This is the Osaurus pin for the merged vMLX main fix, not a new Osaurus runtime behavior change.
- It improves the safe hybrid SSM cache path for exact-boundary snapshots; full low-footprint Nemo Ultra speed proof remains a separate runtime gate.
