### PR TITLE
Estimate image context tokens from resolution, not byte size

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+#if canImport(ImageIO)
+    import ImageIO
+#endif
+#if canImport(CoreGraphics)
+    import CoreGraphics
+#endif
+
 public struct Attachment: Codable, Sendable, Equatable, Identifiable {
     public let id: UUID
     public let kind: Kind
@@ -399,11 +406,18 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
     public var estimatedTokens: Int {
         switch kind {
         case .image(let data):
-            // Base64-encoded byte expansion (×4/3) then chars→tokens via
-            // the canonical heuristic.
-            return max(1, (data.count * 4) / 3 / TokenEstimator.charsPerToken)
-        case .imageRef(_, let byteCount):
-            return max(1, (byteCount * 4) / 3 / TokenEstimator.charsPerToken)
+            // Vision tokens scale with image RESOLUTION, not file size — the
+            // processor resizes then patchifies, so a model never sees the raw
+            // (or compressed) bytes. Estimating from byte length made a 1–2.5 MB
+            // photo read as hundreds of thousands of tokens and falsely tripped
+            // the send-budget gate (a 70 KB screenshot slipped under, a JPEG of
+            // the same picture did not). Derive from pixel dimensions instead.
+            return Attachment.estimatedImageTokens(forEncodedImage: data)
+        case .imageRef(_, _):
+            // Spilled to the blob store: pixel dimensions aren't available here
+            // (only the on-disk byte count), so fall back to a conservative
+            // per-image constant rather than the misleading byte-based figure.
+            return Attachment.defaultImageTokenEstimate
         case .document(_, let content, _):
             return TokenEstimator.estimate(content)
         case .documentRef(_, _, let fileSize):
@@ -417,6 +431,66 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
             // Bounded ~2K tokens regardless of file size (8 frames × 256 tokens)
             return 2048
         }
+    }
+
+    // MARK: - Image token estimation
+
+    /// Per-image vision-token estimate used when pixel dimensions can't be
+    /// read (e.g. a spilled `imageRef`). Mid-range across VL families — Gemma 3
+    /// emits a fixed 256 tokens/image, Qwen2.5-VL tiles dynamically up to a few
+    /// thousand — so this neither wildly over- nor under-counts a typical photo.
+    public static let defaultImageTokenEstimate = 1024
+
+    /// Longest-side pixel budget a VL processor resizes to before patchifying.
+    /// Representative of common defaults (Qwen2-VL / SmolVLM ≈ 1.5 k px). Larger
+    /// images are downscaled, so token cost saturates rather than growing with
+    /// resolution.
+    private static let imageResizeLongSide = 1536
+    /// Effective patch stride: a 14 px ViT patch after 2×2 spatial merge.
+    private static let imagePatchStride = 28.0
+    /// Floor (≈ one merged tile) and ceiling for a single image. The ceiling
+    /// keeps one attachment from ever falsely tripping the hard send-gate.
+    private static let imageTokenFloor = 256
+    private static let imageTokenCeiling = 4096
+
+    /// Estimate vision tokens for an encoded image by reading its pixel
+    /// dimensions (header-only, no full decode) rather than its byte size.
+    public static func estimatedImageTokens(forEncodedImage data: Data) -> Int {
+        guard let size = imagePixelSize(data) else { return defaultImageTokenEstimate }
+        return estimatedImageTokens(pixelWidth: size.width, pixelHeight: size.height)
+    }
+
+    /// Estimate vision tokens from pixel dimensions: resize the long side into
+    /// the processor's budget, then count merged patches, floored/capped to a
+    /// sane single-image range.
+    public static func estimatedImageTokens(pixelWidth: Int, pixelHeight: Int) -> Int {
+        guard pixelWidth > 0, pixelHeight > 0 else { return defaultImageTokenEstimate }
+        let longSide = max(pixelWidth, pixelHeight)
+        let scale = longSide > imageResizeLongSide
+            ? Double(imageResizeLongSide) / Double(longSide) : 1.0
+        let w = Double(pixelWidth) * scale
+        let h = Double(pixelHeight) * scale
+        let tokens =
+            Int((w / imagePatchStride).rounded(.up))
+            * Int((h / imagePatchStride).rounded(.up))
+        return min(max(tokens, imageTokenFloor), imageTokenCeiling)
+    }
+
+    /// Read an encoded image's pixel dimensions from its header without
+    /// decoding the bitmap. Returns nil when ImageIO can't parse the data.
+    private static func imagePixelSize(_ data: Data) -> (width: Int, height: Int)? {
+        #if canImport(ImageIO)
+            guard
+                let source = CGImageSourceCreateWithData(data as CFData, nil),
+                let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                    as? [CFString: Any],
+                let width = props[kCGImagePropertyPixelWidth] as? Int,
+                let height = props[kCGImagePropertyPixelHeight] as? Int
+            else { return nil }
+            return (width, height)
+        #else
+            return nil
+        #endif
     }
 
     // MARK: - Spillover hooks (memory + disk-cache integration)

--- a/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
@@ -33,9 +33,16 @@ import Testing
         let medium = Attachment.estimatedImageTokens(pixelWidth: 768, pixelHeight: 768)
         #expect(small >= 256)
         #expect(medium > small)
-        // A huge image is downscaled by the processor, so token cost saturates
-        // at the ceiling rather than growing unbounded.
-        #expect(Attachment.estimatedImageTokens(pixelWidth: 8000, pixelHeight: 6000) == 4096)
+        // A huge image is downscaled to the processor's long-side budget before
+        // patchifying, so token cost saturates (driven by the resize, not raw
+        // resolution) and stays bounded — it does NOT grow with pixel count.
+        let huge = Attachment.estimatedImageTokens(pixelWidth: 8000, pixelHeight: 6000)
+        #expect(huge <= 4096)
+        // Same 4:3 image gives the same estimate whether passed at 8000×6000 or
+        // already at the 1536-px-long-side it resizes to.
+        #expect(huge == Attachment.estimatedImageTokens(pixelWidth: 1536, pixelHeight: 1152))
+        // And a larger image never costs more than a smaller one past the budget.
+        #expect(huge >= medium)
     }
 
     @Test func invalidDimensionsFallBackToDefault() {

--- a/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
@@ -1,0 +1,93 @@
+//
+//  AttachmentImageTokenEstimateTests.swift
+//  osaurus
+//
+//  Regression coverage for image context-budget estimation. Vision tokens
+//  scale with image RESOLUTION, not file size; a prior byte-based estimate
+//  made multi-MB photos read as hundreds of thousands of tokens and falsely
+//  disabled Send (a small screenshot slipped under the gate, a large JPEG of
+//  the same picture did not).
+//
+
+import Foundation
+import Testing
+
+#if canImport(CoreGraphics)
+    import CoreGraphics
+#endif
+#if canImport(ImageIO)
+    import ImageIO
+    import UniformTypeIdentifiers
+#endif
+
+@testable import OsaurusCore
+
+@Suite struct AttachmentImageTokenEstimateTests {
+
+    @Test func tinyImageFloorsAtOneMergedTile() {
+        #expect(Attachment.estimatedImageTokens(pixelWidth: 16, pixelHeight: 16) == 256)
+    }
+
+    @Test func estimateScalesWithResolutionThenSaturates() {
+        let small = Attachment.estimatedImageTokens(pixelWidth: 224, pixelHeight: 224)
+        let medium = Attachment.estimatedImageTokens(pixelWidth: 768, pixelHeight: 768)
+        #expect(small >= 256)
+        #expect(medium > small)
+        // A huge image is downscaled by the processor, so token cost saturates
+        // at the ceiling rather than growing unbounded.
+        #expect(Attachment.estimatedImageTokens(pixelWidth: 8000, pixelHeight: 6000) == 4096)
+    }
+
+    @Test func invalidDimensionsFallBackToDefault() {
+        #expect(
+            Attachment.estimatedImageTokens(pixelWidth: 0, pixelHeight: 0)
+                == Attachment.defaultImageTokenEstimate)
+    }
+
+    @Test func undecodableDataFallsBackToDefault() {
+        let junk = Data(repeating: 0xAB, count: 8192)
+        #expect(
+            Attachment.estimatedImageTokens(forEncodedImage: junk)
+                == Attachment.defaultImageTokenEstimate)
+    }
+
+    // The core regression: a real encoded image's estimate is bounded by its
+    // resolution and capped — never proportional to byte length.
+    @Test func encodedImageEstimateIsBoundedNotByteProportional() throws {
+        #if canImport(CoreGraphics) && canImport(ImageIO)
+            let data = try Self.makePNG(width: 1280, height: 960)
+            let tokens = Attachment.image(data).estimatedTokens
+            #expect(tokens >= 256)
+            #expect(tokens <= 4096)
+            // Sanity: the OLD byte-based formula (bytes * 4 / 3 / 4) would be a
+            // different, byte-driven number. The new estimate must match the
+            // dimension math instead.
+            #expect(tokens == Attachment.estimatedImageTokens(pixelWidth: 1280, pixelHeight: 960))
+        #endif
+    }
+
+    #if canImport(CoreGraphics) && canImport(ImageIO)
+        private enum TestError: Error { case failed }
+
+        private static func makePNG(width: Int, height: Int) throws -> Data {
+            let space = CGColorSpaceCreateDeviceRGB()
+            guard
+                let ctx = CGContext(
+                    data: nil, width: width, height: height, bitsPerComponent: 8,
+                    bytesPerRow: 0, space: space,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+            else { throw TestError.failed }
+            ctx.setFillColor(CGColor(red: 0.2, green: 0.5, blue: 0.8, alpha: 1))
+            ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+            guard let image = ctx.makeImage() else { throw TestError.failed }
+            let out = NSMutableData()
+            guard
+                let dest = CGImageDestinationCreateWithData(
+                    out, UTType.png.identifier as CFString, 1, nil)
+            else { throw TestError.failed }
+            CGImageDestinationAddImage(dest, image, nil)
+            guard CGImageDestinationFinalize(dest) else { throw TestError.failed }
+            return out as Data
+        }
+    #endif
+}


### PR DESCRIPTION
## Problem

Dragging a 1–2.5 MB image into chat instantly spikes the context-budget estimate to hundreds of thousands / millions of tokens and **disables Send**. A ~70 KB screenshot of the same content works; a large JPEG of it does not. Reported with `~10990k / 262k tokens` on Qwen3.6 35B A3B mxfp4 (Thinking + Sandbox), intermittently reproducible across models.

## Root cause

`Attachment.estimatedTokens` derived **image** tokens from base64 byte length:

```swift
case .image(let data):
    return max(1, (data.count * 4) / 3 / TokenEstimator.charsPerToken)
```

Vision tokens scale with **resolution**, not file bytes — the processor resizes then patchifies, so JPEG compression ratio is irrelevant to token cost. A high-res photo whose decoded bitmap is ~33 MB read as **~11,000,000 tokens** (matching the `~10990k` report), blowing past the window and tripping the hard send-budget gate (`canSend`).

Measured old vs. new (window 262144):

| Image | OLD (byte-based) | NEW (dimension-based) | Send |
|---|---|---|---|
| 640×480 (70 KB) | 23,333 | 414 | both ok |
| 1024×768 (1 MB) | 333,333 → BLOCK | 1,036 | ok |
| 4032×3024 (2.5 MB) | 833,333 → BLOCK | 2,310 | ok |
| 8000×6000 (33 MB decoded) | 11,000,000 → BLOCK | 2,310 | ok |

## Fix

Estimate from **pixel dimensions**: read the image header via ImageIO (no full decode), resize the long side into a representative processor budget (1536 px), count merged patches (14 px ViT patch × 2×2 spatial merge = 28 px stride), floor at 256 (Gemma 3 fixed-tile) and **cap at 4096** so a single image can never falsely trip the gate. A spilled `imageRef` (pixel dimensions unavailable) falls back to a 1024 constant instead of the misleading byte figure.

Model-agnostic by design — exact per-image counts vary by VL family (Gemma 3 emits 256/image; Qwen2.5-VL tiles dynamically) and the real count is processor-determined at decode. The budget gate only needs a sane bound, which this provides without ever over-counting a real image into a false block.

## Tests

`AttachmentImageTokenEstimateTests` covers the floor, resolution scaling → ceiling saturation, undecodable-data fallback, and the byte-proportional regression. Server-side `estimatePromptTokens` was checked and is unaffected (it counts only text `content`, not image data).