### PR TITLE
Repin vmlx 466c0a10: Gemma4 bf16 global-attention fp32 upcast (fixes long-context <pad>)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
+        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
+        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
+            revision: "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
+        let expectedRuntimeHardenedRevision = "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b03f85afff4da38361b6a4d2a3e4c511f24c4958"
+        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repins vmlx-swift to `466c0a10` (osaurus-ai/vmlx-swift main), pulling in **vmlx #60**: the fix for Gemma-4 long-context `<pad>` degeneration.

## The bug

Gemma-4 (`gemma4_unified`) **bf16** models degenerated to pure `<pad>` from the **first generated token** once the prompt crossed **~26k tokens** — deterministic, content-independent, prefill-side (it padded even with `max_tokens=1`). It was masked by the SSD prefix cache (a repeated prompt replays good stored KV), which made it look intermittent.

## Root cause (vmlx #60)

Gemma-4's 8 global full-attention layers (`head_dim=512`, attention over all positions) are routed to the **unfused Metal SDPA fallback** (512 ∉ the fused set `{64,80,128}`), which reduces the softmax in the activation dtype. vmlx's fp32 upcast guard fired only for `.float16`; this model is **bf16**, so the global layers reduced the softmax over `N` keys in bf16, and bf16's 8-bit mantissa lost enough precision past ~26k positions to collapse the logits → `argmax` = `<pad>`. vmlx now also upcasts the global (non-sliding) layers to fp32 for bf16; sliding layers stay bf16 (window ≤1024).

## Verification (live, gemma-4-12b-it-mxfp8, M5 Max, this repinned build)

Cold, unique-content prompts (prefix cache defeated), secret-recall test:

| context | before | after |
|---|---|---|
| ≤24k | ✅ | ✅ |
| 28k, 32k, 36k, 40k, 44k | ❌ pure `<pad>` | ✅ exact recall, `finish=stop` |

Decode speed ~30 tok/s (only 8/48 layers upcast — no meaningful regression).

## Pin spots (5)

- `Packages/OsaurusCore/Package.swift` (`revision:`)
- `App/osaurus.xcodeproj/.../Package.resolved`
- `osaurus.xcworkspace/.../Package.resolved`
- `Packages/OsaurusCore/Package.resolved`
- `Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift` (`expectedRuntimeHardenedRevision`)