### PR TITLE
Resolve indexed sharded local model bundles

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3547,6 +3547,7 @@ public actor ModelRuntime {
             }
             let directWeightSentinels = [
                 "model.safetensors",
+                "model.safetensors.index.json",
                 "weights.safetensors",
                 "model-00001-of-00001.safetensors",
             ]

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -55,6 +55,27 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(resolved?.resolvingSymlinksInPath().path == realModel.resolvingSymlinksInPath().path)
     }
 
+    @Test("Indexed sharded bundle resolves from model.safetensors.index.json")
+    func indexedShardedBundleResolvesFromManifestSentinel() throws {
+        let (root, realModel) = try makeRoot()
+        try FileManager.default.createDirectory(at: realModel, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"mimo_v2"}"#.utf8).write(
+            to: realModel.appendingPathComponent("config.json")
+        )
+        try Data("{}".utf8).write(
+            to: realModel.appendingPathComponent("tokenizer.json")
+        )
+        try Data(#"{"weight_map":{"model.embed_tokens.weight":"model_pp0_ep0_shard0.safetensors"}}"#.utf8).write(
+            to: realModel.appendingPathComponent("model.safetensors.index.json")
+        )
+
+        let resolved = ModelRuntime.resolveLocalModelDirectory(
+            forModelId: "OsaurusAI/TestModel",
+            in: root
+        )
+        #expect(resolved?.resolvingSymlinksInPath().path == realModel.resolvingSymlinksInPath().path)
+    }
+
     @Test("Friendly non-CRACK id resolves to local CRACK bundle")
     func friendlyNonCrackIdResolvesToLocalCrackBundle() throws {
         let root = try makeIsolatedDir()


### PR DESCRIPTION
## Summary

- Treat `model.safetensors.index.json` as a direct local weight sentinel in `ModelRuntime.resolveLocalModelDirectory`.
- Add a focused resolver regression for indexed sharded bundles that use manifest-driven shard names such as `model_pp0_ep0_shard0.safetensors`.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ModelRuntimeFindDirectoryTests/indexedShardedBundleResolvesFromManifestSentinel`

Additional local live proof from the preceding patched Release app build:

- Build log: `.agents/final-perfect/artifacts/osaurus-mimo-index-20260609-233834-nosign-build.log`
- MiMo source-bundle app proof: `.agents/final-perfect/artifacts/mimo-v25-source-after-index-20260609-234606`

That live run discovered `mimo-v2.5`, moved past the previous false `Model not downloaded: mimo-v2.5` resolver failure, and cleanly refused before load with HTTP 503 `insufficient_resources` because the only local MiMo source bundle requires about 293.9 GB available/projected while the machine had about 112.2 GB available. Health stayed healthy with `mlx_last_error=null`, no resident model, and no new crash report.

## Boundary

This fixes local indexed sharded bundle resolution and proves crash-safe handling for the local MiMo source bundle. It does not claim converted MiMo JANG/JANGTQ chat/tool/cache/VL/audio readiness; no converted local MiMo release bundle was found for that proof row.
