### PR TITLE
Pin vMLX streamed parser fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
+        "revision" : "5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
+        "revision" : "5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9b7c73bc753bf3465e1be6e24f4650b175598278"
+            revision: "5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -541,12 +541,13 @@ struct RuntimePolicySourceTests {
         // same 8-bit affine Mamba projection metadata as mamba_proj-stamped
         // bundles, plus the Nemotron-H JANGTQ mmap auto-BF16 load path that
         // keeps TQ tensors raw while promoting non-TQ tensors out of fp16
-        // AsType-heavy decode.
+        // AsType-heavy decode, plus streamed DSV4 request-tool prefix
+        // buffering and the Gemma4 native tool-call parser regression pin.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "9b7c73bc753bf3465e1be6e24f4650b175598278"
+        let expectedRuntimeHardenedRevision = "5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -554,7 +555,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, and Osaurus MLXPress cold-tier opt-in policy; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, and the Gemma4 native tool-call parser regression pin; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b7c73bc753bf3465e1be6e24f4650b175598278"
+        "revision" : "5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92"
       }
     },
     {


### PR DESCRIPTION
Summary
- Pin Osaurus to vMLX `5cb7cf411ba4ac72a3da843b027a9e5d4ed82b92`.
- Keep the OsaurusCore manifest and SwiftPM lockfiles aligned with the merged vMLX streamed parser fix.
- Update the runtime pin source guard so stale vMLX pins fail locally.

Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|ToolSerializationStabilityTests|SwiftTransformersTokenizerLoaderTests/gemma4ToolSchemasDropBooleanAdditionalProperties' --jobs 1 --no-parallel`
