### PR TITLE
Stabilize CI-sensitive tests

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -717,30 +717,155 @@ private actor CompletionRecorder {
     func record(_ name: String) { order.append(name) }
 }
 
+/// Lets tests measure overlap without relying on task-start jitter.
+private actor BatchStartBarrier {
+    private let expectedCount: Int
+    private var started: Set<String> = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(expectedCount: Int) {
+        self.expectedCount = expectedCount
+    }
+
+    func waitForAllStarted(_ name: String) async {
+        started.insert(name)
+        if started.count >= expectedCount {
+            releaseWaiters()
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+            if started.count >= expectedCount {
+                releaseWaiters()
+            }
+        }
+    }
+
+    private func releaseWaiters() {
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+}
+
+/// Releases batch calls in a deterministic completion order once all tasks are parked.
+private actor BatchCompletionController {
+    private let expectedNames: Set<String>
+    private var started: Set<String> = []
+    private var released: Set<String> = []
+    private var completed: [String] = []
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var completionWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(expectedNames: Set<String>) {
+        self.expectedNames = expectedNames
+    }
+
+    var completionOrder: [String] { completed }
+
+    func markStarted(_ name: String) {
+        started.insert(name)
+        if expectedNames.isSubset(of: started) {
+            releaseStartWaiters()
+        }
+    }
+
+    func waitForAllStarted() async {
+        if expectedNames.isSubset(of: started) {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+            if expectedNames.isSubset(of: started) {
+                releaseStartWaiters()
+            }
+        }
+    }
+
+    func waitForRelease(_ name: String) async {
+        if released.contains(name) {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            releaseWaiters[name, default: []].append(continuation)
+            if released.contains(name) {
+                releaseWaiters.removeValue(forKey: name)?.forEach { $0.resume() }
+            }
+        }
+    }
+
+    func release(_ name: String) {
+        released.insert(name)
+        releaseWaiters.removeValue(forKey: name)?.forEach { $0.resume() }
+    }
+
+    func markCompleted(_ name: String) {
+        completed.append(name)
+        releaseCompletionWaiters()
+    }
+
+    func waitForCompletedCount(_ count: Int) async {
+        if completed.count >= count {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            completionWaiters.append((count, continuation))
+            releaseCompletionWaiters()
+        }
+    }
+
+    private func releaseStartWaiters() {
+        let pending = startWaiters
+        startWaiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+
+    private func releaseCompletionWaiters() {
+        let ready = completionWaiters.filter { completed.count >= $0.0 }
+        completionWaiters.removeAll { completed.count >= $0.0 }
+        for waiter in ready {
+            waiter.1.resume()
+        }
+    }
+}
+
 struct AgentToolLoopParallelBatchTests {
 
     @Test func resultsComeBackInInputOrderUnderRandomCompletion() async {
         // slow finishes LAST but is FIRST in the input — the executor must
         // re-sort by input index, not completion order.
-        let recorder = CompletionRecorder()
         let calls: [(invocation: ServiceToolInvocation, callId: String)] = [
             (ServiceToolInvocation(toolName: "slow", jsonArguments: "{}", toolCallId: nil), "call_slow"),
             (ServiceToolInvocation(toolName: "fast", jsonArguments: "{}", toolCallId: nil), "call_fast"),
             (ServiceToolInvocation(toolName: "medium", jsonArguments: "{}", toolCallId: nil), "call_med"),
         ]
-        let executions = await AgentToolLoop.runBatchInParallel(calls) { invocation, _ in
-            let delayMs: UInt64 = invocation.toolName == "slow" ? 120 : invocation.toolName == "medium" ? 60 : 0
-            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
-            await recorder.record(invocation.toolName)
-            return "ran:\(invocation.toolName)"
+        let controller = BatchCompletionController(expectedNames: Set(calls.map { $0.invocation.toolName }))
+        let batchTask = Task {
+            await AgentToolLoop.runBatchInParallel(calls) { invocation, _ in
+                await controller.markStarted(invocation.toolName)
+                await controller.waitForRelease(invocation.toolName)
+                await controller.markCompleted(invocation.toolName)
+                return "ran:\(invocation.toolName)"
+            }
         }
+
+        await controller.waitForAllStarted()
+        await controller.release("fast")
+        await controller.waitForCompletedCount(1)
+        await controller.release("medium")
+        await controller.waitForCompletedCount(2)
+        await controller.release("slow")
+        let executions = await batchTask.value
 
         #expect(executions.map(\.result) == ["ran:slow", "ran:fast", "ran:medium"])
         #expect(executions.allSatisfy { !$0.isError })
         // The calls actually overlapped: fast completed before slow.
-        let completion = await recorder.order
-        #expect(completion.first == "fast")
-        #expect(completion.last == "slow")
+        #expect(await controller.completionOrder == ["fast", "medium", "slow"])
     }
 
     @Test func throwingCallBecomesErrorEnvelopeWithoutAbortingBatch() async {

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -21,21 +21,30 @@ struct ModelManagerTests {
     }
 
     @Test func loadAvailableModels_initializesStates() async throws {
-        // `ModelManager.init` calls `loadAvailableModels()` synchronously, which
-        // populates `availableModels` + `downloadStates` before init returns. No
-        // sleep needed; the previous 2s `Task.sleep` predated the sync refactor.
+        // `ModelManager.init` calls `loadAvailableModels()` synchronously, while
+        // download-state probing is intentionally applied off-main so startup
+        // does not block on disk scans. Wait for that async state sync here.
         let manager = await MainActor.run { ModelManager() }
 
-        let isLoading = await MainActor.run { manager.isLoadingModels }
-        let models = await MainActor.run { manager.availableModels }
-        let states = await MainActor.run { manager.downloadStates }
+        var models: [MLXModel] = []
+        var states: [String: DownloadState] = [:]
+        for _ in 0 ..< 100 {
+            (models, states) = await MainActor.run {
+                (manager.availableModels, manager.downloadStates)
+            }
+            if !models.isEmpty, models.allSatisfy({ states[$0.id] != nil }) {
+                break
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
 
+        let isLoading = await MainActor.run { manager.isLoadingModels }
         #expect(isLoading == false)
 
         if models.count > 0 {
-            for model in models {
-                #expect(states[model.id] != nil)
-            }
+            let missing = models.filter { states[$0.id] == nil }.map(\.id)
+            let missingList = missing.joined(separator: ", ")
+            #expect(missing.isEmpty, "missing download state for models: \(missingList)")
         }
     }
 
@@ -399,8 +408,14 @@ struct ModelManagerTests {
             let first = ModelManager.discoverLocalModels()
             #expect(first.isEmpty)
 
-            try await Task.sleep(nanoseconds: 200_000_000)
-            let second = ModelManager.discoverLocalModels()
+            var second: [MLXModel] = []
+            for _ in 0 ..< 100 {
+                second = ModelManager.discoverLocalModels()
+                if second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"] {
+                    break
+                }
+                try await Task.sleep(nanoseconds: 25_000_000)
+            }
             #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
         }
     }

--- a/Packages/OsaurusCore/Tests/Provider/XAIOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/XAIOAuthServiceTests.swift
@@ -118,9 +118,10 @@ struct XAIOAuthServiceTests {
         let error = XAIOAuthError.loopbackBindFailed("Address already in use")
         let message = XAIOAuthService.diagnosticMessage(for: error)
 
-        // Port number may be locale-formatted (e.g. "56,121" with thousands
-        // separator) when interpolated inside a localized string.
-        #expect(message.contains("56121") || message.contains("56,121"))
+        // Port number may be locale-formatted with a thousands separator
+        // when interpolated inside a localized string.
+        let digitsOnly = String(message.filter(\.isNumber))
+        #expect(digitsOnly.contains("56121"))
         #expect(message.contains("Close any other in-progress sign-in"))
         #expect(message.contains("Address already in use"))
     }

--- a/Packages/OsaurusCore/Tests/Sandbox/LiveExecRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/LiveExecRegistryTests.swift
@@ -72,14 +72,21 @@ struct LiveExecRegistryTests {
         await registry.register(makeEntry(toolCallId: "live-1"))
         await registry.register(makeEntry(toolCallId: "live-2"))
 
-        // Give the sink enough time to drain the two emissions.
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        let history = await collector.snapshots
-        // 1 initial empty + 1 per register.
-        #expect(history.count >= 2)
-        let lastIds = history.last.map { Set($0.keys) } ?? []
-        #expect(lastIds.contains("live-1"))
-        #expect(lastIds.contains("live-2"))
+        let expectedIds: Set<String> = ["live-1", "live-2"]
+        var history = await collector.snapshots
+        for _ in 0 ..< 200 {
+            if history.contains(where: { Set($0.keys).isSuperset(of: expectedIds) }) {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            history = await collector.snapshots
+        }
+        let observedIds =
+            history
+            .last(where: { Set($0.keys).isSuperset(of: expectedIds) })
+            .map { Set($0.keys) } ?? []
+        #expect(observedIds.contains("live-1"))
+        #expect(observedIds.contains("live-2"))
         await registry.clearAll()
     }
 

--- a/Packages/OsaurusCore/Tests/Skill/SkillSearchServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillSearchServiceTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import OsaurusCore
 
+@Suite(.serialized)
 struct SkillSearchServiceTests {
 
     @Test func searchFallsBackToBuiltInSkillsWhenUninitialized() async {


### PR DESCRIPTION
## Summary

This is a test-only cleanup to make the core CI lane less sensitive to scheduling, locale, and async-state timing. It addresses failures that appeared while preparing otherwise unrelated feature PRs for review.

## Rationale

- The parallel batch ordering test used sleeps to infer completion order, but CI scheduling jitter could invert the observed order before all closures had actually started. The test now uses a start barrier before applying artificial delays.
- The model manager state test assumed synchronous download-state population even though state probing is intentionally applied off-main. The test now waits briefly for that async sync.
- The xAI OAuth diagnostic test allowed one localized thousands separator but not all locale formats. It now compares the digits.
- Skill search tests share singleton state, so the suite is serialized like other shared-state tests.

## Validation

- `xcrun swift-format lint --configuration .swift-format --strict --recursive Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift Packages/OsaurusCore/Tests/Provider/XAIOAuthServiceTests.swift Packages/OsaurusCore/Tests/Skill/SkillSearchServiceTests.swift Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift`
- `git diff --check origin/main`
- Focused Swift tests for the changed cases
- Five repeated runs of `AgentToolLoopParallelBatchTests/resultsComeBackInInputOrderUnderRandomCompletion`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-ci-stability make ci-test`

## Rollback

Revert this test-only commit if CI does not show the same stability improvement.