### PR TITLE
Restore Swift-format parity on current main

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift
@@ -565,7 +565,10 @@ struct ProviderHelpLinks: View {
                     // thread on a LaunchServices XPC round-trip that can stall
                     // long enough to trip the hang watchdog.
                     NSWorkspace.shared.open(
-                        url, configuration: NSWorkspace.OpenConfiguration(), completionHandler: nil)
+                        url,
+                        configuration: NSWorkspace.OpenConfiguration(),
+                        completionHandler: nil
+                    )
                 }
             } label: {
                 HStack(spacing: 6) {
@@ -589,8 +592,10 @@ struct ProviderHelpLinks: View {
                         // Async open to avoid blocking the main thread on the
                         // synchronous LaunchServices XPC round-trip.
                         NSWorkspace.shared.open(
-                            url, configuration: NSWorkspace.OpenConfiguration(),
-                            completionHandler: nil)
+                            url,
+                            configuration: NSWorkspace.OpenConfiguration(),
+                            completionHandler: nil
+                        )
                     }
                 } label: {
                     HStack(spacing: 6) {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1455,9 +1455,10 @@ public actor ModelRuntime {
         // uncapped) while the UI/displaySummary showed the resolved value, so
         // the two diverged and the slider never reached the coordinator.
         var resolvedSettings = settings
-        resolvedSettings.cache = settings.resolvedMemorySafetyPlan(
-            host: MemoryStatus.snapshot()
-        ).cache
+        resolvedSettings.cache =
+            settings.resolvedMemorySafetyPlan(
+                host: MemoryStatus.snapshot()
+            ).cache
         let diskCacheDir = Self.cacheDiskDirectoryOverride(for: resolvedSettings.cache)
         if let diskCacheDir {
             OsaurusPaths.ensureExistsSilent(diskCacheDir)

--- a/Packages/OsaurusCore/Tests/Service/GemmaToolsScrambleReproTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GemmaToolsScrambleReproTests.swift
@@ -66,7 +66,7 @@ struct GemmaToolsScrambleReproTests {
         var i = s.startIndex
         while i < s.endIndex {
             let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
-            r.append(String(s[i..<j]))
+            r.append(String(s[i ..< j]))
             i = j
         }
         return r
@@ -76,8 +76,8 @@ struct GemmaToolsScrambleReproTests {
         let x = Array(a), y = Array(b)
         var k = 0
         while k < min(x.count, y.count), x[k] == y[k] { k += 1 }
-        let ca = String(x[max(0, k - 18)..<min(x.count, k + 18)])
-        let cb = String(y[max(0, k - 18)..<min(y.count, k + 18)])
+        let ca = String(x[max(0, k - 18) ..< min(x.count, k + 18)])
+        let cb = String(y[max(0, k - 18) ..< min(y.count, k + 18)])
         return "len in=\(x.count) out=\(b.count); first diff @\(k)\n      IN : …\(ca)…\n      OUT: …\(cb)…"
     }
 
@@ -143,7 +143,8 @@ struct GemmaToolsScrambleReproTests {
             let got = reassembleVisible(chunked(stream, size: size), through: proc)
             #expect(
                 got.text.hasPrefix("The weather report follows next."),
-                "size=\(size) corrupted prose before tool call: \(got.text.debugDescription)")
+                "size=\(size) corrupted prose before tool call: \(got.text.debugDescription)"
+            )
         }
     }
 
@@ -156,7 +157,8 @@ struct GemmaToolsScrambleReproTests {
             let got = reassembleVisible(chunked(stream, size: size), through: proc)
             #expect(
                 got.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                "size=\(size) leaked envelope text: \(got.text.debugDescription)")
+                "size=\(size) leaked envelope text: \(got.text.debugDescription)"
+            )
             #expect(got.calls.count == 1, "size=\(size) expected 1 tool call, got \(got.calls.count)")
             #expect(got.calls.first?.function.name == "get_weather")
         }

--- a/Packages/OsaurusCore/Tests/Service/ToolCallProcessorFuzzTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolCallProcessorFuzzTests.swift
@@ -63,7 +63,7 @@ struct ToolCallProcessorFuzzTests {
 
     private func randomProse(_ rng: inout RNG, words: Int) -> String {
         var out = ""
-        for i in 0..<words {
+        for i in 0 ..< words {
             if i > 0 { out += " " }
             out += rng.pick(vocab)
         }
@@ -76,7 +76,7 @@ struct ToolCallProcessorFuzzTests {
         while i < s.endIndex {
             let size = 1 + rng.int(5)  // 1..5 char chunks, like SentencePiece tokens
             let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
-            r.append(String(s[i..<j]))
+            r.append(String(s[i ..< j]))
             i = j
         }
         return r
@@ -109,7 +109,7 @@ struct ToolCallProcessorFuzzTests {
         var failures = 0
         var firstFailure = ""
         for f in formats {
-            for seed in UInt64(1)...600 {
+            for seed in UInt64(1) ... 600 {
                 var rng = RNG(seed &* 0x100_0000 &+ UInt64(f.rawValue.count))
                 let prose = randomProse(&rng, words: 8 + rng.int(60))
                 let proc = ToolCallProcessor(format: f, tools: nil)
@@ -140,7 +140,7 @@ struct ToolCallProcessorFuzzTests {
     func fuzzGemmaToolDetection() {
         var failures = 0
         var firstFailure = ""
-        for seed in UInt64(1)...800 {
+        for seed in UInt64(1) ... 800 {
             var rng = RNG(seed &* 0xABCD &+ 7)
             let lead = randomProse(&rng, words: 3 + rng.int(20))
             let sep = rng.pick([" ", "\n", "\n\n", ". ", ":\n"])


### PR DESCRIPTION
## Business rationale

Current `main` is GitHub-green, but the local contributor gate documented for this repo failed immediately when run with the repo `.swift-format` config. That blocks feature branches from producing clean local gate evidence after rebasing to current `main`. This PR restores parity by applying `swift-format` to the exact files that fail on a clean checkout.

## Coding rationale

This is intentionally formatting-only. It does not change behavior, tests, dependencies, workflows, or lint configuration. Isolating this cleanup keeps later feature PRs scoped to their functionality instead of making each branch carry unrelated formatting noise.

## Latest refresh

- Base after fresh fetch: `214ce0f756fa7a5bce41dde492254e9c14381ece` (`Repin vmlx a6472300: Gemma4 drifted tool-call envelope fix (stops leaked <|tool_call|> markup) (#1504)`)
- Head after rebase: `c36cff3430c23525b24e73ac61bfba1316937614`
- Rebase result: clean, no conflicts
- Branch push: refreshed with `--force-with-lease` after the full local gate passed

## Acceptance criteria

- [x] Clean `main` Swift-format failures are resolved with the repo `.swift-format` config.
- [x] Diff is limited to formatting-only changes in the four failing files.
- [x] Full local gate passes after the formatting cleanup.

## Quality gate

- [x] `xcrun swift-format lint --configuration .swift-format --strict --recursive Packages App` — clean
- [x] `swiftlint lint --config .swiftlint.yml --force-exclude --reporter github-actions-logging` — completed with existing repo warnings only
- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning` — clean
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-swiftformat-refresh-cli swift test --package-path Packages/OsaurusCLI --parallel` — green
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-swiftformat-refresh-core make ci-test` — green
- [x] `swift build --package-path Packages/OsaurusCore -c release` — green
- [x] Fetch freshness — confirmed after `git fetch --all --prune`; `origin/main` stayed `214ce0f756fa7a5bce41dde492254e9c14381ece`
- [x] Gate head SHA: `c36cff3430c23525b24e73ac61bfba1316937614`
- [x] `LANE_GATE_OK 2026-06-14T20:02:01Z`

## Debug evidence

Before formatting, clean `main` failed:

```text
Packages/OsaurusCore/Tests/Service/ToolCallProcessorFuzzTests.swift:66:19: error: [Spacing] add 1 space
Packages/OsaurusCore/Tests/Service/GemmaToolsScrambleReproTests.swift:146:94: error: [AddLines] add 1 line break
Packages/OsaurusCore/Models/Configuration/ProviderPresets.swift:568:1: error: [LineLength] line is too long
Packages/OsaurusCore/Services/ModelRuntime.swift:1458:33: error: [AddLines] add 1 line break
```

After applying repo `swift-format`, the full gate completed with `LANE_GATE_OK 2026-06-14T20:02:01Z` on the rebased head.

## Self-review

### Regression review

Changed files are formatting-only in `ProviderPresets.swift`, `ModelRuntime.swift`, `GemmaToolsScrambleReproTests.swift`, and `ToolCallProcessorFuzzTests.swift`. No call sites, control flow, constants, public API, persisted state, or test assertions changed. Coverage is the existing full `make ci-test` lane plus release build.

### Performance review

No algorithmic or runtime behavior changed. The diff only splits calls/expressions and normalizes range spacing, so there is no change to CPU, memory, I/O, or hot-path complexity.

## Rebase notes

Rebased cleanly over `214ce0f756fa7a5bce41dde492254e9c14381ece` after the pre-push fetch.

## Rollback

Revert commit `c36cff3430c23525b24e73ac61bfba1316937614`.
