### PR TITLE
Re-pin vmlx-swift to main (357c81d4): DiffusionGemma router crash fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
+        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
+        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
+            revision: "357c81d4c786fb75f6b912bd09df009662655ac1"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -598,12 +598,16 @@ struct RuntimePolicySourceTests {
         // target before generation, plus the memory-safety resolver fix that
         // preserves explicit disabled prefix-cache settings and disables
         // dependent paged-KV/block-disk cache topology instead of forcing the
-        // default cache stack back on.
+        // default cache stack back on,
+        // plus the DiffusionGemma MoE-router crash fix that dequantizes the
+        // QuantizedEmbedding tied head before the soft self-conditioning
+        // matmul so the 26B-A4B diffusion router no longer traps (SIGTRAP)
+        // on denoising step >= 2.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
+        let expectedRuntimeHardenedRevision = "357c81d4c786fb75f6b912bd09df009662655ac1"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7d9a85fe2e568063292daa9ffba1f6a65ddcf175"
+        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
       }
     },
     {


### PR DESCRIPTION
Bumps vmlx-swift 7d9a85fe → 357c81d4 (osaurus-ai/vmlx-swift#52) to pull in the DiffusionGemma MoE-router crash fix.

**Bug:** diffusiongemma-26B-A4B (mxfp4/mxfp8) crashed the whole app (SIGTRAP) on denoising step ≥2 — the MoE router received a 0-D scalar because the soft self-conditioning embedding did `probs @ embed_tokens.weight` against a quantized (q6) tied head whose packed weight is grouped along hidden.

**Fix (engine):** dequantize the embedding table for the soft-embedding when the head is a QuantizedEmbedding; dense bundles unchanged.

**Verified live (Release):** diffusiongemma-26B-A4B mxfp4 + mxfp8 → coherent, no crash; gemma-4-12B-it-qat-mxfp4 unchanged ~57 tok/s. Pin-only change (4 files).