### PR TITLE
Pin vMLX runtime diagnostics update

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
+        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
+        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3fe488bd78497999ed385190fc3639eec0d02a38"
+            revision: "9b7c73bc753bf3465e1be6e24f4650b175598278"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -546,7 +546,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "3fe488bd78497999ed385190fc3639eec0d02a38"
+        let expectedRuntimeHardenedRevision = "9b7c73bc753bf3465e1be6e24f4650b175598278"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3fe488bd78497999ed385190fc3639eec0d02a38"
+        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin all Osaurus vMLX Swift resolver surfaces to `osaurus-ai/vmlx-swift@9b7c73bc753bf3465e1be6e24f4650b175598278`.
- Keep the runtime source-policy guard aligned with the same pinned revision.
- This is a pin/guard consistency PR only; it does not add Osaurus runtime behavior changes, sampler overrides, prompt coercion, or forced reasoning/tool behavior.

## Why this is narrow
The pinned vMLX change is the already-merged runtime diagnostics update from vMLX PR #31. Its profiler path is default-off unless `VMLINUX_NEMOTRON_LAYER_PROFILE=1` is explicitly set, and Osaurus does not set that flag.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter MLXBatchAdapterTests/effectiveGenerationSettings_preservesNemotronUltraBundleDefaultsWithoutInventingTopK --jobs 1 --no-parallel`
  - `/tmp/osaurus-nemotron-ultra-defaults-20260606-194240.log`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter MLXBatchAdapterTests/nemotronUltraCacheCoordinatorKeyPreservesRealHybridTopology --jobs 1 --no-parallel`
  - `/tmp/osaurus-nemotron-ultra-cache-key-20260606-194240.log`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter ModelMediaCapabilitiesMCDCTests --jobs 1 --no-parallel`
  - `/tmp/osaurus-nemotron-vmlx-pin-media-capabilities-20260606-195512.log`
  - Covers Nemotron Omni/text-only boundaries, Qwen2/2.5/3/3.5/3.6 VL, Holo3 VL, SmolVLM, ZAYA1-VL, PaliGemma, Idefics, FastVLM/LLava-Qwen2, Pixtral, GLM OCR, LFM2-VL, Gemma 3/4 VLM, and Mistral 3/3.5/4 VL boundaries.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests --jobs 1 --no-parallel`
  - First run correctly failed because workspace/app resolver pins still pointed at the old SHA.
  - After updating those resolver pins and the guard constant, rerun passed: `/tmp/osaurus-nemotron-vmlx-pin-runtime-policy-source-rerun-20260606-195554.log`
  - Covers vMLX pin consistency, SSM rederive/cache policy, loaded topology use, tool-parser leak boundaries, reasoning sentinel routing, image preprocessing metadata preservation, no hidden reasoning defaults, keychain-free live proof policy, and Sentry token-count-only breadcrumbs.
