### PR TITLE
Repin vmlx: DiffusionGemma prefill-progress + MLXLMCommon Swift 5 language-mode fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
+        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
+        "revision" : "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
+        "revision" : "63cb9f0b48882f80a72abfa909bd7738ad417f18"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "63cb9f0b48882f80a72abfa909bd7738ad417f18"
+        "revision" : "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
@@ -65,19 +65,49 @@ extension ModelInfo {
     // disk — synchronous I/O that hangs the UI when it runs on every body eval.
     // Only successful loads are cached (so a not-yet-downloaded model is re-probed),
     // and the cache is dropped on `.localModelsChanged` to stay in sync with disk.
+    //
+    // `.localModelsChanged` only fires when the discovered model *set* changes,
+    // NOT when a `config.json` is rewritten in place at the same id/path (e.g. a
+    // bundle re-quantized or its context window edited under the same name). To
+    // keep the resolved context window — and every other config-derived field —
+    // honest across in-place edits, each hit re-stats the cached `config.json`
+    // and only reuses the memo when its modification date is unchanged. The hit
+    // path stays cheap: it stats the already-resolved `configURL` (one syscall),
+    // never re-running the directory-enumerating `findModelDirectory`.
+    private struct CacheEntry {
+        let info: ModelInfo
+        let configPath: String
+        let configModDate: Date?
+    }
     private static let cacheLock = NSLock()
-    private nonisolated(unsafe) static var cache: [String: ModelInfo] = [:]
+    private nonisolated(unsafe) static var cache: [String: CacheEntry] = [:]
     private nonisolated(unsafe) static var didInstallObserver = false
+
+    /// Modification date of a file, or nil if it is missing/unreadable. Used to
+    /// detect in-place `config.json` edits that `.localModelsChanged` misses.
+    /// Goes through `FileManager.attributesOfItem` on a path string rather than
+    /// `URL.resourceValues`: `NSURL` caches resource values per instance, so
+    /// re-statting a stored `URL` would return the date from when it was first
+    /// read (never seeing the in-place edit) — exactly the staleness this guards.
+    private static func fileModificationDate(atPath path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate]
+            as? Date
+    }
 
     /// Load model info from a model identifier (e.g., "mlx-community/Qwen3-1.7B-4bit" or "qwen3-1.7b-4bit")
     static func load(modelId: String) -> ModelInfo? {
         ensureCacheObserverInstalled()
         cacheLock.lock()
-        if let cached = cache[modelId] {
-            cacheLock.unlock()
-            return cached
-        }
+        let cached = cache[modelId]
         cacheLock.unlock()
+        if let cached,
+            fileModificationDate(atPath: cached.configPath) == cached.configModDate
+        {
+            // Memo is still consistent with on-disk `config.json`.
+            return cached.info
+        }
+        // Cache miss, or the cached `config.json` changed on disk since it was
+        // memoized (stale window/metadata) — re-probe from disk.
 
         // Try to find the model directory
         guard let directory = findModelDirectory(for: modelId) else {
@@ -86,8 +116,14 @@ extension ModelInfo {
 
         let info = load(from: directory, modelId: modelId)
         if let info {
+            let configPath = directory.appendingPathComponent("config.json").path
+            let entry = CacheEntry(
+                info: info,
+                configPath: configPath,
+                configModDate: fileModificationDate(atPath: configPath)
+            )
             cacheLock.lock()
-            cache[modelId] = info
+            cache[modelId] = entry
             cacheLock.unlock()
         }
         return info

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "90b978b3181e38856231340854e47187ffaa8455492014bf4e6b2780929a3470",
+  "originHash" : "93d2d6d085f26570fc44b317ce6c5e01cbeb2eb015b66376bb3657941e49adb8",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
+        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
+            revision: "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "839d9f5592012843402d77afd671c6e1633b99a4"
+            revision: "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "63cb9f0b48882f80a72abfa909bd7738ad417f18"
+            revision: "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
+            revision: "63cb9f0b48882f80a72abfa909bd7738ad417f18"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "63cb9f0b48882f80a72abfa909bd7738ad417f18"
+        let expectedRuntimeHardenedRevision = "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "839d9f5592012843402d77afd671c6e1633b99a4"
+        let expectedRuntimeHardenedRevision = "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
+        let expectedRuntimeHardenedRevision = "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
+        let expectedRuntimeHardenedRevision = "63cb9f0b48882f80a72abfa909bd7738ad417f18"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "839d9f5592012843402d77afd671c6e1633b99a4"
+        "revision" : "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "63cb9f0b48882f80a72abfa909bd7738ad417f18"
+        "revision" : "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5225a29de0d8c19335cdef566a2ffc5a8b2fffbd"
+        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "613a06ad4c7f94e24ccdc26cf9c31a6eb867bfb0"
+        "revision" : "63cb9f0b48882f80a72abfa909bd7738ad417f18"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repins vmlx-swift to `b03f85af` (osaurus-ai/vmlx-swift main), pulling in two fixes:

1. **DiffusionGemma prefill-progress counter** (vmlx #57) — block-diffusion models (DiffusionGemma) previously showed the prefill counter frozen at `0/N` for the entire 26B encoder prefill, reading as "stuck on loading." The block-diffusion iterator now streams `.prefillProgress` frames (deferred construction + per-chunk frames through the monotonic gate), like the autoregressive path.

2. **MLXLMCommon Swift 5 language-mode pin** (vmlx #59) — contributors on Swift 6.0/6.1 toolchains could not build vmlx: the batch engine's actor code emitted region-based-isolation errors (`Sending 'slot'/'inputForPrepare' risks causing data races`) when compiled in the Swift 6 language mode. That target is now compiled in the Swift 5 language mode (the diagnostics become warnings); every other vmlx target — including the Jinja target that needs bare-slash regex literals — stays in Swift 6 mode. No real data race exists (MLXLMCommon compiles cleanly in Swift 6 mode on Swift 6.3).

## Repin spots (4)

- `App/osaurus.xcodeproj/.../swiftpm/Package.resolved`
- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift` (`expectedRuntimeHardenedRevision`)
- `osaurus.xcworkspace/.../swiftpm/Package.resolved`

## Validation

- Release build **succeeds**; `MLXLMCommon` compiles at `-swift-version 5`, `VMLXJinja` at `-swift-version 6`.
- DiffusionGemma prefill counter advances `0 → … → N (100%)` live (was frozen); AR prefill streaming regression-clean.
---

## Added: invalidate `ModelInfo` cache on in-place `config.json` edits

The process-wide `ModelInfo` memo (added for UI hang-avoidance) was dropped only on `.localModelsChanged`, which fires when the discovered model *set* changes — **not** when a `config.json` is rewritten in place at the same id/path (e.g. a bundle re-quantized or its context window edited under the same name). That left every config-derived field — including the resolved context window used by the chat-UI / agent-loop history compaction — **stale until an app restart**.

`load(modelId:)` now re-stats the cached `config.json` on each hit and reuses the memo only when its modification date is unchanged; otherwise it re-probes from disk. The hit path stays cheap (a single `stat` of the already-resolved config path, no directory re-enumeration) and goes through `FileManager.attributesOfItem` rather than `URL.resourceValues` (NSURL caches resource values per instance and would never observe the edit).

Also aligns the nested `OsaurusCore/Package.resolved` vmlx pin with the workspace repin (`b03f85af`).

**Live proof** (dev app, no restart): `POST /show` context_length `131072` → edit `text_config.max_position_embeddings=31337` in place → `POST /show` returns `31337` → restore → `131072`. PASS.

> Note: this is a correctness fix for stale context windows; it is **not** related to the separate, still-open gemma-4 long-context `<pad>` degeneration (which the investigation showed is not an osaurus windowing/truncation issue).