### PR TITLE
Fix Gemma-4 JANG audio: one-time patch adds fp16 multimodal passthrough to configs

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1246,6 +1246,14 @@ public actor ModelRuntime {
         // gets a clear error and the server stays up.
         try Self.validateUnsupportedPlainDSV4AffineJANG(at: localURL, name: name)
         try await Self.ensureJANGTQSidecar(at: localURL, modelId: id, name: name)
+        // One-time, idempotent: Gemma-4 JANG (affine) audio bundles shipped
+        // without the `quantization.multimodal` fp16-passthrough flag that the
+        // mxfp4/mxfp8 QAT bundles carry. Without it the audio embeddings fuse at
+        // the affine-quantized precision and the model degenerates on audio
+        // input (a spurious `thought` channel stub / dropped answer). Adding the
+        // flag — exactly the value the mxfp bundles use — restores clean audio
+        // and leaves vision unaffected (verified live on 12B JANG_4M).
+        Self.patchGemma4JangAudioMultimodalIfNeeded(at: localURL, name: name)
         // Compute the incoming bundle's on-disk weight size for *every* policy.
         // Previously only `manualMultiModel` did this (strict left it 0), which
         // meant the resident-RAM accounting — and the pre-load feasibility gate
@@ -3411,6 +3419,71 @@ public actor ModelRuntime {
                         + "Fix: set weight_format to \"mxtq\" in jang_config.json, "
                         + "or re-download from a corrected source."
                 ]
+            )
+        }
+    }
+
+    /// One-time, idempotent config repair for Gemma-4 JANG (affine) **audio**
+    /// bundles. The mxfp4/mxfp8 QAT bundles set
+    /// `quantization.multimodal = "fp16_passthrough_embedders_early_fusion"`,
+    /// which keeps the multimodal embedders at fp16 for early fusion; the JANG
+    /// bundles shipped without it and therefore fuse audio at the affine quant
+    /// precision, degenerating on audio input (spurious `thought` channel stub /
+    /// dropped answer) while text and vision stay fine. Add the flag once, in
+    /// place, exactly matching the mxfp value — verified live to restore clean
+    /// audio on 12B JANG_4M with no effect on vision.
+    ///
+    /// Only fires for: Gemma-4 family, a JANG/affine bundle, that actually ships
+    /// an audio embedder, and whose `quantization.multimodal` is still missing.
+    /// Once written, the missing-flag guard fails on every subsequent load, so
+    /// the file is patched exactly once.
+    static func patchGemma4JangAudioMultimodalIfNeeded(at directory: URL, name: String) {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+
+        // 1. Gemma-4 family only.
+        let modelType = (json["model_type"] as? String)?.lowercased() ?? ""
+        guard modelType.hasPrefix("gemma4") else { return }
+
+        // 2. JANG / affine bundle only — the mxfp bundles already carry the flag.
+        let weightFormat = (json["weight_format"] as? String)?.lowercased() ?? ""
+        var quantization = json["quantization"] as? [String: Any] ?? [:]
+        let quantMode = (quantization["mode"] as? String)?.lowercased() ?? ""
+        let isJangAffine =
+            weightFormat.contains("jang") || weightFormat.contains("affine")
+            || quantMode == "affine"
+        guard isJangAffine else { return }
+
+        // 3. Idempotency: only when the flag is genuinely absent. After we write
+        //    it, this guard fails next load and the file is never rewritten.
+        if let existing = quantization["multimodal"], !(existing is NSNull) { return }
+
+        // 4. Audio bundles only — must actually ship the `embed_audio`
+        //    projection. Vision-only JANG rows (26B/31B carry no audio tensors)
+        //    are left untouched so their vision fusion is unaffected.
+        let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
+        guard let indexData = try? Data(contentsOf: indexURL, options: .mappedIfSafe),
+            indexData.range(of: Data("embed_audio.embedding_projection".utf8)) != nil
+        else { return }
+
+        // Patch + persist exactly once, atomically, matching the mxfp QAT value.
+        quantization["multimodal"] = "fp16_passthrough_embedders_early_fusion"
+        json["quantization"] = quantization
+        guard
+            let out = try? JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+        else { return }
+        do {
+            try out.write(to: configURL, options: .atomic)
+            genLog.info(
+                "patched Gemma-4 JANG audio config: added quantization.multimodal fp16 passthrough model=\(name, privacy: .public)"
+            )
+        } catch {
+            genLog.error(
+                "failed to patch Gemma-4 JANG audio config model=\(name, privacy: .public): \(String(describing: error), privacy: .public)"
             )
         }
     }


### PR DESCRIPTION
## Problem

Gemma-4 **JANG_4M** bundles degenerate on **audio** input — the model prepends a spurious `<|channel>thought` stub or drops the answer — while **mxfp4 and mxfp8 audio are fine**, and text/vision are fine on all quants.

## Root cause

The mxfp4/mxfp8 QAT bundles set `quantization.multimodal = "fp16_passthrough_embedders_early_fusion"`, which keeps the multimodal embedders at fp16 for early fusion. The JANG (affine) bundles shipped **without** that flag, so the audio embeddings fuse at the affine-quantized precision and the model degenerates on audio.

Verified live: adding the flag to a JANG_4M config turns audio output from `thoughtThe…` garbage into a clean correct answer, with vision unaffected.

## Fix

On model load, a **one-time, idempotent, in-place** config repair: for a bundle that is
- Gemma-4 family (`model_type` starts with `gemma4`),
- JANG/affine (`weight_format`/`quantization.mode`),
- actually ships an audio embedder (`embed_audio.embedding_projection`), and
- is **missing** `quantization.multimodal`,

write the same `fp16_passthrough_embedders_early_fusion` value the mxfp bundles use. Once written, the missing-flag guard returns early, so the file is **never rewritten**.

Left untouched: vision-only JANG rows (26B/31B — no audio tensors) and the already-correct mxfp4/mxfp8 bundles.

## Verification (live, gemma-4-12b JANG_4M)

| | before | after one-time patch |
|---|---|---|
| `quantization.multimodal` | absent | `fp16_passthrough_embedders_early_fusion` |
| audio | `thoughtThe… ` garbage / dropped | **`Starfish`** (clean) |
| vision | works | works (unchanged) |
| mxfp4 / mxfp8 configs | — | **not modified** |
| 2nd load | — | no rewrite (idempotent) |