### PR TITLE
Document Gemma checkpoint memory safety contract

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -70,6 +70,22 @@
         }
       }
     },
+    "Allow Experimental MLXPress" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Experimentelles MLXPress erlauben"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "允许实验性 MLXPress"
+          }
+        }
+      }
+    },
     "Agent traffic is protected by the Osaurus Secure Channel: forward-secret, mutually authenticated end-to-end encryption." : {
       "localizations" : {
         "de" : {
@@ -130,6 +146,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "端到端加密"
+          }
+        }
+      }
+    },
+    "Fail Closed When Estimate Is Unknown" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bei unbekannter Schätzung geschlossen fehlschlagen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "估算未知时关闭式失败"
           }
         }
       }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift
@@ -1,0 +1,230 @@
+//
+//  MemorySafetySection.swift
+//  osaurus
+//
+//  User-facing controls for the vMLX memory-safety policy. These
+//  controls persist into `VMLXServerRuntimeSettings.memorySafety` and
+//  take effect through `ModelRuntime.resolveMemorySafetyLoadPlan(...)`
+//  on the next model load.
+//
+
+@preconcurrency import MLXLMCommon
+import SwiftUI
+
+struct MemorySafetySection: View {
+    @Binding var draft: VMLXServerRuntimeSettings
+
+    private var resolvedPlan: VMLXResolvedMemorySafetyPlan {
+        draft.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            host: MemoryStatus.snapshot()
+        )
+    }
+
+    var body: some View {
+        ServerSettingsCard(
+            section: .memorySafety,
+            status: .engineReady,
+            blurb:
+                "Controls the load-time memory policy used by local vMLX models. Changes apply on the next model load."
+        ) {
+            SettingsField(
+                label: "Mode",
+                hint:
+                    "Safe Auto is the default. Strict can refuse before load when a request cannot fit the selected budget."
+            ) {
+                Picker("", selection: $draft.memorySafety.mode) {
+                    ForEach(VMLXMemorySafetyMode.allCases, id: \.self) { mode in
+                        Text(modeTitle(mode)).tag(mode)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+            }
+
+            SettingsField(
+                label: "Safety Level",
+                hint:
+                    "0 favors performance, 2 is Safe Auto, 3 is strict, and 4 is diagnostic/custom."
+            ) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Slider(value: sliderBinding, in: 0 ... 4, step: 1)
+                    Text(sliderLabel)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            SettingsDivider()
+
+            SettingsSubsection(label: "Resolved Plan") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(resolvedPlan.displaySummary)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textSelection(.enabled)
+
+                    HStack(spacing: 12) {
+                        summaryPill("Load", value: loadCapSummary)
+                        summaryPill("Allocator", value: allocatorCapSummary)
+                        summaryPill("KV", value: kvCapSummary)
+                        summaryPill("Concurrency", value: concurrencySummary)
+                    }
+
+                    ForEach(resolvedPlan.warnings, id: \.self) { warning in
+                        Text(warning)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            SettingsDivider()
+
+            SettingsSubsection(label: "Advanced Overrides") {
+                VStack(alignment: .leading, spacing: 12) {
+                    SettingsToggle(
+                        title: L("Allow Experimental MLXPress"),
+                        description:
+                            "Only routed bundles with proven support should use this. It is never enabled by default.",
+                        isOn: $draft.memorySafety.allowExperimentalMLXPress
+                    )
+
+                    SettingsToggle(
+                        title: L("Fail Closed When Estimate Is Unknown"),
+                        description:
+                            "Strict diagnostic behavior for environments that prefer refusal over unknown memory risk.",
+                        isOn: $draft.memorySafety.failClosedWhenEstimateUnknown
+                    )
+
+                    OptionalDoubleField(
+                        label: "Custom Physical Memory Fraction",
+                        placeholder: "Blank = mode default",
+                        help: "Fraction from 0.10 to 1.00.",
+                        value: $draft.memorySafety.customPhysicalMemoryFraction,
+                        clamp: 0.10 ... 1.00,
+                        format: "%.2f"
+                    )
+
+                    OptionalIntField(
+                        label: "Allocator Cache Cap (MB)",
+                        placeholder: "Blank = mode default",
+                        help: "Maximum MLX allocator cache, in MiB.",
+                        value: allocatorCacheMB,
+                        clamp: 1 ... 262144
+                    )
+
+                    OptionalIntField(
+                        label: "Per-Session KV Cap (tokens)",
+                        placeholder: "Blank = mode default",
+                        help: "Maximum cached tokens per chat slot for this memory mode.",
+                        value: $draft.memorySafety.customDefaultMaxKVSize
+                    )
+
+                    OptionalIntField(
+                        label: "Max Concurrent Sequences",
+                        placeholder: "Blank = mode default",
+                        help: "Upper bound for concurrent decode slots under this memory mode.",
+                        value: $draft.memorySafety.customMaxConcurrentSequences,
+                        clamp: 1 ... 32
+                    )
+                }
+            }
+        }
+    }
+
+    private var sliderBinding: Binding<Double> {
+        Binding(
+            get: { Double(draft.memorySafety.slider) },
+            set: { newValue in
+                draft.memorySafety.slider = Int(newValue.rounded()).clamped(to: 0 ... 4)
+            }
+        )
+    }
+
+    private var allocatorCacheMB: Binding<Int?> {
+        Binding(
+            get: {
+                draft.memorySafety.customAllocatorCacheBytes.map {
+                    Int($0 / UInt64(1 << 20))
+                }
+            },
+            set: { newValue in
+                guard let newValue else {
+                    draft.memorySafety.customAllocatorCacheBytes = nil
+                    return
+                }
+                draft.memorySafety.customAllocatorCacheBytes = UInt64(max(1, newValue)) * UInt64(1 << 20)
+            }
+        )
+    }
+
+    private var sliderLabel: String {
+        switch draft.memorySafety.slider {
+        case 0: return "Performance"
+        case 1: return "Balanced"
+        case 2: return "Safe Auto"
+        case 3: return "Strict"
+        default: return "Diagnostic / Custom"
+        }
+    }
+
+    private var loadCapSummary: String {
+        capSummary(resolvedPlan.loadConfiguration.memoryLimit)
+    }
+
+    private var allocatorCapSummary: String {
+        capSummary(resolvedPlan.loadConfiguration.maxResidentBytes)
+    }
+
+    private var kvCapSummary: String {
+        resolvedPlan.cache.defaultMaxKVSize.map(String.init) ?? "default"
+    }
+
+    private var concurrencySummary: String {
+        resolvedPlan.concurrency.maxConcurrentSequences.map(String.init) ?? "default"
+    }
+
+    private func summaryPill(_ label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 11, design: .monospaced))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private func capSummary(_ cap: ResidentCap) -> String {
+        switch cap {
+        case .unlimited:
+            return "unlimited"
+        case .fraction(let fraction):
+            return String(format: "%.0f%%", fraction * 100)
+        case .absolute(let bytes):
+            return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .memory)
+        }
+    }
+
+    private func modeTitle(_ mode: VMLXMemorySafetyMode) -> String {
+        switch mode {
+        case .performance: return "Performance"
+        case .balanced: return "Balanced"
+        case .safeAuto: return "Safe Auto"
+        case .strict: return "Strict"
+        case .diagnosticDangerous: return "Diagnostic / Dangerous"
+        }
+    }
+}
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
@@ -21,6 +21,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
     case sampling
     case concurrency
     case cache
+    case memorySafety
     case speculative
     case liveActivity
     case multimodal
@@ -40,6 +41,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
         case .sampling: return "Sampling Defaults"
         case .concurrency: return "Concurrency & Batching"
         case .cache: return "Cache"
+        case .memorySafety: return "Memory Safety"
         case .speculative: return "Speculative Decoding"
         case .liveActivity: return "Live Activity"
         case .multimodal: return "Multimodal"
@@ -59,6 +61,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
         case .sampling: return "slider.horizontal.3"
         case .concurrency: return "gauge.with.dots.needle.bottom.0percent"
         case .cache: return "externaldrive.connected.to.line.below"
+        case .memorySafety: return "memorychip.fill"
         case .speculative: return "bolt.horizontal"
         case .liveActivity: return "waveform.path.ecg"
         case .multimodal: return "photo.on.rectangle.angled"
@@ -75,7 +78,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
             return .server
         case .sampling:
             return .generation
-        case .concurrency, .cache, .speculative, .liveActivity:
+        case .concurrency, .cache, .memorySafety, .speculative, .liveActivity:
             return .performance
         case .multimodal, .tools:
             return .capabilities

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -152,6 +152,8 @@ struct ServerSettingsTabContent: View {
                         .id(ServerSettingsSection.concurrency)
                     CacheSection(draft: $draft)
                         .id(ServerSettingsSection.cache)
+                    MemorySafetySection(draft: $draft)
+                        .id(ServerSettingsSection.memorySafety)
                     MTPSection(draft: $draft)
                         .id(ServerSettingsSection.speculative)
                     LiveActivitySection()

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -127,23 +127,31 @@ Important display rule:
 - If they differ, treat the observed runtime status as the current applied MLX
   state and the resolved plan as the requested policy.
 
-## Missing Settings Setter
+## Settings Control Surface
 
-Changed-setting proof is currently `BLOCKED: controls missing`.
+Changed-setting proof is currently `PARTIAL: source/UI path added, live app proof pending`.
 
-The current app exposes memory-safety status but no shipped UI, CLI, or HTTP
-setter for `memorySafety.mode` or `memorySafety.slider`. `/admin/cache-stats` is
-read-only.
+The app exposes memory-safety status through `/admin/cache-stats.memory_safety`
+and now exposes a Server Settings section that edits
+`VMLXServerRuntimeSettings.memorySafety`. The section persists through the
+existing Server Settings save path, which calls `ServerController.saveRuntimeSettings(_:)`
+and updates `ServerRuntimeSettingsStore.snapshot()`.
 
-The UI/settings work should persist:
+`/admin/cache-stats` remains read-only; it is the status surface, not the
+mutation surface.
+
+The Server Settings section persists:
 
 - `memorySafety.mode`
 - `memorySafety.slider`
 - `memorySafety.allowExperimentalMLXPress`
 - `memorySafety.failClosedWhenEstimateUnknown`
 - `memorySafety.customPhysicalMemoryFraction`
+- `memorySafety.customAllocatorCacheBytes`
+- `memorySafety.customDefaultMaxKVSize`
+- `memorySafety.customMaxConcurrentSequences`
 
-After UI/CLI/API support lands, proof must show:
+Live proof still must show:
 
 1. The user changes and saves the setting.
 2. `/admin/cache-stats.memory_safety` shows the changed mode/slider.

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -11,7 +11,7 @@ Status: `PARTIAL RELEASE CHECKPOINT`.
 
 Gemma 4 text/chat/tool/cache behavior is usable on the current main app build
 for a checkpoint. Audio/video generation, full all-family Sentry closure, and
-user-mutable memory-safety controls are not complete.
+manual UI-click proof for memory-safety controls are not complete.
 
 Current app proof baseline:
 
@@ -129,7 +129,7 @@ Important display rule:
 
 ## Settings Control Surface
 
-Changed-setting proof is currently `PARTIAL: source/UI path added, live app proof pending`.
+Changed-setting proof is currently `PARTIAL: app/API apply proof passed; manual UI click/save proof pending`.
 
 The app exposes memory-safety status through `/admin/cache-stats.memory_safety`
 and now exposes a Server Settings section that edits
@@ -153,11 +153,26 @@ The Server Settings section persists:
 
 Live proof still must show:
 
-1. The user changes and saves the setting.
+1. The user changes and saves the setting through the Server Settings UI.
 2. `/admin/cache-stats.memory_safety` shows the changed mode/slider.
 3. The next model load uses the changed `load_configuration`.
 4. If a reload is required, the UI says the setting takes effect on next load.
 5. Gemma chat/tool/cache/weird-character proof still passes after the change.
+
+Current PR #1462 app/API proof:
+
+- Artifact root: `.agents/gemma-final/artifacts/memory-safety-apply-pr1462-20260610-220637`
+- Built app: `/Users/eric/Library/Developer/Xcode/DerivedData/osaurus-fknwhdrdztffeoffkagufseezytr/Build/Products/Debug/osaurus.app`
+- Default isolated launch reported Safe Auto through `/admin/cache-stats.memory_safety`:
+  `mode=safe_auto slider=2 load_cap=0.7 allocator_cap=absolute(134217728) max_concurrent=1 kv_cap=65536`.
+- Changed isolated launch reported Strict through `/admin/cache-stats.memory_safety`:
+  `mode=strict slider=3 load_cap=0.6 allocator_cap=absolute(67108864) max_concurrent=1 kv_cap=4096`.
+- Live `gemma-4-e2b-it-qat-mxfp4` chat under the changed Strict plan answered
+  exactly `memory safety applied`, stopped normally, and reported
+  `29.1005` completion token/s for the three-token response.
+- The loaded E2B cache row kept Gemma's expected topology: 15 layers, 3 KV
+  layers, 12 rotating KV layers, disk-backed restore required, block disk
+  enabled, MLXPress disabled, and TurboQuant KV layer count 0.
 
 Do not substitute cache toggles for the memory-safety slider. Cache controls are
 real settings, but they do not prove the memory-safety contract is user

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -1,0 +1,211 @@
+# Gemma 4 Checkpoint And Memory Safety Spec - 2026-06-11
+
+This document is the tracked team-facing checkpoint for the Gemma 4 QAT
+MXFP4/JANG_4M release lane and the memory-safety settings contract. Private
+raw artifacts and wider family notes remain under `.agents/`; this file records
+what can be shared in the repo without pretending unproven rows are complete.
+
+## Current Release Boundary
+
+Status: `PARTIAL RELEASE CHECKPOINT`.
+
+Gemma 4 text/chat/tool/cache behavior is usable on the current main app build
+for a checkpoint. Audio/video generation, full all-family Sentry closure, and
+user-mutable memory-safety controls are not complete.
+
+Current app proof baseline:
+
+- Osaurus commit: `0f5f060ca7e0660cea0a5d095012e1d60ebc58c8`
+- vMLX Swift pin: `ef025f2556978d033131f745c00dd8128c8d5151`
+- Built app: `build/DerivedData-gemma-current-main-0f5f060-20260610-210706/Build/Products/Release/osaurus.app`
+- Build log: `.agents/gemma-final/artifacts/osaurus-main-0f5f060-live-e2e-build-20260610-210706.log`
+
+## Gemma 4 Live Proof
+
+Current-main live Osaurus API proof passed for all ten local Gemma 4 text rows:
+
+- `gemma-4-e2b-it-qat-mxfp4`
+- `gemma-4-e2b-it-qat-jang_4m`
+- `gemma-4-e4b-it-qat-mxfp4`
+- `gemma-4-e4b-it-qat-jang_4m`
+- `gemma-4-12b-it-qat-mxfp4`
+- `gemma-4-12b-it-qat-jang_4m`
+- `gemma-4-26b-a4b-it-qat-mxfp4`
+- `gemma-4-26b-a4b-it-qat-jang_4m`
+- `gemma-4-31b-it-qat-mxfp4`
+- `gemma-4-31b-it-qat-jang_4m`
+
+Each row passed the live multi-turn required-tool harness:
+
+- First required `line_count` tool call used exact multiline argument
+  `red\ngreen\nblue`.
+- The visible follow-up acknowledged the tool result.
+- A later required `line_count` call after conversation history used exact
+  argument `one\ntwo`.
+- No tool protocol, reasoning protocol, replacement-character, or C0/C1 control
+  leakage was observed.
+- Cache topology matched Gemma rotating/full KV with disk-backed restore.
+
+Current-main weird-character replay also passed for each row with default
+settings and with `thinking: disabled`.
+
+Representative current-main speed from API-reported token/s:
+
+| Row | Default | Thinking Disabled |
+| --- | ---: | ---: |
+| E2B MXFP4 | 110.53 | 109.96 |
+| E2B JANG_4M | 101.52 | 103.53 |
+| E4B MXFP4 | 71.53 | 71.96 |
+| E4B JANG_4M | 64.97 | 64.29 |
+| 12B MXFP4 | 45.97 | 45.85 |
+| 12B JANG_4M | 38.86 | 38.34 |
+| 26B MXFP4 | 87.66 | 86.03 |
+| 26B JANG_4M | 74.22 | 75.38 |
+| 31B MXFP4 | 21.73 | 21.62 |
+| 31B JANG_4M | 16.98 | 16.83 |
+
+Representative current-main repeat-cache proof passed for E2B MXFP4 and
+JANG_4M: repeated identical prompts kept a stable prefix hash and produced a
+repeat disk L2 hit.
+
+## Gemma Media And Reasoning Boundary
+
+Representative image proof passed on current main for:
+
+- `gemma-4-12b-it-qat-mxfp4`
+- `gemma-4-12b-it-qat-jang_4m`
+
+Both answered a red PNG as `Red`, repeated the answer consistently, kept stable
+prefix/cache behavior, and kept the server healthy.
+
+Audio/video are not claimed as generation features. Current live behavior is a
+typed refusal boundary:
+
+- Audio returns HTTP 400: `Gemma4 audio input is not enabled because native audio routing still needs live model proof.`
+- Video returns HTTP 400 when the bundle does not advertise video.
+
+Reasoning behavior is bundle/API driven:
+
+- Default and explicit disabled reasoning rows produced visible answers without
+  protocol leakage.
+- High reasoning passed with sufficient output budget (`max_tokens=256`) and
+  kept reasoning in `reasoning_content`.
+- High reasoning with too-small output budgets can length-stop with
+  reasoning-only output and must not be promoted as a clean UX row.
+
+## Memory Safety Settings Contract
+
+The runtime contract exists and is visible, but user controls are not complete.
+
+Current default resolved plan visible in `/admin/cache-stats.memory_safety`:
+
+- `mode=safe_auto`
+- `slider=2`
+- `load_configuration.memory_limit = fraction 0.7`
+- `load_configuration.max_resident_bytes = absolute 134217728`
+- `load_configuration.use_mmap_safetensors = true`
+- `load_configuration.jang_press_policy.kind = disabled`
+- `cache.prefix_enabled = true`
+- `cache.block_disk_enabled = true`
+- `cache.paged_kv_enabled = true`
+- `cache.live_kv_codec = engine_selected`
+- `cache.default_max_kv_size = 65536`
+- `cache.enable_ssm_rederive = true`
+- `concurrency.max_concurrent_sequences = 1`
+
+The model load path consumes the resolved plan:
+
+- `ModelRuntime.resolveMemorySafetyLoadPlan(...)` resolves the plan.
+- `memorySafetyPlan.loadConfiguration` is passed to `loadModelContainer(...)`.
+- `/admin/cache-stats.memory_safety.memory_status` exposes the live runtime
+  `MemoryStatus`, including actual `memory_limit`, `cache_limit`,
+  `physical_memory`, and `current_rss`.
+
+Important display rule:
+
+- Show both the resolved plan and the observed runtime memory status.
+- If they differ, treat the observed runtime status as the current applied MLX
+  state and the resolved plan as the requested policy.
+
+## Missing Settings Setter
+
+Changed-setting proof is currently `BLOCKED: controls missing`.
+
+The current app exposes memory-safety status but no shipped UI, CLI, or HTTP
+setter for `memorySafety.mode` or `memorySafety.slider`. `/admin/cache-stats` is
+read-only.
+
+The UI/settings work should persist:
+
+- `memorySafety.mode`
+- `memorySafety.slider`
+- `memorySafety.allowExperimentalMLXPress`
+- `memorySafety.failClosedWhenEstimateUnknown`
+- `memorySafety.customPhysicalMemoryFraction`
+
+After UI/CLI/API support lands, proof must show:
+
+1. The user changes and saves the setting.
+2. `/admin/cache-stats.memory_safety` shows the changed mode/slider.
+3. The next model load uses the changed `load_configuration`.
+4. If a reload is required, the UI says the setting takes effect on next load.
+5. Gemma chat/tool/cache/weird-character proof still passes after the change.
+
+Do not substitute cache toggles for the memory-safety slider. Cache controls are
+real settings, but they do not prove the memory-safety contract is user
+controllable.
+
+## RAM Policy
+
+Do not add hardcoded RAM rejection rules to make a release look safe. Memory
+policy must be a user-visible setting with typed warnings or graceful refusal
+before unsafe load paths.
+
+Allowed behavior:
+
+- Advisory feasibility status.
+- Graceful typed refusal when a strict user-selected policy cannot be satisfied.
+- Clear UI/status warnings when estimates are unknown or over budget.
+- Conservative defaults that preserve model behavior.
+
+Forbidden behavior:
+
+- Silent sampler changes.
+- Forced thinking or parser stripping to hide output bugs.
+- Arbitrary hardcoded physical-memory percentages that block otherwise valid
+  user choices.
+- Catch-after-crash wrappers for process-fatal MLX/Metal failures.
+
+## Adjacent Rows
+
+Qwen MTP MXFP4 27B and 35B have current-main live chat/tool/cache proof with
+hybrid SSM companion plus disk L2 hits. Native MTP acceleration remains partial
+because the local bundles report preserved MTP weights but no production
+`vmlx_mtp_tuning.json`.
+
+MiMo V2.5 JANGTQ_2 remains partial: required tool-call arguments passed and
+cache topology matched the bundle, but the visible tool-result follow-up
+answered the line count incorrectly. Do not mark MiMo release-green until
+tool-result grounding is fixed and live proof passes.
+
+Nex N2 remains a follow-up lane. Existing evidence shows useful topology proof
+but slow or blocked rows; do not block the Gemma checkpoint on N2 unless a
+shared runtime change regresses Gemma.
+
+## Required Release Checkers
+
+Before final checkpoint release, run:
+
+```sh
+scripts/live-proof/assert-osaurus-pr-hygiene.sh
+scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh
+scripts/live-proof/assert-no-hidden-local-sampler-defaults.sh
+scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh
+scripts/live-proof/assert-openresponses-cache-proof-wiring.sh
+scripts/live-proof/assert-server-settings-runtime-wiring.sh
+scripts/live-proof/assert-tool-choice-required-routing.sh
+scripts/live-proof/assert-model-tool-capability-surfaces.sh
+```
+
+Then run live Osaurus app/API proof, not only source tests, for any model row
+claimed fixed.

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -10,8 +10,8 @@ what can be shared in the repo without pretending unproven rows are complete.
 Status: `PARTIAL RELEASE CHECKPOINT`.
 
 Gemma 4 text/chat/tool/cache behavior is usable on the current main app build
-for a checkpoint. Audio/video generation, full all-family Sentry closure, and
-manual UI-click proof for memory-safety controls are not complete.
+for a checkpoint. Audio/video generation and full all-family Sentry closure are
+not complete. Memory-safety controls now have manual UI save proof on PR #1462.
 
 Current app proof baseline:
 
@@ -95,7 +95,7 @@ Reasoning behavior is bundle/API driven:
 
 ## Memory Safety Settings Contract
 
-The runtime contract exists and is visible, but user controls are not complete.
+The runtime contract exists, is visible, and has PR #1462 manual UI save proof.
 
 Current default resolved plan visible in `/admin/cache-stats.memory_safety`:
 
@@ -129,7 +129,7 @@ Important display rule:
 
 ## Settings Control Surface
 
-Changed-setting proof is currently `PARTIAL: app/API apply proof passed; manual UI click/save proof pending`.
+Changed-setting proof is currently `FIXED for PR #1462 UI/app/API application`.
 
 The app exposes memory-safety status through `/admin/cache-stats.memory_safety`
 and now exposes a Server Settings section that edits
@@ -151,7 +151,7 @@ The Server Settings section persists:
 - `memorySafety.customDefaultMaxKVSize`
 - `memorySafety.customMaxConcurrentSequences`
 
-Live proof still must show:
+Live proof now shows:
 
 1. The user changes and saves the setting through the Server Settings UI.
 2. `/admin/cache-stats.memory_safety` shows the changed mode/slider.
@@ -173,6 +173,26 @@ Current PR #1462 app/API proof:
 - The loaded E2B cache row kept Gemma's expected topology: 15 layers, 3 KV
   layers, 12 rotating KV layers, disk-backed restore required, block disk
   enabled, MLXPress disabled, and TurboQuant KV layer count 0.
+
+Current PR #1462 manual UI proof:
+
+- Artifact root: `.agents/gemma-final/artifacts/memory-safety-ui-proof-pr1462-20260610-221751`
+- The PR-built Debug app exposed Server Settings -> Memory Safety.
+- The UI was changed to `mode=strict`, `slider=3`, then saved and reported
+  `Settings saved successfully` / `All changes saved`.
+- `/admin/cache-stats.memory_safety` after the UI save reported
+  `mode=strict slider=3 load_cap=0.6 allocator_cap=absolute(134217728) max_concurrent=1 kv_cap=65536`.
+- A live `gemma-4-e2b-it-qat-mxfp4` chat after the UI save answered exactly
+  `ui memory safety applied`, stopped normally, and reported `28.8658`
+  completion token/s in `usage.tokens_per_second`.
+- The status endpoint after that generation still reported the same Strict
+  plan, `use_mmap_safetensors=true`, `jang_press_policy.kind=disabled`,
+  `paged_kv_enabled=true`, `block_disk_enabled=true`, and
+  `max_concurrent_sequences=1`.
+- Nuance: this UI proof preserved the existing Cache page per-session window
+  override, so Strict reported `kv_cap=65536`. The earlier isolated app/API
+  proof without that override reported `kv_cap=4096`. This is intentional
+  user-setting precedence, not a hidden hardcoded RAM rule.
 
 Do not substitute cache toggles for the memory-safety slider. Cache controls are
 real settings, but they do not prove the memory-safety contract is user

--- a/scripts/live-proof/assert-server-settings-runtime-wiring.sh
+++ b/scripts/live-proof/assert-server-settings-runtime-wiring.sh
@@ -37,6 +37,7 @@ reject_text() {
 CACHE_UI="$ROOT/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift"
 CONCURRENCY_UI="$ROOT/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift"
 MTP_UI="$ROOT/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift"
+MEMORY_SAFETY_UI="$ROOT/Packages/OsaurusCore/Views/Settings/ServerSettings/MemorySafetySection.swift"
 STORE="$ROOT/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift"
 RUNTIME="$ROOT/Packages/OsaurusCore/Services/ModelRuntime.swift"
 CONTROLLER="$ROOT/Packages/OsaurusCore/Networking/ServerController.swift"
@@ -47,6 +48,7 @@ for pair in \
   "$CACHE_UI:CacheSection" \
   "$CONCURRENCY_UI:ConcurrencySection" \
   "$MTP_UI:MTPSection" \
+  "$MEMORY_SAFETY_UI:MemorySafetySection" \
   "$STORE:ServerRuntimeSettingsStore" \
   "$RUNTIME:ModelRuntime" \
   "$CONTROLLER:ServerController" \
@@ -94,6 +96,20 @@ require_text "$MTP_UI" 'Auto uses it only when the model ships a verified native
   "UI describes MTP auto-detect contract"
 require_text "$MTP_UI" 'value: \$draft\.mtp\.draftTokenLimit' \
   "UI exposes MTP draft token limit"
+require_text "$MEMORY_SAFETY_UI" 'selection: \$draft\.memorySafety\.mode' \
+  "UI exposes memory-safety mode"
+require_text "$MEMORY_SAFETY_UI" 'draft\.memorySafety\.slider' \
+  "UI exposes memory-safety slider"
+require_text "$MEMORY_SAFETY_UI" 'draft\.resolvedMemorySafetyPlan' \
+  "UI shows resolved memory-safety plan"
+require_text "$MEMORY_SAFETY_UI" 'value: \$draft\.memorySafety\.customPhysicalMemoryFraction' \
+  "UI exposes memory-safety custom load fraction"
+require_text "$MEMORY_SAFETY_UI" 'customAllocatorCacheBytes' \
+  "UI exposes memory-safety allocator cache cap"
+require_text "$MEMORY_SAFETY_UI" 'value: \$draft\.memorySafety\.customDefaultMaxKVSize' \
+  "UI exposes memory-safety KV cap"
+require_text "$MEMORY_SAFETY_UI" 'value: \$draft\.memorySafety\.customMaxConcurrentSequences' \
+  "UI exposes memory-safety concurrency cap"
 
 echo "--- persisted automatic defaults ---"
 require_text "$STORE" 'continuousBatching: true' \

--- a/scripts/live-proof/assert-server-settings-runtime-wiring.sh
+++ b/scripts/live-proof/assert-server-settings-runtime-wiring.sh
@@ -144,6 +144,18 @@ require_text "$RUNTIME" 'settings\.resolvedLoadConfiguration' \
   "runtime consumes MTP load configuration"
 require_text "$RUNTIME" 'settings\.resolvedMTPDraftStrategy' \
   "runtime consumes MTP draft strategy"
+require_text "$RUNTIME" 'resolveMemorySafetyLoadPlan' \
+  "runtime resolves memory-safety plan for model loads"
+require_text "$RUNTIME" 'memorySafetyPlan\.loadConfiguration' \
+  "runtime applies memory-safety load configuration"
+require_text "$RUNTIME" 'memorySafety=\\\(mtpPlan\.memorySafetySummary' \
+  "runtime logs resolved memory-safety summary during load"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" '"memory_safety": Self\.memorySafetyJSONObject' \
+  "cache stats expose memory-safety status"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" '"display_summary": plan\.displaySummary' \
+  "memory-safety status exposes display summary"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" '"memory_status": memoryStatusJSONObject' \
+  "memory-safety status exposes live memory status"
 require_text "$ADAPTER" 'turboQuantCompressions' \
   "runtime diagnostics report TurboQuant compression count"
 require_text "$ADAPTER" 'nativeMTPDepthSummary' \


### PR DESCRIPTION
## Summary
- Add a tracked Gemma 4 checkpoint and memory-safety contract spec for the release lane.
- Add a real Server Settings -> Memory Safety section that edits `VMLXServerRuntimeSettings.memorySafety` through the existing draft/save path.
- Record what current live Osaurus proof actually covers: Gemma text/tool/cache/weird-character rows, representative image/refusal/reasoning boundaries, and current token/s.
- Extend the server-settings runtime guard so memory-safety UI controls, status exposure, and load-plan application cannot disappear silently.

## Status
- Default Safe Auto settings are visible in `/admin/cache-stats.memory_safety`.
- Model loads consume `memorySafetyPlan.loadConfiguration`.
- The UI control path exists for mode/slider/advanced overrides and has manual save proof.
- Changed-setting app/API proof passed: an isolated Strict launch changed `/admin/cache-stats.memory_safety`, and the next live `gemma-4-e2b-it-qat-mxfp4` load/chat used that status surface while keeping expected Gemma topology.
- Manual UI click/save proof passed in the PR-built app: Server Settings -> Memory Safety saved `mode=strict`, `slider=3`; `/admin/cache-stats.memory_safety` reflected it; a live E2B MXFP4 request answered exactly `ui memory safety applied`.

## Verification
- `scripts/live-proof/assert-server-settings-runtime-wiring.sh`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build` from `Packages/OsaurusCore`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ServerRuntimeSettingsStoreTests` from `Packages/OsaurusCore`
- `bash scripts/i18n/check.sh`
- `git diff --check`
- Keychain-free Debug app build produced `/Users/eric/Library/Developer/Xcode/DerivedData/osaurus-fknwhdrdztffeoffkagufseezytr/Build/Products/Debug/osaurus.app`
- Live PR #1462 settings/app proof artifact: `.agents/gemma-final/artifacts/memory-safety-apply-pr1462-20260610-220637`
  - Default status: `mode=safe_auto slider=2 load_cap=0.7 allocator_cap=absolute(134217728) max_concurrent=1 kv_cap=65536`
  - Changed status: `mode=strict slider=3 load_cap=0.6 allocator_cap=absolute(67108864) max_concurrent=1 kv_cap=4096`
  - `gemma-4-e2b-it-qat-mxfp4` response: `memory safety applied`, `29.1005` API token/s, MLXPress disabled, TurboQuant KV 0, disk-backed rotating/full KV topology.
- Live PR #1462 manual UI proof artifact: `.agents/gemma-final/artifacts/memory-safety-ui-proof-pr1462-20260610-221751`
  - UI saved Strict slider 3 and reported `Settings saved successfully` / `All changes saved`.
  - Status after save: `mode=strict slider=3 load_cap=0.6 allocator_cap=absolute(134217728) max_concurrent=1 kv_cap=65536`.
  - `gemma-4-e2b-it-qat-mxfp4` response after UI save: `ui memory safety applied`, `28.8658` API token/s.
  - Nuance: the UI proof preserved the existing Cache page per-session KV override, so Strict reported `kv_cap=65536`; the isolated proof without that override reported `kv_cap=4096`.

## Known Boundary
- Gemma audio/video remain typed-refusal boundaries, not generation support.
- Broader Qwen/MiMo/N2/Sentry closure is intentionally not claimed by this Gemma checkpoint.