### PR TITLE
Repin vMLX 839d9f55: live prefill streaming + tool-name canonicalization + monotonic prefill %, prefix-cache proven

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
+        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
+        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
+            revision: "839d9f5592012843402d77afd671c6e1633b99a4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
+        let expectedRuntimeHardenedRevision = "839d9f5592012843402d77afd671c6e1633b99a4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "53e7c208771a36143d0f4da1ab8f80f529e0a6b7"
+        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
       }
     },
     {


### PR DESCRIPTION
## What
Repins osaurus to vmlx-swift main `839d9f55`, landing three runtime fixes proven live against the osaurus chat runtime, plus osaurus-side regression coverage.

### vMLX fixes carried by this pin
- **Prefill progress streams live** — `TokenIterator` construction (and thus the whole prompt prefill) is deferred into the streaming task, so the prompt-processing counter gets strictly-increasing frames *during* prefill instead of one post-prefill burst. `prepare` still runs once → model output and tokens/sec bit-identical.
- **Tool-call name canonicalization** — names that differ only by case from a registered tool (e.g. Gemma 4 MXFP8 emitting `Get_weather` for `get_weather`) are rewritten to the registered spelling, fixing case-sensitive dispatch failures.
- **Monotonic prefill progress** — clamps emitted frames so the reported %% never ticks backward across partial / diverging-prefix cache restores.

### osaurus-side
- Adds `GemmaToolsScrambleReproTests` and `ToolCallProcessorFuzzTests`.
- Updates the runtime-hardened revision guard to `839d9f55`.

## Live proof (dev app, runtime)
- Prefill frames animate live: gemma-4-12b SWA (25 frames/8s), lfm (companion-SSM), minimax (plain-KV); qwen HybridPool single-pass by design.
- Warm prefix reuse cold→warm ~6–7×: gemma-4-12b **mxfp8** (3.67→0.53s), **qat-jang_4m** (3.78→0.50s), **qat-mxfp4** (4.61→0.77s); `disk_l2_hits` increments on warm hits.
- Mid-chat tools + reasoning toggled on/off across 8–12 turns (mxfp8 + qat): coherent, correct tool calls, correct reasoning toggling, no zero-token, no leaked markers.
- Artifact scan: 0 U+FFFE/sentinel leaks, 0 control chars, prefill % monotonic.
- 0-token 'ended without completion info' reproduced as **client cancellation** of slow cold prefills (runtime recovers) — not RAM, not a concurrency/cache bug.
- RAM: RSS ~7.8 GB (12B mxfp8), memory_safety allowed, no blocking issues, kv_cap=65536.

## Deferred (separate decisions, not in this PR)
- Slider-governs-default-cap (`defaultMaxKVSize` seed=nil) — migration semantics need sign-off.
- Folding disk-L2 hits into `prefix_hits` — the telemetry-separation test keeps tiers separate by design; `disk_l2_hits` already reports prefix reuse.