### PR TITLE
Fix QuickTime video data URL materialization

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2694,7 +2694,9 @@ public actor ModelRuntime {
         // Header looks like `audio/wav;base64` or `video/mp4`. Take the part
         // after the slash, before any `;`.
         var ext = defaultExtension
-        let isAudioMime = header.lowercased().hasPrefix("audio/")
+        let lowerHeader = header.lowercased()
+        let isAudioMime = lowerHeader.hasPrefix("audio/")
+        let isVideoMime = lowerHeader.hasPrefix("video/")
         if let slash = header.firstIndex(of: "/") {
             let afterSlash = header[header.index(after: slash)...]
             if let semi = afterSlash.firstIndex(of: ";") {
@@ -2712,6 +2714,12 @@ public actor ModelRuntime {
                 case "x-wav", "wave": ext = "wav"
                 case "mpeg", "mp3", "x-mpeg": ext = "mp3"
                 case "x-m4a", "mp4": ext = "m4a"
+                default: break
+                }
+            }
+            if isVideoMime {
+                switch ext {
+                case "quicktime", "x-quicktime", "qt": ext = "mov"
                 default: break
                 }
             }

--- a/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/MaterializeMediaDataUrlMCDCTests.swift
@@ -128,6 +128,18 @@ struct MaterializeMediaDataUrlMCDCTests {
         if let url { try? FileManager.default.removeItem(at: url) }
     }
 
+    @Test("video/quicktime data URL materializes to .mov for AVFoundation")
+    func videoQuickTimeCanonicalizesToMov() {
+        let payload = Data(repeating: 0xEF, count: 16)
+        let b64 = payload.base64EncodedString()
+        let url = mappedURL(forVideoDataURL: "data:video/quicktime;base64,\(b64)")
+        #expect(
+            url?.pathExtension == "mov",
+            "video/quicktime must materialize as .mov so AVFoundation selects the QuickTime decoder"
+        )
+        if let url { try? FileManager.default.removeItem(at: url) }
+    }
+
     @Test("D6 T (audio/mp4): canonicalizes to .m4a (audio path keeps fix's intent)")
     func d6_audioMp4_canonicalizesToM4a() {
         // Audio path with format=mp4 → wraps as data:audio/mp4 → D6=T


### PR DESCRIPTION
## Summary

- Canonicalizes `data:video/quicktime`, `video/x-quicktime`, and `video/qt` temp files to `.mov` before AVFoundation opens them.
- Adds a focused regression that verifies QuickTime data URLs materialize with `.mov`.

## Proof

- Focused source tests passed:
  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 swift test --package-path Packages/OsaurusCore --filter 'MaterializeMediaDataUrlMCDCTests|MultimodalContentPartTests|MLXServiceRuntimePolicyTests' --jobs 1`
  Result: 37 Swift Testing tests passed.

- Keychain-free Release build passed:
  `.agents/final-perfect/artifacts/osaurus-n2-video-quicktime-fix-retry-20260610-030023-nosign-build.log`

- App-live NeX N2 JANGTQ2 QuickTime video proof passed:
  `.agents/final-perfect/artifacts/nex-n2-jangtq2-video-triangle-quicktime-fix-open-20260610-030843/summary.json`
  First and repeat requests returned HTTP 200 content `triangle`, no parser/reasoning/tool/special-token leakage, no weird control characters, `/health` healthy after repeat, and no new DiagnosticReports `.ips`.

## Boundary

The video proof harness queried stale `/v1/cache/status`, so this PR proves QuickTime materialization, visible video answer, leak/weird-character safety, token/s reporting, and crash safety. Video cache hit telemetry still needs a rerun against `/admin/cache-stats` before claiming disk L2 / SSM companion video repeat hits.
