### PR TITLE
Repin vmlx a6472300: Gemma4 drifted tool-call envelope fix (stops leaked <|tool_call|> markup)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
+        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
+        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
+            revision: "a647230075e957cfacea538771f452b4a7ece345"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
+        let expectedRuntimeHardenedRevision = "a647230075e957cfacea538771f452b4a7ece345"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "466c0a10f8bf9d78914af6d3351c9ab98c704e15"
+        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repins vmlx-swift to `a6472300`, pulling in **vmlx #61**: the fix for Gemma-4 leaking raw tool-call markup into the visible chat transcript.

## The bug

`gemma-4-12b` (JANG_4M) in the agent/sandbox flow printed the raw envelope as assistant text instead of executing the call:

```
<|tool_call|>call:capabilities_load({"ids": ["tool/browser_navigate", ...]})<tool_call|>
```

Gemma-4's **native** format is `<|tool_call>call:name{key:value}<tool_call|>`, but live rows **drift** to `<|tool_call|>call:name({json})<tool_call|>` (extra `|` in the open tag + JSON args in parens). The streaming parser only knew the native open tag, so it never buffered the drifted envelope and leaked it as content. (Non-streaming survived via the bare-`call:` EOS fallback, which is why plain-API tool tests passed and masked this.)

## Fix (vmlx #61)

- Add `<|tool_call|>` to Gemma4 `startTagAliases` so streaming buffers the drifted envelope.
- Stop the function name at `{` or `(` so `call:name({json})` parses. Native unchanged.
- Regression tests for the drifted envelope (whole-string + tiny streaming chunks) + native no-regression.

## Verification (live, gemma-4-12b JANG_4M, this repinned build)

Forcing the exact screenshot envelope, streaming `/v1/chat/completions`:

| envelope | before | after |
|---|---|---|
| `<\|tool_call\|>call:capabilities_load({"ids":[...]})<tool_call\|>` | leaked as visible text, `tool_calls: []` | **parsed** to `capabilities_load{ids:[...]}`, no leak |
| native `<\|tool_call>call:name{...}<tool_call\|>` | parsed | parsed (no regression) |

## Pin spots (5)

`Package.swift`, the three `Package.resolved`, and `RuntimePolicySourceTests.expectedRuntimeHardenedRevision`.