### PR TITLE
improved external model management (reveal in Finder, prune deleted)

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -1953,6 +1953,14 @@ extension AppDelegate {
     ) {
         closePopoverAndPerform { [weak self] in
             guard let self = self else { return }
+            // Reopening a reused window doesn't rebuild the SwiftUI graph, so
+            // the Models grid wouldn't otherwise notice external models the
+            // user deleted on disk while the app stayed running. Prune them
+            // off the main thread; it posts `.localModelsChanged` only when
+            // something actually went missing.
+            Task.detached(priority: .utility) {
+                ExternalModelLocator.pruneMissing()
+            }
             // Records the screen the window opens to; `handleTabChange` only
             // fires on later switches, so this captures the initial tab too.
             let shownTab = initialTab ?? ManagementStateManager.shared.selectedTab

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -11525,6 +11525,9 @@
         }
       }
     },
+    "Copy Path" : {
+
+    },
     "Copy phrase" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -197,6 +197,60 @@ enum ExternalModelLocator {
         }
     }
 
+    /// Drop registry entries whose bundle no longer exists on disk — e.g. the
+    /// user deleted an external model's files directly in Finder. Cheap: just
+    /// a `config.json` existence check per entry (no directory walk), so it's
+    /// safe to call whenever a model list is about to be shown. Persists the
+    /// trimmed manifest and posts `.localModelsChanged` if anything was
+    /// removed, which rebuilds the picker cache and refreshes the Models grid.
+    ///
+    /// This exists because the in-memory `registry` (and the manifest) are
+    /// loaded once and only fully re-derived by `rescan()` at launch. Closing
+    /// and reopening the window reuses the cached registry, so a model deleted
+    /// out from under us would otherwise linger in the UI until the next quit.
+    @discardableResult
+    static func pruneMissing() -> Bool {
+        // Snapshot under the lock, then do the `fileExists` probes UNLOCKED.
+        // Holding the lock across filesystem I/O would block any concurrent
+        // (possibly main-thread) `models()` / `path(forId:)` caller for the
+        // duration of the scan — the same reason `path` and `rescan` keep
+        // their I/O outside the lock. Callers must still invoke this off the
+        // main thread.
+        lock.lock()
+        let snapshot = loadedLocked()
+        lock.unlock()
+
+        let fm = FileManager.default
+        var missing: [String: String] = [:]  // key -> probed bundlePath
+        for (key, entry) in snapshot {
+            let configPath = URL(fileURLWithPath: entry.bundlePath, isDirectory: true)
+                .appendingPathComponent("config.json").path
+            if !fm.fileExists(atPath: configPath) {
+                missing[key] = entry.bundlePath
+            }
+        }
+        guard !missing.isEmpty else { return false }
+
+        // Re-acquire briefly to apply. Only drop the exact entry we probed:
+        // a concurrent `rescan()` may have re-registered the id at a new,
+        // still-valid path while we were probing, and that must survive.
+        lock.lock()
+        var map = loadedLocked()
+        var removed = false
+        for (key, probedPath) in missing where map[key]?.bundlePath == probedPath {
+            map.removeValue(forKey: key)
+            removed = true
+        }
+        if removed { registry = map }
+        lock.unlock()
+
+        if removed {
+            persist(map)
+            NotificationCenter.default.post(name: .localModelsChanged, object: nil)
+        }
+        return removed
+    }
+
     // MARK: - Rescan
 
     /// Re-scan the enabled external roots, update the registry, persist the

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -71,6 +71,9 @@ struct ModelDetailView: View, Identifiable {
     @State private var isRepairing = false
     @State private var repairResult: Bool?
 
+    /// Transient "copied" feedback for the external-model path copy button
+    @State private var didCopyPath = false
+
     /// Normalized model ID for API usage
     private var apiModelId: String {
         let last = model.id.split(separator: "/").last.map(String.init) ?? model.name
@@ -854,42 +857,71 @@ struct ModelDetailView: View, Identifiable {
 
     private var completedFooter: some View {
         HStack(spacing: 12) {
-            Button(action: {
-                Task { await modelManager.deleteModel(model) }
-                dismiss()
-            }) {
-                Text("Delete Model", bundle: .module)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(theme.errorColor)
-            }
-            .buttonStyle(PlainButtonStyle())
-
-            Button(action: {
-                repairResult = nil
-                isRepairing = true
-                Task {
-                    await repairModel()
-                    isRepairing = false
-                }
-            }) {
-                HStack(spacing: 4) {
-                    if isRepairing {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle())
-                            .scaleEffect(0.5)
-                            .frame(width: 12, height: 12)
-                    } else if let result = repairResult {
-                        Image(systemName: result ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
-                            .font(.system(size: 11))
-                            .foregroundColor(result ? theme.successColor : theme.errorColor)
+            if isExternalModel {
+                // Externally-discovered models (Hugging Face cache, LM Studio)
+                // aren't owned by Osaurus, so in-app delete can't remove their
+                // files — it only forgets them until the next rescan re-adds
+                // them. Offer "Reveal in Finder" instead so users can delete
+                // these unrecognized models manually.
+                Button(action: revealModelInFinder) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "folder")
+                            .font(.system(size: 12))
+                        Text("Reveal in Finder", bundle: .module)
+                            .font(.system(size: 13, weight: .medium))
                     }
-                    Text("Repair", bundle: .module)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(theme.accentColor)
+                    .foregroundColor(theme.accentColor)
                 }
+                .buttonStyle(PlainButtonStyle())
+
+                Button(action: copyModelPath) {
+                    HStack(spacing: 4) {
+                        Image(systemName: didCopyPath ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12))
+                        Text(didCopyPath ? "Copied!" : "Copy Path", bundle: .module)
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .foregroundColor(didCopyPath ? theme.successColor : theme.secondaryText)
+                }
+                .buttonStyle(PlainButtonStyle())
+            } else {
+                Button(action: {
+                    Task { await modelManager.deleteModel(model) }
+                    dismiss()
+                }) {
+                    Text("Delete Model", bundle: .module)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(theme.errorColor)
+                }
+                .buttonStyle(PlainButtonStyle())
+
+                Button(action: {
+                    repairResult = nil
+                    isRepairing = true
+                    Task {
+                        await repairModel()
+                        isRepairing = false
+                    }
+                }) {
+                    HStack(spacing: 4) {
+                        if isRepairing {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                                .scaleEffect(0.5)
+                                .frame(width: 12, height: 12)
+                        } else if let result = repairResult {
+                            Image(systemName: result ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                                .font(.system(size: 11))
+                                .foregroundColor(result ? theme.successColor : theme.errorColor)
+                        }
+                        Text("Repair", bundle: .module)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(theme.accentColor)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(isRepairing)
             }
-            .buttonStyle(PlainButtonStyle())
-            .disabled(isRepairing)
 
             Spacer()
 
@@ -905,6 +937,32 @@ struct ModelDetailView: View, Identifiable {
                     )
             }
             .buttonStyle(PlainButtonStyle())
+        }
+    }
+
+    /// True for models discovered outside Osaurus (Hugging Face cache, LM
+    /// Studio). Their files live in another app's directory, so Osaurus
+    /// offers "Reveal in Finder" rather than an in-app delete.
+    private var isExternalModel: Bool {
+        model.externalSource != nil || model.bundleDirectory != nil
+    }
+
+    /// Selects the model's on-disk bundle in Finder so the user can inspect
+    /// or delete it manually.
+    private func revealModelInFinder() {
+        NSWorkspace.shared.activateFileViewerSelecting([model.localDirectory])
+    }
+
+    /// Copies the model's on-disk path to the pasteboard, with brief
+    /// "Copied!" feedback on the button.
+    private func copyModelPath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(model.localDirectory.path, forType: .string)
+
+        withAnimation(.easeInOut(duration: 0.15)) { didCopyPath = true }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            withAnimation(.easeInOut(duration: 0.15)) { didCopyPath = false }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
@@ -156,6 +156,15 @@ struct ModelPickerView: View {
             // refresh remote model lists on open so newly-added/removed
             // models surface
             await RemoteProviderManager.shared.refreshConnectedProviders()
+
+            // Drop external models (HF cache, LM Studio) the user deleted on
+            // disk while the app stayed running — the picker cache is built
+            // once and only rebuilds on `.localModelsChanged`, which this
+            // posts when something went missing. Cheap existence check; no-op
+            // when nothing changed. Runs last since it's the lowest priority.
+            await Task.detached(priority: .utility) {
+                ExternalModelLocator.pruneMissing()
+            }.value
         }
         .onDisappear {
             searchDebounceTask?.cancel()


### PR DESCRIPTION
## Summary

  - added Reveal in Finder and Copy Path actions for external models (Hugging Face cache, LM Studio) in the model detail sheet since the app couldn't delete files it doesn't own
  - replaced the non-functional Delete/Repair buttons for external models
  - fixed external models lingering in the Models grid and chat picker after being deleted from disk while the app stayed running

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
