### PR TITLE
Add DiffusionGemma support: capability gating, runtime pin, diffusion speed setting

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -71,6 +71,14 @@ enum ModelFamilyNames {
         matches(#"(^|/|[\-_])gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
     }
 
+    /// DiffusionGemma block-diffusion bundles (`model_type=diffusion_gemma`).
+    /// Keep this separate from ordinary Gemma 4 AR/QAT matching because the
+    /// runtime needs a denoising-canvas engine, not TokenIterator decode.
+    static func isDiffusionGemmaFamily(_ modelId: String) -> Bool {
+        matches(#"(^|/|[\-_])diffusion[\-_]?gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
+            || modelId.lowercased() == "diffusion_gemma"
+    }
+
     /// LFM2 / LFM2.5 text and MoE bundles. Accept LiquidAI repo ids,
     /// local JANG bundle ids, and bare picker aliases while rejecting adjacent
     /// future-family names like `lfm21` / `lfm2x`.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -207,6 +207,14 @@ public enum ModelMediaCapabilities {
             return .imageOnly
         }
 
+        // DiffusionGemma: block-diffusion Gemma with the Gemma4 unified
+        // vision tower — image-in/text-out only (no audio config, no
+        // video_token_id). Name-matched here for the id-only path; the
+        // directory/json path matches model_type == "diffusion_gemma".
+        if ModelFamilyNames.isDiffusionGemmaFamily(modelId) {
+            return .imageOnly
+        }
+
         // Image-only VLM families. Substring-match the bundle name.
         let imageOnlyPatterns: [String] = [
             "paligemma", "idefics3", "fastvlm", "llava-qwen2", "llava_qwen2",
@@ -341,6 +349,14 @@ public enum ModelMediaCapabilities {
         // vision is only the omni path, already handled above.)
         guard hasVisionConfig else {
             return .textOnly
+        }
+
+        // DiffusionGemma: block-diffusion Gemma with the Gemma4 unified
+        // vision tower. Image-in/text-out only — the checkpoint has no
+        // audio config and no video_token_id. Checked before the gemma4
+        // prefix branch since its model_type is `diffusion_gemma`.
+        if modelType == "diffusion_gemma" {
+            return .imageOnly
         }
 
         // Gemma4: audio capability is checkpoint-fact-driven, not

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -167,6 +167,17 @@ public enum ServerRuntimeSettingsStore {
         {
             normalized.mtp.mode = .auto
         }
+        // Osaurus product default for block-diffusion models: 16 denoising
+        // steps (~74 tok/s on diffusiongemma-26B-A4B MXFP4, coherent) vs the
+        // bundle's 48 (~37 tok/s). Seeded exactly once; afterwards a blank
+        // field is an explicit "use bundle default" choice.
+        if normalized.generation.diffusionMaxDenoisingSteps == nil,
+            !FileManager.default.fileExists(
+                atPath: diffusionDefaultsMigrationMarkerURL().path)
+        {
+            normalized.generation.diffusionMaxDenoisingSteps = 16
+            writeDiffusionDefaultsMigrationMarker()
+        }
         if shouldRepairLegacyCacheDefaults(normalized.cache) {
             // Keep companion-cache repair independent from the live KV codec.
             // Engine-selected is the default policy now, but ModelRuntime
@@ -292,6 +303,8 @@ public enum ServerRuntimeSettingsStore {
             minP: nil,
             repetitionPenalty: nil
         )
+        settings.generation.diffusionMaxDenoisingSteps = 16
+        writeDiffusionDefaultsMigrationMarker()
 
         // Concurrency: legacy UserDefaults key for BatchEngine max
         // batch size. Falls back to nil so vmlx's coordinator chooses
@@ -401,6 +414,22 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func cacheDefaultsMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(cacheDefaultsMigrationMarkerName)
+    }
+
+    /// One-shot seed of the Osaurus diffusion default (16 denoising steps,
+    /// the measured speed/quality knee for diffusiongemma-26B-A4B). The
+    /// marker keeps a user's later "blank = bundle default" choice sticky.
+    static let diffusionDefaultsMigrationMarkerName =
+        "diffusion-defaults-migrated.marker"
+
+    private nonisolated static func diffusionDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(diffusionDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func writeDiffusionDefaultsMigrationMarker() {
+        let url = diffusionDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
     }
 
     private nonisolated static func pagedCacheDefaultOffMigrationMarkerURL() -> URL {

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -74,6 +74,7 @@ enum VLMDetection {
         let trimmed = modelType.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalized = trimmed.lowercased()
         guard normalized != "zaya" else { return false }
+        if normalized == "diffusion_gemma" { return true }
         return VLMTypeRegistry.supportedModelTypes.contains(trimmed)
             || VLMTypeRegistry.supportedModelTypes.contains(normalized)
     }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+            revision: "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1059,6 +1059,12 @@ struct MLXBatchAdapter {
             enableCompiledBatchDecode: effective.compiledBatchDecode,
             prefillStepSize: runtime.concurrency.prefillStepSize
         )
+        // Block-diffusion speed/quality budget (DiffusionGemma): server
+        // setting, default 16 (seeded by ServerRuntimeSettingsStore).
+        // nil = bundle's generation_config.json value. Ignored by
+        // autoregressive models.
+        mlxParams.diffusionMaxDenoisingSteps =
+            runtime.generation.diffusionMaxDenoisingSteps
         let cacheTopology = await container.cacheTopologySnapshot()
         let effectiveKVMode = ModelRuntime.defaultKVMode(
             for: ServerRuntimeSettingsStore.snapshot().cache,

--- a/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
@@ -44,6 +44,11 @@ import Testing
         #expect(VLMDetection.isVLM(modelType: "qwen2_5_vl"))
     }
 
+    @Test func isVLMModelType_recognizesDiffusionGemma() {
+        #expect(VLMDetection.isVLM(modelType: "diffusion_gemma"))
+        #expect(!VLMDetection.isVLM(modelType: "diffusion_gemma_text"))
+    }
+
     @Test func isVLMModelType_preservesCaseSensitiveRegistryEntries() {
         #expect(VLMDetection.isVLM(modelType: "NemotronH_Nano_Omni_Reasoning_V3"))
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -231,6 +231,21 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-mxfp8") == .imageOnly)
     }
 
+@Test("D6: DiffusionGemma is image-only, not video/audio")
+    func d6_diffusionGemmaImageOnly() {
+        for modelId in [
+            "google/diffusiongemma-26B-A4B-it",
+            "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4",
+            "diffusion_gemma",
+        ] {
+            let cap = ModelMediaCapabilities.from(modelId: modelId)
+            #expect(cap == .imageOnly, "\(modelId) must advertise image only")
+            #expect(cap.supportsImage)
+            #expect(!cap.supportsVideo)
+            #expect(!cap.supportsAudio)
+        }
+    }
+
     // MARK: - D7: Mistral 3 / 3.5 (image only via Pixtral wrap)
 
     @Test("D7: Mistral 3 / 3.5 → .imageOnly")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -603,7 +603,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        let expectedRuntimeHardenedRevision = "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
@@ -69,6 +69,20 @@ struct GenerationDefaultsSection: View {
 
             SettingsDivider()
 
+            SettingsSubsection(label: "Diffusion Models") {
+                OptionalIntField(
+                    label: "Denoising Steps per Canvas",
+                    placeholder: "Blank = model default (48)",
+                    help: "Speed/quality budget for block-diffusion models "
+                        + "(DiffusionGemma). 16 ≈ 2× faster than the model "
+                        + "default and stays coherent; below 12 quality "
+                        + "degrades. Ignored by ordinary models.",
+                    value: $draft.generation.diffusionMaxDenoisingSteps
+                )
+            }
+
+            SettingsDivider()
+
             SettingsSubsection(label: "Streaming") {
                 VStack(alignment: .leading, spacing: 8) {
                     ServerSettingsPlannedBanner(

--- a/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
@@ -1,0 +1,155 @@
+# DiffusionGemma Osaurus Integration
+
+Date: 2026-06-12 (updated same day: native engine landed)
+
+## Current Source Truth
+
+- Source bundle: `google/diffusiongemma-26B-A4B-it`
+- `model_type`: `diffusion_gemma`, architecture
+  `DiffusionGemmaForBlockDiffusion`
+- 30-layer Gemma4-style MoE (128 experts, top-8), 26B total / ~4B active,
+  256-token canvas, sliding window 1024
+- Vision: `vision_config` present, `image_token_id = 258880`,
+  `vision_soft_tokens_per_image = 280`
+- Audio: `audio_config = null`, `audio_token_id = null`
+- Video: processor metadata present, but `video_token_id = null`
+
+## Engine status (vmlx-swift)
+
+The native block-diffusion engine is implemented in vmlx-swift
+(branch `codex/diffusiongemma-runtime`, PR #47): encoder prefill +
+bidirectional canvas decoder, entropy-bound sampler, adaptive stopping,
+self-conditioning — all parameters from the bundle's
+`generation_config.json`. Reference doc on the vmlx side:
+`docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md` (verification rows:
+token/s, multi-turn, tool calls, prefix/disk cache, memory, isolation).
+
+## How DiffusionGemma flows through Osaurus — teammate wiring map
+
+1. **Discovery / capability**: `VLMDetection` recognizes
+   `diffusion_gemma` as VLM-shaped; `ModelFamilyNames.isDiffusionGemmaFamily`
+   keeps it distinct from Gemma-4 AR; `ModelMediaCapabilities` advertises
+   image-only (audio/video blocked until runtime-proven).
+2. **Loading**: `loadModelContainer` iterates factories; the VLM factory
+   rejects `diffusion_gemma` (`unsupportedModelType`) and the LLM factory
+   creates `DiffusionGemmaModel`. No Osaurus-side routing code needed.
+3. **Generation**: `MLXBatchAdapter` routes every request through
+   `BatchEngine.generate`. For `BlockDiffusionModel` conformers,
+   BatchEngine takes its **exclusive solo path** (same mechanism as
+   native MTP) into `BlockDiffusionTokenIterator`. The batched `submit()`
+   path is rejected loudly (the model's `prepare()` throws) — block
+   diffusion can never silently AR-decode or share batch slots.
+4. **Parsers**: tool calls use the Gemma-4 format
+   (`<|tool_call>call:name{...}<tool_call|>`, mapped from
+   `model_type` in `ToolCallFormat.infer`); reasoning stamp is `harmony`
+   (`<|channel>thought…<channel|>`). Both verified live with zero marker
+   leakage through `TextToolTokenLoopHandler`.
+5. **Caching**: encoder cache is Gemma4 topology (RotatingKVCache
+   window-1024 sliding + KVCacheSimple full layers, fp16 KV — no
+   TurboQuant). Rotating layers can't round-trip paged KV blocks, so the
+   iterator marks the coordinator paged-incompatible and prompt
+   boundaries are served by the **disk (L2/SSD) tier**. Verified:
+   fresh-coordinator resume restored 138/138 prompt tokens with
+   `prefillSec=0.000`; turn-extension hit passes; multi-turn live-cache
+   sessions keep the full reply via the end-of-turn cache commit.
+
+## Speed/quality control (the Osaurus setting)
+
+`GenerateParameters.diffusionMaxDenoisingSteps` (vmlx) caps the
+denoising budget per 256-token canvas. Measured on MXFP4, M5 Max,
+~740-token essay:
+
+| steps | tok/s | coherency |
+|---|---|---|
+| 48 (bundle default) | 37 | clean |
+| 24 | 58 | clean |
+| **16 (Osaurus default)** | **74** | clean (essay + multi-turn recall verified) |
+| 8 | 140 | BREAKS (word salad) |
+
+Wiring:
+
+- Contract field: `VMLXServerGenerationDefaults.diffusionMaxDenoisingSteps`
+  (`nil` = bundle default; validation errors `< 1`, warns `< 12`).
+- Osaurus default: **16**, seeded once by `ServerRuntimeSettingsStore`
+  (`diffusion-defaults-migrated.marker`; after seeding, a blank field is a
+  sticky "use bundle default" choice).
+- Request flow: `RuntimeConfig.snapshot()` →
+  `MLXBatchAdapter` sets `mlxParams.diffusionMaxDenoisingSteps` →
+  `BlockDiffusionParameters.overriding(parameters:)` at dispatch.
+- UI: Server → Settings → Sampling → "Diffusion Models" →
+  "Denoising Steps per Canvas" (`GenerationDefaultsSection`).
+- Per-request API override: not exposed on the OpenAI wire yet
+  (server-level setting only).
+
+## Quant bundles
+
+vmlx PR #45 (merged, `710eb0d7…`) added the converter; both local quants
+verified:
+
+- MXFP4: 15 GB, 15 shards, `total_size=15944852880`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — ~37 tok/s @48 steps,
+  ~74 tok/s @16, peak RSS 12.7 GB
+- MXFP8: 26 GB, 23 shards, `total_size=27918936056`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — converges in fewer steps
+  (sometimes faster than MXFP4 end-to-end), peak RSS 23.8 GB
+
+## Pin management
+
+`Packages/OsaurusCore/Package.swift` pins `osaurus-ai/vmlx-swift` by
+revision; the same revision must appear in BOTH lockfiles
+(`Packages/OsaurusCore/Package.resolved`,
+`osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`) AND in the
+`RuntimePolicySourceTests` "vmlx pin uses consolidated package" expected
+revision constant — the focused test fails on any mismatch by design.
+
+Focused verification command:
+
+```sh
+OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
+OSAURUS_TEST_ROOT=/tmp/osaurus-dg-tests \
+swift test --package-path Packages/OsaurusCore \
+  --filter 'VLMDetectionTests|ModelMediaCapabilitiesMCDCTests|RuntimePolicySourceTests'
+```
+
+Debugging note: a bare `error: fatalError` from SwiftPM is a masked
+clang `fatal error:` — grep the full log. Fresh vmlx worktrees need
+`git submodule update --init --recursive` (Source/Cmlx) and tests need
+`scripts/prepare-mlx-metal.sh` metallibs.
+
+## Boundaries (unchanged)
+
+- Image-only capability advertised; **runtime VL is not yet wired** in
+  vmlx (vision tower ships in the bundles but text-only generation is
+  what's proven). Audio absent; video has no `video_token_id`.
+- Block diffusion is exclusive-solo in BatchEngine; batched canvas
+  scheduling is future work.
+
+## Live dev-build verification (2026-06-12)
+
+All proven through the running Debug app's OpenAI API (`/v1/chat/completions`):
+
+- **Detection scoping**: `gemma-4-12b-it-mxfp4` generates with **zero**
+  `[BlockDiffusion]` engine lines; `diffusiongemma-*` emits them. Routing
+  is by Swift type conformance (`model is BlockDiffusionModel`) — only
+  `DiffusionGemmaModel` conforms, so no name-based misrouting is possible.
+- **Settings take effect**: changing
+  `generation.diffusionMaxDenoisingSteps` 16 → 32 in
+  `server-runtime.json` (what the Settings panel writes) and restarting
+  flips the engine to `maxDenoisingSteps=32`; restored to 16.
+- **Multi-turn single session + reasoning toggle**: 4-turn conversation,
+  `enable_thinking` toggled per turn — reasoning content present only on
+  ON turns, recall held across all turns (name + number + 42+8=50), SSD
+  prefix cache restored 56 tokens mid-conversation, per-turn prefill
+  0.09–0.33 s.
+- **Vision**: a base64 gradient PNG was correctly described
+  ("vertical gradient … vibrant red at the top to deep blue at the
+  bottom") at the default 16-step setting.
+
+## Published bundles
+
+- `OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
+- `OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+
+Each ships the model card (eos `[1,106,50]`, chat template, Gemma-4 tool /
+harmony reasoning parser notes, image capability, diffusion-settings docs)
+and the Osaurus banner.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {


### PR DESCRIPTION
## Summary

Adds DiffusionGemma (block-diffusion Gemma, `model_type: diffusion_gemma`) to Osaurus, pinned to the vmlx-swift runtime at `7d9a85fe` (text generation + vision + multi-turn SSD prefix cache + tool/reasoning parsers). Rebased clean onto current `main`; **14 files, one commit, 137/137 focused tests**.

- **Capability gating**: `diffusion_gemma` detected as image-only (audio and video blocked — the checkpoint has no audio config and no `video_token_id`) on both the name path and the directory/json path; a dedicated family matcher keeps it separate from Gemma-4 AR.
- **Speed/quality setting**: server-side `diffusionMaxDenoisingSteps`, Osaurus default **16** (~74 tok/s vs the bundle's 48 ≈ 37 tok/s on diffusiongemma-26B-A4B MXFP4; below 12 degrades), seeded once by `ServerRuntimeSettingsStore`, editable in Server → Settings → Sampling → "Diffusion Models", flowing through `MLXBatchAdapter` → `GenerateParameters.diffusionMaxDenoisingSteps`.
- **Isolation**: routing is by Swift type conformance (`model is BlockDiffusionModel`) — only `DiffusionGemmaModel` conforms, so no other family can be misrouted. Verified live: `gemma-4-12b` generates with **zero** `[BlockDiffusion]` engine lines.

## Live dev-build verification (Debug app, OpenAI API)

- **Settings take effect**: changed the denoise steps 16 → 32 via the settings file the panel writes, restarted, engine flipped to `maxDenoisingSteps=32`; restored to 16.
- **Multi-turn single session + reasoning toggle**: 4-turn chat with `enable_thinking` toggled per turn — reasoning content present only on ON turns, recall held across all turns (name + favorite number + 42+8=50), SSD prefix cache restored 56 tokens mid-conversation, per-turn prefill 0.09–0.33 s.
- **Vision**: base64 gradient PNG correctly described at the default 16-step setting.
- **Tools**: structured `get_weather({"location":"Paris"})` from "the city where the Eiffel Tower is", `finish_reason=tool_calls`, no marker leakage.

## Engine + bundles

vmlx-swift main `7d9a85fe` (PRs #47 engine, #49 cache boundaries, #51 vision). Published quants: `OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4` and `-MXFP8` (model cards with eos `[1,106,50]`, chat template, Gemma-4 tool / harmony reasoning parser notes, image capability, diffusion settings, Osaurus banner).

Teammate wiring map: `docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md`.

Supersedes #1483 (which was based on a stale main).
