### PR TITLE
Cache policy: TurboQuant off by default for all models + strip tool-markers (no tools), repin vMLX b02d9afc

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "b02d9afcf10a99161fb4ce74343230e773024287"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90b978b3181e38856231340854e47187ffaa8455492014bf4e6b2780929a3470",
+  "originHash" : "194708caca36cae4754bf61971d807931ee48a6b63bb06761d4d6f720991ac55",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "b02d9afcf10a99161fb4ce74343230e773024287"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+            revision: "b02d9afcf10a99161fb4ce74343230e773024287"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1583,48 +1583,39 @@ public actor ModelRuntime {
         modelName: String,
         cacheTopology: ModelCacheTopologySnapshot? = nil
     ) -> Bool {
-        // Hybrid and path-dependent caches keep fp16 live KV by default until
-        // a row proves TurboQuant for that exact topology. TurboQuant KV is
-        // not a substitute for SSM/CCA/CSA/HSA/SWA companion-state restore.
+        // POLICY (Eric directive 2026-06-12): TurboQuant KV is NEVER enabled
+        // automatically for ANY family. `liveKVCodec=engineSelected` (the
+        // shipped default) therefore resolves to native fp16 KV for every
+        // model.
         //
-        // Step 3.7 mixes full-attention KV layers with rotating/SWA layers.
-        // Current no-sign Osaurus warm rows prove disk L2 restore on that
-        // topology, but not TurboQuant-KV decode stability after tool history,
-        // so engine-selected defaults must leave Step live KV native/fp16.
-        if ModelFamilyNames.isStepFamily(modelName) {
-            return false
-        }
-
-        if ModelFamilyNames.isDSV4Family(modelName)
-            || ModelFamilyNames.isZayaFamily(modelName)
-            || ModelFamilyNames.isZayaVLFamily(modelName)
-            || Self.isKnownHybridModel(name: modelName)
-        {
-            return false
-        }
-        if let cacheTopology {
-            // No Gemma special case: Gemma 4's SWA topology (5:1 sliding
-            // 1024-token rotating windows + MQA full layers) keeps native KV
-            // tiny (~70 MB at 4k ctx on 26B-A4B), so TurboQuant buys almost
-            // no RAM while costing real decode throughput — measured
-            // 2026-06-12 on M5 Max RunBench, greedy, kvMode none vs tq33:
-            // 26B-A4B MXFP4 92.3 -> 54.0 tok/s (-42%), 12B MXFP4 48.6 ->
-            // 34.5 (-29%). The earlier forced `return kvLayerCount > 0`
-            // here is what regressed Gemma app decode from the documented
-            // 100+ tok/s 26B rows. The generic rotating-layer rule below
-            // now applies; TurboQuant stays available for Gemma via the
-            // explicit cache.liveKVCodec=turboQuant setting.
-            if cacheTopology.mambaLayerCount > 0
-                || cacheTopology.arraysLayerCount > 0
-                || cacheTopology.hybridPoolLayerCount > 0
-                || cacheTopology.rotatingKVLayerCount > 0
-                || cacheTopology.rotatingWrapperLayerCount > 0
-            {
-                return false
-            }
-            return cacheTopology.kvLayerCount > 0
-        }
-        return ModelFamilyNames.isMiniMaxFamily(modelName)
+        // vMLX's settings resolve `.engineSelected -> .turboQuant()`, so this
+        // runtime gate is the single point that decides whether engine-
+        // selected actually turns TurboQuant on. Previously it returned true
+        // for full-KV families (MiniMax) and for any topology with KV layers
+        // and no rotating/hybrid layers — which silently force-enabled
+        // TurboQuant on multiple families. TurboQuant's per-step
+        // compress/decompress cost outweighs its RAM savings at the context
+        // lengths Osaurus serves and measurably regresses decode:
+        //   Gemma 4 26B-A4B MXFP4  92.3 -> 54.0 tok/s  (-42%)
+        //   Gemma 4 12B    MXFP4   48.6 -> 34.5 tok/s  (-29%)
+        // (M5 Max RunBench, greedy, kvMode none vs tq33, 2026-06-12). Every
+        // rotating/SWA/full-KV family pays the same tax. The Gemma SWA
+        // regression was the visible symptom of a blanket problem; the blanket
+        // fix is to never auto-select TurboQuant for anyone.
+        //
+        // TurboQuant remains fully available on demand via an explicit
+        // `cache.liveKVCodec=turboQuant` setting — that path bypasses this
+        // function entirely (see `defaultKVMode`), so opting in is unaffected.
+        // A kernel-level TurboQuant encode/decode optimization is a separate
+        // future lane; until it lands and a per-family proof row exists, the
+        // engine default stays native fp16.
+        //
+        // `modelName`/`cacheTopology` are retained for signature/test
+        // stability and future per-family opt-in proof rows; intentionally
+        // unused while the blanket-off policy holds.
+        _ = modelName
+        _ = cacheTopology
+        return false
     }
 
     nonisolated static func cacheCoordinatorModelKey(

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -656,12 +656,17 @@ struct MLXBatchAdapterTests {
     @Test func cacheKVModeTagTracksEffectiveCoordinatorPolicy() {
         var settings = VMLXServerRuntimeSettings()
 
+        // POLICY (2026-06-12): engineSelected resolves to native fp16 for
+        // EVERY family — TurboQuant is never auto-enabled. Previously MiniMax
+        // (full-KV) resolved to turbo(3,3); the per-step compress/decompress
+        // tax regresses decode across families, so engine-selected stays fp16.
+        // TurboQuant is opt-in only via an explicit liveKVCodec=turboQuant.
         settings.cache.liveKVCodec = .engineSelected
         #expect(
             ModelRuntime.cacheKVModeTag(
                 for: settings.cache,
                 modelName: "MiniMax-M2.7-JANG_K-CRACK"
-            ) == "turbo(3,3)"
+            ) == "fp16"
         )
         #expect(
             ModelRuntime.cacheKVModeTag(
@@ -744,6 +749,8 @@ struct MLXBatchAdapterTests {
                 )
             ) == "fp16"
         )
+        // MiniMax full-KV topology also stays native under engineSelected now
+        // (was turbo(3,3) before the blanket-off policy).
         #expect(
             ModelRuntime.cacheKVModeTag(
                 for: settings.cache,
@@ -754,6 +761,18 @@ struct MLXBatchAdapterTests {
                     turboQuantKVLayerCount: 0,
                     rotatingKVLayerCount: 0
                 )
+            ) == "fp16"
+        )
+
+        // Explicit opt-in still works: liveKVCodec=turboQuant resolves to
+        // turbo(3,3) regardless of family (bypasses the auto gate).
+        settings.cache.liveKVCodec = .turboQuant
+        settings.cache.turboQuantKeyBits = 3
+        settings.cache.turboQuantValueBits = 3
+        #expect(
+            ModelRuntime.cacheKVModeTag(
+                for: settings.cache,
+                modelName: "MiniMax-M2.7-JANG_K-CRACK"
             ) == "turbo(3,3)"
         )
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -603,7 +603,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        let expectedRuntimeHardenedRevision = "b02d9afcf10a99161fb4ce74343230e773024287"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -913,28 +913,26 @@ struct RuntimePolicySourceTests {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         #expect(
             runtime.contains("shouldUseTurboQuantByDefault"),
-            "ModelRuntime must resolve engine-selected cache policy per family/topology instead of enabling TurboQuant globally"
+            "ModelRuntime must own the engine-selected TurboQuant gate"
         )
+        // POLICY (2026-06-12): TurboQuant KV is never auto-enabled for ANY
+        // family. shouldUseTurboQuantByDefault must unconditionally return
+        // false so engineSelected resolves to native fp16 everywhere; the
+        // per-step compress/decompress tax regresses decode across families
+        // (Gemma 26B-A4B -42%, 12B -29%). TQ is opt-in only via explicit
+        // liveKVCodec=turboQuant.
         #expect(
-            runtime.contains("ModelFamilyNames.isDSV4Family(modelName)")
-                && runtime.contains("ModelFamilyNames.isZayaFamily(modelName)")
-                && runtime.contains("ModelFamilyNames.isZayaVLFamily(modelName)")
-                && runtime.contains("ModelFamilyNames.isGemmaFamily(modelName)")
-                && runtime.contains("Self.isKnownHybridModel(name: modelName)"),
-            "Engine-selected TurboQuant must stay off by default for DSV4, ZAYA/ZAYA-VL, Gemma, and hybrid topologies until exact rows prove it"
+            runtime.contains("Eric directive 2026-06-12")
+                && runtime.contains("TurboQuant KV is NEVER enabled")
+                && runtime.contains("liveKVCodec=turboQuant"),
+            "shouldUseTurboQuantByDefault must document and enforce the blanket TurboQuant-off-by-default policy"
         )
+        // The function must NOT reintroduce a family/topology branch that can
+        // return true (which is what silently force-enabled TurboQuant before).
         #expect(
-            runtime.contains("ModelFamilyNames.isStepFamily(modelName)")
-                && runtime.contains("return false")
-                && runtime.contains("Step 3.7 mixes full-attention KV layers with rotating/SWA layers"),
-            "Step 3.7 mixed-SWA topology must stay native/fp16 by default until a warm tool-history row proves TurboQuant-KV stability"
-        )
-        #expect(
-            !runtime.contains("warm disk hit path is not stable yet")
-                && !runtime.contains(
-                    "ModelFamilyNames.isLFM2Family(modelName) {\n            // Current live Osaurus rows prove LFM2.5"
-                ),
-            "LFM2 must not carry the temporary disk-restore disable gate once required-tool history stability is fixed in vMLX"
+            !runtime.contains("return cacheTopology.kvLayerCount > 0")
+                && !runtime.contains("return ModelFamilyNames.isMiniMaxFamily(modelName)"),
+            "shouldUseTurboQuantByDefault must not auto-select TurboQuant for full-KV families (MiniMax) or KV-bearing topologies"
         )
         let mlxService = try Self.source("Services/Inference/MLXService.swift")
         #expect(
@@ -943,12 +941,6 @@ struct RuntimePolicySourceTests {
                 && mlxService.contains("Step 3.7 tool parsing/template selection is owned by the pinned")
                 && mlxService.contains("return ModelMediaCapabilities.descriptor(modelId: modelId)"),
             "Step 3.7 runtime policy must stay text-only/tool-capable and must not block preflight on external bundle metadata until Step VLM is wired and proven"
-        )
-        #expect(
-            !runtime.contains(
-                "if ModelFamilyNames.isGemmaFamily(modelName) {\n                return cacheTopology.kvLayerCount > 0")
-                && runtime.contains("rotatingKVLayerCount > 0"),
-            "Gemma SWA must NOT be special-cased into TurboQuant KV: the generic rotating-topology rule keeps it native. Forcing TQ on Gemma 4 measured -42% decode on 26B-A4B and -29% on 12B (2026-06-12 RunBench) for ~70 MB of KV savings; TurboQuant remains available via explicit cache.liveKVCodec=turboQuant."
         )
     }
 

--- a/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
+++ b/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
@@ -1,0 +1,113 @@
+# Osaurus + vMLX Cache & Runtime Policy Reference (2026-06-12)
+
+Comprehensive reference for the cache stack, KV codecs, RAM safety, and the
+per-family runtime nuances after the Gemma 4 speed/audio work and the
+TurboQuant-off-by-default policy change. This is the source of truth for
+"what is the default, why, and where is it enforced."
+
+## 1. Default cache topology (every model, unless explicitly overridden)
+
+| Layer | Default | Enforced at |
+|---|---|---|
+| Paged RAM KV cache | **OFF** | `VMLXPagedKVCacheSettings.enabled=false`; vMLX `CacheCoordinatorConfig.usePagedCache = reuseEnabled && cache.pagedKV.enabled` |
+| Prefix cache (SSD-backed) | **ON** | `VMLXPrefixCacheSettings.enabled=true`; forces block-disk L2 on |
+| Block-disk L2 cache | **ON** | `VMLXBlockDiskCacheSettings.enabled=true` |
+| Legacy disk cache | **OFF** | `VMLXDiskCacheSettings.enabled=false` |
+| Live KV codec | **native fp16** | `liveKVCodec=engineSelected` → `shouldUseTurboQuantByDefault` returns false (see §2) |
+| TurboQuant KV | **OFF (opt-in only)** | See §2 |
+| SSM re-derive | ON | `enableSSMReDerive=true` (hybrid families only) |
+| Memory safety | safe_auto | `memorySafety.mode` |
+
+**The only default cache is SSD prefix + block-disk L2. No paged RAM cache for any model. No TurboQuant encode/decode for any model.**
+
+## 2. TurboQuant KV — OFF by default for ALL families (policy 2026-06-12)
+
+### Why
+TurboQuant compresses live KV (`turbo(3,3)` = 3-bit key / 3-bit value) to save
+RAM. At the context lengths Osaurus serves, the per-step compress/decompress
+cost outweighs the RAM savings and measurably regresses decode throughput
+across every family that carries KV:
+- Gemma 4 26B-A4B MXFP4: 92.3 → 54.0 tok/s (−42%) with `tq33` vs native
+- Gemma 4 12B MXFP4: 48.6 → 34.5 tok/s (−29%)
+(M5 Max, RunBench, greedy, `kvMode none` vs `tq33`.)
+
+The Gemma SWA regression (the visible "26B used to do 100+ tok/s" symptom)
+was one instance of a blanket problem: any rotating/SWA/full-KV topology paid
+the same tax.
+
+### The resolution chain (where it's decided)
+1. Osaurus ships `liveKVCodec = .engineSelected` (the default codec choice).
+2. vMLX's `VMLXServerCacheSettings.defaultKVMode` resolves `.engineSelected` to
+   `.turboQuant()`.
+3. **`ModelRuntime.shouldUseTurboQuantByDefault(...)` is the single runtime
+   gate that decides whether engine-selected actually turns TurboQuant on.**
+   As of 2026-06-12 it **unconditionally returns false** — so engine-selected
+   resolves to native fp16 KV for every model.
+
+### Opt-in path (unchanged)
+Setting `cache.liveKVCodec = .turboQuant` (with `turboQuantKeyBits`/
+`turboQuantValueBits`) bypasses the auto gate entirely (`defaultKVMode`
+returns `.turboQuant(keyBits:valueBits:)` directly). TurboQuant remains fully
+available for anyone who explicitly wants it.
+
+### Telemetry
+`/admin/cache-stats` → `effective_kv_mode` reports the actual resolved codec
+(`"fp16"` under the default policy; `"turbo(3,3)"` only under explicit opt-in).
+`turbo_quant_kv_layer_count` counts actually-materialized TurboQuant layers
+(0 under the default policy). Do not describe a model as TurboQuant-encoded
+when `effective_kv_mode=fp16`.
+
+### Future lane
+A kernel-level TurboQuant encode/decode optimization (threadgroup-shared
+codebook, vectorized packed loads, simdgroup-matrix dequant) could make TQ
+cheap enough to default on for RAM-constrained loads. Until that lands with a
+per-family proof row, the engine default stays native fp16.
+
+## 3. RAM safety
+
+- `memorySafety.mode` ∈ {performance, balanced, safeAuto (default), strict,
+  diagnosticDangerous}. Each maps to a distinct load fraction + allocator cap
+  (`resolvedMemorySafetyPlan` → `LoadConfiguration.memoryLimit`/
+  `maxResidentBytes` → MLX `Memory` limits).
+- RAM feasibility is **advisory** in safe_auto (verdict logged + surfaced, load
+  proceeds; unified memory + mmap can page/compress). **strict** mode sets
+  `blocksOverBudget=true` and refuses loads whose projected working set exceeds
+  the resolved budget.
+- Backstop when a too-large bundle is loaded: idle-resident-model eviction
+  (`strictSingleModel` / flexible-budget eviction) fires before the new load.
+  RE-VERIFY: eviction fires before OOM on a genuinely over-budget load (the
+  hard pre-load refusal was demoted to advisory in osaurus #1454).
+
+## 4. Per-family cache/runtime nuances
+
+| Family | Live KV (default) | Companion / special state | Notes |
+|---|---|---|---|
+| Gemma 4 (gemma4/gemma4_unified) | fp16 native | SWA: 5 sliding (RotatingKVCache win=1024) : 1 full (MQA, unbounded). attention_k_eq_v on full layers. | Dual RoPE (proportional p-RoPE θ=1e6 full / default θ=1e4 sliding). Tied 262k embed; q6 head opt-in. Audio: 12B unified raw-frame `embed_audio`; E-series mel + conformer `audio_tower`. |
+| Qwen 3.5/3.6 MoE (+MTP) | fp16 native | Hybrid SSM (gated-delta) + MoE streaming experts | MTP autodetection from sidecar tensors → native-MTP draft. Streaming-experts auto-enable (verify decode). |
+| LFM2 / LFM2.5 (hybrid) | fp16 native | SSM companion state + required-tool template | Required-tool parser churn — verify e2e tool history. |
+| DeepSeek-V4-Flash | fp16 native | HCA + SWA + CSA combo cache; disk-backed restore | Combo cache restore needs all three companion states; never substitute TQ. |
+| ZAYA1 / ZAYA1-VL (CCA) | fp16 native | CCA companion disk payload | Fail-closed on CCA disk miss — verify it actually hits, not just fails safe. |
+| Nemotron-H / Omni (hybrid SSM) | fp16 native | Mamba SSM + conv decode fast path | Weighted-MoE fast path now opt-in (env flag). Audio: Parakeet conformer. |
+| Step 3.7 | fp16 native | Mixed full-KV + rotating/SWA | Text-only + tool-capable; tool parsing owned by vMLX Step runtime. |
+| MiniMax M2.7 | fp16 native (was turbo) | Full KV (62 layers) | Now fp16 under blanket-off policy; was the one family auto-TQ'd without topology. |
+
+## 5. Correctness components (kernels / parsers)
+
+- **mx matmul / quantized matmul**: MXFP4 (4-bit packed, affine scales/biases),
+  JANG_4M mixed-precision per-layer overrides, JANGTQ TurboQuant packed.
+- **Hadamard 2D/3D**: used in rotary/quant transforms; verify shape handling on
+  hybrid/MoE paths.
+- **mrope**: multimodal RoPE for VL families; Gemma 4 uses dual-RoPE (not mrope).
+- **Reasoning parsers**: `ReasoningParser.forPrompt` stamps per family; Gemma 4
+  `<|channel>thought` (think_in_template=false). Held-tail detokenizer fix
+  (bf5871d) prevents dropped text between chunks.
+- **Tool parsers**: per-family `ToolCallFormat` → parser. Gemma 4 = `call:name{}`
+  with `<|tool_call>`/`<tool_call|>` markers. Strip-only mode (vMLX #50) strips
+  markers when no tools offered so they never leak as visible text.
+
+## 6. Verification gate (every change)
+A change to any of the above is not done until **live multi-turn chat in the
+dev-built Osaurus app** (pinned to the exact code) confirms: real tool calls,
+clean coherent text (no missing/garbled/random-char output), no marker leaks,
+correct cache telemetry, and RAM verdicts. CI + unit tests are necessary but
+not sufficient.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "b02d9afcf10a99161fb4ce74343230e773024287"
       }
     },
     {


### PR DESCRIPTION
## Summary
One comprehensive cache/runtime-policy PR, repinned to merged vMLX main `b02d9afcf10a99161fb4ce74343230e773024287`. Two behavior changes, both proven live in the dev-built app, plus a full policy reference doc.

### 1. TurboQuant KV OFF by default for ALL models
Previously `liveKVCodec=engineSelected` (the shipped default) resolved in vMLX to `.turboQuant()`, and `shouldUseTurboQuantByDefault` gated that per family/topology — returning true for full-KV families (MiniMax) and any KV-bearing non-rotating topology. That **silently force-enabled TurboQuant on multiple families** at the same per-step compress/decompress decode tax the Gemma SWA regression exposed (26B-A4B −42%, 12B −29%). PR #1485 only exempted Gemma; the others were still exposed.

`shouldUseTurboQuantByDefault` now **unconditionally returns false** → engine-selected resolves to **native fp16 KV for every model**. TurboQuant remains fully available on demand via an explicit `cache.liveKVCodec=turboquant` setting (that path bypasses the auto gate). A kernel-level TurboQuant encode/decode optimization is a separate future lane.

### 2. Strip tool-call control markers when a request offers no tools (vMLX b02d9afc)
With thinking on and zero tools in the request, a Gemma4 bundle that emits tool-call syntax anyway leaked literal `<|tool_call>`/`call:` markers into visible text. vMLX now runs a strip-only ToolCallProcessor for tagged formats even with no tools.

### 3. Policy reference doc
`docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md` — default cache topology (paged OFF, prefix + block-disk L2 ON, TurboQuant OFF), the full TurboQuant resolution chain, RAM safety, and per-family cache nuances (Gemma SWA, Qwen MoE+MTP, LFM2 hybrid SSM, DeepSeek-V4 HCA+SWA+CSA, ZAYA CCA, Nemotron, Step, MiniMax).

## Live proof (dev-built app, this exact pin, multi-message sessions)
- **Settings toggle ENFORCEMENT** via `/admin/runtime-settings` (the UI panel's surface), 12B MXFP4, 4-turn sessions:
  - A default → `effective_kv_mode=fp16`, paged off, coherent ✅
  - B toggle TurboQuant ON → `effective_kv_mode=turbo(3,3)` ENFORCED, still coherent ✅
  - C toggle paged ON → `paged_kv_enabled=true` ENFORCED, coherent ✅
  - D revert → back to fp16 / paged-off ✅
- **TQ-off proof on the family that was auto-TQ'd:** MiniMax-M2.7 now reports `effective_kv_mode=fp16` (was `turbo(3,3)`), coherent multi-turn (Tokyo → Japan).
- **Gemma multi-turn tool gate:** 9/10 bundles clean across 3-turn tool conversations with context carry (1 E2B flag = known temp=1 sampling, greedy clean).
- **Reasoning on/off:** with adequate `max_tokens` the reasoning channel closes and the final is correct; at a tight budget the final truncates to empty (finish=length) — the UI "answer may be in reasoning above" banner correctly warns of this.

## Defaults are unchanged behavior for the common case
Paged off, prefix + SSD block-disk L2 on, native fp16 KV — the only change is that engine-selected no longer auto-picks TurboQuant for the few families that previously got it silently.

## Tests
86 OsaurusCore policy/adapter tests pass; cacheKVModeTag now expects fp16 for MiniMax under engine-selected and turbo(3,3) only under explicit opt-in; source policy pins the blanket-off contract.