### PR TITLE
Add storage location standards audit

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -991,6 +991,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     plan: memorySafetyPlan,
                     memoryStatus: memoryStatus
                 ),
+                "storage_locations": Self.storageLocationsJSONObject(),
             ]
             let data = try? JSONSerialization.data(withJSONObject: obj, options: .osaurusCanonical)
             let body = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
@@ -1351,6 +1352,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return [:]
         }
         return object
+    }
+
+    /// Storage-location standards audit block for `/admin/cache-stats`.
+    /// Read-only probe + pure classification; see issue #1422 and
+    /// `docs/STORAGE.md` (Storage Location Standards).
+    private static func storageLocationsJSONObject() -> [String: Any] {
+        StorageLocationStandards.jsonObject(for: StorageLocationStandards.currentReport())
     }
 
     private static func memorySafetyJSONObject(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2003,6 +2003,31 @@ struct RuntimePolicySourceTests {
         #expect(runtimeSettingsTests.contains("memorySafety.slider == 2"))
     }
 
+    @Test("admin cache stats exposes a read-only storage location standards block")
+    func adminCacheStatsExposesStorageLocationStandards() throws {
+        let httpHandler = try Self.source("Networking/HTTPHandler.swift")
+        let standards = try Self.source("Utils/StorageLocationStandards.swift")
+
+        #expect(
+            httpHandler.contains("\"storage_locations\": Self.storageLocationsJSONObject()")
+        )
+        #expect(httpHandler.contains("StorageLocationStandards.currentReport()"))
+
+        // The audit surface is diagnostics-only for #1422: it must classify
+        // and report, never migrate. Pin both the stable reason codes and the
+        // absence of any filesystem mutation in the audit module.
+        #expect(standards.contains("case homeDotDirectory = \"home_dot_directory\""))
+        #expect(standards.contains("\"root_home_dot_directory_not_apple_spec\""))
+        #expect(standards.contains("\"legacy_application_support_root_present\""))
+        #expect(standards.contains("\"migration_decision_pending\""))
+        #expect(standards.contains("\"spec_compliant\""))
+        #expect(standards.contains("legacyApplicationSupportFolderName = \"com.dinoki.osaurus\""))
+        #expect(!standards.contains("copyItem"))
+        #expect(!standards.contains("moveItem"))
+        #expect(!standards.contains("removeItem"))
+        #expect(!standards.contains("createDirectory"))
+    }
+
     @Test("ModelRuntime does not repair reasoning parser output")
     func modelRuntimeDoesNotRepairReasoningParserOutput() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")

--- a/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
@@ -1,0 +1,308 @@
+//
+//  StorageLocationStandardsTests.swift
+//
+//  Pin the #1422 storage-location audit: classification of the active
+//  app-data root, the legacy Application Support root, the models root, and
+//  the stable reason-code / JSON diagnostic surface. The classifier is a
+//  pure function over `Inputs`, so every case here is hermetic — no real
+//  home directory, no filesystem mutation, no `OsaurusPaths` global state.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct StorageLocationStandardsTests {
+
+    private func makeInputs(
+        activeRootPath: String = "/Users/sam/.osaurus",
+        rootSource: StorageLocationStandards.RootSource = .standard,
+        home: String = "/Users/sam",
+        support: String? = "/Users/sam/Library/Application Support",
+        legacyPresent: Bool = false,
+        candidatePresent: Bool = false,
+        modelsRootPath: String = "/Users/sam/MLXModels"
+    ) -> StorageLocationStandards.Inputs {
+        StorageLocationStandards.Inputs(
+            activeRootPath: activeRootPath,
+            rootSource: rootSource,
+            homeDirectoryPath: home,
+            applicationSupportPath: support,
+            legacyApplicationSupportRootPath: support.map { "\($0)/com.dinoki.osaurus" },
+            legacyApplicationSupportRootPresent: legacyPresent,
+            appleSpecCandidateRootPath: support.map { "\($0)/Osaurus" },
+            appleSpecCandidateRootPresent: candidatePresent,
+            modelsRootPath: modelsRootPath
+        )
+    }
+
+    // MARK: - Root classification
+
+    @Test("Default ~/.osaurus root classifies as home dot-directory, not spec-compliant")
+    func homeDotDirectoryRoot() {
+        let report = StorageLocationStandards.audit(makeInputs())
+
+        #expect(report.classification == .homeDotDirectory)
+        #expect(!report.specCompliant)
+        #expect(
+            report.reasonCodes == [
+                "root_home_dot_directory_not_apple_spec",
+                "migration_decision_pending",
+                "models_root_home_visible_by_design",
+            ]
+        )
+        #expect(report.findings[0].severity == .warning)
+        #expect(report.findings[0].message.contains("~/Library/Application Support"))
+        #expect(report.findings[0].message.contains("~/.local/share"))
+    }
+
+    @Test("Application Support root classifies as Apple-spec compliant with no findings")
+    func applicationSupportRoot() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/Users/sam/Library/Application Support/Osaurus",
+                modelsRootPath: "/Users/sam/Library/Application Support/Osaurus/models"
+            )
+        )
+
+        #expect(report.classification == .appleApplicationSupport)
+        #expect(report.specCompliant)
+        #expect(report.modelsRootClassification == .applicationSupport)
+        #expect(report.findings.isEmpty)
+        #expect(report.reasonCodes.isEmpty)
+    }
+
+    @Test("Root equal to the Application Support directory itself counts as under it")
+    func rootEqualToApplicationSupport() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(activeRootPath: "/Users/sam/Library/Application Support")
+        )
+
+        #expect(report.classification == .appleApplicationSupport)
+        #expect(report.specCompliant)
+    }
+
+    @Test("Dot-directory below a subfolder of home is custom, not home dot-directory")
+    func nestedDotDirectoryIsCustom() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(activeRootPath: "/Users/sam/Documents/.osaurus")
+        )
+
+        #expect(report.classification == .custom)
+        #expect(!report.specCompliant)
+        #expect(report.reasonCodes.contains("root_custom_location"))
+    }
+
+    @Test("External-volume root is custom and models on the same volume are external")
+    func externalVolumeRoot() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/Volumes/External/osaurus-data",
+                modelsRootPath: "/Volumes/External/MLXModels"
+            )
+        )
+
+        #expect(report.classification == .custom)
+        #expect(report.modelsRootClassification == .externalOrCustom)
+        #expect(report.reasonCodes == ["root_custom_location"])
+    }
+
+    @Test("Trailing slashes and dot segments normalize before comparison")
+    func pathNormalization() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/Users/sam/Library/Application Support/./Osaurus/",
+                modelsRootPath: "/Users/sam/Library/Application Support/Osaurus/models"
+            )
+        )
+
+        #expect(report.classification == .appleApplicationSupport)
+        #expect(report.specCompliant)
+    }
+
+    // MARK: - Overrides
+
+    @Test("Test override reports test_override and suppresses spec assessment")
+    func testOverrideClassification() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/tmp/osaurus-test",
+                rootSource: .testOverride
+            )
+        )
+
+        #expect(report.classification == .testOverride)
+        #expect(!report.specCompliant)
+        #expect(report.reasonCodes == ["root_overridden_for_tests"])
+        #expect(report.findings[0].severity == .info)
+    }
+
+    @Test("Environment override reports environment_override and suppresses spec assessment")
+    func environmentOverrideClassification() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/tmp/osaurus-test-env",
+                rootSource: .environmentOverride
+            )
+        )
+
+        #expect(report.classification == .environmentOverride)
+        #expect(report.reasonCodes == ["root_environment_override"])
+    }
+
+    // MARK: - Legacy root
+
+    @Test("Legacy com.dinoki.osaurus root present adds a warning and the re-merge caveat")
+    func legacyRootPresent() {
+        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
+
+        #expect(report.legacyApplicationSupportRootPresent)
+        #expect(
+            report.reasonCodes == [
+                "root_home_dot_directory_not_apple_spec",
+                "legacy_application_support_root_present",
+                "migration_decision_pending",
+                "models_root_home_visible_by_design",
+            ]
+        )
+        let legacy = report.findings.first {
+            $0.code == .legacyApplicationSupportRootPresent
+        }
+        #expect(legacy?.severity == .warning)
+        #expect(legacy?.message.contains("re-merges") == true)
+        #expect(legacy?.message.contains("com.dinoki.osaurus") == true)
+    }
+
+    @Test("Legacy root present alongside a compliant root still pends the migration decision")
+    func legacyRootWithCompliantActive() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                activeRootPath: "/Users/sam/Library/Application Support/Osaurus",
+                legacyPresent: true,
+                modelsRootPath: "/Volumes/External/MLXModels"
+            )
+        )
+
+        #expect(report.specCompliant)
+        #expect(
+            report.reasonCodes == [
+                "legacy_application_support_root_present",
+                "migration_decision_pending",
+            ]
+        )
+    }
+
+    // MARK: - Models root
+
+    @Test("Home-visible models root is an info-level by-design finding, not a violation")
+    func modelsRootHomeVisible() {
+        let report = StorageLocationStandards.audit(makeInputs())
+        let finding = report.findings.first {
+            $0.code == .modelsRootHomeVisibleByDesign
+        }
+
+        #expect(report.modelsRootClassification == .homeVisible)
+        #expect(finding?.severity == .info)
+    }
+
+    @Test("Models finding is suppressed under test and environment overrides")
+    func modelsFindingSuppressedForOverrides() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(rootSource: .testOverride)
+        )
+
+        #expect(report.modelsRootClassification == .homeVisible)
+        #expect(!report.reasonCodes.contains("models_root_home_visible_by_design"))
+    }
+
+    // MARK: - Diagnostic surface stability
+
+    @Test("Reason-code raw values are pinned")
+    func reasonCodeRawValuesPinned() {
+        let expected: [StorageLocationStandards.ReasonCode: String] = [
+            .rootHomeDotDirectoryNotAppleSpec: "root_home_dot_directory_not_apple_spec",
+            .rootOverriddenForTests: "root_overridden_for_tests",
+            .rootEnvironmentOverride: "root_environment_override",
+            .rootCustomLocation: "root_custom_location",
+            .legacyApplicationSupportRootPresent: "legacy_application_support_root_present",
+            .migrationDecisionPending: "migration_decision_pending",
+            .modelsRootHomeVisibleByDesign: "models_root_home_visible_by_design",
+        ]
+
+        #expect(StorageLocationStandards.ReasonCode.allCases.count == expected.count)
+        for (code, raw) in expected {
+            #expect(code.rawValue == raw)
+        }
+    }
+
+    @Test("JSON object carries the full snake_case diagnostic surface")
+    func jsonObjectShape() throws {
+        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
+        let json = StorageLocationStandards.jsonObject(for: report)
+
+        #expect(
+            Set(json.keys) == [
+                "classification",
+                "spec_compliant",
+                "active_root",
+                "apple_spec_candidate_root",
+                "apple_spec_candidate_root_present",
+                "legacy_application_support_root",
+                "legacy_application_support_root_present",
+                "models_root",
+                "models_root_classification",
+                "reason_codes",
+                "findings",
+                "summary",
+            ]
+        )
+        #expect(json["classification"] as? String == "home_dot_directory")
+        #expect(json["spec_compliant"] as? Bool == false)
+        #expect(json["legacy_application_support_root_present"] as? Bool == true)
+        #expect(json["models_root_classification"] as? String == "home_visible")
+
+        let findings = try #require(json["findings"] as? [[String: Any]])
+        #expect(findings.count == report.findings.count)
+        for entry in findings {
+            #expect(entry["code"] is String)
+            #expect(entry["severity"] is String)
+            #expect(entry["message"] is String)
+        }
+
+        // The block must serialize with the same canonical options the
+        // endpoint uses.
+        #expect(JSONSerialization.isValidJSONObject(json))
+    }
+
+    @Test("JSON object uses NSNull for absent Application Support paths")
+    func jsonObjectNullability() {
+        let report = StorageLocationStandards.audit(makeInputs(support: nil))
+        let json = StorageLocationStandards.jsonObject(for: report)
+
+        #expect(json["apple_spec_candidate_root"] is NSNull)
+        #expect(json["legacy_application_support_root"] is NSNull)
+    }
+
+    @Test("Summary stays one stable line")
+    func summaryShape() {
+        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
+
+        #expect(
+            report.summary
+                == "root=home_dot_directory (non-compliant); legacy_root=present; "
+                + "models_root=home_visible"
+        )
+        #expect(!report.summary.contains("\n"))
+    }
+
+    @Test("Missing Application Support directory still classifies the home dot-directory")
+    func missingApplicationSupport() {
+        let report = StorageLocationStandards.audit(makeInputs(support: nil))
+
+        #expect(report.classification == .homeDotDirectory)
+        #expect(report.appleSpecCandidateRootPath == nil)
+        #expect(!report.appleSpecCandidateRootPresent)
+    }
+}

--- a/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
+++ b/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
@@ -1,0 +1,414 @@
+//
+//  StorageLocationStandards.swift
+//  osaurus
+//
+//  Storage-location standards audit for issue #1422.
+//
+//  Osaurus currently keeps its app data in `~/.osaurus/` (see
+//  `OsaurusPaths`), which follows neither Apple's file-system guidance
+//  (`~/Library/Application Support/...`) nor the XDG base-directory spec
+//  (`~/.local/share/...`). Relocating the root is a data-safety decision —
+//  the Keychain data-encryption key is paired with the existing tree, the
+//  HKDF salt sidecar lives inside it, sandbox tooling references
+//  `~/.osaurus` literally, and plugin/container trees can be large — so this
+//  module deliberately performs **no migration**. It only classifies the
+//  current layout and reports stable reason codes through
+//  `/admin/cache-stats` so users and maintainers can see exactly where data
+//  lives and why. Classification is a pure function over `Inputs`; the live
+//  probe is read-only and never mutates the filesystem.
+//
+
+import Foundation
+
+public enum StorageLocationStandards {
+
+    // MARK: - Model
+
+    /// Where the active app-data root was resolved from.
+    public enum RootSource: String, Sendable {
+        case standard
+        case testOverride = "test_override"
+        case environmentOverride = "environment_override"
+    }
+
+    /// Classification of the active app-data root against platform
+    /// storage-location conventions.
+    public enum RootClassification: String, Sendable {
+        case appleApplicationSupport = "apple_application_support"
+        case homeDotDirectory = "home_dot_directory"
+        case testOverride = "test_override"
+        case environmentOverride = "environment_override"
+        case custom
+    }
+
+    /// Classification of the model-weights root, reported separately from
+    /// the app-data root because user-managed weights are home-visible by
+    /// design today.
+    public enum ModelsRootClassification: String, Sendable {
+        case applicationSupport = "application_support"
+        case homeVisible = "home_visible"
+        case externalOrCustom = "external_or_custom"
+    }
+
+    /// Stable, machine-readable reason codes. These are part of the
+    /// diagnostic surface — do not rename existing raw values.
+    public enum ReasonCode: String, CaseIterable, Sendable {
+        case rootHomeDotDirectoryNotAppleSpec = "root_home_dot_directory_not_apple_spec"
+        case rootOverriddenForTests = "root_overridden_for_tests"
+        case rootEnvironmentOverride = "root_environment_override"
+        case rootCustomLocation = "root_custom_location"
+        case legacyApplicationSupportRootPresent = "legacy_application_support_root_present"
+        case migrationDecisionPending = "migration_decision_pending"
+        case modelsRootHomeVisibleByDesign = "models_root_home_visible_by_design"
+    }
+
+    public enum Severity: String, Sendable {
+        case info
+        case warning
+    }
+
+    /// One audited fact with a stable code and a human-readable explanation.
+    public struct Finding: Equatable, Sendable {
+        public let code: ReasonCode
+        public let severity: Severity
+        public let message: String
+
+        public init(code: ReasonCode, severity: Severity, message: String) {
+            self.code = code
+            self.severity = severity
+            self.message = message
+        }
+    }
+
+    /// Everything the pure classifier needs. Built by `currentInputs()` in
+    /// production; built by hand in tests.
+    public struct Inputs: Equatable, Sendable {
+        public let activeRootPath: String
+        public let rootSource: RootSource
+        public let homeDirectoryPath: String
+        public let applicationSupportPath: String?
+        public let legacyApplicationSupportRootPath: String?
+        public let legacyApplicationSupportRootPresent: Bool
+        public let appleSpecCandidateRootPath: String?
+        public let appleSpecCandidateRootPresent: Bool
+        public let modelsRootPath: String
+
+        public init(
+            activeRootPath: String,
+            rootSource: RootSource,
+            homeDirectoryPath: String,
+            applicationSupportPath: String?,
+            legacyApplicationSupportRootPath: String?,
+            legacyApplicationSupportRootPresent: Bool,
+            appleSpecCandidateRootPath: String?,
+            appleSpecCandidateRootPresent: Bool,
+            modelsRootPath: String
+        ) {
+            self.activeRootPath = activeRootPath
+            self.rootSource = rootSource
+            self.homeDirectoryPath = homeDirectoryPath
+            self.applicationSupportPath = applicationSupportPath
+            self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
+            self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
+            self.appleSpecCandidateRootPath = appleSpecCandidateRootPath
+            self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
+            self.modelsRootPath = modelsRootPath
+        }
+    }
+
+    /// Audit result. `reasonCodes` mirrors `findings` for compact consumers.
+    public struct Report: Equatable, Sendable {
+        public let classification: RootClassification
+        public let specCompliant: Bool
+        public let activeRootPath: String
+        public let appleSpecCandidateRootPath: String?
+        public let appleSpecCandidateRootPresent: Bool
+        public let legacyApplicationSupportRootPath: String?
+        public let legacyApplicationSupportRootPresent: Bool
+        public let modelsRootPath: String
+        public let modelsRootClassification: ModelsRootClassification
+        public let findings: [Finding]
+
+        public var reasonCodes: [String] {
+            findings.map { $0.code.rawValue }
+        }
+
+        public var summary: String {
+            let compliance = specCompliant ? "apple-spec" : "non-compliant"
+            let legacy = legacyApplicationSupportRootPresent ? "present" : "absent"
+            return "root=\(classification.rawValue) (\(compliance)); "
+                + "legacy_root=\(legacy); "
+                + "models_root=\(modelsRootClassification.rawValue)"
+        }
+
+        public init(
+            classification: RootClassification,
+            specCompliant: Bool,
+            activeRootPath: String,
+            appleSpecCandidateRootPath: String?,
+            appleSpecCandidateRootPresent: Bool,
+            legacyApplicationSupportRootPath: String?,
+            legacyApplicationSupportRootPresent: Bool,
+            modelsRootPath: String,
+            modelsRootClassification: ModelsRootClassification,
+            findings: [Finding]
+        ) {
+            self.classification = classification
+            self.specCompliant = specCompliant
+            self.activeRootPath = activeRootPath
+            self.appleSpecCandidateRootPath = appleSpecCandidateRootPath
+            self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
+            self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
+            self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
+            self.modelsRootPath = modelsRootPath
+            self.modelsRootClassification = modelsRootClassification
+            self.findings = findings
+        }
+    }
+
+    // MARK: - Live probe (read-only)
+
+    /// Name of the legacy pre-`~/.osaurus` root under Application Support.
+    public static let legacyApplicationSupportFolderName = "com.dinoki.osaurus"
+
+    /// Proposed Apple-spec folder name under Application Support. Reported
+    /// as a candidate only; nothing is created or moved.
+    public static let appleSpecCandidateFolderName = "Osaurus"
+
+    /// Gather live inputs. Read-only: performs `fileExists` probes plus the
+    /// same root resolution `OsaurusPaths.root()` already performed for the
+    /// running process; it never creates, copies, or deletes anything.
+    public static func currentInputs(fileManager fm: FileManager = .default) -> Inputs {
+        let testRootOverride = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let rootSource: RootSource
+        if OsaurusPaths.overrideRoot != nil {
+            rootSource = .testOverride
+        } else if testRootOverride?.isEmpty == false {
+            rootSource = .environmentOverride
+        } else {
+            rootSource = .standard
+        }
+        let support = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        let legacy = support?.appendingPathComponent(
+            legacyApplicationSupportFolderName,
+            isDirectory: true
+        )
+        let candidate = support?.appendingPathComponent(
+            appleSpecCandidateFolderName,
+            isDirectory: true
+        )
+        return Inputs(
+            activeRootPath: OsaurusPaths.root().path,
+            rootSource: rootSource,
+            homeDirectoryPath: fm.homeDirectoryForCurrentUser.path,
+            applicationSupportPath: support?.path,
+            legacyApplicationSupportRootPath: legacy?.path,
+            legacyApplicationSupportRootPresent: legacy.map { fm.fileExists(atPath: $0.path) }
+                ?? false,
+            appleSpecCandidateRootPath: candidate?.path,
+            appleSpecCandidateRootPresent: candidate.map { fm.fileExists(atPath: $0.path) }
+                ?? false,
+            modelsRootPath: DirectoryPickerService.effectiveModelsDirectory().path
+        )
+    }
+
+    /// Convenience: live probe + pure classification.
+    public static func currentReport(fileManager: FileManager = .default) -> Report {
+        audit(currentInputs(fileManager: fileManager))
+    }
+
+    // MARK: - Pure classification
+
+    public static func audit(_ inputs: Inputs) -> Report {
+        let classification = classifyRoot(inputs)
+        let modelsClassification = classifyModelsRoot(inputs)
+        var findings: [Finding] = []
+
+        switch classification {
+        case .appleApplicationSupport:
+            break
+        case .homeDotDirectory:
+            findings.append(
+                Finding(
+                    code: .rootHomeDotDirectoryNotAppleSpec,
+                    severity: .warning,
+                    message:
+                        "App data root \(inputs.activeRootPath) is a home dot-directory. "
+                        + "Apple's file-system guidance places app data under "
+                        + "~/Library/Application Support; the XDG equivalent is "
+                        + "~/.local/share. See docs/STORAGE.md (Storage Location Standards)."
+                )
+            )
+        case .testOverride:
+            findings.append(
+                Finding(
+                    code: .rootOverriddenForTests,
+                    severity: .info,
+                    message:
+                        "Storage root is overridden via OsaurusPaths.overrideRoot for tests; "
+                        + "spec compliance was not assessed."
+                )
+            )
+        case .environmentOverride:
+            findings.append(
+                Finding(
+                    code: .rootEnvironmentOverride,
+                    severity: .info,
+                    message:
+                        "Storage root is overridden via OSAURUS_TEST_ROOT; "
+                        + "spec compliance was not assessed."
+                )
+            )
+        case .custom:
+            findings.append(
+                Finding(
+                    code: .rootCustomLocation,
+                    severity: .info,
+                    message:
+                        "Storage root \(inputs.activeRootPath) is neither the default home "
+                        + "dot-directory nor under Application Support."
+                )
+            )
+        }
+
+        if inputs.legacyApplicationSupportRootPresent {
+            let legacyPath =
+                inputs.legacyApplicationSupportRootPath
+                ?? legacyApplicationSupportFolderName
+            findings.append(
+                Finding(
+                    code: .legacyApplicationSupportRootPresent,
+                    severity: .warning,
+                    message:
+                        "Legacy root \(legacyPath) still exists. OsaurusPaths re-merges it "
+                        + "into the active root on the first path access of every launch "
+                        + "(newer file wins), which can resurrect files that were since "
+                        + "changed under the active root. A one-shot migration marker is "
+                        + "pending."
+                )
+            )
+        }
+
+        if classification == .homeDotDirectory || inputs.legacyApplicationSupportRootPresent {
+            findings.append(
+                Finding(
+                    code: .migrationDecisionPending,
+                    severity: .info,
+                    message:
+                        "Relocating the storage root is deferred pending a maintainer "
+                        + "decision: the Keychain data-encryption key is paired with the "
+                        + "current tree, the HKDF salt sidecar lives inside it, sandbox "
+                        + "tooling references ~/.osaurus literally, and plugin/container "
+                        + "trees can be large."
+                )
+            )
+        }
+
+        let usesStandardRoot = classification != .testOverride && classification != .environmentOverride
+        if usesStandardRoot && modelsClassification == .homeVisible {
+            findings.append(
+                Finding(
+                    code: .modelsRootHomeVisibleByDesign,
+                    severity: .info,
+                    message:
+                        "Model weights root \(inputs.modelsRootPath) is a home-visible "
+                        + "folder (user-managed weights by design); it is a separate "
+                        + "decision from the app-data root."
+                )
+            )
+        }
+
+        return Report(
+            classification: classification,
+            specCompliant: classification == .appleApplicationSupport,
+            activeRootPath: inputs.activeRootPath,
+            appleSpecCandidateRootPath: inputs.appleSpecCandidateRootPath,
+            appleSpecCandidateRootPresent: inputs.appleSpecCandidateRootPresent,
+            legacyApplicationSupportRootPath: inputs.legacyApplicationSupportRootPath,
+            legacyApplicationSupportRootPresent: inputs.legacyApplicationSupportRootPresent,
+            modelsRootPath: inputs.modelsRootPath,
+            modelsRootClassification: modelsClassification,
+            findings: findings
+        )
+    }
+
+    // MARK: - JSON
+
+    /// Snake-case JSON object for `/admin/cache-stats`. Mirrors the
+    /// `memory_safety` block conventions (NSNull for absent optionals).
+    public static func jsonObject(for report: Report) -> [String: Any] {
+        [
+            "classification": report.classification.rawValue,
+            "spec_compliant": report.specCompliant,
+            "active_root": report.activeRootPath,
+            "apple_spec_candidate_root": report.appleSpecCandidateRootPath as Any? ?? NSNull(),
+            "apple_spec_candidate_root_present": report.appleSpecCandidateRootPresent,
+            "legacy_application_support_root": report.legacyApplicationSupportRootPath as Any?
+                ?? NSNull(),
+            "legacy_application_support_root_present": report.legacyApplicationSupportRootPresent,
+            "models_root": report.modelsRootPath,
+            "models_root_classification": report.modelsRootClassification.rawValue,
+            "reason_codes": report.reasonCodes,
+            "findings": report.findings.map { finding in
+                [
+                    "code": finding.code.rawValue,
+                    "severity": finding.severity.rawValue,
+                    "message": finding.message,
+                ]
+            },
+            "summary": report.summary,
+        ]
+    }
+
+    // MARK: - Helpers
+
+    private static func classifyRoot(_ inputs: Inputs) -> RootClassification {
+        switch inputs.rootSource {
+        case .testOverride:
+            return .testOverride
+        case .environmentOverride:
+            return .environmentOverride
+        case .standard:
+            break
+        }
+        let activeRootIsInApplicationSupport =
+            inputs.applicationSupportPath.map { isSubpath(inputs.activeRootPath, of: $0) } ?? false
+        if activeRootIsInApplicationSupport {
+            return .appleApplicationSupport
+        }
+        let root = URL(fileURLWithPath: normalizedPath(inputs.activeRootPath))
+        let rootParentPath = root.deletingLastPathComponent().path
+        let normalizedHomePath = normalizedPath(inputs.homeDirectoryPath)
+        if root.lastPathComponent.hasPrefix(".") && rootParentPath == normalizedHomePath {
+            return .homeDotDirectory
+        }
+        return .custom
+    }
+
+    private static func classifyModelsRoot(_ inputs: Inputs) -> ModelsRootClassification {
+        let modelsRootIsInApplicationSupport =
+            inputs.applicationSupportPath.map { isSubpath(inputs.modelsRootPath, of: $0) } ?? false
+        if modelsRootIsInApplicationSupport {
+            return .applicationSupport
+        }
+        if isSubpath(inputs.modelsRootPath, of: inputs.homeDirectoryPath) {
+            return .homeVisible
+        }
+        return .externalOrCustom
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    private static func isSubpath(_ path: String, of parent: String) -> Bool {
+        let child = normalizedPath(path)
+        let base = normalizedPath(parent)
+        if child == base {
+            return true
+        }
+        let prefix = base.hasSuffix("/") ? base : base + "/"
+        return child.hasPrefix(prefix)
+    }
+}

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -15,6 +15,7 @@ This document covers what's encrypted, how the key is managed, and the user-faci
 - [Storage Settings](#storage-settings)
 - [Background Maintenance](#background-maintenance)
 - [Storage Paths Reference](#storage-paths-reference)
+- [Storage Location Standards](#storage-location-standards)
 - [Limitations and Trade-offs](#limitations-and-trade-offs)
 
 ---
@@ -172,6 +173,34 @@ The ticker is started from [`AppDelegate`](../Packages/OsaurusCore/AppDelegate.s
 | `~/.osaurus/scheduler.sqlite` | SQLCipher cross-agent next-run + pause slots |
 
 The DEK lives in macOS Keychain, **not** in `~/.osaurus/`.
+
+---
+
+## Storage Location Standards
+
+Issue [#1422](https://github.com/osaurus-ai/osaurus/issues/1422) is right: the app-data root `~/.osaurus/` follows neither [Apple's file-system guidance](https://developer.apple.com/documentation/foundation/using-the-file-system-effectively) (app data belongs under `~/Library/Application Support/`) nor the [XDG base-directory spec](https://specifications.freedesktop.org/basedir/latest/) (`~/.local/share/`, `~/.config/`, `~/.cache/`). Historically the data deliberately moved *out of* `~/Library/Application Support/com.dinoki.osaurus/` *into* `~/.osaurus/` (see `OsaurusPaths.defaultRoot`), so this is a known trade-off, not an accident.
+
+### Where things stand
+
+| Root | Current location | Spec-compliant target |
+|---|---|---|
+| App data | `~/.osaurus/` | `~/Library/Application Support/Osaurus/` |
+| Legacy app data | `~/Library/Application Support/com.dinoki.osaurus/` (merged into `~/.osaurus/` when present; never deleted) | n/a — retired after a one-shot migration marker lands |
+| Model weights | `~/MLXModels/` (legacy `~/Documents/MLXModels/`, env override, or user-picked folder) | separate decision — weights are user-managed and home-visible by design |
+
+### The audit surface
+
+`GET /admin/cache-stats` now returns a read-only `storage_locations` block (built by [`StorageLocationStandards`](../Packages/OsaurusCore/Utils/StorageLocationStandards.swift)) reporting: the active root and its classification (`apple_application_support`, `home_dot_directory`, `test_override`, `environment_override`, `custom`), `spec_compliant`, whether the legacy `com.dinoki.osaurus` root still exists, the models root classification, and stable snake_case `reason_codes` with human-readable findings. The audit never creates, copies, moves, or deletes anything.
+
+### Why the root has not moved (yet)
+
+Relocating `~/.osaurus/` is a data-safety decision pending an explicit maintainer call, because:
+
+- The Keychain DEK is paired with the existing tree, and the HKDF salt sidecar (`~/.osaurus/.storage-key.salt`) must travel with the data it unlocks (see Key Management above).
+- Sandbox tooling references `~/.osaurus/` literally (e.g. the node workspace path), and plugin/container trees can be many gigabytes — a silent move on upgrade is not acceptable.
+- `OsaurusPaths.defaultRoot` currently **re-merges** a still-present legacy `com.dinoki.osaurus/` root into `~/.osaurus/` on the first path access of every launch (newer file wins), which can resurrect files the user has since changed. Any migration design must first add a one-shot migration marker so this loop ends.
+
+Until that decision, the contract is: paths resolve exclusively through `OsaurusPaths`, the audit reports reality instead of hiding it, and no code outside `OsaurusPaths` may invent a storage root.
 
 ---
 


### PR DESCRIPTION
## Maintainer status

Ready for maintainer review. This PR is non-draft, rebased on current main, and implements the storage-location standards audit as a single focused feature.

## Maintainer rationale

**Business rationale:** Users need clear diagnostics before any storage migration work. This adds a read-only audit for the active Osaurus storage root, legacy root presence, model root placement, and Apple Application Support compliance without moving data or changing defaults.

**Coding rationale:** The audit is isolated in `StorageLocationStandards`, exposed through the existing cache-stats admin surface, documented in `docs/STORAGE.md`, and covered by focused tests for home-dot-directory, Application Support, legacy roots, overrides, and JSON output stability.

## Acceptance criteria

- Read-only storage-location diagnostics report active root class, model root class, legacy-root caveats, and migration readiness.
- Existing `~/.osaurus` behavior is classified as current by-design rather than silently changed.
- Admin cache stats exposes the diagnostic surface without requiring a model load or migration.
- Tests pin reason codes, summary text, JSON shape, override behavior, and legacy-root warnings.
- No storage data is created, copied, deleted, or migrated by this PR.

## Quality gate

LANE_GATE_OK 2026-06-12T10:47:04Z

- [x] `git fetch --all --prune` before push; base `origin/main` `f1b069debc9a` (`fixed main thread app hangs (#1472)`).
- [x] `git rebase origin/main`; one `HTTPHandler.swift` conflict resolved by keeping upstream runtime/cache coverage and adding the storage diagnostic field.
- [x] `git diff --check origin/main`.
- [x] `swift-format lint --configuration .swift-format --strict --recursive` on touched storage/network/test paths.
- [x] `swiftlint lint --config .swiftlint.yml --force-exclude` on the new storage helper: 0 violations. The broader touched-file lint command reports existing unrelated warnings in `HTTPHandler.swift` only.
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-storage-style-* swift test --package-path Packages/OsaurusCore --filter 'StorageLocationStandardsTests|RuntimePolicySourceTests'` (101 tests).
- [x] `swift build --package-path Packages/OsaurusCore -c release` succeeded on the pushed head; existing repo warnings only.
- [ ] GitHub CI on this PR head.

## Debug evidence

The focused tests exercise Apple Application Support detection, the existing home-dot-directory root, custom roots, test/environment overrides, model-root classification, legacy root warnings, JSON serialization, and cache-stats exposure.

## Self-review

### Regression review

This is read-only diagnostic code plus one admin JSON field. It does not alter `OsaurusPaths.root()`, model-path resolution, database paths, Keychain access, migration behavior, or default tool exposure.

### Performance review

The audit uses path normalization and file-exists checks only. It avoids directory walks and is safe to call from the cache-stats diagnostic path.

## Rollback

Revert this PR commit to remove the storage diagnostic type, cache-stats field, tests, and docs update. No data migration rollback is needed because this PR does not mutate storage.
