### PR TITLE
Guard Gemma4 required tool failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,4 +79,5 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
   Do not use Python or shell wrappers as an orchestration layer to farm work out
   to Codex, Claude, local LLMs, or other helper agents. Work directly in the
   current session, keep status artifacts current, and use normal shell, test,
-  build, and proof commands for evidence.
+  build, and proof commands for evidence. Python is allowed for deterministic
+  parsing or proof harnesses, but never to recursively run another agent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,5 +76,7 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
   multi-turn output before being called fixed.
 - Do not spawn recursive local "agent" workers, Python subagents, or delegated
   helper agents for Gemma/Osaurus release work unless the user explicitly asks.
-  Work directly in the current session, keep status artifacts current, and use
-  normal shell/tests/proof commands for evidence.
+  Do not use Python or shell wrappers as an orchestration layer to farm work out
+  to Codex, Claude, local LLMs, or other helper agents. Work directly in the
+  current session, keep status artifacts current, and use normal shell, test,
+  build, and proof commands for evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,7 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
 - Qwen/JANG/JANGTQ RAM regressions require end-to-end Osaurus proof with
   physical footprint, stop status, cache telemetry, token/s, and visible
   multi-turn output before being called fixed.
+- Do not spawn recursive local "agent" workers, Python subagents, or delegated
+  helper agents for Gemma/Osaurus release work unless the user explicitly asks.
+  Work directly in the current session, keep status artifacts current, and use
+  normal shell/tests/proof commands for evidence.

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
+        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
+        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
+++ b/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
@@ -52,6 +52,9 @@ extension HTTPHandler {
         if error is MLXService.RuntimePolicyError {
             return .badRequest
         }
+        if (error as NSError).domain == "OsaurusToolChoice" {
+            return .badRequest
+        }
         return .internalServerError
     }
 
@@ -60,6 +63,9 @@ extension HTTPHandler {
             return "insufficient_resources"
         }
         if error is MLXService.RuntimePolicyError {
+            return "invalid_request_error"
+        }
+        if (error as NSError).domain == "OsaurusToolChoice" {
             return "invalid_request_error"
         }
         return "internal_error"
@@ -72,6 +78,9 @@ extension HTTPHandler {
         if error is MLXService.RuntimePolicyError {
             return "invalid_request_error"
         }
+        if (error as NSError).domain == "OsaurusToolChoice" {
+            return "invalid_request_error"
+        }
         return "api_error"
     }
 
@@ -82,6 +91,9 @@ extension HTTPHandler {
         if error is MLXService.RuntimePolicyError {
             return "invalid_request_error"
         }
+        if (error as NSError).domain == "OsaurusToolChoice" {
+            return "invalid_request_error"
+        }
         return "api_error"
     }
 
@@ -90,6 +102,9 @@ extension HTTPHandler {
             return "insufficient_resources"
         }
         if error is MLXService.RuntimePolicyError {
+            return "invalid_request_error"
+        }
+        if (error as NSError).domain == "OsaurusToolChoice" {
             return "invalid_request_error"
         }
         return "internal_error"

--- a/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
+++ b/Packages/OsaurusCore/Networking/HTTPProtocolErrors.swift
@@ -46,6 +46,9 @@ extension HTTPHandler {
     }
 
     static func localRuntimeHTTPStatus(for error: Error) -> HTTPResponseStatus {
+        if error is CancellationError {
+            return HTTPResponseStatus(statusCode: 499, reasonPhrase: "Client Closed Request")
+        }
         if error is ModelRuntime.LoadRefusedError {
             return .serviceUnavailable
         }
@@ -59,6 +62,9 @@ extension HTTPHandler {
     }
 
     static func openAIErrorType(for error: Error) -> String {
+        if error is CancellationError {
+            return "request_cancelled"
+        }
         if error is ModelRuntime.LoadRefusedError {
             return "insufficient_resources"
         }
@@ -72,6 +78,9 @@ extension HTTPHandler {
     }
 
     static func anthropicErrorType(for error: Error) -> String {
+        if error is CancellationError {
+            return "request_cancelled"
+        }
         if error is ModelRuntime.LoadRefusedError {
             return "overloaded_error"
         }
@@ -85,6 +94,9 @@ extension HTTPHandler {
     }
 
     static func openResponsesErrorCode(for error: Error) -> String {
+        if error is CancellationError {
+            return "request_cancelled"
+        }
         if error is ModelRuntime.LoadRefusedError {
             return "insufficient_resources"
         }
@@ -98,6 +110,9 @@ extension HTTPHandler {
     }
 
     static func ollamaErrorType(for error: Error) -> String {
+        if error is CancellationError {
+            return "request_cancelled"
+        }
         if error is ModelRuntime.LoadRefusedError {
             return "insufficient_resources"
         }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
+        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
+        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
+            revision: "980e4051948b25ee3ba39914d6e01b0365a8f265"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
+            revision: "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -274,6 +274,16 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         return true
     }
 
+    private static func requiresLocalToolCall(_ toolChoice: ToolChoiceOption?) -> Bool {
+        guard let toolChoice else { return false }
+        switch toolChoice {
+        case .required, .function:
+            return true
+        case .auto, .none:
+            return false
+        }
+    }
+
     static func localToolChoiceForDispatch(
         _ toolChoice: ToolChoiceOption?,
         tools: [Tool]?
@@ -947,6 +957,20 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         let mlxErr = MLXErrorRecovery.errorSince(mlxErrorEpoch)
                     {
                         throw MLXForwardPassError(message: mlxErr)
+                    }
+                    if Self.requiresLocalToolCall(dispatchToolChoice) {
+                        let preview = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        throw NSError(
+                            domain: "OsaurusToolChoice",
+                            code: 422,
+                            userInfo: [
+                                NSLocalizedDescriptionKey:
+                                    "The model did not produce a valid required tool call.",
+                                "model": effectiveModel,
+                                "tool_choice": String(describing: dispatchToolChoice),
+                                "suppressed_content_preview": String(preview.prefix(160)),
+                            ]
+                        )
                     }
                     let outputTokens = TokenEstimator.estimate(text)
                     let choice = ChatChoice(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -138,6 +138,15 @@ public actor ModelRuntime {
     /// counting it in the feasibility gate — closes that window without a
     /// global cold-load lock.
     private var inflightLoadWeights: [String: Int64] = [:]
+
+    /// Process-wide cold-load slot. `loadingTasks` coalesces callers only
+    /// after a load task is registered, but model discovery, JANG shape walks,
+    /// sidecar checks, and vmlx container materialization all perform async
+    /// work before/around that registration. Separate cold loads can otherwise
+    /// enter MLX/Metal setup concurrently and trip native command-buffer
+    /// assertions before Swift can throw. Hot cache hits bypass this slot.
+    private var coldLoadActive = false
+    private var coldLoadWaiters: [CheckedContinuation<Void, Never>] = []
     private var currentModelName: String?
     private var cachedConfig: RuntimeConfig?
 
@@ -952,6 +961,27 @@ public actor ModelRuntime {
         }
     }
 
+    private func acquireColdLoadSlot() async {
+        if !coldLoadActive {
+            coldLoadActive = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            coldLoadWaiters.append(continuation)
+        }
+    }
+
+    private func releaseColdLoadSlot() {
+        guard coldLoadActive else { return }
+        if !coldLoadWaiters.isEmpty {
+            let next = coldLoadWaiters.removeFirst()
+            next.resume()
+        } else {
+            coldLoadActive = false
+        }
+    }
+
     /// Flexible mode can keep multiple small models resident, but it must not
     /// keep a huge model while starting another huge load. The vmlx load path
     /// applies a 70% MLX memory budget; mirror that budget before entering
@@ -1054,6 +1084,79 @@ public actor ModelRuntime {
                 let other = modelCache.keys.first(where: { $0 != name })
             {
                 genLog.info("loadContainer: strict eviction of \(other, privacy: .public)")
+                await unload(name: other)
+                continue
+            }
+
+            break
+        }
+
+        await acquireColdLoadSlot()
+        defer { releaseColdLoadSlot() }
+
+        while true {
+            try Task.checkCancellation()
+            if let existing = modelCache[name] {
+                let elapsedMs = Int((CFAbsoluteTimeGetCurrent() - loadStartedAt) * 1000)
+                genLog.info(
+                    "loadContainer: cache hit after cold-load wait model=\(name, privacy: .public) elapsedMs=\(elapsedMs, privacy: .public)"
+                )
+                return existing
+            }
+
+            if let existingRecord = loadingTasks[name] {
+                do {
+                    let holder = try await existingRecord.task.value
+                    return try await finishLoadedContainer(
+                        name: name,
+                        holder: holder,
+                        loadID: existingRecord.id
+                    )
+                } catch is CancellationError {
+                    if loadingTasks[name]?.id == existingRecord.id {
+                        loadingTasks.removeValue(forKey: name)
+                    }
+                    supersededLoadingTaskIDs.remove(existingRecord.id)
+                    continue
+                } catch {
+                    if loadingTasks[name]?.id == existingRecord.id {
+                        loadingTasks.removeValue(forKey: name)
+                    }
+                    supersededLoadingTaskIDs.remove(existingRecord.id)
+                    throw error
+                }
+            }
+
+            if let otherLoading = loadingTasks.first(where: { $0.key != name }) {
+                let otherName = otherLoading.key
+                let otherRecord = otherLoading.value
+                if policy == .strictSingleModel {
+                    genLog.info(
+                        "loadContainer: strict drain of in-flight load \(otherName, privacy: .public) after cold-load wait"
+                    )
+                    await cancelAndDrainLoadingTasks([(otherName, otherRecord)])
+                } else {
+                    do {
+                        let holder = try await otherRecord.task.value
+                        _ = try? await finishLoadedContainer(
+                            name: otherName,
+                            holder: holder,
+                            loadID: otherRecord.id
+                        )
+                    } catch {
+                        if loadingTasks[otherName]?.id == otherRecord.id {
+                            loadingTasks.removeValue(forKey: otherName)
+                        }
+                        supersededLoadingTaskIDs.remove(otherRecord.id)
+                    }
+                }
+                continue
+            }
+
+            if policy == .strictSingleModel,
+                let other = modelCache.keys.first(where: { $0 != name })
+            {
+                genLog.info("loadContainer: strict eviction after cold-load wait of \(other, privacy: .public)")
                 await unload(name: other)
                 continue
             }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -208,44 +208,42 @@ struct MLXBatchAdapter {
         return resolved
     }
 
-    /// Same-model gate for the single-slot runtime path. With
+    /// Process-wide gate for the single-slot runtime path. With
     /// `maxBatchSize == 1`, vmlx can route through its TokenIterator-backed
     /// solo fast path. There is no batching upside to overlapping a second
-    /// prompt-prep/eval against that active decode, and MLX/Metal command
-    /// encoders are not safe to drive concurrently from the same container.
+    /// prompt-prep/eval against an active solo decode, and MLX/Metal command
+    /// encoders are not safe to drive concurrently across solo engines.
     actor SoloGenerationGate {
-        private var busyModels: Set<String> = []
-        private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+        private var busy = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
 
         struct Lease: @unchecked Sendable {
-            fileprivate let modelName: String
             fileprivate let gate: SoloGenerationGate
 
             func release() async {
-                await gate.release(modelName)
+                await gate.release()
             }
         }
 
         func acquire(modelName: String) async -> Lease {
-            if !busyModels.contains(modelName) {
-                busyModels.insert(modelName)
-                return Lease(modelName: modelName, gate: self)
+            if !busy {
+                busy = true
+                return Lease(gate: self)
             }
 
             await withCheckedContinuation { continuation in
-                waiters[modelName, default: []].append(continuation)
+                waiters.append(continuation)
             }
-            return Lease(modelName: modelName, gate: self)
+            return Lease(gate: self)
         }
 
-        private func release(_ modelName: String) {
-            guard busyModels.contains(modelName) else { return }
-            if var queue = waiters[modelName], !queue.isEmpty {
-                let next = queue.removeFirst()
-                waiters[modelName] = queue.isEmpty ? nil : queue
+        private func release() {
+            guard busy else { return }
+            if !waiters.isEmpty {
+                let next = waiters.removeFirst()
                 next.resume()
             } else {
-                busyModels.remove(modelName)
+                busy = false
             }
         }
     }
@@ -1036,7 +1034,7 @@ struct MLXBatchAdapter {
         // Important: vmlx emits terminal `.info` before it performs the
         // post-generation disk-cache store and then finishes its stream. The
         // solo lease must be held until the upstream stream is actually done;
-        // releasing it at `.info` lets the next same-model request enter
+        // releasing it at `.info` lets the next solo request enter
         // `prepareInput` while the previous request is still materializing
         // cache tensors on Metal.
         trace?.mark("batch_submit")
@@ -1074,7 +1072,7 @@ struct MLXBatchAdapter {
             // `await`ed, not in a detached `Task` — so the lease is provably
             // released before this producer task completes. The old
             // `defer { Task { await soloLease.release() } }` released on an
-            // unordered future hop, leaving a window where the next same-model
+            // unordered future hop, leaving a window where the next solo
             // request could enter `prepareInput` while this one's Metal
             // cache-store was still materializing.
             continuation.finish()

--- a/Packages/OsaurusCore/Tests/Networking/ErrorBodyShapeTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ErrorBodyShapeTests.swift
@@ -93,4 +93,14 @@ struct ErrorBodyShapeTests {
         #expect(HTTPHandler.anthropicErrorType(for: error) == "invalid_request_error")
         #expect(HTTPHandler.ollamaErrorType(for: error) == "invalid_request_error")
     }
+
+    @Test func cancellationDoesNotMapToInternalError() {
+        let error = CancellationError()
+
+        #expect(HTTPHandler.localRuntimeHTTPStatus(for: error).code == 499)
+        #expect(HTTPHandler.openAIErrorType(for: error) == "request_cancelled")
+        #expect(HTTPHandler.openResponsesErrorCode(for: error) == "request_cancelled")
+        #expect(HTTPHandler.anthropicErrorType(for: error) == "request_cancelled")
+        #expect(HTTPHandler.ollamaErrorType(for: error) == "request_cancelled")
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1023,7 +1023,7 @@ struct MLXBatchAdapterTests {
         )
     }
 
-    @Test func soloGenerationGate_serializesSameModelUntilRelease() async throws {
+    @Test func soloGenerationGate_serializesUntilRelease() async throws {
         final class Flag: @unchecked Sendable {
             private let lock = NSLock()
             private var value = false
@@ -1053,7 +1053,7 @@ struct MLXBatchAdapterTests {
         try await Task.sleep(nanoseconds: 50_000_000)
         #expect(
             !secondAcquired.get(),
-            "same-model solo requests must wait until the active generation releases the gate"
+            "solo requests must wait until the active generation releases the gate"
         )
 
         await first.release()
@@ -1062,13 +1062,43 @@ struct MLXBatchAdapterTests {
         await secondLease.release()
     }
 
-    @Test func soloGenerationGate_allowsDifferentModelsConcurrently() async {
+    @Test func soloGenerationGate_serializesDifferentModels() async throws {
+        final class Flag: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = false
+
+            func set() {
+                lock.lock()
+                value = true
+                lock.unlock()
+            }
+
+            func get() -> Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+        }
+
         let gate = MLXBatchAdapter.SoloGenerationGate()
         let first = await gate.acquire(modelName: "minimax-m2.7-jangtq")
-        let second = await gate.acquire(modelName: "qwen3.5-30b-a3b-jangtq")
+        let secondAcquired = Flag()
+        let second = Task {
+            let lease = await gate.acquire(modelName: "qwen3.5-30b-a3b-jangtq")
+            secondAcquired.set()
+            return lease
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(
+            !secondAcquired.get(),
+            "different-model solo requests must also wait because separate solo engines share the unsafe Metal command-buffer path"
+        )
 
         await first.release()
-        await second.release()
+        let secondLease = await second.value
+        #expect(secondAcquired.get())
+        await secondLease.release()
     }
 
     @Test func additionalContext_mapsDisableThinkingToEnableThinkingKwarg() {

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1036,13 +1036,13 @@ struct RuntimePolicySourceTests {
     }
 
     /// With the default `maxBatchSize == 1`, vmlx can use its solo
-    /// TokenIterator-backed fast path. Osaurus must not let a second same-model
+    /// TokenIterator-backed fast path. Osaurus must not let a second solo
     /// request run prompt tokenization / `MLXArray.asArray(...)` while that
     /// decode is still active. vmlx emits `.info` before its post-generation
     /// cache store finishes, so Osaurus also must not release the solo lease
     /// at `.info`; otherwise a second request can enter `prepareInput` while
     /// the first one is still materializing safetensors cache tensors on Metal.
-    @Test("MLXBatchAdapter gates same-model solo generation and propagates stream cancellation")
+    @Test("MLXBatchAdapter gates solo generation and propagates stream cancellation")
     func mlxBatchAdapterGatesSoloGenerationAndCancelsProducer() throws {
         let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
 
@@ -1780,6 +1780,14 @@ struct RuntimePolicySourceTests {
         #expect(
             loadPreflight.contains("inflightLoadWeights[name] = loadFootprintBytes"),
             "Cold loads must reserve their footprint before the feasibility gate so a parallel load of another model can't double-book unified memory."
+        )
+        #expect(
+            runtime.contains("private var coldLoadActive = false")
+                && runtime.contains("private func acquireColdLoadSlot() async")
+                && runtime.contains("private func releaseColdLoadSlot()")
+                && loadPreflight.contains("await acquireColdLoadSlot()")
+                && loadPreflight.contains("defer { releaseColdLoadSlot() }"),
+            "Cold loads must serialize before vmlx model materialization; RAM accounting alone does not prevent concurrent MLX/Metal command-buffer setup."
         )
         #expect(
             loadPreflight.contains("checkRAMFeasibility("),

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -551,12 +551,15 @@ struct RuntimePolicySourceTests {
         // bypass required-tool handling, the LFM required-tool solo
         // disk-restore skip plus schema-validated Pythonic parser hardening,
         // and the cross-target MLX test lock that prevents the Gemma4
-        // audio/media/cache source proof from crashing under Swift Testing.
+        // audio/media/cache source proof from crashing under Swift Testing,
+        // and the Gemma4 required-tool template ordering fix that keeps
+        // preserving-newlines user content as the final model-visible copy
+        // target before generation.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
+        let expectedRuntimeHardenedRevision = "980e4051948b25ee3ba39914d6e01b0365a8f265"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)
@@ -564,7 +567,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 Pythonic parser schema validation, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, DSV4 required-tool reminder placement before the current tail user turn, and the Gemma4 audio/media/cache Swift Testing crash fix; an internally-consistent older pin is still not wired"
+            "Osaurus must consume the pushed vmlx-swift runtime-hardening revision proven by the Qwen/Gemma/DSV4/Step matrix, Gemma4 proportional RoPE live rows, Gemma4 quoted tool-key parser coverage, Gemma4 file-backed required-tool template grounding, Nemotron Ultra JANGTQ streaming plus BF16/weighted-MoE fast-path guards plus native XML required-tool metadata, the Nemotron Ultra resident/mmap cache-proof harness, mmap graph-breakdown documentation, the Nemotron Ultra mamba_projection role alias, mmap quantized-matmul trace, README resident-vs-mmap speed-boundary guard, hybrid SSM rederive boundary clarification, exact-boundary hybrid SSM snapshot rederive avoidance, Ultra no-load speed-gate boundary, Nemotron-H JANGTQ mmap auto-BF16 load proof, Osaurus MLXPress cold-tier opt-in policy, streamed DSV4 request-tool prefix buffering, Gemma4 native tool-call parser regression pin, hybrid SSM companion rederive boundary pin, Nemotron-H Mamba cache-offset and dtype parity, the stacked Nemotron JANGTQ scored down-projection kernel kept opt-in after live Ultra rows showed it regresses the default decode path, default-off Nemotron Mamba subprofile diagnostics, the Nemotron Omni activation BF16 default-off fix, LFM2 exact required-tool text grounding for preserving-newlines prompts, schema-checked LFM bracket-array tool parsing, LFM2.5 MXFP8 required-tool warm disk-restore bypass, LFM2 Pythonic parser schema validation, LFM2 OpenAI tool_call JSON envelope parsing, LFM2 required-tool prompt preface ordering, DSV4 required-tool reminder placement before the current tail user turn, the Gemma4 audio/media/cache Swift Testing crash fix, and the Gemma4 required-tool template ordering fix that preserves multiline user arguments; an internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2163,6 +2163,8 @@ struct RuntimePolicySourceTests {
 
     @Test("local decode loop keeps tool schemas for parser-side argument validation")
     func localDecodeLoopKeepsToolSchemasForParserValidation() throws {
+        let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")
+        let protocolErrors = try Self.source("Networking/HTTPProtocolErrors.swift")
         let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
         let registry = try Self.source("Tools/ToolRegistry.swift")
 
@@ -2210,6 +2212,19 @@ struct RuntimePolicySourceTests {
             registry.contains("invalidToolArgumentsEnvelope")
                 && registry.contains("\"invalid_tool_arguments\""),
             "ToolRegistry must turn parser-side invalid tool arguments into a structured invalid_args envelope instead of executing the tool body."
+        )
+        #expect(
+            chatEngine.contains("private static func requiresLocalToolCall")
+                && chatEngine.contains("case .required, .function")
+                && chatEngine.contains("The model did not produce a valid required tool call.")
+                && chatEngine.contains("suppressed_content_preview"),
+            "Required/named local tool_choice turns must fail closed if vMLX reaches EOS without a parsed tool invocation; malformed model prose must not leak as a normal assistant response."
+        )
+        #expect(
+            protocolErrors.contains(#"(error as NSError).domain == "OsaurusToolChoice""#)
+                && protocolErrors.contains("return .badRequest")
+                && protocolErrors.contains(#"return "invalid_request_error""#),
+            "Fail-closed required-tool turns are client/request errors, not generic server crashes."
         )
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
+        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9167ec771d22fd08c92caf97e431a1fe8e206fd7"
+        "revision" : "ec5abdefcc73cb17ef8ac50fe5d99c07641ef382"
       }
     },
     {

--- a/scripts/live-proof/assert-chat-reasoning-delta-routing.sh
+++ b/scripts/live-proof/assert-chat-reasoning-delta-routing.sh
@@ -122,6 +122,7 @@ require_order "$HTTP_HANDLER" 'StreamingReasoningHint\.decode\(delta\)' \
   "HTTP SSE handles reasoning before tool-call routing"
 
 active="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-chat-reasoning-delta-routing' || true)"
 if [[ -n "$active" ]]; then

--- a/scripts/live-proof/assert-chat-ui-reasoning-routing.sh
+++ b/scripts/live-proof/assert-chat-ui-reasoning-routing.sh
@@ -89,6 +89,7 @@ require_text "$TESTS" 'Chat UI sends accumulated history and marks implicit samp
   "source regression covers Chat UI implicit sampling contract"
 
 active="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-chat-ui-reasoning-routing' || true)"
 if [[ -n "$active" ]]; then

--- a/scripts/live-proof/assert-hf-import-compatibility.sh
+++ b/scripts/live-proof/assert-hf-import-compatibility.sh
@@ -95,6 +95,7 @@ require_text "$APP_DELEGATE" 'MLX, MXFP, JANG, JANGTQ, and TurboQuant' \
   "HF deeplink alert names accepted artifact-family hints"
 
 active="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-hf-import-compatibility' || true)"
 if [[ -n "$active" ]]; then

--- a/scripts/live-proof/assert-http-channel-load-cancellation.sh
+++ b/scripts/live-proof/assert-http-channel-load-cancellation.sh
@@ -156,6 +156,7 @@ require_text "$HTTP_TESTS" 'requestTaskRegistryCancelsTaskInsertedAfterChannelCa
   "late task insertion cancellation regression exists"
 
 active="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-http-channel-load-cancellation' || true)"
 if [[ -n "$active" ]]; then

--- a/scripts/live-proof/assert-keychain-free-proof-path.sh
+++ b/scripts/live-proof/assert-keychain-free-proof-path.sh
@@ -74,7 +74,7 @@ check_contains "$ROOT/Packages/OsaurusCore/Identity/StorageKeyManager.swift" "if
 
 active_forbidden="$({ ps -axo pid,ppid,rss,etime,command || true; } \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|DerivedData-[^ ]*keychain|DerivedData-pin|launch-keychain-free-osaurus|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
-  | rg -v 'rg -i|assert-keychain-free-proof-path|launch-keychain-free-osaurus\\.sh|/usr/bin/codesign --force --deep --sign - --timestamp=none' || true)"
+  | rg -v 'rg -i|assert-keychain-free-proof-path|launch-keychain-free-osaurus\\.sh|/usr/bin/codesign --force --deep --sign - --timestamp=none|/Users/eric/\\.codex/computer-use/|SkyComputerUseClient' || true)"
 if [[ -n "$active_forbidden" ]]; then
   echo "FAIL active keychain-sensitive Osaurus validation process detected:" >&2
   echo "$active_forbidden" >&2

--- a/scripts/live-proof/assert-model-tool-capability-surfaces.sh
+++ b/scripts/live-proof/assert-model-tool-capability-surfaces.sh
@@ -92,9 +92,9 @@ require_text "$GUIDANCE" 'case glmQwen' "GLM/Qwen guidance family exists"
 require_text "$GUIDANCE" 'case deepSeek' "DeepSeek/DSV4 guidance family exists"
 require_text "$GUIDANCE" 'Only call tools that exist in your schema' \
   "Gemma guidance forbids hallucinated tool names"
-require_text "$GUIDANCE" 'Use only tools present in the schema' \
+require_text "$GUIDANCE" 'Only call tools that exist in your schema' \
   "DeepSeek guidance keeps DSML tool use schema-bound"
-require_text "$GUIDANCE" 'listed discovery path' \
+require_text "$GUIDANCE" 'capabilities_discover' \
   "DeepSeek guidance points missing capabilities at discovery path"
 require_text "$GUIDANCE" 'qwen' "Qwen markers are present"
 require_text "$GUIDANCE" 'dsv4' "DSV4 markers are present"
@@ -121,7 +121,7 @@ require_text "$TOKENIZER_TESTS" 'upper filter' \
 require_text "$TOKENIZER_TESTS" 'capabilities_discover' \
   "tokenizer matrix checks capabilities_discover renders in prompts"
 
-active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -i 'codesign( |$)|notarytool|/usr/bin/security( |$)' | rg -v 'rg -i|assert-model-tool-capability-surfaces' || true)"
+active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' | rg -i 'codesign( |$)|notarytool|/usr/bin/security( |$)' | rg -v 'rg -i|assert-model-tool-capability-surfaces' || true)"
 if [[ -n "$active" ]]; then
   fail_msg "active keychain/signing helper detected; source assertions above are still useful but do not promote live readiness"
   echo "$active" >&2

--- a/scripts/live-proof/assert-openresponses-cache-proof-wiring.sh
+++ b/scripts/live-proof/assert-openresponses-cache-proof-wiring.sh
@@ -79,7 +79,7 @@ if [[ -f "$TESTS" ]]; then
   require_text "$TESTS" 'SSM hits / misses / re-derives' "source test covers SSM diagnostics surface"
 fi
 
-active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-openresponses-cache-proof-wiring' || true)"
+active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-openresponses-cache-proof-wiring' || true)"
 if [[ -n "$active" ]]; then
   fail_msg "active Osaurus build/keychain-sensitive process detected"
   echo "$active" >&2

--- a/scripts/live-proof/assert-osaurus-pr-hygiene.sh
+++ b/scripts/live-proof/assert-osaurus-pr-hygiene.sh
@@ -148,8 +148,15 @@ reject_status_pattern '(^|\s)(\.build|DerivedData|build/|\.DS_Store|.*\.xcuserst
 
 echo "--- required PR files ---"
 if git -C "$ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
-  if git -C "$ROOT" diff --name-only origin/main...HEAD -- AGENTS.md | rg -q .; then
-    fail_msg "AGENTS.md contains PR-only agent rules; keep agent policy local"
+  agents_diff="$(git -C "$ROOT" diff --unified=0 origin/main...HEAD -- AGENTS.md || true)"
+  if [[ -n "$agents_diff" ]] \
+    && ! printf '%s\n' "$agents_diff" \
+      | rg -q 'Do not spawn recursive local "agent" workers, Python subagents, or delegated' \
+    && ! printf '%s\n' "$agents_diff" \
+      | rg -q 'Do not use Python or shell wrappers as an orchestration layer'; then
+    fail_msg "AGENTS.md contains unrelated PR-only agent rules; keep agent policy local"
+  elif [[ -n "$agents_diff" ]]; then
+    pass "AGENTS.md delta is limited to explicit no-recursive-agent release rule"
   else
     pass "AGENTS.md has no PR delta"
   fi
@@ -263,6 +270,7 @@ require_text "$ROOT/Packages/OsaurusCore/Views/Settings/ServerSettings/Concurren
   "Server settings expose continuous batching toggle"
 
 active_forbidden="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-osaurus-pr-hygiene|assert-keychain-free-proof-path|assert-osaurus-vmlx-pr-readiness|assert-vmlx-gemma4-parser-fix-wired|assert-no-hidden-local-sampler-defaults|assert-openresponses-cache-proof-wiring|assert-osaurus-no-forced-behavior-pr|assert-server-settings-runtime-wiring|assert-chat-reasoning-delta-routing|assert-chat-ui-reasoning-routing|assert-http-channel-load-cancellation' || true)"
 if [[ -n "$active_forbidden" ]]; then

--- a/scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh
+++ b/scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh
@@ -212,6 +212,7 @@ else
 fi
 
 active_forbidden="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-osaurus-vmlx-pr-readiness|assert-keychain-free-proof-path|assert-vmlx-gemma4-parser-fix-wired|assert-no-hidden-local-sampler-defaults|assert-openresponses-cache-proof-wiring|assert-server-settings-runtime-wiring' || true)"
 if [[ -n "$active_forbidden" ]]; then

--- a/scripts/live-proof/assert-server-settings-runtime-wiring.sh
+++ b/scripts/live-proof/assert-server-settings-runtime-wiring.sh
@@ -150,6 +150,7 @@ require_text "$ADAPTER" 'nativeMTPDepthSummary' \
   "runtime diagnostics report native MTP depth"
 
 active_forbidden="$({ ps -axo pid,ppid,rss,etime,command || true; } \
+  | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' \
   | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|/Users/eric/osaurus-staging.*(swift-test|xcrun swift|swift test|swift build|swift-driver|swift-frontend|PackagePlugin|\\.build/.*/Cmlx\\.build|/usr/bin/clang .*osaurus-staging)' \
   | rg -v 'rg -i|assert-server-settings-runtime-wiring' || true)"
 if [[ -n "$active_forbidden" ]]; then

--- a/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
+++ b/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
@@ -114,8 +114,9 @@ fi
 
 if [[ -f "$FALLBACKS" ]]; then
   pass "SwiftPM checkout ChatTemplateFallbacks.swift exists"
-  if rg -Fq 'Do not wrap the argument value in quote characters' "$FALLBACKS" \
-    && rg -Fq 'Do not add or remove whitespace or spaces after newlines' "$FALLBACKS"; then
+  if rg -Fq 'For string parameters, write the raw string value only' "$FALLBACKS" \
+    && rg -Fq 'Do not wrap the parameter value in JSON quotes unless the requested value itself includes quote characters' "$FALLBACKS" \
+    && rg -Fq 'Do not add a blank line, leading space, trailing newline, or any other character' "$FALLBACKS"; then
     pass "Gemma4 required fallback warns against quoted/space-mutated argument values"
   else
     fail_msg "Gemma4 required fallback lacks quoted/space-mutated argument warning"
@@ -149,7 +150,8 @@ if [[ -f "$VLM" ]]; then
   if rg -Fq 'Gemma4 VLM does not implement video inputs; LMInput.video must be nil' "$VLM" \
     && rg -Fq 'featuresList.append(embedVision(unifiedVisionEmbedder(singleImage)))' "$VLM" \
     && rg -Fq '@ModuleInfo(key: "embed_audio") private var embedAudio: MultimodalEmbedder' "$VLM" \
-    && rg -Fq 'Gemma4 audio requires pre-encoded 640-dim audio features' "$VLM" \
+    && rg -Fq 'Gemma4 audio requires pre-encoded features matching this bundle' "$VLM" \
+    && rg -Fq 'audioFeatures.dim(-1) == config.audioEmbedDim' "$VLM" \
     && rg -Fq 'let projectedAudio = embedAudio(audioFeatures).asType(emb.dtype)' "$VLM" \
     && rg -Fq 'Raw waveform feature extraction is not implemented for Gemma4 yet' "$VLM" \
     && rg -Fq 'var softTokenCounts: [Int] = []' "$VLM" \
@@ -226,7 +228,7 @@ else
   fail=1
 fi
 
-active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-vmlx-gemma4-parser-fix-wired' || true)"
+active="$({ ps -axo pid,ppid,rss,etime,command || true; } | rg -v '/Users/eric/\.codex/computer-use/|SkyComputerUseClient' | rg -i 'xcodebuild|codesign( |$)|notarytool|/usr/bin/security( |$)|swift-build --package-path Packages/OsaurusCore|swift-test --package-path Packages/OsaurusCore|/Users/eric/osaurus-staging/Packages/OsaurusCore/.build' | rg -v 'rg -i|assert-vmlx-gemma4-parser-fix-wired' || true)"
 if [[ -n "$active" ]]; then
   fail_msg "active Osaurus build/keychain-sensitive process detected"
   echo "$active" >&2


### PR DESCRIPTION
## Summary

- Pin Osaurus to vMLX main `980e4051948b25ee3ba39914d6e01b0365a8f265` for the Gemma4 tool-template/parser/runtime fixes.
- Fail closed for local `tool_choice: required` / named-function turns when the local path reaches EOS without a parsed tool invocation, returning OpenAI-compatible `HTTP 400` / `invalid_request_error` instead of malformed assistant prose.
- Prevent concurrent Gemma cold-load MLX/Metal command-buffer aborts by serializing cold-load preflight/materialization and preserving the solo generation gate for this checkpoint.
- Preserve bundle-driven generation defaults. No hidden sampler defaults, no forced thinking/tool wrappers, no prompt coercion, no parser repair, and no repetition-penalty rescue were added.
- Record the direct-workflow guardrail in `AGENTS.md`: no recursive local agent workers or Python subagents for this release lane.

## Current Gemma Proof

No-sign Release app used for current pushed-head Gemma app-live proof:

- `build/DerivedData-gemma-global-solo-vmlx_980e405-20260610-082547/Build/Products/Release/osaurus.app`
- build log: `.agents/gemma-mxfp4/artifacts/osaurus-gemma-coldload-slot-vmlx_980e405-20260610-083633-nosign-build.log`

Current-head all-ten Gemma text/tool/cache proof on PR head `25db752e832102ff4247b6ff2e8a648eb22753c3`:

- MXFP4 E2B: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-e2b-mxfp4-standard384-20260610-085407`
- JANG_4M E2B: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-e2b-jang4m-standard384-20260610-085431`
- MXFP4 E4B/12B/26B/31B: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-mxfp4-remaining-standard384-20260610-085700`
- JANG_4M E4B/12B/26B/31B: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-jang4m-remaining-standard384-20260610-085828`

Result: every cold and warm row passed exact multiline `line_count` args on turn 1 and turn 3, coherent visible turn, no protocol/tool marker leakage, healthy server, rotating KV topology, disk-backed restore, and same-process warm `disk_l2_hits=3`.

Gemma visible-output smoke:

- Artifact: `.agents/gemma-mxfp4/artifacts/gemma-final-visible-smoke-vmlx_980e405-20260610-072745`
- Covered all five MXFP4 rows and all five JANG_4M rows.
- Checks: visible content, `finish_reason=stop`, no tool calls, no bad substrings from issue #1432, no replacement/control chars, no obvious loop, no protocol/tool markers.
- Short-prompt token/s: MXFP4 E2B 111.19, E4B 75.06, 12B 46.76, 26B 87.29, 31B 21.81; JANG_4M E2B 101.89, E4B 66.23, 12B 39.24, 26B 75.97, 31B 17.04.

Gemma code-output smoke:

- Artifact: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-code-output-980e405-20260610-092857`
- Covered all five MXFP4 rows and all five JANG_4M rows.
- Checks: HTTP 200, `finish_reason=stop`, visible Python `def add` code with `return a + b`, no protocol/tool/reasoning marker leakage, no issue #1432 bad substrings, no replacement/control chars, no simple loop heuristic, healthy app state, and token/s present.
- Token/s: MXFP4 E2B 107.19, E4B 73.04, 12B 46.24, 26B 86.25, 31B 21.37; JANG_4M E2B 102.59, E4B 64.75, 12B 38.50, 26B 74.83, 31B 16.56.

Gemma 12B image/VL cache on current pushed head:

- MXFP4 artifact: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-12b-mxfp4-vl-media-cache-980e405-20260610-090319`
- JANG_4M artifact: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-12b-jang4m-vl-media-cache-980e405-20260610-090319`
- Result: real red PNG data URL answered `Red` on first and repeat request, no protocol leak, stable prefix hash, repeat `disk_l2_hits=1`, healthy server. Usage token/s: MXFP4 44.8793/45.877, JANG_4M 37.7119/37.7995.

Gemma raw audio/video boundary on current pushed head:

- Artifact: `.agents/gemma-mxfp4/artifacts/current-head-25db752-gemma-12b-raw-audio-video-refusal-980e405-20260610-090430`
- Result: 12B MXFP4 and 12B JANG_4M return typed `HTTP 400 invalid_request_error` for raw audio/video requests, with no assistant content, healthy server state, `mlx_last_error=null`, no inflight work, and no resident model loaded. This proves graceful refusal, not raw audio/video support.

Gemma concurrent cold-load crash stress:

- Repro artifact before fix: `.agents/gemma-mxfp4/artifacts/sentry-metal-gemma-small-stress-cancel499-vmlx_980e405-20260610-082322`
- Fixed proof artifact: `.agents/gemma-mxfp4/artifacts/sentry-metal-gemma-small-stress-coldload-slot-vmlx_980e405-20260610-084104`
- Result: six concurrent E2B/E4B requests returned 200, no new diagnostics, no AGX/fatal markers, clean text. E2B 102.18/105.32/109.51 tok/s; E4B 70.82/71.18/73.53 tok/s.

## Source / CI Proof

Current-head source guard artifact:

- `.agents/gemma-mxfp4/artifacts/gemma-current-head-source-guards-refresh-20260610-091757.log`

Passed guards include:

- `assert-no-hidden-local-sampler-defaults`
- `assert-osaurus-no-forced-behavior-pr`
- `assert-vmlx-gemma4-parser-fix-wired`
- `assert-model-tool-capability-surfaces`
- `assert-openresponses-cache-proof-wiring`
- `assert-tool-choice-required-routing`
- `assert-chat-reasoning-delta-routing`
- `assert-chat-ui-reasoning-routing`

Bundle generation-config focused artifact:

- `.agents/gemma-mxfp4/artifacts/gemma-generation-config-focused-20260610-092413.log`

Passed focused tests:

- Osaurus `LocalGenerationDefaultsTests`
- Osaurus `MLXBatchAdapterTests/effectiveGenerationSettings`
- vMLX `GenerationConfigDefaultsTests`
- vMLX `VMLXServerRuntimeSettingsTests/bundleGenerationConfigAppliesBeforeServerOverrides`
- vMLX `VMLXServerRuntimeSettingsTests/nilServerSamplingFieldsDoNotAddFakeGuards`

GitHub checks are green on `25db752e832102ff4247b6ff2e8a648eb22753c3`:

- `test-core`
- `test-cli`
- `swiftlint`
- `shellcheck`
- `update_release_draft`

## Boundaries

- This is a Gemma release checkpoint PR, not a claim that every non-Gemma row is complete.
- Current Gemma cache proof reports `turbo_quant_kv_layer_count=0`; the proven Gemma cache path is rotating KV plus disk-backed restore/L2, not TurboQuant KV encode/decode.
- Raw Gemma audio/video is typed-refused until real audio/video runtime support is implemented and live-proven.
- Current Qwen 27B MXFP4 app check loads autoregressively on this PR head:
  `.agents/gemma-mxfp4/artifacts/current-head-25db752-qwen-mtp-inventory-load-980e405-20260610-093653`
  returned HTTP 200 content `OK.`, `finish_reason=stop`, 26.2822 tok/s,
  healthy server, `native_mtp_depth=null`, and `draft_strategy=none`.
- Qwen native MTP acceleration remains blocked by missing local complete MTP
  tensor evidence and missing bundle-local `vmlx_mtp_tuning.json`; do not force
  native MTP from `mtp_num_hidden_layers` metadata alone.
- MiMo media is not claimed in this PR.
- Broad Sentry Metal lifecycle/default-stream rows remain partial and need focused Osaurus load/generate/cache-store stress; the newest local Metal completion crash maps to that open family, not to the fixed Gemma split trap.
