### PR TITLE
Pin vMLX Gemma4 RoPE and MoE fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
+        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
+        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
+        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
+        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
+        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
+        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
+        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
+        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
+        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
+        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
+        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
+        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "90678f31107eb784f164117177338ea6eae58fcb"
+            revision: "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ca9b5b99b0623e04a14e7a569c0e282b43294937"
+            revision: "7cd35d09415fb262660a76930bb841a67f076fc4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
+            revision: "90678f31107eb784f164117177338ea6eae58fcb"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7cd35d09415fb262660a76930bb841a67f076fc4"
+            revision: "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
+            revision: "60513292e9969287c2ba256b5823aabd32cccc16"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "60513292e9969287c2ba256b5823aabd32cccc16"
+            revision: "7e3ca977426c28fb1130d9514adc60575f536a91"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -278,6 +278,23 @@ struct ModelManagerTests {
         #expect(detected.map(\.id).contains("JANGQ-AI/Step-3.7-Flash-JANGTQ_K"))
     }
 
+    @Test func scanLocalModels_detectsExternalGemma4QATRootWhenConfigured() async throws {
+        guard let rawRoot = ProcessInfo.processInfo.environment["OSAURUS_TEST_GEMMA4_QAT_ROOT"],
+            !rawRoot.isEmpty
+        else {
+            return
+        }
+
+        let root = URL(fileURLWithPath: (rawRoot as NSString).expandingTildeInPath, isDirectory: true)
+        let detected = ModelManager.scanLocalModels(at: root)
+        let ids = Set(detected.map { $0.id.lowercased() })
+        #expect(ids.contains("osaurusai/gemma-4-e2b-it-qat-mxfp4"))
+        #expect(ids.contains("osaurusai/gemma-4-e4b-it-qat-mxfp4"))
+        #expect(ids.contains("osaurusai/gemma-4-12b-it-qat-mxfp4"))
+        #expect(ids.contains("osaurusai/gemma-4-26b-a4b-it-qat-mxfp4"))
+        #expect(ids.contains("osaurusai/gemma-4-31b-it-qat-mxfp4"))
+    }
+
     @Test func scanLocalModels_skipsLargeSupportTreesBesideJANGBundles() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("osu-jangq-root-\(UUID().uuidString)")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "7cd35d09415fb262660a76930bb841a67f076fc4"
+        let expectedRuntimeHardenedRevision = "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "90678f31107eb784f164117177338ea6eae58fcb"
+        let expectedRuntimeHardenedRevision = "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
+        let expectedRuntimeHardenedRevision = "90678f31107eb784f164117177338ea6eae58fcb"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
+        let expectedRuntimeHardenedRevision = "60513292e9969287c2ba256b5823aabd32cccc16"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "60513292e9969287c2ba256b5823aabd32cccc16"
+        let expectedRuntimeHardenedRevision = "7e3ca977426c28fb1130d9514adc60575f536a91"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "ca9b5b99b0623e04a14e7a569c0e282b43294937"
+        let expectedRuntimeHardenedRevision = "7cd35d09415fb262660a76930bb841a67f076fc4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
+        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
+        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "90678f31107eb784f164117177338ea6eae58fcb"
+        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ca9b5b99b0623e04a14e7a569c0e282b43294937"
+        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "129f8c0a4f5f538e9ee74231735f837b1bc2babf564aab4434be6d56236072f1",
+  "originHash" : "4a755408e62144c003029e2c3d4950e6d405104239cd7eab8817ae91f0aea02e",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b54f8be09e65347dfe8584c08354ffa0a3dd5872"
+        "revision" : "60513292e9969287c2ba256b5823aabd32cccc16"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7cd35d09415fb262660a76930bb841a67f076fc4"
+        "revision" : "ca6d47dbb4be6f040bbf528f2c421ae28e732e6f"
       }
     },
     {

--- a/scripts/live-proof/assert-no-hidden-local-sampler-defaults.sh
+++ b/scripts/live-proof/assert-no-hidden-local-sampler-defaults.sh
@@ -51,7 +51,7 @@ if [[ -f "$ADAPTER" ]]; then
   require_text "$ADAPTER" 'return false' "implicit sampling does not authorize native MTP greedy rewrite"
 fi
 
-active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-no-hidden-local-sampler-defaults' || true)"
+active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -v '/Users/eric/.codex/computer-use/.*/SkyComputerUseClient' | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-no-hidden-local-sampler-defaults' || true)"
 if [[ -n "$active" ]]; then
   fail_msg "active Osaurus build/keychain-sensitive process detected"
   echo "$active" >&2

--- a/scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh
+++ b/scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh
@@ -79,6 +79,7 @@ require_regex "$SOURCE_ROOT/Services/ModelRuntime/MLXBatchAdapter.swift" \
 
 echo "--- keychain/build process boundary ---"
 active_forbidden="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/.codex/computer-use/.*/SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-osaurus-no-forced-behavior-pr' || true)"
 if [[ -n "$active_forbidden" ]]; then


### PR DESCRIPTION
## Summary
- Pins Osaurus to vMLX main `7cd35d09415fb262660a76930bb841a67f076fc4`.
- Carries the Gemma4 PLE quantization shape inference fix, E4B asymmetric RoPE coverage, and 26B-A4B fused MoE expert weight sanitization.
- Updates the runtime pin source guard to require the new vMLX SHA.

## Proof
- vMLX focused regression passed: `focused-gemma4-moe-ple-quant-rope-media-tool-regression-20260609-071014.log`.
- Direct vMLX E4B RunBench passed 3/3 turns, no loop, avg wall 52.0 tok/s, avg API decode 90.8 tok/s.
- Direct vMLX 26B-A4B RunBench passed 3/3 turns, no loop, avg wall 49.6 tok/s, avg API decode 101.8 tok/s.
- Osaurus pin guard passed: `RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening`.
- Keychain-free no-sign Release build passed: `build/DerivedData-gemma4-moe-vmlx7cd35d0-071640/Build/Products/Release/osaurus.app`.
- Live app/API tool-cache proofs passed warm on the rebuilt app for:
  - `gemma-4-26b-a4b-it-qat-mxfp4`: exact tools, visible answer, disk L2 hits, 52.71 tok/s.
  - `gemma-4-e4b-it-qat-mxfp4`: original RoPE crash path no longer traps, exact tools, disk L2 hits, 27.09 tok/s.
  - `gemma-4-e2b-it-qat-mxfp4`: exact tools, disk L2 hits, 30.76 tok/s.
  - `gemma-4-12b-it-qat-mxfp4`: exact tools, disk L2 hits, 26.14 tok/s.
  - `gemma-4-31b-it-qat-mxfp4`: exact tools, disk L2 hits, 13.12 tok/s.

## Boundaries
- No forced thinking tags, sampler/repetition hacks, prompt coercion, or catch-after-crash wrapper was added.
- The 26B-A4B no-reasoning tool/cache path is fixed; a direct thinking-on probe remains PARTIAL because it produced reasoning text with empty visible answer.
- E-series/26B-A4B/31B media rows were not re-proven in this continuation; prior Gemma4 media policy boundaries still apply.
