### PR TITLE
Let the RAM-safety slider govern the default KV/context cap (seed=nil)

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -369,7 +369,15 @@ public enum ServerRuntimeSettingsStore {
             liveKVCodec: .engineSelected,
             turboQuantKeyBits: nil,
             turboQuantValueBits: nil,
-            defaultMaxKVSize: 65536,
+            // nil so the RAM-safety slider governs the default KV/context cap:
+            // vmlx resolves `customDefaultMaxKVSize ?? cache.defaultMaxKVSize
+            // ?? profile.defaultMaxKVSize`, so a non-nil seed here would pin the
+            // cap and make the slider inert. The default slider position
+            // (safe_auto) resolves to 65536, so the out-of-box cap is unchanged;
+            // moving the slider (strict -> 16384, performance -> 131072,
+            // diagnostic -> uncapped) now actually takes effect. Users can still
+            // set an explicit cap in Cache settings, which overrides the slider.
+            defaultMaxKVSize: nil,
             longPromptMultiplier: 2.0,
             storedKVCodec: .auto,
             legacyDisk: VMLXDiskCacheSettings(

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -40,7 +40,10 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(migrated.cache.blockDisk.enabled == true)
             #expect(migrated.cache.legacyDisk.enabled == false)
             #expect(migrated.cache.liveKVCodec == .engineSelected)
-            #expect(migrated.cache.defaultMaxKVSize == 65536)
+            // nil: the seed leaves the default KV cap to the RAM-safety slider
+            // (safe_auto resolves to 65536 in vmlx, so the effective out-of-box
+            // cap is unchanged, but the slider now governs it).
+            #expect(migrated.cache.defaultMaxKVSize == nil)
             #expect(migrated.cache.longPromptMultiplier == 2.0)
             #expect(migrated.cache.enableSSMReDerive == true)
             #expect(migrated.mtp.mode == .auto)
@@ -69,7 +72,8 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(snapshot.cache.blockDisk.enabled == true)
             #expect(snapshot.cache.legacyDisk.enabled == false)
             #expect(snapshot.cache.liveKVCodec == .engineSelected)
-            #expect(snapshot.cache.defaultMaxKVSize == 65536)
+            // nil: slider governs the default KV cap (see migrate test above).
+            #expect(snapshot.cache.defaultMaxKVSize == nil)
             #expect(snapshot.cache.longPromptMultiplier == 2.0)
             #expect(snapshot.cache.enableSSMReDerive == true)
             #expect(snapshot.mtp.mode == .auto)


### PR DESCRIPTION
## What
Seed `defaultMaxKVSize` as `nil` instead of `65536`.

vmlx resolves the cap as `customDefaultMaxKVSize ?? cache.defaultMaxKVSize ?? profile.defaultMaxKVSize`. A non-nil seed pinned the cap and made the slider **inert** for the default. With `nil`, the memory-safety profile governs.

## Behavior
- **safe_auto (default)** still resolves to **65536** → out-of-box cap unchanged.
- **strict → 16384**, **performance → 131072**, **diagnostic → uncapped** now actually take effect.
- Explicit cap in Cache settings still overrides the slider.
- **New installs only** — existing persisted values untouched; legacy-default repair fingerprints intentionally kept at 65536 (they detect the historical seed).

## Tests
Updated the two settings tests that asserted migrated default == 65536 to expect `nil`.

## Live proof (osaurus runtime, cache.defaultMaxKVSize=nil)
PUT memory-safety mode via `/admin/runtime-settings`, read resolved `kv_cap` from `/admin/cache-stats`:
- strict → **16384**
- performance → **131072**
- safe_auto → **65536**
- settings restored. VERDICT: slider governs the nil default cap.