### PR TITLE
fixed app hangs in streaming tables, oauth sign in and remote tunnel connect

### DIFF
--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -209,7 +209,7 @@ public final class RelayTunnelManager: ObservableObject {
         if enabled {
             agentStatuses[agentId] = .connecting
             if isConnected {
-                addAgentToTunnel(agentId: agentId)
+                Task { await addAgentToTunnel(agentId: agentId) }
             } else {
                 Task { await connect() }
             }
@@ -290,10 +290,13 @@ public final class RelayTunnelManager: ObservableObject {
             return
         }
 
-        guard let masterKey = obtainMasterKey() else {
+        guard let masterKey = await obtainMasterKey() else {
             for agent in agents { agentStatuses[agent.id] = .error("No identity") }
             return
         }
+
+        // Re-check after the suspension: another connect may have won the race
+        guard webSocketTask == nil || !isConnected else { return }
 
         let session = URLSession(configuration: .default)
         let task = session.webSocketTask(with: Self.relayURL)
@@ -634,7 +637,7 @@ public final class RelayTunnelManager: ObservableObject {
 
     // MARK: - Mid-Session Agent Management
 
-    private func addAgentToTunnel(agentId: UUID) {
+    private func addAgentToTunnel(agentId: UUID) async {
         ensureAgentIdentity(agentId)
 
         guard let agent = AgentManager.shared.agent(for: agentId),
@@ -645,7 +648,7 @@ public final class RelayTunnelManager: ObservableObject {
             return
         }
 
-        guard let masterKey = obtainMasterKey() else {
+        guard let masterKey = await obtainMasterKey() else {
             agentStatuses[agentId] = .error("No identity")
             return
         }
@@ -733,10 +736,15 @@ public final class RelayTunnelManager: ObservableObject {
 
     // MARK: - Helpers
 
-    private func obtainMasterKey() -> Data? {
-        guard OsaurusIdentity.exists() else { return nil }
-        let context = OsaurusIdentityContext.biometric()
-        return try? MasterKey.getPrivateKey(context: context)
+    /// Fetch the master key off the main actor. The keychain lookups behind
+    /// this round-trip to securityd over blocking XPC, which can stall the
+    /// main thread for seconds when the daemon is busy.
+    private func obtainMasterKey() async -> Data? {
+        await Task.detached(priority: .userInitiated) {
+            guard OsaurusIdentity.exists() else { return nil }
+            let context = OsaurusIdentityContext.biometric()
+            return try? MasterKey.getPrivateKey(context: context)
+        }.value
     }
 
     private static func signAgentAuth(

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -216,7 +216,7 @@ public enum MCPOAuthService {
             resource: canonical
         )
 
-        guard NSWorkspace.shared.open(url) else {
+        guard await NSWorkspace.shared.openAsync(url) else {
             throw MCPOAuthError.browserOpenFailed
         }
 

--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -423,7 +423,7 @@ public enum OpenAICodexOAuthService {
         }
         defer { server.stop() }
 
-        guard NSWorkspace.shared.open(url) else {
+        guard await NSWorkspace.shared.openAsync(url) else {
             throw OpenAICodexOAuthError.browserOpenFailed
         }
 

--- a/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
@@ -109,7 +109,7 @@ public enum OpenRouterOAuthService {
             state: state
         )
 
-        guard NSWorkspace.shared.open(authURL) else {
+        guard await NSWorkspace.shared.openAsync(authURL) else {
             throw OpenRouterOAuthError.invalidAuthorizationCallback
         }
 

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -408,7 +408,7 @@ public enum XAIOAuthService {
         }
         defer { server.stop() }
 
-        guard NSWorkspace.shared.open(url) else {
+        guard await NSWorkspace.shared.openAsync(url) else {
             throw XAIOAuthError.browserOpenFailed
         }
 

--- a/Packages/OsaurusCore/Utils/NSWorkspaceAsyncOpen.swift
+++ b/Packages/OsaurusCore/Utils/NSWorkspaceAsyncOpen.swift
@@ -1,0 +1,22 @@
+//
+//  NSWorkspaceAsyncOpen.swift
+//  osaurus
+//
+//  Non-blocking URL opening for async flows.
+//
+
+import AppKit
+
+extension NSWorkspace {
+    /// Open a URL without blocking the calling thread. The synchronous
+    /// `open(_:)` round-trips to LaunchServices over blocking XPC, which can
+    /// stall the main thread for seconds when LaunchServices is busy, so
+    /// async flows use this completion-handler variant bridged to async.
+    public func openAsync(_ url: URL) async -> Bool {
+        await withCheckedContinuation { continuation in
+            open(url, configuration: NSWorkspace.OpenConfiguration()) { _, error in
+                continuation.resume(returning: error == nil)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -693,6 +693,9 @@ final class NativeMarkdownTableView: NSView {
 
     // [row][col]; row 0 is headers
     private var cellFields: [[CellTextView]] = []
+    // Source text currently rendered in each cell, used to skip re-rendering
+    // unchanged cells when the grid reconfigures during streaming
+    private var cellTexts: [[String]] = []
     private let separator = NSBox()
 
     /// Called after the grid re-measures and its height changes.
@@ -728,12 +731,19 @@ final class NativeMarkdownTableView: NSView {
         let themeChanged = fingerprint != lastThemeFingerprint
         guard contentChanged || widthChanged || themeChanged else { return }
 
+        // Width only affects rendered text when it crosses a typography scale
+        // step; otherwise a width change is purely a relayout.
+        let scaleChanged =
+            Typography.scale(for: max(width, 1)) != Typography.scale(for: max(lastWidth, 1))
+
         self.headers = headers
         self.rows = rows
         lastWidth = width
         lastThemeFingerprint = fingerprint
 
-        rebuildCells(theme: theme)
+        if contentChanged || themeChanged || scaleChanged {
+            updateCells(theme: theme, rerenderAll: themeChanged || scaleChanged)
+        }
         relayout(width: width)
     }
 
@@ -750,42 +760,72 @@ final class NativeMarkdownTableView: NSView {
 
     // MARK: - Private: Cell Construction
 
-    private func rebuildCells(theme: any ThemeProtocol) {
-        for row in cellFields { for cell in row { cell.removeFromSuperview() } }
-        cellFields.removeAll()
-
+    /// Reconcile the cell grid against the current headers/rows in place.
+    /// A streaming table reconfigures once per delta, and tearing down and
+    /// recreating every NSTextView each time hangs the UI on large tables,
+    /// so existing cells are reused and only changed text is re-rendered.
+    private func updateCells(theme: any ThemeProtocol, rerenderAll: Bool) {
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
+
+        // A column-count change invalidates per-cell reuse; start over.
+        if columnCount == 0 || cellFields.first?.count != columnCount {
+            for row in cellFields { for cell in row { cell.removeFromSuperview() } }
+            cellFields.removeAll()
+            cellTexts.removeAll()
+        }
         guard columnCount > 0 else { return }
 
         let scale = Typography.scale(for: max(lastWidth, 1))
         let bodyFontSize = CGFloat(theme.bodySize) * scale
 
-        // Header row
-        let headerCells: [CellTextView] = (0 ..< columnCount).map { i in
-            let text = i < headers.count ? headers[i] : ""
-            return makeCellField(
-                text: text,
-                weight: .semibold,
-                fontSize: bodyFontSize,
-                theme: theme
-            )
-        }
-        cellFields.append(headerCells)
-        for cell in headerCells { addSubview(cell) }
-
-        // Body rows
+        // Target grid; row 0 is headers
+        var grid: [[String]] = [(0 ..< columnCount).map { $0 < headers.count ? headers[$0] : "" }]
         for row in rows {
-            let cells: [CellTextView] = (0 ..< columnCount).map { i in
-                let text = i < row.count ? row[i] : ""
-                return makeCellField(
-                    text: text,
-                    weight: .regular,
-                    fontSize: bodyFontSize,
-                    theme: theme
-                )
+            grid.append((0 ..< columnCount).map { $0 < row.count ? row[$0] : "" })
+        }
+
+        // Drop rows that no longer exist
+        while cellFields.count > grid.count {
+            for cell in cellFields.removeLast() { cell.removeFromSuperview() }
+            cellTexts.removeLast()
+        }
+
+        for (rowIdx, rowTexts) in grid.enumerated() {
+            let weight: NSFont.Weight = rowIdx == 0 ? .semibold : .regular
+            if rowIdx < cellFields.count {
+                // Existing row: re-render only the cells whose text changed
+                for (colIdx, text) in rowTexts.enumerated() {
+                    let cell = cellFields[rowIdx][colIdx]
+                    if rerenderAll {
+                        cell.selectedTextAttributes = [
+                            .backgroundColor: NSColor(theme.selectionColor)
+                        ]
+                        cell.insertionPointColor = NSColor(theme.cursorColor)
+                    }
+                    guard rerenderAll || cellTexts[rowIdx][colIdx] != text else { continue }
+                    let attr = renderCellAttributedString(
+                        text: text,
+                        weight: weight,
+                        fontSize: bodyFontSize,
+                        theme: theme
+                    )
+                    cell.textStorage?.setAttributedString(attr)
+                    cellTexts[rowIdx][colIdx] = text
+                }
+            } else {
+                // New row appended by the stream
+                let cells = rowTexts.map { text in
+                    makeCellField(
+                        text: text,
+                        weight: weight,
+                        fontSize: bodyFontSize,
+                        theme: theme
+                    )
+                }
+                cellFields.append(cells)
+                cellTexts.append(rowTexts)
+                for cell in cells { addSubview(cell) }
             }
-            cellFields.append(cells)
-            for cell in cells { addSubview(cell) }
         }
     }
 
@@ -899,12 +939,17 @@ final class NativeMarkdownTableView: NSView {
             var x: CGFloat = 0
             let rowH = rowHeights[rowIdx]
             for (colIdx, field) in row.enumerated() {
-                field.frame = NSRect(
+                let frame = NSRect(
                     x: x,
                     y: y,
                     width: columnWidth,
                     height: rowH
                 )
+                // Setting an NSTextView's frame kicks off ruler and inspector
+                // bar updates even when nothing moved, so skip no-op writes.
+                if field.frame != frame {
+                    field.frame = frame
+                }
                 x += columnWidth
                 if colIdx < row.count - 1 { x += columnGap }
             }


### PR DESCRIPTION
## Summary

  - reused existing table cells while streaming responses instead of tearing down and rebuilding the whole grid on every update which froze the UI on large tables
  - skipped redundant re-rendering and layout work when table content, width or theme had not actually changed
  - opened the browser for OAuth sign in flows without blocking the main thread which previously stalled the app for seconds when the system was busy
  - moved security key lookups during remote tunnel connection off the main thread so a slow system keychain no longer hangs the app

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
