### PR TITLE
Add runtime proof matrix reporting

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofMatrixReporter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofMatrixReporter.swift
@@ -1,0 +1,404 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+
+/// Decoded output from `scripts/live-proof/classify-runtime-proof-summary.py`.
+///
+/// The classifier owns live-artifact parsing. This type intentionally models
+/// only the fields needed for the read-only matrix so the UI/docs layer cannot
+/// invent new proof claims from raw harness data.
+public struct RuntimeProofClassificationReport: Codable, Sendable, Equatable {
+    public var generatedAt: String?
+    public var summaryPath: String?
+    public var manifestPath: String?
+    public var artifactRoot: String?
+    public var verdictCounts: [String: Int]
+    public var requiredRowsNotProven: [String]
+    public var passed: Bool
+    public var rows: [RuntimeProofClassificationRow]
+    public var issueCoverage: [String: RuntimeProofIssueCoverage]
+
+    public init(
+        generatedAt: String? = nil,
+        summaryPath: String? = nil,
+        manifestPath: String? = nil,
+        artifactRoot: String? = nil,
+        verdictCounts: [String: Int] = [:],
+        requiredRowsNotProven: [String] = [],
+        passed: Bool = false,
+        rows: [RuntimeProofClassificationRow] = [],
+        issueCoverage: [String: RuntimeProofIssueCoverage] = [:]
+    ) {
+        self.generatedAt = generatedAt
+        self.summaryPath = summaryPath
+        self.manifestPath = manifestPath
+        self.artifactRoot = artifactRoot
+        self.verdictCounts = verdictCounts
+        self.requiredRowsNotProven = requiredRowsNotProven
+        self.passed = passed
+        self.rows = rows
+        self.issueCoverage = issueCoverage
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case generatedAt = "generated_at"
+        case summaryPath = "summary_path"
+        case manifestPath = "manifest_path"
+        case artifactRoot = "artifact_root"
+        case verdictCounts = "verdict_counts"
+        case requiredRowsNotProven = "required_rows_not_proven"
+        case passed
+        case rows
+        case issueCoverage = "issue_coverage"
+    }
+}
+
+public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
+    public var id: String
+    public var model: String?
+    public var family: String?
+    public var priority: String?
+    public var requirements: [String]
+    public var artifactPaths: [String]
+    public var summaryPath: String?
+    public var verdict: RuntimeProofVerdict
+    public var acceptableForProvenClaim: Bool
+    public var blockers: [RuntimeProofMatrixMessage]
+    public var warnings: [RuntimeProofMatrixMessage]
+    public var failedChecks: [String]
+
+    public init(
+        id: String,
+        model: String? = nil,
+        family: String? = nil,
+        priority: String? = nil,
+        requirements: [String] = [],
+        artifactPaths: [String] = [],
+        summaryPath: String? = nil,
+        verdict: RuntimeProofVerdict,
+        acceptableForProvenClaim: Bool = false,
+        blockers: [RuntimeProofMatrixMessage] = [],
+        warnings: [RuntimeProofMatrixMessage] = [],
+        failedChecks: [String] = []
+    ) {
+        self.id = id
+        self.model = model
+        self.family = family
+        self.priority = priority
+        self.requirements = requirements
+        self.artifactPaths = artifactPaths
+        self.summaryPath = summaryPath
+        self.verdict = verdict
+        self.acceptableForProvenClaim = acceptableForProvenClaim
+        self.blockers = blockers
+        self.warnings = warnings
+        self.failedChecks = failedChecks
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case model
+        case family
+        case priority
+        case requirements
+        case artifactPaths = "artifact_paths"
+        case summaryPath = "summary_path"
+        case verdict
+        case acceptableForProvenClaim = "acceptable_for_proven_claim"
+        case blockers
+        case warnings
+        case failedChecks = "failed_checks"
+    }
+}
+
+public struct RuntimeProofIssueCoverage: Codable, Sendable, Equatable {
+    public var verdict: RuntimeProofVerdict
+    public var note: String
+    public var rows: [String]
+    public var requiredRowsNotProven: [String]
+
+    public init(
+        verdict: RuntimeProofVerdict,
+        note: String,
+        rows: [String] = [],
+        requiredRowsNotProven: [String] = []
+    ) {
+        self.verdict = verdict
+        self.note = note
+        self.rows = rows
+        self.requiredRowsNotProven = requiredRowsNotProven
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case verdict
+        case note
+        case rows
+        case requiredRowsNotProven = "required_rows_not_proven"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.verdict = try container.decode(RuntimeProofVerdict.self, forKey: .verdict)
+        self.note = try container.decodeIfPresent(String.self, forKey: .note) ?? ""
+        self.rows = try container.decodeIfPresent([String].self, forKey: .rows) ?? []
+        self.requiredRowsNotProven =
+            try container.decodeIfPresent([String].self, forKey: .requiredRowsNotProven) ?? []
+    }
+}
+
+public struct RuntimeProofMatrixMessage: Codable, Sendable, Equatable {
+    public var requirement: String?
+    public var message: String
+
+    public init(requirement: String? = nil, message: String) {
+        self.requirement = requirement
+        self.message = message
+    }
+}
+
+public struct RuntimeProofMatrixRow: Codable, Sendable, Equatable {
+    public var id: String
+    public var model: String
+    public var family: String
+    public var priority: String
+    public var verdict: RuntimeProofVerdict
+    public var requirements: [String]
+    public var evidencePointers: [String]
+    public var blockers: [String]
+    public var isSchemaOnly: Bool
+
+    public init(
+        id: String,
+        model: String,
+        family: String,
+        priority: String,
+        verdict: RuntimeProofVerdict,
+        requirements: [String],
+        evidencePointers: [String],
+        blockers: [String],
+        isSchemaOnly: Bool = false
+    ) {
+        self.id = id
+        self.model = model
+        self.family = family
+        self.priority = priority
+        self.verdict = verdict
+        self.requirements = requirements
+        self.evidencePointers = evidencePointers
+        self.blockers = blockers
+        self.isSchemaOnly = isSchemaOnly
+    }
+}
+
+public struct RuntimeProofMatrixSurface: Codable, Sendable, Equatable {
+    public var generatedAt: String
+    public var sourceClassificationPath: String?
+    public var artifactRoot: String?
+    public var verdictCounts: [String: Int]
+    public var rows: [RuntimeProofMatrixRow]
+    public var issueCoverage: [String: RuntimeProofIssueCoverage]
+
+    public init(
+        generatedAt: String,
+        sourceClassificationPath: String?,
+        artifactRoot: String?,
+        verdictCounts: [String: Int],
+        rows: [RuntimeProofMatrixRow],
+        issueCoverage: [String: RuntimeProofIssueCoverage]
+    ) {
+        self.generatedAt = generatedAt
+        self.sourceClassificationPath = sourceClassificationPath
+        self.artifactRoot = artifactRoot
+        self.verdictCounts = verdictCounts
+        self.rows = rows
+        self.issueCoverage = issueCoverage
+    }
+}
+
+public enum RuntimeProofMatrixReporter {
+    public static let markdownBeginMarker = "<!-- BEGIN RUNTIME PROOF MATRIX -->"
+    public static let markdownEndMarker = "<!-- END RUNTIME PROOF MATRIX -->"
+
+    public static func decodeClassification(data: Data) throws -> RuntimeProofClassificationReport {
+        let decoder = JSONDecoder()
+        return try decoder.decode(RuntimeProofClassificationReport.self, from: data)
+    }
+
+    public static func surface(
+        from report: RuntimeProofClassificationReport,
+        sourceClassificationPath: String? = nil,
+        generatedAt: String? = nil
+    ) -> RuntimeProofMatrixSurface {
+        let rows = matrixRows(from: report)
+        return RuntimeProofMatrixSurface(
+            generatedAt: generatedAt ?? report.generatedAt ?? "unknown",
+            sourceClassificationPath: sourceClassificationPath,
+            artifactRoot: report.artifactRoot,
+            verdictCounts: verdictCounts(for: rows),
+            rows: rows,
+            issueCoverage: report.issueCoverage
+        )
+    }
+
+    public static func matrixRows(from report: RuntimeProofClassificationReport) -> [RuntimeProofMatrixRow] {
+        let liveRows = report.rows.map(matrixRow(from:))
+        let existing = Set(liveRows.map(\.id))
+        let schemaRows = requiredSchemaRows.filter { !existing.contains($0.id) }
+        return (liveRows + schemaRows).sorted(by: rowSort)
+    }
+
+    public static func markdownMatrix(
+        from report: RuntimeProofClassificationReport,
+        sourceClassificationPath: String? = nil,
+        generatedAt: String? = nil
+    ) -> String {
+        let surface = surface(
+            from: report,
+            sourceClassificationPath: sourceClassificationPath,
+            generatedAt: generatedAt
+        )
+        var lines: [String] = [
+            markdownBeginMarker,
+            "",
+            "Generated from \(escapeMarkdown(surface.sourceClassificationPath ?? report.summaryPath ?? "PROOF_CLASSIFICATION.json")) at \(escapeMarkdown(surface.generatedAt)).",
+            "",
+            "| Row | Model | Family | Verdict | Requirements | Evidence | Blockers |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for row in surface.rows {
+            lines.append(
+                [
+                    row.id,
+                    row.model,
+                    row.family,
+                    row.verdict.rawValue,
+                    row.requirements.joined(separator: ", "),
+                    row.evidencePointers.isEmpty ? "none" : row.evidencePointers.joined(separator: "<br>"),
+                    row.blockers.isEmpty ? "none" : row.blockers.joined(separator: "<br>"),
+                ]
+                .map(escapeMarkdown)
+                .joined(separator: " | ")
+                .withMarkdownTablePipes()
+            )
+        }
+        lines.append("")
+        lines.append(markdownEndMarker)
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    public static func replaceMarkedMatrix(in document: String, with matrixMarkdown: String) -> String {
+        guard
+            let begin = document.range(of: markdownBeginMarker),
+            let end = document.range(of: markdownEndMarker, range: begin.upperBound ..< document.endIndex)
+        else {
+            let separator = document.hasSuffix("\n") ? "\n" : "\n\n"
+            return document + separator + matrixMarkdown
+        }
+        return String(document[..<begin.lowerBound]) + matrixMarkdown + String(document[end.upperBound...])
+    }
+
+    private static func matrixRow(from row: RuntimeProofClassificationRow) -> RuntimeProofMatrixRow {
+        let evidence = uniqueNonEmpty([row.summaryPath].compactMap { $0 } + row.artifactPaths)
+        let blockers = row.blockers.map { message in
+            if let requirement = message.requirement, !requirement.isEmpty {
+                return "\(requirement): \(message.message)"
+            }
+            return message.message
+        }
+        return RuntimeProofMatrixRow(
+            id: row.id,
+            model: row.model ?? row.id,
+            family: row.family ?? "unknown",
+            priority: row.priority ?? "unspecified",
+            verdict: row.verdict,
+            requirements: normalizedRequirements(row.requirements),
+            evidencePointers: evidence,
+            blockers: blockers,
+            isSchemaOnly: false
+        )
+    }
+
+    private static let requiredSchemaRows: [RuntimeProofMatrixRow] = [
+        RuntimeProofMatrixRow(
+            id: "issue-903-system-prompt-injection-schema",
+            model: "all local chat runtimes",
+            family: "cross-family",
+            priority: "schema-required",
+            verdict: .unproven,
+            requirements: [
+                "visible_output",
+                "tokens_per_second",
+                "no_parser_marker_leak",
+                "multi_turn_coherency",
+                "system_prompt_injection",
+            ],
+            evidencePointers: [],
+            blockers: [
+                "requires a live artifact with an explicit system-prompt injection probe, visible output, token/s, multi-turn coherency, and no parser marker leakage"
+            ],
+            isSchemaOnly: true
+        ),
+        RuntimeProofMatrixRow(
+            id: "issue-1163-hy3-harmony-retro-validation-schema",
+            model: "Hy3/harmony local rows",
+            family: "hy3",
+            priority: "schema-required",
+            verdict: .unproven,
+            requirements: [
+                "visible_output",
+                "tokens_per_second",
+                "no_parser_marker_leak",
+                "multi_turn_coherency",
+            ],
+            evidencePointers: [],
+            blockers: [
+                "requires a Hy3/harmony live artifact; sibling model rows or source-only parser checks do not prove this issue"
+            ],
+            isSchemaOnly: true
+        ),
+    ]
+
+    private static func normalizedRequirements(_ requirements: [String]) -> [String] {
+        requirements
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .sorted()
+    }
+
+    private static func uniqueNonEmpty(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for value in values where !value.isEmpty && !seen.contains(value) {
+            seen.insert(value)
+            result.append(value)
+        }
+        return result
+    }
+
+    private static func verdictCounts(for rows: [RuntimeProofMatrixRow]) -> [String: Int] {
+        Dictionary(grouping: rows, by: { $0.verdict.rawValue })
+            .mapValues(\.count)
+            .merging(
+                Dictionary(uniqueKeysWithValues: RuntimeProofVerdict.allCases.map { ($0.rawValue, 0) }),
+                uniquingKeysWith: { lhs, _ in lhs }
+            )
+    }
+
+    private static func rowSort(_ lhs: RuntimeProofMatrixRow, _ rhs: RuntimeProofMatrixRow) -> Bool {
+        let left = [lhs.family, lhs.model, lhs.id]
+        let right = [rhs.family, rhs.model, rhs.id]
+        return left.lexicographicallyPrecedes(right)
+    }
+
+    private static func escapeMarkdown(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\n", with: "<br>")
+            .replacingOccurrences(of: "|", with: "\\|")
+    }
+}
+
+extension String {
+    fileprivate func withMarkdownTablePipes() -> String {
+        "| \(self) |"
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimeProofMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimeProofMatrixTests.swift
@@ -1,0 +1,178 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Runtime proof matrix reporter")
+struct RuntimeProofMatrixTests {
+    @Test("markdown matrix renders deterministically from classification JSON")
+    func markdownMatrixIsDeterministic() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+
+        let first = RuntimeProofMatrixReporter.markdownMatrix(
+            from: report,
+            sourceClassificationPath: "/tmp/runtime/PROOF_CLASSIFICATION.json",
+            generatedAt: "2026-06-11T00:00:00Z"
+        )
+        let second = RuntimeProofMatrixReporter.markdownMatrix(
+            from: report,
+            sourceClassificationPath: "/tmp/runtime/PROOF_CLASSIFICATION.json",
+            generatedAt: "2026-06-11T00:00:00Z"
+        )
+
+        #expect(first == second)
+        #expect(first.contains("| gemma4-text-required | Gemma4 text | gemma4 | proven |"))
+        #expect(first.contains("issue-903-system-prompt-injection-schema"))
+        #expect(first.contains("issue-1163-hy3-harmony-retro-validation-schema"))
+        #expect(
+            first.contains(
+                "| issue-903-system-prompt-injection-schema | all local chat runtimes | cross-family | unproven |"
+            )
+        )
+    }
+
+    @Test("schema-only issue rows stay unproven and require evidence fields")
+    func schemaRowsRemainUnproven() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+        let rows = RuntimeProofMatrixReporter.matrixRows(from: report)
+
+        let promptInjection = try #require(rows.first { $0.id == "issue-903-system-prompt-injection-schema" })
+        #expect(promptInjection.verdict == .unproven)
+        #expect(promptInjection.isSchemaOnly)
+        #expect(promptInjection.requirements.contains("system_prompt_injection"))
+        #expect(promptInjection.requirements.contains("tokens_per_second"))
+        #expect(promptInjection.requirements.contains("no_parser_marker_leak"))
+        #expect(promptInjection.evidencePointers.isEmpty)
+
+        let hy3 = try #require(rows.first { $0.id == "issue-1163-hy3-harmony-retro-validation-schema" })
+        #expect(hy3.verdict == .unproven)
+        #expect(hy3.family == "hy3")
+        #expect(hy3.blockers.contains { $0.contains("sibling model rows") })
+    }
+
+    @Test("surface recomputes counts including schema rows")
+    func surfaceIncludesSchemaCounts() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+        let surface = RuntimeProofMatrixReporter.surface(
+            from: report,
+            sourceClassificationPath: "/tmp/runtime/PROOF_CLASSIFICATION.json",
+            generatedAt: "2026-06-11T00:00:00Z"
+        )
+
+        #expect(surface.generatedAt == "2026-06-11T00:00:00Z")
+        #expect(surface.verdictCounts["proven"] == 1)
+        #expect(surface.verdictCounts["partial"] == 1)
+        #expect(surface.verdictCounts["failed"] == 0)
+        #expect(surface.verdictCounts["unproven"] == 2)
+        #expect(surface.issueCoverage["#903"]?.verdict == .unproven)
+        #expect(surface.rows.count == 4)
+    }
+
+    @Test("marked matrix replacement only replaces the generated block")
+    func replaceMarkedMatrix() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+        let matrix = RuntimeProofMatrixReporter.markdownMatrix(
+            from: report,
+            generatedAt: "2026-06-11T00:00:00Z"
+        )
+        let original = """
+            # Runtime validation standard
+
+            Keep this intro.
+
+            \(RuntimeProofMatrixReporter.markdownBeginMarker)
+            stale
+            \(RuntimeProofMatrixReporter.markdownEndMarker)
+
+            Keep this footer.
+            """
+
+        let updated = RuntimeProofMatrixReporter.replaceMarkedMatrix(in: original, with: matrix)
+
+        #expect(updated.contains("Keep this intro."))
+        #expect(updated.contains("Keep this footer."))
+        #expect(!updated.contains("stale"))
+        #expect(updated.contains("gemma4-text-required"))
+    }
+
+    private static let fixtureData = Data(
+        """
+        {
+          "generated_at": "2026-06-11T00:00:00Z",
+          "summary_path": "/tmp/runtime/SUMMARY.json",
+          "manifest_path": "scripts/live-proof/family-runtime-chat-matrix.json",
+          "artifact_root": "/tmp/runtime",
+          "verdict_counts": {
+            "proven": 1,
+            "partial": 1,
+            "failed": 0,
+            "unproven": 0
+          },
+          "required_rows_not_proven": [
+            "qwen-cache-partial"
+          ],
+          "passed": false,
+          "rows": [
+            {
+              "id": "qwen-cache-partial",
+              "model": "Qwen cache",
+              "family": "qwen",
+              "priority": "required",
+              "requirements": [
+                "tokens_per_second",
+                "cache_hit"
+              ],
+              "artifact_paths": [
+                "/tmp/runtime/qwen/SUMMARY.json"
+              ],
+              "summary_path": "/tmp/runtime/qwen/SUMMARY.json",
+              "verdict": "partial",
+              "acceptable_for_proven_claim": false,
+              "blockers": [
+                {
+                  "requirement": "cache_hit",
+                  "message": "row lacks required topology-specific cache evidence"
+                }
+              ],
+              "warnings": [],
+              "failed_checks": []
+            },
+            {
+              "id": "gemma4-text-required",
+              "model": "Gemma4 text",
+              "family": "gemma4",
+              "priority": "required",
+              "requirements": [
+                "visible_output",
+                "tokens_per_second",
+                "no_parser_marker_leak",
+                "multi_turn_coherency"
+              ],
+              "artifact_paths": [
+                "/tmp/runtime/gemma4/SUMMARY.json"
+              ],
+              "summary_path": "/tmp/runtime/gemma4/SUMMARY.json",
+              "verdict": "proven",
+              "acceptable_for_proven_claim": true,
+              "blockers": [],
+              "warnings": [],
+              "failed_checks": []
+            }
+          ],
+          "issue_coverage": {
+            "#903": {
+              "verdict": "unproven",
+              "note": "system-prompt injection rows are schema-only until live proof exists"
+            },
+            "#1163": {
+              "verdict": "unproven",
+              "note": "Hy3/harmony parser closure needs a local Hy3 row, not sibling inference",
+              "rows": []
+            }
+          }
+        }
+        """.utf8
+    )
+}

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -145,6 +145,13 @@ VL model was tested through a text/tool path without a real media payload and
 media cache salt. Those rows stay useful as evidence, but they must not close a
 runtime/media issue as proven.
 
+Use `scripts/live-proof/render-runtime-proof-matrix.py` to render the latest
+`PROOF_CLASSIFICATION.json` into the matrix appendix in
+[`RUNTIME_VALIDATION_STANDARD.md`](RUNTIME_VALIDATION_STANDARD.md). The renderer
+also writes a read-only JSON surface for inspection workflows, and it keeps the
+#903 system-prompt-injection and #1163 Hy3/harmony schema rows `unproven` until
+real live artifacts exist.
+
 osaurus deliberately does not pass `GenerateParameters.maxKVSize` -- a
 global rotating cache window forced from the app layer conflicted with
 sliding-window attention layers (e.g. Gemma-4 with a fixed per-layer

--- a/docs/RUNTIME_VALIDATION_STANDARD.md
+++ b/docs/RUNTIME_VALIDATION_STANDARD.md
@@ -310,6 +310,33 @@ If a user-visible TTFT is slow but `promptMs` is fast, inspect template render,
 cache materialization, media preprocessing, and first-token decode before
 calling it a cache miss.
 
+## Runtime proof matrix appendix
+
+Render the machine-readable classifier report into this appendix after a live
+matrix run:
+
+```bash
+scripts/live-proof/render-runtime-proof-matrix.py \
+  build/runtime-validation/YYYYMMDD-HHMM/PROOF_CLASSIFICATION.json \
+  --update-doc docs/RUNTIME_VALIDATION_STANDARD.md \
+  --json-surface build/runtime-validation/YYYYMMDD-HHMM/runtime-proof-surface.json
+```
+
+The renderer is source/UX only. It cannot promote proof rows; it only displays
+the verdicts already written by `classify-runtime-proof-summary.py`. The schema
+rows for #903 and #1163 stay `unproven` until live artifacts exist.
+
+<!-- BEGIN RUNTIME PROOF MATRIX -->
+
+Generated from PROOF_CLASSIFICATION.json at not generated in this checkout.
+
+| Row | Model | Family | Verdict | Requirements | Evidence | Blockers |
+|---|---|---|---|---|---|---|
+| issue-903-system-prompt-injection-schema | all local chat runtimes | cross-family | unproven | visible_output, tokens_per_second, no_parser_marker_leak, multi_turn_coherency, system_prompt_injection | none | requires a live artifact with an explicit system-prompt injection probe, visible output, token/s, multi-turn coherency, and no parser marker leakage |
+| issue-1163-hy3-harmony-retro-validation-schema | Hy3/harmony local rows | hy3 | unproven | visible_output, tokens_per_second, no_parser_marker_leak, multi_turn_coherency | none | requires a Hy3/harmony live artifact; sibling model rows or source-only parser checks do not prove this issue |
+
+<!-- END RUNTIME PROOF MATRIX -->
+
 ## Recommended next tooling
 
 Add these scripts as follow-up work:

--- a/scripts/live-proof/render-runtime-proof-matrix.py
+++ b/scripts/live-proof/render-runtime-proof-matrix.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Render PROOF_CLASSIFICATION.json into a maintainer-readable proof matrix.
+
+This script is deliberately a renderer only. It does not classify artifacts or
+promote proof rows; ``classify-runtime-proof-summary.py`` remains the source of
+verdicts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from collections import Counter
+from typing import Any
+
+
+BEGIN = "<!-- BEGIN RUNTIME PROOF MATRIX -->"
+END = "<!-- END RUNTIME PROOF MATRIX -->"
+
+SCHEMA_ROWS = [
+    {
+        "id": "issue-903-system-prompt-injection-schema",
+        "model": "all local chat runtimes",
+        "family": "cross-family",
+        "priority": "schema-required",
+        "verdict": "unproven",
+        "requirements": [
+            "visible_output",
+            "tokens_per_second",
+            "no_parser_marker_leak",
+            "multi_turn_coherency",
+            "system_prompt_injection",
+        ],
+        "artifact_paths": [],
+        "blockers": [
+            {
+                "message": (
+                    "requires a live artifact with an explicit system-prompt injection probe, "
+                    "visible output, token/s, multi-turn coherency, and no parser marker leakage"
+                )
+            }
+        ],
+        "schema_only": True,
+    },
+    {
+        "id": "issue-1163-hy3-harmony-retro-validation-schema",
+        "model": "Hy3/harmony local rows",
+        "family": "hy3",
+        "priority": "schema-required",
+        "verdict": "unproven",
+        "requirements": [
+            "visible_output",
+            "tokens_per_second",
+            "no_parser_marker_leak",
+            "multi_turn_coherency",
+        ],
+        "artifact_paths": [],
+        "blockers": [
+            {
+                "message": (
+                    "requires a Hy3/harmony live artifact; sibling model rows or source-only "
+                    "parser checks do not prove this issue"
+                )
+            }
+        ],
+        "schema_only": True,
+    },
+]
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"classification must be a JSON object: {path}")
+    return value
+
+
+def escape_markdown(value: object) -> str:
+    return str(value).replace("\n", "<br>").replace("|", "\\|")
+
+
+def blocker_messages(row: dict[str, Any]) -> list[str]:
+    messages = []
+    for blocker in row.get("blockers") or []:
+        if not isinstance(blocker, dict):
+            continue
+        message = str(blocker.get("message") or "")
+        requirement = blocker.get("requirement")
+        if requirement:
+            messages.append(f"{requirement}: {message}")
+        elif message:
+            messages.append(message)
+    return messages
+
+
+def normalized_row(row: dict[str, Any]) -> dict[str, Any]:
+    evidence = []
+    summary_path = row.get("summary_path")
+    if summary_path:
+        evidence.append(str(summary_path))
+    evidence.extend(str(path) for path in row.get("artifact_paths") or [] if path)
+    evidence = list(dict.fromkeys(path for path in evidence if path))
+    return {
+        "id": str(row.get("id") or ""),
+        "model": str(row.get("model") or row.get("id") or ""),
+        "family": str(row.get("family") or "unknown"),
+        "priority": str(row.get("priority") or "unspecified"),
+        "verdict": str(row.get("verdict") or "unproven"),
+        "requirements": sorted(str(value) for value in row.get("requirements") or [] if value),
+        "evidence": evidence,
+        "blockers": blocker_messages(row),
+        "schema_only": bool(row.get("schema_only")),
+    }
+
+
+def matrix_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = [normalized_row(row) for row in report.get("rows") or [] if isinstance(row, dict)]
+    existing_ids = {row["id"] for row in rows}
+    for schema in SCHEMA_ROWS:
+        if schema["id"] not in existing_ids:
+            rows.append(normalized_row(schema))
+    return sorted(rows, key=lambda row: (row["family"], row["model"], row["id"]))
+
+
+def verdict_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    counts = Counter(row["verdict"] for row in rows)
+    return {key: counts.get(key, 0) for key in ("proven", "partial", "failed", "unproven")}
+
+
+def render_markdown(report: dict[str, Any], source: pathlib.Path, generated_at: str | None = None) -> str:
+    rows = matrix_rows(report)
+    lines = [
+        BEGIN,
+        "",
+        f"Generated from {escape_markdown(source)} at {escape_markdown(generated_at or report.get('generated_at') or 'unknown')}.",
+        "",
+        "| Row | Model | Family | Verdict | Requirements | Evidence | Blockers |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        values = [
+            row["id"],
+            row["model"],
+            row["family"],
+            row["verdict"],
+            ", ".join(row["requirements"]),
+            "<br>".join(row["evidence"]) if row["evidence"] else "none",
+            "<br>".join(row["blockers"]) if row["blockers"] else "none",
+        ]
+        lines.append("| " + " | ".join(escape_markdown(value) for value in values) + " |")
+    lines.extend(["", END, ""])
+    return "\n".join(lines)
+
+
+def replace_marked_matrix(document: str, matrix: str) -> str:
+    begin = document.find(BEGIN)
+    if begin == -1:
+        separator = "\n" if document.endswith("\n") else "\n\n"
+        return document + separator + matrix
+    end = document.find(END, begin)
+    if end == -1:
+        raise ValueError(f"found {BEGIN} without {END}")
+    return document[:begin] + matrix + document[end + len(END) :]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("classification", type=pathlib.Path, help="PROOF_CLASSIFICATION.json")
+    parser.add_argument("--output", type=pathlib.Path, help="write matrix markdown to this file")
+    parser.add_argument("--update-doc", type=pathlib.Path, help="replace or append the marked matrix in this doc")
+    parser.add_argument("--generated-at", help="override generated timestamp for deterministic tests")
+    parser.add_argument("--json-surface", type=pathlib.Path, help="write the read-only row surface as JSON")
+    args = parser.parse_args()
+
+    report = load_json(args.classification)
+    matrix = render_markdown(report, args.classification, generated_at=args.generated_at)
+
+    if args.json_surface:
+        rows = matrix_rows(report)
+        args.json_surface.write_text(
+            json.dumps(
+                {
+                    "generated_at": args.generated_at or report.get("generated_at") or "unknown",
+                    "source_classification_path": str(args.classification),
+                    "artifact_root": report.get("artifact_root"),
+                    "verdict_counts": verdict_counts(rows),
+                    "rows": rows,
+                    "issue_coverage": report.get("issue_coverage") or {},
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if args.update_doc:
+        document = args.update_doc.read_text(encoding="utf-8")
+        args.update_doc.write_text(replace_marked_matrix(document, matrix), encoding="utf-8")
+    elif args.output:
+        args.output.write_text(matrix, encoding="utf-8")
+    else:
+        print(matrix, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a runtime proof matrix reporter and rendering script so model-family evidence can be shown as proven, partial, failed, or unproven without turning source-only assertions into production claims.

## Business rationale

Runtime support claims need visible evidence: RAM status, token/s, cache behavior, cancellation, media-path coverage, and multi-turn output. This PR gives maintainers and testers a clearer way to review those claims without treating source-only rows as production proof.

## Coding rationale

The change is intentionally source/UX/reporting only. It improves evidence representation and documentation without changing runtime defaults, sampler behavior, templates, model loading, or proof status for unverified rows.

## Implementation

- Adds a deterministic proof matrix reporter for runtime evidence rows.
- Adds a script for rendering the matrix into readable documentation.
- Documents the validation standard for proven, partial, failed, and unproven rows.
- Keeps source-only rows explicitly unproven until real evidence fields exist.

## Acceptance criteria

- Proof rows separate proven, partial, failed, and unproven status.
- Schema/source-only issue rows remain unproven.
- Token/s, RAM, cancellation, cache, media, and multi-turn fields are visible in the matrix surface.
- Generated matrix replacement updates only the marked generated block.
- No live runtime capability is claimed without evidence rows.

## Latest refresh

Refreshed on June 15, 2026 against `origin/main` `ae4541d4` (`model picker improvements (#1515)`) after the main-gate stabilization landed. Rebase was clean; new head is `97ed92ba`. GitHub Actions is running on the refreshed head.

## Quality gate

Current refresh validation:

- `git diff --check origin/main`
- `swift-format` from Xcode toolchain on touched Swift files
- `python3 -m py_compile scripts/live-proof/render-runtime-proof-matrix.py`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-runtime-refresh swift test --package-path Packages/OsaurusCore --filter RuntimeProofMatrixTests` — 4 tests passed
- GitHub Actions matrix for `97ed92ba` — running

## Self-review

### Regression review

Regression risk is low because this is reporting/documentation code, not inference-path behavior. The main risk is misclassifying proof rows; tests cover deterministic rendering, marked-block replacement, and keeping schema-only rows unproven.

### Performance review

Performance impact is negligible: matrix generation is offline/reporting work over bounded evidence rows.

## Rollback

Revert this PR to remove the reporter and docs updates. It has no runtime migration or model-state side effects.