### PR TITLE
Pin vMLX MiMo routed JANG fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
+        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
+        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d9c50a9f5f9625152c4b755b2972441445cecd08"
+            revision: "08ed3172a55faf9751f4b148705dbf0a92749829"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "d9c50a9f5f9625152c4b755b2972441445cecd08"
+        let expectedRuntimeHardenedRevision = "08ed3172a55faf9751f4b148705dbf0a92749829"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d9c50a9f5f9625152c4b755b2972441445cecd08"
+        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pins Osaurus to vMLX main `08ed3172a55faf9751f4b148705dbf0a92749829`.
- Keeps all Osaurus vMLX pin surfaces aligned: package manifest, package lockfile, workspace lockfile, app lockfile, and runtime source gate.
- Carries the vMLX MiMo routed affine JANG bit-plan fix into Osaurus after PR #1421 merged.

## Proof
- vMLX main focused tests passed for MiMo/N2 JANG metadata and shape-walk paths.
- Osaurus focused source gate passed:
  `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`, MiMo/N2 preflight rows, and `MLXServiceRuntimePolicyTests/mimoAndN2TextToolPreflightDoesNotRequireMediaBundleProbe`.
- No fake runtime behavior changes: no sampler overrides, prompt coercion, parser stripping, retry-after-crash wrapper, or forced reasoning tags.

## Runtime Status
- Nex-N2-Pro-JANG_1L: app/API correctness and hybrid SSM cache proof already captured; speed remains partial.
- MiMo-V2.5-JANG_2L: vMLX full-RAM direct mode proof is green with bundle `enable_thinking=false`; Osaurus no-sign app build/live proof is being updated on this PR.
