### PR TITLE
Harden skill archive imports

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
+++ b/Packages/OsaurusCore/Managers/SkillImportPolicy.swift
@@ -1,0 +1,226 @@
+//
+//  SkillImportPolicy.swift
+//  osaurus
+//
+//  Guardrails for importing third-party skill archives before they enter the
+//  persisted skill store.
+//
+
+import Foundation
+
+/// Import limits for a third-party skill bundle. The defaults are intentionally
+/// generous for normal skill packs while still bounding the user-clicked ZIP
+/// path before extraction and again before persistence.
+public struct SkillImportPolicy: Sendable, Equatable {
+    public static let `default` = SkillImportPolicy()
+
+    public let maxArchiveBytes: Int64
+    public let maxEntryBytes: Int64
+    public let maxEntryCount: Int
+    public let maxPathDepth: Int
+
+    public init(
+        maxArchiveBytes: Int64 = 50 * 1024 * 1024,
+        maxEntryBytes: Int64 = 10 * 1024 * 1024,
+        maxEntryCount: Int = 512,
+        maxPathDepth: Int = 16
+    ) {
+        self.maxArchiveBytes = maxArchiveBytes
+        self.maxEntryBytes = maxEntryBytes
+        self.maxEntryCount = maxEntryCount
+        self.maxPathDepth = maxPathDepth
+    }
+
+    public func validateArchiveBeforeExtraction(_ zipURL: URL) throws {
+        let attributes = try FileManager.default.attributesOfItem(atPath: zipURL.path)
+        let archiveBytes = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        guard archiveBytes <= maxArchiveBytes else {
+            throw SkillFileError.archiveTooLarge(limitBytes: maxArchiveBytes)
+        }
+
+        let entries = try Self.listArchiveEntries(in: zipURL)
+        try validateArchiveEntries(entries)
+    }
+
+    func validateArchiveEntries(_ entries: [SkillArchiveEntry]) throws {
+        guard entries.count <= maxEntryCount else {
+            throw SkillFileError.archiveEntryLimitExceeded(limit: maxEntryCount)
+        }
+
+        for entry in entries {
+            try validateArchivePath(entry.name)
+            if !entry.isDirectory, entry.uncompressedSize > maxEntryBytes {
+                throw SkillFileError.archiveEntryTooLarge(path: entry.name, limitBytes: maxEntryBytes)
+            }
+        }
+    }
+
+    func validateArchiveEntryNames(_ names: [String]) throws {
+        try validateArchiveEntries(names.map { SkillArchiveEntry(name: $0, uncompressedSize: 0) })
+    }
+
+    public func scanExtractedTree(at rootURL: URL) throws -> SkillImportPlan {
+        let fileManager = FileManager.default
+        let root = rootURL.standardizedFileURL
+        let resolvedRoot = root.resolvingSymlinksInPath().standardizedFileURL
+        var fileCount = 0
+        var skillMarkdowns: [String] = []
+
+        guard
+            let enumerator = fileManager.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+                options: []
+            )
+        else {
+            throw SkillFileError.invalidSkillArchive
+        }
+
+        for case let entry as URL in enumerator {
+            let relativePath = try relativePath(for: entry, in: root)
+            try validateArchivePath(relativePath)
+
+            let values = try entry.resourceValues(
+                forKeys: [.fileSizeKey, .isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey]
+            )
+            guard values.isSymbolicLink != true else {
+                throw SkillFileError.archiveEntryUnsupported(path: relativePath)
+            }
+
+            let resolvedEntry = entry.resolvingSymlinksInPath().standardizedFileURL
+            guard Self.isContained(resolvedEntry, in: resolvedRoot) else {
+                throw SkillFileError.archiveEntryEscapes(path: relativePath)
+            }
+
+            if values.isDirectory == true {
+                continue
+            }
+
+            guard values.isRegularFile == true else {
+                throw SkillFileError.archiveEntryUnsupported(path: relativePath)
+            }
+
+            fileCount += 1
+            guard fileCount <= maxEntryCount else {
+                throw SkillFileError.archiveEntryLimitExceeded(limit: maxEntryCount)
+            }
+
+            let fileSize = Int64(values.fileSize ?? 0)
+            guard fileSize <= maxEntryBytes else {
+                throw SkillFileError.archiveEntryTooLarge(path: relativePath, limitBytes: maxEntryBytes)
+            }
+
+            if entry.lastPathComponent == "SKILL.md" {
+                skillMarkdowns.append(relativePath)
+            }
+        }
+
+        guard let selected = Self.selectedSkillMarkdown(from: skillMarkdowns) else {
+            throw SkillFileError.invalidSkillArchive
+        }
+
+        let ignored = skillMarkdowns.filter { $0 != selected }.sorted()
+        let skillMarkdownURL = root.appendingPathComponent(selected)
+        return SkillImportPlan(
+            skillMarkdownURL: skillMarkdownURL,
+            skillRootURL: skillMarkdownURL.deletingLastPathComponent(),
+            selectedSkillMarkdownPath: selected,
+            ignoredSkillMarkdownPaths: ignored
+        )
+    }
+
+    private func validateArchivePath(_ path: String) throws {
+        guard !path.isEmpty, !(path as NSString).isAbsolutePath else {
+            throw SkillFileError.archiveEntryEscapes(path: path)
+        }
+
+        var components = path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        if components.last?.isEmpty == true {
+            components.removeLast()
+        }
+        guard !components.isEmpty else {
+            throw SkillFileError.archiveEntryEscapes(path: path)
+        }
+        guard !components.contains(where: { $0.isEmpty || $0 == "." || $0 == ".." }) else {
+            throw SkillFileError.archiveEntryEscapes(path: path)
+        }
+        guard components.count <= maxPathDepth else {
+            throw SkillFileError.archiveEntryTooDeep(path: path, limit: maxPathDepth)
+        }
+    }
+
+    private func relativePath(for fileURL: URL, in baseDirectory: URL) throws -> String {
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.pathComponents
+        guard fileComponents.count > baseComponents.count,
+            Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            throw SkillFileError.archiveEntryEscapes(path: fileURL.path)
+        }
+        return fileComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    private static func selectedSkillMarkdown(from paths: [String]) -> String? {
+        paths.min { lhs, rhs in
+            let lhsDepth = lhs.split(separator: "/").count
+            let rhsDepth = rhs.split(separator: "/").count
+            if lhsDepth != rhsDepth { return lhsDepth < rhsDepth }
+            return lhs < rhs
+        }
+    }
+
+    private static func isContained(_ fileURL: URL, in baseDirectory: URL) -> Bool {
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.pathComponents
+        return fileComponents.count >= baseComponents.count
+            && Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+    }
+
+    private static func listArchiveEntries(in zipURL: URL) throws -> [SkillArchiveEntry] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-l", zipURL.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw SkillFileError.archiveListingFailed(output.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        return output.split(separator: "\n").compactMap { line -> SkillArchiveEntry? in
+            let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count >= 4, let size = Int64(parts[0]) else {
+                return nil
+            }
+            let name = parts.dropFirst(3).joined(separator: " ")
+            return SkillArchiveEntry(name: name, uncompressedSize: size)
+        }
+    }
+}
+
+struct SkillArchiveEntry: Sendable, Equatable {
+    let name: String
+    let uncompressedSize: Int64
+
+    var isDirectory: Bool {
+        name.hasSuffix("/")
+    }
+}
+
+public struct SkillImportPlan: Sendable, Equatable {
+    public let skillMarkdownURL: URL
+    public let skillRootURL: URL
+    public let selectedSkillMarkdownPath: String
+    public let ignoredSkillMarkdownPaths: [String]
+}
+
+public struct SkillImportResult: Sendable, Equatable {
+    public let skill: Skill
+    public let notes: [String]
+}

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -9,12 +9,21 @@ import Foundation
 import Observation
 import SwiftUI
 
-public enum SkillFileError: Error, LocalizedError {
+public enum SkillFileError: Error, LocalizedError, Sendable {
     case cannotModifyBuiltIn
     case cannotModifyPluginSkill
     case skillNotFound
     case exportFailed
     case invalidSkillArchive
+    case archiveTooLarge(limitBytes: Int64)
+    case archiveEntryTooLarge(path: String, limitBytes: Int64)
+    case archiveEntryLimitExceeded(limit: Int)
+    case archiveEntryTooDeep(path: String, limit: Int)
+    case archiveEntryEscapes(path: String)
+    case archiveEntryUnsupported(path: String)
+    case archiveListingFailed(String)
+    case skillAlreadyExists(name: String)
+    case skillImportCopyFailed(path: String, reason: String)
 
     public var errorDescription: String? {
         switch self {
@@ -23,7 +32,32 @@ public enum SkillFileError: Error, LocalizedError {
         case .skillNotFound: return L("Skill not found")
         case .exportFailed: return L("Failed to export skill")
         case .invalidSkillArchive: return L("Invalid skill archive - SKILL.md not found")
+        case .archiveTooLarge(let limitBytes):
+            return L("Skill archive is larger than the \(Self.formatBytes(limitBytes)) limit")
+        case .archiveEntryTooLarge(let path, let limitBytes):
+            return L("Skill archive entry \"\(path)\" is larger than the \(Self.formatBytes(limitBytes)) limit")
+        case .archiveEntryLimitExceeded(let limit):
+            return L("Skill archive contains more than \(limit) entries")
+        case .archiveEntryTooDeep(let path, let limit):
+            return L("Skill archive entry \"\(path)\" is deeper than the \(limit)-level limit")
+        case .archiveEntryEscapes(let path):
+            return L("Skill archive entry \"\(path)\" escapes the archive root")
+        case .archiveEntryUnsupported(let path):
+            return L("Skill archive entry \"\(path)\" is not a regular file or directory")
+        case .archiveListingFailed(let details):
+            let suffix = details.isEmpty ? "" : ": \(details)"
+            return L("Could not inspect skill archive\(suffix)")
+        case .skillAlreadyExists(let name):
+            return L("A skill named \"\(name)\" already exists")
+        case .skillImportCopyFailed(let path, let reason):
+            return L("Could not import skill file \"\(path)\": \(reason)")
         }
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        if bytes < 1024 * 1024 { return "\(bytes / 1024) KB" }
+        return "\(bytes / (1024 * 1024)) MB"
     }
 }
 
@@ -227,6 +261,11 @@ public final class SkillManager {
 
     @discardableResult
     public func importSkillFromMarkdown(_ content: String) async throws -> Skill {
+        try await importSkillFromMarkdown(content, overwriteExisting: false)
+    }
+
+    @discardableResult
+    public func importSkillFromMarkdown(_ content: String, overwriteExisting: Bool) async throws -> Skill {
         var skill = try Skill.parseAnyFormat(from: content)
         skill = Skill(
             name: skill.name,
@@ -236,7 +275,7 @@ public final class SkillManager {
             category: skill.category,
             instructions: skill.instructions
         )
-        await SkillStore.save(skill)
+        try Self.installImportedSkill(skill, from: nil, overwriteExisting: overwriteExisting)
         await refresh()
 
         Task { await SkillSearchService.shared.indexSkill(skill) }
@@ -386,25 +425,32 @@ public final class SkillManager {
 
     @discardableResult
     public func importSkillFromZip(_ zipURL: URL) async throws -> Skill {
+        let result = try await importSkillFromZip(zipURL, overwriteExisting: false)
+        return result.skill
+    }
+
+    @discardableResult
+    public func importSkillFromZip(
+        _ zipURL: URL,
+        overwriteExisting: Bool,
+        policy: SkillImportPolicy = .default
+    ) async throws -> SkillImportResult {
         // All filesystem work (unzip, SKILL.md read, nested file copies) runs
         // off the main actor — a large bundle would otherwise block the UI and
         // trip an app-hang. Only the trailing `refresh()` (which mutates
         // observed state) hops back to the main actor.
-        let skill = try await Task.detached(priority: .userInitiated) {
+        let result = try await Task.detached(priority: .userInitiated) {
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
                 UUID().uuidString
             )
             defer { try? FileManager.default.removeItem(at: tempDir) }
 
+            try policy.validateArchiveBeforeExtraction(zipURL)
             try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             try await FileManager.default.unzipItem(at: zipURL, to: tempDir)
 
-            guard let skillMdURL = Self.findSkillMd(in: tempDir) else {
-                throw SkillFileError.invalidSkillArchive
-            }
-
-            let skillDir = skillMdURL.deletingLastPathComponent()
-            let content = try String(contentsOf: skillMdURL, encoding: .utf8)
+            let importPlan = try policy.scanExtractedTree(at: tempDir)
+            let content = try String(contentsOf: importPlan.skillMarkdownURL, encoding: .utf8)
             let parsed = try Skill.parseAnyFormat(from: content)
 
             let skill = Skill(
@@ -418,64 +464,196 @@ public final class SkillManager {
                 directoryName: parsed.xplaceholder_agentSkillsNamex
             )
 
-            await SkillStore.save(skill)
+            try Self.installImportedSkill(
+                skill,
+                from: importPlan.skillRootURL,
+                overwriteExisting: overwriteExisting,
+                stagingBase: tempDir
+            )
 
-            // Copy associated files
-            let destDir = SkillStore.skillDirectory(for: skill)
-            for subdir in ["references", "assets"] {
-                let sourceSubdir = skillDir.appendingPathComponent(subdir)
-                let destSubdir = destDir.appendingPathComponent(subdir)
-
-                if FileManager.default.fileExists(atPath: sourceSubdir.path) {
-                    try? FileManager.default.createDirectory(
-                        at: destSubdir,
-                        withIntermediateDirectories: true
-                    )
-                    if let files = try? FileManager.default.contentsOfDirectory(
-                        at: sourceSubdir,
-                        includingPropertiesForKeys: nil
-                    ) {
-                        for file in files {
-                            try? FileManager.default.copyItem(
-                                at: file,
-                                to: destSubdir.appendingPathComponent(file.lastPathComponent)
-                            )
-                        }
-                    }
-                }
+            let notes: [String]
+            if importPlan.ignoredSkillMarkdownPaths.isEmpty {
+                notes = []
+            } else {
+                let ignored = importPlan.ignoredSkillMarkdownPaths.joined(separator: ", ")
+                notes = [
+                    L("Imported \(importPlan.selectedSkillMarkdownPath); ignored additional SKILL.md files: \(ignored)")
+                ]
             }
-
-            return skill
+            return SkillImportResult(skill: skill, notes: notes)
         }.value
 
         await refresh()
 
-        Task { await SkillSearchService.shared.indexSkill(skill) }
-        return skill
+        Task { await SkillSearchService.shared.indexSkill(result.skill) }
+        return result
     }
 
-    nonisolated private static func findSkillMd(in directory: URL) -> URL? {
-        let rootSkillMd = directory.appendingPathComponent("SKILL.md")
-        if FileManager.default.fileExists(atPath: rootSkillMd.path) {
-            return rootSkillMd
-        }
+    nonisolated private static func installImportedSkill(
+        _ skill: Skill,
+        from sourceSkillRoot: URL?,
+        overwriteExisting: Bool,
+        stagingBase: URL = FileManager.default.temporaryDirectory
+    ) throws {
+        let fileManager = FileManager.default
+        let destination = SkillStore.skillDirectory(for: skill)
+        let stage = stagingBase.appendingPathComponent("skill-import-stage-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: stage) }
 
-        if let contents = try? FileManager.default.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) {
-            for item in contents {
-                var isDir: ObjCBool = false
-                if FileManager.default.fileExists(atPath: item.path, isDirectory: &isDir), isDir.boolValue {
-                    let skillMd = item.appendingPathComponent("SKILL.md")
-                    if FileManager.default.fileExists(atPath: skillMd.path) {
-                        return skillMd
+        try fileManager.createDirectory(at: stage, withIntermediateDirectories: true)
+        try skill.toAgentSkillsFormatWithId().write(
+            to: stage.appendingPathComponent("SKILL.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        if let sourceSkillRoot {
+            for subdirectory in ["references", "assets"] {
+                let source = sourceSkillRoot.appendingPathComponent(subdirectory, isDirectory: true)
+                var isDirectory: ObjCBool = false
+                if fileManager.fileExists(atPath: source.path, isDirectory: &isDirectory) {
+                    guard isDirectory.boolValue else {
+                        throw SkillFileError.skillImportCopyFailed(
+                            path: subdirectory,
+                            reason: L("Expected directory")
+                        )
                     }
+                    try copyImportedSubdirectory(
+                        named: subdirectory,
+                        from: source,
+                        to: stage.appendingPathComponent(subdirectory, isDirectory: true)
+                    )
                 }
             }
         }
-        return nil
+
+        try installStagedSkillDirectory(
+            stage,
+            to: destination,
+            skillName: skill.name,
+            overwriteExisting: overwriteExisting
+        )
+    }
+
+    nonisolated private static func copyImportedSubdirectory(
+        named name: String,
+        from source: URL,
+        to destination: URL
+    ) throws {
+        let fileManager = FileManager.default
+        let sourceRoot = source.standardizedFileURL
+        let destinationRoot = destination.standardizedFileURL
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+
+        guard
+            let enumerator = fileManager.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+                options: []
+            )
+        else {
+            throw SkillFileError.skillImportCopyFailed(path: name, reason: L("Could not inspect directory"))
+        }
+
+        for case let entry as URL in enumerator {
+            let relativePath = try relativePath(for: entry, in: sourceRoot)
+            let importPath = "\(name)/\(relativePath)"
+            do {
+                let values = try entry.resourceValues(
+                    forKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey]
+                )
+                guard values.isSymbolicLink != true else {
+                    throw SkillFileError.archiveEntryUnsupported(path: importPath)
+                }
+
+                let target = destinationRoot.appendingPathComponent(relativePath)
+                try ensureContained(target, in: destinationRoot)
+
+                if values.isDirectory == true {
+                    try fileManager.createDirectory(at: target, withIntermediateDirectories: true)
+                } else if values.isRegularFile == true {
+                    try fileManager.createDirectory(
+                        at: target.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    try fileManager.copyItem(at: entry, to: target)
+                } else {
+                    throw SkillFileError.archiveEntryUnsupported(path: importPath)
+                }
+            } catch let error as SkillFileError {
+                throw error
+            } catch {
+                throw SkillFileError.skillImportCopyFailed(path: importPath, reason: error.localizedDescription)
+            }
+        }
+    }
+
+    nonisolated private static func installStagedSkillDirectory(
+        _ stage: URL,
+        to destination: URL,
+        skillName: String,
+        overwriteExisting: Bool
+    ) throws {
+        let fileManager = FileManager.default
+        let parent = destination.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: destination.path, isDirectory: &isDirectory)
+        if exists {
+            guard isDirectory.boolValue else {
+                throw SkillFileError.skillImportCopyFailed(
+                    path: destination.lastPathComponent,
+                    reason: L("Destination exists and is not a directory")
+                )
+            }
+            guard overwriteExisting else {
+                throw SkillFileError.skillAlreadyExists(name: skillName)
+            }
+        }
+
+        if !exists {
+            try fileManager.moveItem(at: stage, to: destination)
+            return
+        }
+
+        let backup = parent.appendingPathComponent(
+            ".\(destination.lastPathComponent).import-backup-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.moveItem(at: destination, to: backup)
+        do {
+            try fileManager.moveItem(at: stage, to: destination)
+            try? fileManager.removeItem(at: backup)
+        } catch {
+            try? fileManager.removeItem(at: destination)
+            try? fileManager.moveItem(at: backup, to: destination)
+            throw SkillFileError.skillImportCopyFailed(
+                path: destination.lastPathComponent,
+                reason: error.localizedDescription
+            )
+        }
+    }
+
+    nonisolated private static func relativePath(for fileURL: URL, in baseDirectory: URL) throws -> String {
+        let fileComponents = fileURL.standardizedFileURL.pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.pathComponents
+        guard fileComponents.count > baseComponents.count,
+            Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            throw SkillFileError.archiveEntryEscapes(path: fileURL.path)
+        }
+        return fileComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+
+    nonisolated private static func ensureContained(_ fileURL: URL, in baseDirectory: URL) throws {
+        let fileComponents = fileURL.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        let baseComponents = baseDirectory.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        guard fileComponents.count >= baseComponents.count,
+            Array(fileComponents.prefix(baseComponents.count)) == baseComponents
+        else {
+            throw SkillFileError.archiveEntryEscapes(path: fileURL.path)
+        }
     }
 
     // MARK: - Catalog & Instructions

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -57828,6 +57828,246 @@
         }
       }
     },
+    "A skill named \"%@\" already exists" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ein Skill namens \"%@\" existiert bereits"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "名为“%@”的技能已存在"
+          }
+        }
+      }
+    },
+    "Could not import skill file \"%@\": %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Datei \"%@\" konnte nicht importiert werden: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法导入技能文件“%@”：%@"
+          }
+        }
+      }
+    },
+    "Could not inspect directory" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verzeichnis konnte nicht geprüft werden"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法检查目录"
+          }
+        }
+      }
+    },
+    "Could not inspect skill archive%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiv%@ konnte nicht geprüft werden"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法检查技能归档%@"
+          }
+        }
+      }
+    },
+    "Destination exists and is not a directory" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ziel existiert und ist kein Verzeichnis"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "目标已存在且不是目录"
+          }
+        }
+      }
+    },
+    "Expected directory" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verzeichnis erwartet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "预期为目录"
+          }
+        }
+      }
+    },
+    "Imported %@; ignored additional SKILL.md files: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Importiert %@; zusätzliche SKILL.md-Dateien ignoriert: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已导入 %@；已忽略其他 SKILL.md 文件：%@"
+          }
+        }
+      }
+    },
+    "Replace" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ersetzen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "替换"
+          }
+        }
+      }
+    },
+    "Replace Existing Skill?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bestehenden Skill ersetzen?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "替换现有技能？"
+          }
+        }
+      }
+    },
+    "Skill archive contains more than %lld entries" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiv enthält mehr als %lld Einträge"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档包含超过 %lld 个条目"
+          }
+        }
+      }
+    },
+    "Skill archive entry \"%@\" escapes the archive root" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiveintrag \"%@\" verlässt den Archivstamm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档条目“%@”会逃逸归档根目录"
+          }
+        }
+      }
+    },
+    "Skill archive entry \"%@\" is deeper than the %lld-level limit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiveintrag \"%@\" ist tiefer als die Grenze von %lld Ebenen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档条目“%@”超过 %lld 级深度限制"
+          }
+        }
+      }
+    },
+    "Skill archive entry \"%@\" is larger than the %@ limit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiveintrag \"%@\" ist größer als die Grenze von %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档条目“%@”超过 %@ 限制"
+          }
+        }
+      }
+    },
+    "Skill archive entry \"%@\" is not a regular file or directory" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiveintrag \"%@\" ist keine reguläre Datei und kein Verzeichnis"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档条目“%@”不是常规文件或目录"
+          }
+        }
+      }
+    },
+    "Skill archive is larger than the %@ limit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Skill-Archiv ist größer als die Grenze von %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "技能归档超过 %@ 限制"
+          }
+        }
+      }
+    },
     "Zip Bundle" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillImportPolicyTests.swift
@@ -1,0 +1,403 @@
+//
+//  SkillImportPolicyTests.swift
+//  OsaurusCoreTests
+//
+//  Exercises third-party skill archive bounds before imported files enter the
+//  persisted skill directory.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SkillImportPolicyTests {
+
+    @Test func zipImportCopiesReferencesAndAssets() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "safe-skill-bundle",
+                skillName: "Safe Skill",
+                references: ["guide.md": "reference"],
+                assets: ["images/icon.txt": "asset"]
+            )
+            let zipURL = try Self.makeZip(from: source, in: root)
+
+            let result = try await SkillManager.shared.importSkillFromZip(
+                zipURL,
+                overwriteExisting: false,
+                policy: .test
+            )
+
+            #expect(result.skill.name == "Safe Skill")
+            #expect(result.notes.isEmpty)
+
+            let skillDir = SkillStore.skillDirectory(for: result.skill)
+            #expect(
+                try String(
+                    contentsOf: skillDir.appendingPathComponent("references/guide.md"),
+                    encoding: .utf8
+                ) == "reference"
+            )
+            #expect(
+                try String(
+                    contentsOf: skillDir.appendingPathComponent("assets/images/icon.txt"),
+                    encoding: .utf8
+                ) == "asset"
+            )
+
+            let loaded = await SkillStore.load(id: result.skill.id)
+            #expect(loaded?.references.contains { $0.relativePath == "references/guide.md" } == true)
+            #expect(loaded?.assets.contains { $0.relativePath == "assets/images/icon.txt" } == true)
+        }
+    }
+
+    @Test func archivePathValidationRejectsTraversalAndDepth() throws {
+        try Self.expectSkillFileError(matching: { error in
+            if case .archiveEntryEscapes("../SKILL.md") = error { return true }
+            return false
+        }) {
+            try SkillImportPolicy.test.validateArchiveEntryNames(["../SKILL.md"])
+        }
+
+        try Self.expectSkillFileError(matching: { error in
+            if case .archiveEntryTooDeep("a/b/c/d/SKILL.md", 3) = error { return true }
+            return false
+        }) {
+            try SkillImportPolicy(
+                maxArchiveBytes: 1_000_000,
+                maxEntryBytes: 1_000_000,
+                maxEntryCount: 20,
+                maxPathDepth: 3
+            )
+            .validateArchiveEntryNames(["a/b/c/d/SKILL.md"])
+        }
+    }
+
+    @Test func archiveCapsRejectBeforeExtraction() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "large-skill-bundle",
+                skillName: "Large Skill",
+                references: ["large.txt": String(repeating: "x", count: 256)]
+            )
+            let zipURL = try Self.makeZip(from: source, in: root)
+
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveEntryTooLarge(let path, 64) = error {
+                    return path.hasSuffix("references/large.txt")
+                }
+                return false
+            }) {
+                try SkillImportPolicy(maxArchiveBytes: 1_000_000, maxEntryBytes: 64, maxEntryCount: 20, maxPathDepth: 8)
+                    .validateArchiveBeforeExtraction(zipURL)
+            }
+
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveTooLarge(32) = error { return true }
+                return false
+            }) {
+                try SkillImportPolicy(maxArchiveBytes: 32, maxEntryBytes: 1_000_000, maxEntryCount: 20, maxPathDepth: 8)
+                    .validateArchiveBeforeExtraction(zipURL)
+            }
+        }
+    }
+
+    @Test func extractedTreeRejectsSymlinksAndOversizedFiles() async throws {
+        try await Self.withTempRoot { root in
+            let symlinkBundle = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "symlink-skill-bundle",
+                skillName: "Symlink Skill"
+            )
+            let references = symlinkBundle.appendingPathComponent("references", isDirectory: true)
+            try FileManager.default.createDirectory(at: references, withIntermediateDirectories: true)
+            let outside = root.appendingPathComponent("outside-secret.txt")
+            try "secret".write(to: outside, atomically: true, encoding: .utf8)
+            try FileManager.default.createSymbolicLink(
+                at: references.appendingPathComponent("linked-secret.txt"),
+                withDestinationURL: outside
+            )
+
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveEntryUnsupported(let path) = error {
+                    return path.hasSuffix("references/linked-secret.txt")
+                }
+                return false
+            }) {
+                _ = try SkillImportPolicy.test.scanExtractedTree(at: symlinkBundle)
+            }
+
+            let oversizeBundle = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "oversize-skill-bundle",
+                skillName: "Oversize Skill",
+                references: ["too-large.txt": String(repeating: "x", count: 128)]
+            )
+            try Self.expectSkillFileError(matching: { error in
+                if case .archiveEntryTooLarge(let path, 32) = error {
+                    return path == "references/too-large.txt"
+                }
+                return false
+            }) {
+                _ = try SkillImportPolicy(
+                    maxArchiveBytes: 1_000_000,
+                    maxEntryBytes: 32,
+                    maxEntryCount: 20,
+                    maxPathDepth: 8
+                ).scanExtractedTree(at: oversizeBundle)
+            }
+        }
+    }
+
+    @Test func copyFailureLeavesNoPartialSkillDirectory() async throws {
+        try await Self.withTempRoot { root in
+            let source = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "broken-copy-bundle",
+                skillName: "Broken Copy"
+            )
+            try "not a directory".write(
+                to: source.appendingPathComponent("references"),
+                atomically: true,
+                encoding: .utf8
+            )
+            let zipURL = try Self.makeZip(from: source, in: root)
+
+            try await Self.expectAsyncSkillFileError(matching: { error in
+                if case .skillImportCopyFailed(let path, _) = error {
+                    return path == "references"
+                }
+                return false
+            }) {
+                _ = try await SkillManager.shared.importSkillFromZip(
+                    zipURL,
+                    overwriteExisting: false,
+                    policy: .test
+                )
+            }
+
+            let expectedSkill = Skill(name: "Broken Copy", directoryName: "broken-copy")
+            #expect(!FileManager.default.fileExists(atPath: SkillStore.skillDirectory(for: expectedSkill).path))
+        }
+    }
+
+    @Test func duplicateSkillRequiresExplicitOverwrite() async throws {
+        try await Self.withTempRoot { root in
+            let firstSource = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "replace-first",
+                skillName: "Replace Me",
+                references: ["guide.md": "first"]
+            )
+            let secondSource = try Self.makeSkillBundle(
+                in: root,
+                directoryName: "replace-second",
+                skillName: "Replace Me",
+                references: ["guide.md": "second"]
+            )
+
+            let firstZip = try Self.makeZip(from: firstSource, in: root)
+            let secondZip = try Self.makeZip(from: secondSource, in: root)
+            let first = try await SkillManager.shared.importSkillFromZip(
+                firstZip,
+                overwriteExisting: false,
+                policy: .test
+            )
+            let destination = SkillStore.skillDirectory(for: first.skill)
+            #expect(
+                try String(
+                    contentsOf: destination.appendingPathComponent("references/guide.md"),
+                    encoding: .utf8
+                ) == "first"
+            )
+
+            try await Self.expectAsyncSkillFileError(matching: { error in
+                if case .skillAlreadyExists("Replace Me") = error { return true }
+                return false
+            }) {
+                _ = try await SkillManager.shared.importSkillFromZip(
+                    secondZip,
+                    overwriteExisting: false,
+                    policy: .test
+                )
+            }
+            #expect(
+                try String(
+                    contentsOf: destination.appendingPathComponent("references/guide.md"),
+                    encoding: .utf8
+                ) == "first"
+            )
+
+            _ = try await SkillManager.shared.importSkillFromZip(
+                secondZip,
+                overwriteExisting: true,
+                policy: .test
+            )
+            #expect(
+                try String(
+                    contentsOf: destination.appendingPathComponent("references/guide.md"),
+                    encoding: .utf8
+                ) == "second"
+            )
+        }
+    }
+
+    @Test func multiSkillArchiveChoosesShallowestThenLexicographicAndReportsIgnored() async throws {
+        try await Self.withTempRoot { root in
+            let source = root.appendingPathComponent("multi-skill-bundle", isDirectory: true)
+            try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+            try Self.writeSkillMarkdown(named: "Zeta Skill", to: source.appendingPathComponent("z/SKILL.md"))
+            try Self.writeSkillMarkdown(named: "Alpha Skill", to: source.appendingPathComponent("a/SKILL.md"))
+            try Self.writeSkillMarkdown(named: "Deep Skill", to: source.appendingPathComponent("a/deep/SKILL.md"))
+
+            let zipURL = try Self.makeZip(from: source, in: root)
+            let result = try await SkillManager.shared.importSkillFromZip(
+                zipURL,
+                overwriteExisting: false,
+                policy: .test
+            )
+
+            #expect(result.skill.name == "Alpha Skill")
+            #expect(result.notes.count == 1)
+            #expect(result.notes[0].contains("multi-skill-bundle/z/SKILL.md"))
+            #expect(result.notes[0].contains("multi-skill-bundle/a/deep/SKILL.md"))
+        }
+    }
+
+    private static func withTempRoot<T: Sendable>(
+        _ body: @Sendable (URL) async throws -> T
+    ) async throws -> T {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-skill-import-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousRoot = OsaurusPaths.overrideRoot
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+            await SkillManager.shared.refresh()
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+            return try await body(root)
+        }
+    }
+
+    private static func makeSkillBundle(
+        in root: URL,
+        directoryName: String,
+        skillName: String,
+        references: [String: String] = [:],
+        assets: [String: String] = [:]
+    ) throws -> URL {
+        let source = root.appendingPathComponent(directoryName, isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try Self.writeSkillMarkdown(named: skillName, to: source.appendingPathComponent("SKILL.md"))
+
+        for (path, content) in references {
+            let url = source.appendingPathComponent("references/\(path)")
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try content.write(
+                to: url,
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        for (path, content) in assets {
+            let url = source.appendingPathComponent("assets/\(path)")
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try content.write(
+                to: url,
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        return source
+    }
+
+    private static func writeSkillMarkdown(named name: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try """
+        ---
+        name: \(name)
+        description: Test skill
+        version: 1.0.0
+        ---
+
+        # \(name)
+
+        Follow the test instructions.
+        """
+        .write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private static func makeZip(from source: URL, in root: URL) throws -> URL {
+        let zipURL = root.appendingPathComponent("\(source.lastPathComponent)-\(UUID().uuidString).zip")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.currentDirectoryURL = source.deletingLastPathComponent()
+        process.arguments = ["-r", "-q", zipURL.path, source.lastPathComponent]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "SkillImportPolicyTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: output]
+            )
+        }
+        return zipURL
+    }
+
+    private static func expectSkillFileError(
+        matching predicate: (SkillFileError) -> Bool,
+        operation: () throws -> Void
+    ) throws {
+        do {
+            try operation()
+            Issue.record("Expected SkillFileError")
+        } catch let error as SkillFileError {
+            #expect(predicate(error), "Unexpected error: \(error)")
+        }
+    }
+
+    private static func expectAsyncSkillFileError(
+        matching predicate: (SkillFileError) -> Bool,
+        operation: () async throws -> Void
+    ) async throws {
+        do {
+            try await operation()
+            Issue.record("Expected SkillFileError")
+        } catch let error as SkillFileError {
+            #expect(predicate(error), "Unexpected error: \(error)")
+        }
+    }
+}
+
+extension SkillImportPolicy {
+    fileprivate static let test = SkillImportPolicy(
+        maxArchiveBytes: 1_000_000,
+        maxEntryBytes: 1_000_000,
+        maxEntryCount: 40,
+        maxPathDepth: 8
+    )
+}

--- a/Packages/OsaurusCore/Views/Skill/SkillsView.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillsView.swift
@@ -26,6 +26,9 @@ struct SkillsView: View {
     @State private var showProgress = false
     @State private var searchText = ""
     @State private var selectedTab: SkillsTab = .all
+    @State private var pendingOverwriteImportURL: URL?
+    @State private var pendingOverwriteSkillName = ""
+    @State private var showOverwriteConfirmation = false
 
     /// Base skill set for a tab: All, Installed (user-created + plugin), or
     /// Default (built-in).
@@ -201,6 +204,26 @@ struct SkillsView: View {
                 }
             )
         }
+        .alert(L("Replace Existing Skill?"), isPresented: $showOverwriteConfirmation) {
+            Button(L("Cancel"), role: .cancel) {
+                pendingOverwriteImportURL = nil
+                pendingOverwriteSkillName = ""
+            }
+            Button(L("Replace"), role: .destructive) {
+                guard let url = pendingOverwriteImportURL else { return }
+                pendingOverwriteImportURL = nil
+                pendingOverwriteSkillName = ""
+                Task { @MainActor in
+                    await performSkillImport(from: url, overwriteExisting: true)
+                }
+            }
+        } message: {
+            Text(
+                L(
+                    "A skill named \"\(pendingOverwriteSkillName)\" already exists. Replacing it overwrites its SKILL.md, references, and assets."
+                )
+            )
+        }
         .onChange(of: isProcessing || skillManager.isRefreshing) { _, newValue in
             if newValue {
                 // Delay showing the progress bar to avoid flickering for fast operations
@@ -301,28 +324,46 @@ struct SkillsView: View {
         panel.begin { response in
             guard response == .OK, let url = panel.url else { return }
             Task { @MainActor in
-                self.isProcessing = true
-                defer { self.isProcessing = false }
-                do {
-                    let skill: Skill
-                    if url.pathExtension.lowercased() == "zip" {
-                        skill = try await skillManager.importSkillFromZip(url)
-                    } else {
-                        // Read off the main thread so a large file can't hang the UI.
-                        let content = try await Task.detached(priority: .userInitiated) {
-                            try String(contentsOf: url, encoding: .utf8)
-                        }.value
-                        skill = try await skillManager.importSkillFromMarkdown(content)
-                    }
-                    self.showToast(L("Imported \"\(skill.name)\""))
-                } catch {
-                    self.showToast(
-                        L("Import failed: \(error.localizedDescription)"),
-                        isError: true
-                    )
-                }
+                await self.performSkillImport(from: url, overwriteExisting: false)
             }
         }
+    }
+
+    @MainActor
+    private func performSkillImport(from url: URL, overwriteExisting: Bool) async {
+        isProcessing = true
+        defer { isProcessing = false }
+        do {
+            if url.pathExtension.lowercased() == "zip" {
+                let result = try await skillManager.importSkillFromZip(url, overwriteExisting: overwriteExisting)
+                showImportSuccess(for: result.skill, notes: result.notes)
+            } else {
+                // Read off the main thread so a large file can't hang the UI.
+                let content = try await Task.detached(priority: .userInitiated) {
+                    try String(contentsOf: url, encoding: .utf8)
+                }.value
+                let skill = try await skillManager.importSkillFromMarkdown(
+                    content,
+                    overwriteExisting: overwriteExisting
+                )
+                showImportSuccess(for: skill, notes: [])
+            }
+        } catch SkillFileError.skillAlreadyExists(let name) {
+            pendingOverwriteImportURL = url
+            pendingOverwriteSkillName = name
+            showOverwriteConfirmation = true
+        } catch {
+            showToast(
+                L("Import failed: \(error.localizedDescription)"),
+                isError: true
+            )
+        }
+    }
+
+    @MainActor
+    private func showImportSuccess(for skill: Skill, notes: [String]) {
+        let note = notes.first.map { " \($0)" } ?? ""
+        showToast(L("Imported \"\(skill.name)\"") + note)
     }
 
     // MARK: - Empty State

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -57,6 +57,13 @@ Import skills from local files:
 | `.json` | JSON export format |
 | `.zip` | ZIP archive with `SKILL.md` and optional `references/` and `assets/` folders |
 
+Local file imports are checked before they are saved:
+
+- ZIP archives are bounded by archive size, file count, per-file size, and path depth.
+- Archive entries must stay inside the archive root. Symlinks and non-regular files are refused.
+- If a ZIP contains more than one `SKILL.md`, Osaurus imports the shallowest path, then the lexicographically first path, and reports the ignored candidates.
+- Importing a file over an existing skill stops first and asks for an explicit replace confirmation.
+
 ---
 
 ## Managing Skills


### PR DESCRIPTION
## Summary

Harden local skill archive imports so a skill zip cannot escape the import root, sneak in symlinks, exceed bounded archive/tree caps, or silently overwrite an existing skill. Multi-skill archives now choose a deterministic skill root and report ignored candidates instead of leaving selection ambiguous.

## Business rationale

Skill import is a trust boundary. Users can import community or self-built skill bundles, so the importer should fail closed on traversal, symlinks, oversized payloads, duplicate IDs, and partial-copy errors. The UI and docs should also explain what was accepted or rejected.

## Coding rationale

The import policy is centralized so archive entry validation, extracted-tree validation, deterministic root selection, duplicate handling, and cleanup behavior stay consistent across manager and settings flows. The refresh keeps the original scope intact and only updates the branch over the stabilized current main plus a small test-warning cleanup.

## Implementation

- Adds a shared skill import policy for archive entry validation, extracted-tree validation, deterministic root selection, and duplicate handling.
- Wires the policy through the skill manager and settings view.
- Cleans partial copies on failure.
- Adds required catalog entries for new import and archive diagnostics.
- Updates the closest skill documentation.

## Acceptance criteria

- Traversal and excessive archive depth are rejected before extraction.
- Archive caps reject oversized imports before extraction.
- Extracted symlinks and oversized files are rejected.
- Duplicate imports require explicit overwrite.
- Multi-skill archives pick the shallowest then lexicographic root and report ignored candidates.
- Failed imports do not leave partial skill directories behind.
- New archive/import messages are present in the localization catalog.

## Latest refresh

Refreshed on June 15, 2026 against `origin/main` `ae4541d4` (`model picker improvements (#1515)`) after the main-gate stabilization landed. Rebase was clean; new head is `dfec04ab`. GitHub Actions is running on the refreshed head.

## Quality gate

Current refresh validation:

- `git diff --check origin/main`
- `swift-format` from Xcode toolchain on touched Swift files
- `scripts/i18n/check.sh` (passes; existing stale-key warning remains)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-skill-refresh-2 swift test --package-path Packages/OsaurusCore --filter SkillImportPolicyTests` — 7 tests passed
- GitHub Actions matrix for `dfec04ab` — running

## Self-review

### Regression review

Regression risk is limited to local skill archive imports and duplicate-skill handling. The new policy intentionally fails closed, so the main compatibility risk is rejecting malformed archives that previously imported by accident. The localization changes are catalog-only and marked for translator review.

### Performance review

Performance impact is bounded by pre-extraction caps and a single extracted-tree validation pass.

## Rollback

Revert this PR to return to the previous skill import flow and remove the new catalog entries; no migrations or persistent schema changes are introduced.