### PR TITLE
Add Gemma4 media capability diagnostics

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
+        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
+        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
+++ b/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
@@ -50,7 +50,9 @@ Pinned to the regex/substring matcher in
 - PaliGemma, Idefics 3, FastVLM, Llava-Qwen2
 - Pixtral standalone (NOT the Mistral 3 wrapper — that's matched separately)
 - GLM-OCR, LFM2-VL
-- Gemma 3, Gemma 4 (the `-it` VLM variants)
+- Gemma 3, Gemma 4 (the `-it` VLM variants). Gemma4 audio is a
+  proof-required status, not a supported status, until live model routing
+  evidence exists.
 - Mistral 3 / Mistral 3.5 (image only via Pixtral wrapper) — regex `mistral[-_](3|medium-3)`
 - Mistral 4 VL — regex `mistral[-_]?4.*[-_]vl`
 
@@ -249,6 +251,7 @@ let message = ChatMessage(
 import OsaurusCore
 
 let caps = ModelMediaCapabilities.from(modelId: currentModelId)
+let descriptor = ModelMediaCapabilities.descriptor(modelId: currentModelId)
 
 if caps.supportsAudio {
     // show audio picker / drop zone
@@ -263,6 +266,11 @@ print(caps.summary)
 // → "image + video"          (Qwen-VL family)
 // → "image"                   (image-only VLMs)
 // → "text-only"               (dense LLMs)
+
+print(descriptor.audio.status.rawValue)
+// → "supported"  (Nemotron Omni)
+// → "unproven"   (Gemma4 VLM audio before live proof)
+// → "unsupported" (text/image/video-only families)
 ```
 
 For accuracy after model load, prefer:
@@ -284,7 +292,7 @@ community-renamed bundles) resolve correctly via the on-disk config.
 
 | Layer | Test file | Cases |
 |---|---|---|
-| Capability detection (regex/substring) | `Tests/Model/ModelMediaCapabilitiesMCDCTests.swift` | 27 MC/DC-shaped |
+| Capability detection (regex/substring + modality status) | `Tests/Model/ModelMediaCapabilitiesMCDCTests.swift` | MC/DC-shaped + descriptor cases |
 | API content-part round-trip | `Tests/Model/MultimodalContentPartTests.swift` | 9 |
 | Data URL materialization audit fix | `Tests/Model/MaterializeMediaDataUrlMCDCTests.swift` | 11 MC/DC |
 | Hybrid-cache substring matcher | `Tests/Service/IsKnownHybridModelMCDCTests.swift` | 14 MC/DC |

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -29,6 +29,74 @@ import Foundation
 
 public enum ModelMediaCapabilities {
 
+    public enum Modality: String, CaseIterable, Sendable {
+        case image
+        case video
+        case audio
+
+        public var label: String { rawValue }
+    }
+
+    public enum ModalityStatus: String, Sendable {
+        case supported
+        case unsupported
+        case unproven
+        case disabled
+
+        public var isUsable: Bool {
+            self == .supported
+        }
+    }
+
+    public struct ModalityDescriptor: Equatable, Sendable {
+        public let modality: Modality
+        public let status: ModalityStatus
+        public let reason: String
+
+        public var isUsable: Bool { status.isUsable }
+
+        public var summary: String {
+            switch status {
+            case .supported:
+                return "\(modality.label): supported"
+            case .unsupported:
+                return "\(modality.label): unsupported"
+            case .unproven:
+                return "\(modality.label): proof required"
+            case .disabled:
+                return "\(modality.label): disabled"
+            }
+        }
+    }
+
+    public struct Descriptor: Equatable, Sendable {
+        public let modelId: String
+        public let capabilities: Capabilities
+        public let image: ModalityDescriptor
+        public let video: ModalityDescriptor
+        public let audio: ModalityDescriptor
+
+        public func descriptor(for modality: Modality) -> ModalityDescriptor {
+            switch modality {
+            case .image: return image
+            case .video: return video
+            case .audio: return audio
+            }
+        }
+
+        public var statusSummary: String {
+            [image, video, audio].map(\.summary).joined(separator: "; ")
+        }
+
+        public func rejectionMessage(for modality: Modality) -> String {
+            let target = descriptor(for: modality)
+            if capabilities.anyMedia {
+                return "\(target.reason) The current model supports \(capabilities.summary) only."
+            }
+            return "\(target.reason) The current model is text-only."
+        }
+    }
+
     /// Per-modality capability flags for a single model. Drives the
     /// chat composer's drag/drop allowlist + the file-picker's
     /// `allowedContentTypes`.
@@ -210,6 +278,36 @@ public enum ModelMediaCapabilities {
         )
     }
 
+    public static func descriptor(modelId: String) -> Descriptor {
+        buildDescriptor(
+            modelId: modelId,
+            capabilities: from(modelId: modelId),
+            source: "model id"
+        )
+    }
+
+    public static func composerDescriptor(
+        modelId: String?,
+        fallbackSupportsImages: Bool
+    ) -> Descriptor {
+        let normalized = modelId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let displayId = normalized.isEmpty ? "unspecified model" : normalized
+        let capabilities = composerCapabilities(
+            modelId: modelId,
+            fallbackSupportsImages: fallbackSupportsImages
+        )
+        let detected = normalized.isEmpty ? Capabilities.textOnly : from(modelId: normalized)
+        let source =
+            fallbackSupportsImages && capabilities.supportsImage && !detected.supportsImage
+            ? "composer fallback"
+            : "model id"
+        return buildDescriptor(
+            modelId: displayId,
+            capabilities: capabilities,
+            source: source
+        )
+    }
+
     /// Resolve capabilities by inspecting the locally-installed bundle.
     /// Use after the model is downloaded for the most accurate signal.
     /// Falls back to `from(modelId:)` if config.json is unreadable.
@@ -264,7 +362,86 @@ public enum ModelMediaCapabilities {
         return .imageOnly
     }
 
+    public static func descriptor(directory: URL, modelId: String) -> Descriptor {
+        buildDescriptor(
+            modelId: modelId,
+            capabilities: from(directory: directory, modelId: modelId),
+            source: "bundle config"
+        )
+    }
+
     // MARK: - Helpers
+
+    private static func buildDescriptor(
+        modelId: String,
+        capabilities: Capabilities,
+        source: String
+    ) -> Descriptor {
+        Descriptor(
+            modelId: modelId,
+            capabilities: capabilities,
+            image: ModalityDescriptor(
+                modality: .image,
+                status: capabilities.supportsImage ? .supported : .unsupported,
+                reason: capabilities.supportsImage
+                    ? "Image input is enabled by \(source)."
+                    : "Image input is not advertised for \(modelId)."
+            ),
+            video: ModalityDescriptor(
+                modality: .video,
+                status: capabilities.supportsVideo ? .supported : .unsupported,
+                reason: capabilities.supportsVideo
+                    ? "Video input is enabled by \(source)."
+                    : "Video input is not advertised for \(modelId)."
+            ),
+            audio: audioDescriptor(
+                modelId: modelId,
+                capabilities: capabilities,
+                source: source
+            )
+        )
+    }
+
+    private static func audioDescriptor(
+        modelId: String,
+        capabilities: Capabilities,
+        source: String
+    ) -> ModalityDescriptor {
+        if capabilities.supportsAudio {
+            return ModalityDescriptor(
+                modality: .audio,
+                status: .supported,
+                reason: "Audio input is enabled by \(source)."
+            )
+        }
+        if isGemma4VisionFamily(modelId, capabilities: capabilities) {
+            return ModalityDescriptor(
+                modality: .audio,
+                status: .unproven,
+                reason:
+                    "Gemma4 audio input is not enabled because native audio routing still needs live model proof."
+            )
+        }
+        return ModalityDescriptor(
+            modality: .audio,
+            status: .unsupported,
+            reason: "Audio input is not advertised for \(modelId)."
+        )
+    }
+
+    private static func isGemma4VisionFamily(
+        _ modelId: String,
+        capabilities: Capabilities? = nil
+    ) -> Bool {
+        let lower = modelId.lowercased()
+        guard lower.contains("gemma-4") || lower.contains("gemma4") else {
+            return false
+        }
+        if let capabilities {
+            return capabilities.supportsImage
+        }
+        return lower.contains("-it") || lower.contains("_it")
+    }
 
     private static func regexMatches(_ s: String, pattern: String) -> Bool {
         guard let re = try? NSRegularExpression(pattern: pattern) else { return false }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
+        "revision" : "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
+        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
+        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "08ed3172a55faf9751f4b148705dbf0a92749829"
+            revision: "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
+            revision: "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
+            revision: "ca9b5b99b0623e04a14e7a569c0e282b43294937"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -257,15 +257,16 @@ actor MLXService: ToolCapableService {
         )
 
         var issues = serverResult.issues.map { $0.message }
-        let media = mediaCapabilities(modelId: modelId)
+        let mediaDescriptor = mediaCapabilityDescriptor(modelId: modelId)
+        let media = mediaDescriptor.capabilities
         if modalities.contains(.vision), !media.supportsImage {
-            issues.append("Model capability detection reports vision as unsupported.")
+            issues.append(mediaDescriptor.descriptor(for: .image).reason)
         }
         if modalities.contains(.video), !media.supportsVideo {
-            issues.append("Model capability detection reports video as unsupported.")
+            issues.append(mediaDescriptor.descriptor(for: .video).reason)
         }
         if modalities.contains(.audio), !media.supportsAudio {
-            issues.append("Model capability detection reports audio as unsupported.")
+            issues.append(mediaDescriptor.descriptor(for: .audio).reason)
         }
         if !tools.isEmpty,
             !supportsLocalToolCalling(modelName: modelName, modelId: modelId)
@@ -444,12 +445,36 @@ actor MLXService: ToolCapableService {
     private nonisolated static func mediaCapabilities(
         modelId: String
     ) -> ModelMediaCapabilities.Capabilities {
+        mediaCapabilityDescriptor(modelId: modelId).capabilities
+    }
+
+    private nonisolated static func mediaCapabilityDescriptor(
+        modelId: String
+    ) -> ModelMediaCapabilities.Descriptor {
         if isKnownTextOnlyJANGRuntimeFamily(modelId: modelId) {
             // MiMo/N2 JANG and JANGTQ rows are text/tool runtimes in this
             // Osaurus lane. Avoid synchronous directory/VLM probing on large
             // or symlinked external bundles during request preflight; vMLX
             // still owns the real model/template/tool load path.
-            return .textOnly
+            return ModelMediaCapabilities.Descriptor(
+                modelId: modelId,
+                capabilities: .textOnly,
+                image: .init(
+                    modality: .image,
+                    status: .unsupported,
+                    reason: "Image input is not advertised for this text/tool runtime family."
+                ),
+                video: .init(
+                    modality: .video,
+                    status: .unsupported,
+                    reason: "Video input is not advertised for this text/tool runtime family."
+                ),
+                audio: .init(
+                    modality: .audio,
+                    status: .unsupported,
+                    reason: "Audio input is not advertised for this text/tool runtime family."
+                )
+            )
         }
         if ModelFamilyNames.isStepFamily(modelId) {
             // Step 3.7 currently runs through vMLX's Step text runtime in
@@ -457,16 +482,16 @@ actor MLXService: ToolCapableService {
             // Step VLM path is not wired or proven here; keep request gating
             // text-only and avoid blocking runtime preflight on large
             // external-bundle metadata reads.
-            return ModelMediaCapabilities.from(modelId: modelId)
+            return ModelMediaCapabilities.descriptor(modelId: modelId)
         }
         let parts = modelId.split(separator: "/").map(String.init)
         let localDirectory = parts.reduce(DirectoryPickerService.effectiveModelsDirectory()) {
             $0.appendingPathComponent($1, isDirectory: true)
         }
         if FileManager.default.fileExists(atPath: localDirectory.path) {
-            return ModelMediaCapabilities.from(directory: localDirectory, modelId: modelId)
+            return ModelMediaCapabilities.descriptor(directory: localDirectory, modelId: modelId)
         }
-        return ModelMediaCapabilities.from(modelId: modelId)
+        return ModelMediaCapabilities.descriptor(modelId: modelId)
     }
 
     private nonisolated static func isKnownTextOnlyJANGRuntimeFamily(modelId: String) -> Bool {

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -310,6 +310,30 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.Capabilities.omni.anyMedia)
     }
 
+    @Test("Descriptor marks Gemma4 audio as proof-required, not supported")
+    func descriptor_gemma4AudioProofRequired() {
+        let descriptor = ModelMediaCapabilities.descriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4"
+        )
+
+        #expect(descriptor.capabilities == .imageOnly)
+        #expect(descriptor.image.status == .supported)
+        #expect(descriptor.audio.status == .unproven)
+        #expect(!descriptor.audio.isUsable)
+        #expect(descriptor.rejectionMessage(for: .audio).contains("live model proof"))
+    }
+
+    @Test("Descriptor keeps Nemotron Omni audio supported")
+    func descriptor_nemotronOmniAudioSupported() {
+        let descriptor = ModelMediaCapabilities.descriptor(
+            modelId: "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4"
+        )
+
+        #expect(descriptor.capabilities == .omni)
+        #expect(descriptor.audio.status == .supported)
+        #expect(descriptor.audio.isUsable)
+    }
+
     @Test("Composer capabilities merge image fallback only")
     func composerCapabilities_mergeImageFallbackOnly() {
         #expect(

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -109,6 +109,35 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
+    @Test func modelCapabilityRejectsGemma4AudioAsProofRequired() {
+        let message = ChatMessage(
+            role: "user",
+            content: "hear this",
+            contentParts: [
+                .text("hear this"),
+                .audioInput(data: "AAAA", format: "wav"),
+            ]
+        )
+
+        do {
+            try MLXService.validateRuntimePolicy(
+                modelName: "gemma-4-12b-it-mxfp4",
+                modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+                messages: [message],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [],
+                runtime: VMLXServerRuntimeSettings()
+            )
+            Issue.record("Gemma4 audio should remain blocked until live proof exists.")
+        } catch let error as MLXService.RuntimePolicyError {
+            let description = error.errorDescription ?? ""
+            #expect(description.contains("Gemma4 audio input is not enabled"))
+            #expect(description.contains("live model proof"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
     @Test func policyRejectsKnownBadZayaVLJANGTQKDiagnosticArtifact() {
         #expect(throws: MLXService.RuntimePolicyError.self) {
             try MLXService.validateRuntimePolicy(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -554,7 +554,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "08ed3172a55faf9751f4b148705dbf0a92749829"
+        let expectedRuntimeHardenedRevision = "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -884,7 +884,7 @@ struct RuntimePolicySourceTests {
             mlxService.contains("ModelFamilyNames.isStepFamily(modelId)")
                 && mlxService.contains("Step 3.7 currently runs through vMLX's Step text runtime")
                 && mlxService.contains("Step 3.7 tool parsing/template selection is owned by the pinned")
-                && mlxService.contains("return ModelMediaCapabilities.from(modelId: modelId)"),
+                && mlxService.contains("return ModelMediaCapabilities.descriptor(modelId: modelId)"),
             "Step 3.7 runtime policy must stay text-only/tool-capable and must not block preflight on external bundle metadata until Step VLM is wired and proven"
         )
     }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -548,13 +548,15 @@ struct RuntimePolicySourceTests {
         // parser/cache hardening plus LFM/ZAYA cache proof pins carried by
         // the current vMLX runtime branch, including stale ZAYA tool-template
         // shim detection so tagged but non-choice-aware local templates do not
-        // bypass required-tool handling, and the LFM required-tool solo
-        // disk-restore skip plus schema-validated Pythonic parser hardening.
+        // bypass required-tool handling, the LFM required-tool solo
+        // disk-restore skip plus schema-validated Pythonic parser hardening,
+        // and the cross-target MLX test lock that prevents the Gemma4
+        // audio/media/cache source proof from crashing under Swift Testing.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
+        let expectedRuntimeHardenedRevision = "ca9b5b99b0623e04a14e7a569c0e282b43294937"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -562,7 +564,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 Pythonic parser schema validation, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, and DSV4 required-tool reminder placement before the current tail user turn; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 Pythonic parser schema validation, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, DSV4 required-tool reminder placement before the current tail user turn, and the Gemma4 audio/media/cache Swift Testing crash fix; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2618,11 +2618,15 @@ extension FloatingInputCard {
     /// See `Models/Configuration/ModelMediaCapabilities.swift` for the
     /// substring/regex matcher; tests pin the boundary at
     /// `ModelMediaCapabilitiesMCDCTests`.
-    private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
-        ModelMediaCapabilities.composerCapabilities(
+    private var mediaCapabilityDescriptor: ModelMediaCapabilities.Descriptor {
+        ModelMediaCapabilities.composerDescriptor(
             modelId: selectedModel,
             fallbackSupportsImages: supportsImages
         )
+    }
+
+    private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
+        mediaCapabilityDescriptor.capabilities
     }
 
     /// UTTypes the drop zone advertises. `fileURL` stays enabled for
@@ -2702,17 +2706,15 @@ extension FloatingInputCard {
     /// them as opaque documents.
     private func attachIfAllowed(url: URL) {
         let ext = url.pathExtension.lowercased()
-        let cap = mediaCapabilities
+        let descriptor = mediaCapabilityDescriptor
+        let cap = descriptor.capabilities
 
         // Image fast path — only for image-capable models.
         if DocumentParser.isImageFile(url: url) {
             guard cap.supportsImage else {
                 ToastManager.shared.error(
                     L("Cannot attach \(url.lastPathComponent)"),
-                    message:
-                        cap.anyMedia
-                        ? L("The current model supports \(cap.summary) only.")
-                        : L("The current model is text-only.")
+                    message: descriptor.rejectionMessage(for: .image)
                 )
                 return
             }
@@ -2736,13 +2738,27 @@ extension FloatingInputCard {
         }
 
         // Audio path — only for omni models.
-        if cap.supportsAudio, audioExtensions.contains(ext) {
+        if audioExtensions.contains(ext) {
+            guard cap.supportsAudio else {
+                ToastManager.shared.error(
+                    L("Cannot attach \(url.lastPathComponent)"),
+                    message: descriptor.rejectionMessage(for: .audio)
+                )
+                return
+            }
             attachAudio(url: url, ext: ext)
             return
         }
 
         // Video path — Qwen-VL family + SmolVLM 2 + Nemotron-Omni.
-        if cap.supportsVideo, videoExtensions.contains(ext) {
+        if videoExtensions.contains(ext) {
+            guard cap.supportsVideo else {
+                ToastManager.shared.error(
+                    L("Cannot attach \(url.lastPathComponent)"),
+                    message: descriptor.rejectionMessage(for: .video)
+                )
+                return
+            }
             attachVideo(url: url)
             return
         }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08ed3172a55faf9751f4b148705dbf0a92749829"
+        "revision" : "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
+        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9a6765abaa138ace0b79a5b03ccd3546a3bbdd53"
+        "revision" : "65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f"
       }
     },
     {

--- a/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
+++ b/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
@@ -146,18 +146,21 @@ if [[ -f "$VLM" ]]; then
   else
     fail_msg "Gemma4 processor does not preserve tool schemas into LMInput"
   fi
-  if rg -Fq 'LMInput.audio and LMInput.video must be nil' "$VLM" \
+  if rg -Fq 'Gemma4 VLM does not implement video inputs; LMInput.video must be nil' "$VLM" \
     && rg -Fq 'featuresList.append(embedVision(unifiedVisionEmbedder(singleImage)))' "$VLM" \
-    && rg -Fq 'hidden = patchNorm2(hidden)' "$VLM" \
-    && rg -Fq 'hidden = posNorm(hidden + posHidden.asType(hidden.dtype))' "$VLM" \
-    && rg -Fq 'func callAsFunction(_ x: MLXArray) -> MLXArray { proj(rmsNormNoScale(x)) }' "$VLM" \
+    && rg -Fq '@ModuleInfo(key: "embed_audio") private var embedAudio: MultimodalEmbedder' "$VLM" \
+    && rg -Fq 'Gemma4 audio requires pre-encoded 640-dim audio features' "$VLM" \
+    && rg -Fq 'let projectedAudio = embedAudio(audioFeatures).asType(emb.dtype)' "$VLM" \
+    && rg -Fq 'Raw waveform feature extraction is not implemented for Gemma4 yet' "$VLM" \
     && rg -Fq 'var softTokenCounts: [Int] = []' "$VLM" \
     && rg -Fq 'softTokenCounts.append(patchCount / (config.poolingKernelSize * config.poolingKernelSize))' "$VLM" \
     && rg -Fq 'tokenizer.convertTokenToId("<|image>")' "$VLM" \
-    && rg -Fq 'tokenizer.convertTokenToId("<image|>")' "$VLM"; then
-    pass "Gemma4 unified image path uses upstream embedder order and exact soft-token expansion"
+    && rg -Fq 'tokenizer.convertTokenToId("<image|>")' "$VLM" \
+    && rg -Fq 'tokenizer.convertTokenToId("<|audio>")' "$VLM" \
+    && rg -Fq 'tokenizer.convertTokenToId("<audio|>")' "$VLM"; then
+    pass "Gemma4 unified image/pre-encoded-audio path and video/raw-audio boundary are wired"
   else
-    fail_msg "Gemma4 unified image/audio boundary or image embedder wiring is incomplete"
+    fail_msg "Gemma4 unified image/pre-encoded-audio boundary or embedder wiring is incomplete"
   fi
   if rg -Fq 'Gemma4 unified image inputs are not production-supported yet' "$VLM"; then
     fail_msg "Gemma4 unified image path is still guarded as unsupported in the pinned checkout"


### PR DESCRIPTION
## Maintainer status

Ready for maintainer review once GitHub checks finish on head `9656196c77b841e966e71bfdf1558f39dee83ab0`. The PR is non-draft. Local focused regression passed after the latest vMLX pin alignment: `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-pr1427-ci-fix-3 swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests|ChatSessionQueuedSendTests|ModelMediaCapabilitiesMCDCTests|MLXServiceRuntimePolicyTests'` (137 tests). The body below describes the runtime/business rationale.

## Summary

- add a shared media capability descriptor with per-modality status/reason details
- keep Gemma4 VLM audio blocked as proof-required instead of advertising native audio as usable before live proof
- surface model-specific rejection reasons in the composer and MLX runtime preflight paths
- pin `vmlx-swift` to `65679afcb7da5ef1ae4e06cbc2ed2479a7077e7f` and update the Gemma4 parser/media live-proof guard
- document the descriptor/status contract for media attachments

## Business rationale

Users need clear feedback when an attachment is rejected. Gemma4 image-capable variants should not imply audio support until native audio routing has proof, but the UI/runtime should explain that the gap is proof-required instead of producing a generic unsupported/text-only failure. The vMLX pin keeps Osaurus wired to the Gemma4 parser and media boundary fixes this PR depends on.

## Coding rationale

This extends the existing `ModelMediaCapabilities` detector instead of adding a parallel model. The composer and MLX runtime gate both consume the same descriptor, so UI toasts and runtime errors stay aligned. Existing boolean capability fields remain intact for current callers. The dependency pin is kept explicit and covered by `scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh`.

## Validation

- `git diff --check origin/main..HEAD`
- `xcrun swift-format lint` on touched Swift files
- `swiftlint lint --quiet` on touched Swift files (non-failing; reports existing baseline warnings in large touched files)
- `shellcheck scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh`
- `scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-gemma4-media-head swift test --package-path Packages/OsaurusCore --filter 'ModelMediaCapabilitiesMCDCTests|MLXServiceRuntimePolicyTests'`

- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-pr1427-ci-fix-3 swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests|ChatSessionQueuedSendTests|ModelMediaCapabilitiesMCDCTests|MLXServiceRuntimePolicyTests'` (137 tests)

## Notes

`make test` was also attempted with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`; it reached the broader suite but failed in existing `AgentManagerLifecycleNotificationTests.deleteSweepsPerAgentKeychainSecrets` because that test expects a bystander Keychain secret to be readable, while keychain-disabled mode makes Keychain reads return nil.

