### PR TITLE
prevent switching chat windows from interrupting an in-flight chat

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -341,6 +341,23 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         windowStates.values.contains { $0.session.isStreaming }
     }
 
+    /// True when a chat window OTHER than `excluding` is currently streaming a
+    /// local model. Enforces one local generation at a time across windows: the
+    /// shared inference context can only run one, and loading a second would
+    /// evict the first and cancel its in-flight stream.
+    func isOtherWindowStreamingLocalModel(excluding windowId: UUID?) -> Bool {
+        windowStates.contains { id, state in
+            id != windowId && state.session.isStreamingLocalModel
+        }
+    }
+
+    /// True when ANY chat window is currently streaming a local model. Used to
+    /// defer local empty-state greeting generation while a user stream is in
+    /// flight.
+    var isAnyWindowStreamingLocalModel: Bool {
+        windowStates.values.contains { $0.session.isStreamingLocalModel }
+    }
+
     /// Get the count of active windows
     public var windowCount: Int {
         windows.count

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -30,6 +30,12 @@ final class ChatWindowState: ObservableObject {
     /// button actions in `ChatView`.
     @Published var showCloseConfirmation: Bool = false
 
+    /// Drives the "a local model is already running in another window" alert
+    /// raised when the user tries to start a second local generation. Only one
+    /// local generation can run at a time across windows; the alert is
+    /// dismissed by its OK button in `ChatView`.
+    @Published var showLocalModelBusyAlert: Bool = false
+
     /// Imperative hook set by `ChatView` while the inline message editor
     /// is active (and cleared on save/cancel). The window-level Esc
     /// monitor invokes it so Esc cancels the edit even when the editor's

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -2854,6 +2854,22 @@
         }
       }
     },
+    "A local model is already running" : {
+    "localizations" : {
+      "de" : {
+        "stringUnit" : {
+          "state" : "translated",
+          "value" : "Ein lokales Modell wird bereits ausgeführt"
+        }
+      },
+      "zh-Hans" : {
+        "stringUnit" : {
+          "state" : "translated",
+          "value" : "本地模型已在运行"
+        }
+      }
+    }
+  },
     "A microphone button will appear in the chat input when voice is ready" : {
       "localizations" : {
         "de" : {
@@ -32027,6 +32043,22 @@
         }
       }
     },
+    "Only one local model can run at a time, and another chat window is using it right now. Wait for that reply to finish, or switch this chat to a remote model." : {
+    "localizations" : {
+      "de" : {
+        "stringUnit" : {
+          "state" : "translated",
+          "value" : "Es kann immer nur ein lokales Modell gleichzeitig ausgeführt werden, und ein anderes Chat-Fenster verwendet es gerade. Warte, bis diese Antwort abgeschlossen ist, oder wechsle in diesem Chat zu einem Remote-Modell."
+        }
+      },
+      "zh-Hans" : {
+        "stringUnit" : {
+          "state" : "translated",
+          "value" : "一次只能运行一个本地模型，目前另一个聊天窗口正在使用它。请等待该回复完成，或将此聊天切换为远程模型。"
+        }
+      }
+    }
+  },
     "Only use this on trusted hardware for long-running work" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -504,6 +504,30 @@ public actor ModelRuntime {
         Memory.clearCache()
     }
 
+    /// Evict `other` for the strict-single-model policy WITHOUT cancelling an
+    /// in-flight generation.
+    ///
+    /// `unload` shuts the model's batch engine down and cancels its tracked
+    /// generation task, so calling it on a model that is mid-stream kills the
+    /// user's reply — exactly what happened when a second chat window loaded a
+    /// different model while the first was still generating. Wait for the
+    /// active generation's lease to drain first so it finishes cleanly, then
+    /// evict. The wait is bounded so a wedged stream can't block the new load
+    /// forever; the lease is always released in the generation task's teardown,
+    /// so the timeout is a pure safety valve. The UI enforces one local
+    /// generation at a time, so this mainly backstops non-interactive loaders
+    /// (server requests, scheduler) and races.
+    private func strictEvict(_ other: String) async {
+        if await ModelLease.shared.count(for: other) > 0 {
+            genLog.info(
+                "loadContainer: deferring strict eviction of \(other, privacy: .public) until in-flight generation drains"
+            )
+            _ = await ModelLease.shared.waitForZero(other, timeoutSeconds: 300)
+        }
+        genLog.info("loadContainer: strict eviction of \(other, privacy: .public)")
+        await unload(name: other)
+    }
+
     /// Unloads any loaded model whose name is not in `activeNames`.
     /// Models with active leases (in-flight generations) are also kept; the
     /// per-model `unload` call internally waits for the lease to drop before
@@ -1092,8 +1116,7 @@ public actor ModelRuntime {
             if policy == .strictSingleModel,
                 let other = modelCache.keys.first(where: { $0 != name })
             {
-                genLog.info("loadContainer: strict eviction of \(other, privacy: .public)")
-                await unload(name: other)
+                await strictEvict(other)
                 continue
             }
 
@@ -1165,8 +1188,7 @@ public actor ModelRuntime {
             if policy == .strictSingleModel,
                 let other = modelCache.keys.first(where: { $0 != name })
             {
-                genLog.info("loadContainer: strict eviction after cold-load wait of \(other, privacy: .public)")
-                await unload(name: other)
+                await strictEvict(other)
                 continue
             }
 

--- a/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
@@ -1,0 +1,157 @@
+//
+//  LocalModelDetectionTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the contract for `ChatSession.selectedModelIsLocal` /
+//  `isStreamingLocalModel` — the detection that gates the "one local
+//  generation at a time, never interrupt an in-flight chat" behavior. A
+//  model counts as local iff it resolves in the installed-model catalog
+//  (`ModelManager.findInstalledModel`). That catalog merges osaurus-downloaded
+//  models with externally-discovered ones (LM Studio, Hugging Face cache); the
+//  external discovery/merge itself is covered by `ModelManagerTests`, so here
+//  we drive the catalog through `scanLocalModelsOverrideForTests` and assert
+//  the session helpers reflect it. A model's external-source origin must not
+//  change detection — it's still local.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct LocalModelDetectionTests {
+
+    /// Catalog fixtures: one osaurus-downloaded model and one carrying an
+    /// external-source label (as LM Studio / HF-cache models do).
+    private static let catalog: [MLXModel] = [
+        MLXModel(
+            id: "mlx-community/Qwen2.5-7B-Instruct-4bit",
+            name: "Qwen2.5 7B",
+            description: "fixture",
+            downloadURL: "https://example.invalid/qwen"
+        ),
+        MLXModel(
+            id: "lmstudio-community/Llama-3.2-3B-Instruct",
+            name: "Llama 3.2 3B",
+            description: "fixture-external",
+            downloadURL: "https://example.invalid/llama",
+            externalSource: "LM Studio"
+        ),
+    ]
+
+    /// Install a deterministic local-model catalog for the duration of `body`.
+    /// Must run inside `ChatHistoryTestStorage.run`, which holds
+    /// `StoragePathsTestLock` — the same lock the model-scan overrides are
+    /// mutated under elsewhere — so these globals can't race other suites.
+    private func withCatalog(_ models: [MLXModel], _ body: () throws -> Void) rethrows {
+        let prevScan = ModelManager.scanLocalModelsOverrideForTests
+        let prevWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+        let prevExternal = ExternalModelLocator.testRootsOverride
+
+        // No real external roots — the catalog comes entirely from the scan
+        // override so the result is deterministic.
+        ExternalModelLocator.testRootsOverride = []
+        ExternalModelLocator.invalidateInMemory()
+        _ = ExternalModelLocator.rescan()
+        ModelManager.localModelsScanWaitLimitOverrideForTests = 2.0
+        ModelManager.scanLocalModelsOverrideForTests = { _ in models }
+        ModelManager.invalidateLocalModelsCache()
+        // Prime the cache so subsequent `findInstalledModel` calls resolve
+        // synchronously against the fixtures.
+        _ = ModelManager.discoverLocalModels()
+
+        defer {
+            ModelManager.scanLocalModelsOverrideForTests = prevScan
+            ModelManager.localModelsScanWaitLimitOverrideForTests = prevWait
+            ExternalModelLocator.testRootsOverride = prevExternal
+            ExternalModelLocator.invalidateInMemory()
+            ModelManager.invalidateLocalModelsCache()
+        }
+
+        try body()
+    }
+
+    @Test
+    func selectedModelIsLocal_matchesCatalogByRepoTailAndFullId() async throws {
+        try await ChatHistoryTestStorage.run {
+            try withCatalog(Self.catalog) {
+                let session = ChatSession()
+
+                // Repo-tail (the form the picker selects with).
+                session.selectedModel = "Qwen2.5-7B-Instruct-4bit"
+                #expect(session.selectedModelIsLocal)
+
+                // Full provider/repo id.
+                session.selectedModel = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+                #expect(session.selectedModelIsLocal)
+            }
+        }
+    }
+
+    @Test
+    func selectedModelIsLocal_coversExternallyDiscoveredModels() async throws {
+        try await ChatHistoryTestStorage.run {
+            try withCatalog(Self.catalog) {
+                let session = ChatSession()
+
+                // A model whose origin is an external tool (LM Studio / HF
+                // cache) still resolves as local — its source label doesn't
+                // change detection.
+                session.selectedModel = "Llama-3.2-3B-Instruct"
+                #expect(session.selectedModelIsLocal)
+            }
+        }
+    }
+
+    @Test
+    func selectedModelIsLocal_falseForRemoteFoundationAndUnknown() async throws {
+        try await ChatHistoryTestStorage.run {
+            try withCatalog(Self.catalog) {
+                let session = ChatSession()
+
+                // Apple's on-device Foundation model runs on a separate engine.
+                session.selectedModel = "foundation"
+                #expect(!session.selectedModelIsLocal)
+
+                // Remote provider model id (not in the local catalog).
+                session.selectedModel = "openai/gpt-4o"
+                #expect(!session.selectedModelIsLocal)
+
+                // Unknown id.
+                session.selectedModel = "not-a-real-model"
+                #expect(!session.selectedModelIsLocal)
+
+                // No selection.
+                session.selectedModel = nil
+                #expect(!session.selectedModelIsLocal)
+            }
+        }
+    }
+
+    @Test
+    func isStreamingLocalModel_composesStreamingStateWithLocality() async throws {
+        try await ChatHistoryTestStorage.run {
+            try withCatalog(Self.catalog) {
+                let session = ChatSession()
+                session.selectedModel = "Qwen2.5-7B-Instruct-4bit"
+
+                // Local but idle → not a live local generation.
+                session.isStreaming = false
+                #expect(!session.isStreamingLocalModel)
+
+                // Local and streaming → live local generation.
+                session.isStreaming = true
+                #expect(session.isStreamingLocalModel)
+
+                // Streaming a remote model → does not count as local.
+                session.selectedModel = "openai/gpt-4o"
+                #expect(!session.isStreamingLocalModel)
+
+                // Balance the perf-trace begun by the `isStreaming` setter.
+                session.isStreaming = false
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -664,6 +664,34 @@ final class ChatSession: ObservableObject {
         return pickerItems.first { $0.id == model }
     }
 
+    /// True when the selected model is a local model — the kind that runs on
+    /// the device's shared inference context. Covers both osaurus-downloaded
+    /// models and externally-discovered ones (LM Studio, Hugging Face cache),
+    /// since `findInstalledModel` resolves the merged local catalog. Foundation
+    /// (Apple on-device) and remote provider models run on separate engines and
+    /// don't contend. Resolved against the catalog so it doesn't depend on
+    /// `pickerItems` being populated.
+    var selectedModelIsLocal: Bool {
+        guard let model = selectedModel else { return false }
+        return ModelManager.findInstalledModel(named: model) != nil
+    }
+
+    /// True while this session is streaming a reply from a local model.
+    var isStreamingLocalModel: Bool {
+        isStreaming && selectedModelIsLocal
+    }
+
+    /// A local generation would collide with one already running in another
+    /// window. The shared inference context runs a single generation at a time,
+    /// and loading this model could evict (and cancel) the active one — so the
+    /// caller surfaces an alert and refuses the send instead.
+    var localModelBusyInOtherWindow: Bool {
+        selectedModelIsLocal
+            && ChatWindowManager.shared.isOtherWindowStreamingLocalModel(
+                excluding: windowState?.windowId
+            )
+    }
+
     /// Backing store for the streaming-mutated `visibleBlocks` / group-header map.
     /// Deliberately NOT `@Published` — mutations go through the store's own
     /// `objectWillChange`, not the session's, so ChatView's body + every sibling
@@ -966,6 +994,13 @@ final class ChatSession: ObservableObject {
 
     func sendCurrent() {
         guard !isStreaming else { return }
+        // One local generation at a time across all windows: the shared
+        // inference context can't run two, and loading a second would evict and
+        // cancel the active one. Surface the alert and keep the draft intact.
+        if localModelBusyInOtherWindow {
+            windowState?.showLocalModelBusyAlert = true
+            return
+        }
         let text = input
         let attachments = pendingAttachments
         input = ""
@@ -1249,6 +1284,26 @@ final class ChatSession: ObservableObject {
                     for: snapshot,
                     model: model
                 )
+                return
+            }
+
+            // Don't start a local greeting generation while another window is
+            // already running a local model. The shared inference context runs
+            // one generation at a time, so a greeting load here would stall behind
+            // the active user stream (and on the strict-eviction path could
+            // disturb it). Fall back to the static greeting; the pool refills
+            // once inference goes idle. Remote/foundation greetings don't
+            // contend, so they're unaffected.
+            let greetingModelIsLocal = ModelManager.findInstalledModel(named: model) != nil
+            let localStreamBusy = await MainActor.run {
+                ChatWindowManager.shared.isAnyWindowStreamingLocalModel
+            }
+            if greetingModelIsLocal, localStreamBusy {
+                await MainActor.run {
+                    guard let self = self else { return }
+                    guard self.generativeGreetingKey == key else { return }
+                    self.generativeGreetingState = .failed
+                }
                 return
             }
 
@@ -2325,6 +2380,15 @@ final class ChatSession: ObservableObject {
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
         guard activeRunId == nil, !isStreaming else { return }
+
+        // Authoritative guard for every send path (interactive, regeneration,
+        // queued, VAD, programmatic): never start a local generation while
+        // another window is already running one. `sendCurrent` checks this
+        // first so the draft survives; this backstops the rest.
+        if localModelBusyInOtherWindow {
+            windowState?.showLocalModelBusyAlert = true
+            return
+        }
 
         // Fresh run: a previous stop() may have left the flag true. The
         // auto-flush in completeRunCleanup keys off this, so clear it
@@ -3695,6 +3759,17 @@ struct ChatView: View {
                     .primary(L("Continue in Background")) { windowState.confirmCloseInBackground() },
                     .destructive(L("Stop and Close")) { windowState.confirmCloseAndStop() },
                     .cancel(L("Cancel")),
+                ]
+            )
+            .themedAlert(
+                L("A local model is already running"),
+                isPresented: $windowState.showLocalModelBusyAlert,
+                message:
+                    L(
+                        "Only one local model can run at a time, and another chat window is using it right now. Wait for that reply to finish, or switch this chat to a remote model."
+                    ),
+                buttons: [
+                    .cancel(L("OK"))
                 ]
             )
             .themedAlertScope(.chat(windowState.windowId))


### PR DESCRIPTION
## Summary

addresses #1471 

  - fixed an issue where opening or switching to a different chat window could terminate the active chat and interrupt the model's in-progress reply
  - the interruption happened because only one local model can run at a time and loading a second local model evicted the one that was still generating
  - the model runtime now waits for an in-flight reply to finish before switching local models so an active generation is never cancelled to make room for another
  - starting a second local generation while one is already running is now blocked with a clear alert in the new window instead of stopping the first one, and the pending message is preserved so nothing is lost
  - a newly opened window no longer kicks off its empty-state greeting on a local model while another local reply is streaming, so simply opening a window can no longer interrupt an active chat
  - remote models are unaffected and continue to run concurrently across windows
  - confirmed coverage extends to externally discovered local models such as those from LM Studio or the Hugging Face cache since they run through the same local runtime

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
