### PR TITLE
Expose applied generation diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,14 @@ jobs:
           # We deliberately pass a dummy resultBundlePath check first because
           # xcodebuild refuses to overwrite an existing bundle.
           rm -rf "$XCRESULT_PATH"
-          # Per-test-case allowance (60s / 120s hard cap) surfaces a hung
-          # test BEFORE the job wall-timeout — and crucially, surfaces it
-          # WITH A NAME ATTACHED in the xcresult bundle, which the failure
-          # summary step below relies on.
+          # Per-test-case allowance surfaces a hung test BEFORE the job
+          # wall-timeout — and crucially, surfaces it WITH A NAME ATTACHED
+          # in the xcresult bundle, which the failure summary step below
+          # relies on. Keep this above the scheduler-starvation noise floor:
+          # Swift Testing can start hundreds of async suites at once, and
+          # Xcode's default parallel workers have produced false 60s
+          # timeouts on trivial @MainActor tests while a second xctest
+          # worker was still draining unrelated shell/timer-heavy rows.
           #
           # Why no `--quiet` on xcbeautify and no `-test-iterations`:
           # both were band-aids that landed during PR #878's launch-hang
@@ -195,9 +199,12 @@ jobs:
             -skipPackagePluginValidation \
             -skipMacroValidation \
             -enableCodeCoverage NO \
+            -parallel-testing-enabled NO \
+            -parallel-testing-worker-count 1 \
+            -maximum-parallel-testing-workers 1 \
             -test-timeouts-enabled YES \
-            -default-test-execution-time-allowance 60 \
-            -maximum-test-execution-time-allowance 120 \
+            -default-test-execution-time-allowance 180 \
+            -maximum-test-execution-time-allowance 300 \
             COMPILER_INDEX_STORE_ENABLE=NO \
             SWIFT_COMPILATION_MODE=incremental \
             | xcbeautify --renderer github-actions --is-ci \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
 - Never add forced thinking tags, parser repair, hidden sampler defaults,
   repetition-penalty rescues, close-token bias, or prompt/template coercion to
   make a model appear coherent.
+- Never add fake guards, placeholder gates, hardcoded model allowlists,
+  synthetic output filters, or "same behavior" enforcement to make a runtime
+  row look safe. If JANG, JANGTQ, MXFP, VL/audio/video, hybrid cache, SWA,
+  speed, coherency, leaking tool parser output, reasoning boundaries, or RAM
+  policy is wrong, trace the root cause and fix the real function/path. If the
+  root cause is not fixed yet, document the row as `PARTIAL` or `BLOCKED` with
+  exact evidence instead of forcing behavior in prompts, parsers, samplers, or
+  UI state.
 - Chat/API defaults must come from the active model bundle's
   `generation_config.json` or equivalent runtime config unless a user
   explicitly overrides them. Native-trained defaults such as top-k matter for
@@ -58,6 +66,10 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
 - Multi-turn coherency is required: visible answer, reasoning channel behavior,
   no looping, no hidden reasoning-only output, no length-cap fake pass, and no
   raw parser marker leak.
+- Reasoning fixes must preserve the model's real contract. Do not inject fake
+  closers/openers, hide leaked reasoning markers by stripping visible text, or
+  treat a parser cleanup as correctness unless the live output, structured
+  reasoning field, and user-visible answer all prove the boundary is correct.
 - Cache proof must match the model architecture:
   - Full-attention models need real KV, prefix/paged, L2 disk, and TurboQuant
     KV proof when enabled.
@@ -74,6 +86,21 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
 - Qwen/JANG/JANGTQ RAM regressions require end-to-end Osaurus proof with
   physical footprint, stop status, cache telemetry, token/s, and visible
   multi-turn output before being called fixed.
+- Memory limits must apply only through documented user/runtime settings and
+  the resolved runtime plan. Do not add hidden RAM percentage blocks or fake
+  load refusals. If a selected setting or true runtime limit prevents a load or
+  context request, fail before unsafe MLX/Metal allocation with a clear typed
+  API/app error that tells the user what setting or resource limit applied.
+- Server settings are part of runtime proof, not a source-only contract. For
+  every claimed model/runtime row, verify the relevant server setting wiring
+  through live Osaurus panel/API state: generation defaults and overrides,
+  reasoning mode, tool mode, memory enablement, prefix cache, paged KV, L2 disk
+  cache, TurboQuant KV when applicable, media/cache settings, concurrency, and
+  memory-safety settings. Toggle the setting, speak to the model, and confirm
+  the runtime behavior, telemetry, and user-visible state changed as intended.
+  If settings conflict or do not compose for a model family, question the
+  compatibility contract, fix the real wiring, or document the row as
+  `PARTIAL`/`BLOCKED` with the exact incompatible setting combination.
 - Do not spawn recursive local "agent" workers, Python subagents, or delegated
   helper agents for Gemma/Osaurus release work unless the user explicitly asks.
   Do not use Python or shell wrappers as an orchestration layer to farm work out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,14 @@ and deletes rather than calling `SecItemCopyMatching` / `SecItemAdd` /
   If settings conflict or do not compose for a model family, question the
   compatibility contract, fix the real wiring, or document the row as
   `PARTIAL`/`BLOCKED` with the exact incompatible setting combination.
+- Tool, memory, and cache setting proof must exercise the live user flow after
+  the setting changes. Required tool proof includes exact tool args, tool-result
+  history grounding, a second tool call after history, and no parser/protocol
+  leakage. Memory proof, when the shipped flow exposes memory context or memory
+  toggles, must include multi-turn chat that depends on the memory state. Cache
+  proof must include baseline, changed setting, reload when next-load-only,
+  live chat, `/admin/cache-stats`, and typed incompatibility rather than silent
+  ignore for unsupported combinations.
 - Do not spawn recursive local "agent" workers, Python subagents, or delegated
   helper agents for Gemma/Osaurus release work unless the user explicitly asks.
   Do not use Python or shell wrappers as an orchestration layer to farm work out

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
+        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
+        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
+        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
       }
     },
     {

--- a/Packages/OsaurusCore/Folder/FolderContextService.swift
+++ b/Packages/OsaurusCore/Folder/FolderContextService.swift
@@ -120,7 +120,7 @@ public final class FolderContextService: ObservableObject {
                 let manifest = readManifest(url, projectType: projectType)
                 let isGitRepo = checkIsGitRepo(url)
                 let contextFiles = readContextFiles(url)
-                let detectedExtensions = scanForKnownExtensions(
+                let detectedExtensions = Self.scanForKnownExtensions(
                     url,
                     ignorePatterns: projectType.ignorePatterns
                 )
@@ -159,7 +159,7 @@ public final class FolderContextService: ObservableObject {
     /// into `.git` / `node_modules` / `.build` looking for spreadsheets
     /// that the agent would never see anyway. Hidden files are skipped
     /// for the same reason.
-    nonisolated private func scanForKnownExtensions(
+    nonisolated internal static func scanForKnownExtensions(
         _ url: URL,
         ignorePatterns: [String]
     ) -> Set<String> {
@@ -335,7 +335,7 @@ public final class FolderContextService: ObservableObject {
     // MARK: - File Tree Building
 
     /// Check if a filename matches any ignore pattern (wildcard or exact)
-    nonisolated private func shouldIgnore(_ name: String, patterns: [String]) -> Bool {
+    nonisolated private static func shouldIgnore(_ name: String, patterns: [String]) -> Bool {
         for pattern in patterns {
             if pattern.contains("*") {
                 let regex = pattern.replacingOccurrences(of: ".", with: "\\.")
@@ -378,7 +378,7 @@ public final class FolderContextService: ObservableObject {
 
             // Filter out ignored items first
             let visible = contents.filter {
-                !shouldIgnore($0.lastPathComponent, patterns: patterns)
+                !Self.shouldIgnore($0.lastPathComponent, patterns: patterns)
             }
 
             // Sort: directories first, then files, both alphabetically
@@ -479,7 +479,7 @@ public final class FolderContextService: ObservableObject {
                 includingPropertiesForKeys: nil,
                 options: [.skipsHiddenFiles]
             )) ?? []
-        return subContents.filter { !shouldIgnore($0.lastPathComponent, patterns: patterns) }.count
+        return subContents.filter { !Self.shouldIgnore($0.lastPathComponent, patterns: patterns) }.count
     }
 
     /// Compute adaptive max depth based on top-level item count.
@@ -526,7 +526,7 @@ public final class FolderContextService: ObservableObject {
 
         for case let fileURL as URL in enumerator {
             let name = fileURL.lastPathComponent
-            if shouldIgnore(name, patterns: patterns) {
+            if Self.shouldIgnore(name, patterns: patterns) {
                 enumerator.skipDescendants()
                 continue
             }

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1440,6 +1440,7 @@ extension ModelManager {
     private static nonisolated(unsafe) var cachedLocalModels: [MLXModel]?
     private static nonisolated(unsafe) var localModelsScanInFlight = false
     private static nonisolated let localModelsScanWaitLimit: TimeInterval = 10
+    private static nonisolated(unsafe) var lastLocalModelsScanDiagnostic: [String: Any]?
     nonisolated(unsafe) static var scanLocalModelsOverrideForTests: ((URL) -> [MLXModel])?
     nonisolated(unsafe) static var localModelsScanWaitLimitOverrideForTests: TimeInterval?
 
@@ -1451,6 +1452,13 @@ extension ModelManager {
         localModelsCacheCondition.unlock()
         LocalReasoningCapability.invalidate()
         LocalGenerationDefaults.invalidate()
+    }
+
+    nonisolated static func localModelsScanDiagnosticJSONObject() -> [String: Any]? {
+        localModelsCacheCondition.lock()
+        let diagnostic = lastLocalModelsScanDiagnostic
+        localModelsCacheCondition.unlock()
+        return diagnostic
     }
 
     /// Run the blocking local-model discovery off the main actor.
@@ -1540,17 +1548,41 @@ extension ModelManager {
     internal nonisolated static func scanLocalModels(at root: URL) -> [MLXModel] {
         let fm = FileManager.default
         var rootIsDir: ObjCBool = false
-        guard fm.fileExists(atPath: root.path, isDirectory: &rootIsDir), rootIsDir.boolValue else {
+        let rootExists = fm.fileExists(atPath: root.path, isDirectory: &rootIsDir)
+        let rootReadable = access(root.path, R_OK | X_OK) == 0
+
+        func publishDiagnostic(status: String, modelCount: Int, error: String?, currentPath: String? = nil) {
+            let diagnostic: [String: Any] = [
+                "root": root.path,
+                "root_exists": rootExists,
+                "root_is_directory": rootExists && rootIsDir.boolValue,
+                "root_readable": rootReadable,
+                "status": status,
+                "current_path": currentPath as Any? ?? NSNull(),
+                "model_count": modelCount,
+                "error": error as Any? ?? NSNull(),
+                "scanned_at": Date().ISO8601Format(),
+            ]
+            localModelsCacheCondition.lock()
+            lastLocalModelsScanDiagnostic = diagnostic
+            localModelsCacheCondition.unlock()
+        }
+        publishDiagnostic(status: "started", modelCount: 0, error: nil)
+
+        guard rootExists, rootIsDir.boolValue else {
+            publishDiagnostic(status: "failed", modelCount: 0, error: "Model root is missing or is not a directory.")
             return []
         }
 
         var models: [MLXModel] = []
+        var scanError: String?
 
         func exists(_ base: URL, _ name: String) -> Bool {
             access(base.appendingPathComponent(name).path, F_OK) == 0
         }
 
         func directoryEntryNames(_ dir: URL) -> [String]? {
+            errno = 0
             guard let handle = opendir(dir.path) else { return nil }
             defer { closedir(handle) }
 
@@ -1659,9 +1691,20 @@ extension ModelManager {
         // and try the same heuristic at the next level. Maximum depth of 3 keeps the scan bounded
         // — anything deeper is treated as not-a-bundle.
         func scanDir(_ root: URL, prefix: [String], maxDepth: Int) {
+            publishDiagnostic(status: "enumerating", modelCount: models.count, error: nil, currentPath: root.path)
             guard maxDepth > 0,
                 let entryNames = directoryEntryNames(root)
-            else { return }
+            else {
+                if prefix.isEmpty {
+                    let code = errno
+                    let message =
+                        code == 0
+                        ? "Unable to enumerate model root."
+                        : String(cString: strerror(code))
+                    scanError = "Unable to enumerate model root: \(message)"
+                }
+                return
+            }
 
             let modelCountBeforeDirectPass = models.count
             for entryName in entryNames where !entryName.hasPrefix(".") {
@@ -1711,6 +1754,7 @@ extension ModelManager {
                 unique.append(m)
             }
         }
+        publishDiagnostic(status: scanError == nil ? "finished" : "failed", modelCount: unique.count, error: scanError)
         return unique
     }
 }

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1075,7 +1075,7 @@ extension ModelManager {
 
     /// Find an installed model by user-provided name.
     /// Accepts repo name (case-insensitive) or full id (case-insensitive).
-    nonisolated static func findInstalledModel(named name: String) -> (name: String, id: String)? {
+    nonisolated static func findInstalledMLXModel(named name: String) -> MLXModel? {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let models = discoverLocalModels()
@@ -1084,18 +1084,26 @@ extension ModelManager {
         if let match = models.first(where: { m in
             m.id.split(separator: "/").last.map(String.init)?.lowercased() == trimmed.lowercased()
         }) {
-            let repo =
-                match.id.split(separator: "/").last.map(String.init)?.lowercased() ?? trimmed.lowercased()
-            return (repo, match.id)
+            return match
         }
 
         // Try full id match
         if let match = models.first(where: { m in m.id.lowercased() == trimmed.lowercased() }) {
-            let repo =
-                match.id.split(separator: "/").last.map(String.init)?.lowercased() ?? trimmed.lowercased()
-            return (repo, match.id)
+            return match
         }
         return nil
+    }
+
+    /// Find an installed model by user-provided name, returning the canonical
+    /// picker key and model id. Callers that need files inside the bundle must
+    /// use `findInstalledMLXModel(named:)` and `MLXModel.localDirectory` so
+    /// externally-discovered and symlinked bundles keep their real path.
+    nonisolated static func findInstalledModel(named name: String) -> (name: String, id: String)? {
+        guard let match = findInstalledMLXModel(named: name) else { return nil }
+        let repo =
+            match.id.split(separator: "/").last.map(String.init)?.lowercased()
+                ?? name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return (repo, match.id)
     }
 }
 

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1440,6 +1440,8 @@ extension ModelManager {
     private static nonisolated(unsafe) var cachedLocalModels: [MLXModel]?
     private static nonisolated(unsafe) var localModelsScanInFlight = false
     private static nonisolated let localModelsScanWaitLimit: TimeInterval = 10
+    nonisolated(unsafe) static var scanLocalModelsOverrideForTests: ((URL) -> [MLXModel])?
+    nonisolated(unsafe) static var localModelsScanWaitLimitOverrideForTests: TimeInterval?
 
     nonisolated static func invalidateLocalModelsCache() {
         localModelsCacheCondition.lock()
@@ -1484,12 +1486,14 @@ extension ModelManager {
         }
 
         if localModelsScanInFlight {
-            let cached = waitForLocalModelsScan(until: Date().addingTimeInterval(localModelsScanWaitLimit)) ?? []
+            let waitLimit = localModelsScanWaitLimitOverrideForTests ?? localModelsScanWaitLimit
+            let cached = waitForLocalModelsScan(until: Date().addingTimeInterval(waitLimit)) ?? []
             localModelsCacheCondition.unlock()
             return mergeExternalModels(into: cached)
         }
 
-        let deadline = Date().addingTimeInterval(localModelsScanWaitLimit)
+        let waitLimit = localModelsScanWaitLimitOverrideForTests ?? localModelsScanWaitLimit
+        let deadline = Date().addingTimeInterval(waitLimit)
         localModelsScanInFlight = true
         DispatchQueue.global(qos: .utility).async {
             let scanned = scanLocalModels()
@@ -1505,9 +1509,6 @@ extension ModelManager {
             localModelsCacheCondition.unlock()
             return mergeExternalModels(into: cached)
         } else {
-            if cachedLocalModels == nil {
-                cachedLocalModels = []
-            }
             let cached = cachedLocalModels ?? []
             localModelsCacheCondition.unlock()
             return mergeExternalModels(into: cached)
@@ -1526,7 +1527,11 @@ extension ModelManager {
     }
 
     private nonisolated static func scanLocalModels() -> [MLXModel] {
-        return scanLocalModels(at: DirectoryPickerService.effectiveModelsDirectory())
+        let root = DirectoryPickerService.effectiveModelsDirectory()
+        if let override = scanLocalModelsOverrideForTests {
+            return override(root)
+        }
+        return scanLocalModels(at: root)
     }
 
     /// Internal entry point used by tests so they can supply a fixture root.

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -601,6 +601,7 @@ struct CompletionRequest: Decodable, Sendable {
     let maxTokens: Int?
     let temperature: Float?
     let topP: Float?
+    let topK: Int?
     let stop: [String]
     let stream: Bool?
 
@@ -608,6 +609,7 @@ struct CompletionRequest: Decodable, Sendable {
         case model, prompt, temperature, stop, stream
         case maxTokens = "max_tokens"
         case topP = "top_p"
+        case topK = "top_k"
     }
 
     init(from decoder: Decoder) throws {
@@ -625,6 +627,7 @@ struct CompletionRequest: Decodable, Sendable {
         maxTokens = try? c.decodeIfPresent(Int.self, forKey: .maxTokens)
         temperature = try? c.decodeIfPresent(Float.self, forKey: .temperature)
         topP = try? c.decodeIfPresent(Float.self, forKey: .topP)
+        topK = try? c.decodeIfPresent(Int.self, forKey: .topK)
         // `stop` may be a string or an array of strings.
         if let s = try? c.decode(String.self, forKey: .stop) {
             stop = [s]
@@ -651,6 +654,7 @@ struct ChatCompletionRequest: Codable, Sendable {
     var max_completion_tokens: Int? = nil
     let stream: Bool?
     let top_p: Float?
+    var top_k: Int? = nil
     let frequency_penalty: Float?
     let presence_penalty: Float?
     let stop: [String]?
@@ -702,7 +706,7 @@ struct ChatCompletionRequest: Codable, Sendable {
     var resolvedMaxTokens: Int? { max_tokens ?? max_completion_tokens }
 
     private enum CodingKeys: String, CodingKey {
-        case model, messages, temperature, max_tokens, max_completion_tokens, stream, top_p
+        case model, messages, temperature, max_tokens, max_completion_tokens, stream, top_p, top_k
         case frequency_penalty, presence_penalty, stop, n
         case tools, tool_choice, session_id
         case seed, response_format, stream_options
@@ -717,6 +721,7 @@ struct ChatCompletionRequest: Codable, Sendable {
             max_tokens: max_tokens,
             stream: stream,
             top_p: top_p,
+            top_k: top_k,
             frequency_penalty: frequency_penalty,
             presence_penalty: presence_penalty,
             stop: stop,
@@ -751,6 +756,7 @@ struct ChatCompletionRequest: Codable, Sendable {
             max_tokens: max_tokens,
             stream: stream,
             top_p: top_p,
+            top_k: top_k,
             frequency_penalty: frequency_penalty,
             presence_penalty: presence_penalty,
             stop: stop,

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -419,7 +419,7 @@ public enum ModelMediaCapabilities {
                 modality: .audio,
                 status: .unproven,
                 reason:
-                    "Gemma4 audio input is not enabled because native audio routing still needs live model proof."
+                    "Gemma4 audio input is not enabled because the pinned vMLX Gemma4 runtime does not wire audio_tower/embed_audio yet."
             )
         }
         return ModalityDescriptor(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -585,6 +585,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     method: method,
                     path: path
                 )
+            } else if head.method == .GET, path == "/admin/generation-settings" {
+                handleGenerationSettingsEndpoint(
+                    head: head,
+                    context: context,
+                    startTime: startTime,
+                    userAgent: userAgent,
+                    method: method,
+                    path: path
+                )
             } else if head.method == .GET, path == "/models" {
                 handleModelsEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .GET, path == "/tags" {
@@ -763,6 +772,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         runRequestTask(priority: .userInitiated) {
             let cached = await ModelRuntime.shared.cachedModelSummaries()
             let diagnostics = await MLXBatchAdapter.snapshotDiagnostics()
+            let lastEffectiveGenerationSettings =
+                await MLXBatchAdapter.lastEffectiveGenerationSettingsSnapshot()
             var aggregate: [String: Int] = [
                 "prefix_hits": 0,
                 "prefix_misses": 0,
@@ -800,6 +811,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
                 row["native_mtp_status"] = summary.nativeMTPStatus ?? NSNull()
                 row["native_mtp_reason"] = summary.nativeMTPReason ?? NSNull()
+                row["generation_defaults"] = Self.generationDefaultsJSONObject(
+                    LocalGenerationDefaults.defaults(forModelId: summary.name)
+                )
+                if let effective = lastEffectiveGenerationSettings[summary.name] {
+                    row["last_effective_generation"] = Self.effectiveGenerationSettingsJSONObject(effective)
+                } else {
+                    row["last_effective_generation"] = NSNull()
+                }
                 let mlxPress = summary.mlxPressStatus
                 var mlxPressStatus: [String: Any] = [
                     "enabled": mlxPress.enabled,
@@ -991,6 +1010,78 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
     }
 
+    /// `/admin/generation-settings` exposes the bundle-derived defaults and
+    /// the last effective generation settings that were actually submitted to
+    /// vmlx. It intentionally avoids `ModelRuntime` so it remains responsive
+    /// when an in-flight MLX prepare/decode path is blocked.
+    private func handleGenerationSettingsEndpoint(
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext,
+        startTime: Date,
+        userAgent: String?,
+        method: String,
+        path: String
+    ) {
+        let loop = context.eventLoop
+        let ctx = NIOLoopBound(context, eventLoop: loop)
+        let cors = stateRef.value.corsHeaders
+        let hop = Self.makeHop(channel: context.channel, loop: loop)
+        let version = head.version
+        let logSelf = self
+        let logStartTime = startTime
+        let logUserAgent = userAgent
+        let logMethod = method
+        let logPath = path
+
+        runRequestTask(priority: .userInitiated) {
+            let lastEffectiveGenerationSettings =
+                await MLXBatchAdapter.lastEffectiveGenerationSettingsSnapshot()
+            var defaultsByModel: [String: Any] = [:]
+            var effectiveByModel: [String: Any] = [:]
+            for modelName in lastEffectiveGenerationSettings.keys.sorted() {
+                defaultsByModel[modelName] = Self.generationDefaultsJSONObject(
+                    LocalGenerationDefaults.defaults(forModelId: modelName)
+                )
+                if let effective = lastEffectiveGenerationSettings[modelName] {
+                    effectiveByModel[modelName] = Self.effectiveGenerationSettingsJSONObject(effective)
+                }
+            }
+
+            let obj: [String: Any] = [
+                "status": "ok",
+                "timestamp": Date().ISO8601Format(),
+                "source": "last effective settings resolved by Osaurus; stage indicates whether they are pending preload or submitted to vmlx BatchEngine",
+                "models": lastEffectiveGenerationSettings.keys.sorted(),
+                "generation_defaults_by_model": defaultsByModel,
+                "last_effective_generation_by_model": effectiveByModel,
+            ]
+            let data = try? JSONSerialization.data(withJSONObject: obj, options: .osaurusCanonical)
+            let body = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
+            let headers: [(String, String)] =
+                [("Content-Type", "application/json; charset=utf-8")]
+                + cors
+
+            hop {
+                logSelf.sendResponse(
+                    context: ctx.value,
+                    version: version,
+                    status: .ok,
+                    headers: headers,
+                    body: body
+                )
+            }
+            logSelf.logRequest(
+                method: logMethod,
+                path: logPath,
+                userAgent: logUserAgent,
+                requestBody: nil,
+                responseBody: body,
+                responseStatus: 200,
+                startTime: logStartTime
+            )
+        }
+    }
+
     private static func memorySafetyJSONObject(
         settings: VMLXServerRuntimeSettings,
         plan: VMLXResolvedMemorySafetyPlan,
@@ -1051,6 +1142,35 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "default_max_kv_size": cache.defaultMaxKVSize as Any? ?? NSNull(),
             "long_prompt_multiplier": cache.longPromptMultiplier,
             "enable_ssm_rederive": cache.enableSSMReDerive,
+        ]
+    }
+
+    private static func generationDefaultsJSONObject(
+        _ defaults: LocalGenerationDefaults.Defaults
+    ) -> [String: Any] {
+        [
+            "max_tokens": defaults.maxTokens as Any? ?? NSNull(),
+            "temperature": defaults.temperature as Any? ?? NSNull(),
+            "top_p": defaults.topP as Any? ?? NSNull(),
+            "top_k": defaults.topK as Any? ?? NSNull(),
+            "min_p": defaults.minP as Any? ?? NSNull(),
+            "repetition_penalty": defaults.repetitionPenalty as Any? ?? NSNull(),
+            "do_sample": defaults.doSample as Any? ?? NSNull(),
+        ]
+    }
+
+    private static func effectiveGenerationSettingsJSONObject(
+        _ settings: MLXBatchAdapter.EffectiveGenerationSettings
+    ) -> [String: Any] {
+        [
+            "stage": settings.stage,
+            "temperature": settings.temperature,
+            "max_tokens": settings.maxTokens,
+            "top_p": settings.topP,
+            "top_k": settings.topK,
+            "min_p": settings.minP,
+            "repetition_penalty": settings.repetitionPenalty as Any? ?? NSNull(),
+            "compiled_batch_decode": settings.compiledBatchDecode,
         ]
     }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -594,6 +594,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     method: method,
                     path: path
                 )
+            } else if (head.method == .GET || head.method == .PUT), path == "/admin/runtime-settings" {
+                handleRuntimeSettingsEndpoint(
+                    head: head,
+                    context: context,
+                    startTime: startTime,
+                    userAgent: userAgent,
+                    method: method,
+                    path: path
+                )
             } else if head.method == .GET, path == "/models" {
                 handleModelsEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .GET, path == "/tags" {
@@ -1080,6 +1089,265 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 startTime: logStartTime
             )
         }
+    }
+
+    /// `/admin/runtime-settings` is the automation companion for the Server
+    /// Settings panel. GET returns the exact persisted vMLX runtime settings.
+    /// PUT accepts a full `VMLXServerRuntimeSettings` JSON document and applies
+    /// only runtime-scoped changes; network rebinding still belongs to the
+    /// SwiftUI panel / `ServerController` path so an HTTP request cannot
+    /// restart the server out from under itself.
+    private func handleRuntimeSettingsEndpoint(
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext,
+        startTime: Date,
+        userAgent: String?,
+        method: String,
+        path: String
+    ) {
+        let loop = context.eventLoop
+        let ctx = NIOLoopBound(context, eventLoop: loop)
+        let cors = stateRef.value.corsHeaders
+        let hop = Self.makeHop(channel: context.channel, loop: loop)
+        let version = head.version
+        let logSelf = self
+        let logStartTime = startTime
+        let logUserAgent = userAgent
+        let logMethod = method
+        let logPath = path
+        let parsedBody = head.method == .PUT ? readRequestBody() : nil
+
+        runRequestTask(priority: .userInitiated) {
+            let previous = ServerRuntimeSettingsStore.snapshot()
+
+            if head.method == .GET {
+                let body = Self.runtimeSettingsResponseBody(
+                    settings: previous,
+                    previous: nil,
+                    effects: [:]
+                )
+                let headers: [(String, String)] =
+                    [("Content-Type", "application/json; charset=utf-8")]
+                    + cors
+                hop {
+                    logSelf.sendResponse(
+                        context: ctx.value,
+                        version: version,
+                        status: .ok,
+                        headers: headers,
+                        body: body
+                    )
+                }
+                logSelf.logRequest(
+                    method: logMethod,
+                    path: logPath,
+                    userAgent: logUserAgent,
+                    requestBody: nil,
+                    responseBody: body,
+                    responseStatus: 200,
+                    startTime: logStartTime
+                )
+                return
+            }
+
+            guard let parsedBody, !parsedBody.data.isEmpty else {
+                let body = Self.errorBody(
+                    .openai(type: "invalid_request_error"),
+                    message: "Runtime settings PUT requires a JSON VMLXServerRuntimeSettings body."
+                )
+                let headers = [("Content-Type", "application/json; charset=utf-8")] + cors
+                hop {
+                    logSelf.sendResponse(
+                        context: ctx.value,
+                        version: version,
+                        status: .badRequest,
+                        headers: headers,
+                        body: body
+                    )
+                }
+                logSelf.logRequest(
+                    method: logMethod,
+                    path: logPath,
+                    userAgent: logUserAgent,
+                    requestBody: parsedBody?.text,
+                    responseBody: body,
+                    responseStatus: 400,
+                    startTime: logStartTime
+                )
+                return
+            }
+
+            let next: VMLXServerRuntimeSettings
+            do {
+                next = try JSONDecoder().decode(VMLXServerRuntimeSettings.self, from: parsedBody.data)
+            } catch {
+                let body = Self.errorBody(
+                    .openai(type: "invalid_request_error"),
+                    message: "Invalid runtime settings JSON: \(error.localizedDescription)"
+                )
+                let headers = [("Content-Type", "application/json; charset=utf-8")] + cors
+                hop {
+                    logSelf.sendResponse(
+                        context: ctx.value,
+                        version: version,
+                        status: .badRequest,
+                        headers: headers,
+                        body: body
+                    )
+                }
+                logSelf.logRequest(
+                    method: logMethod,
+                    path: logPath,
+                    userAgent: logUserAgent,
+                    requestBody: parsedBody.text,
+                    responseBody: body,
+                    responseStatus: 400,
+                    startTime: logStartTime
+                )
+                return
+            }
+
+            if previous.network != next.network {
+                let body = Self.errorBody(
+                    .openai(type: "invalid_request_error"),
+                    message: "Network runtime settings require the Server Settings panel because they can restart/rebind the HTTP server. Keep network unchanged for /admin/runtime-settings."
+                )
+                let headers = [("Content-Type", "application/json; charset=utf-8")] + cors
+                hop {
+                    logSelf.sendResponse(
+                        context: ctx.value,
+                        version: version,
+                        status: .badRequest,
+                        headers: headers,
+                        body: body
+                    )
+                }
+                logSelf.logRequest(
+                    method: logMethod,
+                    path: logPath,
+                    userAgent: logUserAgent,
+                    requestBody: parsedBody.text,
+                    responseBody: body,
+                    responseStatus: 400,
+                    startTime: logStartTime
+                )
+                return
+            }
+
+            let validationIssues = next.validationIssues()
+            let blockingIssues = validationIssues.filter { $0.severity == .error }
+            guard blockingIssues.isEmpty else {
+                let obj: [String: Any] = [
+                    "error": [
+                        "message": "Runtime settings contain validation errors.",
+                        "type": "invalid_request_error",
+                        "issues": blockingIssues.map(Self.settingsIssueJSONObject),
+                    ] as [String: Any]
+                ]
+                let data = try? JSONSerialization.data(withJSONObject: obj, options: .osaurusCanonical)
+                let body = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
+                let headers = [("Content-Type", "application/json; charset=utf-8")] + cors
+                hop {
+                    logSelf.sendResponse(
+                        context: ctx.value,
+                        version: version,
+                        status: .badRequest,
+                        headers: headers,
+                        body: body
+                    )
+                }
+                logSelf.logRequest(
+                    method: logMethod,
+                    path: logPath,
+                    userAgent: logUserAgent,
+                    requestBody: parsedBody.text,
+                    responseBody: body,
+                    responseStatus: 400,
+                    startTime: logStartTime
+                )
+                return
+            }
+
+            let loadedModelRefreshNeeded =
+                previous.cache != next.cache
+                || previous.multimodal != next.multimodal
+                || previous.mtp != next.mtp
+            let runtimeConfigInvalidated =
+                previous.generation != next.generation
+                || previous.concurrency != next.concurrency
+
+            ServerRuntimeSettingsStore.save(next)
+            if loadedModelRefreshNeeded {
+                await ModelRuntime.shared.clearAll()
+            }
+            if runtimeConfigInvalidated {
+                await ModelRuntime.shared.invalidateConfig()
+            }
+
+            let effects: [String: Any] = [
+                "loaded_model_refresh_needed": loadedModelRefreshNeeded,
+                "runtime_config_invalidated": runtimeConfigInvalidated,
+                "network_restart_rejected": false,
+                "validation_warnings": validationIssues
+                    .filter { $0.severity == .warning }
+                    .map(Self.settingsIssueJSONObject),
+            ]
+            let body = Self.runtimeSettingsResponseBody(
+                settings: next,
+                previous: previous,
+                effects: effects
+            )
+            let headers: [(String, String)] =
+                [("Content-Type", "application/json; charset=utf-8")]
+                + cors
+            hop {
+                logSelf.sendResponse(
+                    context: ctx.value,
+                    version: version,
+                    status: .ok,
+                    headers: headers,
+                    body: body
+                )
+            }
+            logSelf.logRequest(
+                method: logMethod,
+                path: logPath,
+                userAgent: logUserAgent,
+                requestBody: parsedBody.text,
+                responseBody: body,
+                responseStatus: 200,
+                startTime: logStartTime
+            )
+        }
+    }
+
+    private static func runtimeSettingsResponseBody(
+        settings: VMLXServerRuntimeSettings,
+        previous: VMLXServerRuntimeSettings?,
+        effects: [String: Any]
+    ) -> String {
+        var obj: [String: Any] = [
+            "status": "ok",
+            "timestamp": Date().ISO8601Format(),
+            "settings": runtimeSettingsJSONObject(settings),
+            "effects": effects,
+        ]
+        if let previous {
+            obj["previous_settings"] = runtimeSettingsJSONObject(previous)
+        }
+        let data = try? JSONSerialization.data(withJSONObject: obj, options: .osaurusCanonical)
+        return data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
+    }
+
+    private static func runtimeSettingsJSONObject(
+        _ settings: VMLXServerRuntimeSettings
+    ) -> Any {
+        guard let data = try? JSONEncoder().encode(settings),
+            let object = try? JSONSerialization.jsonObject(with: data)
+        else {
+            return [:]
+        }
+        return object
     }
 
     private static func memorySafetyJSONObject(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5285,7 +5285,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             temperature: req.temperature,
             maxTokens: req.resolvedMaxTokens,
             maxTokensExplicit: req.maxTokens != nil,
-            topPOverride: req.topP
+            topPOverride: req.topP,
+            topKOverride: req.topK
         )
         let promptTokens = TokenEstimator.estimate(prompt)
         let cors = stateRef.value.corsHeaders

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -7476,6 +7476,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
 
             let memoryConfig = MemoryConfigurationStore.load()
+            let localModelScan: Any = ModelManager.localModelsScanDiagnosticJSONObject() as Any? ?? NSNull()
             let obj: [String: Any] = [
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
@@ -7492,6 +7493,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "sandbox_status": sandboxStatus,
                 "mlx_last_error": mlxLastError,
                 "index_failures": indexFailures,
+                "local_model_scan": localModelScan,
                 "ram_feasibility": ramFeasibility,
                 "persistence": PersistenceHealth.shared.snapshot(),
             ]

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
+        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
+        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
+        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
+            revision: "76047f3b4492d4fae316267a30fba55163b1c5cd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ef025f2556978d033131f745c00dd8128c8d5151"
+            revision: "23eb84913ab77a9e929ef828481ca6941c03ae80"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "23eb84913ab77a9e929ef828481ca6941c03ae80"
+            revision: "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -147,6 +147,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             maxTokens: maxTokens,
             maxTokensExplicit: request.resolvedMaxTokens != nil,
             topPOverride: request.top_p,
+            topKOverride: request.top_k,
             repetitionPenalty: repPenalty,
             samplingParametersAreImplicit: request.samplingParametersAreImplicit,
             frequencyPenalty: request.frequency_penalty,

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -258,19 +258,22 @@ actor MLXService: ToolCapableService {
         )
 
         var issues = serverResult.issues.map { $0.message }
-        let mediaDescriptor = mediaCapabilityDescriptor(
-            modelId: modelId,
-            modelDirectory: modelDirectory
-        )
-        let media = mediaDescriptor.capabilities
-        if modalities.contains(.vision), !media.supportsImage {
-            issues.append(mediaDescriptor.descriptor(for: .image).reason)
-        }
-        if modalities.contains(.video), !media.supportsVideo {
-            issues.append(mediaDescriptor.descriptor(for: .video).reason)
-        }
-        if modalities.contains(.audio), !media.supportsAudio {
-            issues.append(mediaDescriptor.descriptor(for: .audio).reason)
+        let mediaModalities: Set<ModelRuntimeRequestModality> = [.vision, .video, .audio]
+        if !modalities.isDisjoint(with: mediaModalities) {
+            let mediaDescriptor = mediaCapabilityDescriptor(
+                modelId: modelId,
+                modelDirectory: modelDirectory
+            )
+            let media = mediaDescriptor.capabilities
+            if modalities.contains(.vision), !media.supportsImage {
+                issues.append(mediaDescriptor.descriptor(for: .image).reason)
+            }
+            if modalities.contains(.video), !media.supportsVideo {
+                issues.append(mediaDescriptor.descriptor(for: .video).reason)
+            }
+            if modalities.contains(.audio), !media.supportsAudio {
+                issues.append(mediaDescriptor.descriptor(for: .audio).reason)
+            }
         }
         if !tools.isEmpty,
             !supportsLocalToolCalling(
@@ -307,6 +310,13 @@ actor MLXService: ToolCapableService {
         modelId: String,
         modelDirectory: URL? = nil
     ) -> Bool {
+        let combined = "\(modelName) \(modelId)"
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+        if combined.contains("gemma_3n") || combined.contains("gemma3n") {
+            return false
+        }
+
         if ModelFamilyNames.isStepFamily(modelName) || ModelFamilyNames.isStepFamily(modelId) {
             // Step 3.7 tool parsing/template selection is owned by the pinned
             // vMLX runtime. Do not block request preflight on large external
@@ -320,18 +330,17 @@ actor MLXService: ToolCapableService {
             // vMLX can load and validate the actual runtime contract.
             return true
         }
+        if ModelFamilyNames.isGemmaFamily(modelName) || ModelFamilyNames.isGemmaFamily(modelId) {
+            // Gemma/Gemma4 tool parser/template selection is owned by vMLX.
+            // Avoid synchronous external-bundle metadata reads on text/tool
+            // preflight; media requests are gated separately above.
+            return true
+        }
 
         if let directory = modelDirectory ?? localModelDirectory(modelId: modelId),
             let format = resolvedToolCallFormat(in: directory)
         {
             return format != nil
-        }
-
-        let combined = "\(modelName) \(modelId)"
-            .lowercased()
-            .replacingOccurrences(of: "-", with: "_")
-        if combined.contains("gemma_3n") || combined.contains("gemma3n") {
-            return false
         }
 
         // Unknown/local-unscanned bundles remain permissive; vmlx still owns

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -16,6 +16,8 @@ struct GenerationParameters: Sendable {
     let maxTokensExplicit: Bool
     /// Optional per-request top_p override (falls back to server configuration when nil)
     let topPOverride: Float?
+    /// Optional per-request top_k override (falls back to model/server configuration when nil).
+    let topKOverride: Int?
     /// Optional per-request min_p override (falls back to model configuration when nil).
     let minPOverride: Float?
     /// Optional repetition penalty (applies when supported by backend).
@@ -59,6 +61,7 @@ struct GenerationParameters: Sendable {
         maxTokens: Int,
         maxTokensExplicit: Bool = true,
         topPOverride: Float? = nil,
+        topKOverride: Int? = nil,
         minPOverride: Float? = nil,
         repetitionPenalty: Float? = nil,
         samplingParametersAreImplicit: Bool = false,
@@ -74,6 +77,7 @@ struct GenerationParameters: Sendable {
         self.maxTokens = maxTokens
         self.maxTokensExplicit = maxTokensExplicit
         self.topPOverride = topPOverride
+        self.topKOverride = topKOverride
         self.minPOverride = minPOverride
         self.repetitionPenalty = repetitionPenalty
         self.samplingParametersAreImplicit = samplingParametersAreImplicit

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -148,12 +148,10 @@ enum LocalGenerationDefaults {
     }
 
     private static func localDirectory(forModelId modelId: String) -> URL? {
-        guard let found = ModelManager.findInstalledModel(named: modelId) else {
+        guard let found = ModelManager.findInstalledMLXModel(named: modelId) else {
             return nil
         }
-        let parts = found.id.split(separator: "/").map(String.init)
-        let base = DirectoryPickerService.effectiveModelsDirectory()
-        return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
+        return found.localDirectory
     }
 
     // MARK: - Parsers

--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -46,6 +46,7 @@
 //
 
 import Foundation
+import Darwin
 
 enum LocalGenerationDefaults {
 
@@ -129,9 +130,7 @@ enum LocalGenerationDefaults {
 
     private static func loadJangConfigDefaults(at dir: URL) -> Defaults {
         let url = dir.appendingPathComponent("jang_config.json")
-        guard FileManager.default.fileExists(atPath: url.path),
-            let data = try? Data(contentsOf: url)
-        else {
+        guard let data = readSmallConfigFile(url) else {
             return .empty
         }
         return parseJangConfig(data: data)
@@ -139,12 +138,37 @@ enum LocalGenerationDefaults {
 
     private static func loadHuggingFaceGenerationDefaults(at dir: URL) -> Defaults {
         let url = dir.appendingPathComponent("generation_config.json")
-        guard FileManager.default.fileExists(atPath: url.path),
-            let data = try? Data(contentsOf: url)
-        else {
+        guard let data = readSmallConfigFile(url) else {
             return .empty
         }
         return parse(data: data)
+    }
+
+    private static func readSmallConfigFile(_ url: URL, maxBytes: Int = 1_048_576) -> Data? {
+        let path = url.path
+        return path.withCString { rawPath in
+            let fd = Darwin.open(rawPath, O_RDONLY | O_CLOEXEC)
+            guard fd >= 0 else { return nil }
+            defer { Darwin.close(fd) }
+
+            var statBuffer = stat()
+            guard Darwin.fstat(fd, &statBuffer) == 0,
+                (statBuffer.st_mode & S_IFMT) == S_IFREG,
+                statBuffer.st_size >= 0,
+                statBuffer.st_size <= maxBytes
+            else {
+                return nil
+            }
+
+            var data = Data(count: Int(statBuffer.st_size))
+            let count = data.count
+            guard count > 0 else { return Data() }
+            let readCount = data.withUnsafeMutableBytes { bytes in
+                Darwin.read(fd, bytes.baseAddress, count)
+            }
+            guard readCount == count else { return nil }
+            return data
+        }
     }
 
     private static func localDirectory(forModelId modelId: String) -> URL? {

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import Darwin
 
 enum LocalReasoningCapability {
     struct Capability: Sendable {
@@ -168,9 +169,7 @@ enum LocalReasoningCapability {
     /// `additionalContext` passes it to whatever renderer the model uses.
     static func readJangConfigReasoning(at dir: URL) -> Capability? {
         let url = dir.appendingPathComponent("jang_config.json")
-        guard FileManager.default.fileExists(atPath: url.path),
-            let data = try? Data(contentsOf: url)
-        else {
+        guard let data = readSmallConfigFile(url) else {
             return nil
         }
         return analyzeJangConfig(data: data)
@@ -196,10 +195,9 @@ enum LocalReasoningCapability {
     }
 
     static func readChatTemplate(at dir: URL) -> String? {
-        let fm = FileManager.default
         let jinja = dir.appendingPathComponent("chat_template.jinja")
-        if fm.fileExists(atPath: jinja.path),
-            let s = try? String(contentsOf: jinja, encoding: .utf8)
+        if let data = readSmallConfigFile(jinja),
+            let s = String(data: data, encoding: .utf8)
         {
             return s
         }
@@ -210,8 +208,7 @@ enum LocalReasoningCapability {
             return sidecar
         }
         let tokenizerCfg = dir.appendingPathComponent("tokenizer_config.json")
-        if fm.fileExists(atPath: tokenizerCfg.path),
-            let data = try? Data(contentsOf: tokenizerCfg),
+        if let data = readSmallConfigFile(tokenizerCfg),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         {
             if let tmpl = obj["chat_template"] as? String { return tmpl }
@@ -228,8 +225,7 @@ enum LocalReasoningCapability {
 
     private static func readChatTemplateSidecar(at dir: URL) -> String? {
         let url = dir.appendingPathComponent("chat_template.json")
-        guard FileManager.default.fileExists(atPath: url.path),
-            let data = try? Data(contentsOf: url),
+        guard let data = readSmallConfigFile(url),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let template = obj["chat_template"] as? String
         else {
@@ -247,8 +243,7 @@ enum LocalReasoningCapability {
 
     private static func readTokenizerConfigTemplate(at dir: URL) -> String? {
         let tokenizerCfg = dir.appendingPathComponent("tokenizer_config.json")
-        guard FileManager.default.fileExists(atPath: tokenizerCfg.path),
-            let data = try? Data(contentsOf: tokenizerCfg),
+        guard let data = readSmallConfigFile(tokenizerCfg),
             let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
             return nil
@@ -261,6 +256,33 @@ enum LocalReasoningCapability {
             return tmpl
         }
         return nil
+    }
+
+    private static func readSmallConfigFile(_ url: URL, maxBytes: Int = 1_048_576) -> Data? {
+        let path = url.path
+        return path.withCString { rawPath in
+            let fd = Darwin.open(rawPath, O_RDONLY | O_CLOEXEC)
+            guard fd >= 0 else { return nil }
+            defer { Darwin.close(fd) }
+
+            var statBuffer = stat()
+            guard Darwin.fstat(fd, &statBuffer) == 0,
+                (statBuffer.st_mode & S_IFMT) == S_IFREG,
+                statBuffer.st_size >= 0,
+                statBuffer.st_size <= maxBytes
+            else {
+                return nil
+            }
+
+            var data = Data(count: Int(statBuffer.st_size))
+            let count = data.count
+            guard count > 0 else { return Data() }
+            let readCount = data.withUnsafeMutableBytes { bytes in
+                Darwin.read(fd, bytes.baseAddress, count)
+            }
+            guard readCount == count else { return nil }
+            return data
+        }
     }
 
     private static func isVisionChatTemplate(_ template: String) -> Bool {

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -131,12 +131,10 @@ enum LocalReasoningCapability {
         // `ORG/REPO` id, case-insensitive. Re-implementing the match here was
         // silently returning nil whenever the caller passed a form neither of
         // our candidate heuristics covered.
-        guard let found = ModelManager.findInstalledModel(named: modelId) else {
+        guard let found = ModelManager.findInstalledMLXModel(named: modelId) else {
             return nil
         }
-        let parts = found.id.split(separator: "/").map(String.init)
-        let base = DirectoryPickerService.effectiveModelsDirectory()
-        return parts.reduce(base) { $0.appendingPathComponent($1, isDirectory: true) }
+        return found.localDirectory
     }
 
     /// Read `jang_config.json > chat > reasoning` and surface it as a

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1820,6 +1820,12 @@ public actor ModelRuntime {
         // that is a cache hit and must not flash the UI back to
         // "Loading Model..." on every message.
         let cfg = await getConfig()
+        await MLXBatchAdapter.recordPendingEffectiveGenerationSettings(
+            modelName: modelName,
+            generation: parameters,
+            runtimeDefaults: cfg.generation,
+            maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
+        )
         trace?.mark("load_container_start")
         let shouldReportModelLoad = modelCache[modelName] == nil
         if shouldReportModelLoad {

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -44,6 +44,10 @@ struct MLXBatchAdapter {
         await Registry.shared.snapshotDiagnostics()
     }
 
+    static func lastEffectiveGenerationSettingsSnapshot() async -> [String: EffectiveGenerationSettings] {
+        await Registry.shared.lastEffectiveGenerationSettingsSnapshot()
+    }
+
     /// Result handed back to `ModelRuntime`. The `Generation` stream is
     /// consumed by `GenerationEventMapper`, which translates the upstream
     /// events into `ModelRuntimeEvent`. The producer task exists so callers
@@ -63,6 +67,7 @@ struct MLXBatchAdapter {
     }
 
     struct EffectiveGenerationSettings: Equatable, Sendable {
+        let stage: String
         let temperature: Float
         let maxTokens: Int
         let topP: Float
@@ -79,7 +84,8 @@ struct MLXBatchAdapter {
         maxBatchSize: Int,
         modelDefaults: LocalGenerationDefaults.Defaults,
         draftStrategy: MLXLMCommon.DraftStrategy? = nil,
-        nativeMTPExplicitSamplingFallback: Bool = false
+        nativeMTPExplicitSamplingFallback: Bool = false,
+        stage: String = "resolved"
     ) -> EffectiveGenerationSettings {
         let defaultTemperature: Float? = {
             if modelDefaults.doSample == false {
@@ -106,6 +112,7 @@ struct MLXBatchAdapter {
         )
 
         return EffectiveGenerationSettings(
+            stage: stage,
             temperature: generation.temperature
                 ?? defaultTemperature
                 ?? runtimeTemperature
@@ -123,6 +130,27 @@ struct MLXBatchAdapter {
                     modelName: modelName,
                     maxBatchSize: maxBatchSize
                 )
+        )
+    }
+
+    static func recordPendingEffectiveGenerationSettings(
+        modelName: String,
+        generation: GenerationParameters,
+        runtimeDefaults: VMLXServerGenerationDefaults,
+        maxBatchSize: Int
+    ) async {
+        let modelDefaults = LocalGenerationDefaults.defaults(forModelId: modelName)
+        let effective = Self.effectiveGenerationSettings(
+            modelName: modelName,
+            generation: generation,
+            runtimeDefaults: runtimeDefaults,
+            maxBatchSize: maxBatchSize,
+            modelDefaults: modelDefaults,
+            stage: "pending_preload"
+        )
+        await Registry.shared.recordEffectiveGenerationSettings(
+            modelName: modelName,
+            settings: effective
         )
     }
 
@@ -271,6 +299,7 @@ struct MLXBatchAdapter {
         /// invariant the coalescer enforces.
         private let coalescer = TaskCoalescer<BatchEngine>()
         private var nativeMTPWarmModels: Set<String> = []
+        private var lastEffectiveGenerationSettings: [String: EffectiveGenerationSettings] = [:]
 
         /// Returns the cached engine for `modelName`, creating it on first
         /// use from the supplied `ModelContainer`. The container's existing
@@ -372,6 +401,17 @@ struct MLXBatchAdapter {
         /// has not yet completed.
         internal func registrySnapshot() async -> (resolved: Int, inFlight: Int, draining: Int) {
             await coalescer.snapshot()
+        }
+
+        func recordEffectiveGenerationSettings(
+            modelName: String,
+            settings: EffectiveGenerationSettings
+        ) {
+            lastEffectiveGenerationSettings[modelName] = settings
+        }
+
+        func lastEffectiveGenerationSettingsSnapshot() -> [String: EffectiveGenerationSettings] {
+            lastEffectiveGenerationSettings
         }
 
         /// Aggregate live BatchEngine diagnostics across every resolved
@@ -993,7 +1033,12 @@ struct MLXBatchAdapter {
             maxBatchSize: maxBatchSize,
             modelDefaults: modelDefaults,
             draftStrategy: effectiveDraftStrategy,
-            nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback
+            nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback,
+            stage: "submitted_to_batch_engine"
+        )
+        await Registry.shared.recordEffectiveGenerationSettings(
+            modelName: modelName,
+            settings: effective
         )
         var mlxParams = ModelRuntime.makeGenerateParameters(
             temperature: effective.temperature,

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -861,14 +861,20 @@ struct MLXBatchAdapter {
             return context
         }
         if ModelFamilyNames.isMiMoOrN2JANGRuntimeFamily(modelName) {
+            if toolChoiceRequiresLocalCall(toolChoice) {
+                context["enable_thinking"] = false
+                return context
+            }
             if directRailReasoningEffort {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if let disableThinking {
+                context["enable_thinking"] = !disableThinking
+            } else if hasPositiveReasoningEffort, let normalizedReasoningEffort {
                 context["enable_thinking"] = true
                 context["reasoning_effort"] = normalizedReasoningEffort
-            } else {
+            } else if normalizedReasoningEffort != nil {
                 context["enable_thinking"] = false
             }
             return context

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -121,7 +121,7 @@ struct MLXBatchAdapter {
                 ? generation.maxTokens
                 : (modelDefaults.maxTokens ?? runtimeMaxTokens ?? generation.maxTokens),
             topP: generation.topPOverride ?? modelDefaults.topP ?? runtimeTopP ?? engineDefaults.topP,
-            topK: modelDefaults.topK ?? runtimeTopK ?? engineDefaults.topK,
+            topK: generation.topKOverride ?? modelDefaults.topK ?? runtimeTopK ?? engineDefaults.topK,
             minP: generation.minPOverride ?? modelDefaults.minP ?? runtimeMinP ?? engineDefaults.minP,
             repetitionPenalty: repetitionPenalty,
             compiledBatchDecode: nativeMTPExplicitSamplingFallback
@@ -212,6 +212,7 @@ struct MLXBatchAdapter {
         }
         guard generation.temperature == 0 else { return false }
         if let topP = generation.topPOverride, topP < 1 { return false }
+        if let topK = generation.topKOverride, topK != 0 { return false }
         if let minP = generation.minPOverride, minP != 0 { return false }
         if let repetitionPenalty = generation.repetitionPenalty,
             repetitionPenalty != 0,

--- a/Packages/OsaurusCore/Tests/Folder/FolderPluginHintsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderPluginHintsTests.swift
@@ -121,7 +121,7 @@ struct FolderPluginHintsTests {
         #expect(result == ["osaurus.xlsx"])
     }
 
-    @Test @MainActor func folderContextDetectsOnlyPluginHintedDocumentExtensions() async throws {
+    @Test func folderContextDetectsOnlyPluginHintedDocumentExtensions() async throws {
         let root = try Self.tmpRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
@@ -129,10 +129,13 @@ struct FolderPluginHintsTests {
             try Data(name.utf8).write(to: root.appendingPathComponent(name))
         }
 
-        let context = await FolderContextService.shared.buildContext(from: root)
+        let detectedExtensions = FolderContextService.scanForKnownExtensions(
+            root,
+            ignorePatterns: ProjectType.unknown.ignorePatterns
+        )
 
-        #expect(context.detectedFileExtensions == Set(["xlsx", "pptx", "csv"]))
-        #expect(context.detectedFileExtensions.contains("pdf") == false)
+        #expect(detectedExtensions == Set(["xlsx", "pptx", "csv"]))
+        #expect(detectedExtensions.contains("pdf") == false)
     }
 
     private static func tmpRoot() throws -> URL {

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import OsaurusCore
 
+@Suite(.serialized)
 struct ModelManagerSuggestedTests {
 
     /// Suppress the background OsaurusAI HF org fetch that `ModelManager.init()`
@@ -20,6 +21,26 @@ struct ModelManagerSuggestedTests {
     /// flaking the suite (CI > local because CI consistently has network).
     init() {
         ModelManager.skipBackgroundOrgFetchForTests = true
+    }
+
+    /// `ModelManager.loadAvailableModels()` intentionally overlays cached
+    /// download sizes onto curated entries. Keep this suite on a throwaway
+    /// root so catalog metadata assertions do not depend on a developer or CI
+    /// machine's persisted `ModelSizeCache`.
+    private func withIsolatedModelSizeCache<T>(_ body: () -> T) -> T {
+        OsaurusTestGlobals.withPathsLock {
+            let previous = OsaurusPaths.overrideRoot
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-suggested-models-\(UUID().uuidString)", isDirectory: true)
+            OsaurusPaths.overrideRoot = root
+            ModelSizeCache.invalidateInMemory()
+            defer {
+                OsaurusPaths.overrideRoot = previous
+                ModelSizeCache.invalidateInMemory()
+                try? FileManager.default.removeItem(at: root)
+            }
+            return body()
+        }
     }
 
     // MARK: - Curated catalog
@@ -36,8 +57,8 @@ struct ModelManagerSuggestedTests {
         #expect(ids.contains("osaurusai/ling-2.6-flash-jangtq"))
     }
 
-    @Test func curatedSuggestedIds_matchInitialSuggestedModels() async {
-        let suggested = await MainActor.run { ModelManager().suggestedModels }
+    @Test @MainActor func curatedSuggestedIds_matchInitialSuggestedModels() {
+        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
         let curatedIds = ModelManager.curatedSuggestedIds
         let suggestedIds = Set(suggested.map { $0.id.lowercased() })
         // On a fresh manager (before any HF fetch resolves), `suggestedModels`
@@ -45,8 +66,8 @@ struct ModelManagerSuggestedTests {
         #expect(suggestedIds == curatedIds)
     }
 
-    @Test func curatedOsaurusEntries_haveValidReleaseDates() async {
-        let suggested = await MainActor.run { ModelManager().suggestedModels }
+    @Test @MainActor func curatedOsaurusEntries_haveValidReleaseDates() {
+        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
         let osaurusEntries = suggested.filter { $0.id.hasPrefix("OsaurusAI/") }
 
         // All curated OsaurusAI entries should carry a release date and it
@@ -61,8 +82,8 @@ struct ModelManagerSuggestedTests {
         }
     }
 
-    @Test func miniMaxEntries_haveExpectedMetadata() async {
-        let suggested = await MainActor.run { ModelManager().suggestedModels }
+    @Test @MainActor func miniMaxEntries_haveExpectedMetadata() {
+        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
         let jangtq4 = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
         let jangtq = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ" }
 
@@ -83,8 +104,8 @@ struct ModelManagerSuggestedTests {
         #expect(jangtq?.releasedAt != nil)
     }
 
-    @Test func lingEntries_haveExpectedMetadata() async {
-        let suggested = await MainActor.run { ModelManager().suggestedModels }
+    @Test @MainActor func lingEntries_haveExpectedMetadata() {
+        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
         let mxfp4 = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-MXFP4" }
         let jangtq = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-JANGTQ" }
 
@@ -96,8 +117,8 @@ struct ModelManagerSuggestedTests {
         #expect(jangtq?.releasedAt != nil)
     }
 
-    @Test func lfm25Entry_haveExpectedMetadata() async {
-        let suggested = await MainActor.run { ModelManager().suggestedModels }
+    @Test @MainActor func lfm25Entry_haveExpectedMetadata() {
+        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
         let mxfp8 = suggested.first { $0.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8" }
 
         #expect(mxfp8 != nil)
@@ -110,8 +131,8 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - OsaurusAI org auto-discovery merge
 
-    @Test func applyOsaurusOrgFetch_addsNewEntriesAfterCurated() async {
-        let manager = await MainActor.run { ModelManager() }
+    @Test @MainActor func applyOsaurusOrgFetch_addsNewEntriesAfterCurated() {
+        let manager = withIsolatedModelSizeCache { ModelManager() }
         let curatedCount = ModelManager.curatedSuggestedIds.count
 
         let fresh = MLXModel(
@@ -122,17 +143,15 @@ struct ModelManagerSuggestedTests {
             releasedAt: Date()
         )
 
-        await MainActor.run {
-            manager.applyOsaurusOrgFetch(autoFetched: [fresh])
-        }
+        manager.applyOsaurusOrgFetch(autoFetched: [fresh])
 
-        let after = await MainActor.run { manager.suggestedModels }
+        let after = manager.suggestedModels
         #expect(after.count == curatedCount + 1)
         #expect(after.contains { $0.id == fresh.id })
     }
 
-    @Test func applyOsaurusOrgFetch_curatedEntryWinsOnDuplicateId() async {
-        let manager = await MainActor.run { ModelManager() }
+    @Test @MainActor func applyOsaurusOrgFetch_curatedEntryWinsOnDuplicateId() {
+        let manager = withIsolatedModelSizeCache { ModelManager() }
 
         // Try to clobber a curated entry with auto-fetched metadata.
         let imposter = MLXModel(
@@ -142,20 +161,16 @@ struct ModelManagerSuggestedTests {
             downloadURL: "https://huggingface.co/OsaurusAI/MiniMax-M2.7-JANGTQ4"
         )
 
-        await MainActor.run {
-            manager.applyOsaurusOrgFetch(autoFetched: [imposter])
-        }
+        manager.applyOsaurusOrgFetch(autoFetched: [imposter])
 
-        let curated = await MainActor.run {
-            manager.suggestedModels.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
-        }
+        let curated = manager.suggestedModels.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
         #expect(curated != nil)
         // Curated metadata should be intact.
         #expect(curated?.modelType == "minimax_m2")
         #expect(curated?.description.contains("MiniMax M2.7") == true)
     }
 
-    @Test func applyOsaurusOrgFetch_dropsStaleAutoFetchedOnReapply() async {
+    @Test @MainActor func applyOsaurusOrgFetch_dropsStaleAutoFetchedOnReapply() {
         let stale = MLXModel(
             id: "OsaurusAI/Stale-Repo",
             name: "Stale Repo",
@@ -169,8 +184,7 @@ struct ModelManagerSuggestedTests {
             downloadURL: "https://huggingface.co/OsaurusAI/Kept-Repo"
         )
 
-        // keep init + both applies + read atomic on MainActor to block it out
-        let after = await MainActor.run { () -> [MLXModel] in
+        let after = withIsolatedModelSizeCache { () -> [MLXModel] in
             let manager = ModelManager()
             manager.applyOsaurusOrgFetch(autoFetched: [stale])
             manager.applyOsaurusOrgFetch(autoFetched: [kept])
@@ -180,8 +194,8 @@ struct ModelManagerSuggestedTests {
         #expect(!after.contains { $0.id == stale.id })
     }
 
-    @Test func applyOsaurusOrgFetch_preservesNonOsaurusInjectedEntries() async {
-        let manager = await MainActor.run { ModelManager() }
+    @Test @MainActor func applyOsaurusOrgFetch_preservesNonOsaurusInjectedEntries() {
+        let manager = withIsolatedModelSizeCache { ModelManager() }
 
         let foreign = MLXModel(
             id: "some-org/unrelated-model",
@@ -190,12 +204,10 @@ struct ModelManagerSuggestedTests {
             downloadURL: "https://huggingface.co/some-org/unrelated-model"
         )
 
-        await MainActor.run {
-            manager.suggestedModels.append(foreign)
-            manager.applyOsaurusOrgFetch(autoFetched: [])
-        }
+        manager.suggestedModels.append(foreign)
+        manager.applyOsaurusOrgFetch(autoFetched: [])
 
-        let after = await MainActor.run { manager.suggestedModels }
+        let after = manager.suggestedModels
         #expect(after.contains { $0.id == foreign.id })
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -402,6 +402,21 @@ struct ModelManagerTests {
         #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
     }
 
+    @Test func scanLocalModels_recordsMissingRootDiagnostic() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osu-missing-model-root-\(UUID().uuidString)", isDirectory: true)
+
+        let detected = ModelManager.scanLocalModels(at: root)
+
+        #expect(detected.isEmpty)
+        let diagnostic = try #require(ModelManager.localModelsScanDiagnosticJSONObject())
+        #expect(diagnostic["root"] as? String == root.path)
+        #expect(diagnostic["root_exists"] as? Bool == false)
+        #expect(diagnostic["status"] as? String == "failed")
+        #expect(diagnostic["model_count"] as? Int == 0)
+        #expect((diagnostic["error"] as? String)?.contains("missing") == true)
+    }
+
     @Test func deleteModel_removesDirectoryAndResetsState() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -323,11 +323,16 @@ struct ModelManagerTests {
         let root = URL(fileURLWithPath: (rawRoot as NSString).expandingTildeInPath, isDirectory: true)
         let detected = ModelManager.scanLocalModels(at: root)
         let ids = Set(detected.map { $0.id.lowercased() })
-        #expect(ids.contains("osaurusai/gemma-4-e2b-it-qat-mxfp4"))
-        #expect(ids.contains("osaurusai/gemma-4-e4b-it-qat-mxfp4"))
-        #expect(ids.contains("osaurusai/gemma-4-12b-it-qat-mxfp4"))
-        #expect(ids.contains("osaurusai/gemma-4-26b-a4b-it-qat-mxfp4"))
-        #expect(ids.contains("osaurusai/gemma-4-31b-it-qat-mxfp4"))
+
+        func containsGemma(_ repo: String) -> Bool {
+            ids.contains("osaurusai/\(repo)") || ids.contains("jangq-ai/\(repo)") || ids.contains(repo)
+        }
+
+        #expect(containsGemma("gemma-4-e2b-it-qat-mxfp4"))
+        #expect(containsGemma("gemma-4-e4b-it-qat-mxfp4"))
+        #expect(containsGemma("gemma-4-12b-it-qat-mxfp4"))
+        #expect(containsGemma("gemma-4-26b-a4b-it-qat-mxfp4"))
+        #expect(containsGemma("gemma-4-31b-it-qat-mxfp4"))
     }
 
     @Test func scanLocalModels_skipsLargeSupportTreesBesideJANGBundles() async throws {

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -359,6 +359,49 @@ struct ModelManagerTests {
         #expect(detected.map(\.id) == ["Nex-N2-Pro-JANGTQ2"])
     }
 
+    @Test func discoverLocalModels_timeoutDoesNotCacheEmptyResult() async throws {
+        let previousOverride = ModelManager.scanLocalModelsOverrideForTests
+        let previousWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+        let previousExternalOverride = ExternalModelLocator.testRootsOverride
+        let previousRoot = OsaurusPaths.overrideRoot
+        let manifestRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osu-model-manager-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: manifestRoot, withIntermediateDirectories: true)
+        OsaurusPaths.overrideRoot = manifestRoot
+        ModelManager.invalidateLocalModelsCache()
+        ExternalModelLocator.testRootsOverride = []
+        ExternalModelLocator.invalidateInMemory()
+        ExternalModelLocator.rescan()
+        ModelManager.localModelsScanWaitLimitOverrideForTests = 0.02
+        ModelManager.scanLocalModelsOverrideForTests = { _ in
+            Thread.sleep(forTimeInterval: 0.12)
+            return [
+                MLXModel(
+                    id: "gemma-4-E2B-it-qat-MXFP4",
+                    name: "Gemma 4 E2B",
+                    description: "fixture",
+                    downloadURL: "https://example.invalid/gemma"
+                )
+            ]
+        }
+        defer {
+            ModelManager.scanLocalModelsOverrideForTests = previousOverride
+            ModelManager.localModelsScanWaitLimitOverrideForTests = previousWait
+            ExternalModelLocator.testRootsOverride = previousExternalOverride
+            OsaurusPaths.overrideRoot = previousRoot
+            ExternalModelLocator.invalidateInMemory()
+            ModelManager.invalidateLocalModelsCache()
+            try? FileManager.default.removeItem(at: manifestRoot)
+        }
+
+        let first = ModelManager.discoverLocalModels()
+        #expect(first.isEmpty)
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let second = ModelManager.discoverLocalModels()
+        #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
+    }
+
     @Test func deleteModel_removesDirectoryAndResetsState() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import OsaurusCore
 
+@Suite(.serialized)
 struct ModelManagerTests {
 
     /// Suppress `ModelManager.init`'s background HF org fetch — its async
@@ -360,46 +361,48 @@ struct ModelManagerTests {
     }
 
     @Test func discoverLocalModels_timeoutDoesNotCacheEmptyResult() async throws {
-        let previousOverride = ModelManager.scanLocalModelsOverrideForTests
-        let previousWait = ModelManager.localModelsScanWaitLimitOverrideForTests
-        let previousExternalOverride = ExternalModelLocator.testRootsOverride
-        let previousRoot = OsaurusPaths.overrideRoot
-        let manifestRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osu-model-manager-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: manifestRoot, withIntermediateDirectories: true)
-        OsaurusPaths.overrideRoot = manifestRoot
-        ModelManager.invalidateLocalModelsCache()
-        ExternalModelLocator.testRootsOverride = []
-        ExternalModelLocator.invalidateInMemory()
-        ExternalModelLocator.rescan()
-        ModelManager.localModelsScanWaitLimitOverrideForTests = 0.02
-        ModelManager.scanLocalModelsOverrideForTests = { _ in
-            Thread.sleep(forTimeInterval: 0.12)
-            return [
-                MLXModel(
-                    id: "gemma-4-E2B-it-qat-MXFP4",
-                    name: "Gemma 4 E2B",
-                    description: "fixture",
-                    downloadURL: "https://example.invalid/gemma"
-                )
-            ]
-        }
-        defer {
-            ModelManager.scanLocalModelsOverrideForTests = previousOverride
-            ModelManager.localModelsScanWaitLimitOverrideForTests = previousWait
-            ExternalModelLocator.testRootsOverride = previousExternalOverride
-            OsaurusPaths.overrideRoot = previousRoot
-            ExternalModelLocator.invalidateInMemory()
+        try await StoragePathsTestLock.shared.run {
+            let previousOverride = ModelManager.scanLocalModelsOverrideForTests
+            let previousWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+            let previousExternalOverride = ExternalModelLocator.testRootsOverride
+            let previousRoot = OsaurusPaths.overrideRoot
+            let manifestRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osu-model-manager-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: manifestRoot, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = manifestRoot
             ModelManager.invalidateLocalModelsCache()
-            try? FileManager.default.removeItem(at: manifestRoot)
+            ExternalModelLocator.testRootsOverride = []
+            ExternalModelLocator.invalidateInMemory()
+            ExternalModelLocator.rescan()
+            ModelManager.localModelsScanWaitLimitOverrideForTests = 0.02
+            ModelManager.scanLocalModelsOverrideForTests = { _ in
+                Thread.sleep(forTimeInterval: 0.12)
+                return [
+                    MLXModel(
+                        id: "gemma-4-E2B-it-qat-MXFP4",
+                        name: "Gemma 4 E2B",
+                        description: "fixture",
+                        downloadURL: "https://example.invalid/gemma"
+                    )
+                ]
+            }
+            defer {
+                ModelManager.scanLocalModelsOverrideForTests = previousOverride
+                ModelManager.localModelsScanWaitLimitOverrideForTests = previousWait
+                ExternalModelLocator.testRootsOverride = previousExternalOverride
+                OsaurusPaths.overrideRoot = previousRoot
+                ExternalModelLocator.invalidateInMemory()
+                ModelManager.invalidateLocalModelsCache()
+                try? FileManager.default.removeItem(at: manifestRoot)
+            }
+
+            let first = ModelManager.discoverLocalModels()
+            #expect(first.isEmpty)
+
+            try await Task.sleep(nanoseconds: 200_000_000)
+            let second = ModelManager.discoverLocalModels()
+            #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
         }
-
-        let first = ModelManager.discoverLocalModels()
-        #expect(first.isEmpty)
-
-        try await Task.sleep(nanoseconds: 200_000_000)
-        let second = ModelManager.discoverLocalModels()
-        #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
     }
 
     @Test func scanLocalModels_recordsMissingRootDiagnostic() async throws {

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -310,8 +310,8 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.Capabilities.omni.anyMedia)
     }
 
-    @Test("Descriptor marks Gemma4 audio as proof-required, not supported")
-    func descriptor_gemma4AudioProofRequired() {
+    @Test("Descriptor marks Gemma4 audio as runtime-unwired, not supported")
+    func descriptor_gemma4AudioRuntimeUnwired() {
         let descriptor = ModelMediaCapabilities.descriptor(
             modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4"
         )
@@ -320,7 +320,7 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(descriptor.image.status == .supported)
         #expect(descriptor.audio.status == .unproven)
         #expect(!descriptor.audio.isUsable)
-        #expect(descriptor.rejectionMessage(for: .audio).contains("live model proof"))
+        #expect(descriptor.rejectionMessage(for: .audio).contains("audio_tower/embed_audio"))
     }
 
     @Test("Descriptor keeps Nemotron Omni audio supported")

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -12,6 +12,7 @@
 //
 
 import Foundation
+@preconcurrency import MLXLMCommon
 import NIOCore
 import NIOHTTP1
 import NIOPosix
@@ -19,6 +20,7 @@ import Testing
 
 @testable import OsaurusCore
 
+@Suite(.serialized)
 struct HTTPHandlerEndpointTests {
 
     @Test func health_endpoint_returns_healthy_json() async throws {
@@ -73,6 +75,99 @@ struct HTTPHandlerEndpointTests {
         #expect((resp as? HTTPURLResponse)?.statusCode == 404)
     }
 
+    @Test func runtimeSettings_get_returnsPersistedSnapshot() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            var settings = VMLXServerRuntimeSettings()
+            settings.generation.temperature = 0.31
+            ServerRuntimeSettingsStore.save(settings)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, resp) = try await URLSession.shared.data(
+                from: URL(string: "http://\(server.host):\(server.port)/admin/runtime-settings")!
+            )
+
+            #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+            let decoded = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: data)
+            #expect(decoded.status == "ok")
+            #expect(decoded.settings.generation.temperature == 0.31)
+        }
+    }
+
+    @Test func runtimeSettings_put_persistsAndReportsRuntimeEffects() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            let initial = VMLXServerRuntimeSettings()
+            ServerRuntimeSettingsStore.save(initial)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            var next = initial
+            next.generation.temperature = 0.42
+            next.concurrency.maxConcurrentSequences = 2
+            let (data, resp) = try await putRuntimeSettings(next, server: server)
+
+            #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+            let decoded = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: data)
+            #expect(decoded.settings.generation.temperature == 0.42)
+            #expect(decoded.settings.concurrency.maxConcurrentSequences == 2)
+            #expect(decoded.effects?.runtimeConfigInvalidated == true)
+            #expect(decoded.effects?.loadedModelRefreshNeeded == false)
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let persisted = ServerRuntimeSettingsStore.snapshot()
+            #expect(persisted.generation.temperature == 0.42)
+            #expect(persisted.concurrency.maxConcurrentSequences == 2)
+        }
+    }
+
+    @Test func runtimeSettings_put_rejectsNetworkRebindChanges() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            let initial = VMLXServerRuntimeSettings()
+            ServerRuntimeSettingsStore.save(initial)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            var next = initial
+            next.network.port = 4242
+            let (_, resp) = try await putRuntimeSettings(next, server: server)
+
+            #expect((resp as? HTTPURLResponse)?.statusCode == 400)
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let persisted = ServerRuntimeSettingsStore.snapshot()
+            #expect(persisted.network.port == initial.network.port)
+        }
+    }
+
+    @Test func runtimeSettings_put_rejectsValidationErrors() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            let initial = VMLXServerRuntimeSettings()
+            ServerRuntimeSettingsStore.save(initial)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            var next = initial
+            next.concurrency.maxConcurrentSequences = 0
+            let (data, resp) = try await putRuntimeSettings(next, server: server)
+
+            #expect((resp as? HTTPURLResponse)?.statusCode == 400)
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let error = obj?["error"] as? [String: Any]
+            #expect(error?["type"] as? String == "invalid_request_error")
+
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            let persisted = ServerRuntimeSettingsStore.snapshot()
+            #expect(persisted.concurrency.maxConcurrentSequences == initial.concurrency.maxConcurrentSequences)
+        }
+    }
+
     // MARK: - Test Server Bootstrap
 
     private struct TestServer {
@@ -124,5 +219,59 @@ struct HTTPHandlerEndpointTests {
             await lease.release()
             throw error
         }
+    }
+
+    private struct RuntimeSettingsResponse: Decodable {
+        let status: String
+        let settings: VMLXServerRuntimeSettings
+        let effects: RuntimeSettingsEffects?
+    }
+
+    private struct RuntimeSettingsEffects: Decodable {
+        let loadedModelRefreshNeeded: Bool?
+        let runtimeConfigInvalidated: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case loadedModelRefreshNeeded = "loaded_model_refresh_needed"
+            case runtimeConfigInvalidated = "runtime_config_invalidated"
+        }
+    }
+
+    private func putRuntimeSettings(
+        _ settings: VMLXServerRuntimeSettings,
+        server: TestServer
+    ) async throws -> (Data, URLResponse) {
+        var request = URLRequest(
+            url: URL(string: "http://\(server.host):\(server.port)/admin/runtime-settings")!
+        )
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(settings)
+        return try await URLSession.shared.data(for: request)
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-runtime-settings-endpoint-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor
+    private func withOverriddenRuntimeSettingsDirectory(
+        _ dir: URL,
+        _ body: () async throws -> Void
+    ) async throws {
+        let previous = ServerRuntimeSettingsStore.overrideDirectory
+        ServerRuntimeSettingsStore.overrideDirectory = dir
+        ServerRuntimeSettingsStore.invalidateSnapshot()
+        defer {
+            ServerRuntimeSettingsStore.overrideDirectory = previous
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+            try? FileManager.default.removeItem(at: dir)
+        }
+        try await body()
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1375,7 +1375,7 @@ struct MLXBatchAdapterTests {
         }
     }
 
-    @Test func additionalContext_defaultsMiMoN2JANGThinkingOffButHonorsExplicitOptIn() {
+    @Test func additionalContext_letsMiMoN2JANGUseBundleDefaultButControlsRequiredTools() {
         let unspecified = GenerationParameters(temperature: nil, maxTokens: 16)
         let userEnabled = GenerationParameters(
             temperature: nil,
@@ -1393,8 +1393,34 @@ struct MLXBatchAdapterTests {
                 MLXBatchAdapter.additionalContext(
                     for: unspecified,
                     modelName: modelName
-                )["enable_thinking"] as? Bool == false,
-                "MiMo/N2 JANG text/tool rows should default to the no-thinking rail: \(modelName)"
+                )["enable_thinking"] == nil,
+                "MiMo/N2 JANG follow-ups must use the bundle default unless the user or tool-choice contract overrides it: \(modelName)"
+            )
+
+            let required = MLXBatchAdapter.additionalContext(
+                for: unspecified,
+                modelName: modelName,
+                toolChoice: .required,
+                toolChoiceName: "line_count"
+            )
+            #expect(
+                required["enable_thinking"] as? Bool == false,
+                "MiMo/N2 required tool turns still use the direct tool-call rail: \(modelName)"
+            )
+            #expect(required["tool_choice"] as? String == "required")
+            #expect(required["tool_choice_name"] as? String == "line_count")
+
+            let userDisabled = MLXBatchAdapter.additionalContext(
+                for: GenerationParameters(
+                    temperature: nil,
+                    maxTokens: 16,
+                    modelOptions: ["disableThinking": .bool(true)]
+                ),
+                modelName: modelName
+            )
+            #expect(
+                userDisabled["enable_thinking"] as? Bool == false,
+                "MiMo/N2 must honor explicit thinking-off requests: \(modelName)"
             )
             #expect(
                 MLXBatchAdapter.additionalContext(

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -270,6 +270,7 @@ struct MLXBatchAdapterTests {
             maxTokens: 128,
             maxTokensExplicit: true,
             topPOverride: 0.5,
+            topKOverride: 32,
             minPOverride: 0.01,
             repetitionPenalty: 1.02
         )
@@ -294,7 +295,7 @@ struct MLXBatchAdapterTests {
         #expect(effective.temperature == 0.2)
         #expect(effective.maxTokens == 128)
         #expect(effective.topP == 0.5)
-        #expect(effective.topK == 40)
+        #expect(effective.topK == 32)
         #expect(effective.minP == 0.01)
         #expect(effective.repetitionPenalty == 1.02)
     }
@@ -375,6 +376,7 @@ struct MLXBatchAdapterTests {
             maxTokens: 128,
             maxTokensExplicit: true,
             topPOverride: nil,
+            topKOverride: 32,
             minPOverride: nil,
             repetitionPenalty: nil
         )
@@ -405,7 +407,7 @@ struct MLXBatchAdapterTests {
         #expect(effectiveDraftStrategy == nil)
         #expect(effective.temperature == 0.7)
         #expect(effective.topP == 0.95)
-        #expect(effective.topK == 20)
+        #expect(effective.topK == 32)
         #expect(effective.repetitionPenalty == nil)
         #expect(effective.compiledBatchDecode == false)
     }

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -109,7 +109,7 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
-    @Test func modelCapabilityRejectsGemma4AudioAsProofRequired() {
+    @Test func modelCapabilityRejectsGemma4AudioAsRuntimeUnwired() {
         let message = ChatMessage(
             role: "user",
             content: "hear this",
@@ -128,11 +128,11 @@ struct MLXServiceRuntimePolicyTests {
                 tools: [],
                 runtime: VMLXServerRuntimeSettings()
             )
-            Issue.record("Gemma4 audio should remain blocked until live proof exists.")
+            Issue.record("Gemma4 audio should remain blocked until vMLX wires the runtime audio path.")
         } catch let error as MLXService.RuntimePolicyError {
             let description = error.errorDescription ?? ""
             #expect(description.contains("Gemma4 audio input is not enabled"))
-            #expect(description.contains("live model proof"))
+            #expect(description.contains("audio_tower/embed_audio"))
         } catch {
             Issue.record("Unexpected error type: \(error)")
         }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2513,6 +2513,37 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("Gemma text tool preflight avoids media bundle reads")
+    func gemmaTextToolPreflightAvoidsMediaBundleReads() throws {
+        let service = try Self.source("Services/Inference/MLXService.swift")
+        let validate = try #require(service.range(of: "static func validateRuntimePolicy"))
+        let support = try #require(service.range(of: "nonisolated static func supportsLocalToolCalling"))
+
+        let validateEnd =
+            service.range(
+                of: "nonisolated static func supportsLocalToolCalling",
+                range: validate.lowerBound ..< service.endIndex
+            )
+            .map(\.lowerBound) ?? service.endIndex
+        let validateBody = String(service[validate.lowerBound ..< validateEnd])
+        #expect(validateBody.contains("let mediaModalities: Set<ModelRuntimeRequestModality> = [.vision, .video, .audio]"))
+        #expect(validateBody.contains("if !modalities.isDisjoint(with: mediaModalities)"))
+
+        let supportEnd =
+            service.range(
+                of: "private nonisolated static func localModelDirectory",
+                range: support.lowerBound ..< service.endIndex
+            )
+            .map(\.lowerBound) ?? service.endIndex
+        let supportBody = String(service[support.lowerBound ..< supportEnd])
+        let gemmaFastPath = try #require(supportBody.range(of: "ModelFamilyNames.isGemmaFamily"))
+        let bundleLookup = try #require(supportBody.range(of: "localModelDirectory(modelId: modelId)"))
+        #expect(
+            gemmaFastPath.lowerBound < bundleLookup.lowerBound,
+            "Gemma tool preflight must not synchronously read external bundle metadata."
+        )
+    }
+
     @Test("Runtime docs keep upstream Metal fault boundaries explicit")
     func inferenceDocsKeepUpstreamMetalFaultBoundaries() throws {
         let runtimeDoc = try Self.source("../../docs/INFERENCE_RUNTIME.md")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1957,6 +1957,23 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("\"native_mtp_status\""))
         #expect(httpHandler.contains("\"native_mtp_reason\""))
         #expect(httpHandler.contains("\"mlx_press\""))
+        #expect(httpHandler.contains("\"generation_defaults\""))
+        #expect(httpHandler.contains("\"last_effective_generation\""))
+        #expect(httpHandler.contains("\"stage\": settings.stage"))
+        #expect(httpHandler.contains("LocalGenerationDefaults.defaults(forModelId: summary.name)"))
+        #expect(httpHandler.contains("lastEffectiveGenerationSettingsSnapshot()"))
+        #expect(httpHandler.contains("path == \"/admin/generation-settings\""))
+        #expect(httpHandler.contains("handleGenerationSettingsEndpoint("))
+        #expect(httpHandler.contains("\"generation_defaults_by_model\""))
+        #expect(httpHandler.contains("\"last_effective_generation_by_model\""))
+        #expect(httpHandler.contains("It intentionally avoids `ModelRuntime`"))
+
+        let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        #expect(adapter.contains("recordPendingEffectiveGenerationSettings("))
+        #expect(adapter.contains("stage: \"pending_preload\""))
+        #expect(adapter.contains("stage: \"submitted_to_batch_engine\""))
+        #expect(runtime.contains("MLXBatchAdapter.recordPendingEffectiveGenerationSettings("))
     }
 
     @Test("admin cache stats exposes resolved memory safety status without load refusal")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2151,6 +2151,22 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    @Test("Local bundle config readers preserve discovered bundle paths")
+    func localBundleConfigReadersPreserveDiscoveredBundlePaths() throws {
+        let defaults = try Self.source("Services/LocalGenerationDefaults.swift")
+        let reasoning = try Self.source("Services/LocalReasoningCapability.swift")
+        let manager = try Self.source("Managers/Model/ModelManager.swift")
+
+        #expect(manager.contains("findInstalledMLXModel(named name: String) -> MLXModel?"))
+        #expect(manager.contains("MLXModel.localDirectory"))
+        #expect(defaults.contains("ModelManager.findInstalledMLXModel(named: modelId)"))
+        #expect(defaults.contains("return found.localDirectory"))
+        #expect(!defaults.contains("parts.reduce(base)"))
+        #expect(reasoning.contains("ModelManager.findInstalledMLXModel(named: modelId)"))
+        #expect(reasoning.contains("return found.localDirectory"))
+        #expect(!reasoning.contains("parts.reduce(base)"))
+    }
+
     @Test("Resident same-model turns do not flash model-loading UI")
     func residentSameModelTurnsDoNotFlashModelLoadingUI() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -570,12 +570,15 @@ struct RuntimePolicySourceTests {
         // audio/media/cache source proof from crashing under Swift Testing,
         // and the Gemma4 required-tool template ordering fix that keeps
         // preserving-newlines user content as the final model-visible copy
-        // target before generation.
+        // target before generation, plus the memory-safety resolver fix that
+        // preserves explicit disabled prefix-cache settings and disables
+        // dependent paged-KV/block-disk cache topology instead of forcing the
+        // default cache stack back on.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "ef025f2556978d033131f745c00dd8128c8d5151"
+        let expectedRuntimeHardenedRevision = "76047f3b4492d4fae316267a30fba55163b1c5cd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2161,9 +2161,14 @@ struct RuntimePolicySourceTests {
         #expect(manager.contains("MLXModel.localDirectory"))
         #expect(defaults.contains("ModelManager.findInstalledMLXModel(named: modelId)"))
         #expect(defaults.contains("return found.localDirectory"))
+        #expect(defaults.contains("readSmallConfigFile"))
+        #expect(!defaults.contains("Data(contentsOf:"))
         #expect(!defaults.contains("parts.reduce(base)"))
         #expect(reasoning.contains("ModelManager.findInstalledMLXModel(named: modelId)"))
         #expect(reasoning.contains("return found.localDirectory"))
+        #expect(reasoning.contains("readSmallConfigFile"))
+        #expect(!reasoning.contains("Data(contentsOf:"))
+        #expect(!reasoning.contains("String(contentsOf:"))
         #expect(!reasoning.contains("parts.reduce(base)"))
     }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1968,8 +1968,6 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("\"last_effective_generation_by_model\""))
         #expect(httpHandler.contains("It intentionally avoids `ModelRuntime`"))
 
-        let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
-        let runtime = try Self.source("Services/ModelRuntime.swift")
         #expect(adapter.contains("recordPendingEffectiveGenerationSettings("))
         #expect(adapter.contains("stage: \"pending_preload\""))
         #expect(adapter.contains("stage: \"submitted_to_batch_engine\""))

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -1394,16 +1394,16 @@ struct SwiftTransformersTokenizerLoaderTests {
             "Decoded: \(decoded)"
         )
         #expect(
-            decoded.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#),
+            decoded.contains(#"<|tool_call_start|>["line_count", {"text":"red\ngreen\nblue"}]<|tool_call_end|>"#),
             "Decoded: \(decoded)"
         )
         #expect(decoded.contains("Copy the `text` value exactly from the current user request."), "Decoded: \(decoded)")
         #expect(
-            decoded.contains("This value contains exactly 2 line break(s) and 0 blank lines."),
+            decoded.contains("This value contains exactly 2 line break(s)."),
             "Decoded: \(decoded)"
         )
         #expect(
-            decoded.contains(#"In the native LFM call, each line break is represented by the two characters \n"#),
+            decoded.contains(#"In the native LFM tagged JSON call, each line break is represented by the two characters \n"#),
             "Decoded: \(decoded)"
         )
         #expect(
@@ -1423,29 +1423,30 @@ struct SwiftTransformersTokenizerLoaderTests {
             "Decoded: \(decoded)"
         )
         #expect(!decoded.contains("List of tools:"), "Decoded: \(decoded)")
-        #expect(decoded.contains("line_count(text='red\\ngreen\\nblue')"), "Decoded: \(decoded)")
+        #expect(decoded.contains(#"["line_count", {"text":"red\ngreen\nblue"}]"#), "Decoded: \(decoded)")
+        #expect(!decoded.contains("line_count(text='red\\ngreen\\nblue')"), "Decoded: \(decoded)")
         #expect(!decoded.contains("<tools>"), "Decoded: \(decoded)")
         #expect(!decoded.contains("</tool_call>"), "Decoded: \(decoded)")
         #expect(!decoded.contains(#""name":"line_count""#), "Decoded: \(decoded)")
         #expect(
-            decoded.contains(#"Use the line_count tool on this exact text: red\ngreen\nblue"#),
+            decoded.contains("Use the line_count tool on this exact text: red\ngreen\nblue"),
             "Decoded: \(decoded)"
         )
         #expect(
-            !decoded.contains("Use the line_count tool on this exact text: red\ngreen\nblue"),
+            !decoded.contains(#"Use the line_count tool on this exact text: red\ngreen\nblue"#),
             "Decoded: \(decoded)"
         )
         if let userRange = decoded.range(
-            of: #"Use the line_count tool on this exact text: red\ngreen\nblue"#
+            of: "Use the line_count tool on this exact text: red\ngreen\nblue"
         ) {
-            let afterUser = decoded[userRange.upperBound...]
+            let beforeUser = decoded[..<userRange.lowerBound]
             #expect(
-                afterUser.contains("The API requires a tool call for the next assistant turn."),
-                "Required-tool instruction must trail the latest LFM user turn instead of preceding it. Decoded: \(decoded)"
+                beforeUser.contains("The API requires a tool call for the next assistant turn."),
+                "Required-tool instruction must be present in the LFM system preface. Decoded: \(decoded)"
             )
             #expect(
-                afterUser.contains(#"<|tool_call_start|>[line_count(text='red\ngreen\nblue')]<|tool_call_end|>"#),
-                "Required-tool instruction must keep the exact multiline value after the latest LFM user turn. Decoded: \(decoded)"
+                beforeUser.contains(#"<|tool_call_start|>["line_count", {"text":"red\ngreen\nblue"}]<|tool_call_end|>"#),
+                "Required-tool instruction must keep the exact multiline value in the LFM system preface. Decoded: \(decoded)"
             )
         }
         #expect(!decoded.contains("Today's date:"), "Decoded: \(decoded)")

--- a/Packages/OsaurusCore/Tests/osaurusTests.swift
+++ b/Packages/OsaurusCore/Tests/osaurusTests.swift
@@ -41,6 +41,26 @@ struct osaurusTests {
         #expect(internalMessages[1].content == "Hello")
     }
 
+    @Test func openAI_decodes_topK_samplingOverride() async throws {
+        let json = """
+            {
+              "model": "test-model",
+              "messages": [
+                {"role": "user", "content": "Hi"}
+              ],
+              "max_tokens": 12,
+              "temperature": 0,
+              "top_p": 0.9,
+              "top_k": 32
+            }
+            """.data(using: .utf8)!
+
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: json)
+        #expect(req.temperature == 0)
+        #expect(req.top_p == 0.9)
+        #expect(req.top_k == 32)
+    }
+
     @Test func serverConfiguration_portValidation() async throws {
         var cfg = ServerConfiguration.default
         cfg.port = 0

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -9,20 +9,25 @@ what can be shared in the repo without pretending unproven rows are complete.
 
 Status: `PARTIAL RELEASE CHECKPOINT`.
 
-Gemma 4 text/chat/tool/cache behavior is usable on the current main app build
-for a checkpoint. Audio/video generation and full all-family Sentry closure are
-not complete. Memory-safety controls now have manual UI save proof on PR #1462.
+Gemma 4 text/chat/tool/cache behavior is usable on the current PR #1465 app
+build for a checkpoint. Audio/video generation and full all-family Sentry
+closure are not complete. Memory-safety controls have API/admin proof on PR
+#1465 and prior manual UI save proof on PR #1462.
 
-Current app proof baseline:
+Current PR #1465 proof baseline:
 
-- Osaurus commit: `0f5f060ca7e0660cea0a5d095012e1d60ebc58c8`
-- vMLX Swift pin: `ef025f2556978d033131f745c00dd8128c8d5151`
-- Built app: `build/DerivedData-gemma-current-main-0f5f060-20260610-210706/Build/Products/Release/osaurus.app`
-- Build log: `.agents/gemma-final/artifacts/osaurus-main-0f5f060-live-e2e-build-20260610-210706.log`
+- Osaurus PR: `#1465`
+- Osaurus commit: `1b5214469716e86577b77f4dbea7bd47270f10e3`
+- vMLX Swift pin: `76047f3b4492d4fae316267a30fba55163b1c5cd`
+- GitHub checks: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and
+  `update_release_draft` were green on the commit above.
+- External-root proof after macOS disk access approval:
+  `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-071401/SUMMARY.json`
 
 ## Gemma 4 Live Proof
 
-Current-main live Osaurus API proof passed for all ten local Gemma 4 text rows:
+Current PR #1465 live Osaurus API proof passed for all ten local Gemma 4 text
+rows:
 
 - `gemma-4-e2b-it-qat-mxfp4`
 - `gemma-4-e2b-it-qat-jang_4m`
@@ -46,10 +51,10 @@ Each row passed the live multi-turn required-tool harness:
   leakage was observed.
 - Cache topology matched Gemma rotating/full KV with disk-backed restore.
 
-Current-main weird-character replay also passed for each row with default
-settings and with `thinking: disabled`.
+Current PR #1465 weird-character replay also passed for each row with default
+settings and with thinking disabled.
 
-Representative current-main speed from API-reported token/s:
+Representative release-speed proof from API-reported token/s:
 
 | Row | Default | Thinking Disabled |
 | --- | ---: | ---: |
@@ -64,13 +69,26 @@ Representative current-main speed from API-reported token/s:
 | 31B MXFP4 | 21.73 | 21.62 |
 | 31B JANG_4M | 16.98 | 16.83 |
 
-Representative current-main repeat-cache proof passed for E2B MXFP4 and
-JANG_4M: repeated identical prompts kept a stable prefix hash and produced a
-repeat disk L2 hit.
+Current PR #1465 all-ten text/tool/cache artifact:
+`.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/tool-cache-all10/SUMMARY.json`.
+
+Current PR #1465 no-weird-character/tool-leak artifact:
+`.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/no-weird-chars-tool-leak-all10.json`.
+
+Current PR #1465 issue #1432 replay artifact:
+`.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/issue1432-ai-short-paragraph-all10-corrected-eval.json`.
+
+Representative repeat-cache proof passed for E2B MXFP4 and JANG_4M: repeated
+identical prompts kept a stable prefix hash and produced a repeat disk L2 hit.
 
 ## Gemma Media And Reasoning Boundary
 
-Representative image proof passed on current main for:
+All-ten Gemma image/VL routing proof passed on current PR #1465:
+
+- Artifact:
+  `.agents/gemma-final/artifacts/pr1465-gemma-all-media-vl-audio-video-vmlx_76047f3-20260611-065406/SUMMARY.json`
+
+Earlier representative image proof also passed for:
 
 - `gemma-4-12b-it-qat-mxfp4`
 - `gemma-4-12b-it-qat-jang_4m`
@@ -95,7 +113,8 @@ Reasoning behavior is bundle/API driven:
 
 ## Memory Safety Settings Contract
 
-The runtime contract exists, is visible, and has PR #1462 manual UI save proof.
+The runtime contract exists, is visible, and has PR #1465 API/admin proof plus
+PR #1462 manual UI save proof.
 
 Current default resolved plan visible in `/admin/cache-stats.memory_safety`:
 
@@ -129,7 +148,8 @@ Important display rule:
 
 ## Settings Control Surface
 
-Changed-setting proof is currently `FIXED for PR #1462 UI/app/API application`.
+Changed-setting proof is currently `FIXED for PR #1465 API/admin application`
+and `FIXED for PR #1462 manual UI application`.
 
 The app exposes memory-safety status through `/admin/cache-stats.memory_safety`
 and now exposes a Server Settings section that edits
@@ -151,7 +171,24 @@ The Server Settings section persists:
 - `memorySafety.customDefaultMaxKVSize`
 - `memorySafety.customMaxConcurrentSequences`
 
-Live proof now shows:
+Current PR #1465 API/admin live proof shows:
+
+1. `GET /admin/runtime-settings` returns the persisted vMLX runtime settings.
+2. `PUT /admin/runtime-settings` persists valid generation, cache,
+   memory-safety, media, MTP, and concurrency settings.
+3. Network mutations are rejected from this endpoint because they can restart or
+   rebind the HTTP server.
+4. Cache/media/MTP changes clear loaded models when needed, and
+   generation/concurrency changes invalidate runtime config.
+5. Generation/concurrency, prefix cache, dependent paged KV/block disk, and
+   Strict memory safety were toggled through the API/admin surface.
+6. Each changed state was followed by live Gemma chat, health, cache/status
+   telemetry, and restore-original confirmation.
+
+Artifact:
+`.agents/gemma-final/artifacts/pr1465-gemma-runtime-settings-endpoint-live-vmlx_76047f3-20260611-060337/SUMMARY.json`.
+
+Prior PR #1462 UI proof shows:
 
 1. The user changes and saves the setting through the Server Settings UI.
 2. `/admin/cache-stats.memory_safety` shows the changed mode/slider.
@@ -222,14 +259,19 @@ Forbidden behavior:
 ## Adjacent Rows
 
 Qwen MTP MXFP4 27B and 35B have current-main live chat/tool/cache proof with
-hybrid SSM companion plus disk L2 hits. Native MTP acceleration remains partial
-because the local bundles report preserved MTP weights but no production
-`vmlx_mtp_tuning.json`.
+hybrid SSM companion plus disk L2 hits. PR #1465 replay artifact:
+`.agents/gemma-final/artifacts/pr1465-qwen-mtp-tool-cache-20260611-002516`.
+Native MTP acceleration remains partial because the local bundles report
+preserved MTP weights but no production `vmlx_mtp_tuning.json`; do not force
+greedy sampling or fake native MTP activation.
 
-MiMo V2.5 JANGTQ_2 remains partial: required tool-call arguments passed and
-cache topology matched the bundle, but the visible tool-result follow-up
-answered the line count incorrectly. Do not mark MiMo release-green until
-tool-result grounding is fixed and live proof passes.
+MiMo V2.5 JANGTQ_2 is fixed for the shared text/tool-result regression on PR
+#1465: first required tool call preserved exact args, the ordinary tool-result
+follow-up answered `3 lines were counted.`, a second required tool call after
+history preserved exact args, no parser/protocol markers leaked, and cache
+telemetry showed 9 KV plus 39 rotating layers with disk L2. Artifact:
+`.agents/gemma-final/artifacts/pr1465-mimo-tool-history-fix-live-vmlx_76047f3-20260611-073345/SUMMARY.json`.
+This does not claim MiMo VL/audio/video.
 
 Nex N2 remains a follow-up lane. Existing evidence shows useful topology proof
 but slow or blocked rows; do not block the Gemma checkpoint on N2 unless a

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -288,12 +288,24 @@ This does not claim MiMo VL/audio/video generation.
 
 Nex N2 remains a follow-up lane. Existing evidence shows useful topology proof
 but slow or blocked rows; do not block the Gemma checkpoint on N2 unless a
-shared runtime change regresses Gemma. After macOS disk notification approval,
-the currently available external runtime root still did not expose a launchable
-`nex-n2-pro-jangtq2` bundle. The drive contains the source bundle at
-`/Volumes/EricsLLMDrive/jangq-ai/sources/Nex-N2-Pro` and JANG build/proof
-outputs under `/Users/eric/jang/build`, so current N2 JANGTQ status is
-bundle-availability/discovery blocked, not runtime-proven.
+shared runtime change regresses Gemma.
+
+After macOS disk notification approval, the currently available roots still do
+not expose a launchable `nex-n2-pro-jangtq2` runtime bundle. Current inventory:
+
+- `/Users/eric/.mlxstudio/models` does not list `nex-n2-pro-jangtq2`.
+- `/Volumes/EricsLLMDrive/jangq-ai/sources/Nex-N2-Pro` is the source bundle,
+  not the JANGTQ runtime id.
+- `/Users/eric/jang/build/n2-jangtq2-vmlx-control-20260610` contains only cache
+  DB files and `server.log`, with no config/tokenizer/safetensors runtime
+  bundle files.
+- Other `/Users/eric/jang/build/n2-*` directories are analysis/proof/smoke
+  outputs, not launchable Osaurus model bundles.
+
+Current N2 JANGTQ status is `BLOCKED` on bundle availability/discovery. The next
+gate is to place or build a real launchable runtime bundle, then run the same
+Osaurus live `/v1/models`, load, multi-turn tool, no-leak, token/s, topology
+cache, and health proof used for Gemma.
 
 ## Required Release Checkers
 

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -273,7 +273,10 @@ follow-up answered `3 lines were counted.`, a second required tool call after
 history preserved exact args, no parser/protocol markers leaked, and cache
 telemetry showed 9 KV plus 39 rotating layers with disk L2. Artifact:
 `.agents/gemma-final/artifacts/pr1465-mimo-tool-history-fix-live-vmlx_76047f3-20260611-073345/SUMMARY.json`.
-This does not claim MiMo VL/audio/video.
+MiMo image/audio/video requests are also live-proven as typed HTTP 400 refusal
+boundaries that preserve server health and do not load the 79G bundle. Artifact:
+`.agents/gemma-final/artifacts/pr1465-mimo-media-refusal-vmlx_76047f3-20260611-091152/SUMMARY.json`.
+This does not claim MiMo VL/audio/video generation.
 
 Nex N2 remains a follow-up lane. Existing evidence shows useful topology proof
 but slow or blocked rows; do not block the Gemma checkpoint on N2 unless a

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -10,17 +10,20 @@ what can be shared in the repo without pretending unproven rows are complete.
 Status: `PARTIAL RELEASE CHECKPOINT`.
 
 Gemma 4 text/chat/tool/cache behavior is usable on the current PR #1465 app
-build for a checkpoint. Audio/video generation and full all-family Sentry
-closure are not complete. Memory-safety controls have API/admin proof on PR
-#1465 and prior manual UI save proof on PR #1462.
+build for a checkpoint. Gemma4 audio generation remains a real runtime gap:
+the bundles advertise `audio_config`/audio modality metadata, but the pinned
+vMLX Gemma4 runtime drops `audio_tower.*` / `embed_audio.*` weights and has no
+audio module wired. Video generation and full all-family Sentry closure are not
+complete. Memory-safety controls have API/admin proof on PR #1465 and prior
+manual UI save proof on PR #1462.
 
 Current PR #1465 proof baseline:
 
 - Osaurus PR: `#1465`
-- Osaurus proof/code commit: `15618727da01b71074626837b414e1d77c5fbe0c`
+- Osaurus proof/code branch: `codex/request-cancel-model-admission` (PR head is authoritative)
 - vMLX Swift pin: `76047f3b4492d4fae316267a30fba55163b1c5cd`
 - GitHub checks: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and
-  `update_release_draft` were green on the commit above.
+  `update_release_draft` were green on the previous pushed PR head; recheck after each new push.
 - External-root proof after macOS disk access approval:
   `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-071401/SUMMARY.json`
 - Post-notification-approval tool/cache proof after macOS disk approval:
@@ -101,8 +104,10 @@ prefix/cache behavior, and kept the server healthy.
 Audio/video are not claimed as generation features. Current live behavior is a
 typed refusal boundary:
 
-- Audio returns HTTP 400: `Gemma4 audio input is not enabled because native audio routing still needs live model proof.`
+- Audio returns HTTP 400: `Gemma4 audio input is not enabled because the pinned vMLX Gemma4 runtime does not wire audio_tower/embed_audio yet.`
 - Video returns HTTP 400 when the bundle does not advertise video.
+- Current root-cause refusal proof artifact:
+  `.agents/gemma-final/artifacts/pr1465-gemma-audio-rootcause-refusal-vmlx_76047f3-20260611-093714/SUMMARY.json`
 
 Reasoning behavior is bundle/API driven:
 
@@ -247,6 +252,9 @@ Allowed behavior:
 
 - Advisory feasibility status.
 - Graceful typed refusal when a strict user-selected policy cannot be satisfied.
+- Graceful typed refusal for Gemma4 audio until the vMLX Gemma4 runtime wires
+  the real audio tower/embed path; do not infer audio support from bundle
+  metadata alone.
 - Clear UI/status warnings when estimates are unknown or over budget.
 - Conservative defaults that preserve model behavior.
 

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -28,6 +28,8 @@ Current PR #1465 proof baseline:
   `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-071401/SUMMARY.json`
 - Post-notification-approval tool/cache proof after macOS disk approval:
   `.agents/gemma-final/artifacts/pr1465-post-notification-approval-e2b-tool-cache-vmlx_76047f3-20260611-083237/POST_APPROVAL_SUMMARY.json`
+- External-root all-ten proof after macOS disk access approval:
+  `.agents/gemma-final/artifacts/pr1465-external-root-all10-direct-parent-vmlx_76047f3-20260611-105825/tool-cache-all10/SUMMARY.json`
 
 ## Gemma 4 Live Proof
 
@@ -76,6 +78,19 @@ Representative release-speed proof from API-reported token/s:
 
 Current PR #1465 all-ten text/tool/cache artifact:
 `.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/tool-cache-all10/SUMMARY.json`.
+
+Current PR #1465 external-root all-ten text/tool/cache artifact after macOS
+disk access approval:
+`.agents/gemma-final/artifacts/pr1465-external-root-all10-direct-parent-vmlx_76047f3-20260611-105825/tool-cache-all10/SUMMARY.json`.
+
+The external-root run launched the PR-built Debug app directly with
+`OSU_MODELS_DIR=/Volumes/EricsLLMDrive/jangq-ai`, confirmed all ten Gemma rows
+were listed by `/v1/models`, then reran the same multi-turn required-tool/cache
+harness. All ten rows passed exact tool arguments, tool-result grounding,
+second required tool call after history, no protocol leakage, healthy server
+state, Safe Auto memory-safety telemetry, bundle defaults
+`temperature=1`, `top_k=64`, `top_p=0.95`, and Gemma rotating/full KV with
+disk-backed restore. Every row still reported `turbo_quant_kv_layer_count=0`.
 
 Current PR #1465 no-weird-character/tool-leak artifact:
 `.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/no-weird-chars-tool-leak-all10.json`.

--- a/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
+++ b/docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md
@@ -17,12 +17,14 @@ closure are not complete. Memory-safety controls have API/admin proof on PR
 Current PR #1465 proof baseline:
 
 - Osaurus PR: `#1465`
-- Osaurus commit: `1b5214469716e86577b77f4dbea7bd47270f10e3`
+- Osaurus proof/code commit: `15618727da01b71074626837b414e1d77c5fbe0c`
 - vMLX Swift pin: `76047f3b4492d4fae316267a30fba55163b1c5cd`
 - GitHub checks: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, and
   `update_release_draft` were green on the commit above.
 - External-root proof after macOS disk access approval:
   `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-071401/SUMMARY.json`
+- Post-notification-approval tool/cache proof after macOS disk approval:
+  `.agents/gemma-final/artifacts/pr1465-post-notification-approval-e2b-tool-cache-vmlx_76047f3-20260611-083237/POST_APPROVAL_SUMMARY.json`
 
 ## Gemma 4 Live Proof
 
@@ -275,7 +277,12 @@ This does not claim MiMo VL/audio/video.
 
 Nex N2 remains a follow-up lane. Existing evidence shows useful topology proof
 but slow or blocked rows; do not block the Gemma checkpoint on N2 unless a
-shared runtime change regresses Gemma.
+shared runtime change regresses Gemma. After macOS disk notification approval,
+the currently available external runtime root still did not expose a launchable
+`nex-n2-pro-jangtq2` bundle. The drive contains the source bundle at
+`/Volumes/EricsLLMDrive/jangq-ai/sources/Nex-N2-Pro` and JANG build/proof
+outputs under `/Users/eric/jang/build`, so current N2 JANGTQ status is
+bundle-availability/discovery blocked, not runtime-proven.
 
 ## Required Release Checkers
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
+        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "42fdc7a78fe8ed2282c453a783eb12fa5302d439"
+        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ef025f2556978d033131f745c00dd8128c8d5151"
+        "revision" : "23eb84913ab77a9e929ef828481ca6941c03ae80"
       }
     },
     {

--- a/scripts/live-proof/assert-osaurus-pr-hygiene.sh
+++ b/scripts/live-proof/assert-osaurus-pr-hygiene.sh
@@ -149,14 +149,16 @@ reject_status_pattern '(^|\s)(\.build|DerivedData|build/|\.DS_Store|.*\.xcuserst
 echo "--- required PR files ---"
 if git -C "$ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
   agents_diff="$(git -C "$ROOT" diff --unified=0 origin/main...HEAD -- AGENTS.md || true)"
-  if [[ -n "$agents_diff" ]] \
-    && ! printf '%s\n' "$agents_diff" \
-      | rg -q 'Do not spawn recursive local "agent" workers, Python subagents, or delegated' \
-    && ! printf '%s\n' "$agents_diff" \
-      | rg -q 'Do not use Python or shell wrappers as an orchestration layer'; then
-    fail_msg "AGENTS.md contains unrelated PR-only agent rules; keep agent policy local"
-  elif [[ -n "$agents_diff" ]]; then
-    pass "AGENTS.md delta is limited to explicit no-recursive-agent release rule"
+  if [[ -n "$agents_diff" ]]; then
+    unexpected_agent_bullets="$(printf '%s\n' "$agents_diff" \
+      | rg '^\+[[:space:]]*-' \
+      | rg -v '^\+[[:space:]]*-[[:space:]]*(Never add fake guards|Reasoning fixes must preserve|Memory limits must apply|Server settings are part of runtime proof|Tool, memory, and cache setting proof must exercise|Do not spawn recursive local "agent" workers)' || true)"
+    if [[ -n "$unexpected_agent_bullets" ]]; then
+      echo "$unexpected_agent_bullets" >&2
+      fail_msg "AGENTS.md contains unexpected PR-only agent rules; keep agent policy local"
+    else
+      pass "AGENTS.md delta is limited to explicit release proof/no-fake/no-recursive-agent rules"
+    fi
   else
     pass "AGENTS.md has no PR delta"
   fi

--- a/scripts/live-proof/assert-server-settings-runtime-wiring.sh
+++ b/scripts/live-proof/assert-server-settings-runtime-wiring.sh
@@ -172,6 +172,16 @@ require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" '"display
   "memory-safety status exposes display summary"
 require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" '"memory_status": memoryStatusJSONObject' \
   "memory-safety status exposes live memory status"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" 'path == "/admin/runtime-settings"' \
+  "runtime settings admin endpoint is routed"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" 'previous\.network != next\.network' \
+  "runtime settings endpoint rejects network rebind changes"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" 'ServerRuntimeSettingsStore\.save\(next\)' \
+  "runtime settings endpoint persists through ServerRuntimeSettingsStore"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" 'await ModelRuntime\.shared\.clearAll\(\)' \
+  "runtime settings endpoint refreshes loaded models after cache/media/MTP changes"
+require_text "$ROOT/Packages/OsaurusCore/Networking/HTTPHandler.swift" 'await ModelRuntime\.shared\.invalidateConfig\(\)' \
+  "runtime settings endpoint invalidates runtime config after generation/concurrency changes"
 require_text "$ADAPTER" 'turboQuantCompressions' \
   "runtime diagnostics report TurboQuant compression count"
 require_text "$ADAPTER" 'nativeMTPDepthSummary' \

--- a/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
+++ b/scripts/live-proof/assert-vmlx-gemma4-parser-fix-wired.sh
@@ -128,16 +128,26 @@ fi
 
 if [[ -f "$TOKENIZER_MACROS" ]]; then
   pass "SwiftPM checkout HuggingFaceIntegrationMacros.swift exists"
-  if rg -Fq 'let gemmaRequiredToolChoice' "$TOKENIZER_MACROS" \
-    && rg -Fq 'chat-template required tools -> Gemma4WithTools fallback engaged' "$TOKENIZER_MACROS" \
+  if rg -Fq 'let gemmaToolSchemasPresent' "$TOKENIZER_MACROS" \
+    && rg -Fq 'chat-template tools -> Gemma4WithTools fallback engaged' "$TOKENIZER_MACROS" \
     && rg -Fq 'MLXLMCommon.ChatTemplateFallbacks.gemma4WithTools' "$TOKENIZER_MACROS"; then
-    pass "Gemma4 required tool_choice routes through explicit Gemma fallback"
+    pass "Gemma4 tool schemas route through explicit Gemma fallback"
   else
-    fail_msg "Gemma4 required tool_choice does not route through explicit Gemma fallback"
+    fail_msg "Gemma4 tool schemas do not route through explicit Gemma fallback"
   fi
 else
   warn "SwiftPM vmlx tokenizer macro source missing; cannot inspect Gemma4 required-tool template routing"
   fail=1
+fi
+
+if [[ -f "$FALLBACKS" ]] && [[ -f "$TOKENIZER_MACROS" ]]; then
+  if rg -Fq "additionalContext['tool_choice'] == 'required'" "$FALLBACKS" \
+    && rg -Fq 'render_required_tool_choice_instruction' "$FALLBACKS" \
+    && rg -Fq 'Required tool_choice must not inject a synthetic prompt directive' "$CHECKOUT/Tests/MLXLMTests/Gemma4ChatTemplateProbeTests.swift"; then
+    pass "Gemma4 required tool_choice is handled inside fallback without synthetic prompt directive"
+  else
+    fail_msg "Gemma4 required tool_choice fallback contract is missing or untested"
+  fi
 fi
 
 if [[ -f "$VLM" ]]; then


### PR DESCRIPTION
## Summary
- expose `/admin/generation-settings` for bundle generation defaults and last effective request settings
- record pending/submitted effective generation settings through the live model request path
- include generation defaults/effective settings in `/admin/cache-stats` model rows
- add runtime settings API wiring for generation, cache, memory-safety, media, MTP, and concurrency settings
- pin vMLX to `76047f3b4492d4fae316267a30fba55163b1c5cd` for the Gemma/JANG/MXFP runtime fixes
- fix MiMo/N2 JANG-style ordinary tool-result follow-ups so they use the bundle template default instead of a hidden no-thinking override
- update the committed team-facing Gemma/memory-safety spec: `docs/GEMMA4_CHECKPOINT_MEMORY_SAFETY_SPEC_2026_06_11.md`

## Verification
- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 swift build --package-path Packages/OsaurusCore`
- `swift test --package-path Packages/OsaurusCore --filter MLXBatchAdapterTests/additionalContext_letsMiMoN2JANGUseBundleDefaultButControlsRequiredTools --jobs 1`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/modelRuntimeWeightSizePreflightIsManualMultiModelOnly|RuntimePolicySourceTests/adminCacheStatsExposesResolvedMemorySafetyStatus|ServerConfigurationStoreTests/modelLoadRAMThresholds_decodeClampAndSort --jobs 1`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 swift test --package-path Packages/OsaurusCore --filter RuntimePolicySourceTests/mtpBundlesAutoResolveVMLXTuningIntoLoadAndGeneration|RuntimePolicySourceTests/chatUISendsAccumulatedHistoryAndMarksImplicitSamplingWithoutForcingNativeMTP|MLXBatchAdapterTests/effectiveGenerationSettings_nativeMTP|MLXBatchAdapterTests/effectiveDraftStrategy_dropsNativeMTP|MLXBatchAdapterTests/additionalContext_defaultsQwenThinkingOffButHonorsExplicitOptIn --jobs 1`
- `scripts/live-proof/assert-no-hidden-local-sampler-defaults.sh`
- `scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh`
- GitHub checks green on `15618727da01b71074626837b414e1d77c5fbe0c`: `test-core`, `test-cli`, `swiftlint`, `shellcheck`, `update_release_draft`

## Live Proof
- Gemma all-ten text/tool/cache proof: `.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/tool-cache-all10/SUMMARY.json`
- Gemma all-ten no-weird-character/tool-leak proof: `.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/no-weird-chars-tool-leak-all10.json`
- Gemma issue #1432 replay proof: `.agents/gemma-final/artifacts/pr1465-gemma-42fd-debug-all10-live-20260611-051547/issue1432-ai-short-paragraph-all10-corrected-eval.json`
- Gemma runtime-settings API proof on vMLX `76047f3`: `.agents/gemma-final/artifacts/pr1465-gemma-runtime-settings-endpoint-live-vmlx_76047f3-20260611-060337/SUMMARY.json`
- Gemma all-ten media proof: `.agents/gemma-final/artifacts/pr1465-gemma-all-media-vl-audio-video-vmlx_76047f3-20260611-065406/SUMMARY.json`
- External-root proof after macOS disk access approval: `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-071401/SUMMARY.json`
- External-root post-approval smoke rerun: `.agents/gemma-final/artifacts/pr1465-external-root-post-disk-approval-vmlx_76047f3-20260611-0809-smoke/SUMMARY.json`
- Qwen MTP tool/cache proof: `.agents/gemma-final/artifacts/pr1465-qwen-mtp-tool-cache-20260611-002516/SUMMARY.json`
- MiMo shared tool-result regression proof: `.agents/gemma-final/artifacts/pr1465-mimo-tool-history-fix-live-vmlx_76047f3-20260611-073345/SUMMARY.json`

## Release Boundary
- Proven for this checkpoint: Gemma 4 QAT MXFP4/JANG_4M text chat, multi-turn tool calls, tool-result grounding, no weird/control-character output, generation defaults visibility, runtime settings API toggles, Safe Auto memory-safety telemetry, direct external-root discovery/load, image/VL routing, and typed audio/video refusals.
- Adjacent proven row: Qwen 27B/35B MXFP4 MTP discovery/load, multi-turn tools, hybrid SSM cache topology, and diagnostic native MTP status.
- Not claimed: Gemma audio generation, Gemma video generation, Gemma TurboQuant KV, Qwen native MTP acceleration/speculative decode without tuned `vmlx_mtp_tuning.json`, all-family Sentry closure, N2 JANGTQ readiness, MiMo/N2 VL/audio/video readiness.
- Current Gemma cache wording should stay precise: rotating/full KV plus disk-backed restore/L2; runtime telemetry reports `turbo_quant_kv_layer_count=0`, so this PR does not claim TurboQuant KV for Gemma.
- RAM feasibility is advisory on this PR: low available/projected memory records `.tight` and remains visible in health/status, but does not silently hard-refuse user-requested loads through a hidden 90 percent rule.
- Low-RAM simulated/real 24 GB admission proof, UI/CLI memory-safety slider completeness beyond the API/admin and prior panel evidence, dedicated concurrency stress, N2 JANG speed, and N2 JANGTQ remain follow-up work.