### PR TITLE
Pin vMLX runtime cache parser fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbf39a26eee389852f8d5f15e1156d4817eb74dd"
+        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbf39a26eee389852f8d5f15e1156d4817eb74dd"
+        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "cbf39a26eee389852f8d5f15e1156d4817eb74dd"
+            revision: "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -542,12 +542,14 @@ struct RuntimePolicySourceTests {
         // bundles, plus the Nemotron-H JANGTQ mmap auto-BF16 load path that
         // keeps TQ tensors raw while promoting non-TQ tensors out of fp16
         // AsType-heavy decode, plus streamed DSV4 request-tool prefix
-        // buffering and the Gemma4 native tool-call parser regression pin.
+        // buffering, the Gemma4 native tool-call parser regression pin,
+        // generation-config suppress_tokens propagation, and seed-boundary
+        // hybrid SSM full-hit restore.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "cbf39a26eee389852f8d5f15e1156d4817eb74dd"
+        let expectedRuntimeHardenedRevision = "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbf39a26eee389852f8d5f15e1156d4817eb74dd"
+        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
       }
     },
     {


### PR DESCRIPTION
## Summary

Pins Osaurus to vMLX `31a98ef8b068013549fa85f7a4c2bc17e59c0bbc`, the merged runtime-cache/parser fix from osaurus-ai/vmlx-swift#34.

This brings in:
- `generation_config.json` `suppress_tokens` propagation into local generation.
- Hybrid SSM seed-boundary restore on full prefix/cache hits.
- Focused cross-family vMLX source/small-GPU coverage for Gemma4, Qwen hybrid SSM, DSV4 CSA/HSA/SWA cache, ZAYA CCA, VLM media cache salt, generation defaults, no hidden reasoning close bias, and multi-turn parser dispatch.

This PR intentionally keeps the Osaurus side scoped to the runtime pin plus source guard update. No prompt coercion, hidden sampler override, forced reasoning tags, or parser repair is added here.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift package --package-path Packages/OsaurusCore resolve`
  - resolved `vmlx-swift` at `31a98ef8b068013549fa85f7a4c2bc17e59c0bbc`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests --jobs 1 --no-parallel`
  - passed: 79 tests in `Runtime source policy`

## Notes

The first focused test run caught a real app resolver mismatch: `App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` was still pinned to `cbf39a2` while the package/workspace pins were on `31a98ef`. This PR updates all three resolver surfaces plus the manifest.

No signed app build or fresh large-model live decode row is included in this PR. Those remain separate release proof, not hidden by this pin.


Additional validation after CI:

- Clean vMLX worktree at exact pinned SHA `31a98ef8b068013549fa85f7a4c2bc17e59c0bbc`:
  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'MiMoV2FlashCacheTopologyTests|GenerationConfigDefaultsTests|SSMReDeriveParityTests|BatchEngineGrowingChatCacheSourceTests|CacheCoordinatorTopologyFocusedTests|NoHiddenReasoningCloseBiasFocusedTests|DSMLInlineJSONToolFallbackFocusedTests|DeepseekV4ChatTemplateFallbackFocusedTests|Gemma4ToolCallParserFocusedTests|VLShapeGuardFocusedTests|VMLXServerRuntimeSettingsTests|ZayaThinkingAndRederiveContractTests|LocalChatTemplateFamilySnapshotTests' --jobs 1 --no-parallel`
  - passed after SwiftPM metallib artifact placement: XCTest 16 tests, Swift Testing 239 tests in 23 suites.
  - coverage includes Gemma4 tool/schema boolean `additionalProperties`, generation suppress tokens, Qwen/MiMo hybrid cache, SSM companion restore/rederive, DSV4 parser/template fallback, ZAYA CCA/reasoning scope, VL shape/media guards, server generation defaults, and no hidden reasoning close-token forcing.
