### PR TITLE
Gemma 4 audio + GGUF-class speed: repin vMLX 1ab081eb, fix TurboQuant KV regression, decode performance settings

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "020ec0d5f96cc158dd82ea1973cae66c0b70face"
+        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -343,6 +343,25 @@ public enum ModelMediaCapabilities {
             return .textOnly
         }
 
+        // Gemma4: audio capability is checkpoint-fact-driven, not
+        // name-driven. The same family ships three different audio
+        // realities (verified against the OsaurusAI QAT weight maps):
+        //   12B (gemma4_unified)  — encoder-free `embed_audio` raw-frame
+        //                           projection; vMLX decodes raw audio
+        //                           natively via unified chunking.
+        //   E2B/E4B (gemma4)      — mel + conformer `audio_tower` plus
+        //                           `embed_audio`.
+        //   26B-A4B / 31B         — NO audio tensors in the checkpoint;
+        //                           audio is impossible there, not
+        //                           "unwired", so it stays unsupported.
+        if modelType.hasPrefix("gemma4") {
+            return Capabilities(
+                supportsImage: true,
+                supportsVideo: false,
+                supportsAudio: gemma4BundleSupportsAudio(directory: directory)
+            )
+        }
+
         // Cross-check the family-by-model_type for video support.
         // model_types known to support video at the engine level:
         let videoCapableModelTypes: Set<String> = [
@@ -368,6 +387,32 @@ public enum ModelMediaCapabilities {
             capabilities: from(directory: directory, modelId: modelId),
             source: "bundle config"
         )
+    }
+
+    /// True when a locally-installed Gemma4 bundle ships the audio input
+    /// tensors the runtime needs. Checks the safetensors weight map for
+    /// `embed_audio.embedding_projection` — present in the 12B unified
+    /// (raw-frame) and E2B/E4B (mel + `audio_tower`) checkpoints, absent
+    /// from 26B-A4B / 31B. A raw byte scan is used instead of full JSON
+    /// decoding because the 12B index is multi-MB and this runs on the
+    /// capability-resolution path.
+    private static func gemma4BundleSupportsAudio(directory: URL) -> Bool {
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        if let data = try? Data(contentsOf: indexURL, options: .mappedIfSafe) {
+            return data.range(of: Data("embed_audio.embedding_projection".utf8)) != nil
+        }
+        // Single-file bundles: fall back to the config's audio marker.
+        // Gemma4 configs always carry audio_token_id, so use audio_config
+        // presence (E-series) only; without an index we cannot prove the
+        // unified embed_audio tensor exists, so stay conservative.
+        let configURL = directory.appendingPathComponent("config.json")
+        if let data = try? Data(contentsOf: configURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let audioConfig = json["audio_config"], !(audioConfig is NSNull)
+        {
+            return true
+        }
+        return false
     }
 
     // MARK: - Helpers
@@ -415,11 +460,27 @@ public enum ModelMediaCapabilities {
             )
         }
         if isGemma4VisionFamily(modelId, capabilities: capabilities) {
+            // Bundle-fact gate: `from(directory:)` only reports audio for
+            // Gemma4 bundles whose weight map actually ships
+            // `embed_audio.embedding_projection`. When detection ran against
+            // the installed bundle, reaching here means this checkpoint has
+            // no audio input tensors (26B-A4B / 31B) — audio is impossible
+            // for the checkpoint, not pending runtime wiring. Name-only
+            // detection cannot see the weight map, so it must not claim
+            // checkpoint facts.
+            if source == "bundle config" {
+                return ModalityDescriptor(
+                    modality: .audio,
+                    status: .unsupported,
+                    reason:
+                        "This Gemma4 checkpoint ships no audio input tensors (no embed_audio/audio_tower in the weight map); audio input is not possible for this bundle."
+                )
+            }
             return ModalityDescriptor(
                 modality: .audio,
                 status: .unproven,
                 reason:
-                    "Gemma4 audio input is not enabled because the pinned vMLX Gemma4 runtime does not wire audio_tower/embed_audio yet."
+                    "Gemma4 audio is enabled per-bundle from the installed weight map (12B unified and E-series ship audio tensors; 26B-A4B/31B do not). Install the model so the bundle can be inspected."
             )
         }
         return ModalityDescriptor(

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "51f6dad0588b5dca4a20a23398239420093f0d35a823ebaebef365226ebc05fd",
+  "originHash" : "90b978b3181e38856231340854e47187ffaa8455492014bf4e6b2780929a3470",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -367,14 +367,6 @@
       "location" : "https://github.com/rryam/VecturaKit",
       "state" : {
         "revision" : "3bc52538f16a95d956c575abbc7e0423737dfd64"
-      }
-    },
-    {
-      "identity" : "vmlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/osaurus-ai/vmlx-swift",
-      "state" : {
-        "revision" : "020ec0d5f96cc158dd82ea1973cae66c0b70face"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -370,6 +370,14 @@
       }
     },
     {
+      "identity" : "vmlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/osaurus-ai/vmlx-swift",
+      "state" : {
+        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+      }
+    },
+    {
       "identity" : "yyjson",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ibireme/yyjson.git",

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "020ec0d5f96cc158dd82ea1973cae66c0b70face"
+            revision: "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -14295,6 +14295,22 @@
         }
       }
     },
+    "Decode Performance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dekodier-Leistung"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\u89e3\u7801\u6027\u80fd"
+          }
+        }
+      }
+    },
     "Decode-split count" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1309,6 +1309,7 @@ public actor ModelRuntime {
             try Task.checkCancellation()
             let tokenizerLoader = SwiftTransformersTokenizerLoader()
             let serverSettings = ServerRuntimeSettingsStore.snapshot()
+            Self.applyPerformancePolicy(serverSettings)
             let mtpPlan = Self.resolveNativeMTPLaunchPlan(
                 modelName: name,
                 modelDirectory: localURL,
@@ -2206,6 +2207,31 @@ public actor ModelRuntime {
     /// penalties / stop sequences. `stopSequences` becomes `extraStopStrings` — the
     /// library matches against the post-reasoning, post-tool-call `.chunk`
     /// stream and halts with `.info(stopReason: .stop)` on a hit.
+    /// Apply the server performance settings that act through process-level
+    /// engine policy rather than per-call parameters. Called before every
+    /// model load so a settings change takes effect on the next load:
+    ///  - tiedHeadCodec -> TiedHeadQuantizationPolicy (vmlx loader consults
+    ///    it; only applies to quantized bundles whose tied head ships
+    ///    unquantized — see VMLXServerPerformanceSettings docs)
+    ///  - compiledDecode -> VMLX_ENABLE_UNSAFE_COMPILE process gate (vmlx
+    ///    keeps MLX compile globally opt-in pending the PR #1173
+    ///    model-switch corruption root cause; the per-request flag is set
+    ///    in makeGenerateParameters)
+    nonisolated static func applyPerformancePolicy(_ settings: VMLXServerRuntimeSettings) {
+        let perf = settings.effectivePerformance
+        if let quant = perf.tiedHeadCodec.quantization {
+            TiedHeadQuantizationPolicy.current = .init(
+                bits: quant.bits, groupSize: quant.groupSize)
+        } else {
+            TiedHeadQuantizationPolicy.current = nil
+        }
+        if perf.compiledDecode {
+            setenv("VMLX_ENABLE_UNSAFE_COMPILE", "1", 1)
+        } else {
+            unsetenv("VMLX_ENABLE_UNSAFE_COMPILE")
+        }
+    }
+
     nonisolated static func makeGenerateParameters(
         temperature: Float,
         maxTokens: Int,
@@ -2233,6 +2259,12 @@ public actor ModelRuntime {
         if let prefillStepSize, prefillStepSize > 0 {
             params.prefillStepSize = prefillStepSize
         }
+        // Experimental solo compiled decode (server settings performance
+        // group). The engine additionally requires the process-level
+        // VMLX_ENABLE_UNSAFE_COMPILE gate set by applyPerformancePolicy,
+        // so a stale parameter alone can never engage compile.
+        params.enableCompiledDecode =
+            ServerRuntimeSettingsStore.snapshot().effectivePerformance.compiledDecode
         return params
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1603,9 +1603,17 @@ public actor ModelRuntime {
             return false
         }
         if let cacheTopology {
-            if ModelFamilyNames.isGemmaFamily(modelName) {
-                return cacheTopology.kvLayerCount > 0
-            }
+            // No Gemma special case: Gemma 4's SWA topology (5:1 sliding
+            // 1024-token rotating windows + MQA full layers) keeps native KV
+            // tiny (~70 MB at 4k ctx on 26B-A4B), so TurboQuant buys almost
+            // no RAM while costing real decode throughput — measured
+            // 2026-06-12 on M5 Max RunBench, greedy, kvMode none vs tq33:
+            // 26B-A4B MXFP4 92.3 -> 54.0 tok/s (-42%), 12B MXFP4 48.6 ->
+            // 34.5 (-29%). The earlier forced `return kvLayerCount > 0`
+            // here is what regressed Gemma app decode from the documented
+            // 100+ tok/s 26B rows. The generic rotating-layer rule below
+            // now applies; TurboQuant stays available for Gemma via the
+            // explicit cache.liveKVCodec=turboQuant setting.
             if cacheTopology.mambaLayerCount > 0
                 || cacheTopology.arraysLayerCount > 0
                 || cacheTopology.hybridPoolLayerCount > 0

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -310,8 +310,12 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.Capabilities.omni.anyMedia)
     }
 
-    @Test("Descriptor marks Gemma4 audio as runtime-unwired, not supported")
-    func descriptor_gemma4AudioRuntimeUnwired() {
+    @Test("Descriptor gates Gemma4 audio per-bundle when only the name is known")
+    func descriptor_gemma4AudioBundleGatedByName() {
+        // Name-only detection cannot see the weight map, so audio stays
+        // unproven with the per-bundle gating message. Installed-bundle
+        // detection (`from(directory:)`) flips audio on iff the weight map
+        // ships embed_audio.embedding_projection (12B unified + E-series).
         let descriptor = ModelMediaCapabilities.descriptor(
             modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4"
         )
@@ -320,7 +324,7 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(descriptor.image.status == .supported)
         #expect(descriptor.audio.status == .unproven)
         #expect(!descriptor.audio.isUsable)
-        #expect(descriptor.rejectionMessage(for: .audio).contains("audio_tower/embed_audio"))
+        #expect(descriptor.rejectionMessage(for: .audio).contains("Gemma4 audio is enabled per-bundle"))
     }
 
     @Test("Descriptor keeps Nemotron Omni audio supported")

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -693,6 +693,10 @@ struct MLXBatchAdapterTests {
                 modelName: "JANGQ-AI/Step-3.7-Flash-JANG_2L"
             ) == "fp16"
         )
+        // Gemma SWA topologies stay native even when topology facts are
+        // present: rotating layers route through the generic rule (no Gemma
+        // special case). Forcing turbo(3,3) here measured -42% decode on
+        // 26B-A4B and -29% on 12B for ~70 MB of KV savings (2026-06-12).
         let gemmaSWATopology = ModelCacheTopologySnapshot(
             layerCount: 6,
             kvLayerCount: 3,
@@ -708,7 +712,7 @@ struct MLXBatchAdapterTests {
                 for: settings.cache,
                 modelName: "Gemma-4-26B-A4B-it-JANG_4M-CRACK",
                 cacheTopology: gemmaSWATopology
-            ) == "turbo(3,3)"
+            ) == "fp16"
         )
         #expect(
             ModelRuntime.cacheKVModeTag(

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -109,7 +109,7 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
-    @Test func modelCapabilityRejectsGemma4AudioAsRuntimeUnwired() {
+    @Test func modelCapabilityGatesGemma4AudioOnBundleFacts() {
         let message = ChatMessage(
             role: "user",
             content: "hear this",
@@ -119,6 +119,11 @@ struct MLXServiceRuntimePolicyTests {
             ]
         )
 
+        // Name-only detection cannot see the weight map, so audio stays
+        // rejected with the per-bundle gating message — NOT a blanket
+        // "runtime unwired" claim. With an installed bundle directory,
+        // capability comes from the weight map itself: 12B unified and
+        // E-series checkpoints ship audio tensors; 26B-A4B/31B do not.
         do {
             try MLXService.validateRuntimePolicy(
                 modelName: "gemma-4-12b-it-mxfp4",
@@ -128,11 +133,10 @@ struct MLXServiceRuntimePolicyTests {
                 tools: [],
                 runtime: VMLXServerRuntimeSettings()
             )
-            Issue.record("Gemma4 audio should remain blocked until vMLX wires the runtime audio path.")
+            Issue.record("Gemma4 audio must stay rejected when bundle facts are unavailable.")
         } catch let error as MLXService.RuntimePolicyError {
             let description = error.errorDescription ?? ""
-            #expect(description.contains("Gemma4 audio input is not enabled"))
-            #expect(description.contains("audio_tower/embed_audio"))
+            #expect(description.contains("Gemma4 audio is enabled per-bundle"))
         } catch {
             Issue.record("Unexpected error type: \(error)")
         }

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -603,7 +603,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "020ec0d5f96cc158dd82ea1973cae66c0b70face"
+        let expectedRuntimeHardenedRevision = "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -945,9 +945,10 @@ struct RuntimePolicySourceTests {
             "Step 3.7 runtime policy must stay text-only/tool-capable and must not block preflight on external bundle metadata until Step VLM is wired and proven"
         )
         #expect(
-            runtime.contains("if ModelFamilyNames.isGemmaFamily(modelName)")
-                && runtime.contains("return cacheTopology.kvLayerCount > 0"),
-            "Gemma SWA must allow TurboQuant for KV-capable full-attention layers while topology tags preserve rotating SWA layers"
+            !runtime.contains(
+                "if ModelFamilyNames.isGemmaFamily(modelName) {\n                return cacheTopology.kvLayerCount > 0")
+                && runtime.contains("rotatingKVLayerCount > 0"),
+            "Gemma SWA must NOT be special-cased into TurboQuant KV: the generic rotating-topology rule keeps it native. Forcing TQ on Gemma 4 measured -42% decode on 26B-A4B and -29% on 12B (2026-06-12 RunBench) for ~70 MB of KV savings; TurboQuant remains available via explicit cache.liveKVCodec=turboQuant."
         )
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
@@ -1,0 +1,70 @@
+//
+//  DecodePerformanceSection.swift
+//  osaurus
+//
+//  User-facing controls for `VMLXServerRuntimeSettings.performance`:
+//  the tied-LM-head load codec and the experimental compiled decode
+//  toggle. Both act through `ModelRuntime.applyPerformancePolicy(_:)`
+//  on the next model load; compiled decode additionally flows through
+//  `makeGenerateParameters` per request.
+//
+//  Measured context (M5 Max, Gemma 4 E2B QAT, greedy, 2026-06-12):
+//  fp16 head 120.1 tok/s -> q6 head 132.5 -> + compiled decode 165.3,
+//  vs the documented llama.cpp GGUF decode baseline of 173.7 tok/s.
+//
+
+@preconcurrency import MLXLMCommon
+import SwiftUI
+
+struct DecodePerformanceSection: View {
+    @Binding var draft: VMLXServerRuntimeSettings
+
+    private var performanceBinding: Binding<VMLXServerPerformanceSettings> {
+        Binding(
+            get: { draft.effectivePerformance },
+            set: { draft.performance = $0 }
+        )
+    }
+
+    var body: some View {
+        ServerSettingsCard(
+            section: .decodePerformance,
+            status: .engineReady,
+            blurb:
+                "Decode-throughput options for local vMLX models. Changes apply on the next model load."
+        ) {
+            SettingsField(
+                label: "Tied LM Head Codec",
+                hint:
+                    "Quantizes a tied output head that ships unquantized inside an otherwise-quantized bundle (e.g. Gemma 4 QAT's fp16 262k-vocab head, ~1 GB read per decoded token on E2B). q6 matches the precision class of llama.cpp's GGUF Q6_K output head. Never alters heads the bundle ships pre-quantized, and never applies to full-precision bundles."
+            ) {
+                Picker("", selection: performanceBinding.tiedHeadCodec) {
+                    ForEach(VMLXTiedHeadCodec.allCases, id: \.self) { codec in
+                        Text(codecTitle(codec)).tag(codec)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+            }
+
+            SettingsField(
+                label: "Compiled Decode (Experimental)",
+                hint:
+                    "Fuses the per-token decode graph with MLX compile (+25% measured on Gemma 4 QAT). Experimental: kept off by default until the historical model-switch corruption (PR #1173) is root-caused. If model switching misbehaves with this on, turn it off and reload."
+            ) {
+                Toggle("", isOn: performanceBinding.compiledDecode)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+            }
+        }
+    }
+
+    private func codecTitle(_ codec: VMLXTiedHeadCodec) -> String {
+        switch codec {
+        case .fp16Passthrough: return "As shipped (fp16 passthrough)"
+        case .q8: return "8-bit (q8, conservative)"
+        case .q6: return "6-bit (q6, GGUF-head parity)"
+        case .q4: return "4-bit (q4, fastest)"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsSection.swift
@@ -22,6 +22,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
     case concurrency
     case cache
     case memorySafety
+    case decodePerformance
     case speculative
     case liveActivity
     case multimodal
@@ -42,6 +43,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
         case .concurrency: return L("Concurrency & Batching")
         case .cache: return L("Cache")
         case .memorySafety: return L("Memory Safety")
+        case .decodePerformance: return L("Decode Performance")
         case .speculative: return L("Speculative Decoding")
         case .liveActivity: return L("Live Activity")
         case .multimodal: return L("Multimodal")
@@ -62,6 +64,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
         case .concurrency: return "gauge.with.dots.needle.bottom.0percent"
         case .cache: return "externaldrive.connected.to.line.below"
         case .memorySafety: return "memorychip.fill"
+        case .decodePerformance: return "speedometer"
         case .speculative: return "bolt.horizontal"
         case .liveActivity: return "waveform.path.ecg"
         case .multimodal: return "photo.on.rectangle.angled"
@@ -78,7 +81,7 @@ enum ServerSettingsSection: String, CaseIterable, Hashable, Identifiable {
             return .server
         case .sampling:
             return .generation
-        case .concurrency, .cache, .memorySafety, .speculative, .liveActivity:
+        case .concurrency, .cache, .memorySafety, .decodePerformance, .speculative, .liveActivity:
             return .performance
         case .multimodal, .tools:
             return .capabilities

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -154,6 +154,8 @@ struct ServerSettingsTabContent: View {
                         .id(ServerSettingsSection.cache)
                     MemorySafetySection(draft: $draft)
                         .id(ServerSettingsSection.memorySafety)
+                    DecodePerformanceSection(draft: $draft)
+                        .id(ServerSettingsSection.decodePerformance)
                     MTPSection(draft: $draft)
                         .id(ServerSettingsSection.speculative)
                     LiveActivitySection()

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -470,6 +470,40 @@ Post-main merge checkpoint for Osaurus PR #1469, 2026-06-12:
   paged cache off by default, disk L2/prefix telemetry, prefill events on the
   direct chat surface, and repeat cache hits.
 
+## Gemma Speed + Audio Checkpoint (vMLX main 1ab081eb)
+
+Follow-up checkpoint, 2026-06-12, after merged `osaurus-ai/vmlx-swift`
+PR #46 (vMLX main `1ab081eb1d51568ae636f64b9ac76cd3ab4d2534`):
+
+- The audio and raw-speed deferrals from the previous checkpoint are
+  resolved at the engine level. vMLX main now carries:
+  - the TaskLocal prefill reporter crash fix (`dc52096`), which the
+    previous `020ec0d5` pin was missing — raw Gemma 4 QAT generation on
+    that pin segfaults at generation start (`RunBench` repro,
+    `/tmp/gemma4-speed-proof/e2b-mxfp4-perf.log`);
+  - Gemma 4 audio for every checkpoint that ships audio tensors: 12B
+    unified raw-waveform chunking (Gemma4UnifiedAudioFeatureExtractor
+    parity) and the E-series conformer `audio_tower` port (proof: E2B
+    transcribed synthesized speech verbatim,
+    `/tmp/gemma4-audio-proof/PROOF-SUMMARY.txt`). 26B-A4B/31B ship no
+    audio tensors; Osaurus now reports audio per-bundle from the weight
+    map instead of a blanket "runtime unwired" refusal;
+  - decode-speed levers vs the documented llama.cpp E2B GGUF baseline
+    (7384.7 prefill / 173.7 decode tok/s): TaskLocal fix 120.1 →
+    tied-head q6 132.5 → compiled decode 165.3 tok/s (MXFP4; JANG_4M
+    165.1), and prefill measured at 10,068 tok/s on a 1,957-token
+    prompt — above the GGUF prefill baseline. Bench artifacts under
+    `/tmp/gemma4-speed-proof/`.
+- Osaurus wires the levers as the Decode Performance settings section
+  (`performance.tiedHeadCodec`, default fp16 passthrough;
+  `performance.compiledDecode`, default off — experimental pending the
+  PR #1173 model-switch corruption root cause). Defaults change no
+  behavior; both levers act on the next model load via
+  `ModelRuntime.applyPerformancePolicy`.
+- The E2B JANG_4M ~7 GB load footprint is the bundle's own on-disk size
+  (7.3 GB, mixed-precision profile) mapped via mmap — not a runtime
+  leak. MXFP4 E2B is 3.8 GB on disk / ~1.7 GB footprint.
+
 ## Provider wire-format requirements
 
 Quirks discovered live, handled automatically by Osaurus. Useful if you

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "020ec0d5f96cc158dd82ea1973cae66c0b70face"
+        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
       }
     },
     {


### PR DESCRIPTION
## Summary

All-in-one follow-up to the Gemma 4 correctness checkpoint (#1469): native audio, the decode-speed regression fix, and the decode performance settings surface, pinned to merged vMLX main `1ab081eb1d51568ae636f64b9ac76cd3ab4d2534` (osaurus-ai/vmlx-swift PR #46).

## What changed

### 1. Gemma 4 audio is real now (per-bundle, no fake gates)
- vMLX main implements both audio paths: 12B unified raw-waveform chunking (`Gemma4UnifiedAudioFeatureExtractor` parity — 640 raw samples/40 ms per soft token straight into `embed_audio`) and the full E-series conformer `audio_tower` port (128-mel front end, 12 chunked-attention conformer layers, clipped linears, ceil(melFrames/4) token expansion).
- Osaurus audio capability is now **bundle-fact-gated**: an installed Gemma4 bundle advertises audio iff its weight map ships `embed_audio.embedding_projection` (12B unified + E2B/E4B). 26B-A4B/31B ship **no audio tensors** — their refusal now says audio is impossible for the checkpoint instead of the false "pinned vMLX does not wire audio_tower/embed_audio yet".
- Live app proof (Release nosign build `077c88a7`, OpenAI-compatible `input_audio` with a real synthesized-speech WAV):
  - 12B JANG_4M transcribed verbatim: "The quick brown fox jumps over the lazy dog." (unified path, 41.4 tok/s)
  - E2B MXFP4 transcribed verbatim through the conformer tower (61.1 tok/s)
  - Artifacts: `/tmp/osaurus-final-pr/proof/row2-12b-jang-audio.json`, `row3-e2b-mxfp4-audio-tower.json`

### 2. The Gemma decode-speed regression: forced TurboQuant KV
`shouldUseTurboQuantByDefault` special-cased the Gemma family INTO `turbo(3,3)` KV, overriding the generic rule that keeps rotating/SWA topologies native. Gemma 4's 5:1 SWA + MQA topology keeps native KV tiny (~70 MB at 4k ctx on 26B-A4B), so TQ bought almost no RAM while costing:
- 26B-A4B MXFP4: 92.3 → 54.0 tok/s (−42%)
- 12B MXFP4: 48.6 → 34.5 tok/s (−29%)

This is the regression from the previously documented 100+ tok/s 26B rows. Gemma now falls through to the generic native-KV rule; TurboQuant stays available via the explicit `cache.liveKVCodec=turboQuant` setting. The contradictory source-test pin that froze the forced-TQ branch is replaced with one pinning the corrected contract and the measurements. Live telemetry now reports `effective_kv_mode=fp16` for Gemma with paged KV off and SSD block-disk/prefix caching on (defaults unchanged).

### 3. Decode Performance settings (new server panel section)
`VMLXServerRuntimeSettings.performance` (optional; existing server-runtime.json decodes unchanged):
- **Tied LM Head Codec** (default: as-shipped fp16): load-time quantization for tied heads that ship unquantized inside quantized bundles. Gemma 4 QAT ships the 262k-vocab head fp16 — ~1.07 GB weight read per decoded token on E2B; llama.cpp's Q4 GGUFs ship a Q6_K head, which is most of why GGUF decoded faster. q8/q6/q4 measured with identical greedy prefixes and coherent output.
- **Compiled Decode (experimental, default off)**: vMLX main now supports MLX compiled decode for hybrid sliding+full SWA cache topologies (it was silently disabled for exactly these families). +25% decode measured. Kept opt-in behind the PR #1173 model-switch gate.
- Wiring: `ModelRuntime.applyPerformancePolicy` (per-load) + `makeGenerateParameters` (per-request). Settings → engine → telemetry verified live.

### 4. Speed results (M5 Max, greedy, 128 tokens, median-of-3, raw engine vs same-machine llama-bench Q4_K_XL)

| Size | GGUF Q4 decode | vMLX MXFP4 (levers) | vMLX JANG_4M (levers) | vMLX default (native KV) MXFP4 |
|---|---|---|---|---|
| E2B | 167.7 | **178.0 (+6%)** | 164.4 | 119.6 |
| E4B | 104.6 | **113.6 (+9%)** | 91.8 | 74.9 |
| 12B | pending | 48.6 | 39.5 | 42.7 |
| 26B-A4B | pending | 100.8 | 84.8 | 87.7 |
| 31B | pending | 21.8 | 16.3 | 20.1 |

Prefill E2B: vMLX **10,068 tok/s** vs GGUF 7,455 (+35%). 31B is at its memory-bandwidth ceiling (~87% of theoretical). JANG_4M trails MXFP4 by design — the 4M mixed-precision profile carries 2–2.5× more bytes than Q4_K_XL. Full GGUF table for 12B/26B/31B lands as a PR comment (bench running). Matrix + logs: `/tmp/gemma4-speed-proof/`.

### 5. Live E2E proof (mandatory dev-build, real-user usage)
Keychain-free Release app at head `077c88a7`, launched isolated, `/Users/eric/models` (23 bundles visible), all through real API surfaces:
- **Coherency**: 12B JANG_4M physics explanation, clean prose, 34.3 tok/s in-app (old rows: 18.7).
- **Audio**: verbatim transcriptions (above) — first ever through Osaurus.
- **VL**: E2B red-image → "Red", repeat request 1.9 s → 0.3 s with `disk_l2_hits=1` (SSD prefix/block cache hit, paged 0/0).
- **Tools**: `/agents/default/run` executed real `osaurus_status` — `started`/`completed` frames, `is_error=false`, exact final text, zero marker/control leakage.
- **Reasoning**: `reasoning_effort` → 550 reasoning chars + correct concise answer (5:15pm).
- **RAM safety**: safe_auto verdict `allowed=true`, fresh RSS/budget telemetry (96.2 GB resolved budget).
- **KV/cache telemetry**: `effective_kv_mode=fp16`, topology kv=3/rotating=12 (E2B SWA), `requires_disk_backed_restore=true`, paged disabled, block-disk stores/hits live.
- Artifacts: `/tmp/osaurus-final-pr/proof/row1..row8*`.

## Boundaries (honest)
- Compiled decode and non-default head codecs are **off by default**; numerics shift at the single-token level when enabled (same class as GGUF's Q6_K head deltas).
- Hybrid/CCA SSM async rederivation is untouched by this PR (Gemma has no SSM state; the audited wiring is engine-owned and correct).
- 31B/26B/12B GGUF comparison rows land as a comment when the bench completes.
- Lower-spec teammate footprint proof remains a team gate.