### PR TITLE
Add DiffusionGemma capability gating and runtime pin

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
+        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -410,7 +410,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
+        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -71,6 +71,14 @@ enum ModelFamilyNames {
         matches(#"(^|/|[\-_])gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
     }
 
+    /// DiffusionGemma block-diffusion bundles (`model_type=diffusion_gemma`).
+    /// Keep this separate from ordinary Gemma 4 AR/QAT matching because the
+    /// runtime needs a denoising-canvas engine, not TokenIterator decode.
+    static func isDiffusionGemmaFamily(_ modelId: String) -> Bool {
+        matches(#"(^|/|[\-_])diffusion[\-_]?gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
+            || modelId.lowercased() == "diffusion_gemma"
+    }
+
     /// LFM2 / LFM2.5 text and MoE bundles. Accept LiquidAI repo ids,
     /// local JANG bundle ids, and bare picker aliases while rejecting adjacent
     /// future-family names like `lfm21` / `lfm2x`.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -207,6 +207,14 @@ public enum ModelMediaCapabilities {
             return .imageOnly
         }
 
+        // DiffusionGemma 26B A4B is a block-diffusion VLM. The source bundle
+        // exposes vision_config + image_token_id, but no audio_config,
+        // audio_token_id, or video_token_id. Do not advertise audio/video from
+        // the generic Gemma family name.
+        if ModelFamilyNames.isDiffusionGemmaFamily(modelId) {
+            return .imageOnly
+        }
+
         // Image-only VLM families. Substring-match the bundle name.
         let imageOnlyPatterns: [String] = [
             "paligemma", "idefics3", "fastvlm", "llava-qwen2", "llava_qwen2",
@@ -341,6 +349,10 @@ public enum ModelMediaCapabilities {
         // vision is only the omni path, already handled above.)
         guard hasVisionConfig else {
             return .textOnly
+        }
+
+        if modelType == "diffusion_gemma" {
+            return .imageOnly
         }
 
         // Cross-check the family-by-model_type for video support.

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -165,6 +165,17 @@ public enum ServerRuntimeSettingsStore {
         {
             normalized.mtp.mode = .auto
         }
+        // Osaurus product default for block-diffusion models: 16 denoising
+        // steps (~74 tok/s on diffusiongemma-26B-A4B MXFP4, coherent) vs the
+        // bundle's 48 (~37 tok/s). Seeded exactly once; afterwards a blank
+        // field is an explicit "use bundle default" choice.
+        if normalized.generation.diffusionMaxDenoisingSteps == nil,
+            !FileManager.default.fileExists(
+                atPath: diffusionDefaultsMigrationMarkerURL().path)
+        {
+            normalized.generation.diffusionMaxDenoisingSteps = 16
+            writeDiffusionDefaultsMigrationMarker()
+        }
         if shouldRepairLegacyCacheDefaults(normalized.cache) {
             // Keep companion-cache repair independent from the live KV codec.
             // Engine-selected is the default policy now, but ModelRuntime
@@ -239,7 +250,9 @@ public enum ServerRuntimeSettingsStore {
 
         // Generation defaults: only `genTopP` had a legacy override
         // surfaced in the UI. Everything else stays nil so model
-        // defaults still win.
+        // defaults still win — except the block-diffusion step budget,
+        // which gets the Osaurus product default (16; see
+        // normalizeLoadedSettings).
         let defaultTopP = ServerConfiguration.default.genTopP
         settings.generation = VMLXServerGenerationDefaults(
             streamInterval: 1,
@@ -252,6 +265,8 @@ public enum ServerRuntimeSettingsStore {
             minP: nil,
             repetitionPenalty: nil
         )
+        settings.generation.diffusionMaxDenoisingSteps = 16
+        writeDiffusionDefaultsMigrationMarker()
 
         // Concurrency: legacy UserDefaults key for BatchEngine max
         // batch size. Falls back to nil so vmlx's coordinator chooses
@@ -360,6 +375,22 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func cacheDefaultsMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(cacheDefaultsMigrationMarkerName)
+    }
+
+    /// One-shot seed of the Osaurus diffusion default (16 denoising steps,
+    /// the measured speed/quality knee for diffusiongemma-26B-A4B). The
+    /// marker keeps a user's later "blank = bundle default" choice sticky.
+    static let diffusionDefaultsMigrationMarkerName =
+        "diffusion-defaults-migrated.marker"
+
+    private nonisolated static func diffusionDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(diffusionDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func writeDiffusionDefaultsMigrationMarker() {
+        let url = diffusionDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
     }
 
     private nonisolated static func legacyConfigurationFileURL() -> URL {

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -74,6 +74,7 @@ enum VLMDetection {
         let trimmed = modelType.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalized = trimmed.lowercased()
         guard normalized != "zaya" else { return false }
+        if normalized == "diffusion_gemma" { return true }
         return VLMTypeRegistry.supportedModelTypes.contains(trimmed)
             || VLMTypeRegistry.supportedModelTypes.contains(normalized)
     }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
+        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "df4c60c1d9a806f7210fb2816a3eb05d2c628e340874a72e12a9d1b7d070a354",
+  "originHash" : "529daa635313ccf76bc8a4f8884e67b31bb5ae3ec048d5f10ea586cefbca5bbf",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
+        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "76047f3b4492d4fae316267a30fba55163b1c5cd"
+            revision: "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
+            revision: "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
+            revision: "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1059,6 +1059,12 @@ struct MLXBatchAdapter {
             enableCompiledBatchDecode: effective.compiledBatchDecode,
             prefillStepSize: runtime.concurrency.prefillStepSize
         )
+        // Block-diffusion speed/quality budget (DiffusionGemma): server
+        // setting, default 16 (seeded by ServerRuntimeSettingsStore).
+        // nil = bundle's generation_config.json value. Ignored by
+        // autoregressive models.
+        mlxParams.diffusionMaxDenoisingSteps =
+            runtime.generation.diffusionMaxDenoisingSteps
         let cacheTopology = await container.cacheTopologySnapshot()
         let effectiveKVMode = ModelRuntime.defaultKVMode(
             for: ServerRuntimeSettingsStore.snapshot().cache,

--- a/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
@@ -44,6 +44,11 @@ import Testing
         #expect(VLMDetection.isVLM(modelType: "qwen2_5_vl"))
     }
 
+    @Test func isVLMModelType_recognizesDiffusionGemma() {
+        #expect(VLMDetection.isVLM(modelType: "diffusion_gemma"))
+        #expect(!VLMDetection.isVLM(modelType: "diffusion_gemma_text"))
+    }
+
     @Test func isVLMModelType_preservesCaseSensitiveRegistryEntries() {
         #expect(VLMDetection.isVLM(modelType: "NemotronH_Nano_Omni_Reasoning_V3"))
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -231,6 +231,21 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-mxfp8") == .imageOnly)
     }
 
+    @Test("D6: DiffusionGemma is image-only, not video/audio")
+    func d6_diffusionGemmaImageOnly() {
+        for modelId in [
+            "google/diffusiongemma-26B-A4B-it",
+            "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4",
+            "diffusion_gemma",
+        ] {
+            let cap = ModelMediaCapabilities.from(modelId: modelId)
+            #expect(cap == .imageOnly, "\(modelId) must advertise image only")
+            #expect(cap.supportsImage)
+            #expect(!cap.supportsVideo)
+            #expect(!cap.supportsAudio)
+        }
+    }
+
     // MARK: - D7: Mistral 3 / 3.5 (image only via Pixtral wrap)
 
     @Test("D7: Mistral 3 / 3.5 → .imageOnly")
@@ -321,6 +336,32 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(descriptor.audio.status == .unproven)
         #expect(!descriptor.audio.isUsable)
         #expect(descriptor.rejectionMessage(for: .audio).contains("audio_tower/embed_audio"))
+    }
+
+    @Test("Directory config keeps DiffusionGemma image-only")
+    func directory_diffusionGemmaImageOnly() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try """
+        {
+          "model_type": "diffusion_gemma",
+          "architectures": ["DiffusionGemmaForBlockDiffusion"],
+          "vision_config": {"model_type": "gemma4_vision"},
+          "image_token_id": 258880,
+          "audio_config": null
+        }
+        """.write(to: tmp.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+        let cap = ModelMediaCapabilities.from(
+            directory: tmp,
+            modelId: "google/diffusiongemma-26B-A4B-it"
+        )
+        #expect(cap == .imageOnly)
+        #expect(cap.supportsImage)
+        #expect(!cap.supportsVideo)
+        #expect(!cap.supportsAudio)
     }
 
     @Test("Descriptor keeps Nemotron Omni audio supported")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -578,7 +578,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
+        let expectedRuntimeHardenedRevision = "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -578,7 +578,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
+        let expectedRuntimeHardenedRevision = "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -578,7 +578,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "76047f3b4492d4fae316267a30fba55163b1c5cd"
+        let expectedRuntimeHardenedRevision = "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
@@ -69,6 +69,20 @@ struct GenerationDefaultsSection: View {
 
             SettingsDivider()
 
+            SettingsSubsection(label: "Diffusion Models") {
+                OptionalIntField(
+                    label: "Denoising Steps per Canvas",
+                    placeholder: "Blank = model default (48)",
+                    help: "Speed/quality budget for block-diffusion models "
+                        + "(DiffusionGemma). 16 ≈ 2× faster than the model "
+                        + "default and stays coherent; below 12 quality "
+                        + "degrades. Ignored by ordinary models.",
+                    value: $draft.generation.diffusionMaxDenoisingSteps
+                )
+            }
+
+            SettingsDivider()
+
             SettingsSubsection(label: "Streaming") {
                 VStack(alignment: .leading, spacing: 8) {
                     ServerSettingsPlannedBanner(

--- a/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
@@ -1,0 +1,38 @@
+# DiffusionGemma Osaurus Integration
+
+Date: 2026-06-12
+
+## Current Source Truth
+
+- Source bundle: `/Users/eric/models/google/diffusiongemma-26B-A4B-it`
+- Hub repo: `google/diffusiongemma-26B-A4B-it`
+- `model_type`: `diffusion_gemma`
+- Architecture: `DiffusionGemmaForBlockDiffusion`
+- Vision: `vision_config` present, `image_token_id = 258880`,
+  `vision_soft_tokens_per_image = 280`
+- Audio: `audio_config = null`, `audio_token_id = null`
+- Video: processor metadata is present, but `video_token_id = null`
+
+## Osaurus Boundary
+
+This PR only teaches Osaurus capability surfaces about DiffusionGemma:
+
+- `diffusion_gemma` is VLM-shaped for routing/discovery.
+- DiffusionGemma model ids advertise image support.
+- DiffusionGemma does not advertise audio or video support.
+
+It does not claim runtime generation. Native block-diffusion text/VL generation
+still belongs in vMLX: prompt encoder cache, denoising canvas, self-conditioning,
+entropy-bound accept/renoise, and image soft-token preparation must be implemented
+and live-proven before Osaurus should promote the row.
+
+## Quant Dependency
+
+The companion vMLX branch adds first-party quant prep/conversion scripts for:
+
+- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
+- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+
+Full conversion is blocked on local free space at the time of this note. The
+downloaded BF16 source is 48 GB and the exact-shape estimates are about 14.85 GiB
+for MXFP4 and 26.0 GiB for MXFP8.

--- a/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
@@ -1,38 +1,125 @@
 # DiffusionGemma Osaurus Integration
 
-Date: 2026-06-12
+Date: 2026-06-12 (updated same day: native engine landed)
 
 ## Current Source Truth
 
-- Source bundle: `/Users/eric/models/google/diffusiongemma-26B-A4B-it`
-- Hub repo: `google/diffusiongemma-26B-A4B-it`
-- `model_type`: `diffusion_gemma`
-- Architecture: `DiffusionGemmaForBlockDiffusion`
+- Source bundle: `google/diffusiongemma-26B-A4B-it`
+- `model_type`: `diffusion_gemma`, architecture
+  `DiffusionGemmaForBlockDiffusion`
+- 30-layer Gemma4-style MoE (128 experts, top-8), 26B total / ~4B active,
+  256-token canvas, sliding window 1024
 - Vision: `vision_config` present, `image_token_id = 258880`,
   `vision_soft_tokens_per_image = 280`
 - Audio: `audio_config = null`, `audio_token_id = null`
-- Video: processor metadata is present, but `video_token_id = null`
+- Video: processor metadata present, but `video_token_id = null`
 
-## Osaurus Boundary
+## Engine status (vmlx-swift)
 
-This PR only teaches Osaurus capability surfaces about DiffusionGemma:
+The native block-diffusion engine is implemented in vmlx-swift
+(branch `codex/diffusiongemma-runtime`, PR #47): encoder prefill +
+bidirectional canvas decoder, entropy-bound sampler, adaptive stopping,
+self-conditioning — all parameters from the bundle's
+`generation_config.json`. Reference doc on the vmlx side:
+`docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md` (verification rows:
+token/s, multi-turn, tool calls, prefix/disk cache, memory, isolation).
 
-- `diffusion_gemma` is VLM-shaped for routing/discovery.
-- DiffusionGemma model ids advertise image support.
-- DiffusionGemma does not advertise audio or video support.
+## How DiffusionGemma flows through Osaurus — teammate wiring map
 
-It does not claim runtime generation. Native block-diffusion text/VL generation
-still belongs in vMLX: prompt encoder cache, denoising canvas, self-conditioning,
-entropy-bound accept/renoise, and image soft-token preparation must be implemented
-and live-proven before Osaurus should promote the row.
+1. **Discovery / capability**: `VLMDetection` recognizes
+   `diffusion_gemma` as VLM-shaped; `ModelFamilyNames.isDiffusionGemmaFamily`
+   keeps it distinct from Gemma-4 AR; `ModelMediaCapabilities` advertises
+   image-only (audio/video blocked until runtime-proven).
+2. **Loading**: `loadModelContainer` iterates factories; the VLM factory
+   rejects `diffusion_gemma` (`unsupportedModelType`) and the LLM factory
+   creates `DiffusionGemmaModel`. No Osaurus-side routing code needed.
+3. **Generation**: `MLXBatchAdapter` routes every request through
+   `BatchEngine.generate`. For `BlockDiffusionModel` conformers,
+   BatchEngine takes its **exclusive solo path** (same mechanism as
+   native MTP) into `BlockDiffusionTokenIterator`. The batched `submit()`
+   path is rejected loudly (the model's `prepare()` throws) — block
+   diffusion can never silently AR-decode or share batch slots.
+4. **Parsers**: tool calls use the Gemma-4 format
+   (`<|tool_call>call:name{...}<tool_call|>`, mapped from
+   `model_type` in `ToolCallFormat.infer`); reasoning stamp is `harmony`
+   (`<|channel>thought…<channel|>`). Both verified live with zero marker
+   leakage through `TextToolTokenLoopHandler`.
+5. **Caching**: encoder cache is Gemma4 topology (RotatingKVCache
+   window-1024 sliding + KVCacheSimple full layers, fp16 KV — no
+   TurboQuant). Rotating layers can't round-trip paged KV blocks, so the
+   iterator marks the coordinator paged-incompatible and prompt
+   boundaries are served by the **disk (L2/SSD) tier**. Verified:
+   fresh-coordinator resume restored 138/138 prompt tokens with
+   `prefillSec=0.000`; turn-extension hit passes; multi-turn live-cache
+   sessions keep the full reply via the end-of-turn cache commit.
 
-## Quant Dependency
+## Speed/quality control (the Osaurus setting)
 
-The companion vMLX branch adds first-party quant prep/conversion scripts for:
+`GenerateParameters.diffusionMaxDenoisingSteps` (vmlx) caps the
+denoising budget per 256-token canvas. Measured on MXFP4, M5 Max,
+~740-token essay:
 
-- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
-- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+| steps | tok/s | coherency |
+|---|---|---|
+| 48 (bundle default) | 37 | clean |
+| 24 | 58 | clean |
+| **16 (Osaurus default)** | **74** | clean (essay + multi-turn recall verified) |
+| 8 | 140 | BREAKS (word salad) |
 
-Full conversion is blocked on local free space at the time of this note. The
-downloaded BF16 source is 48 GB and the exact-shape estimates are about 14.85 GiB
-for MXFP4 and 26.0 GiB for MXFP8.
+Wiring:
+
+- Contract field: `VMLXServerGenerationDefaults.diffusionMaxDenoisingSteps`
+  (`nil` = bundle default; validation errors `< 1`, warns `< 12`).
+- Osaurus default: **16**, seeded once by `ServerRuntimeSettingsStore`
+  (`diffusion-defaults-migrated.marker`; after seeding, a blank field is a
+  sticky "use bundle default" choice).
+- Request flow: `RuntimeConfig.snapshot()` →
+  `MLXBatchAdapter` sets `mlxParams.diffusionMaxDenoisingSteps` →
+  `BlockDiffusionParameters.overriding(parameters:)` at dispatch.
+- UI: Server → Settings → Sampling → "Diffusion Models" →
+  "Denoising Steps per Canvas" (`GenerationDefaultsSection`).
+- Per-request API override: not exposed on the OpenAI wire yet
+  (server-level setting only).
+
+## Quant bundles
+
+vmlx PR #45 (merged, `710eb0d7…`) added the converter; both local quants
+verified:
+
+- MXFP4: 15 GB, 15 shards, `total_size=15944852880`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — ~37 tok/s @48 steps,
+  ~74 tok/s @16, peak RSS 12.7 GB
+- MXFP8: 26 GB, 23 shards, `total_size=27918936056`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — converges in fewer steps
+  (sometimes faster than MXFP4 end-to-end), peak RSS 23.8 GB
+
+## Pin management
+
+`Packages/OsaurusCore/Package.swift` pins `osaurus-ai/vmlx-swift` by
+revision; the same revision must appear in BOTH lockfiles
+(`Packages/OsaurusCore/Package.resolved`,
+`osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`) AND in the
+`RuntimePolicySourceTests` "vmlx pin uses consolidated package" expected
+revision constant — the focused test fails on any mismatch by design.
+
+Focused verification command:
+
+```sh
+OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
+OSAURUS_TEST_ROOT=/tmp/osaurus-dg-tests \
+swift test --package-path Packages/OsaurusCore \
+  --filter 'VLMDetectionTests|ModelMediaCapabilitiesMCDCTests|RuntimePolicySourceTests'
+```
+
+Debugging note: a bare `error: fatalError` from SwiftPM is a masked
+clang `fatal error:` — grep the full log. Fresh vmlx worktrees need
+`git submodule update --init --recursive` (Source/Cmlx) and tests need
+`scripts/prepare-mlx-metal.sh` metallibs.
+
+## Boundaries (unchanged)
+
+- Image-only capability advertised; **runtime VL is not yet wired** in
+  vmlx (vision tower ships in the bundles but text-only generation is
+  what's proven). Audio absent; video has no `video_token_id`.
+- Block diffusion is exclusive-solo in BatchEngine; batched canvas
+  scheduling is future work.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
+        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bfaefa6bcdffab849dd6852c52eb081f038f7e9c"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4a755408e62144c003029e2c3d4950e6d405104239cd7eab8817ae91f0aea02e",
+  "originHash" : "0544725836feb76abfab53307181320d9c6f07fd9e96641d4039931c498aa676",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -428,7 +428,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "76047f3b4492d4fae316267a30fba55163b1c5cd"
+        "revision" : "2878a8f6b3b4ea03ca19a62124cfe643dbb641d8"
       }
     },
     {


### PR DESCRIPTION
## Summary

Adds Osaurus-side DiffusionGemma support: capability gating, the pin to the merged vmlx-swift block-diffusion runtime, and the diffusion speed/quality server setting.

- recognizes `diffusion_gemma` as VLM-shaped for model_type detection
- adds a strict DiffusionGemma family matcher separate from Gemma 4 AR/QAT names
- advertises DiffusionGemma as image-only for model-id and directory-based media capability checks (audio/video stay blocked until runtime-proven)
- pins `vmlx-swift` to `2878a8f6b3b4ea03ca19a62124cfe643dbb641d8` (main: "Add DiffusionGemma block-diffusion runtime") across the manifest, all three lockfiles, and the RuntimePolicySource pin test
- adds the diffusion denoising-step server setting: Osaurus default **16** (≈74 tok/s on diffusiongemma-26B-A4B MXFP4, coherent) vs the bundle default 48 (≈37 tok/s); seeded once by `ServerRuntimeSettingsStore`, flows through `MLXBatchAdapter` into `GenerateParameters.diffusionMaxDenoisingSteps`, editable in Server → Settings → Sampling → "Diffusion Models" (blank = bundle default)

## Runtime status

The vmlx-swift engine is merged to main and live-verified (full rows in vmlx `docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md`):

- long-form: 37 tok/s @48 steps, 74 tok/s @16 (MXFP4); MXFP8 converges in fewer steps
- 3-turn ChatSession coherency with fact recall, warm prefill 0.07–0.13 s
- structured tool calls via the Gemma-4 parser through BatchEngine's exclusive solo path, zero marker leakage
- disk/SSD prefix cache: fresh-coordinator session resume restores the full prompt boundary with zero prefill
- peak RSS 12.7 GB (MXFP4) / 23.8 GB (MXFP8)

## Validation

- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=… swift test --package-path Packages/OsaurusCore --filter 'VLMDetectionTests|ModelMediaCapabilitiesMCDCTests|RuntimePolicySourceTests'` — **136/136 passed** at the final pin
- `swift package --package-path Packages/OsaurusCore resolve` — working copy at `2878a8f6…`
- `git diff --check` clean; source guard checks for family matcher / VLM detection / media capabilities / tests all present

## Boundary

Runtime VL is not claimed: the vision tower ships in the bundles but image generation is not wired in vmlx yet; text generation (with tools/reasoning/caching) is what is proven. Audio is absent from the bundle config; video has no `video_token_id`.

Teammate wiring map: `docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md`.
