### PR TITLE
Expose native MTP runtime status

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -797,6 +797,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 } else {
                     row["native_mtp_depth"] = NSNull()
                 }
+                row["native_mtp_status"] = summary.nativeMTPStatus ?? NSNull()
+                row["native_mtp_reason"] = summary.nativeMTPReason ?? NSNull()
                 let mlxPress = summary.mlxPressStatus
                 var mlxPressStatus: [String: Any] = [
                     "enabled": mlxPress.enabled,

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -45,6 +45,8 @@ public actor ModelRuntime {
         let isCurrent: Bool
         let draftStrategyDescription: String?
         let nativeMTPDepth: Int?
+        let nativeMTPStatus: String?
+        let nativeMTPReason: String?
         let mlxPressStatus: MLXPressStatus
         let cacheStats: CacheCoordinatorStatsSnapshot?
         let cacheTopology: ModelCacheTopologySnapshot?
@@ -73,19 +75,25 @@ public actor ModelRuntime {
         let weightsSizeBytes: Int64
         let isVLM: Bool
         let draftStrategy: MLXLMCommon.DraftStrategy?
+        let nativeMTPStatus: String?
+        let nativeMTPReason: String?
         var cacheTopology: ModelCacheTopologySnapshot?
         init(
             name: String,
             container: ModelContainer,
             weightsSizeBytes: Int64,
             isVLM: Bool = false,
-            draftStrategy: MLXLMCommon.DraftStrategy? = nil
+            draftStrategy: MLXLMCommon.DraftStrategy? = nil,
+            nativeMTPStatus: String? = nil,
+            nativeMTPReason: String? = nil
         ) {
             self.name = name
             self.container = container
             self.weightsSizeBytes = weightsSizeBytes
             self.isVLM = isVLM
             self.draftStrategy = draftStrategy
+            self.nativeMTPStatus = nativeMTPStatus
+            self.nativeMTPReason = nativeMTPReason
         }
     }
 
@@ -187,6 +195,8 @@ public actor ModelRuntime {
                 isCurrent: holder.name == currentModelName,
                 draftStrategyDescription: Self.describeDraftStrategy(holder.draftStrategy),
                 nativeMTPDepth: Self.nativeMTPDepth(holder.draftStrategy),
+                nativeMTPStatus: holder.nativeMTPStatus,
+                nativeMTPReason: holder.nativeMTPReason,
                 mlxPressStatus: holder.container.mlxPressStatus(),
                 cacheStats: holder.container.cacheCoordinator?.snapshotStats(),
                 cacheTopology: holder.cacheTopology
@@ -1305,7 +1315,9 @@ public actor ModelRuntime {
                 container: container,
                 weightsSizeBytes: loadFootprintBytes,
                 isVLM: isVLM,
-                draftStrategy: mtpPlan.draftStrategy
+                draftStrategy: mtpPlan.draftStrategy,
+                nativeMTPStatus: mtpPlan.statusLine,
+                nativeMTPReason: mtpPlan.reason
             )
         }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1947,6 +1947,8 @@ struct RuntimePolicySourceTests {
         let httpHandler = try Self.source("Networking/HTTPHandler.swift")
         #expect(httpHandler.contains("\"draft_strategy\""))
         #expect(httpHandler.contains("\"native_mtp_depth\""))
+        #expect(httpHandler.contains("\"native_mtp_status\""))
+        #expect(httpHandler.contains("\"native_mtp_reason\""))
         #expect(httpHandler.contains("\"mlx_press\""))
     }
 


### PR DESCRIPTION
## Summary

- Expose native MTP runtime status and reason in `/admin/cache-stats` next to `draft_strategy` and `native_mtp_depth`.
- Carry the native MTP plan status from model load into cached model summaries.
- Add source coverage so the admin endpoint keeps surfacing MTP status fields.

## Verification

Source:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/mtpBundlesAutoResolveVMLXTuningIntoLoadAndGeneration`
- `git diff --check origin/main..HEAD`

Local no-sign app proof on the fresh branch build:

- Release app rebuilt successfully from `10a7ac28` with vMLX `c2e8e02101117a64347601f303458ea363b83ee0`.
- Qwen 27B MTP diagnostic row loaded in Osaurus and `/admin/cache-stats` returned `native_mtp_status` and `native_mtp_reason`, explaining that native speculative MTP is off because bundle-local `vmlx_mtp_tuning.json` is missing.
- Gemma final sanity on the same app passed multi-turn tool/parser/cache-topology rows for all ten expected Gemma 4 QAT models: E2B/E4B/12B/26B/31B across MXFP4 and JANG_4M.
- Gemma issue #1432 replay passed on `gemma-4-26b-a4b-it-qat-mxfp4` and `gemma-4-31b-it-qat-jang_4m`: coherent visible text, healthy server, no reported weird-character substrings, no control/protocol leakage, no obvious loop.
- Repeat prompt cache mechanics passed for all ten Gemma rows: stable prefix hash, positive disk L2 delta, rotating disk-backed topology, healthy server, and no protocol leakage.

## Boundaries

- This PR does not force native MTP on. It only makes the active MTP decision visible.
- This PR does not add sampler overrides, prompt coercion, parser stripping, forced thinking/tool wrappers, or RAM hard blocks.
- Qwen native MTP acceleration remains partial until a tuned bundle with usable `vmlx_mtp_tuning.json` proves non-null native MTP depth during live generation.
- Gemma exact literal one-word output remains partial for three smaller sampled rows in a repeat-cache diagnostic (`fruit`/`Fruit` instead of `apple`), while cache mechanics and multi-turn tool behavior passed.
- Gemma audio/video generation remains outside this checkpoint; current release-safe behavior is typed refusal unless a real media route is implemented and proven.
