### PR TITLE
Apply memory safety plan to model loads

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -102,6 +102,7 @@ public actor ModelRuntime {
         let draftStrategy: MLXLMCommon.DraftStrategy?
         let statusLine: String?
         let reason: String
+        let memorySafetySummary: String
     }
 
     /// Sendable wrapper around an immutable snapshot of chat messages.
@@ -1287,7 +1288,7 @@ public actor ModelRuntime {
                 settings: serverSettings
             )
             genLog.info(
-                "loadContainer: native MTP plan model=\(name, privacy: .public) nativeMTP=\(mtpPlan.loadConfiguration.nativeMTP, privacy: .public) draftStrategy=\(Self.describeDraftStrategy(mtpPlan.draftStrategy), privacy: .public) reason=\(mtpPlan.reason, privacy: .public) status=\(mtpPlan.statusLine ?? "none", privacy: .public)"
+                "loadContainer: native MTP plan model=\(name, privacy: .public) nativeMTP=\(mtpPlan.loadConfiguration.nativeMTP, privacy: .public) draftStrategy=\(Self.describeDraftStrategy(mtpPlan.draftStrategy), privacy: .public) reason=\(mtpPlan.reason, privacy: .public) status=\(mtpPlan.statusLine ?? "none", privacy: .public) memorySafety=\(mtpPlan.memorySafetySummary, privacy: .public)"
             )
             let container = try await loadModelContainer(
                 from: localURL,
@@ -2198,11 +2199,19 @@ public actor ModelRuntime {
         settings: VMLXServerRuntimeSettings
     ) -> NativeMTPLaunchPlan {
         if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName) {
+            let memorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
+                modelName: modelName,
+                modelDirectory: modelDirectory,
+                settings: settings,
+                baseLoadConfiguration: .osaurusProduction,
+                inspectBundleFacts: false
+            )
             return NativeMTPLaunchPlan(
-                loadConfiguration: .osaurusProduction,
+                loadConfiguration: memorySafetyPlan.loadConfiguration,
                 draftStrategy: nil,
                 statusLine: nil,
-                reason: "MiMo/N2 JANG text runtime is not an MTP bundle; using autoregressive load."
+                reason: "MiMo/N2 JANG text runtime is not an MTP bundle; using autoregressive load.",
+                memorySafetySummary: memorySafetyPlan.displaySummary
             )
         }
         let configData = try? Data(contentsOf: modelDirectory.appendingPathComponent("config.json"))
@@ -2217,11 +2226,19 @@ public actor ModelRuntime {
             genLog.error(
                 "native MTP inspection failed for \(modelDirectory.lastPathComponent, privacy: .public): \(String(describing: error), privacy: .public)"
             )
+            let memorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
+                modelName: modelName,
+                modelDirectory: modelDirectory,
+                settings: settings,
+                baseLoadConfiguration: .osaurusProduction,
+                inspectBundleFacts: true
+            )
             return NativeMTPLaunchPlan(
-                loadConfiguration: .osaurusProduction,
+                loadConfiguration: memorySafetyPlan.loadConfiguration,
                 draftStrategy: nil,
                 statusLine: nil,
-                reason: "MTP inspection failed; using autoregressive load."
+                reason: "MTP inspection failed; using autoregressive load.",
+                memorySafetySummary: memorySafetyPlan.displaySummary
             )
         }
 
@@ -2241,13 +2258,48 @@ public actor ModelRuntime {
             jangConfig: jangConfig,
             status: status
         )
+        let memorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
+            modelName: modelName,
+            modelDirectory: modelDirectory,
+            settings: settings,
+            baseLoadConfiguration: loadConfiguration,
+            inspectBundleFacts: true
+        )
 
         return NativeMTPLaunchPlan(
-            loadConfiguration: loadConfiguration,
+            loadConfiguration: memorySafetyPlan.loadConfiguration,
             draftStrategy: draftStrategy,
             statusLine: status?.statusLine,
-            reason: launch.reason
+            reason: launch.reason,
+            memorySafetySummary: memorySafetyPlan.displaySummary
         )
+    }
+
+    private nonisolated static func resolveMemorySafetyLoadPlan(
+        modelName: String,
+        modelDirectory: URL,
+        settings: VMLXServerRuntimeSettings,
+        baseLoadConfiguration: LoadConfiguration,
+        inspectBundleFacts: Bool
+    ) -> VMLXResolvedMemorySafetyPlan {
+        let bundleFacts = inspectBundleFacts
+            ? LoadBundleFacts.inspect(bundleURL: modelDirectory)
+            : nil
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: baseLoadConfiguration,
+            bundleFacts: bundleFacts,
+            host: MemoryStatus.snapshot(),
+            request: nil
+        )
+        if !plan.blockingIssues.isEmpty {
+            let issueSummary = plan.blockingIssues
+                .map { "\($0.field): \($0.message)" }
+                .joined(separator: "; ")
+            genLog.warning(
+                "loadContainer: memory safety plan produced advisory blocking issues for \(modelName, privacy: .public): \(issueSummary, privacy: .public)"
+            )
+        }
+        return plan
     }
 
     private nonisolated static func describeDraftStrategy(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1732,10 +1732,17 @@ struct RuntimePolicySourceTests {
 
         #expect(runtime.contains("loadConfiguration: mtpPlan.loadConfiguration"))
         #expect(runtime.contains("resolvedLoadConfiguration("))
+        #expect(runtime.contains("resolveMemorySafetyLoadPlan("))
+        #expect(runtime.contains("settings.resolvedMemorySafetyPlan("))
+        #expect(runtime.contains("baseLoadConfiguration: loadConfiguration"))
+        #expect(runtime.contains("request: nil"))
+        #expect(runtime.contains("memorySafetySummary: memorySafetyPlan.displaySummary"))
         #expect(runtime.contains("base: .osaurusProduction"))
-        #expect(runtime.contains("loadConfiguration: .osaurusProduction"))
+        #expect(runtime.contains("baseLoadConfiguration: .osaurusProduction"))
+        #expect(runtime.contains("loadConfiguration: memorySafetyPlan.loadConfiguration"))
         #expect(!runtime.contains("base: .default"))
         #expect(!runtime.contains("loadConfiguration: .default"))
+        #expect(!runtime.contains("throw LoadRefusedError("))
         #expect(
             !runtime.contains(
                 "loadModelContainer(\n                from: localURL,\n                using: tokenizerLoader\n            )"


### PR DESCRIPTION
## Summary
- resolve the vMLX memory safety plan before loading local models
- pass the resolved load configuration through the existing MTP-aware load path
- keep MiMo/N2 fast paths from doing extra bundle fact reads and avoid adding hard RAM refusal behavior

## Verification
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path Packages/OsaurusCore --filter 'RuntimePolicySourceTests/modelRuntimeUsesTypedVMLXLoadConfiguration|RuntimePolicySourceTests/mtpBundlesAutoResolveVMLXTuningIntoLoadAndGeneration|RuntimePolicySourceTests/mimoAndN2TextRuntimeMetadataAvoidsVLMBundleReads|RuntimePolicySourceTests/adminCacheStatsExposesResolvedMemorySafetyStatus|ServerRuntimeSettingsStoreTests'
- scripts/live-proof/assert-osaurus-pr-hygiene.sh
- scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh