### PR TITLE
hide embedding model from showing up for chat

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
@@ -128,7 +128,14 @@ final class ModelPickerItemCache: ObservableObject {
         }
 
         let localModels = await Task.detached(priority: .userInitiated) {
+            // Exclude embedding/encoder-only bundles (e.g. potion-base-4M
+            // pulled into the HF cache by the memory feature): they can't
+            // generate chat completions. They remain visible in the Models
+            // management UI and usable via /v1/embeddings. Reading
+            // `isEmbedding` here also warms its memoized verdict off the
+            // main actor, like the `isVLM` warm-up below.
             let models = ModelManager.discoverLocalModels()
+                .filter { !$0.isEmbedding }
             // Warm the memoized VLM verdicts while still off the main actor:
             // `fromMLXModel` below reads `isVLM` on the MainActor, and a cold
             // cache would otherwise fault one config.json read per model there.

--- a/Packages/OsaurusCore/Models/Configuration/EmbeddingDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/EmbeddingDetection.swift
@@ -1,0 +1,178 @@
+//
+//  EmbeddingDetection.swift
+//  osaurus
+//
+//  Single source of truth for embedding/encoder-only model detection.
+//  Classifies a bundle from its config.json (`architectures` /
+//  `model_type`) so embedding repos that arrive via the HF-cache or
+//  LM Studio import (e.g. minishlab/potion-base-4M downloaded by the
+//  memory feature, sentence-transformers/all-MiniLM-L6-v2 from Python
+//  tooling) are not offered as chat models.
+//
+//  The classifier is deliberately conservative: a bundle is only called
+//  an embedding model when its config positively identifies a known
+//  encoder-only family. Unknown, missing, or malformed configs stay
+//  chat-capable so a novel causal LM is never hidden from the picker.
+//
+
+import Foundation
+
+enum EmbeddingDetection {
+    // MARK: - Memoization
+
+    // Mirrors VLMDetection: verdicts are pure functions of the on-disk
+    // bundle, are read from SwiftUI body evaluations via
+    // `MLXModel.isEmbedding`, and each cold call reads + parses
+    // config.json synchronously. Cached per directory and dropped on
+    // `.localModelsChanged` to stay in sync with downloads/deletions.
+    private static let cacheLock = NSLock()
+    private nonisolated(unsafe) static var verdictCache: [String: Bool] = [:]
+    private nonisolated(unsafe) static var didInstallObserver = false
+
+    private static func cachedVerdict(_ key: String, compute: () -> Bool) -> Bool {
+        ensureCacheObserverInstalled()
+        cacheLock.lock()
+        if let cached = verdictCache[key] {
+            cacheLock.unlock()
+            return cached
+        }
+        cacheLock.unlock()
+
+        let result = compute()
+
+        cacheLock.lock()
+        verdictCache[key] = result
+        cacheLock.unlock()
+        return result
+    }
+
+    private static func ensureCacheObserverInstalled() {
+        cacheLock.lock()
+        let already = didInstallObserver
+        didInstallObserver = true
+        cacheLock.unlock()
+        if already { return }
+
+        NotificationCenter.default.addObserver(
+            forName: .localModelsChanged,
+            object: nil,
+            queue: nil
+        ) { _ in
+            EmbeddingDetection.cacheLock.lock()
+            EmbeddingDetection.verdictCache.removeAll(keepingCapacity: true)
+            EmbeddingDetection.cacheLock.unlock()
+        }
+    }
+
+    /// Whether the bundle at `directory` is an embedding/encoder-only model
+    /// per its config.json. Missing or unparseable configs return `false`.
+    static func isEmbedding(at directory: URL) -> Bool {
+        cachedVerdict("dir:\(directory.path)") {
+            guard let json = readConfigJSON(at: directory) else { return false }
+            return isEmbeddingConfig(json)
+        }
+    }
+
+    /// Pure classifier over a parsed config.json. Exposed for tests.
+    ///
+    /// Decision order:
+    /// 1. Any generative architecture marker (`*ForCausalLM`,
+    ///    `*ForConditionalGeneration`, `*LMHeadModel`, ...) → not embedding.
+    /// 2. A `vision_config` block → not embedding (VLM, handled elsewhere).
+    /// 3. A known encoder-only `model_type` (bert, model2vec, ...) → embedding.
+    /// 4. A non-empty `architectures` list whose entries are all
+    ///    encoder-style heads (`*Model`, `*ForMaskedLM`, ...) → embedding.
+    /// 5. Anything else → not embedding (stay chat-capable).
+    static func isEmbeddingConfig(_ json: [String: Any]) -> Bool {
+        let architectures = (json["architectures"] as? [String]) ?? []
+
+        if architectures.contains(where: isGenerativeArchitecture(_:)) {
+            return false
+        }
+        if json["vision_config"] != nil {
+            return false
+        }
+
+        if let modelType = json["model_type"] as? String {
+            let normalized =
+                modelType
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .replacingOccurrences(of: "-", with: "_")
+            if embeddingModelTypes.contains(normalized) {
+                return true
+            }
+        }
+
+        if !architectures.isEmpty,
+            architectures.allSatisfy(isEncoderArchitecture(_:))
+        {
+            return true
+        }
+
+        return false
+    }
+
+    // MARK: - Private
+
+    /// Encoder-only families used by embedding models. Normalized to
+    /// lowercase with `-` folded to `_` before lookup.
+    private static let embeddingModelTypes: Set<String> = [
+        "bert",
+        "camembert",
+        "deberta",
+        "deberta_v2",
+        "distilbert",
+        "electra",
+        "model2vec",
+        "modernbert",
+        "mpnet",
+        "nomic_bert",
+        "roberta",
+        "xlm_roberta",
+    ]
+
+    /// Architecture-head markers that imply text generation. Substring match
+    /// so family prefixes (`Qwen2ForCausalLM`, `GPT2LMHeadModel`,
+    /// `Gemma3ForConditionalGeneration`) are all caught.
+    private static let generativeArchitectureMarkers = [
+        "ForCausalLM",
+        "ForConditionalGeneration",
+        "LMHeadModel",
+        "ForImageTextToText",
+        "ForVision2Seq",
+        "ForSpeechSeq2Seq",
+    ]
+
+    /// Encoder task heads that cannot generate chat completions.
+    private static let encoderArchitectureMarkers = [
+        "ForMaskedLM",
+        "ForSequenceClassification",
+        "ForTokenClassification",
+        "ForQuestionAnswering",
+        "ForMultipleChoice",
+        "ForNextSentencePrediction",
+        "ForPreTraining",
+    ]
+
+    private static func isGenerativeArchitecture(_ name: String) -> Bool {
+        generativeArchitectureMarkers.contains { name.contains($0) }
+    }
+
+    /// True for the bare encoder (`BertModel`, `XLMRobertaModel`, model2vec's
+    /// `StaticModel`) or an encoder task head. Generative markers are checked
+    /// first, so the `*Model` suffix here can't swallow a causal-LM entry.
+    private static func isEncoderArchitecture(_ name: String) -> Bool {
+        if isGenerativeArchitecture(name) { return false }
+        return name.hasSuffix("Model")
+            || encoderArchitectureMarkers.contains { name.contains($0) }
+    }
+
+    private static func readConfigJSON(at directory: URL) -> [String: Any]? {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return json
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -318,6 +318,15 @@ struct MLXModel: Identifiable, Codable {
         return VLMDetection.isVLM(modelId: id)
     }
 
+    /// Whether this bundle is an embedding/encoder-only model (BERT family,
+    /// model2vec, etc.) that cannot generate chat completions. Detected from
+    /// the on-disk config.json; bundles that aren't on disk return false.
+    /// Used to keep embedding repos imported from the HF cache / LM Studio
+    /// out of chat surfaces while leaving them available to `/v1/embeddings`.
+    var isEmbedding: Bool {
+        EmbeddingDetection.isEmbedding(at: localDirectory)
+    }
+
     /// Extracts the model family from the name/id (e.g., "Llama", "Qwen", "Gemma", "Phi")
     var family: String {
         let name = self.name.lowercased()

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -65,6 +65,11 @@ struct ModelPickerItem: Identifiable, Hashable {
     /// Whether this is a Vision Language Model
     let isVLM: Bool
 
+    /// Whether this is an embedding/encoder-only model (BERT family,
+    /// model2vec, etc.). Set from `MLXModel.isEmbedding` for local items so
+    /// `isLikelyChatCapable` can exclude them without re-reading config.json.
+    let isEmbedding: Bool
+
     /// Description of the model (optional)
     let description: String?
 
@@ -75,6 +80,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         parameterCount: String? = nil,
         quantization: String? = nil,
         isVLM: Bool = false,
+        isEmbedding: Bool = false,
         description: String? = nil
     ) {
         self.id = id
@@ -83,6 +89,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         self.parameterCount = parameterCount
         self.quantization = quantization
         self.isVLM = isVLM
+        self.isEmbedding = isEmbedding
         self.description = description
     }
 
@@ -115,6 +122,7 @@ extension ModelPickerItem {
             parameterCount: model.parameterCount,
             quantization: model.quantization,
             isVLM: model.isVLM,
+            isEmbedding: model.isEmbedding,
             description: model.description
         )
     }
@@ -158,10 +166,15 @@ extension ModelPickerItem {
     /// picker is never left empty when models exist.
     var isLikelyChatCapable: Bool {
         switch source {
-        case .foundation, .local:
-            // Foundation is Apple's on-device chat model; `.local` items come
-            // from the curated MLX catalog, which is chat-only.
+        case .foundation:
+            // Foundation is Apple's on-device chat model.
             return true
+        case .local:
+            // `.local` items include disk-scanned and externally-imported
+            // bundles (HF cache, LM Studio), not just the curated chat
+            // catalog, so an embedding repo can appear here. The flag is
+            // detected from the bundle's config.json at item construction.
+            return !isEmbedding
         case .remote:
             return !Self.isLikelyEmbeddingOrRerankerID(id)
         }

--- a/Packages/OsaurusCore/Tests/Model/EmbeddingDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/EmbeddingDetectionTests.swift
@@ -1,0 +1,175 @@
+//
+//  EmbeddingDetectionTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the config.json-based embedding/encoder-only classifier that keeps
+//  embedding repos (potion-base-4M pulled into the HF cache by the memory
+//  feature, all-MiniLM-L6-v2 from Python tooling, etc.) out of the chat
+//  picker. The classifier must be conservative: only positively-identified
+//  encoder-only configs are flagged; unknown or malformed configs stay
+//  chat-capable so a novel causal LM is never hidden.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct EmbeddingDetectionTests {
+
+    // MARK: - Pure config classifier: embedding configs
+
+    @Test func potionStyleModel2VecConfigIsEmbedding() {
+        // minishlab/potion-base-4M: model2vec static embedding model.
+        let config: [String: Any] = [
+            "model_type": "model2vec",
+            "architectures": ["StaticModel"],
+            "hidden_dim": 128,
+            "normalize": true,
+        ]
+        #expect(EmbeddingDetection.isEmbeddingConfig(config))
+    }
+
+    @Test func miniLMStyleBertConfigIsEmbedding() {
+        // sentence-transformers/all-MiniLM-L6-v2.
+        let config: [String: Any] = [
+            "model_type": "bert",
+            "architectures": ["BertModel"],
+            "hidden_size": 384,
+        ]
+        #expect(EmbeddingDetection.isEmbeddingConfig(config))
+    }
+
+    @Test func knownEmbeddingModelTypesAreFlagged() {
+        for modelType in [
+            "bert", "distilbert", "roberta", "xlm-roberta", "XLM-RoBERTa",
+            "nomic_bert", "modernbert", "model2vec", "mpnet",
+        ] {
+            #expect(
+                EmbeddingDetection.isEmbeddingConfig(["model_type": modelType]),
+                "Expected model_type \(modelType) to be flagged as embedding"
+            )
+        }
+    }
+
+    @Test func encoderOnlyArchitecturesWithoutModelTypeAreFlagged() {
+        // Architecture-suffix fallback for configs whose model_type isn't in
+        // the known family set.
+        #expect(EmbeddingDetection.isEmbeddingConfig(["architectures": ["NewEncoderModel"]]))
+        #expect(EmbeddingDetection.isEmbeddingConfig(["architectures": ["SomeBertForMaskedLM"]]))
+        #expect(
+            EmbeddingDetection.isEmbeddingConfig([
+                "architectures": ["XForSequenceClassification"]
+            ])
+        )
+    }
+
+    // MARK: - Pure config classifier: chat configs must NOT be flagged
+
+    @Test func causalLMConfigsAreNotEmbedding() {
+        for architectures in [
+            ["Qwen2ForCausalLM"],
+            ["LlamaForCausalLM"],
+            ["GPT2LMHeadModel"],
+            ["Gemma3ForConditionalGeneration"],
+        ] {
+            #expect(
+                !EmbeddingDetection.isEmbeddingConfig(["architectures": architectures]),
+                "Did not expect \(architectures) to be flagged as embedding"
+            )
+        }
+    }
+
+    @Test func generativeArchitectureWinsOverEmbeddingModelType() {
+        // A causal-LM head must override a model_type that happens to be in
+        // the embedding family set.
+        let config: [String: Any] = [
+            "model_type": "bert",
+            "architectures": ["BertLMHeadModel"],
+        ]
+        #expect(!EmbeddingDetection.isEmbeddingConfig(config))
+    }
+
+    @Test func mixedArchitecturesAreNotEmbedding() {
+        let config: [String: Any] = [
+            "architectures": ["SomethingModel", "SomethingForCausalLM"]
+        ]
+        #expect(!EmbeddingDetection.isEmbeddingConfig(config))
+    }
+
+    @Test func vlmConfigIsNotEmbedding() {
+        // VLM configs carry vision_config; even when architectures look
+        // encoder-ish, the VLM path owns them.
+        let config: [String: Any] = [
+            "model_type": "qwen2_vl",
+            "architectures": ["Qwen2VLModel"],
+            "vision_config": ["depth": 32],
+        ]
+        #expect(!EmbeddingDetection.isEmbeddingConfig(config))
+    }
+
+    @Test func unknownOrEmptyConfigsAreNotEmbedding() {
+        #expect(!EmbeddingDetection.isEmbeddingConfig([:]))
+        #expect(!EmbeddingDetection.isEmbeddingConfig(["model_type": "qwen2"]))
+        #expect(!EmbeddingDetection.isEmbeddingConfig(["model_type": "llama"]))
+        // MLX conversions sometimes drop `architectures`; an unknown
+        // model_type alone must not flag.
+        #expect(!EmbeddingDetection.isEmbeddingConfig(["model_type": "some_new_family"]))
+    }
+
+    // MARK: - On-disk detection
+
+    private func makeBundle(config: [String: Any]?) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osu-embed-detect-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let config {
+            let data = try JSONSerialization.data(withJSONObject: config)
+            try data.write(to: dir.appendingPathComponent("config.json"))
+        }
+        return dir
+    }
+
+    @Test func detectsEmbeddingBundleOnDisk() throws {
+        let dir = try makeBundle(config: [
+            "model_type": "bert",
+            "architectures": ["BertModel"],
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(EmbeddingDetection.isEmbedding(at: dir))
+    }
+
+    @Test func causalBundleOnDiskIsNotEmbedding() throws {
+        let dir = try makeBundle(config: [
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(!EmbeddingDetection.isEmbedding(at: dir))
+    }
+
+    @Test func missingConfigIsNotEmbedding() throws {
+        let dir = try makeBundle(config: nil)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(!EmbeddingDetection.isEmbedding(at: dir))
+    }
+
+    @Test func mlxModelIsEmbeddingReadsBundleDirectory() throws {
+        // External bundles (HF cache / LM Studio) pin `bundleDirectory`;
+        // `MLXModel.isEmbedding` must resolve through it.
+        let dir = try makeBundle(config: [
+            "model_type": "model2vec",
+            "architectures": ["StaticModel"],
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let model = MLXModel(
+            id: "minishlab/potion-base-4M",
+            name: "Potion Base 4M",
+            description: "fixture",
+            downloadURL: "https://example.invalid/potion",
+            bundleDirectory: dir,
+            externalSource: "Hugging Face cache"
+        )
+        #expect(model.isEmbedding)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -117,4 +117,73 @@ struct ModelPickerItemCacheTests {
             #expect(final.count == initialCount)
         }
     }
+
+    /// Embedding/encoder-only bundles (e.g. potion-base-4M pulled into the
+    /// HF cache by the memory feature) must be excluded from the chat
+    /// picker's item list, while regular causal-LM bundles pass through.
+    @Test func computeItems_excludesLocalEmbeddingBundles() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            // Two on-disk fixture bundles classified purely via config.json.
+            func makeBundle(config: [String: Any]) throws -> URL {
+                let dir = FileManager.default.temporaryDirectory
+                    .appendingPathComponent(
+                        "osu-picker-cache-\(UUID().uuidString)",
+                        isDirectory: true
+                    )
+                try FileManager.default.createDirectory(
+                    at: dir,
+                    withIntermediateDirectories: true
+                )
+                try JSONSerialization.data(withJSONObject: config)
+                    .write(to: dir.appendingPathComponent("config.json"))
+                return dir
+            }
+            let chatDir = try makeBundle(config: [
+                "model_type": "qwen2",
+                "architectures": ["Qwen2ForCausalLM"],
+            ])
+            let embedDir = try makeBundle(config: [
+                "model_type": "model2vec",
+                "architectures": ["StaticModel"],
+            ])
+
+            let fixtures = [
+                MLXModel(
+                    id: "fixture/chat-model-4bit",
+                    name: "Fixture Chat Model",
+                    description: "fixture",
+                    downloadURL: "https://example.invalid/chat",
+                    bundleDirectory: chatDir
+                ),
+                MLXModel(
+                    id: "fixture/potion-base-4M",
+                    name: "Fixture Embedding Model",
+                    description: "fixture",
+                    downloadURL: "https://example.invalid/potion",
+                    bundleDirectory: embedDir
+                ),
+            ]
+
+            let prevScan = ModelManager.scanLocalModelsOverrideForTests
+            let prevWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+            ModelManager.localModelsScanWaitLimitOverrideForTests = 2.0
+            ModelManager.scanLocalModelsOverrideForTests = { _ in fixtures }
+            ModelManager.invalidateLocalModelsCache()
+
+            let items = await ModelPickerItemCache.shared.buildModelPickerItems()
+            let ids = items.map(\.id)
+
+            // Restore globals and rebuild before asserting so fixture
+            // entries can't linger in the shared cache for later suites.
+            ModelManager.scanLocalModelsOverrideForTests = prevScan
+            ModelManager.localModelsScanWaitLimitOverrideForTests = prevWait
+            ModelManager.invalidateLocalModelsCache()
+            await ModelPickerItemCache.shared.buildModelPickerItems()
+            try? FileManager.default.removeItem(at: chatDir)
+            try? FileManager.default.removeItem(at: embedDir)
+
+            #expect(ids.contains("fixture/chat-model-4bit"))
+            #expect(!ids.contains("fixture/potion-base-4M"))
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemChatCapabilityTests.swift
@@ -131,16 +131,75 @@ struct ModelPickerItemChatCapabilityTests {
         #expect(ModelPickerItem.foundation().isLikelyChatCapable)
     }
 
-    @Test func localModelsAreAlwaysChatCapable() {
-        // Local models come from the curated MLX catalog (chat-only), so the
-        // heuristic is bypassed even if the name happens to match an
-        // embedding pattern.
+    @Test func localNonEmbeddingModelsAreChatCapable() {
+        // Local items use the config.json-derived `isEmbedding` flag, not
+        // the name heuristic — an embedding-looking name must not trip it.
         let localLooksLikeEmbedding = ModelPickerItem(
             id: "mlx-community/some-embedded-model-name",
             displayName: "Some Embedded",
             source: .local
         )
         #expect(localLooksLikeEmbedding.isLikelyChatCapable)
+    }
+
+    @Test func localEmbeddingModelsAreNotChatCapable() {
+        // An embedding bundle imported from the HF cache (e.g.
+        // minishlab/potion-base-4M downloaded by the memory feature) is not
+        // chat-capable, even though its name matches no embedding token.
+        let item = ModelPickerItem(
+            id: "minishlab/potion-base-4M",
+            displayName: "Potion Base 4M",
+            source: .local,
+            isEmbedding: true
+        )
+        #expect(!item.isLikelyChatCapable)
+    }
+
+    @Test func firstChatCapable_skipsLeadingLocalEmbedding() {
+        // Alphabetical ordering frequently puts all-MiniLM/potion first in
+        // the local list; default selection must skip past them.
+        let items: [ModelPickerItem] = [
+            ModelPickerItem(
+                id: "sentence-transformers/all-MiniLM-L6-v2",
+                displayName: "All MiniLM L6 v2",
+                source: .local,
+                isEmbedding: true
+            ),
+            ModelPickerItem(
+                id: "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                displayName: "Llama 3.2 3B",
+                source: .local
+            ),
+        ]
+        #expect(items.firstChatCapable?.id == "mlx-community/Llama-3.2-3B-Instruct-4bit")
+    }
+
+    @Test func fromMLXModel_carriesEmbeddingVerdictFromBundleConfig() throws {
+        // The picker item's flag must come from the bundle's config.json via
+        // MLXModel.isEmbedding, so HF-cache imports are classified by
+        // architecture rather than by name.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osu-picker-embed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let config: [String: Any] = [
+            "model_type": "bert",
+            "architectures": ["BertModel"],
+        ]
+        try JSONSerialization.data(withJSONObject: config)
+            .write(to: dir.appendingPathComponent("config.json"))
+
+        let model = MLXModel(
+            id: "sentence-transformers/all-MiniLM-L6-v2",
+            name: "All MiniLM L6 v2",
+            description: "fixture",
+            downloadURL: "https://example.invalid/minilm",
+            bundleDirectory: dir,
+            externalSource: "Hugging Face cache"
+        )
+        let item = ModelPickerItem.fromMLXModel(model)
+        #expect(item.isEmbedding)
+        #expect(!item.isLikelyChatCapable)
     }
 
     @Test func remoteEmbeddingIsNotChatCapable() {


### PR DESCRIPTION
## Summary

hide embedding model from showing up

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
