### PR TITLE
Pin vMLX runtime proof harness

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
+        "revision" : "046c48fc9848f00f4221ea3308be99cd45de410d"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
+        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "03f6c66fd5d6227c46f3d3b706e72a0e283a9008ce29e74cba10a2694437b15d",
+  "originHash" : "7dd2a2ba149419ad8da48afe5f377ee8a8ffe101451683754baca7afa8d5ec9e",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
+        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
+        "revision" : "046c48fc9848f00f4221ea3308be99cd45de410d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
+            revision: "046c48fc9848f00f4221ea3308be99cd45de410d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
+            revision: "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -546,7 +546,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
+        let expectedRuntimeHardenedRevision = "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -546,7 +546,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
+        let expectedRuntimeHardenedRevision = "046c48fc9848f00f4221ea3308be99cd45de410d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "31a98ef8b068013549fa85f7a4c2bc17e59c0bbc"
+        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "28e7299c06cafcaa356c6edcd5d6ddaf3b68b417"
+        "revision" : "046c48fc9848f00f4221ea3308be99cd45de410d"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pin Osaurus to vMLX main `28e7299c06cafcaa356c6edcd5d6ddaf3b68b417`.
- Update the OsaurusCore, workspace, and app SwiftPM locks to the same runtime SHA.
- Update the runtime source guard so drift is caught in source tests.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel`
- vMLX main contains PR #36: `28e7299 Tighten Nemotron production proof harness (#36)`
- vMLX validation before pin: `swift build --product RunBench --jobs 1`, `swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel`

## Runtime Evidence Boundary
- This PR is the Osaurus pin to the already-merged vMLX runtime proof harness.
- Nemotron Ultra proof artifacts showed production load through `loadConfiguration: .osaurusProduction`, `NemotronHModel`, tool format `nemotron`, reasoning stamp `deepseek_r1`, and an official matrix with 10 pass / 0 fail.
- Hybrid SSM paged prefix cache remains guarded: prefix/paged cache is rejected unless Mamba companion state can be restored or rederived, so Osaurus does not silently reuse unsafe KV-only state for hybrid SSM turns.
