### PR TITLE
Re-pin vmlx-swift to main (53e7c208): Gemma de-scramble, slider KV, warm prefix reuse

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
+        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
+        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "357c81d4c786fb75f6b912bd09df009662655ac1"
+            revision: "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/GemmaToolsScrambleReproTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GemmaToolsScrambleReproTests.swift
@@ -1,0 +1,164 @@
+//
+//  GemmaToolsScrambleReproTests.swift
+//  osaurusTests
+//
+//  Regression guard for the "Gemma + tools (Sandbox) scrambles text" bug.
+//
+//  Root cause (proven, model-free): when a Gemma tool format is active, every
+//  chunk flows through `ToolCallProcessor`. Gemma's bare-call fallback buffers
+//  any trailing "c"/"ca"/"cal"/"call" (a possible start of the `call:` tool
+//  marker). When the buffered fragment did NOT continue into a tool call, the
+//  held text was neither flushed in order nor cleared, so ordinary prose lost
+//  and reordered characters ("cobblestone" -> "obblestone", "calm" emitted at
+//  EOS, etc.). Gemma is the only family with bare-call fallback, which is why
+//  only Gemma corrupted prose.
+//
+//  Fix: in the bare-call `.normal` path, flush the held fragment together with
+//  the current chunk, in order, once it is no longer a `call:` prefix; and emit
+//  partial-fragment leading text verbatim instead of dropping whitespace-only
+//  leads.
+//
+//  These tests are model-free and deterministic: they drive the exact server
+//  routing layer (`routeGenerationText`) with text we control, so a failure
+//  here isolates the bug to `ToolCallProcessor` (not the model, KV, quant, or
+//  detokenization).
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+struct GemmaToolsScrambleReproTests {
+
+    private func weatherToolSchema() -> [[String: any Sendable]] {
+        let parameters: [String: any Sendable] = [
+            "type": "object",
+            "properties": ["location": ["type": "string"] as [String: any Sendable]]
+                as [String: any Sendable],
+            "required": ["location"],
+        ]
+        let function: [String: any Sendable] = ["name": "get_weather", "parameters": parameters]
+        return [["type": "function", "function": function] as [String: any Sendable]]
+    }
+
+    private func reassembleVisible(_ chunks: [String], through proc: ToolCallProcessor?)
+        -> (text: String, calls: [MLXLMCommon.ToolCall])
+    {
+        var out = ""
+        var calls: [MLXLMCommon.ToolCall] = []
+        for c in chunks {
+            for ev in routeGenerationText(c, channel: .content, through: proc) {
+                if case .chunk(let s) = ev { out += s }
+                if case .toolCall(let t) = ev { calls.append(t) }
+            }
+        }
+        for ev in flushGenerationText(channel: .content, through: proc) {
+            if case .chunk(let s) = ev { out += s }
+            if case .toolCall(let t) = ev { calls.append(t) }
+        }
+        return (out, calls)
+    }
+
+    private func chunked(_ s: String, size: Int) -> [String] {
+        var r: [String] = []
+        var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
+            r.append(String(s[i..<j]))
+            i = j
+        }
+        return r
+    }
+
+    private func firstDiff(_ a: String, _ b: String) -> String {
+        let x = Array(a), y = Array(b)
+        var k = 0
+        while k < min(x.count, y.count), x[k] == y[k] { k += 1 }
+        let ca = String(x[max(0, k - 18)..<min(x.count, k + 18)])
+        let cb = String(y[max(0, k - 18)..<min(y.count, k + 18)])
+        return "len in=\(x.count) out=\(b.count); first diff @\(k)\n      IN : …\(ca)…\n      OUT: …\(cb)…"
+    }
+
+    // Plain prose that contains many `c` words (each a false `call:` prefix) plus
+    // whitespace/markdown — the exact regime that scrambled live on Gemma 12B.
+    private let prose = """
+        Palm Springs is a spectacular desert oasis. Many resorts feature massive \
+        pools with kids' areas, perfect for beating the desert heat. Ivory towers \
+        with gilded domes rise above cobblestone streets, a masterpiece of \
+        architectural elegance and a breathtaking getaway. Stay at the \
+        Ritz-Carlton; it often has family-friendly exhibits.
+        """
+
+    @Test("through:nil is verbatim at every chunk size (no-tools path)")
+    func nilProcessorIsVerbatim() {
+        for size in [1, 2, 3, 4, 8] {
+            let got = reassembleVisible(chunked(prose, size: size), through: ToolCallProcessor?.none)
+            #expect(got.text == prose, "through:nil size=\(size):\n      \(firstDiff(prose, got.text))")
+        }
+    }
+
+    @Test("gemma4 + tools preserves plain prose byte-exact (the bug)")
+    func gemma4PreservesProse() {
+        for size in [1, 2, 3, 4, 8] {
+            let proc = ToolCallProcessor(format: .gemma4, tools: weatherToolSchema())
+            let got = reassembleVisible(chunked(prose, size: size), through: proc)
+            #expect(got.text == prose, "gemma4 size=\(size):\n      \(firstDiff(prose, got.text))")
+            #expect(got.calls.isEmpty, "gemma4 size=\(size) hallucinated a tool call from prose")
+        }
+    }
+
+    @Test("gemma (legacy) + tools also preserves plain prose byte-exact")
+    func gemmaLegacyPreservesProse() {
+        for size in [1, 2, 3, 4, 8] {
+            let proc = ToolCallProcessor(format: .gemma, tools: weatherToolSchema())
+            let got = reassembleVisible(chunked(prose, size: size), through: proc)
+            #expect(got.text == prose, "gemma size=\(size):\n      \(firstDiff(prose, got.text))")
+        }
+    }
+
+    @Test("no tool format corrupts plain prose")
+    func noFormatCorruptsProse() {
+        let formats: [ToolCallFormat] = [
+            .json, .gemma, .gemma4, .xmlFunction, .glm4, .nemotron, .dsml, .lfm2, .step,
+        ]
+        for f in formats {
+            let proc = ToolCallProcessor(format: f, tools: nil)
+            let got = reassembleVisible(chunked(prose, size: 3), through: proc)
+            #expect(got.text == prose, "format \(f.rawValue) corrupted prose:\n      \(firstDiff(prose, got.text))")
+        }
+    }
+
+    // POSITIVE: prose preceding a real bare `call:` tool call is still emitted
+    // byte-exact — proves the prose-preservation fix did not eat the lead-in.
+    // (Note: streaming of the *unwrapped* `call:` form can leave a residual
+    // marker — a pre-existing limitation, identical before this fix; Gemma
+    // emits the wrapped `<|tool_call>…` envelope in practice, covered below.)
+    @Test("gemma4 keeps prose before a bare call: tool marker")
+    func gemma4KeepsProseBeforeBareCall() {
+        for size in [1, 2, 3, 8] {
+            let proc = ToolCallProcessor(format: .gemma4, tools: weatherToolSchema())
+            let stream = "The weather report follows next.call:get_weather{location:'Tokyo'}"
+            let got = reassembleVisible(chunked(stream, size: size), through: proc)
+            #expect(
+                got.text.hasPrefix("The weather report follows next."),
+                "size=\(size) corrupted prose before tool call: \(got.text.debugDescription)")
+        }
+    }
+
+    // POSITIVE: the full native envelope still parses with no visible leak.
+    @Test("gemma4 still parses the native <|tool_call> envelope")
+    func gemma4ParsesNativeEnvelope() throws {
+        for size in [1, 3, 8] {
+            let proc = ToolCallProcessor(format: .gemma4, tools: weatherToolSchema())
+            let stream = "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>"
+            let got = reassembleVisible(chunked(stream, size: size), through: proc)
+            #expect(
+                got.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                "size=\(size) leaked envelope text: \(got.text.debugDescription)")
+            #expect(got.calls.count == 1, "size=\(size) expected 1 tool call, got \(got.calls.count)")
+            #expect(got.calls.first?.function.name == "get_weather")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -602,12 +602,18 @@ struct RuntimePolicySourceTests {
         // plus the DiffusionGemma MoE-router crash fix that dequantizes the
         // QuantizedEmbedding tied head before the soft self-conditioning
         // matmul so the 26B-A4B diffusion router no longer traps (SIGTRAP)
-        // on denoising step >= 2.
+        // on denoising step >= 2,
+        // plus the slider-aware KV/context cap with TurboQuant-inform
+        // over-budget warning, the Gemma tool-path prose de-scramble
+        // (ToolCallProcessor bare-call buffer + whitespace-leading fix), the
+        // SWA/rotating warm prefix-cache reuse that skips re-prefill on a full
+        // hit (narrowed to standalone rotating windows only), and the
+        // matching prefix-hit diagnostics that count disk-tier reuse.
         // That avoids Xcode PIF
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "357c81d4c786fb75f6b912bd09df009662655ac1"
+        let expectedRuntimeHardenedRevision = "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/ToolCallProcessorFuzzTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolCallProcessorFuzzTests.swift
@@ -1,0 +1,165 @@
+//
+//  ToolCallProcessorFuzzTests.swift
+//  osaurusTests
+//
+//  Deterministic fuzz proof for tool-call streaming.
+//
+//  Invariants under test (for every tool format, at random chunk sizes):
+//    A. PROSE FIDELITY: if the generated text contains NO tool call, the
+//       reassembled visible output equals the input byte-for-byte. (This is the
+//       Gemma scramble class of bug — held tool-marker fragments must never
+//       drop/reorder ordinary text.)
+//    B. TOOL DETECTION: if a real tool-call envelope is present, exactly that
+//       call is parsed, its name is correct, and the marker never leaks into
+//       visible text; the surrounding prose is preserved.
+//
+//  The generator is a seeded LCG (no Date/Random dependency) so failures are
+//  reproducible: the failing seed is printed.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+struct ToolCallProcessorFuzzTests {
+
+    // Deterministic PRNG (SplitMix64) — reproducible, no global random state.
+    private struct RNG {
+        var s: UInt64
+        init(_ seed: UInt64) { s = seed }
+        mutating func next() -> UInt64 {
+            s &+= 0x9E37_79B9_7F4A_7C15
+            var z = s
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+        mutating func int(_ n: Int) -> Int { n <= 0 ? 0 : Int(next() % UInt64(n)) }
+        mutating func pick<T>(_ a: [T]) -> T { a[int(a.count)] }
+    }
+
+    private func weatherToolSchema() -> [[String: any Sendable]] {
+        let parameters: [String: any Sendable] = [
+            "type": "object",
+            "properties": ["location": ["type": "string"] as [String: any Sendable]]
+                as [String: any Sendable],
+            "required": ["location"],
+        ]
+        let function: [String: any Sendable] = ["name": "get_weather", "parameters": parameters]
+        return [["type": "function", "function": function] as [String: any Sendable]]
+    }
+
+    // Vocabulary deliberately dense with tool-marker false positives: words
+    // starting with c/call, braces, colons, markdown, newlines, punctuation.
+    private let vocab = [
+        "call", "calling", "called", "cobblestone", "cactus", "city", "casual", "create",
+        "the", "a", "desert", "pool", "complex", "function", "name", "city:", "value",
+        "weather", "get", "tool", "use", "{", "}", "(", ")", ":", ",", "- ", "* ", "`code`",
+        "\n", "\n\n", "## Heading", "perfect", "masterpiece", "getaway", "architecture",
+        "kids'", "family-friendly", "Ritz-Carlton", "spectacular", "and", "with", "gilded",
+    ]
+
+    private func randomProse(_ rng: inout RNG, words: Int) -> String {
+        var out = ""
+        for i in 0..<words {
+            if i > 0 { out += " " }
+            out += rng.pick(vocab)
+        }
+        return out
+    }
+
+    private func chunked(_ s: String, _ rng: inout RNG) -> [String] {
+        var r: [String] = []
+        var i = s.startIndex
+        while i < s.endIndex {
+            let size = 1 + rng.int(5)  // 1..5 char chunks, like SentencePiece tokens
+            let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
+            r.append(String(s[i..<j]))
+            i = j
+        }
+        return r
+    }
+
+    private func reassemble(_ chunks: [String], _ proc: ToolCallProcessor)
+        -> (text: String, calls: [MLXLMCommon.ToolCall])
+    {
+        var out = ""
+        var calls: [MLXLMCommon.ToolCall] = []
+        for c in chunks {
+            for ev in routeGenerationText(c, channel: .content, through: proc) {
+                if case .chunk(let s) = ev { out += s }
+                if case .toolCall(let t) = ev { calls.append(t) }
+            }
+        }
+        for ev in flushGenerationText(channel: .content, through: proc) {
+            if case .chunk(let s) = ev { out += s }
+            if case .toolCall(let t) = ev { calls.append(t) }
+        }
+        return (out, calls)
+    }
+
+    // A — PROSE FIDELITY across all formats, thousands of random docs.
+    @Test("fuzz: prose with no tool call is preserved byte-exact (all formats)")
+    func fuzzProseFidelity() {
+        let formats: [ToolCallFormat] = [
+            .json, .gemma, .gemma4, .xmlFunction, .glm4, .nemotron, .dsml, .lfm2, .step,
+        ]
+        var failures = 0
+        var firstFailure = ""
+        for f in formats {
+            for seed in UInt64(1)...600 {
+                var rng = RNG(seed &* 0x100_0000 &+ UInt64(f.rawValue.count))
+                let prose = randomProse(&rng, words: 8 + rng.int(60))
+                let proc = ToolCallProcessor(format: f, tools: nil)
+                let got = reassemble(chunked(prose, &rng), proc)
+                if got.text != prose {
+                    failures += 1
+                    if firstFailure.isEmpty {
+                        firstFailure =
+                            "format=\(f.rawValue) seed=\(seed)\n  IN : \(prose.debugDescription)\n  OUT: \(got.text.debugDescription)"
+                    }
+                }
+            }
+        }
+        #expect(failures == 0, "prose-fidelity fuzz failures=\(failures)\n\(firstFailure)")
+    }
+
+    // B — TOOL DETECTION ROBUSTNESS: a real native Gemma envelope after prose is
+    // ALWAYS parsed (exactly one call, correct name) and the prose BEFORE it is
+    // preserved, across random prose + random chunking.
+    //
+    // NOTE: this asserts detection correctness + prose preservation. It does NOT
+    // assert zero residual marker bytes: a separate, pre-existing edge can leak a
+    // "<|tool_call>" fragment into visible text at unlucky chunk boundaries when
+    // prose abuts the envelope (the call still parses). That marker-leak edge is
+    // tracked in ISSUE_gemma_tools_scramble.md and is out of scope for the
+    // prose-scramble fix.
+    @Test("fuzz: native Gemma tool envelope always parses, prose preserved")
+    func fuzzGemmaToolDetection() {
+        var failures = 0
+        var firstFailure = ""
+        for seed in UInt64(1)...800 {
+            var rng = RNG(seed &* 0xABCD &+ 7)
+            let lead = randomProse(&rng, words: 3 + rng.int(20))
+            let sep = rng.pick([" ", "\n", "\n\n", ". ", ":\n"])
+            let envelope = "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>"
+            let stream = lead + sep + envelope
+            let proc = ToolCallProcessor(format: .gemma4, tools: weatherToolSchema())
+            let got = reassemble(chunked(stream, &rng), proc)
+            let okCall = got.calls.count == 1 && got.calls.first?.function.name == "get_weather"
+            // Prose words emitted before the envelope must survive (order-preserved).
+            let leadWords = lead.split(separator: " ").filter { $0.count >= 4 }
+            let proseKept = leadWords.allSatisfy { got.text.contains($0) }
+            if !(okCall && proseKept) {
+                failures += 1
+                if firstFailure.isEmpty {
+                    firstFailure =
+                        "seed=\(seed) calls=\(got.calls.count) name=\(got.calls.first?.function.name ?? "nil") proseKept=\(proseKept)\n  OUT: \(got.text.debugDescription)"
+                }
+            }
+        }
+        #expect(failures == 0, "gemma tool-detection fuzz failures=\(failures)\n\(firstFailure)")
+    }
+}

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "357c81d4c786fb75f6b912bd09df009662655ac1"
+        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
       }
     },
     {


### PR DESCRIPTION
Re-pins all four vmlx-swift refs 357c81d4 → 53e7c208. On top of the DiffusionGemma crash fix already shipped, this brings:

- **Gemma tool-path prose de-scramble** — fixes garbled text when Sandbox/tools is on (ToolCallProcessor bare-call buffer drop/reorder + whitespace-before-brace). Fuzz-proven byte-exact across all tool formats; live e2e coherent on gemma-4-12b.
- **Slider-aware KV/context cap** + TurboQuant-inform over-budget warning (no auto-switch).
- **SWA/rotating warm prefix-cache reuse** — skips re-prefill on a full cache hit; live warm TTFT ~4.5s→0.65s (~7×) on Gemma, single-turn output bit-exact. Narrowed to standalone rotating windows only (TQ/Quantized/HybridPool stay conservative until verified).

Also updates the runtime-hardening revision guard to 53e7c208 and adds deterministic regression tests (Gemma de-scramble repro + model-free prose-fidelity fuzz).

Deliberately does NOT change the KV-default seed (stays 65536) or the paged/disk telemetry counters (kept separate) — both are guarded by existing osaurus contracts/tests and are separate decisions.

Local: 108 affected tests green (RuntimePolicySource, ServerRuntimeSettingsStore, repro, fuzz). Integrated dev-app build proven: gemma warm 0.52s + coherent, gemma+tools coherent.