### PR TITLE
Run deploy-appcast on macOS

### DIFF
--- a/.github/workflows/deploy-appcast.yml
+++ b/.github/workflows/deploy-appcast.yml
@@ -21,7 +21,9 @@ permissions:
 
 jobs:
   deploy-appcast:
-    runs-on: ubuntu-latest
+    # Sparkle's generate_appcast/sign_update binaries are macOS Mach-O; they
+    # cannot run on ubuntu-latest (Exec format error / exit 126).
+    runs-on: macos-26
     timeout-minutes: 10
     env:
       VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
Fixes `Deploy Sparkle Appcast` workflow exit 126: Sparkle's `generate_appcast` is a macOS Mach-O binary and cannot run on `ubuntu-latest`.

## Test plan
- [ ] Merge
- [ ] Re-run **Deploy Sparkle Appcast** for `0.19.13`

Made with [Cursor](https://cursor.com)