### PR TITLE
Pin vMLX memory safety contract

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
+        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
+        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "c2e8e02101117a64347601f303458ea363b83ee0"
+            revision: "ef025f2556978d033131f745c00dd8128c8d5151"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -575,7 +575,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "c2e8e02101117a64347601f303458ea363b83ee0"
+        let expectedRuntimeHardenedRevision = "ef025f2556978d033131f745c00dd8128c8d5151"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "c2e8e02101117a64347601f303458ea363b83ee0"
+        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
       }
     },
     {


### PR DESCRIPTION
## Summary

- pin Osaurus to `vmlx-swift` main commit `ef025f2556978d033131f745c00dd8128c8d5151`
- update the runtime policy source guard to require that vMLX revision
- keep all SwiftPM pin surfaces aligned across OsaurusCore, workspace, and app resolved files

## Context

This pulls in `osaurus-ai/vmlx-swift#41`, which adds the vMLX memory-safety settings contract, resolver, focused tests, and the tracked Osaurus UI integration spec. This PR does not implement the Osaurus UI/CLI slider persistence yet; it makes the merged engine contract available to Osaurus from a vMLX main SHA.

## Verification

```sh
scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh
scripts/live-proof/assert-osaurus-pr-hygiene.sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/vmlxPinIncludesRuntimeHardening|RuntimePolicySourceTests/modelRuntimeWeightSizePreflightIsManualMultiModelOnly|RuntimePolicySourceTests/sentryInferenceBreadcrumbsExposeTokenCountWithoutPromptFilter|MetalGateTests'
```

Results:

- vMLX readiness source guard passed
- Osaurus PR hygiene guard passed
- Swift Testing passed 5 tests in 2 suites
