### PR TITLE
Fix MiMo JANG telemetry and N2 media preflight

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -8717,17 +8717,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private static func chatCompletionResponseJSONObject(_ response: ChatCompletionResponse) -> [String: Any] {
+        var usage: [String: Any] = [
+            "prompt_tokens": response.usage.prompt_tokens,
+            "completion_tokens": response.usage.completion_tokens,
+            "total_tokens": response.usage.total_tokens,
+        ]
+        if let tokensPerSecond = response.usage.tokens_per_second {
+            usage["tokens_per_second"] = tokensPerSecond
+        }
+
         var object: [String: Any] = [
             "id": response.id,
             "object": response.object,
             "created": response.created,
             "model": response.model,
             "choices": response.choices.map(chatChoiceJSONObject(_:)),
-            "usage": [
-                "prompt_tokens": response.usage.prompt_tokens,
-                "completion_tokens": response.usage.completion_tokens,
-                "total_tokens": response.usage.total_tokens,
-            ],
+            "usage": usage,
         ]
         if let fingerprint = response.system_fingerprint {
             object["system_fingerprint"] = fingerprint

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -926,9 +926,11 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     var text = ""
                     var reasoning = ""
                     var terminalStopReason = "stop"
+                    var authoritativeTokensPerSecond: Double?
                     for try await delta in stream {
                         try Task.checkCancellation()
                         if let stats = StreamingStatsHint.decode(delta) {
+                            authoritativeTokensPerSecond = stats.tokensPerSecond
                             if let stopReason = stats.stopReason, !stopReason.isEmpty {
                                 terminalStopReason = stopReason
                             }
@@ -961,7 +963,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     let usage = Usage(
                         prompt_tokens: inputTokens,
                         completion_tokens: outputTokens,
-                        total_tokens: inputTokens + outputTokens
+                        total_tokens: inputTokens + outputTokens,
+                        tokens_per_second: authoritativeTokensPerSecond
                     )
 
                     let response = ChatCompletionResponse(
@@ -1038,10 +1041,12 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             var reasoning = ""
             var terminalStopReason = "stop"
             var authoritativeOutputTokens: Int?
+            var authoritativeTokensPerSecond: Double?
             for try await delta in stream {
                 try Task.checkCancellation()
                 if let stats = StreamingStatsHint.decode(delta) {
                     authoritativeOutputTokens = stats.tokenCount
+                    authoritativeTokensPerSecond = stats.tokensPerSecond
                     if let stopReason = stats.stopReason, !stopReason.isEmpty {
                         terminalStopReason = stopReason
                     }
@@ -1074,7 +1079,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             let usage = Usage(
                 prompt_tokens: inputTokens,
                 completion_tokens: outputTokens,
-                total_tokens: inputTokens + outputTokens
+                total_tokens: inputTokens + outputTokens,
+                tokens_per_second: authoritativeTokensPerSecond
             )
 
             let response = ChatCompletionResponse(

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -242,7 +242,8 @@ actor MLXService: ToolCapableService {
         messages: [ChatMessage],
         parameters: GenerationParameters,
         tools: [Tool],
-        runtime: VMLXServerRuntimeSettings
+        runtime: VMLXServerRuntimeSettings,
+        modelDirectory: URL? = nil
     ) throws {
         let modalities = requestedModalities(
             messages: messages,
@@ -257,7 +258,10 @@ actor MLXService: ToolCapableService {
         )
 
         var issues = serverResult.issues.map { $0.message }
-        let mediaDescriptor = mediaCapabilityDescriptor(modelId: modelId)
+        let mediaDescriptor = mediaCapabilityDescriptor(
+            modelId: modelId,
+            modelDirectory: modelDirectory
+        )
         let media = mediaDescriptor.capabilities
         if modalities.contains(.vision), !media.supportsImage {
             issues.append(mediaDescriptor.descriptor(for: .image).reason)
@@ -269,7 +273,11 @@ actor MLXService: ToolCapableService {
             issues.append(mediaDescriptor.descriptor(for: .audio).reason)
         }
         if !tools.isEmpty,
-            !supportsLocalToolCalling(modelName: modelName, modelId: modelId)
+            !supportsLocalToolCalling(
+                modelName: modelName,
+                modelId: modelId,
+                modelDirectory: modelDirectory
+            )
         {
             issues.append("Model capability detection reports tool calling as unsupported.")
         }
@@ -449,7 +457,8 @@ actor MLXService: ToolCapableService {
     }
 
     private nonisolated static func mediaCapabilityDescriptor(
-        modelId: String
+        modelId: String,
+        modelDirectory: URL? = nil
     ) -> ModelMediaCapabilities.Descriptor {
         if isKnownMediaTextOnlyJANGRuntimeFamily(modelId: modelId) {
             // MiMo JANG/JANGTQ text/tool rows are supported through the vMLX
@@ -484,10 +493,13 @@ actor MLXService: ToolCapableService {
             // external-bundle metadata reads.
             return ModelMediaCapabilities.descriptor(modelId: modelId)
         }
-        let parts = modelId.split(separator: "/").map(String.init)
-        let localDirectory = parts.reduce(DirectoryPickerService.effectiveModelsDirectory()) {
-            $0.appendingPathComponent($1, isDirectory: true)
-        }
+        let localDirectory =
+            modelDirectory
+            ?? modelId.split(separator: "/").map(String.init).reduce(
+                DirectoryPickerService.effectiveModelsDirectory()
+            ) {
+                $0.appendingPathComponent($1, isDirectory: true)
+            }
         if FileManager.default.fileExists(atPath: localDirectory.path) {
             return ModelMediaCapabilities.descriptor(directory: localDirectory, modelId: modelId)
         }

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -451,11 +451,11 @@ actor MLXService: ToolCapableService {
     private nonisolated static func mediaCapabilityDescriptor(
         modelId: String
     ) -> ModelMediaCapabilities.Descriptor {
-        if isKnownTextOnlyJANGRuntimeFamily(modelId: modelId) {
-            // MiMo/N2 JANG and JANGTQ rows are text/tool runtimes in this
-            // Osaurus lane. Avoid synchronous directory/VLM probing on large
-            // or symlinked external bundles during request preflight; vMLX
-            // still owns the real model/template/tool load path.
+        if isKnownMediaTextOnlyJANGRuntimeFamily(modelId: modelId) {
+            // MiMo JANG/JANGTQ text/tool rows are supported through the vMLX
+            // text runtime. The bundle carries visual/audio weights, but vMLX
+            // has no MiMo VLM/omni factory yet and the text loader drops those
+            // weights. Keep media disabled until that real path exists.
             return ModelMediaCapabilities.Descriptor(
                 modelId: modelId,
                 capabilities: .textOnly,
@@ -502,5 +502,14 @@ actor MLXService: ToolCapableService {
         }
         return normalized.contains("mimo-v2.5")
             || normalized.contains("nex-n2-pro")
+    }
+
+    private nonisolated static func isKnownMediaTextOnlyJANGRuntimeFamily(modelId: String) -> Bool {
+        let normalized = modelId.lowercased().replacingOccurrences(of: "_", with: "-")
+        guard normalized.contains("jang") else { return false }
+        if normalized.contains("-vl") || normalized.contains("omni") {
+            return false
+        }
+        return normalized.contains("mimo-v2.5")
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -821,6 +821,19 @@ struct MLXBatchAdapter {
             }
             return context
         }
+        if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName) {
+            if directRailReasoningEffort {
+                context["enable_thinking"] = false
+                return context
+            }
+            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+                context["enable_thinking"] = true
+                context["reasoning_effort"] = normalizedReasoningEffort
+            } else {
+                context["enable_thinking"] = false
+            }
+            return context
+        }
         if ModelFamilyNames.isGemmaFamily(modelName) {
             if directRailReasoningEffort {
                 context["enable_thinking"] = false

--- a/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
@@ -388,6 +388,7 @@ struct ChatEngineTests {
         #expect(resp.choices.first?.finish_reason == "length")
         #expect(resp.usage.completion_tokens == 180)
         #expect(resp.usage.total_tokens == resp.usage.prompt_tokens + 180)
+        #expect(resp.usage.tokens_per_second == 52.5)
     }
 
     @Test func completeChat_omittedMaxTokensPreservesModelDefaultContract() async throws {
@@ -1077,6 +1078,7 @@ struct ChatEngineTests {
         let resp = try await engine.completeChat(request: req)
         #expect(resp.choices.first?.message.content == "truncated")
         #expect(resp.choices.first?.finish_reason == "length")
+        #expect(resp.usage.tokens_per_second == 12.5)
     }
 
     @Test func completeChat_preservesReasoningContentForToolCapableNonStreamingCompletion() async throws {

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -152,6 +152,57 @@ struct HTTPHandlerChatStreamingTests {
         }
     }
 
+    @Test func nonStreamingChatCompletions_preservesTokensPerSecondInUsage() async throws {
+        struct StatsEngine: ChatEngineProtocol {
+            func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<
+                String, Error
+            > {
+                fatalError("not used")
+            }
+
+            func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+                ChatCompletionResponse(
+                    id: "chatcmpl-test",
+                    created: 0,
+                    model: request.model,
+                    choices: [
+                        ChatChoice(
+                            index: 0,
+                            message: ChatMessage(role: "assistant", content: "ok"),
+                            finish_reason: "stop"
+                        )
+                    ],
+                    usage: Usage(
+                        prompt_tokens: 3,
+                        completion_tokens: 4,
+                        total_tokens: 7,
+                        tokens_per_second: 88.25
+                    ),
+                    system_fingerprint: nil
+                )
+            }
+        }
+
+        let server = try await startTestServer(with: StatsEngine())
+        defer { Task { await server.shutdown() } }
+
+        var request = URLRequest(
+            url: URL(string: "http://\(server.host):\(server.port)/chat/completions")!
+        )
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.authenticate()
+        request.disablePersistenceForTests()
+        request.httpBody = #"""
+            {"model":"fake","stream":false,"messages":[{"role":"user","content":"hi"}]}
+            """#.data(using: .utf8)
+
+        let (data, resp) = try await URLSession.shared.data(for: request)
+        let body = String(decoding: data, as: UTF8.self)
+        #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+        #expect(body.contains("\"tokens_per_second\":88.25"))
+    }
+
     @Test func sse_path_writes_role_content_finish_done() async throws {
         let server = try await startTestServer(
             with: MockChatEngine(deltas: ["a", "b", "c"], completeText: "", model: "fake")

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1322,6 +1322,73 @@ struct MLXBatchAdapterTests {
         #expect(stepJang2LRequired["enable_thinking"] as? Bool == false)
     }
 
+    @Test func additionalContext_defaultsMiMoN2JANGThinkingOffButHonorsExplicitOptIn() {
+        let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
+        let userEnabled = GenerationParameters(
+            temperature: nil,
+            maxTokens: 16,
+            modelOptions: ["disableThinking": .bool(false)]
+        )
+
+        for modelName in [
+            "mimo-v2.5-jangtq_2",
+            "JANGQ-AI/MiMo-V2.5-JANG_2L",
+            "nex-n2-pro-jangtq2",
+            "Nex-N2-Pro-JANG_1L",
+        ] {
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: unspecified,
+                    modelName: modelName
+                )["enable_thinking"] as? Bool == false,
+                "MiMo/N2 JANG text/tool rows should default to the no-thinking rail: \(modelName)"
+            )
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: userEnabled,
+                    modelName: modelName
+                )["enable_thinking"] as? Bool == true,
+                "MiMo/N2 must honor explicit thinking opt-in: \(modelName)"
+            )
+
+            let directOff = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("no_think")]
+                ),
+                modelName: modelName
+            )
+            #expect(directOff["enable_thinking"] as? Bool == false)
+            #expect(directOff["reasoning_effort"] == nil)
+
+            let apiReasoning = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["reasoningEffort": .string("high")]
+                ),
+                modelName: modelName
+            )
+            #expect(apiReasoning["enable_thinking"] as? Bool == true)
+            #expect(apiReasoning["reasoning_effort"] as? String == "high")
+        }
+
+        for modelName in [
+            "mimo-v2.5-bf16",
+            "nex-n2-pro-source",
+            "dataset/mimosa-jangtq",
+        ] {
+            #expect(
+                MLXBatchAdapter.additionalContext(
+                    for: unspecified,
+                    modelName: modelName
+                )["enable_thinking"] == nil,
+                "Non-JANG or boundary-mismatched MiMo/N2 names must not get a synthetic thinking kwarg: \(modelName)"
+            )
+        }
+    }
+
     @Test func additionalContext_defaultsLingThinkingOffButHonorsExplicitOptIn() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -228,6 +228,12 @@ struct MLXServiceRuntimePolicyTests {
     }
 
     @Test func n2JANGTQMediaPreflightUsesBundleVisionConfig() throws {
+        let bundle = try Self.makeMediaCapabilityBundle(
+            modelType: "qwen3_5_moe",
+            hasVisionConfig: true
+        )
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
         let message = ChatMessage(
             role: "user",
             content: "describe this",
@@ -244,7 +250,8 @@ struct MLXServiceRuntimePolicyTests {
             messages: [message],
             parameters: GenerationParameters(temperature: nil, maxTokens: 16),
             tools: [],
-            runtime: VMLXServerRuntimeSettings()
+            runtime: VMLXServerRuntimeSettings(),
+            modelDirectory: bundle
         )
     }
 
@@ -293,5 +300,22 @@ struct MLXServiceRuntimePolicyTests {
                 ])
             )
         )
+    }
+
+    private static func makeMediaCapabilityBundle(
+        modelType: String,
+        hasVisionConfig: Bool
+    ) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-media-cap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var config: [String: Any] = ["model_type": modelType]
+        if hasVisionConfig {
+            config["vision_config"] = ["image_size": 224]
+        }
+        let data = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try data.write(to: directory.appendingPathComponent("config.json"))
+        return directory
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -227,6 +227,57 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
+    @Test func n2JANGTQMediaPreflightUsesBundleVisionConfig() throws {
+        let message = ChatMessage(
+            role: "user",
+            content: "describe this",
+            contentParts: [
+                .text("describe this"),
+                .imageUrl(url: "data:image/png;base64,AAAA", detail: nil),
+                .videoUrl(url: "data:video/mp4;base64,AAAA"),
+            ]
+        )
+
+        try MLXService.validateRuntimePolicy(
+            modelName: "nex-n2-pro-jangtq2",
+            modelId: "Nex-N2-Pro-JANGTQ2",
+            messages: [message],
+            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+            tools: [],
+            runtime: VMLXServerRuntimeSettings()
+        )
+    }
+
+    @Test func mimoJANGTQMediaPreflightStaysBlockedUntilVMLXHasMediaRuntime() {
+        let message = ChatMessage(
+            role: "user",
+            content: "describe this",
+            contentParts: [
+                .text("describe this"),
+                .imageUrl(url: "data:image/png;base64,AAAA", detail: nil),
+                .audioInput(data: "AAAA", format: "wav"),
+            ]
+        )
+
+        do {
+            try MLXService.validateRuntimePolicy(
+                modelName: "mimo-v2.5-jangtq_2",
+                modelId: "JANGQ-AI/MiMo-V2.5-JANGTQ_2",
+                messages: [message],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [],
+                runtime: VMLXServerRuntimeSettings()
+            )
+            Issue.record("MiMo media should remain blocked until vMLX ships MiMo media runtime support.")
+        } catch let error as MLXService.RuntimePolicyError {
+            let description = error.errorDescription ?? ""
+            #expect(description.contains("Image input is not advertised"))
+            #expect(description.contains("Audio input is not advertised"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
     private static func lineCountTool() -> OsaurusCore.Tool {
         OsaurusCore.Tool(
             type: "function",


### PR DESCRIPTION
## Summary
- preserve non-streaming token/s from engine stats in chat completion `usage.tokens_per_second`
- default MiMo/N2 JANG and JANGTQ template context to no-thinking unless explicit reasoning is requested
- fix N2 JANG/JANGTQ media capability preflight so N2 uses bundle config/directory detection instead of the MiMo text-only shortcut
- keep MiMo media blocked until vMLX has a real MiMo VLM/omni runtime; MiMo text/tool/cache uses the converted JANGTQ bundle, not the full source bundle

## vMLX Pin
- Osaurus pins `osaurus-ai/vmlx-swift` main at `9167ec771d22fd08c92caf97e431a1fe8e206fd7`
- All four pin surfaces in this branch point at that SHA

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSU_MODELS_DIR=/Volumes/EricsLLMDrive/jangq-ai swift test --package-path Packages/OsaurusCore --filter MLXServiceRuntimePolicyTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSU_MODELS_DIR=/Volumes/EricsLLMDrive/jangq-ai swift test --package-path Packages/OsaurusCore --filter 'MLXServiceRuntimePolicyTests|MLXBatchAdapterTests|ChatEngineTests|HTTPHandlerChatStreamingTests'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSU_MODELS_DIR=/Volumes/EricsLLMDrive/jangq-ai swift test --package-path Packages/OsaurusCore --filter 'LocalGenerationDefaultsTests|MultiTurnGenConfigToolsAbortTests'`
- keychain-free Release app build: `build/DerivedData-n2-media-5c41377-20260610-011958/Build/Products/Release/osaurus.app`
- MiMo JANGTQ_2 live text/tool/cache artifacts: `.agents/final-perfect/artifacts/mimo-v25-jangtq2-*-nothink-oneshell-20260610-010*`
- N2 JANGTQ2 live image preflight/resource artifacts: `.agents/final-perfect/artifacts/nex-n2-jangtq2-image*-media-5c41377-20260610-012*`

## Live Boundaries
- MiMo JANGTQ_2 text chat, forced tool call JSON, no visible tool/reasoning leakage, warm token/s telemetry, and disk-L2 cache reuse are app-live proven.
- N2 JANGTQ2 media preflight is fixed and reached the image processing/resource path without native crash; the valid-image generation row is currently memory-blocked and returns typed `insufficient_resources` before unsafe load.
- MiMo VL/audio/video are not claimed by this PR because current vMLX MiMo runtime is text-only and drops the media weights.
- Gemma issue #1432 remains tied to the vMLX Gemma runtime updates already on the pinned main SHA; this PR does not add fake sampler or prompt guards.
