### PR TITLE
Make release reruns idempotent and add appcast-only deploy

### DIFF
--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -1,0 +1,38 @@
+name: Deploy Sparkle Appcast
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to publish (e.g. 0.19.13)"
+        required: true
+        type: string
+      channel:
+        description: "Sparkle channel"
+        required: true
+        default: release
+        type: choice
+        options:
+          - release
+          - beta
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-appcast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VERSION: ${{ inputs.version }}
+      SPARKLE_CHANNEL: ${{ inputs.channel }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Generate and Deploy Sparkle Appcast
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          PUBLIC_REPO: ${{ github.repository }}
+        run: bash scripts/release/generate_and_deploy_appcast.sh

--- a/scripts/build/create_release.sh
+++ b/scripts/build/create_release.sh
@@ -35,13 +35,25 @@ else
   echo "::warning::${DSYM_ZIP} not found — release will ship without dSYMs."
 fi
 
-gh release create "${VERSION}" \
-  "${RELEASE_ASSETS[@]}" \
-  --repo "${PUBLIC_REPO}" \
-  --notes-file RELEASE_NOTES.md \
-  "${RELEASE_FLAGS[@]}"
+if gh release view "${VERSION}" --repo "${PUBLIC_REPO}" >/dev/null 2>&1; then
+  echo "Release ${VERSION} already exists; refreshing notes and re-uploading assets."
+  gh release edit "${VERSION}" \
+    --repo "${PUBLIC_REPO}" \
+    --notes-file RELEASE_NOTES.md \
+    "${RELEASE_FLAGS[@]}"
+  gh release upload "${VERSION}" \
+    "${RELEASE_ASSETS[@]}" \
+    --repo "${PUBLIC_REPO}" \
+    --clobber
+else
+  gh release create "${VERSION}" \
+    "${RELEASE_ASSETS[@]}" \
+    --repo "${PUBLIC_REPO}" \
+    --notes-file RELEASE_NOTES.md \
+    "${RELEASE_FLAGS[@]}"
+fi
 
-echo "✅ Release created successfully"
+echo "✅ Release published successfully"
 if [ "$IS_BETA" = "true" ]; then
   echo "🧪 Beta release URL: https://github.com/${PUBLIC_REPO}/releases/tag/${VERSION}"
 else


### PR DESCRIPTION
## Summary
- `create_release.sh` now refreshes an existing GitHub Release instead of failing when a tag/release already exists (fixes reruns after a partial release).
- Adds a `Deploy Sparkle Appcast` workflow_dispatch job to publish the Sparkle feed without a full ~30m rebuild.

## Context
Release `0.19.13` built and published successfully, but the appcast push to `main` was blocked by branch rules. A full rerun would have failed again at `gh release create`.

## Test plan
- [ ] Merge this PR
- [ ] Run **Actions → Deploy Sparkle Appcast → Run workflow** with version `0.19.13`
- [ ] Confirm `https://osaurus-ai.github.io/osaurus/appcast.xml` lists `0.19.13`

Made with [Cursor](https://cursor.com)