### PR TITLE
Pin vMLX Gemma4 tool recovery

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
+        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
+        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7e3ca977426c28fb1130d9514adc60575f536a91"
+            revision: "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -556,7 +556,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "7e3ca977426c28fb1130d9514adc60575f536a91"
+        let expectedRuntimeHardenedRevision = "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7e3ca977426c28fb1130d9514adc60575f536a91"
+        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Pins Osaurus to vMLX `9167ec771d22fd08c92caf97e431a1fe8e206fd7`.
- Pulls in the Gemma4 runtime/parser checkpoint covering the prior RoPE/PLE/MoE path plus schema-constrained MXFP4 tool-call drift recovery.
- Updates the runtime policy source test expected vMLX pin.

## Verified
- vMLX: `swift test --filter Gemma4ZyphraToolParserFocusedTests --filter Gemma4PLECoherenceTests --filter Gemma4TemplateFallbackSourceTests --filter Gemma4ToolCallParserFocusedTests` passed.
- vMLX: `swift build` passed.
- Osaurus no-sign Release build passed: `.agents/gemma-mxfp4/artifacts/osaurus-gemma4-parser-vmlx_9167ec7-20260609-215735-nosign-build.log`.
- Osaurus source policy test passed: `swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests` with 80 Swift Testing tests.
- MXFP4 live Osaurus all-five tool/multiturn proof passed: `.agents/gemma-mxfp4/artifacts/osaurus-final-mxfp4-all-tool-multiturn-20260609-220448`.
- JANG4M live Osaurus all-five tool/multiturn proof passed: `.agents/gemma-mxfp4/artifacts/osaurus-final-jang4m-all-tool-multiturn-20260609-220552`.
- JANG4M speed sanity on final pin: E2B 105.99 tok/s, E4B 67.98 tok/s, 12B 40.25 tok/s; artifact `.agents/gemma-mxfp4/artifacts/osaurus-9167ec7-jang4m-speed-e2b-e4b-12b-20260609-221101`.
- No new native osaurus crash report was produced after the final 9167ec7 proofs.

## Scope Boundaries
- This checkpoint claims Gemma4 JANG4M/MXFP4 text chat, required tool calls, multiline tool args, no visible protocol/reasoning/tool leakage in the proof rows, and cold disk-backed cache topology.
- It does not claim VL/audio/video rows, NeX N2 video, MIMO v2.5, reasoning UI metadata, or TurboQuant KV as the Gemma default. Those remain tracked follow-up work.
