### PR TITLE
Add RDMA TB5 distributed scaffold

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/DistributedRuntimeReadiness.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/DistributedRuntimeReadiness.swift
@@ -1,0 +1,248 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+
+public enum DistributedTensorAddressClass: String, Codable, Sendable, Equatable, Hashable {
+    case thunderboltLoopback
+    case thunderboltDirect
+    case tailscaleControl
+    case localLoopback
+    case privateOther
+    case linkLocal
+    case unknown
+
+    public var isAllowedForTensorDataPlane: Bool {
+        switch self {
+        case .thunderboltLoopback, .thunderboltDirect:
+            return true
+        case .tailscaleControl, .localLoopback, .privateOther, .linkLocal, .unknown:
+            return false
+        }
+    }
+}
+
+public struct DistributedTensorEndpoint: Codable, Sendable, Equatable, Hashable {
+    public let rawValue: String
+    public let host: String
+    public let port: UInt16?
+    public let addressClass: DistributedTensorAddressClass
+
+    public init(_ rawValue: String) {
+        let parsed = Self.parse(rawValue)
+        self.rawValue = rawValue
+        self.host = parsed.host
+        self.port = parsed.port
+        self.addressClass = Self.classify(host: parsed.host)
+    }
+
+    public var isAllowedForTensorDataPlane: Bool {
+        addressClass.isAllowedForTensorDataPlane
+    }
+
+    private static func parse(_ rawValue: String) -> (host: String, port: UInt16?) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return ("", nil) }
+
+        if let components = URLComponents(string: trimmed),
+           components.scheme != nil,
+           let host = components.host {
+            return (host, components.port.flatMap(UInt16.init))
+        }
+
+        if trimmed.hasPrefix("["),
+           let closeIndex = trimmed.firstIndex(of: "]") {
+            let host = String(trimmed[trimmed.index(after: trimmed.startIndex)..<closeIndex])
+            let rest = trimmed[trimmed.index(after: closeIndex)...]
+            let port = rest.hasPrefix(":") ? UInt16(rest.dropFirst()) : nil
+            return (host, port)
+        }
+
+        if trimmed.filter({ $0 == ":" }).count == 1,
+           let colon = trimmed.lastIndex(of: ":") {
+            let host = String(trimmed[..<colon])
+            let port = UInt16(trimmed[trimmed.index(after: colon)...])
+            if port != nil {
+                return (host, port)
+            }
+        }
+
+        return (trimmed, nil)
+    }
+
+    private static func classify(host: String) -> DistributedTensorAddressClass {
+        let lower = host.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .lowercased()
+
+        if lower == "localhost" || lower == "::1" {
+            return .localLoopback
+        }
+
+        let parts = lower.split(separator: ".")
+        guard parts.count == 4,
+              let a = Int(parts[0]),
+              let b = Int(parts[1]),
+              let c = Int(parts[2]),
+              let d = Int(parts[3]),
+              (0...255).contains(a),
+              (0...255).contains(b),
+              (0...255).contains(c),
+              (0...255).contains(d)
+        else {
+            return .unknown
+        }
+
+        switch (a, b, c) {
+        case (10, 20, 0):
+            return .thunderboltLoopback
+        case (10, 10, _):
+            return .thunderboltDirect
+        case (100, _, _):
+            return .tailscaleControl
+        case (127, _, _):
+            return .localLoopback
+        case (169, 254, _):
+            return .linkLocal
+        default:
+            if a == 10
+                || (a == 172 && (16...31).contains(b))
+                || (a == 192 && b == 168) {
+                return .privateOther
+            }
+            return .unknown
+        }
+    }
+}
+
+public enum DistributedRuntimeReadinessLevel: String, Codable, Sendable, Equatable, Hashable {
+    case info
+    case warning
+    case error
+}
+
+public struct DistributedRuntimeFinding: Codable, Sendable, Equatable, Hashable {
+    public let level: DistributedRuntimeReadinessLevel
+    public let code: String
+    public let message: String
+
+    public init(level: DistributedRuntimeReadinessLevel, code: String, message: String) {
+        self.level = level
+        self.code = code
+        self.message = message
+    }
+}
+
+public struct DistributedRuntimeReadinessReport: Codable, Sendable, Equatable {
+    public let endpoints: [DistributedTensorEndpoint]
+    public let worldSize: Int
+    public let librdmaLoadable: Bool?
+    public let jacclAvailable: Bool?
+    public let ibvDevicesConfigured: Bool?
+    public let findings: [DistributedRuntimeFinding]
+
+    public var isRunnable: Bool {
+        findings.allSatisfy { $0.level != .error }
+    }
+}
+
+public enum DistributedRuntimeReadiness {
+    public static func evaluate(
+        dataPlaneAddresses: [String],
+        worldSize: Int,
+        librdmaLoadable: Bool? = nil,
+        jacclAvailable: Bool? = nil,
+        ibvDevicesConfigured: Bool? = nil
+    ) -> DistributedRuntimeReadinessReport {
+        let endpoints = orderedUnique(dataPlaneAddresses).map(DistributedTensorEndpoint.init)
+        var findings: [DistributedRuntimeFinding] = []
+
+        if worldSize <= 1 {
+            findings.append(.init(
+                level: .error,
+                code: "single_rank_not_tp",
+                message: "Tensor-parallel readiness requires at least two ranks; size-1 fallback is not proof."
+            ))
+        }
+
+        if endpoints.isEmpty {
+            findings.append(.init(
+                level: .warning,
+                code: "missing_data_plane_addresses",
+                message: "No tensor data-plane addresses were supplied."
+            ))
+        }
+
+        for endpoint in endpoints {
+            switch endpoint.addressClass {
+            case .thunderboltLoopback, .thunderboltDirect:
+                findings.append(.init(
+                    level: .info,
+                    code: "thunderbolt_data_plane_address",
+                    message: "\(endpoint.host) is accepted as a Thunderbolt tensor data-plane address."
+                ))
+            case .tailscaleControl:
+                findings.append(.init(
+                    level: .error,
+                    code: "tailscale_data_plane_forbidden",
+                    message: "\(endpoint.host) is Tailscale/control-plane only and must not carry tensor-parallel data."
+                ))
+            case .localLoopback:
+                findings.append(.init(
+                    level: .warning,
+                    code: "loopback_not_multirank_proof",
+                    message: "\(endpoint.host) is local loopback and cannot prove multi-rank tensor parallelism."
+                ))
+            case .privateOther, .linkLocal, .unknown:
+                findings.append(.init(
+                    level: .warning,
+                    code: "unproven_data_plane_address",
+                    message: "\(endpoint.host) is \(endpoint.addressClass.rawValue), not a proven Thunderbolt tensor data-plane address."
+                ))
+            }
+        }
+
+        if librdmaLoadable == false {
+            findings.append(.init(
+                level: .error,
+                code: "librdma_unavailable",
+                message: "librdma is not loadable on this host."
+            ))
+        }
+
+        if jacclAvailable == false {
+            findings.append(.init(
+                level: .error,
+                code: "jaccl_unavailable",
+                message: "JACCL is not available; distributed execution must stay disabled."
+            ))
+        }
+
+        if ibvDevicesConfigured == false {
+            findings.append(.init(
+                level: .error,
+                code: "ibv_devices_missing",
+                message: "MLX_IBV_DEVICES is not configured for the tensor-parallel ranks."
+            ))
+        }
+
+        return DistributedRuntimeReadinessReport(
+            endpoints: endpoints,
+            worldSize: worldSize,
+            librdmaLoadable: librdmaLoadable,
+            jacclAvailable: jacclAvailable,
+            ibvDevicesConfigured: ibvDevicesConfigured,
+            findings: findings
+        )
+    }
+
+    private static func orderedUnique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var out: [String] = []
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { continue }
+            out.append(trimmed)
+        }
+        return out
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/DistributedRuntimeReadinessTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DistributedRuntimeReadinessTests.swift
@@ -1,0 +1,79 @@
+// Copyright © 2026 osaurus.
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Distributed runtime readiness")
+struct DistributedRuntimeReadinessTests {
+    @Test("Thunderbolt loopback and direct addresses are accepted")
+    func thunderboltAddressesAreAccepted() {
+        let loopback = DistributedTensorEndpoint("10.20.0.1:29500")
+        let direct = DistributedTensorEndpoint("10.10.6.2")
+
+        #expect(loopback.addressClass == .thunderboltLoopback)
+        #expect(loopback.isAllowedForTensorDataPlane)
+        #expect(direct.addressClass == .thunderboltDirect)
+        #expect(direct.isAllowedForTensorDataPlane)
+    }
+
+    @Test("Tailscale addresses are control-plane only")
+    func tailscaleAddressesAreRejected() {
+        let report = DistributedRuntimeReadiness.evaluate(
+            dataPlaneAddresses: ["10.20.0.1:29500", "100.93.216.67:29500"],
+            worldSize: 4,
+            librdmaLoadable: true,
+            jacclAvailable: true,
+            ibvDevicesConfigured: true
+        )
+
+        #expect(!report.isRunnable)
+        #expect(report.endpoints.map(\.addressClass).contains(.tailscaleControl))
+        #expect(report.findings.contains { $0.code == "tailscale_data_plane_forbidden" && $0.level == .error })
+    }
+
+    @Test("Size one fallback is not tensor-parallel proof")
+    func sizeOneFallbackIsRejected() {
+        let report = DistributedRuntimeReadiness.evaluate(
+            dataPlaneAddresses: ["10.20.0.1:29500"],
+            worldSize: 1,
+            librdmaLoadable: true,
+            jacclAvailable: true,
+            ibvDevicesConfigured: true
+        )
+
+        #expect(!report.isRunnable)
+        #expect(report.findings.contains { $0.code == "single_rank_not_tp" })
+    }
+
+    @Test("JACCL and IBV gates stay separate from librdma")
+    func jacclAndIBVGatesStaySeparate() {
+        let report = DistributedRuntimeReadiness.evaluate(
+            dataPlaneAddresses: ["10.20.0.1:29500", "10.20.0.2:29500"],
+            worldSize: 4,
+            librdmaLoadable: true,
+            jacclAvailable: false,
+            ibvDevicesConfigured: false
+        )
+
+        #expect(!report.isRunnable)
+        #expect(!report.findings.contains { $0.code == "librdma_unavailable" })
+        #expect(report.findings.contains { $0.code == "jaccl_unavailable" })
+        #expect(report.findings.contains { $0.code == "ibv_devices_missing" })
+    }
+
+    @Test("Unknown private addresses are warnings, not proof")
+    func unknownPrivateAddressesAreWarnings() {
+        let report = DistributedRuntimeReadiness.evaluate(
+            dataPlaneAddresses: ["192.168.1.20"],
+            worldSize: 4,
+            librdmaLoadable: true,
+            jacclAvailable: true,
+            ibvDevicesConfigured: true
+        )
+
+        #expect(report.isRunnable)
+        #expect(report.endpoints.first?.addressClass == .privateOther)
+        #expect(report.findings.contains { $0.code == "unproven_data_plane_address" && $0.level == .warning })
+    }
+}

--- a/docs/RDMA_TB5_NODE_DISCOVERY_PRODUCT_SPEC_2026_06_10.md
+++ b/docs/RDMA_TB5_NODE_DISCOVERY_PRODUCT_SPEC_2026_06_10.md
@@ -1,0 +1,189 @@
+# RDMA/TB5 Node Discovery Product Spec
+
+Updated: 2026-06-10
+
+## Goal
+
+Make multi-Mac RDMA/TB5 tensor-parallel discovery easy when Osaurus is running
+on each Mac, while preventing accidental VPN/Tailscale data-plane use.
+
+The user-facing flow should make the right path obvious:
+
+1. Turn on RDMA/TB5 cluster mode on each Mac.
+2. See nearby eligible Osaurus nodes.
+3. Run automatic checks.
+4. Confirm a rank/port plan.
+5. Start only when every node has a proven internal RDMA/Thunderbolt data-plane
+   route and a compatible vMLX runtime.
+
+## Non-Goals For The First PR
+
+- No automatic cluster join.
+- No background model sharing.
+- No silent use of Tailscale, VPN, Wi-Fi, or random LAN routes for tensor data.
+- No claim that a model family is distributed-ready from discovery alone.
+- No UI implementation in the initial scaffold PR.
+
+## Network Rules
+
+### Control Plane
+
+Control-plane discovery may use:
+
+- Bonjour/mDNS service advertisement on the local network.
+- Explicit manual host entry.
+- A user-approved pairing code or local trust token.
+
+Control-plane discovery must not imply model execution readiness.
+
+### Data Plane
+
+Tensor-parallel data must use a real internal high-speed path:
+
+- Preferred AdLab-style Thunderbolt loopbacks: `10.20.0.x`.
+- Direct Thunderbolt links: `10.10.x.x`.
+- Future user-defined RDMA/private fabric ranges only after route and interface
+  checks prove the traffic does not leave the intended internal fabric.
+
+Forbidden for tensor data:
+
+- Tailscale `100.x`.
+- Other VPN interfaces.
+- Wi-Fi unless explicitly marked diagnostic-only.
+- Localhost/loopback as multi-node proof.
+- Any address where the interface cannot be identified.
+
+Tailscale can remain useful for SSH/control diagnostics, but it must never be
+selected as the tensor data-plane path.
+
+## Discovery Architecture
+
+Each running Osaurus node should advertise a local discovery record with:
+
+- Node id.
+- User-visible device name.
+- Osaurus version.
+- vMLX pin/version.
+- Distributed runtime capability version.
+- Candidate control endpoints.
+- Candidate data-plane endpoints.
+- JACCL availability.
+- `librdma` load status.
+- `MLX_IBV_DEVICES` matrix readiness.
+- Available model shard roots, only as redacted/digest metadata.
+- Supported roles: coordinator, rank worker, local-only.
+
+The discovery record must separate candidates from proof. A candidate address is
+not usable until the verifier marks it as a passing data-plane route.
+
+## Fallback Check Ladder
+
+The UI and runtime should run checks in this order and label each level:
+
+1. **Presence**: another Osaurus node advertises itself.
+2. **Trust**: the node is paired or approved by the user.
+3. **Version**: Osaurus and vMLX distributed capability versions are compatible.
+4. **Address classification**: candidate data-plane addresses are not VPN,
+   Tailscale, localhost, or unknown.
+5. **Route check**: each data-plane address resolves to the intended internal
+   interface.
+6. **Port check**: the coordinator and rank worker ports are reachable on the
+   internal address, not via VPN.
+7. **RDMA check**: `librdma` is loadable and RDMA is enabled.
+8. **JACCL check**: JACCL backend is available.
+9. **IBV matrix check**: every rank has the expected peer device entries and
+   empty self slot.
+10. **Collective smoke**: ring smoke first where useful, then JACCL multi-rank
+    all-sum/all-gather proof.
+11. **Model shard check**: every rank has the expected shard/digest for the
+    selected model.
+12. **Runtime proof**: worker liveness, rank agreement, token authority,
+    token/s, and architecture-specific cache evidence.
+
+If a lower check passes and a higher check fails, the UI must show `PARTIAL` and
+the exact blocker. It must not collapse that into a generic ready state.
+
+## UI Surface
+
+### Menu Entry
+
+Add a future menu item:
+
+- Label: `Distributed Inference`
+- Default state: disabled/off unless the user enables the feature.
+- Secondary status text: `Off`, `Discovering`, `Partial`, `Ready`, `Blocked`,
+  or `Running`.
+
+### Node Discovery Panel
+
+Expected controls:
+
+- Toggle: `Enable node discovery`.
+- Toggle: `Allow this Mac to serve as a rank`.
+- Button: `Scan`.
+- Button: `Run checks`.
+- Button: `Copy diagnostics`.
+- Button: `Start cluster` only when all required gates pass.
+- Button: `Stop cluster` when running.
+- Manual entry: host/IP and port, with a clear `control` vs `data` selector.
+
+Expected node cards:
+
+- Device name.
+- Role: coordinator/rank/local-only.
+- Rank assignment.
+- Control endpoint.
+- Data-plane endpoint.
+- Interface label.
+- RDMA/JACCL/IBV status.
+- Model shard status.
+- Last check time.
+
+### Animation / State Language
+
+Animations should reflect state transitions, not decorate the panel:
+
+- Scanning: subtle pulsing ring around candidate nodes.
+- Checking: per-node progress sweep through the fallback ladder.
+- Partial: amber interrupted path between nodes, with the failing gate selected.
+- Ready: solid internal-fabric links between all selected ranks.
+- Blocked: red link only on the failing edge, not the whole graph if only one
+  peer is blocked.
+- Running: compact live throughput/rank-agreement pulse, only after runtime
+  proof starts.
+
+Do not animate unknown or unproven nodes as connected.
+
+## Required Diagnostics Copy
+
+`Copy diagnostics` should include:
+
+- Osaurus version and commit.
+- vMLX pin.
+- Node id and redacted hostname.
+- Candidate control addresses.
+- Candidate data-plane addresses.
+- Address classifications.
+- Interface names.
+- Route result.
+- Port result.
+- `librdma` load status.
+- JACCL status.
+- IBV matrix summary.
+- Collective smoke result.
+- Model shard digest status.
+- Runtime proof summary if a model ran.
+
+Do not include local model paths, secrets, full hostnames, tokens, or private
+keys unless the user explicitly exports a developer diagnostic bundle.
+
+## Acceptance Criteria
+
+- A user with Osaurus open on every Mac can discover nodes without copying shell
+  commands.
+- The panel never chooses Tailscale `100.x` or VPN routes for tensor data.
+- Every node shows the exact failing gate when not ready.
+- A size-1 fallback never appears as distributed-ready.
+- A route pass never appears as model-ready.
+- Starting distributed execution is impossible until data-plane, RDMA/JACCL,
+  IBV, collective, shard, and runtime gates required for the selected mode pass.

--- a/docs/RDMA_TB5_TENSOR_PARALLEL_OSAURUS_SCAFFOLD_2026_06_10.md
+++ b/docs/RDMA_TB5_TENSOR_PARALLEL_OSAURUS_SCAFFOLD_2026_06_10.md
@@ -1,0 +1,53 @@
+# RDMA/TB5 Tensor Parallel Osaurus Scaffold
+
+Updated: 2026-06-10
+
+## Purpose
+
+This PR starts the Osaurus side of RDMA/TB5 tensor-parallel integration without
+turning on cluster execution or adding UI. The immediate scope is host policy,
+readiness vocabulary, and proof gates that can later consume vMLX distributed
+probe output.
+
+## Boundary
+
+- Osaurus owns opt-in policy, readiness reporting, host identity, future UI, and
+  API health surfaces.
+- vMLX owns distributed group initialization, JACCL/RDMA collectives, tensor
+  sharding plans, model execution, token authority, cache topology, and live
+  generation proof.
+- AdLab Python/Qwen/MiMo work is provenance. The product path is Swift engine
+  code and Swift proof artifacts.
+
+## Current Source Scaffold
+
+- `DistributedRuntimeReadiness` classifies tensor data-plane endpoints and
+  records readiness findings.
+- `10.20.0.x` Thunderbolt loopbacks and `10.10.x.x` direct Thunderbolt links are
+  accepted as tensor data-plane addresses.
+- `100.x` Tailscale addresses are rejected for tensor data-plane use.
+  Tailscale remains control-plane/SSH only.
+- Size-1 distributed fallback is explicitly rejected as tensor-parallel proof.
+- `librdma`, JACCL availability, and `MLX_IBV_DEVICES` configuration are tracked
+  as separate gates.
+
+## Not Included Yet
+
+- No UI or Settings panel changes.
+- No automatic peer discovery or background cluster joining.
+- No Osaurus runtime switch to distributed execution.
+- No vMLX pin bump in this PR.
+- No claim that Qwen, MiMo, JANG, MXFP, VL, audio, or video rows have live
+  readiness proof.
+- No node-discovery UI yet. See
+  `docs/RDMA_TB5_NODE_DISCOVERY_PRODUCT_SPEC_2026_06_10.md` for the team-facing
+  discovery, menu, button, animation, and fallback-check spec.
+
+## Next Steps
+
+1. Consume vMLX `DistributedProbe --json` once the corresponding vMLX changes
+   are published and pinned.
+2. Add `MLX_IBV_DEVICES` JSON matrix validation and route-table evidence.
+3. Add package-owned proof ingestion for worker liveness, rank agreement,
+   decode token/s, token authority, and architecture-specific cache evidence.
+4. Add UI only after the non-UI readiness state is backed by live proof.

--- a/scripts/live-proof/assert-rdma-tb5-distributed-scaffold.sh
+++ b/scripts/live-proof/assert-rdma-tb5-distributed-scaffold.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+
+pass() { echo "PASS $*"; }
+fail_msg() { echo "FAIL $*" >&2; fail=1; }
+
+require_text() {
+  local file="$1" pattern="$2" label="$3"
+  if rg -U -q "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail_msg "missing $label in ${file#$ROOT/}"
+  fi
+}
+
+reject_text() {
+  local file="$1" pattern="$2" label="$3"
+  if rg -U -n "$pattern" "$file"; then
+    fail_msg "forbidden $label in ${file#$ROOT/}"
+  else
+    pass "no $label"
+  fi
+}
+
+SOURCE="$ROOT/Packages/OsaurusCore/Services/ModelRuntime/DistributedRuntimeReadiness.swift"
+TESTS="$ROOT/Packages/OsaurusCore/Tests/Service/DistributedRuntimeReadinessTests.swift"
+DOC="$ROOT/docs/RDMA_TB5_TENSOR_PARALLEL_OSAURUS_SCAFFOLD_2026_06_10.md"
+SPEC="$ROOT/docs/RDMA_TB5_NODE_DISCOVERY_PRODUCT_SPEC_2026_06_10.md"
+
+for file in "$SOURCE" "$TESTS" "$DOC" "$SPEC"; do
+  [[ -f "$file" ]] || fail_msg "missing ${file#$ROOT/}"
+done
+
+require_text "$SOURCE" 'case thunderboltLoopback' "source classifies Thunderbolt loopbacks"
+require_text "$SOURCE" 'case thunderboltDirect' "source classifies direct Thunderbolt links"
+require_text "$SOURCE" 'case tailscaleControl' "source marks Tailscale separately"
+require_text "$SOURCE" 'Tailscale/control-plane only' "source rejects Tailscale data-plane"
+require_text "$SOURCE" 'single_rank_not_tp' "source rejects size-1 TP fallback"
+require_text "$SOURCE" 'librdmaLoadable' "source tracks librdma separately"
+require_text "$SOURCE" 'jacclAvailable' "source tracks JACCL separately"
+require_text "$SOURCE" 'ibvDevicesConfigured' "source tracks IBV device config separately"
+
+require_text "$TESTS" 'tailscale_data_plane_forbidden' "tests cover Tailscale rejection"
+require_text "$TESTS" 'single_rank_not_tp' "tests cover size-1 fallback rejection"
+require_text "$TESTS" 'jaccl_unavailable' "tests cover JACCL gate"
+require_text "$TESTS" 'ibv_devices_missing' "tests cover IBV gate"
+
+require_text "$DOC" 'No UI or Settings panel changes' "doc keeps UI out of this scaffold"
+require_text "$DOC" 'No vMLX pin bump in this PR' "doc records no vMLX pin bump"
+require_text "$DOC" 'Tailscale remains control-plane/SSH only' "doc records Tailscale boundary"
+reject_text "$DOC" 'live-ready' "doc avoids live-ready claim"
+
+require_text "$SPEC" 'Enable node discovery' "spec includes node discovery toggle"
+require_text "$SPEC" 'Distributed Inference' "spec includes distributed inference menu"
+require_text "$SPEC" 'Scan' "spec includes scan button"
+require_text "$SPEC" 'Run checks' "spec includes check button"
+require_text "$SPEC" 'Start cluster' "spec includes start button"
+require_text "$SPEC" 'Animations should reflect state transitions' "spec covers animations"
+require_text "$SPEC" 'Tailscale `100.x`' "spec forbids Tailscale data-plane"
+require_text "$SPEC" 'Route check' "spec includes route fallback check"
+require_text "$SPEC" 'IBV matrix check' "spec includes IBV fallback check"
+require_text "$SPEC" 'Collective smoke' "spec includes collective fallback check"
+require_text "$SPEC" 'Runtime proof' "spec includes runtime proof fallback check"
+require_text "$SPEC" 'A size-1 fallback never appears as distributed-ready' "spec blocks size-1 false ready"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "RDMA/TB5 distributed scaffold guard failed." >&2
+  exit 1
+fi
+
+echo "RDMA/TB5 distributed scaffold guard passed."


### PR DESCRIPTION
## Summary

Starts the Osaurus-side RDMA/TB5 distributed inference scaffold so teammates can review the discovery/readiness contract before UI and runtime wiring land.

This adds:

- `DistributedRuntimeReadiness` for classifying tensor data-plane endpoints and reporting readiness findings.
- Focused tests for Thunderbolt data-plane acceptance, Tailscale rejection, size-1 fallback rejection, and separate librdma/JACCL/IBV gates.
- A scaffold doc that defines the Osaurus/vMLX boundary and explicitly avoids runtime-ready claims.
- A product spec for node discovery, menu/buttons, fallback checks, animations, diagnostics copy, and acceptance criteria.
- A live-proof guard script that keeps the source/docs/spec aligned.

## Boundaries

This PR does not turn on distributed execution, add UI, bump the vMLX pin, or claim model-family runtime proof. It is meant to be the Osaurus-side PR where the team can review and iterate on the RDMA/TB5 wiring data and discovery UX contract.

The data-plane policy intentionally rejects Tailscale `100.x` and local loopback as tensor-parallel proof. Tailscale can remain control-plane/SSH only; tensor data must use proven internal RDMA/Thunderbolt addresses such as `10.20.0.x` or direct `10.10.x.x` links.

## Validation

- `scripts/live-proof/assert-rdma-tb5-distributed-scaffold.sh`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-rdma-tb5-test DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Packages/OsaurusCore --filter DistributedRuntimeReadinessTests --jobs 1`

The focused Swift command built OsaurusCore and ran 5 tests in the `Distributed runtime readiness` suite successfully.

## Follow-Up Work

- Consume vMLX distributed probe JSON once the Swift engine changes are landed and pinned.
- Add route/interface checks, port reachability, IBV matrix validation, and collective smoke ingestion.
- Wire the future `Distributed Inference` menu/panel from the product spec after the non-UI readiness state has proof.
- Add live multi-rank model proof before any release-ready claim for Qwen, MiMo, JANG, MXFP, VL, audio, or video distributed rows.

