### PR TITLE
Repin vmlx 36aebd42: strip tool-call markers when no tools offered (fixes chat-UI envelope leak)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
+        "revision" : "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
+        "revision" : "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a647230075e957cfacea538771f452b4a7ece345"
+            revision: "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -613,7 +613,7 @@ struct RuntimePolicySourceTests {
         // duplicate-product collisions with the app graph while keeping yyjson
         // as one shared C dependency. Osaurus must not carry SwiftPM
         // moduleAliases for that collision.
-        let expectedRuntimeHardenedRevision = "a647230075e957cfacea538771f452b4a7ece345"
+        let expectedRuntimeHardenedRevision = "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a647230075e957cfacea538771f452b4a7ece345"
+        "revision" : "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repins vmlx to `36aebd42` (vmlx #62): fixes the chat-UI agent/sandbox tool-call **markup leak**.

## The bug (tpae's screenshots)

gemma-4-12b JANG_4M printed the raw envelope into the transcript instead of executing it:
`<|tool_call>call:capabilities_load({"ids":[...]})<tool_call|>`.

## Root cause

The agent/sandbox flow renders gemma's tool schema into the **system prompt**, so the request's `tools` field goes out **empty**. The `Evaluate.swift` / `SpecDecStream.swift` streaming generators built the `ToolCallProcessor` as `activeTools.map { ... }` → **nil processor when no tools** → the model's tool-call envelope passed straight to visible text. (BatchEngine had the strip-only fallback; these paths didn't. API tests always passed a `tools` array, which is why they never reproduced it.)

## Fix (vmlx #62)

Build a **strip-only** `ToolCallProcessor` for tagged formats even when the `tools` field is empty. Tools-present unchanged. Regression test added.

## Verification (live)

- `tools:[]` and omitted `tools` no longer leak the gemma envelope (this repinned build).
- Cross-model matrix (gemma×3, qwen, nemotron, zaya-vl, lfm2, minimax): tool recognition + multiturn + empty-tools regression all pass.
- A harsh adversarial leak scan across 15 models is running to flag any remaining tool/reasoning/structural marker leaks.