### PR TITLE
Make RAM pressure advisory for local model loads

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
+        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
+        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -112,9 +112,10 @@ final class ModelManager: NSObject, ObservableObject {
             /// Only include models whose `compatibility` is `.tight`
             /// (memory usage between 75 % and 95 % of total RAM)
             case tightFit = "Tight Fit"
-            /// Exclude models whose `compatibility` is `.tooLarge`
-            /// (memory usage above the 95 % ratio threshold). Models with
-            /// unknown memory info pass through unchanged
+            /// Exclude models whose advisory `compatibility` is `.tooLarge`
+            /// (memory usage above the 95 % ratio threshold). This filter is
+            /// user-selected catalog triage only; runtime load/download does
+            /// not block RAM pressure from this estimate.
             case hideTooLarge = "Hide Too Large"
 
             var id: String { rawValue }

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -70,7 +70,8 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
     /// Projected physical-memory fraction above which a model load is marked tight.
     public var modelLoadRAMSoftThreshold: Double
 
-    /// Projected physical-memory fraction above which a model load is refused.
+    /// Projected physical-memory fraction above which a model load is marked
+    /// very tight. This is advisory telemetry, not a load/download block.
     public var modelLoadRAMHardThreshold: Double
 
     /// Maximum HTTP request body size, in bytes, accepted by the public

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
+        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
+        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "638a2b9f490337ed5a3864b84ceca1724d85e13c"
+            revision: "c2e8e02101117a64347601f303458ea363b83ee0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "980e4051948b25ee3ba39914d6e01b0365a8f265"
+            revision: "638a2b9f490337ed5a3864b84ceca1724d85e13c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -152,7 +152,7 @@ public actor ModelRuntime {
 
     /// Result of the most recent pre-load RAM feasibility check. Surfaced via
     /// `lastRAMFeasibilitySnapshot()` so `/health` and the model picker can
-    /// show why a load was refused or flagged as tight without re-scanning.
+    /// show why a load was flagged as tight without re-scanning.
     private var lastRAMFeasibility: RAMFeasibility?
 
     /// Every in-flight generation wrapper task, keyed by a monotonic id.
@@ -635,7 +635,8 @@ public actor ModelRuntime {
             /// Above the soft (warn) threshold but below the hard ceiling —
             /// loaded anyway, but resident pressure is high.
             case tight
-            /// Above the hard ceiling — the load was refused.
+            /// Reserved for explicit future policy refusals. RAM pressure
+            /// alone is advisory and should not set this verdict.
             case refused
         }
         public let modelName: String
@@ -834,12 +835,13 @@ public actor ModelRuntime {
         lastRAMFeasibility
     }
 
-    /// Pre-load RAM feasibility gate. Records `lastRAMFeasibility` for
-    /// observability and throws only when the projected footprint exceeds the
-    /// physical hard ceiling. A low immediately-free page count is recorded as
-    /// `.tight` (warn) but does not refuse — unified memory makes that count an
-    /// unreliable proxy for whether a load can succeed. Applies to all
-    /// eviction policies.
+    /// Pre-load RAM feasibility assessment. Records `lastRAMFeasibility` for
+    /// observability but does not reject a user-requested load solely because
+    /// RAM is currently full or projected pressure crosses a configured
+    /// fraction of physical memory. Unified-memory macOS can compress, purge,
+    /// and page mmap-backed weights; hard rejection here blocked valid
+    /// JANG/JANGTQ/quantized loads before vMLX could prove the real footprint.
+    /// Applies to all eviction policies.
     private func checkRAMFeasibility(
         modelName: String,
         incomingWeightsBytes: Int64,
@@ -867,19 +869,16 @@ public actor ModelRuntime {
         let softLimit = Int64(Double(physical) * thresholds.soft)
         let hardLimit = Int64(Double(physical) * thresholds.hard)
 
-        // Refusal is gated solely on the projected footprint vs. the physical
-        // hard ceiling. On unified-memory Macs the OS satisfies a load by
-        // compressing/evicting, so the immediately-free page count (`available`)
-        // routinely sits well below a model's full weight size even when the
-        // load would succeed. Treat a shortfall there as `.tight` (warn) rather
-        // than refusing — otherwise an un-discounted bundle (e.g. a non-routed
-        // MXFP8 MoE budgeted at its whole shard total) is rejected before
-        // vMLX's mmap-backed loader can prove the real footprint.
+        // On unified-memory Macs the OS satisfies a load by compressing,
+        // evicting, or paging, so the immediately-free page count
+        // (`available`) routinely sits below a model's full weight size even
+        // when the load would succeed. A hard threshold refusal here is a fake
+        // stability fix: it avoids crashes by blocking valid mmap-backed
+        // loads. Keep the signal, evict idle resident models before this
+        // point, and let real load errors propagate.
         let lowAvailable = available > 0 && requiredAvailable > available
         let verdict: RAMFeasibility.Verdict
-        if projected > hardLimit {
-            verdict = .refused
-        } else if projected > softLimit || lowAvailable {
+        if projected > hardLimit || projected > softLimit || lowAvailable {
             verdict = .tight
         } else {
             verdict = .ok
@@ -905,26 +904,16 @@ public actor ModelRuntime {
         case .ok:
             break
         case .tight:
-            genLog.error(
-                "loadContainer: RAM tight for \(modelName, privacy: .public) projected=\(projected, privacy: .public) soft=\(softLimit, privacy: .public) physical=\(physical, privacy: .public) available=\(available, privacy: .public) requiredAvailable=\(requiredAvailable, privacy: .public)"
+            genLog.warning(
+                "loadContainer: RAM tight for \(modelName, privacy: .public) projected=\(projected, privacy: .public) soft=\(softLimit, privacy: .public) hard=\(hardLimit, privacy: .public) physical=\(physical, privacy: .public) available=\(available, privacy: .public) requiredAvailable=\(requiredAvailable, privacy: .public)"
             )
         case .refused:
-            genLog.error(
-                "loadContainer: refusing \(modelName, privacy: .public) — projected footprint \(projected, privacy: .public)B hard limit \(hardLimit, privacy: .public)B available \(available, privacy: .public)B requiredAvailable \(requiredAvailable, privacy: .public)B physical \(physical, privacy: .public)B"
+            genLog.warning(
+                "loadContainer: RAM assessment marked refused for \(modelName, privacy: .public), but RAM pressure preflight is advisory; proceeding"
             )
             CrashReportingService.recordBreadcrumb(
                 category: "model.load",
-                message:
-                    "refused model=\(modelName) weightsBytes=\(incomingWeightsBytes) loadFootprintBytes=\(incomingLoadFootprintBytes) kvHeadroomBytes=\(kvHeadroom) availableBytes=\(available) requiredAvailableBytes=\(requiredAvailable) physicalBytes=\(physical)"
-            )
-            let projGB = String(format: "%.1f", Double(projected) / 1_073_741_824)
-            let physGB = String(format: "%.1f", Double(physical) / 1_073_741_824)
-            let availGB = String(format: "%.1f", Double(max(available, 0)) / 1_073_741_824)
-            let requiredGB = String(format: "%.1f", Double(requiredAvailable) / 1_073_741_824)
-            throw LoadRefusedError(
-                modelName: modelName,
-                message:
-                    "Not enough memory to load \(modelName): needs ~\(requiredGB) GB available now (~\(projGB) GB projected with resident models), but this Mac has \(availGB) GB currently available out of \(physGB) GB. Clear memory, unload other models, or choose a smaller/more-quantized model."
+                message: "ram-advisory model=\(modelName) verdict=refused"
             )
         }
     }
@@ -1254,11 +1243,10 @@ public actor ModelRuntime {
         }
         try Task.checkCancellation()
 
-        // Pre-load RAM feasibility gate (all policies). After strict eviction /
-        // flexible budget trimming above, `resident` reflects what will still
-        // be alive when this load lands. If projected footprint blows past the
-        // hard ceiling, refuse with a clear error instead of letting the OS
-        // jetsam/OOM-kill us mid-load. A softer threshold only warns.
+        // Pre-load RAM feasibility assessment (all policies). After strict
+        // eviction / flexible budget trimming above, `resident` reflects what
+        // will still be alive when this load lands. Pressure is reported via
+        // health/logs, but RAM fullness is not a user-requested load block.
         try checkRAMFeasibility(
             modelName: name,
             incomingWeightsBytes: weightsBytes,

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -623,7 +623,8 @@ public actor ModelRuntime {
     }
 
     private static func flexibleResidentBudgetBytes() -> Int64 {
-        Int64(Double(ProcessInfo.processInfo.physicalMemory) * 0.70)
+        let thresholds = ServerRuntimeSettingsStore.modelLoadRAMThresholds()
+        return Int64(Double(ProcessInfo.processInfo.physicalMemory) * thresholds.soft)
     }
 
     /// Snapshot of the most recent pre-load RAM feasibility assessment.
@@ -991,9 +992,9 @@ public actor ModelRuntime {
     }
 
     /// Flexible mode can keep multiple small models resident, but it must not
-    /// keep a huge model while starting another huge load. The vmlx load path
-    /// applies a 70% MLX memory budget; mirror that budget before entering
-    /// `loadWeights` so Hy3-sized residents do not collide with the next load.
+    /// keep a huge model while starting another huge load. Mirror the
+    /// configured RAM soft threshold before entering `loadWeights` so
+    /// Hy3-sized residents do not collide with the next load.
     private func unloadForFlexibleResidentBudget(
         targetName: String,
         incomingWeightsSizeBytes: Int64

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateDownloadTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateDownloadTests.swift
@@ -104,4 +104,48 @@ struct ConfigureAIStateDownloadTests {
         let after = ModelManager.shared.downloadService.downloadStates[model.id]
         #expect(after == .notStarted)
     }
+
+    @Test func localPathStaysAvailableAt24GBAndBelow() {
+        #expect(ConfigureAIState.isLocalTabAvailable(totalMemoryGB: 24) == true)
+        #expect(ConfigureAIState.isLocalTabAvailable(totalMemoryGB: 8) == true)
+
+        let state = ConfigureAIState()
+        #expect(state.availablePaths(totalMemoryGB: 24) == [.local, .apiProvider])
+        #expect(state.availablePaths(totalMemoryGB: 8) == [.local, .apiProvider])
+
+        state.selectedPath = .local
+        state.applyDefaultPathIfNeeded(totalMemoryGB: 24)
+        #expect(state.selectedPath == .local)
+    }
+
+    @Test func ensureLocalSelectionDoesNotDeadEndWhenAllCuratedModelsAreTooLarge() {
+        let manager = ModelManager.shared
+        let originalSuggested = manager.suggestedModels
+        defer { manager.suggestedModels = originalSuggested }
+
+        manager.suggestedModels = [
+            MLXModel(
+                id: "test/large-a-\(UUID().uuidString)",
+                name: "Large A",
+                description: "",
+                downloadURL: "https://example.com/large-a",
+                isTopSuggestion: true,
+                downloadSizeBytes: 40 * 1024 * 1024 * 1024
+            ),
+            MLXModel(
+                id: "test/large-b-\(UUID().uuidString)",
+                name: "Large B",
+                description: "",
+                downloadURL: "https://example.com/large-b",
+                isTopSuggestion: true,
+                downloadSizeBytes: 48 * 1024 * 1024 * 1024
+            ),
+        ]
+
+        let state = ConfigureAIState()
+        state.ensureLocalSelection(totalMemoryGB: 24)
+
+        #expect(state.selectedModel != nil)
+        #expect(state.selectedModel?.isTopSuggestion == true)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1800,7 +1800,8 @@ struct RuntimePolicySourceTests {
         #expect(
             runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds()")
                 && !runtime.contains("ramHardThreshold = 0.90")
-                && !runtime.contains("ramSoftThreshold = 0.70"),
+                && !runtime.contains("ramSoftThreshold = 0.70")
+                && !runtime.contains("* 0.70"),
             "RAM load thresholds must come from persisted server configuration, not hidden hardcoded ModelRuntime constants."
         )
         #expect(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -575,7 +575,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "980e4051948b25ee3ba39914d6e01b0365a8f265"
+        let expectedRuntimeHardenedRevision = "c2e8e02101117a64347601f303458ea363b83ee0"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -17,6 +17,22 @@ struct RuntimePolicySourceTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    private static func functionBody(_ signature: String, in source: String) throws -> String {
+        let start = try #require(source.range(of: signature))
+        let peers = [
+            "\n    private func ",
+            "\n    private static func ",
+            "\n    private nonisolated static func ",
+            "\n    @Test",
+        ]
+        let end =
+            peers.compactMap {
+                source.range(of: $0, range: start.upperBound ..< source.endIndex)?.lowerBound
+            }
+            .min() ?? source.endIndex
+        return String(source[start.lowerBound ..< end])
+    }
+
     private static func vmlxPinRevision(in source: String) throws -> String {
         let location = try #require(source.range(of: "https://github.com/osaurus-ai/vmlx-swift"))
         let end = source.index(location.lowerBound, offsetBy: 800, limitedBy: source.endIndex) ?? source.endIndex
@@ -1795,7 +1811,7 @@ struct RuntimePolicySourceTests {
         )
         #expect(
             loadPreflight.contains("checkRAMFeasibility("),
-            "All policies must pass the pre-load RAM feasibility gate before vmlx starts loading."
+            "All policies must record the pre-load RAM feasibility assessment before vmlx starts loading."
         )
         #expect(
             runtime.contains("ServerRuntimeSettingsStore.modelLoadRAMThresholds()")
@@ -1808,19 +1824,22 @@ struct RuntimePolicySourceTests {
             runtime.contains("availableMemoryBytes()")
                 && runtime.contains("requiredAvailable > available")
                 && runtime.contains("incomingLoadFootprintBytes")
-                && runtime.contains("availableBytes=")
-                && runtime.contains("Clear memory, unload other models, or choose a smaller/more-quantized model."),
-            "The load gate must track available memory and expose a user-actionable resource message when it refuses, not a fatal C++ exception."
+                && runtime.contains("availableMemoryBytes: available"),
+            "The load assessment must track available memory and expose it through health/logs without using it as a hard RAM block."
         )
-        // A low immediately-free page count must not by itself refuse a load:
-        // unified memory makes that count an unreliable proxy for whether a
-        // load can succeed, so refusal is gated on the physical hard ceiling
-        // (`projected > hardLimit`) while low-available only marks `.tight`.
+        let assessmentBody = try Self.functionBody(
+            "private func checkRAMFeasibility",
+            in: runtime
+        )
+        // RAM pressure must not refuse a user-requested load: unified memory
+        // makes both free pages and projected hard-threshold estimates
+        // advisory for mmap-backed JANG/JANGTQ/quantized loads.
         #expect(
-            runtime.contains("let lowAvailable = available > 0 && requiredAvailable > available")
-                && runtime.contains("if projected > hardLimit {")
-                && runtime.contains("} else if projected > softLimit || lowAvailable {"),
-            "Refusal must depend only on the physical hard ceiling; a free-page shortfall warns (.tight) but does not block a load vMLX could satisfy via unified memory."
+            assessmentBody.contains("let lowAvailable = available > 0 && requiredAvailable > available")
+                && assessmentBody.contains("projected > hardLimit || projected > softLimit || lowAvailable")
+                && !assessmentBody.contains("throw LoadRefusedError(")
+                && !assessmentBody.contains("verdict = .refused"),
+            "RAM pressure must warn as .tight, not throw or mark a hard refusal before vMLX attempts the load."
         )
 
         let health = try Self.source("Networking/HTTPHandler.swift")

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCards.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCards.swift
@@ -139,7 +139,7 @@ struct OnboardingRowBadge {
         case success
         /// Yellow chip — used for the "Tight fit" capability hint.
         case warning
-        /// Red chip — used for "Too large for this Mac" on disabled rows.
+        /// Red chip — used for high-risk compatibility warnings.
         case error
         /// Category chip whose color, icon, and label all come from the
         /// `ModelUseCase`. The badge's `text` field is unused for this

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -166,21 +166,17 @@ final class ConfigureAIState: ObservableObject {
     /// both finalize. Reset whenever credentials are cleared (back / reselect).
     var hasFinalizedAPI = false
 
-    /// Whether the Local tab should be offered at all on this Mac. Under the
-    /// `cloudDefaultMemoryCeilingGB` threshold the curated local picks are too
-    /// heavy to run well, so we hide Local entirely and steer the user to a
-    /// hosted provider. `totalMemoryGB <= 0` (monitor not reported yet) fails
-    /// open so we never wrongly hide Local on a capable machine.
+    /// Whether the Local tab should be offered at all on this Mac. RAM is an
+    /// advisory fit signal only; users can still choose local models on small
+    /// machines because mmap-backed runtimes may succeed under macOS memory
+    /// compression/paging even when a static estimate looks tight.
     static func isLocalTabAvailable(totalMemoryGB: Double) -> Bool {
-        totalMemoryGB <= 0 || totalMemoryGB >= cloudDefaultMemoryCeilingGB
+        true
     }
 
-    /// Paths offered on this Mac: both tabs normally, Cloud-only when the
-    /// machine can't comfortably run a local brain.
+    /// Paths offered on this Mac.
     func availablePaths(totalMemoryGB: Double) -> [ConfigurePath] {
-        Self.isLocalTabAvailable(totalMemoryGB: totalMemoryGB)
-            ? [.local, .apiProvider]
-            : [.apiProvider]
+        [.local, .apiProvider]
     }
 
     // No footer caption on either tab. The reassurance copy crowded the footer,
@@ -253,24 +249,15 @@ final class ConfigureAIState: ObservableObject {
         }
     }
 
-    /// At or below this much unified memory, onboarding defaults to the Cloud
-    /// tab: the curated local picks are compute-intensive, so a small machine
-    /// is more likely to have a good first run with a hosted provider.
-    private static let cloudDefaultMemoryCeilingGB: Double = 24
-
-    /// Picks the lowest-friction default tab for this Mac on first appearance
-    /// (see `cloudDefaultMemoryCeilingGB`). Applied at most once (see
-    /// `didApplyDefaultPath`) so it never overrides a path the user chose by
-    /// hand.
+    /// Picks the lowest-friction default tab for this Mac on first appearance.
+    /// Local remains available even on low-RAM Macs; compatibility only affects
+    /// the recommended model and warning badges.
     func applyDefaultPathIfNeeded(totalMemoryGB: Double) {
         guard !didApplyDefaultPath else { return }
         // `totalMemoryGB == 0` means the monitor hasn't reported yet; wait for
         // a real value before committing to a default.
         guard totalMemoryGB > 0 else { return }
         didApplyDefaultPath = true
-        if totalMemoryGB <= Self.cloudDefaultMemoryCeilingGB {
-            selectedPath = .apiProvider
-        }
     }
 
     /// Auto-selects the recommended local pick — the best model this Mac can
@@ -286,14 +273,11 @@ final class ConfigureAIState: ObservableObject {
     ///      quality, so "the best the machine can handle" is the best
     ///      first-run experience.
     ///
-    /// Stays nil when nothing is downloaded and every curated candidate is
-    /// `.tooLarge`, so the picker shows the empty-state redirect instead.
+    /// Falls back to the smallest curated top pick when every option is tight
+    /// or too large, so onboarding never dead-ends on RAM estimates alone.
     /// `.unknown` (no param info / monitor not yet populated) fails open.
     func ensureLocalSelection(totalMemoryGB: Double) {
         guard selectedModel == nil else { return }
-        let fits: (MLXModel) -> Bool = {
-            $0.compatibility(totalMemoryGB: totalMemoryGB) != .tooLarge
-        }
 
         // 1. A curated top pick already on disk wins. Onboarding only shows
         // top picks, so we don't fall back to ad-hoc downloaded models that
@@ -305,13 +289,14 @@ final class ConfigureAIState: ObservableObject {
         }
 
         // 2. The largest top pick the Mac can comfortably run.
-        let candidates = ModelManager.shared.suggestedModels.filter {
-            $0.isTopSuggestion && fits($0)
-        }
+        let candidates = ModelManager.shared.suggestedModels.filter(\.isTopSuggestion)
         let comfortable = candidates.filter {
             $0.compatibility(totalMemoryGB: totalMemoryGB) == .compatible
         }
-        let pool = comfortable.isEmpty ? candidates : comfortable
+        let tight = candidates.filter {
+            $0.compatibility(totalMemoryGB: totalMemoryGB) == .tight
+        }
+        let pool = !comfortable.isEmpty ? comfortable : (!tight.isEmpty ? tight : candidates)
         selectedModel =
             pool.max(by: { ($0.estimatedMemoryGB ?? 0) < ($1.estimatedMemoryGB ?? 0) })
             ?? candidates.first
@@ -826,18 +811,7 @@ struct ConfigureAIBody: View {
     @ViewBuilder
     private var localPickerView: some View {
         let pairs = localPickerModels
-        // A model already on disk is always selectable — the user
-        // downloaded (and presumably ran) it before, so the compat
-        // heuristic shouldn't lock them out. Only not-yet-downloaded
-        // curated picks are gated on fit.
-        let hasAnyRunnable = pairs.contains { $0.model.isDownloaded || $0.compatibility != .tooLarge }
-
-        // When nothing fits (no models on disk and no runnable curated
-        // pick), redirecting to the Cloud / Ollama tab beats a dead-end
-        // list of disabled rows.
-        if !hasAnyRunnable {
-            localNoCompatibleModelsView
-        } else {
+        if !pairs.isEmpty {
             // Be opinionated: surface a single recommended pick (the model
             // `ensureLocalSelection` chose) and tuck everything else behind a
             // disclosure, so first-run isn't a wall of model choices.
@@ -882,7 +856,7 @@ struct ConfigureAIBody: View {
             badgesBelowTitle: true,
             accessory: .radio(isSelected: state.selectedModel?.id == model.id),
             isSelected: state.selectedModel?.id == model.id,
-            isDisabled: pair.compatibility == .tooLarge && !model.isDownloaded
+            isDisabled: false
         ) {
             // No `withAnimation` — selecting a model otherwise
             // morphs the CTA between "Continue" and
@@ -946,53 +920,6 @@ struct ConfigureAIBody: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
-        }
-    }
-
-    /// Empty-state shown when no curated top suggestion can run on this
-    /// Mac. Buttons drive the same `selectPath(...)` machinery as the
-    /// segmented control so the substate slide stays consistent.
-    private var localNoCompatibleModelsView: some View {
-        OnboardingGlassCard {
-            VStack(alignment: .leading, spacing: 14) {
-                HStack(spacing: 12) {
-                    ZStack {
-                        Circle()
-                            .fill(theme.warningColor.opacity(0.14))
-                            .frame(
-                                width: OnboardingMetrics.cardIcon,
-                                height: OnboardingMetrics.cardIcon
-                            )
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(theme.warningColor)
-                    }
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("No local models fit this Mac", bundle: .module)
-                            .font(theme.font(size: 14, weight: .semibold))
-                            .foregroundColor(theme.primaryText)
-                        Text(
-                            "Local models are compute-intensive and our curated picks need more unified memory than this machine has. We recommend a different path.",
-                            bundle: .module
-                        )
-                        .font(theme.font(size: 12))
-                        .foregroundColor(theme.secondaryText)
-                        .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer(minLength: 0)
-                }
-
-                HStack(spacing: 10) {
-                    Spacer()
-                    OnboardingCompactButton(
-                        title: "Pick a Cloud provider",
-                        style: .accent,
-                        action: { state.selectPath(.apiProvider) }
-                    )
-                }
-            }
-            .padding(.horizontal, OnboardingMetrics.cardPaddingH)
-            .padding(.vertical, OnboardingMetrics.cardPaddingV)
         }
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
+        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "980e4051948b25ee3ba39914d6e01b0365a8f265"
+        "revision" : "638a2b9f490337ed5a3864b84ceca1724d85e13c"
       }
     },
     {


### PR DESCRIPTION
## Summary
- make `ModelRuntime.checkRAMFeasibility` warning-only for RAM pressure: soft/hard thresholds and low available memory now record `.tight` telemetry instead of throwing `LoadRefusedError` before vMLX attempts the load
- keep idle/resident eviction and `/health` RAM telemetry intact so support logs still show projected pressure without blocking valid mmap/JANG/JANGTQ/quantized loads
- keep Local onboarding available on 24GB and smaller Macs; compatibility now drives recommendation order and warning badges, not hidden tabs, disabled rows, or dead-end screens
- restore/keep the proven Gemma vMLX pin `980e4051948b25ee3ba39914d6e01b0365a8f265`; no experimental N2/MiMo pin is included

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests --filter ConfigureAIStateDownloadTests --filter ModelFilterPerformanceTests`
- Earlier focused checks also passed: `ConfigureAIStateDownloadTests`, `RuntimePolicySourceTests/modelRuntimeWeightSizePreflightIsManualMultiModelOnly`, `ModelFilterPerformanceTests`

## Release boundary
- source-tested app policy fix only; not a fresh Gemma/N2/MiMo live model-quality proof
- no sampler/template/parser coercion
- no forced model behavior
- no fake RAM/download block or hardcoded 24GB rejection
- `.agents/` notes remain private/ignored
