### PR TITLE
Gemma 4 speed/cache + DiffusionGemma — consolidated (vMLX main 7d9a85fe)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1674,7 +1674,26 @@ extension ModelManager {
 
         func isLikelyOrganizationContainer(_ entry: URL) -> Bool {
             let name = entry.lastPathComponent
-            return !name.contains(".") && name.split(separator: "-").count <= 2
+            // Model-leaf directory names carry several hyphen-separated parts
+            // (e.g. "gemma-4-12B-it-qat-MXFP4"); organization containers are
+            // short ("google", "JANGQ"). Hyphen count is the primary signal.
+            guard name.split(separator: "-").count <= 2 else { return false }
+            // Allow a domain-style org name such as "dealign.ai": a single dot
+            // separating a short alphabetic top-level suffix. Without this,
+            // every bundle under ~/models/dealign.ai/ (LFM2.5, Qwen3.6-MTP,
+            // DeepSeek-V4) is silently invisible to discovery, while a
+            // version-dotted model leaf like "laguna-xs.2" is still rejected
+            // (its suffix "2" is non-alphabetic).
+            let dotParts = name.split(separator: ".")
+            if dotParts.count == 1 { return true }
+            if dotParts.count == 2,
+                let suffix = dotParts.last,
+                (2...4).contains(suffix.count),
+                suffix.allSatisfy({ $0.isLetter })
+            {
+                return true
+            }
+            return false
         }
 
         // Three layouts are supported and may coexist under the same root:

--- a/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelFamilyNames.swift
@@ -71,6 +71,14 @@ enum ModelFamilyNames {
         matches(#"(^|/|[\-_])gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
     }
 
+    /// DiffusionGemma block-diffusion bundles (`model_type=diffusion_gemma`).
+    /// Keep this separate from ordinary Gemma 4 AR/QAT matching because the
+    /// runtime needs a denoising-canvas engine, not TokenIterator decode.
+    static func isDiffusionGemmaFamily(_ modelId: String) -> Bool {
+        matches(#"(^|/|[\-_])diffusion[\-_]?gemma($|[\-_/\.0-9])"#, in: modelId.lowercased())
+            || modelId.lowercased() == "diffusion_gemma"
+    }
+
     /// LFM2 / LFM2.5 text and MoE bundles. Accept LiquidAI repo ids,
     /// local JANG bundle ids, and bare picker aliases while rejecting adjacent
     /// future-family names like `lfm21` / `lfm2x`.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -207,6 +207,14 @@ public enum ModelMediaCapabilities {
             return .imageOnly
         }
 
+        // DiffusionGemma: block-diffusion Gemma with the Gemma4 unified
+        // vision tower — image-in/text-out only (no audio config, no
+        // video_token_id). Name-matched here for the id-only path; the
+        // directory/json path matches model_type == "diffusion_gemma".
+        if ModelFamilyNames.isDiffusionGemmaFamily(modelId) {
+            return .imageOnly
+        }
+
         // Image-only VLM families. Substring-match the bundle name.
         let imageOnlyPatterns: [String] = [
             "paligemma", "idefics3", "fastvlm", "llava-qwen2", "llava_qwen2",
@@ -341,6 +349,14 @@ public enum ModelMediaCapabilities {
         // vision is only the omni path, already handled above.)
         guard hasVisionConfig else {
             return .textOnly
+        }
+
+        // DiffusionGemma: block-diffusion Gemma with the Gemma4 unified
+        // vision tower. Image-in/text-out only — the checkpoint has no
+        // audio config and no video_token_id. Checked before the gemma4
+        // prefix branch since its model_type is `diffusion_gemma`.
+        if modelType == "diffusion_gemma" {
+            return .imageOnly
         }
 
         // Gemma4: audio capability is checkpoint-fact-driven, not

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -167,6 +167,17 @@ public enum ServerRuntimeSettingsStore {
         {
             normalized.mtp.mode = .auto
         }
+        // Osaurus product default for block-diffusion models: 16 denoising
+        // steps (~74 tok/s on diffusiongemma-26B-A4B MXFP4, coherent) vs the
+        // bundle's 48 (~37 tok/s). Seeded exactly once; afterwards a blank
+        // field is an explicit "use bundle default" choice.
+        if normalized.generation.diffusionMaxDenoisingSteps == nil,
+            !FileManager.default.fileExists(
+                atPath: diffusionDefaultsMigrationMarkerURL().path)
+        {
+            normalized.generation.diffusionMaxDenoisingSteps = 16
+            writeDiffusionDefaultsMigrationMarker()
+        }
         if shouldRepairLegacyCacheDefaults(normalized.cache) {
             // Keep companion-cache repair independent from the live KV codec.
             // Engine-selected is the default policy now, but ModelRuntime
@@ -292,6 +303,8 @@ public enum ServerRuntimeSettingsStore {
             minP: nil,
             repetitionPenalty: nil
         )
+        settings.generation.diffusionMaxDenoisingSteps = 16
+        writeDiffusionDefaultsMigrationMarker()
 
         // Concurrency: legacy UserDefaults key for BatchEngine max
         // batch size. Falls back to nil so vmlx's coordinator chooses
@@ -401,6 +414,22 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func cacheDefaultsMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(cacheDefaultsMigrationMarkerName)
+    }
+
+    /// One-shot seed of the Osaurus diffusion default (16 denoising steps,
+    /// the measured speed/quality knee for diffusiongemma-26B-A4B). The
+    /// marker keeps a user's later "blank = bundle default" choice sticky.
+    static let diffusionDefaultsMigrationMarkerName =
+        "diffusion-defaults-migrated.marker"
+
+    private nonisolated static func diffusionDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(diffusionDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func writeDiffusionDefaultsMigrationMarker() {
+        let url = diffusionDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
     }
 
     private nonisolated static func pagedCacheDefaultOffMigrationMarkerURL() -> URL {

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -85,9 +85,15 @@ public enum ServerRuntimeSettingsStore {
     @MainActor
     public static func loadOrMigrate() -> VMLXServerRuntimeSettings {
         if let existing = load() { return existing }
-        let migrated = migratedFromLegacy(
-            serverConfiguration: ServerConfigurationStore.load() ?? .default,
-            userDefaults: .standard
+        // Brand-new install (no settings file): run the freshly-migrated
+        // settings through the same normalization as a loaded file so the
+        // product defaults (q6 tied head, diffusion denoising budget, cache
+        // repairs) are seeded on the very first launch, not only on reload.
+        let migrated = normalizeLoadedSettings(
+            migratedFromLegacy(
+                serverConfiguration: ServerConfigurationStore.load() ?? .default,
+                userDefaults: .standard
+            )
         )
         save(migrated)
         return migrated
@@ -177,6 +183,23 @@ public enum ServerRuntimeSettingsStore {
         {
             normalized.generation.diffusionMaxDenoisingSteps = 16
             writeDiffusionDefaultsMigrationMarker()
+        }
+        // Osaurus product default: quantize the unquantized Gemma 4 QAT tied
+        // head to q6 (GGUF Q6_K-parity head bandwidth) instead of fp16
+        // passthrough. This is the safe speed lever — affine head quantization,
+        // no compile/model-switch risk — and is the largest out-of-box Gemma 4
+        // QAT speedup. Seeded once for installs that have never picked a codec
+        // (nil performance, or the engine fp16 default); the marker keeps a
+        // user's later explicit fp16 choice sticky.
+        if (normalized.performance == nil
+            || normalized.performance?.tiedHeadCodec == .fp16Passthrough),
+            !FileManager.default.fileExists(
+                atPath: tiedHeadDefaultsMigrationMarkerURL().path)
+        {
+            var perf = normalized.effectivePerformance
+            perf.tiedHeadCodec = .q6
+            normalized.performance = perf
+            writeTiedHeadDefaultsMigrationMarker()
         }
         if shouldRepairLegacyCacheDefaults(normalized.cache) {
             // Keep companion-cache repair independent from the live KV codec.
@@ -428,6 +451,26 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func writeDiffusionDefaultsMigrationMarker() {
         let url = diffusionDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url, options: [.atomic])
+    }
+
+    /// Osaurus product default for the tied-LM-head codec: q6 (6-bit affine,
+    /// the bandwidth/quality point matching the llama.cpp Q6_K output head used
+    /// by the documented GGUF baselines). Gemma 4 QAT bundles ship the 262k
+    /// tied head UNQUANTIZED (fp16), which streams ~1 GB/token; q6 is the safe
+    /// speed lever (no model-switch-compile risk, unlike compiled decode).
+    /// Seeded once; afterwards the user's explicit codec choice (including
+    /// fp16 passthrough) stays sticky.
+    static let tiedHeadDefaultsMigrationMarkerName =
+        "tied-head-q6-default-migrated.marker"
+
+    private nonisolated static func tiedHeadDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(tiedHeadDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func writeTiedHeadDefaultsMigrationMarker() {
+        let url = tiedHeadDefaultsMigrationMarkerURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         try? Data().write(to: url, options: [.atomic])
     }

--- a/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
+++ b/Packages/OsaurusCore/Models/Configuration/VLMDetection.swift
@@ -74,6 +74,7 @@ enum VLMDetection {
         let trimmed = modelType.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalized = trimmed.lowercased()
         guard normalized != "zaya" else { return false }
+        if normalized == "diffusion_gemma" { return true }
         return VLMTypeRegistry.supportedModelTypes.contains(trimmed)
             || VLMTypeRegistry.supportedModelTypes.contains(normalized)
     }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1276,9 +1276,29 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 previous.cache != next.cache
                 || previous.multimodal != next.multimodal
                 || previous.mtp != next.mtp
+                // The tied-head codec applies at model construction
+                // (TiedHeadQuantizationPolicy is read while loading the head),
+                // so a change takes effect on the next load — evicting the
+                // resident model makes the toggle live. Compare
+                // effectivePerformance so a nil<->explicit-default edit
+                // (semantically unchanged) does not force a spurious reload.
+                //
+                // NOTE: the *compiled-decode* lever is different — MLX caches
+                // its compile state at the first model load of the process, so
+                // it can only engage when VMLX_ENABLE_UNSAFE_COMPILE is set
+                // before that first load (i.e. at launch from a persisted
+                // setting). A mid-session reload cannot turn it on; that is
+                // surfaced separately via `compiled_decode_restart_required`.
+                || previous.effectivePerformance != next.effectivePerformance
             let runtimeConfigInvalidated =
                 previous.generation != next.generation
                 || previous.concurrency != next.concurrency
+            // Compiled decode is a process-startup lever (see above): a change
+            // to it only takes effect after restarting Osaurus, so report that
+            // explicitly rather than letting the toggle look live.
+            let compiledDecodeRestartRequired =
+                previous.effectivePerformance.compiledDecode
+                != next.effectivePerformance.compiledDecode
 
             ServerRuntimeSettingsStore.save(next)
             if loadedModelRefreshNeeded {
@@ -1291,6 +1311,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let effects: [String: Any] = [
                 "loaded_model_refresh_needed": loadedModelRefreshNeeded,
                 "runtime_config_invalidated": runtimeConfigInvalidated,
+                "compiled_decode_restart_required": compiledDecodeRestartRequired,
                 "network_restart_rejected": false,
                 "validation_warnings":
                     validationIssues

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+            revision: "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1583,48 +1583,39 @@ public actor ModelRuntime {
         modelName: String,
         cacheTopology: ModelCacheTopologySnapshot? = nil
     ) -> Bool {
-        // Hybrid and path-dependent caches keep fp16 live KV by default until
-        // a row proves TurboQuant for that exact topology. TurboQuant KV is
-        // not a substitute for SSM/CCA/CSA/HSA/SWA companion-state restore.
+        // POLICY (Eric directive 2026-06-12): TurboQuant KV is NEVER enabled
+        // automatically for ANY family. `liveKVCodec=engineSelected` (the
+        // shipped default) therefore resolves to native fp16 KV for every
+        // model.
         //
-        // Step 3.7 mixes full-attention KV layers with rotating/SWA layers.
-        // Current no-sign Osaurus warm rows prove disk L2 restore on that
-        // topology, but not TurboQuant-KV decode stability after tool history,
-        // so engine-selected defaults must leave Step live KV native/fp16.
-        if ModelFamilyNames.isStepFamily(modelName) {
-            return false
-        }
-
-        if ModelFamilyNames.isDSV4Family(modelName)
-            || ModelFamilyNames.isZayaFamily(modelName)
-            || ModelFamilyNames.isZayaVLFamily(modelName)
-            || Self.isKnownHybridModel(name: modelName)
-        {
-            return false
-        }
-        if let cacheTopology {
-            // No Gemma special case: Gemma 4's SWA topology (5:1 sliding
-            // 1024-token rotating windows + MQA full layers) keeps native KV
-            // tiny (~70 MB at 4k ctx on 26B-A4B), so TurboQuant buys almost
-            // no RAM while costing real decode throughput — measured
-            // 2026-06-12 on M5 Max RunBench, greedy, kvMode none vs tq33:
-            // 26B-A4B MXFP4 92.3 -> 54.0 tok/s (-42%), 12B MXFP4 48.6 ->
-            // 34.5 (-29%). The earlier forced `return kvLayerCount > 0`
-            // here is what regressed Gemma app decode from the documented
-            // 100+ tok/s 26B rows. The generic rotating-layer rule below
-            // now applies; TurboQuant stays available for Gemma via the
-            // explicit cache.liveKVCodec=turboQuant setting.
-            if cacheTopology.mambaLayerCount > 0
-                || cacheTopology.arraysLayerCount > 0
-                || cacheTopology.hybridPoolLayerCount > 0
-                || cacheTopology.rotatingKVLayerCount > 0
-                || cacheTopology.rotatingWrapperLayerCount > 0
-            {
-                return false
-            }
-            return cacheTopology.kvLayerCount > 0
-        }
-        return ModelFamilyNames.isMiniMaxFamily(modelName)
+        // vMLX's settings resolve `.engineSelected -> .turboQuant()`, so this
+        // runtime gate is the single point that decides whether engine-
+        // selected actually turns TurboQuant on. Previously it returned true
+        // for full-KV families (MiniMax) and for any topology with KV layers
+        // and no rotating/hybrid layers — which silently force-enabled
+        // TurboQuant on multiple families. TurboQuant's per-step
+        // compress/decompress cost outweighs its RAM savings at the context
+        // lengths Osaurus serves and measurably regresses decode:
+        //   Gemma 4 26B-A4B MXFP4  92.3 -> 54.0 tok/s  (-42%)
+        //   Gemma 4 12B    MXFP4   48.6 -> 34.5 tok/s  (-29%)
+        // (M5 Max RunBench, greedy, kvMode none vs tq33, 2026-06-12). Every
+        // rotating/SWA/full-KV family pays the same tax. The Gemma SWA
+        // regression was the visible symptom of a blanket problem; the blanket
+        // fix is to never auto-select TurboQuant for anyone.
+        //
+        // TurboQuant remains fully available on demand via an explicit
+        // `cache.liveKVCodec=turboQuant` setting — that path bypasses this
+        // function entirely (see `defaultKVMode`), so opting in is unaffected.
+        // A kernel-level TurboQuant encode/decode optimization is a separate
+        // future lane; until it lands and a per-family proof row exists, the
+        // engine default stays native fp16.
+        //
+        // `modelName`/`cacheTopology` are retained for signature/test
+        // stability and future per-family opt-in proof rows; intentionally
+        // unused while the blanket-off policy holds.
+        _ = modelName
+        _ = cacheTopology
+        return false
     }
 
     nonisolated static func cacheCoordinatorModelKey(

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1059,6 +1059,12 @@ struct MLXBatchAdapter {
             enableCompiledBatchDecode: effective.compiledBatchDecode,
             prefillStepSize: runtime.concurrency.prefillStepSize
         )
+        // Block-diffusion speed/quality budget (DiffusionGemma): server
+        // setting, default 16 (seeded by ServerRuntimeSettingsStore).
+        // nil = bundle's generation_config.json value. Ignored by
+        // autoregressive models.
+        mlxParams.diffusionMaxDenoisingSteps =
+            runtime.generation.diffusionMaxDenoisingSteps
         let cacheTopology = await container.cacheTopologySnapshot()
         let effectiveKVMode = ModelRuntime.defaultKVMode(
             for: ServerRuntimeSettingsStore.snapshot().cache,

--- a/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/VLMDetectionTests.swift
@@ -44,6 +44,11 @@ import Testing
         #expect(VLMDetection.isVLM(modelType: "qwen2_5_vl"))
     }
 
+    @Test func isVLMModelType_recognizesDiffusionGemma() {
+        #expect(VLMDetection.isVLM(modelType: "diffusion_gemma"))
+        #expect(!VLMDetection.isVLM(modelType: "diffusion_gemma_text"))
+    }
+
     @Test func isVLMModelType_preservesCaseSensitiveRegistryEntries() {
         #expect(VLMDetection.isVLM(modelType: "NemotronH_Nano_Omni_Reasoning_V3"))
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -231,6 +231,21 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(ModelMediaCapabilities.from(modelId: "gemma-4-12b-it-mxfp8") == .imageOnly)
     }
 
+@Test("D6: DiffusionGemma is image-only, not video/audio")
+    func d6_diffusionGemmaImageOnly() {
+        for modelId in [
+            "google/diffusiongemma-26B-A4B-it",
+            "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4",
+            "diffusion_gemma",
+        ] {
+            let cap = ModelMediaCapabilities.from(modelId: modelId)
+            #expect(cap == .imageOnly, "\(modelId) must advertise image only")
+            #expect(cap.supportsImage)
+            #expect(!cap.supportsVideo)
+            #expect(!cap.supportsAudio)
+        }
+    }
+
     // MARK: - D7: Mistral 3 / 3.5 (image only via Pixtral wrap)
 
     @Test("D7: Mistral 3 / 3.5 → .imageOnly")

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -124,6 +124,45 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
+    @Test func runtimeSettings_put_performanceChange_refreshesLoadedModel() async throws {
+        // Decode-performance levers (compiled decode + tied-head codec) are
+        // applied at model LOAD, so toggling them must evict the resident model
+        // — otherwise the UI toggle silently no-ops until a manual reload.
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            let initial = VMLXServerRuntimeSettings()
+            ServerRuntimeSettingsStore.save(initial)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            // Tied-head change alone: live via reload, no restart required.
+            var headOnly = initial
+            headOnly.performance = VMLXServerPerformanceSettings(
+                tiedHeadCodec: .q6, compiledDecode: false)
+            let (headData, headResp) = try await putRuntimeSettings(headOnly, server: server)
+            #expect((headResp as? HTTPURLResponse)?.statusCode == 200)
+            let headDecoded = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: headData)
+            #expect(headDecoded.effects?.loadedModelRefreshNeeded == true)
+            #expect(headDecoded.effects?.compiledDecodeRestartRequired == false)
+            #expect(headDecoded.settings.effectivePerformance.tiedHeadCodec == .q6)
+
+            // Compiled-decode toggle: a process-startup lever, so the response
+            // must report restart_required (it cannot engage mid-session).
+            var next = headOnly
+            next.performance = VMLXServerPerformanceSettings(
+                tiedHeadCodec: .q6, compiledDecode: true)
+            let (data, resp) = try await putRuntimeSettings(next, server: server)
+
+            #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+            let decoded = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: data)
+            #expect(decoded.effects?.loadedModelRefreshNeeded == true)
+            #expect(decoded.effects?.compiledDecodeRestartRequired == true)
+            #expect(decoded.settings.effectivePerformance.compiledDecode == true)
+            #expect(decoded.settings.effectivePerformance.tiedHeadCodec == .q6)
+        }
+    }
+
     @Test func runtimeSettings_put_rejectsNetworkRebindChanges() async throws {
         let dir = try makeTempDirectory()
         try await withOverriddenRuntimeSettingsDirectory(dir) {
@@ -230,10 +269,12 @@ struct HTTPHandlerEndpointTests {
     private struct RuntimeSettingsEffects: Decodable {
         let loadedModelRefreshNeeded: Bool?
         let runtimeConfigInvalidated: Bool?
+        let compiledDecodeRestartRequired: Bool?
 
         private enum CodingKeys: String, CodingKey {
             case loadedModelRefreshNeeded = "loaded_model_refresh_needed"
             case runtimeConfigInvalidated = "runtime_config_invalidated"
+            case compiledDecodeRestartRequired = "compiled_decode_restart_required"
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -92,6 +92,11 @@ struct ServerRuntimeSettingsStoreTests {
             // an explicit user value round-trips and is not clobbered on load.
             // (The seed only fills a nil field once, on first launch.)
             settings.generation.diffusionMaxDenoisingSteps = 24
+            // Set an explicit (non-fp16) tied-head codec so the one-time q6
+            // tied-head-default seed is a no-op here; this asserts an explicit
+            // user codec round-trips and is not clobbered on load.
+            settings.performance = VMLXServerPerformanceSettings(
+                tiedHeadCodec: .q8, compiledDecode: false)
             settings.concurrency.maxConcurrentSequences = 5
             settings.cache.defaultMaxKVSize = 16_384
             settings.memorySafety.mode = .strict
@@ -103,6 +108,25 @@ struct ServerRuntimeSettingsStoreTests {
 
             #expect(loaded == settings)
             #expect(ServerRuntimeSettingsStore.snapshot() == settings)
+        }
+    }
+
+    @Test @MainActor func load_seedsQ6TiedHeadDefault() async throws {
+        // Fresh install (no codec ever chosen) should default the tied-head
+        // codec to q6 — the GGUF-parity head bandwidth point and the largest
+        // safe out-of-box Gemma 4 QAT speed lever.
+        let dir = try makeTempDirectory()
+        try await withOverriddenDirectory(dir) {
+            var settings = VMLXServerRuntimeSettings()
+            settings.network.port = 4242
+            // performance left nil (never configured)
+            ServerRuntimeSettingsStore.save(settings)
+            ServerRuntimeSettingsStore.invalidateSnapshot()
+
+            let loaded = try #require(ServerRuntimeSettingsStore.load())
+            #expect(loaded.effectivePerformance.tiedHeadCodec == .q6)
+            // compiled decode stays OFF by default (correctness gate #1173).
+            #expect(loaded.effectivePerformance.compiledDecode == false)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -87,6 +87,11 @@ struct ServerRuntimeSettingsStoreTests {
             settings.network.host = "0.0.0.0"
             settings.network.corsOrigins = ["https://example.com"]
             settings.generation.temperature = 0.42
+            // Set an explicit non-default diffusion budget so the one-time
+            // diffusion-defaults seed migration is a no-op here; this asserts
+            // an explicit user value round-trips and is not clobbered on load.
+            // (The seed only fills a nil field once, on first launch.)
+            settings.generation.diffusionMaxDenoisingSteps = 24
             settings.concurrency.maxConcurrentSequences = 5
             settings.cache.defaultMaxKVSize = 16_384
             settings.memorySafety.mode = .strict

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -656,12 +656,17 @@ struct MLXBatchAdapterTests {
     @Test func cacheKVModeTagTracksEffectiveCoordinatorPolicy() {
         var settings = VMLXServerRuntimeSettings()
 
+        // POLICY (2026-06-12): engineSelected resolves to native fp16 for
+        // EVERY family — TurboQuant is never auto-enabled. Previously MiniMax
+        // (full-KV) resolved to turbo(3,3); the per-step compress/decompress
+        // tax regresses decode across families, so engine-selected stays fp16.
+        // TurboQuant is opt-in only via an explicit liveKVCodec=turboQuant.
         settings.cache.liveKVCodec = .engineSelected
         #expect(
             ModelRuntime.cacheKVModeTag(
                 for: settings.cache,
                 modelName: "MiniMax-M2.7-JANG_K-CRACK"
-            ) == "turbo(3,3)"
+            ) == "fp16"
         )
         #expect(
             ModelRuntime.cacheKVModeTag(
@@ -744,6 +749,8 @@ struct MLXBatchAdapterTests {
                 )
             ) == "fp16"
         )
+        // MiniMax full-KV topology also stays native under engineSelected now
+        // (was turbo(3,3) before the blanket-off policy).
         #expect(
             ModelRuntime.cacheKVModeTag(
                 for: settings.cache,
@@ -754,6 +761,18 @@ struct MLXBatchAdapterTests {
                     turboQuantKVLayerCount: 0,
                     rotatingKVLayerCount: 0
                 )
+            ) == "fp16"
+        )
+
+        // Explicit opt-in still works: liveKVCodec=turboQuant resolves to
+        // turbo(3,3) regardless of family (bypasses the auto gate).
+        settings.cache.liveKVCodec = .turboQuant
+        settings.cache.turboQuantKeyBits = 3
+        settings.cache.turboQuantValueBits = 3
+        #expect(
+            ModelRuntime.cacheKVModeTag(
+                for: settings.cache,
+                modelName: "MiniMax-M2.7-JANG_K-CRACK"
             ) == "turbo(3,3)"
         )
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -603,7 +603,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        let expectedRuntimeHardenedRevision = "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -913,28 +913,26 @@ struct RuntimePolicySourceTests {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         #expect(
             runtime.contains("shouldUseTurboQuantByDefault"),
-            "ModelRuntime must resolve engine-selected cache policy per family/topology instead of enabling TurboQuant globally"
+            "ModelRuntime must own the engine-selected TurboQuant gate"
         )
+        // POLICY (2026-06-12): TurboQuant KV is never auto-enabled for ANY
+        // family. shouldUseTurboQuantByDefault must unconditionally return
+        // false so engineSelected resolves to native fp16 everywhere; the
+        // per-step compress/decompress tax regresses decode across families
+        // (Gemma 26B-A4B -42%, 12B -29%). TQ is opt-in only via explicit
+        // liveKVCodec=turboQuant.
         #expect(
-            runtime.contains("ModelFamilyNames.isDSV4Family(modelName)")
-                && runtime.contains("ModelFamilyNames.isZayaFamily(modelName)")
-                && runtime.contains("ModelFamilyNames.isZayaVLFamily(modelName)")
-                && runtime.contains("ModelFamilyNames.isGemmaFamily(modelName)")
-                && runtime.contains("Self.isKnownHybridModel(name: modelName)"),
-            "Engine-selected TurboQuant must stay off by default for DSV4, ZAYA/ZAYA-VL, Gemma, and hybrid topologies until exact rows prove it"
+            runtime.contains("Eric directive 2026-06-12")
+                && runtime.contains("TurboQuant KV is NEVER enabled")
+                && runtime.contains("liveKVCodec=turboQuant"),
+            "shouldUseTurboQuantByDefault must document and enforce the blanket TurboQuant-off-by-default policy"
         )
+        // The function must NOT reintroduce a family/topology branch that can
+        // return true (which is what silently force-enabled TurboQuant before).
         #expect(
-            runtime.contains("ModelFamilyNames.isStepFamily(modelName)")
-                && runtime.contains("return false")
-                && runtime.contains("Step 3.7 mixes full-attention KV layers with rotating/SWA layers"),
-            "Step 3.7 mixed-SWA topology must stay native/fp16 by default until a warm tool-history row proves TurboQuant-KV stability"
-        )
-        #expect(
-            !runtime.contains("warm disk hit path is not stable yet")
-                && !runtime.contains(
-                    "ModelFamilyNames.isLFM2Family(modelName) {\n            // Current live Osaurus rows prove LFM2.5"
-                ),
-            "LFM2 must not carry the temporary disk-restore disable gate once required-tool history stability is fixed in vMLX"
+            !runtime.contains("return cacheTopology.kvLayerCount > 0")
+                && !runtime.contains("return ModelFamilyNames.isMiniMaxFamily(modelName)"),
+            "shouldUseTurboQuantByDefault must not auto-select TurboQuant for full-KV families (MiniMax) or KV-bearing topologies"
         )
         let mlxService = try Self.source("Services/Inference/MLXService.swift")
         #expect(
@@ -943,12 +941,6 @@ struct RuntimePolicySourceTests {
                 && mlxService.contains("Step 3.7 tool parsing/template selection is owned by the pinned")
                 && mlxService.contains("return ModelMediaCapabilities.descriptor(modelId: modelId)"),
             "Step 3.7 runtime policy must stay text-only/tool-capable and must not block preflight on external bundle metadata until Step VLM is wired and proven"
-        )
-        #expect(
-            !runtime.contains(
-                "if ModelFamilyNames.isGemmaFamily(modelName) {\n                return cacheTopology.kvLayerCount > 0")
-                && runtime.contains("rotatingKVLayerCount > 0"),
-            "Gemma SWA must NOT be special-cased into TurboQuant KV: the generic rotating-topology rule keeps it native. Forcing TQ on Gemma 4 measured -42% decode on 26B-A4B and -29% on 12B (2026-06-12 RunBench) for ~70 MB of KV savings; TurboQuant remains available via explicit cache.liveKVCodec=turboQuant."
         )
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
@@ -50,7 +50,7 @@ struct DecodePerformanceSection: View {
             SettingsField(
                 label: "Compiled Decode (Experimental)",
                 hint:
-                    "Fuses the per-token decode graph with MLX compile (+25% measured on Gemma 4 QAT). Experimental: kept off by default until the historical model-switch corruption (PR #1173) is root-caused. If model switching misbehaves with this on, turn it off and reload."
+                    "Fuses the per-token decode graph with MLX compile (+25% measured on Gemma 4 QAT). Takes effect after restarting Osaurus — MLX fixes its compile state at the first model load of the process, so toggling this mid-session cannot turn it on/off live (the setting is saved and applies on next launch). Experimental: kept off by default until the historical model-switch corruption (PR #1173) is root-caused. If model switching misbehaves with this on, turn it off and restart."
             ) {
                 Toggle("", isOn: performanceBinding.compiledDecode)
                     .toggleStyle(.switch)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/GenerationDefaultsSection.swift
@@ -69,6 +69,20 @@ struct GenerationDefaultsSection: View {
 
             SettingsDivider()
 
+            SettingsSubsection(label: "Diffusion Models") {
+                OptionalIntField(
+                    label: "Denoising Steps per Canvas",
+                    placeholder: "Blank = model default (48)",
+                    help: "Speed/quality budget for block-diffusion models "
+                        + "(DiffusionGemma). 16 ≈ 2× faster than the model "
+                        + "default and stays coherent; below 12 quality "
+                        + "degrades. Ignored by ordinary models.",
+                    value: $draft.generation.diffusionMaxDenoisingSteps
+                )
+            }
+
+            SettingsDivider()
+
             SettingsSubsection(label: "Streaming") {
                 VStack(alignment: .leading, spacing: 8) {
                     ServerSettingsPlannedBanner(

--- a/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
+++ b/docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md
@@ -1,0 +1,113 @@
+# Osaurus + vMLX Cache & Runtime Policy Reference (2026-06-12)
+
+Comprehensive reference for the cache stack, KV codecs, RAM safety, and the
+per-family runtime nuances after the Gemma 4 speed/audio work and the
+TurboQuant-off-by-default policy change. This is the source of truth for
+"what is the default, why, and where is it enforced."
+
+## 1. Default cache topology (every model, unless explicitly overridden)
+
+| Layer | Default | Enforced at |
+|---|---|---|
+| Paged RAM KV cache | **OFF** | `VMLXPagedKVCacheSettings.enabled=false`; vMLX `CacheCoordinatorConfig.usePagedCache = reuseEnabled && cache.pagedKV.enabled` |
+| Prefix cache (SSD-backed) | **ON** | `VMLXPrefixCacheSettings.enabled=true`; forces block-disk L2 on |
+| Block-disk L2 cache | **ON** | `VMLXBlockDiskCacheSettings.enabled=true` |
+| Legacy disk cache | **OFF** | `VMLXDiskCacheSettings.enabled=false` |
+| Live KV codec | **native fp16** | `liveKVCodec=engineSelected` → `shouldUseTurboQuantByDefault` returns false (see §2) |
+| TurboQuant KV | **OFF (opt-in only)** | See §2 |
+| SSM re-derive | ON | `enableSSMReDerive=true` (hybrid families only) |
+| Memory safety | safe_auto | `memorySafety.mode` |
+
+**The only default cache is SSD prefix + block-disk L2. No paged RAM cache for any model. No TurboQuant encode/decode for any model.**
+
+## 2. TurboQuant KV — OFF by default for ALL families (policy 2026-06-12)
+
+### Why
+TurboQuant compresses live KV (`turbo(3,3)` = 3-bit key / 3-bit value) to save
+RAM. At the context lengths Osaurus serves, the per-step compress/decompress
+cost outweighs the RAM savings and measurably regresses decode throughput
+across every family that carries KV:
+- Gemma 4 26B-A4B MXFP4: 92.3 → 54.0 tok/s (−42%) with `tq33` vs native
+- Gemma 4 12B MXFP4: 48.6 → 34.5 tok/s (−29%)
+(M5 Max, RunBench, greedy, `kvMode none` vs `tq33`.)
+
+The Gemma SWA regression (the visible "26B used to do 100+ tok/s" symptom)
+was one instance of a blanket problem: any rotating/SWA/full-KV topology paid
+the same tax.
+
+### The resolution chain (where it's decided)
+1. Osaurus ships `liveKVCodec = .engineSelected` (the default codec choice).
+2. vMLX's `VMLXServerCacheSettings.defaultKVMode` resolves `.engineSelected` to
+   `.turboQuant()`.
+3. **`ModelRuntime.shouldUseTurboQuantByDefault(...)` is the single runtime
+   gate that decides whether engine-selected actually turns TurboQuant on.**
+   As of 2026-06-12 it **unconditionally returns false** — so engine-selected
+   resolves to native fp16 KV for every model.
+
+### Opt-in path (unchanged)
+Setting `cache.liveKVCodec = .turboQuant` (with `turboQuantKeyBits`/
+`turboQuantValueBits`) bypasses the auto gate entirely (`defaultKVMode`
+returns `.turboQuant(keyBits:valueBits:)` directly). TurboQuant remains fully
+available for anyone who explicitly wants it.
+
+### Telemetry
+`/admin/cache-stats` → `effective_kv_mode` reports the actual resolved codec
+(`"fp16"` under the default policy; `"turbo(3,3)"` only under explicit opt-in).
+`turbo_quant_kv_layer_count` counts actually-materialized TurboQuant layers
+(0 under the default policy). Do not describe a model as TurboQuant-encoded
+when `effective_kv_mode=fp16`.
+
+### Future lane
+A kernel-level TurboQuant encode/decode optimization (threadgroup-shared
+codebook, vectorized packed loads, simdgroup-matrix dequant) could make TQ
+cheap enough to default on for RAM-constrained loads. Until that lands with a
+per-family proof row, the engine default stays native fp16.
+
+## 3. RAM safety
+
+- `memorySafety.mode` ∈ {performance, balanced, safeAuto (default), strict,
+  diagnosticDangerous}. Each maps to a distinct load fraction + allocator cap
+  (`resolvedMemorySafetyPlan` → `LoadConfiguration.memoryLimit`/
+  `maxResidentBytes` → MLX `Memory` limits).
+- RAM feasibility is **advisory** in safe_auto (verdict logged + surfaced, load
+  proceeds; unified memory + mmap can page/compress). **strict** mode sets
+  `blocksOverBudget=true` and refuses loads whose projected working set exceeds
+  the resolved budget.
+- Backstop when a too-large bundle is loaded: idle-resident-model eviction
+  (`strictSingleModel` / flexible-budget eviction) fires before the new load.
+  RE-VERIFY: eviction fires before OOM on a genuinely over-budget load (the
+  hard pre-load refusal was demoted to advisory in osaurus #1454).
+
+## 4. Per-family cache/runtime nuances
+
+| Family | Live KV (default) | Companion / special state | Notes |
+|---|---|---|---|
+| Gemma 4 (gemma4/gemma4_unified) | fp16 native | SWA: 5 sliding (RotatingKVCache win=1024) : 1 full (MQA, unbounded). attention_k_eq_v on full layers. | Dual RoPE (proportional p-RoPE θ=1e6 full / default θ=1e4 sliding). Tied 262k embed; q6 head opt-in. Audio: 12B unified raw-frame `embed_audio`; E-series mel + conformer `audio_tower`. |
+| Qwen 3.5/3.6 MoE (+MTP) | fp16 native | Hybrid SSM (gated-delta) + MoE streaming experts | MTP autodetection from sidecar tensors → native-MTP draft. Streaming-experts auto-enable (verify decode). |
+| LFM2 / LFM2.5 (hybrid) | fp16 native | SSM companion state + required-tool template | Required-tool parser churn — verify e2e tool history. |
+| DeepSeek-V4-Flash | fp16 native | HCA + SWA + CSA combo cache; disk-backed restore | Combo cache restore needs all three companion states; never substitute TQ. |
+| ZAYA1 / ZAYA1-VL (CCA) | fp16 native | CCA companion disk payload | Fail-closed on CCA disk miss — verify it actually hits, not just fails safe. |
+| Nemotron-H / Omni (hybrid SSM) | fp16 native | Mamba SSM + conv decode fast path | Weighted-MoE fast path now opt-in (env flag). Audio: Parakeet conformer. |
+| Step 3.7 | fp16 native | Mixed full-KV + rotating/SWA | Text-only + tool-capable; tool parsing owned by vMLX Step runtime. |
+| MiniMax M2.7 | fp16 native (was turbo) | Full KV (62 layers) | Now fp16 under blanket-off policy; was the one family auto-TQ'd without topology. |
+
+## 5. Correctness components (kernels / parsers)
+
+- **mx matmul / quantized matmul**: MXFP4 (4-bit packed, affine scales/biases),
+  JANG_4M mixed-precision per-layer overrides, JANGTQ TurboQuant packed.
+- **Hadamard 2D/3D**: used in rotary/quant transforms; verify shape handling on
+  hybrid/MoE paths.
+- **mrope**: multimodal RoPE for VL families; Gemma 4 uses dual-RoPE (not mrope).
+- **Reasoning parsers**: `ReasoningParser.forPrompt` stamps per family; Gemma 4
+  `<|channel>thought` (think_in_template=false). Held-tail detokenizer fix
+  (bf5871d) prevents dropped text between chunks.
+- **Tool parsers**: per-family `ToolCallFormat` → parser. Gemma 4 = `call:name{}`
+  with `<|tool_call>`/`<tool_call|>` markers. Strip-only mode (vMLX #50) strips
+  markers when no tools offered so they never leak as visible text.
+
+## 6. Verification gate (every change)
+A change to any of the above is not done until **live multi-turn chat in the
+dev-built Osaurus app** (pinned to the exact code) confirms: real tool calls,
+clean coherent text (no missing/garbled/random-char output), no marker leaks,
+correct cache telemetry, and RAM verdicts. CI + unit tests are necessary but
+not sufficient.

--- a/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
@@ -1,0 +1,155 @@
+# DiffusionGemma Osaurus Integration
+
+Date: 2026-06-12 (updated same day: native engine landed)
+
+## Current Source Truth
+
+- Source bundle: `google/diffusiongemma-26B-A4B-it`
+- `model_type`: `diffusion_gemma`, architecture
+  `DiffusionGemmaForBlockDiffusion`
+- 30-layer Gemma4-style MoE (128 experts, top-8), 26B total / ~4B active,
+  256-token canvas, sliding window 1024
+- Vision: `vision_config` present, `image_token_id = 258880`,
+  `vision_soft_tokens_per_image = 280`
+- Audio: `audio_config = null`, `audio_token_id = null`
+- Video: processor metadata present, but `video_token_id = null`
+
+## Engine status (vmlx-swift)
+
+The native block-diffusion engine is implemented in vmlx-swift
+(branch `codex/diffusiongemma-runtime`, PR #47): encoder prefill +
+bidirectional canvas decoder, entropy-bound sampler, adaptive stopping,
+self-conditioning — all parameters from the bundle's
+`generation_config.json`. Reference doc on the vmlx side:
+`docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md` (verification rows:
+token/s, multi-turn, tool calls, prefix/disk cache, memory, isolation).
+
+## How DiffusionGemma flows through Osaurus — teammate wiring map
+
+1. **Discovery / capability**: `VLMDetection` recognizes
+   `diffusion_gemma` as VLM-shaped; `ModelFamilyNames.isDiffusionGemmaFamily`
+   keeps it distinct from Gemma-4 AR; `ModelMediaCapabilities` advertises
+   image-only (audio/video blocked until runtime-proven).
+2. **Loading**: `loadModelContainer` iterates factories; the VLM factory
+   rejects `diffusion_gemma` (`unsupportedModelType`) and the LLM factory
+   creates `DiffusionGemmaModel`. No Osaurus-side routing code needed.
+3. **Generation**: `MLXBatchAdapter` routes every request through
+   `BatchEngine.generate`. For `BlockDiffusionModel` conformers,
+   BatchEngine takes its **exclusive solo path** (same mechanism as
+   native MTP) into `BlockDiffusionTokenIterator`. The batched `submit()`
+   path is rejected loudly (the model's `prepare()` throws) — block
+   diffusion can never silently AR-decode or share batch slots.
+4. **Parsers**: tool calls use the Gemma-4 format
+   (`<|tool_call>call:name{...}<tool_call|>`, mapped from
+   `model_type` in `ToolCallFormat.infer`); reasoning stamp is `harmony`
+   (`<|channel>thought…<channel|>`). Both verified live with zero marker
+   leakage through `TextToolTokenLoopHandler`.
+5. **Caching**: encoder cache is Gemma4 topology (RotatingKVCache
+   window-1024 sliding + KVCacheSimple full layers, fp16 KV — no
+   TurboQuant). Rotating layers can't round-trip paged KV blocks, so the
+   iterator marks the coordinator paged-incompatible and prompt
+   boundaries are served by the **disk (L2/SSD) tier**. Verified:
+   fresh-coordinator resume restored 138/138 prompt tokens with
+   `prefillSec=0.000`; turn-extension hit passes; multi-turn live-cache
+   sessions keep the full reply via the end-of-turn cache commit.
+
+## Speed/quality control (the Osaurus setting)
+
+`GenerateParameters.diffusionMaxDenoisingSteps` (vmlx) caps the
+denoising budget per 256-token canvas. Measured on MXFP4, M5 Max,
+~740-token essay:
+
+| steps | tok/s | coherency |
+|---|---|---|
+| 48 (bundle default) | 37 | clean |
+| 24 | 58 | clean |
+| **16 (Osaurus default)** | **74** | clean (essay + multi-turn recall verified) |
+| 8 | 140 | BREAKS (word salad) |
+
+Wiring:
+
+- Contract field: `VMLXServerGenerationDefaults.diffusionMaxDenoisingSteps`
+  (`nil` = bundle default; validation errors `< 1`, warns `< 12`).
+- Osaurus default: **16**, seeded once by `ServerRuntimeSettingsStore`
+  (`diffusion-defaults-migrated.marker`; after seeding, a blank field is a
+  sticky "use bundle default" choice).
+- Request flow: `RuntimeConfig.snapshot()` →
+  `MLXBatchAdapter` sets `mlxParams.diffusionMaxDenoisingSteps` →
+  `BlockDiffusionParameters.overriding(parameters:)` at dispatch.
+- UI: Server → Settings → Sampling → "Diffusion Models" →
+  "Denoising Steps per Canvas" (`GenerationDefaultsSection`).
+- Per-request API override: not exposed on the OpenAI wire yet
+  (server-level setting only).
+
+## Quant bundles
+
+vmlx PR #45 (merged, `710eb0d7…`) added the converter; both local quants
+verified:
+
+- MXFP4: 15 GB, 15 shards, `total_size=15944852880`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — ~37 tok/s @48 steps,
+  ~74 tok/s @16, peak RSS 12.7 GB
+- MXFP8: 26 GB, 23 shards, `total_size=27918936056`, 295 quantized
+  tensors, 752 passthrough, 1,342 indexed — converges in fewer steps
+  (sometimes faster than MXFP4 end-to-end), peak RSS 23.8 GB
+
+## Pin management
+
+`Packages/OsaurusCore/Package.swift` pins `osaurus-ai/vmlx-swift` by
+revision; the same revision must appear in BOTH lockfiles
+(`Packages/OsaurusCore/Package.resolved`,
+`osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`) AND in the
+`RuntimePolicySourceTests` "vmlx pin uses consolidated package" expected
+revision constant — the focused test fails on any mismatch by design.
+
+Focused verification command:
+
+```sh
+OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
+OSAURUS_TEST_ROOT=/tmp/osaurus-dg-tests \
+swift test --package-path Packages/OsaurusCore \
+  --filter 'VLMDetectionTests|ModelMediaCapabilitiesMCDCTests|RuntimePolicySourceTests'
+```
+
+Debugging note: a bare `error: fatalError` from SwiftPM is a masked
+clang `fatal error:` — grep the full log. Fresh vmlx worktrees need
+`git submodule update --init --recursive` (Source/Cmlx) and tests need
+`scripts/prepare-mlx-metal.sh` metallibs.
+
+## Boundaries (unchanged)
+
+- Image-only capability advertised; **runtime VL is not yet wired** in
+  vmlx (vision tower ships in the bundles but text-only generation is
+  what's proven). Audio absent; video has no `video_token_id`.
+- Block diffusion is exclusive-solo in BatchEngine; batched canvas
+  scheduling is future work.
+
+## Live dev-build verification (2026-06-12)
+
+All proven through the running Debug app's OpenAI API (`/v1/chat/completions`):
+
+- **Detection scoping**: `gemma-4-12b-it-mxfp4` generates with **zero**
+  `[BlockDiffusion]` engine lines; `diffusiongemma-*` emits them. Routing
+  is by Swift type conformance (`model is BlockDiffusionModel`) — only
+  `DiffusionGemmaModel` conforms, so no name-based misrouting is possible.
+- **Settings take effect**: changing
+  `generation.diffusionMaxDenoisingSteps` 16 → 32 in
+  `server-runtime.json` (what the Settings panel writes) and restarting
+  flips the engine to `maxDenoisingSteps=32`; restored to 16.
+- **Multi-turn single session + reasoning toggle**: 4-turn conversation,
+  `enable_thinking` toggled per turn — reasoning content present only on
+  ON turns, recall held across all turns (name + number + 42+8=50), SSD
+  prefix cache restored 56 tokens mid-conversation, per-turn prefill
+  0.09–0.33 s.
+- **Vision**: a base64 gradient PNG was correctly described
+  ("vertical gradient … vibrant red at the top to deep blue at the
+  bottom") at the default 16-step setting.
+
+## Published bundles
+
+- `OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
+- `OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+
+Each ships the model card (eos `[1,106,50]`, chat template, Gemma-4 tool /
+harmony reasoning parser notes, image capability, diffusion-settings docs)
+and the Osaurus banner.

--- a/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md
@@ -153,3 +153,16 @@ All proven through the running Debug app's OpenAI API (`/v1/chat/completions`):
 Each ships the model card (eos `[1,106,50]`, chat template, Gemma-4 tool /
 harmony reasoning parser notes, image capability, diffusion-settings docs)
 and the Osaurus banner.
+
+## Known limitation: bf16 full-precision bundle (not a shipping path)
+
+`diffusiongemma-26b-a4b-it` (bf16, ~52GB) currently fails to load with a clear
+HTTP 500: `Unhandled keys [down_proj, gate_up_proj] ... DiffusionGemmaExperts`.
+Root cause: the unquantized bundle ships **bare** stacked expert tensors
+(`...experts.gate_up_proj`, `...experts.down_proj` with no `.weight` suffix),
+while `DiffusionGemma.sanitize()` only remaps the quantized layout
+(`.experts.gate_up_proj.weight/.scales/.biases`). The **mxfp4 and mxfp8
+variants — the supported/shipping diffusion paths — load and run coherently**;
+bf16 is a reference precision not used on-device. Tracked for the diffusion
+engine lane (vmlx-swift `DiffusionGemma.swift`); fails loudly with no crash or
+garble, so it does not affect the quantized product paths.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1ab081eb1d51568ae636f64b9ac76cd3ab4d2534"
+        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
       }
     },
     {


### PR DESCRIPTION
## Summary

One cohesive PR consolidating the Gemma 4 speed/cache work with the DiffusionGemma Osaurus integration, repinned to vmlx-swift main `7d9a85fe`.

Two streams land together so the runtime contract is consistent:
1. **Gemma 4 speed + cache policy** — TurboQuant KV off by default for every family, fp16 KV + SSD prefix cache as the default topology, performance-policy wiring (tied-head quantization + compiled decode), and a model-discovery fix that makes domain-style org dirs (e.g. `dealign.ai/`) visible.
2. **DiffusionGemma** — capability gating, model-finding, chat template / tool + reasoning parser wiring, and the block-diffusion runtime pin (native engine on vmlx-swift main).

## Default runtime contract (per directive)

- **TurboQuant KV: NEVER auto-selected** for any family. `shouldUseTurboQuantByDefault` now unconditionally returns `false`; TurboQuant remains fully available on explicit opt-in (`liveKVCodec=turboquant`). Kernel-level TQ encode/decode optimization is a separate future lane.
- **Paged KV: off by default** for all models. Only the **SSD prefix cache** (+ block-disk L2) is on.
- Toggling either on via the runtime-settings surface **actually enforces** and is reverted cleanly.

## Live verification (dev-built app, this branch)

Discovery fix confirmed live — **37 models** now visible incl. LFM2.5-8B, Qwen3.6-MTP, DiffusionGemma, MiniMax, DSV4.

| Area | Result |
|---|---|
| Gemma4 QAT jang_4m + mxfp4 (12B/26B/31B/E2B/E4B) | multi-turn coherent, no marker/reasoning leaks, no control chars |
| Settings enforcement (both quant types) | default `fp16`/paged-off → TQ→`turbo(3,3)` → paged→on → revert; every row enforced + coherent |
| Reasoning on/off | correct answer both modes; reasoning present on / empty off; **no tag leak** into content |
| Multi-tool agentic session | 3 distinct tools called correctly across turns + follow-ups, no leak |
| Prefix / SSD cache | disk-L2 hits confirmed on real multi-turn extension path |
| Diffusion mxfp4 + mxfp8 (shipping variants) | load + coherent, BlockDiffusion solo path, fp16 KV |
| LFM2.5-8B / Qwen3.6-MTP / MiniMax | load + coherent + fp16 KV |
| DSV4-flash-jang | intentional graceful runtime-policy block (pre-existing) |

**Known limitation (non-shipping):** the bf16 full-precision `diffusiongemma-26b-a4b-it` reference bundle fails to load with a clear HTTP 500 (unfused expert keys); the quantized mxfp4/mxfp8 variants that ship work. Tracked for the diffusion engine lane.

## Docs

- `docs/CACHE_AND_RUNTIME_POLICY_2026_06_12.md` — default cache topology, TurboQuant resolution chain, RAM safety, per-family cache nuances.
- `docs/DIFFUSIONGEMMA_OSAURUS_INTEGRATION_2026_06_12.md` — discovery→load→generation→parser→cache wiring map.

## Test

OsaurusCore: RuntimePolicySourceTests, MLXBatchAdapterTests, VLMDetectionTests, ModelMediaCapabilities MC/DC — green.

## Decode-performance defaults + toggle enforcement (added)

- **q6 tied head is the default for all Gemma 4 QAT.** The QAT bundles ship the 262k tied LM head unquantized (fp16, ~1 GB/token); the tied-head codec now defaults to q6 (GGUF Q6_K-parity head) via a one-shot seed. Safe lever (affine head quant, no compile/model-switch risk); largest out-of-box Gemma 4 QAT speedup. Live: fresh install → `tiedHeadCodec=q6`, coherent; clean q6 speedup E2B 118 → 132.
- **Decode Performance toggles enforce.** A performance change reloads the model so the tied-head codec applies live (E2B 118 → 132 on a mid-session toggle). Compiled decode is a process-startup lever (MLX caches compile state at first load) so it reports `compiled_decode_restart_required` + a UI hint; it persists and engages on restart (26B-A4B 36 → 111, 12B 45 → 58). Compiled decode stays off by default (correctness gate #1173).
- TurboQuant + paged remain off by default; their toggles enforce live (verified earlier).
