### PR TITLE
Pin vMLX LFM runtime hardening

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "edcef93f6a0147d3e568aa512adf94a42cf212e9"
+        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
+        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
+        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
+        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1461,13 +1461,8 @@ extension ModelManager {
     /// layouts.
     internal nonisolated static func scanLocalModels(at root: URL) -> [MLXModel] {
         let fm = FileManager.default
-        guard
-            (try? fm.contentsOfDirectory(
-                at: root,
-                includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-                options: [.skipsHiddenFiles]
-            )) != nil
-        else {
+        var rootIsDir: ObjCBool = false
+        guard fm.fileExists(atPath: root.path, isDirectory: &rootIsDir), rootIsDir.boolValue else {
             return []
         }
 
@@ -1517,6 +1512,21 @@ extension ModelManager {
             return false
         }
 
+        func shouldDescendIntoLocalModelCandidate(_ entry: URL) -> Bool {
+            let name = entry.lastPathComponent.lowercased()
+            let skippedInfrastructureDirectories: Set<String> = [
+                "__pycache__",
+                "sources",
+                "source",
+                "cache",
+                "tokenizer",
+                "text_encoder",
+                "transformer",
+                "vae",
+            ]
+            return !skippedInfrastructureDirectories.contains(name)
+        }
+
         // Three layouts are supported and may coexist under the same root:
         //   1. Flat:        <root>/<modelDir>/{config.json,tokenizer.*,*.safetensors}
         //   2. Nested:      <root>/<org>/<repo>/{config.json,...}        (HF style)
@@ -1532,13 +1542,11 @@ extension ModelManager {
         // — anything deeper is treated as not-a-bundle.
         func scanDir(_ root: URL, prefix: [String], maxDepth: Int) {
             guard maxDepth > 0,
-                let entries = try? fm.contentsOfDirectory(
-                    at: root,
-                    includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-                    options: [.skipsHiddenFiles]
-                )
+                let entryNames = try? fm.contentsOfDirectory(atPath: root.path)
             else { return }
-            for entry in entries {
+            for entryName in entryNames where !entryName.hasPrefix(".") {
+                let entry = root.appendingPathComponent(entryName, isDirectory: true)
+                guard shouldDescendIntoLocalModelCandidate(entry) else { continue }
                 guard let resolved = resolvedDirectory(entry) else { continue }
                 let nameComponents = prefix + [entry.lastPathComponent]
                 if isModelBundle(resolved) {

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -798,6 +798,19 @@ struct Usage: Codable, Sendable {
     let prompt_tokens: Int
     let completion_tokens: Int
     let total_tokens: Int
+    let tokens_per_second: Double?
+
+    init(
+        prompt_tokens: Int,
+        completion_tokens: Int,
+        total_tokens: Int,
+        tokens_per_second: Double? = nil
+    ) {
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = total_tokens
+        self.tokens_per_second = tokens_per_second
+    }
 }
 
 /// Chat completion response

--- a/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
+++ b/Packages/OsaurusCore/Models/Chat/ResponseWriters.swift
@@ -413,6 +413,7 @@ final class SSEResponseWriter: ResponseWriter {
     func writeUsageChunk(
         promptTokens: Int,
         completionTokens: Int,
+        tokensPerSecond: Double? = nil,
         model: String,
         responseId: String,
         created: Int,
@@ -428,7 +429,8 @@ final class SSEResponseWriter: ResponseWriter {
         chunk.usage = Usage(
             prompt_tokens: promptTokens,
             completion_tokens: completionTokens,
-            total_tokens: promptTokens + completionTokens
+            total_tokens: promptTokens + completionTokens,
+            tokens_per_second: tokensPerSecond
         )
         writeSSEChunk(chunk, context: context)
     }

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -297,6 +297,11 @@ struct MLXModel: Identifiable, Codable {
         {
             return false
         }
+        if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(id)
+            || ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(name)
+        {
+            return false
+        }
         if isDownloaded { return VLMDetection.isVLM(at: localDirectory) }
         if let mt = modelType { return VLMDetection.isVLM(modelType: mt) }
         return VLMDetection.isVLM(modelId: id)

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -70,6 +70,21 @@ enum ModelFamilyNames {
         ) != nil
     }
 
+    /// MiMo V2.5 and Nex N2 local JANG/JANGTQ bundles are text/tool runtimes in
+    /// this release lane. Matching is name-only and deliberately requires the
+    /// JANG marker so future non-JANG MiMo/N2 media bundles still flow through
+    /// bundle metadata detection.
+    static func isMiMoOrN2JANGRuntimeFamily(_ modelId: String) -> Bool {
+        let normalized =
+            modelId
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jang") else { return false }
+        return normalized.contains("mimo-v2.5")
+            || normalized.contains("nex-n2-pro")
+    }
+
     /// DeepSeek-V4 / DSV4 Flash bundles (`model_type=deepseek_v4`).
     /// Match both public repo forms (`DeepSeek-V4-...`) and shorthand
     /// runtime names (`DSV4-...`, `deepseekv4-...`) while avoiding

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -86,6 +86,9 @@ enum VLMDetection {
         {
             return false
         }
+        if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelId) {
+            return false
+        }
         return cachedVerdict("id:\(modelId)") {
             guard let dir = findLocalModelDirectory(forModelId: modelId) else { return false }
             return isVLM(at: dir)

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4752,6 +4752,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
                     )
                     var authoritativeCompletionTokens: Int?
+                    var authoritativeTokensPerSecond: Double?
                     var streamFinishReason = "stop"
                     for try await delta in stream {
                         try Task.checkCancellation()
@@ -4783,6 +4784,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         if let stats = StreamingStatsHint.decode(delta) {
                             authoritativeCompletionTokens = stats.tokenCount
+                            authoritativeTokensPerSecond = stats.tokensPerSecond
                             if let stopReason = stats.stopReason {
                                 streamFinishReason = stopReason
                             }
@@ -4824,6 +4826,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     httpTrace.set("http_prompt_tokens_estimate", promptTokens)
                     httpTrace.set("http_completion_tokens", completionTokens)
                     let finalStreamFinishReason = streamFinishReason
+                    let finalTokensPerSecond = authoritativeTokensPerSecond
                     hop {
                         writerBound.value.writeFinishWithReason(
                             finalStreamFinishReason,
@@ -4836,6 +4839,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             writerBound.value.writeUsageChunk(
                                 promptTokens: promptTokens,
                                 completionTokens: completionTokens,
+                                tokensPerSecond: finalTokensPerSecond,
                                 model: model,
                                 responseId: responseId,
                                 created: created,

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
+        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7dd2a2ba149419ad8da48afe5f377ee8a8ffe101451683754baca7afa8d5ec9e",
+  "originHash" : "df4c60c1d9a806f7210fb2816a3eb05d2c628e340874a72e12a9d1b7d070a354",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "edcef93f6a0147d3e568aa512adf94a42cf212e9"
+        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
+        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
+        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "edcef93f6a0147d3e568aa512adf94a42cf212e9"
+            revision: "5441ab41f14ee3164e93d36558a1f9213c27dda3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
+            revision: "aabc41936f1ce2746d1098a14f12b441a04ed30b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "aabc41936f1ce2746d1098a14f12b441a04ed30b"
+            revision: "d9c50a9f5f9625152c4b755b2972441445cecd08"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5441ab41f14ee3164e93d36558a1f9213c27dda3"
+            revision: "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/DirectoryPickerService.swift
+++ b/Packages/OsaurusCore/Services/DirectoryPickerService.swift
@@ -282,9 +282,8 @@ final class DirectoryPickerService: ObservableObject {
     /// cached; this performs the filesystem work on every invocation.
     nonisolated private static func resolveDefaultModelsDirectory() -> URL {
         let fileManager = FileManager.default
-        if let override = ProcessInfo.processInfo.environment["OSU_MODELS_DIR"], !override.isEmpty {
-            let expanded = (override as NSString).expandingTildeInPath
-            return URL(fileURLWithPath: expanded, isDirectory: true)
+        if let override = modelsDirectoryEnvironmentOverride() {
+            return override
         }
         let homeURL = fileManager.homeDirectoryForCurrentUser
         let newDefault = homeURL.appendingPathComponent("MLXModels")
@@ -313,8 +312,8 @@ final class DirectoryPickerService: ObservableObject {
         // when the user's app has a saved bookmark. Treat an explicit env
         // override as stronger than persisted UI state so probes are
         // deterministic and do not accidentally scan a stale volume.
-        if let override = ProcessInfo.processInfo.environment["OSU_MODELS_DIR"], !override.isEmpty {
-            return defaultModelsDirectory()
+        if let override = modelsDirectoryEnvironmentOverride() {
+            return override
         }
 
         // Use cached bookmark URL to avoid expensive IPC
@@ -324,6 +323,14 @@ final class DirectoryPickerService: ObservableObject {
 
         // Fallback precedence matches instance property
         return defaultModelsDirectory()
+    }
+
+    nonisolated private static func modelsDirectoryEnvironmentOverride() -> URL? {
+        guard let raw = ProcessInfo.processInfo.environment["OSU_MODELS_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else { return nil }
+        return URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true)
     }
 
     /// Reset directory selection

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -304,6 +304,13 @@ actor MLXService: ToolCapableService {
             // bundle metadata reads before vMLX can load the model.
             return true
         }
+        if isKnownTextOnlyJANGRuntimeFamily(modelId: modelId) {
+            // MiMo/N2 JANG and JANGTQ tool parsing/template selection is owned
+            // by the pinned vMLX runtime. Keep Osaurus request preflight from
+            // synchronously walking large or symlinked model bundles before
+            // vMLX can load and validate the actual runtime contract.
+            return true
+        }
 
         if let directory = modelDirectory ?? localModelDirectory(modelId: modelId),
             let format = resolvedToolCallFormat(in: directory)
@@ -437,6 +444,13 @@ actor MLXService: ToolCapableService {
     private nonisolated static func mediaCapabilities(
         modelId: String
     ) -> ModelMediaCapabilities.Capabilities {
+        if isKnownTextOnlyJANGRuntimeFamily(modelId: modelId) {
+            // MiMo/N2 JANG and JANGTQ rows are text/tool runtimes in this
+            // Osaurus lane. Avoid synchronous directory/VLM probing on large
+            // or symlinked external bundles during request preflight; vMLX
+            // still owns the real model/template/tool load path.
+            return .textOnly
+        }
         if ModelFamilyNames.isStepFamily(modelId) {
             // Step 3.7 currently runs through vMLX's Step text runtime in
             // Osaurus. Some source bundles carry vision metadata, but the
@@ -453,5 +467,15 @@ actor MLXService: ToolCapableService {
             return ModelMediaCapabilities.from(directory: localDirectory, modelId: modelId)
         }
         return ModelMediaCapabilities.from(modelId: modelId)
+    }
+
+    private nonisolated static func isKnownTextOnlyJANGRuntimeFamily(modelId: String) -> Bool {
+        let normalized = modelId.lowercased().replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jang") else { return false }
+        if normalized.contains("-vl") || normalized.contains("omni") {
+            return false
+        }
+        return normalized.contains("mimo-v2.5")
+            || normalized.contains("nex-n2-pro")
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2833,15 +2833,16 @@ public actor ModelRuntime {
         modelName: String? = nil
     ) -> Int64 {
         guard rawWeightsBytes > 0, let modelDirectory else { return rawWeightsBytes }
-        guard isRoutedJANGTQCompressionLoad(at: modelDirectory, modelName: modelName) else {
+        guard isRoutedJANGCompressionLoad(at: modelDirectory, modelName: modelName) else {
             return rawWeightsBytes
         }
 
-        // vMLX `.osaurusProduction` loads routed JANGTQ through mmap-backed
-        // safetensors and MLXPress compression-first residency. The default
-        // compression policy advises 70% of routed weights cold, so the
-        // pre-load crash-prevention gate should budget the hot working set,
-        // not require the entire routed shard total to be immediately free.
+        // vMLX `.osaurusProduction` loads routed JANG/JANGTQ through
+        // mmap-backed safetensors and MLXPress compression-first residency.
+        // The default compression policy advises 70% of routed weights cold,
+        // so the pre-load crash-prevention gate should budget the hot working
+        // set, not require the entire routed shard total to be immediately
+        // free.
         let hotFraction = 0.30
         let floor: Int64 = 4 * 1024 * 1024 * 1024
         let estimated = Int64(Double(rawWeightsBytes) * hotFraction)
@@ -2849,14 +2850,27 @@ public actor ModelRuntime {
     }
 
     private static func isRoutedJANGTQCompressionLoad(at directory: URL, modelName: String?) -> Bool {
+        isRoutedJANGCompressionLoad(at: directory, modelName: modelName, requireJANGTQ: true)
+    }
+
+    private static func isRoutedJANGCompressionLoad(
+        at directory: URL,
+        modelName: String?,
+        requireJANGTQ: Bool = false
+    ) -> Bool {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: directory.appendingPathComponent("jangtq_runtime.safetensors").path)
-        else { return false }
+        let hasJANGTQSidecar = fm.fileExists(
+            atPath: directory.appendingPathComponent("jangtq_runtime.safetensors").path
+        )
         if let modelName,
             ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName),
-            modelName.lowercased().contains("jangtq")
+            fm.fileExists(atPath: directory.appendingPathComponent("jang_config.json").path)
         {
-            return true
+            let normalized = modelName.lowercased().replacingOccurrences(of: "_", with: "-")
+            if normalized.contains("jangtq") {
+                return hasJANGTQSidecar
+            }
+            return !requireJANGTQ
         }
 
         let config = Self.readJSONObject(at: directory.appendingPathComponent("config.json"))
@@ -2871,17 +2885,31 @@ public actor ModelRuntime {
             ((jang["quantization"] as? [String: Any]).flatMap { Self.stringValue($0["profile"]) }
                 ?? Self.stringValue(jang["profile"])
                 ?? "")
+        let format =
+            (Self.stringValue(jang["format"])
+                ?? Self.stringValue(config["format"])
+                ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
         let declaresJANGTQ =
             weightFormat.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "mxtq"
             || profile.lowercased().contains("jangtq")
             || (modelName?.lowercased().contains("jangtq") ?? false)
-        guard declaresJANGTQ else { return false }
+        if declaresJANGTQ, !hasJANGTQSidecar { return false }
+        guard !requireJANGTQ || declaresJANGTQ else { return false }
+        let declaresJANG =
+            declaresJANGTQ
+            || format == "jang"
+            || profile.lowercased().contains("jang")
+            || (modelName?.lowercased().contains("jang") ?? false)
+        guard declaresJANG else { return false }
 
         let routedExperts =
             Self.intValue(config["n_routed_experts"])
             ?? Self.intValue(config["num_routed_experts"])
             ?? Self.intValue(config["num_experts"])
             ?? Self.intValue(config["num_local_experts"])
+            ?? Self.intValue((config["text_config"] as? [String: Any])?["num_experts"])
         if (routedExperts ?? 0) > 0 { return true }
 
         if let actions = (jang["quantization"] as? [String: Any])?["actions"] as? [String: Any],
@@ -2896,7 +2924,20 @@ public actor ModelRuntime {
         {
             return true
         }
+        if config["routed_expert_bits"] != nil
+            || jang["routed_expert_bits"] != nil
+            || config["routed_expert_bit_plan"] != nil
+            || jang["routed_expert_bit_plan"] != nil
+        {
+            return true
+        }
         if Self.stringValue((config["quantization"] as? [String: Any])?["routed_experts"]) != nil {
+            return true
+        }
+        if let architecture = jang["architecture"] as? [String: Any],
+            let hasMoE = architecture["has_moe"] as? Bool,
+            hasMoE
+        {
             return true
         }
         return false

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -663,6 +663,9 @@ public actor ModelRuntime {
         modelDirectory: URL? = nil,
         modelName: String? = nil
     ) -> Int64 {
+        if let knownHeadroom = Self.knownMiMoOrN2JANGTQKVHeadroomBytes(modelName: modelName) {
+            return knownHeadroom
+        }
         if let modelDirectory,
             let architectureHeadroom = estimatedArchitectureKVHeadroomBytes(at: modelDirectory)
         {
@@ -678,6 +681,23 @@ public actor ModelRuntime {
         let scaled = Int64(Double(weights) * 0.20)
         let floor: Int64 = 512 * 1024 * 1024
         return max(scaled, floor)
+    }
+
+    private static func knownMiMoOrN2JANGTQKVHeadroomBytes(modelName: String?) -> Int64? {
+        guard let modelName else { return nil }
+        let normalized =
+            modelName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jangtq") else { return nil }
+        if normalized.contains("mimo-v2.5") {
+            return 512 * 1024 * 1024
+        }
+        if normalized.contains("nex-n2-pro") {
+            return 4 * 1024 * 1024 * 1024
+        }
+        return nil
     }
 
     private static func estimatedArchitectureKVHeadroomBytes(at directory: URL) -> Int64? {
@@ -707,10 +727,10 @@ public actor ModelRuntime {
                 return hidden / heads
             }()
         let maxPositions =
-            intValue(config["max_position_embeddings"])
+            effectiveKVPositionBudget(config: config)
+            ?? intValue(config["max_position_embeddings"])
             ?? intValue(config["max_sequence_length"])
             ?? intValue(config["seq_length"])
-            ?? intValue(config["sliding_window"])
             ?? 32768
         guard let kvHeads, let headDim, kvHeads > 0, headDim > 0, maxPositions > 0 else {
             return nil
@@ -756,6 +776,26 @@ public actor ModelRuntime {
             return pattern.filter { $0 == "*" || $0 == "A" || $0 == "a" }.count
         }
         return intValue(config["num_hidden_layers"]) ?? 0
+    }
+
+    private static func effectiveKVPositionBudget(config: [String: Any]) -> Int? {
+        // Sliding-window/chunked attention families such as MiMo expose a very
+        // large theoretical context window, but vMLX does not preallocate KV
+        // for that full value at load time. The pre-load crash gate should
+        // budget the configured active window instead of rejecting before the
+        // mmap/JANGTQ path can prove its footprint.
+        let window =
+            intValue(config["sliding_window_size"])
+            ?? intValue(config["sliding_window"])
+            ?? intValue(config["attention_chunk_size"])
+        guard let window, window > 0 else { return nil }
+        if config["sliding_window_size"] != nil
+            || config["sliding_window"] != nil
+            || config["attention_chunk_size"] != nil
+        {
+            return window
+        }
+        return nil
     }
 
     private static func mambaLayerCount(in config: [String: Any]) -> Int {
@@ -1072,7 +1112,7 @@ public actor ModelRuntime {
         // meant the resident-RAM accounting — and the pre-load feasibility gate
         // below — were blind under the default strict policy. The value also
         // feeds `mlxCacheLimit()` and the `/health` + model-picker surfaces.
-        let weightsBytes = Self.computeWeightsSizeBytes(at: localURL)
+        let weightsBytes = Self.computeWeightsSizeBytes(at: localURL, modelName: name)
         let loadFootprintBytes = Self.effectiveLoadFootprintBytes(
             rawWeightsBytes: weightsBytes,
             modelDirectory: localURL,
@@ -1132,6 +1172,7 @@ public actor ModelRuntime {
             let tokenizerLoader = SwiftTransformersTokenizerLoader()
             let serverSettings = ServerRuntimeSettingsStore.snapshot()
             let mtpPlan = Self.resolveNativeMTPLaunchPlan(
+                modelName: name,
                 modelDirectory: localURL,
                 settings: serverSettings
             )
@@ -2040,9 +2081,18 @@ public actor ModelRuntime {
     }
 
     private nonisolated static func resolveNativeMTPLaunchPlan(
+        modelName: String,
         modelDirectory: URL,
         settings: VMLXServerRuntimeSettings
     ) -> NativeMTPLaunchPlan {
+        if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName) {
+            return NativeMTPLaunchPlan(
+                loadConfiguration: .osaurusProduction,
+                draftStrategy: nil,
+                statusLine: nil,
+                reason: "MiMo/N2 JANG text runtime is not an MTP bundle; using autoregressive load."
+            )
+        }
         let configData = try? Data(contentsOf: modelDirectory.appendingPathComponent("config.json"))
         let jangConfig = try? JangLoader.loadConfig(at: modelDirectory)
         let status: MTPBundleStatus?
@@ -2678,8 +2728,30 @@ public actor ModelRuntime {
         }
     }
 
-    private static func computeWeightsSizeBytes(at url: URL) -> Int64 {
+    private static func computeWeightsSizeBytes(at url: URL, modelName: String? = nil) -> Int64 {
         let fm = FileManager.default
+
+        if let knownSize = Self.knownMiMoOrN2JANGTQWeightsSizeBytes(modelName: modelName),
+            fm.fileExists(atPath: url.appendingPathComponent("jangtq_runtime.safetensors").path)
+        {
+            return knownSize
+        }
+
+        for indexName in [
+            "model.safetensors.index.json",
+            "pytorch_model.safetensors.index.json",
+        ] {
+            let indexURL = url.appendingPathComponent(indexName)
+            guard fm.fileExists(atPath: indexURL.path),
+                let data = try? Data(contentsOf: indexURL),
+                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let metadata = object["metadata"] as? [String: Any]
+            else { continue }
+
+            if let totalSize = Self.int64Value(metadata["total_size"]), totalSize > 0 {
+                return totalSize
+            }
+        }
 
         let directWeightNames = [
             "model.safetensors",
@@ -2738,6 +2810,23 @@ public actor ModelRuntime {
         return total
     }
 
+    private static func knownMiMoOrN2JANGTQWeightsSizeBytes(modelName: String?) -> Int64? {
+        guard let modelName else { return nil }
+        let normalized =
+            modelName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jangtq") else { return nil }
+        if normalized.contains("mimo-v2.5") {
+            return 83_308_734_780
+        }
+        if normalized.contains("nex-n2-pro") {
+            return 108_459_132_884
+        }
+        return nil
+    }
+
     static func effectiveLoadFootprintBytes(
         rawWeightsBytes: Int64,
         modelDirectory: URL?,
@@ -2763,6 +2852,12 @@ public actor ModelRuntime {
         let fm = FileManager.default
         guard fm.fileExists(atPath: directory.appendingPathComponent("jangtq_runtime.safetensors").path)
         else { return false }
+        if let modelName,
+            ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName),
+            modelName.lowercased().contains("jangtq")
+        {
+            return true
+        }
 
         let config = Self.readJSONObject(at: directory.appendingPathComponent("config.json"))
         let jang = Self.readJSONObject(at: directory.appendingPathComponent("jang_config.json"))
@@ -2794,9 +2889,14 @@ public actor ModelRuntime {
         {
             return true
         }
-        if let mxtqBits = jang["mxtq_bits"] as? [String: Any],
-            mxtqBits["routed_expert"] != nil
+        let configMxtqBits = config["mxtq_bits"] as? [String: Any]
+        let jangMxtqBits = jang["mxtq_bits"] as? [String: Any]
+        if configMxtqBits?["routed_expert"] != nil
+            || jangMxtqBits?["routed_expert"] != nil
         {
+            return true
+        }
+        if Self.stringValue((config["quantization"] as? [String: Any])?["routed_experts"]) != nil {
             return true
         }
         return false
@@ -3074,6 +3174,14 @@ public actor ModelRuntime {
         return nil
     }
 
+    private static func int64Value(_ value: Any?) -> Int64? {
+        if let int = value as? Int { return Int64(int) }
+        if let int64 = value as? Int64 { return int64 }
+        if let number = value as? NSNumber { return number.int64Value }
+        if let string = value as? String { return Int64(string) }
+        return nil
+    }
+
     /// Async wrapper around `validateJANGTQSidecarIfRequired` that, on a
     /// "missing sidecar but stamp says JANGTQ" failure (and ONLY that
     /// specific failure), tries once to download
@@ -3101,6 +3209,25 @@ public actor ModelRuntime {
                     ]
                 )
             }
+            return
+        }
+        if Self.isMiMoOrN2JANGTQName(modelId) || Self.isMiMoOrN2JANGTQName(name) {
+            let sidecarURL = directory.appendingPathComponent("jangtq_runtime.safetensors")
+            guard FileManager.default.fileExists(atPath: sidecarURL.path) else {
+                throw NSError(
+                    domain: "ModelRuntime",
+                    code: 2,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Model '\(name)' is a MiMo/N2 JANGTQ bundle but is missing "
+                            + "required sidecar file 'jangtq_runtime.safetensors'. "
+                            + "Re-download the full model or obtain the sidecar from the original publisher."
+                    ]
+                )
+            }
+            // MiMo/N2 JANGTQ bundle validation is owned by the pinned vMLX
+            // runtime. Avoid a synchronous Foundation read of `jang_config.json`
+            // on large or symlinked external app bundles before vMLX can load.
             return
         }
 
@@ -3175,6 +3302,16 @@ public actor ModelRuntime {
             .replacingOccurrences(of: "_", with: "-")
         return normalized.contains("step-3.7")
             && normalized.contains("jangtq")
+    }
+
+    private static func isMiMoOrN2JANGTQName(_ value: String) -> Bool {
+        let normalized =
+            value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jangtq") else { return false }
+        return ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(normalized)
     }
 
     /// Build the ordered list of HF `<org>/<repo>` candidates to try when

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -278,6 +278,30 @@ struct ModelManagerTests {
         #expect(detected.map(\.id).contains("JANGQ-AI/Step-3.7-Flash-JANGTQ_K"))
     }
 
+    @Test func scanLocalModels_skipsLargeSupportTreesBesideJANGBundles() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("osu-jangq-root-\(UUID().uuidString)")
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let n2 = root.appendingPathComponent("Nex-N2-Pro-JANGTQ2")
+        try fm.createDirectory(at: n2, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: n2.appendingPathComponent("config.json"))
+        try Data("{}".utf8).write(to: n2.appendingPathComponent("tokenizer.json"))
+        try Data("{}".utf8).write(to: n2.appendingPathComponent("model.safetensors.index.json"))
+
+        for supportName in ["sources", "__pycache__", "tokenizer", "transformer", "text_encoder", "vae"] {
+            let supportDir = root.appendingPathComponent(supportName).appendingPathComponent("Nested")
+            try fm.createDirectory(at: supportDir, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: supportDir.appendingPathComponent("config.json"))
+            try Data("{}".utf8).write(to: supportDir.appendingPathComponent("tokenizer.json"))
+            try Data("{}".utf8).write(to: supportDir.appendingPathComponent("model.safetensors.index.json"))
+        }
+
+        let detected = ModelManager.scanLocalModels(at: root)
+        #expect(detected.map(\.id) == ["Nex-N2-Pro-JANGTQ2"])
+    }
+
     @Test func deleteModel_removesDirectoryAndResetsState() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -609,6 +609,7 @@ struct HTTPHandlerChatStreamingTests {
         #expect(status == 200)
         #expect(body.contains("\"content\":\"hello\""))
         #expect(body.contains("\"completion_tokens\":77"))
+        #expect(body.contains("\"tokens_per_second\":12.5"))
         #expect(body.contains("\"finish_reason\":\"length\""))
         #expect(!body.contains("\u{FFFE}"))
     }

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -182,6 +182,22 @@ struct MLXServiceRuntimePolicyTests {
         )
     }
 
+    @Test func mimoAndN2TextToolPreflightDoesNotRequireMediaBundleProbe() throws {
+        for (modelName, modelId) in [
+            ("mimo-v2.5-jangtq_2", "JANGQ-AI/MiMo-V2.5-JANGTQ_2"),
+            ("nex-n2-pro-jangtq2", "Nex-N2-Pro-JANGTQ2"),
+        ] {
+            try MLXService.validateRuntimePolicy(
+                modelName: modelName,
+                modelId: modelId,
+                messages: [ChatMessage(role: "user", content: "Use line_count on alpha\nbeta.")],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [Self.lineCountTool()],
+                runtime: VMLXServerRuntimeSettings()
+            )
+        }
+    }
+
     private static func lineCountTool() -> OsaurusCore.Tool {
         OsaurusCore.Tool(
             type: "function",

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -225,6 +225,109 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(effective == 24 * 1024 * 1024 * 1024)
     }
 
+    @Test("Plain MiMo JANG config-side routed metadata uses hot working set")
+    func plainMiMoJANGConfigRoutedMetadataUsesCompressionHotSet() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "mimo_v2",
+              "n_routed_experts": 256,
+              "num_experts_per_tok": 8,
+              "jang_profile": "JANG_2L_322_D3E16",
+              "routed_expert_bits": {
+                "gate_proj": 3,
+                "up_proj": 2,
+                "down_proj": 2
+              },
+              "quantization": {
+                "routed_experts": "tq_prestacked_switch_mlp"
+              }
+            }
+            """
+        let jang = """
+            {
+              "format": "jang",
+              "profile": "JANG_2L_322_D3E16",
+              "num_experts": 256,
+              "expert_layout": "stacked_affine_switch_mlp",
+              "routed_expert_bits": {
+                "gate_proj": 3,
+                "up_proj": 2,
+                "down_proj": 2
+              }
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        try Data(jang.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+
+        let raw: Int64 = 105 * 1024 * 1024 * 1024
+        let effective = ModelRuntime.effectiveLoadFootprintBytes(
+            rawWeightsBytes: raw,
+            modelDirectory: dir,
+            modelName: "mimo-v2.5-jang_2l"
+        )
+
+        #expect(effective == Int64(Double(raw) * 0.30))
+    }
+
+    @Test("Plain N2 JANG nested text-config routed metadata uses hot working set")
+    func plainN2JANGNestedTextConfigRoutedMetadataUsesCompressionHotSet() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "qwen3_5_moe",
+              "text_config": {
+                "model_type": "qwen3_5_moe_text",
+                "num_experts": 512,
+                "num_experts_per_tok": 10,
+                "full_attention_interval": 4
+              }
+            }
+            """
+        let jang = """
+            {
+              "format": "jang",
+              "quantization": {
+                "profile": "JANG_1L",
+                "actual_bits": 2.13
+              },
+              "architecture": {
+                "has_moe": true,
+                "has_ssm": true
+              }
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        try Data(jang.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+
+        let raw: Int64 = 111 * 1024 * 1024 * 1024
+        let effective = ModelRuntime.effectiveLoadFootprintBytes(
+            rawWeightsBytes: raw,
+            modelDirectory: dir,
+            modelName: "nex-n2-pro-jang_1l"
+        )
+
+        #expect(effective == Int64(Double(raw) * 0.30))
+    }
+
+    @Test("Known MiMo and N2 plain JANG names use hot working set without config JSON")
+    func knownPlainMiMoAndN2JANGNamesAvoidBundleJSONRead() throws {
+        for name in ["MiMo-V2.5-JANG_2L", "Nex-N2-Pro-JANG_1L"] {
+            let dir = try makeIsolatedDir()
+            try Data("{".utf8).write(to: dir.appendingPathComponent("config.json"))
+            try Data("{".utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+
+            let raw: Int64 = 100 * 1024 * 1024 * 1024
+            let effective = ModelRuntime.effectiveLoadFootprintBytes(
+                rawWeightsBytes: raw,
+                modelDirectory: dir,
+                modelName: name
+            )
+
+            #expect(effective == 30 * 1024 * 1024 * 1024)
+        }
+    }
+
     @Test("MiMo and N2 JANGTQ known names use hot working set without config JSON")
     func mimoAndN2JANGTQKnownNameLoadFootprintAvoidsBundleJSONRead() throws {
         for name in ["MiMo-V2.5-JANGTQ_2", "Nex-N2-Pro-JANGTQ2"] {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -187,6 +187,114 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(effective == 30 * 1024 * 1024 * 1024)
     }
 
+    @Test("MiMo JANGTQ config-side routed metadata uses hot working set")
+    func mimoJANGTQConfigRoutedMetadataUsesCompressionHotSet() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "mimo_v2",
+              "jang_profile": "JANGTQ_2",
+              "mxtq_bits": {
+                "routed_expert": {
+                  "gate_proj": 2,
+                  "up_proj": 2,
+                  "down_proj": 2
+                }
+              },
+              "quantization": {
+                "routed_experts": "tq_prestacked_switch_mlp"
+              }
+            }
+            """
+        let jang = """
+            {
+              "weight_format": "mxtq"
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        try Data(jang.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+        try Data([0]).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+
+        let raw: Int64 = 80 * 1024 * 1024 * 1024
+        let effective = ModelRuntime.effectiveLoadFootprintBytes(
+            rawWeightsBytes: raw,
+            modelDirectory: dir,
+            modelName: "mimo-v2.5-jangtq_2"
+        )
+
+        #expect(effective == 24 * 1024 * 1024 * 1024)
+    }
+
+    @Test("MiMo and N2 JANGTQ known names use hot working set without config JSON")
+    func mimoAndN2JANGTQKnownNameLoadFootprintAvoidsBundleJSONRead() throws {
+        for name in ["MiMo-V2.5-JANGTQ_2", "Nex-N2-Pro-JANGTQ2"] {
+            let dir = try makeIsolatedDir()
+            try Data("{".utf8).write(to: dir.appendingPathComponent("config.json"))
+            try Data("{".utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+            try Data([0]).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+
+            let raw: Int64 = 100 * 1024 * 1024 * 1024
+            let effective = ModelRuntime.effectiveLoadFootprintBytes(
+                rawWeightsBytes: raw,
+                modelDirectory: dir,
+                modelName: name
+            )
+
+            #expect(effective == 30 * 1024 * 1024 * 1024)
+        }
+    }
+
+    @Test("MiMo and N2 JANGTQ known names estimate KV headroom without config JSON")
+    func mimoAndN2JANGTQKnownNameKVHeadroomAvoidsBundleJSONRead() throws {
+        let dir = try makeIsolatedDir()
+        try Data("{".utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let weights: Int64 = 30 * 1024 * 1024 * 1024
+        #expect(
+            ModelRuntime.estimatedKVHeadroomBytes(
+                forWeights: weights,
+                modelDirectory: dir,
+                modelName: "MiMo-V2.5-JANGTQ_2"
+            ) == 512 * 1024 * 1024
+        )
+        #expect(
+            ModelRuntime.estimatedKVHeadroomBytes(
+                forWeights: weights,
+                modelDirectory: dir,
+                modelName: "Nex-N2-Pro-JANGTQ2"
+            ) == 4 * 1024 * 1024 * 1024
+        )
+    }
+
+    @Test("MiMo sliding-window KV headroom does not charge full theoretical context")
+    func mimoSlidingWindowKVHeadroomUsesActiveWindow() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "mimo_v2",
+              "num_hidden_layers": 48,
+              "num_attention_heads": 64,
+              "num_key_value_heads": 4,
+              "hidden_size": 4096,
+              "max_position_embeddings": 1048576,
+              "sliding_window_size": 128,
+              "attention_chunk_size": 128,
+              "torch_dtype": "bfloat16"
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let weights: Int64 = 80 * 1024 * 1024 * 1024
+        let fallback = ModelRuntime.estimatedKVHeadroomBytes(forWeights: weights)
+        let topology = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir
+        )
+
+        #expect(fallback == 16 * 1024 * 1024 * 1024)
+        #expect(topology == 512 * 1024 * 1024)
+    }
+
     @Test("Non-JANGTQ and missing-sidecar models keep raw pre-load RAM budget")
     func nonJANGTQLoadFootprintKeepsRawBudget() throws {
         let plain = try makeIsolatedDir()
@@ -243,6 +351,32 @@ struct ModelRuntimeFindDirectoryTests {
         try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
         // Should not throw.
         try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "MiniMax-JANGTQ-OK")
+    }
+
+    @Test("MiMo and N2 JANGTQ app load preflight requires sidecar without reading bundle JSON")
+    func mimoAndN2JANGTQSidecarFastPathAvoidsBundleJSONRead() async throws {
+        for name in ["MiMo-V2.5-JANGTQ_2", "Nex-N2-Pro-JANGTQ2"] {
+            let dir = try makeIsolatedDir()
+            // Deliberately malformed: this proves the app-side async preflight
+            // is not synchronously opening/parsing jang_config.json for these
+            // vMLX-owned runtime rows when the sidecar is present.
+            try Data("{".utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+            try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
+
+            try await ModelRuntime.ensureJANGTQSidecar(at: dir, modelId: name, name: name)
+        }
+    }
+
+    @Test("MiMo and N2 JANGTQ app load preflight refuses missing sidecar")
+    func mimoAndN2JANGTQSidecarFastPathStillRejectsMissingSidecar() async throws {
+        for name in ["MiMo-V2.5-JANGTQ_2", "Nex-N2-Pro-JANGTQ2"] {
+            let dir = try makeIsolatedDir()
+            try Data("{".utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+
+            await #expect(throws: Error.self) {
+                try await ModelRuntime.ensureJANGTQSidecar(at: dir, modelId: name, name: name)
+            }
+        }
     }
 
     @Test("Non-JANGTQ jang_config is passed through (no sidecar required)")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -548,12 +548,13 @@ struct RuntimePolicySourceTests {
         // parser/cache hardening plus LFM/ZAYA cache proof pins carried by
         // the current vMLX runtime branch, including stale ZAYA tool-template
         // shim detection so tagged but non-choice-aware local templates do not
-        // bypass required-tool handling.
+        // bypass required-tool handling, and the LFM required-tool solo
+        // disk-restore skip plus schema-validated Pythonic parser hardening.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "edcef93f6a0147d3e568aa512adf94a42cf212e9"
+        let expectedRuntimeHardenedRevision = "5441ab41f14ee3164e93d36558a1f9213c27dda3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -561,7 +562,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, and DSV4 required-tool reminder placement before the current tail user turn; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 Pythonic parser schema validation, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, and DSV4 required-tool reminder placement before the current tail user turn; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "aabc41936f1ce2746d1098a14f12b441a04ed30b"
+        let expectedRuntimeHardenedRevision = "d9c50a9f5f9625152c4b755b2972441445cecd08"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "5441ab41f14ee3164e93d36558a1f9213c27dda3"
+        let expectedRuntimeHardenedRevision = "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
+        let expectedRuntimeHardenedRevision = "aabc41936f1ce2746d1098a14f12b441a04ed30b"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -1730,6 +1730,18 @@ struct RuntimePolicySourceTests {
         let body = String(runtime[start.lowerBound ..< end])
 
         #expect(body.contains("contentsOfDirectory("))
+        let knownMiMoN2Size = try #require(body.range(of: "knownMiMoOrN2JANGTQWeightsSizeBytes"))
+        let indexRead = try #require(body.range(of: "Data(contentsOf: indexURL)"))
+        #expect(
+            knownMiMoN2Size.lowerBound < indexRead.lowerBound,
+            "Known MiMo/N2 JANGTQ app preflight must not open external index JSON before it can use exact bundle-size metadata."
+        )
+        let totalSize = try #require(body.range(of: "metadata[\"total_size\"]"))
+        let shardLoop = try #require(body.range(of: "for shardCount in 2 ... 256"))
+        #expect(
+            totalSize.lowerBound < shardLoop.lowerBound,
+            "Sharded safetensors bundles must use metadata.total_size before probing every shard file on external volumes."
+        )
         #expect(
             !body.contains("enumerator("),
             "Weight-size preflight must not recursively walk huge model bundles or symlinked cache folders on the request path."
@@ -1751,7 +1763,7 @@ struct RuntimePolicySourceTests {
         // because the pre-load RAM-feasibility gate and the in-flight-load
         // reservation both need the incoming bundle's footprint up front.
         #expect(loadPreflight.contains("if policy == .manualMultiModel"))
-        #expect(loadPreflight.contains("let weightsBytes = Self.computeWeightsSizeBytes(at: localURL)"))
+        #expect(loadPreflight.contains("let weightsBytes = Self.computeWeightsSizeBytes(at: localURL, modelName: name)"))
         #expect(
             loadPreflight.contains("let loadFootprintBytes = Self.effectiveLoadFootprintBytes("),
             "Routed mmap/JANGTQ loads must feed the RAM gate with vMLX's effective hot working set, not the whole safetensors shard total."
@@ -1779,6 +1791,67 @@ struct RuntimePolicySourceTests {
         #expect(health.contains("\"available_memory_bytes\": f.availableMemoryBytes"))
         #expect(health.contains("\"required_available_bytes\": f.requiredAvailableBytes"))
         #expect(health.contains("\"incoming_load_footprint_bytes\": f.incomingLoadFootprintBytes"))
+    }
+
+    @Test("MiMo and N2 text runtime metadata avoids VLM bundle reads")
+    func mimoAndN2TextRuntimeMetadataAvoidsVLMBundleReads() throws {
+        let model = try Self.source("Models/Configuration/MLXModel.swift")
+        let vlm = try Self.source("Models/Configuration/VLMDetection.swift")
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+
+        let isVLMStart = try #require(model.range(of: "var isVLM: Bool"))
+        let isDownloaded = try #require(
+            model.range(
+                of: "if isDownloaded { return VLMDetection.isVLM(at: localDirectory) }",
+                range: isVLMStart.lowerBound ..< model.endIndex
+            )
+        )
+        let modelFastPath = try #require(
+            model.range(
+                of: "ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily",
+                range: isVLMStart.lowerBound ..< isDownloaded.lowerBound
+            )
+        )
+        #expect(modelFastPath.lowerBound < isDownloaded.lowerBound)
+
+        let idStart = try #require(vlm.range(of: "static func isVLM(modelId: String)"))
+        let dirLookup = try #require(
+            vlm.range(
+                of: "findLocalModelDirectory(forModelId: modelId)",
+                range: idStart.lowerBound ..< vlm.endIndex
+            )
+        )
+        let vlmFastPath = try #require(
+            vlm.range(
+                of: "ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelId)",
+                range: idStart.lowerBound ..< dirLookup.lowerBound
+            )
+        )
+        #expect(vlmFastPath.lowerBound < dirLookup.lowerBound)
+
+        let compressionStart = try #require(runtime.range(of: "private static func isRoutedJANGTQCompressionLoad"))
+        let jsonRead = try #require(
+            runtime.range(of: "Self.readJSONObject", range: compressionStart.lowerBound ..< runtime.endIndex)
+        )
+        let compressionFastPath = try #require(
+            runtime.range(
+                of: "ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName)",
+                range: compressionStart.lowerBound ..< jsonRead.lowerBound
+            )
+        )
+        #expect(compressionFastPath.lowerBound < jsonRead.lowerBound)
+
+        let mtpStart = try #require(runtime.range(of: "private nonisolated static func resolveNativeMTPLaunchPlan"))
+        let mtpJSONRead = try #require(
+            runtime.range(of: "Data(contentsOf:", range: mtpStart.lowerBound ..< runtime.endIndex)
+        )
+        let mtpFastPath = try #require(
+            runtime.range(
+                of: "ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName)",
+                range: mtpStart.lowerBound ..< mtpJSONRead.lowerBound
+            )
+        )
+        #expect(mtpFastPath.lowerBound < mtpJSONRead.lowerBound)
     }
 
     @Test("MTP bundles auto-resolve vmlx tuning into load and generation")
@@ -2300,6 +2373,24 @@ struct RuntimePolicySourceTests {
         #expect(!featuresDoc.contains("default `4`"))
         #expect(adapter.contains("hot-resized BatchEngine"))
         #expect(adapter.contains("rejected updateMaxBatchSize"))
+    }
+
+    @Test("MiMo and N2 tool preflight does not walk external bundles")
+    func mimoAndN2ToolPreflightAvoidsExternalBundleWalk() throws {
+        let service = try Self.source("Services/Inference/MLXService.swift")
+        let support = try #require(service.range(of: "nonisolated static func supportsLocalToolCalling"))
+        let end = service.range(of: "private nonisolated static func localModelDirectory", range: support.lowerBound..<service.endIndex)
+            .map(\.lowerBound) ?? service.endIndex
+        let body = String(service[support.lowerBound..<end])
+        let jangFastPath = try #require(body.range(of: "isKnownTextOnlyJANGRuntimeFamily"))
+        let bundleLookup = try #require(body.range(of: "localModelDirectory(modelId: modelId)"))
+
+        #expect(body.contains("if isKnownTextOnlyJANGRuntimeFamily(modelId: modelId)"))
+        #expect(body.contains("return true"))
+        #expect(
+            jangFastPath.lowerBound < bundleLookup.lowerBound,
+            "MiMo/N2 JANG tool preflight must short-circuit before external bundle metadata lookup."
+        )
     }
 
     @Test("Runtime docs keep upstream Metal fault boundaries explicit")

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
+        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "590fa2854fc8effc5618cdb2dfddd98e2ac3c3724f82232e93c3cf7b6e5e6e11",
+  "originHash" : "988547d2be295587092907cbe309cf4c6afd8725bc67dc9538943849e6776070",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "edcef93f6a0147d3e568aa512adf94a42cf212e9"
+        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5441ab41f14ee3164e93d36558a1f9213c27dda3"
+        "revision" : "98d47308012ab0e88e7b4aa4543f7920c13c4d53"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "988547d2be295587092907cbe309cf4c6afd8725bc67dc9538943849e6776070",
+  "originHash" : "129f8c0a4f5f538e9ee74231735f837b1bc2babf564aab4434be6d56236072f1",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aabc41936f1ce2746d1098a14f12b441a04ed30b"
+        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
       }
     },
     {


### PR DESCRIPTION
## Summary
- pin OsaurusCore and app/workspace resolver surfaces to vMLX main 98d47308
- update the runtime source-policy guard so all pin surfaces must consume the same hardened vMLX main SHA
- carries LFM required-tool cache-restore skip and Pythonic parser schema validation merged in osaurus-ai/vmlx-swift main

## Verification
- env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening --jobs 1 --no-parallel
- no-sign app build: scripts/live-proof/build-keychain-free-osaurus.sh build/DerivedData-keychain-free-lfm-solo-cache-5441ab41-20260608
- cold live proof artifact: /tmp/osaurus-lfm25-mxfp8-5441ab41-cold-20260608-150825

## Boundary
LFM2.5 MXFP8 warm multi-turn proof remains partial. Warm 2048 proved disk_l2_hits=1 and ssm_companion_hits=1, then later failed schema-exact turn 3; repeat warm failed turn 1. This PR carries real source hardening and graceful invalid-args behavior, not a full LFM release promotion.