### PR TITLE
Restore main CI gate stability

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/Attachment.swift
+++ b/Packages/OsaurusCore/Models/Chat/Attachment.swift
@@ -466,7 +466,8 @@ public struct Attachment: Codable, Sendable, Equatable, Identifiable {
     public static func estimatedImageTokens(pixelWidth: Int, pixelHeight: Int) -> Int {
         guard pixelWidth > 0, pixelHeight > 0 else { return defaultImageTokenEstimate }
         let longSide = max(pixelWidth, pixelHeight)
-        let scale = longSide > imageResizeLongSide
+        let scale =
+            longSide > imageResizeLongSide
             ? Double(imageResizeLongSide) / Double(longSide) : 1.0
         let w = Double(pixelWidth) * scale
         let h = Double(pixelHeight) * scale

--- a/Packages/OsaurusCore/Services/Context/ClipboardService.swift
+++ b/Packages/OsaurusCore/Services/Context/ClipboardService.swift
@@ -224,7 +224,9 @@ public final class ClipboardService: ObservableObject {
             try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms
             let currentChangeCount = await Self.onPasteboardQueue { $0.changeCount }
             if currentChangeCount != startChangeCount {
-                print("[ClipboardService] Pasteboard update detected at iteration \(i+1). New count: \(currentChangeCount)")
+                print(
+                    "[ClipboardService] Pasteboard update detected at iteration \(i+1). New count: \(currentChangeCount)"
+                )
                 await performPasteboardRefresh()
 
                 if case .text(let text) = currentContent {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3475,7 +3475,8 @@ public actor ModelRuntime {
         guard
             let out = try? JSONSerialization.data(
                 withJSONObject: json,
-                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            )
         else { return }
         do {
             try out.write(to: configURL, options: .atomic)

--- a/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AttachmentImageTokenEstimateTests.swift
@@ -48,14 +48,16 @@ import Testing
     @Test func invalidDimensionsFallBackToDefault() {
         #expect(
             Attachment.estimatedImageTokens(pixelWidth: 0, pixelHeight: 0)
-                == Attachment.defaultImageTokenEstimate)
+                == Attachment.defaultImageTokenEstimate
+        )
     }
 
     @Test func undecodableDataFallsBackToDefault() {
         let junk = Data(repeating: 0xAB, count: 8192)
         #expect(
             Attachment.estimatedImageTokens(forEncodedImage: junk)
-                == Attachment.defaultImageTokenEstimate)
+                == Attachment.defaultImageTokenEstimate
+        )
     }
 
     // The core regression: a real encoded image's estimate is bounded by its
@@ -80,9 +82,14 @@ import Testing
             let space = CGColorSpaceCreateDeviceRGB()
             guard
                 let ctx = CGContext(
-                    data: nil, width: width, height: height, bitsPerComponent: 8,
-                    bytesPerRow: 0, space: space,
-                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+                    data: nil,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: space,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                )
             else { throw TestError.failed }
             ctx.setFillColor(CGColor(red: 0.2, green: 0.5, blue: 0.8, alpha: 1))
             ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
@@ -90,7 +97,11 @@ import Testing
             let out = NSMutableData()
             guard
                 let dest = CGImageDestinationCreateWithData(
-                    out, UTType.png.identifier as CFString, 1, nil)
+                    out,
+                    UTType.png.identifier as CFString,
+                    1,
+                    nil
+                )
             else { throw TestError.failed }
             CGImageDestinationAddImage(dest, image, nil)
             guard CGImageDestinationFinalize(dest) else { throw TestError.failed }

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -27,19 +27,22 @@ struct ModelManagerSuggestedTests {
     /// download sizes onto curated entries. Keep this suite on a throwaway
     /// root so catalog metadata assertions do not depend on a developer or CI
     /// machine's persisted `ModelSizeCache`.
-    private func withIsolatedModelSizeCache<T>(_ body: () -> T) -> T {
-        OsaurusTestGlobals.withPathsLock {
-            let previous = OsaurusPaths.overrideRoot
-            let root = FileManager.default.temporaryDirectory
-                .appendingPathComponent("osaurus-suggested-models-\(UUID().uuidString)", isDirectory: true)
-            OsaurusPaths.overrideRoot = root
-            ModelSizeCache.invalidateInMemory()
-            defer {
-                OsaurusPaths.overrideRoot = previous
+    @MainActor
+    private func withIsolatedModelSizeCache(_ body: @MainActor @Sendable () -> Void) async {
+        await StoragePathsTestLock.shared.run {
+            await MainActor.run {
+                let previous = OsaurusPaths.overrideRoot
+                let root = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("osaurus-suggested-models-\(UUID().uuidString)", isDirectory: true)
+                OsaurusPaths.overrideRoot = root
                 ModelSizeCache.invalidateInMemory()
-                try? FileManager.default.removeItem(at: root)
+                defer {
+                    OsaurusPaths.overrideRoot = previous
+                    ModelSizeCache.invalidateInMemory()
+                    try? FileManager.default.removeItem(at: root)
+                }
+                body()
             }
-            return body()
         }
     }
 
@@ -57,189 +60,208 @@ struct ModelManagerSuggestedTests {
         #expect(ids.contains("osaurusai/ling-2.6-flash-jangtq"))
     }
 
-    @Test @MainActor func curatedSuggestedIds_matchInitialSuggestedModels() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let curatedIds = ModelManager.curatedSuggestedIds
-        let suggestedIds = Set(suggested.map { $0.id.lowercased() })
-        // On a fresh manager (before any HF fetch resolves), `suggestedModels`
-        // is exactly the curated catalog.
-        #expect(suggestedIds == curatedIds)
+    @Test @MainActor func curatedSuggestedIds_matchInitialSuggestedModels() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let curatedIds = ModelManager.curatedSuggestedIds
+            let suggestedIds = Set(suggested.map { $0.id.lowercased() })
+            // On a fresh manager (before any HF fetch resolves), `suggestedModels`
+            // is exactly the curated catalog.
+            #expect(suggestedIds == curatedIds)
+        }
     }
 
-    @Test @MainActor func curatedOsaurusEntries_haveValidReleaseDates() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let osaurusEntries = suggested.filter { $0.id.hasPrefix("OsaurusAI/") }
+    @Test @MainActor func curatedOsaurusEntries_haveValidReleaseDates() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let osaurusEntries = suggested.filter { $0.id.hasPrefix("OsaurusAI/") }
 
-        // All curated OsaurusAI entries should carry a release date and it
-        // should be after the project's epoch (2025-01-01) — guards against
-        // the date helper silently falling back to `Date(timeIntervalSince1970: 0)`.
-        let projectEpoch = Date(timeIntervalSince1970: 1_735_689_600)  // 2025-01-01
-        for model in osaurusEntries {
-            #expect(model.releasedAt != nil, "Missing releasedAt for \(model.id)")
-            if let d = model.releasedAt {
-                #expect(d > projectEpoch, "Suspicious releasedAt for \(model.id): \(d)")
+            // All curated OsaurusAI entries should carry a release date and it
+            // should be after the project's epoch (2025-01-01) — guards against
+            // the date helper silently falling back to `Date(timeIntervalSince1970: 0)`.
+            let projectEpoch = Date(timeIntervalSince1970: 1_735_689_600)  // 2025-01-01
+            for model in osaurusEntries {
+                #expect(model.releasedAt != nil, "Missing releasedAt for \(model.id)")
+                if let d = model.releasedAt {
+                    #expect(d > projectEpoch, "Suspicious releasedAt for \(model.id): \(d)")
+                }
             }
         }
     }
 
-    @Test @MainActor func miniMaxEntries_haveExpectedMetadata() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let jangtq4 = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
-        let jangtq = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ" }
+    @Test @MainActor func miniMaxEntries_haveExpectedMetadata() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let jangtq4 = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
+            let jangtq = suggested.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ" }
 
-        #expect(jangtq4 != nil)
-        #expect(jangtq != nil)
+            #expect(jangtq4 != nil)
+            #expect(jangtq != nil)
 
-        // Download sizes are no longer hand-coded; they're sourced from the
-        // revision-gated `ModelSizeCache` (empty in a fresh test run), so the
-        // curated entry carries no size until the org refresh fills it in.
-        #expect(jangtq4?.downloadSizeBytes == nil)
-        #expect(jangtq?.downloadSizeBytes == nil)
+            // Download sizes are no longer hand-coded; they're sourced from the
+            // revision-gated `ModelSizeCache` (empty in a fresh test run), so the
+            // curated entry carries no size until the org refresh fills it in.
+            #expect(jangtq4?.downloadSizeBytes == nil)
+            #expect(jangtq?.downloadSizeBytes == nil)
 
-        // model_type drives pre-download routing through the JANGTQ loader.
-        #expect(jangtq4?.modelType == "minimax_m2")
-        #expect(jangtq?.modelType == "minimax_m2")
+            // model_type drives pre-download routing through the JANGTQ loader.
+            #expect(jangtq4?.modelType == "minimax_m2")
+            #expect(jangtq?.modelType == "minimax_m2")
 
-        #expect(jangtq4?.releasedAt != nil)
-        #expect(jangtq?.releasedAt != nil)
+            #expect(jangtq4?.releasedAt != nil)
+            #expect(jangtq?.releasedAt != nil)
+        }
     }
 
-    @Test @MainActor func lingEntries_haveExpectedMetadata() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let mxfp4 = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-MXFP4" }
-        let jangtq = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-JANGTQ" }
+    @Test @MainActor func lingEntries_haveExpectedMetadata() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let mxfp4 = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-MXFP4" }
+            let jangtq = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-JANGTQ" }
 
-        #expect(mxfp4 != nil)
-        #expect(jangtq != nil)
-        #expect(mxfp4?.modelType == "bailing_hybrid")
-        #expect(jangtq?.modelType == "bailing_hybrid")
-        #expect(mxfp4?.releasedAt != nil)
-        #expect(jangtq?.releasedAt != nil)
+            #expect(mxfp4 != nil)
+            #expect(jangtq != nil)
+            #expect(mxfp4?.modelType == "bailing_hybrid")
+            #expect(jangtq?.modelType == "bailing_hybrid")
+            #expect(mxfp4?.releasedAt != nil)
+            #expect(jangtq?.releasedAt != nil)
+        }
     }
 
-    @Test @MainActor func lfm25Entry_haveExpectedMetadata() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let mxfp8 = suggested.first { $0.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8" }
+    @Test @MainActor func lfm25Entry_haveExpectedMetadata() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let mxfp8 = suggested.first { $0.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8" }
 
-        #expect(mxfp8 != nil)
-        #expect(mxfp8?.modelType == "lfm2_moe")
-        #expect(mxfp8?.isTopSuggestion == true)
-        // Sizes now come from `ModelSizeCache` (empty here), not literals.
-        #expect(mxfp8?.downloadSizeBytes == nil)
-        #expect(mxfp8?.releasedAt != nil)
+            #expect(mxfp8 != nil)
+            #expect(mxfp8?.modelType == "lfm2_moe")
+            #expect(mxfp8?.isTopSuggestion == true)
+            // Sizes now come from `ModelSizeCache` (empty here), not literals.
+            #expect(mxfp8?.downloadSizeBytes == nil)
+            #expect(mxfp8?.releasedAt != nil)
+        }
     }
 
     // MARK: - OsaurusAI org auto-discovery merge
 
-    @Test @MainActor func applyOsaurusOrgFetch_addsNewEntriesAfterCurated() {
-        let manager = withIsolatedModelSizeCache { ModelManager() }
-        let curatedCount = ModelManager.curatedSuggestedIds.count
+    @Test @MainActor func applyOsaurusOrgFetch_addsNewEntriesAfterCurated() async {
+        await withIsolatedModelSizeCache {
+            let manager = ModelManager()
+            let curatedCount = ModelManager.curatedSuggestedIds.count
 
-        let fresh = MLXModel(
-            id: "OsaurusAI/Brand-New-Repo-XYZ",
-            name: "Brand New Repo XYZ",
-            description: "From OsaurusAI on Hugging Face.",
-            downloadURL: "https://huggingface.co/OsaurusAI/Brand-New-Repo-XYZ",
-            releasedAt: Date()
-        )
+            let fresh = MLXModel(
+                id: "OsaurusAI/Brand-New-Repo-XYZ",
+                name: "Brand New Repo XYZ",
+                description: "From OsaurusAI on Hugging Face.",
+                downloadURL: "https://huggingface.co/OsaurusAI/Brand-New-Repo-XYZ",
+                releasedAt: Date()
+            )
 
-        manager.applyOsaurusOrgFetch(autoFetched: [fresh])
+            manager.applyOsaurusOrgFetch(autoFetched: [fresh])
 
-        let after = manager.suggestedModels
-        #expect(after.count == curatedCount + 1)
-        #expect(after.contains { $0.id == fresh.id })
+            let after = manager.suggestedModels
+            #expect(after.count == curatedCount + 1)
+            #expect(after.contains { $0.id == fresh.id })
+        }
     }
 
-    @Test @MainActor func applyOsaurusOrgFetch_curatedEntryWinsOnDuplicateId() {
-        let manager = withIsolatedModelSizeCache { ModelManager() }
+    @Test @MainActor func applyOsaurusOrgFetch_curatedEntryWinsOnDuplicateId() async {
+        await withIsolatedModelSizeCache {
+            let manager = ModelManager()
 
-        // Try to clobber a curated entry with auto-fetched metadata.
-        let imposter = MLXModel(
-            id: "OsaurusAI/MiniMax-M2.7-JANGTQ4",
-            name: "Should Not Replace",
-            description: "from auto-fetch",
-            downloadURL: "https://huggingface.co/OsaurusAI/MiniMax-M2.7-JANGTQ4"
-        )
+            // Try to clobber a curated entry with auto-fetched metadata.
+            let imposter = MLXModel(
+                id: "OsaurusAI/MiniMax-M2.7-JANGTQ4",
+                name: "Should Not Replace",
+                description: "from auto-fetch",
+                downloadURL: "https://huggingface.co/OsaurusAI/MiniMax-M2.7-JANGTQ4"
+            )
 
-        manager.applyOsaurusOrgFetch(autoFetched: [imposter])
+            manager.applyOsaurusOrgFetch(autoFetched: [imposter])
 
-        let curated = manager.suggestedModels.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
-        #expect(curated != nil)
-        // Curated metadata should be intact.
-        #expect(curated?.modelType == "minimax_m2")
-        #expect(curated?.description.contains("MiniMax M2.7") == true)
+            let curated = manager.suggestedModels.first { $0.id == "OsaurusAI/MiniMax-M2.7-JANGTQ4" }
+            #expect(curated != nil)
+            // Curated metadata should be intact.
+            #expect(curated?.modelType == "minimax_m2")
+            #expect(curated?.description.contains("MiniMax M2.7") == true)
+        }
     }
 
-    @Test @MainActor func applyOsaurusOrgFetch_dropsStaleAutoFetchedOnReapply() {
-        let stale = MLXModel(
-            id: "OsaurusAI/Stale-Repo",
-            name: "Stale Repo",
-            description: "From OsaurusAI on Hugging Face.",
-            downloadURL: "https://huggingface.co/OsaurusAI/Stale-Repo"
-        )
-        let kept = MLXModel(
-            id: "OsaurusAI/Kept-Repo",
-            name: "Kept Repo",
-            description: "From OsaurusAI on Hugging Face.",
-            downloadURL: "https://huggingface.co/OsaurusAI/Kept-Repo"
-        )
-
-        let after = withIsolatedModelSizeCache { () -> [MLXModel] in
+    @Test @MainActor func applyOsaurusOrgFetch_dropsStaleAutoFetchedOnReapply() async {
+        await withIsolatedModelSizeCache {
+            let stale = MLXModel(
+                id: "OsaurusAI/Stale-Repo",
+                name: "Stale Repo",
+                description: "From OsaurusAI on Hugging Face.",
+                downloadURL: "https://huggingface.co/OsaurusAI/Stale-Repo"
+            )
+            let kept = MLXModel(
+                id: "OsaurusAI/Kept-Repo",
+                name: "Kept Repo",
+                description: "From OsaurusAI on Hugging Face.",
+                downloadURL: "https://huggingface.co/OsaurusAI/Kept-Repo"
+            )
             let manager = ModelManager()
             manager.applyOsaurusOrgFetch(autoFetched: [stale])
             manager.applyOsaurusOrgFetch(autoFetched: [kept])
-            return manager.suggestedModels
+            let after = manager.suggestedModels
+            #expect(after.contains { $0.id == kept.id })
+            #expect(!after.contains { $0.id == stale.id })
         }
-        #expect(after.contains { $0.id == kept.id })
-        #expect(!after.contains { $0.id == stale.id })
     }
 
-    @Test @MainActor func applyOsaurusOrgFetch_preservesNonOsaurusInjectedEntries() {
-        let manager = withIsolatedModelSizeCache { ModelManager() }
+    @Test @MainActor func applyOsaurusOrgFetch_preservesNonOsaurusInjectedEntries() async {
+        await withIsolatedModelSizeCache {
+            let manager = ModelManager()
 
-        let foreign = MLXModel(
-            id: "some-org/unrelated-model",
-            name: "Unrelated",
-            description: "manual",
-            downloadURL: "https://huggingface.co/some-org/unrelated-model"
-        )
+            let foreign = MLXModel(
+                id: "some-org/unrelated-model",
+                name: "Unrelated",
+                description: "manual",
+                downloadURL: "https://huggingface.co/some-org/unrelated-model"
+            )
 
-        manager.suggestedModels.append(foreign)
-        manager.applyOsaurusOrgFetch(autoFetched: [])
+            manager.suggestedModels.append(foreign)
+            manager.applyOsaurusOrgFetch(autoFetched: [])
 
-        let after = manager.suggestedModels
-        #expect(after.contains { $0.id == foreign.id })
+            let after = manager.suggestedModels
+            #expect(after.contains { $0.id == foreign.id })
+        }
     }
 
     // MARK: - Top-pick reorg (precision-first)
 
-    @Test @MainActor func topPicks_includeGemmaQATSpineAndPrecisionFirstFlagships() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
-        for id in [
-            "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
-            "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
-            "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
-            "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8",
-            "OsaurusAI/gemma-4-E4B-it-8bit",
-            "OsaurusAI/gemma-4-E2B-it-8bit",
-            "OsaurusAI/Qwen3.6-27B-MXFP4",
-            "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
-        ] {
-            #expect(topIds.contains(id), "expected \(id) to be a Top Pick")
+    @Test @MainActor func topPicks_includeGemmaQATSpineAndPrecisionFirstFlagships() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
+            for id in [
+                "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
+                "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
+                "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
+                "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8",
+                "OsaurusAI/gemma-4-E4B-it-8bit",
+                "OsaurusAI/gemma-4-E2B-it-8bit",
+                "OsaurusAI/Qwen3.6-27B-MXFP4",
+                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
+            ] {
+                #expect(topIds.contains(id), "expected \(id) to be a Top Pick")
+            }
         }
     }
 
-    @Test @MainActor func lowerPrecisionSiblings_demotedFromTopPicks() {
-        let suggested = withIsolatedModelSizeCache { ModelManager().suggestedModels }
-        let e4b4 = suggested.first { $0.id == "OsaurusAI/gemma-4-E4B-it-4bit" }
-        #expect(e4b4 != nil)
-        #expect(e4b4?.isTopSuggestion == false)
-        // The MXFP4 35B MoE is kept in the catalog but demoted in favour of
-        // its MXFP8-MTP sibling.
-        let qwen35mxfp4 = suggested.first { $0.id == "OsaurusAI/Qwen3.6-35B-A3B-mxfp4" }
-        #expect(qwen35mxfp4 != nil)
-        #expect(qwen35mxfp4?.isTopSuggestion == false)
+    @Test @MainActor func lowerPrecisionSiblings_demotedFromTopPicks() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let e4b4 = suggested.first { $0.id == "OsaurusAI/gemma-4-E4B-it-4bit" }
+            #expect(e4b4 != nil)
+            #expect(e4b4?.isTopSuggestion == false)
+            // The MXFP4 35B MoE is kept in the catalog but demoted in favour of
+            // its MXFP8-MTP sibling.
+            let qwen35mxfp4 = suggested.first { $0.id == "OsaurusAI/Qwen3.6-35B-A3B-mxfp4" }
+            #expect(qwen35mxfp4 != nil)
+            #expect(qwen35mxfp4?.isTopSuggestion == false)
+        }
     }
 
     @Test func retiredModels_absentFromCuratedCatalog() {
@@ -266,62 +288,64 @@ struct ModelManagerSuggestedTests {
         #expect(!ids.contains("osaurusai/mistral-medium-3.5-128b-jangtq2"))
     }
 
-    @Test @MainActor func retiredOrgRepos_droppedFromAutoFetchMerge() {
-        let manager = withIsolatedModelSizeCache { ModelManager() }
-        // A retired repo reappearing via the org listing must not surface.
-        let retired = MLXModel(
-            id: "OsaurusAI/gemma-4-26B-A4B-it-4bit",
-            name: "x",
-            description: "from auto-fetch",
-            downloadURL: "https://huggingface.co/OsaurusAI/gemma-4-26B-A4B-it-4bit"
-        )
-        manager.applyOsaurusOrgFetch(autoFetched: [retired])
-        #expect(!manager.suggestedModels.contains { $0.id == retired.id })
+    @Test @MainActor func retiredOrgRepos_droppedFromAutoFetchMerge() async {
+        await withIsolatedModelSizeCache {
+            let manager = ModelManager()
+            // A retired repo reappearing via the org listing must not surface.
+            let retired = MLXModel(
+                id: "OsaurusAI/gemma-4-26B-A4B-it-4bit",
+                name: "x",
+                description: "from auto-fetch",
+                downloadURL: "https://huggingface.co/OsaurusAI/gemma-4-26B-A4B-it-4bit"
+            )
+            manager.applyOsaurusOrgFetch(autoFetched: [retired])
+            #expect(!manager.suggestedModels.contains { $0.id == retired.id })
+        }
     }
 
     // MARK: - Onboarding default scenario matrix (Phase 4c)
 
-    @Test @MainActor func onboardingDefault_landsOnGemmaQATSpinePerRAMTier() {
-        // Fetch candidates under the isolated (empty) size cache so estimates
-        // come from the deterministic param heuristic, not a machine's cached
-        // on-disk sizes.
-        let candidates = withIsolatedModelSizeCache {
-            ModelManager().suggestedModels.filter(\.isTopSuggestion)
+    @Test @MainActor func onboardingDefault_landsOnGemmaQATSpinePerRAMTier() async {
+        await withIsolatedModelSizeCache {
+            // Fetch candidates under the isolated (empty) size cache so estimates
+            // come from the deterministic param heuristic, not a machine's cached
+            // on-disk sizes.
+            let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
+            let pick: (Double) -> String? = { gb in
+                ConfigureAIState.recommendedLocalPick(from: candidates, totalMemoryGB: gb)?.id
+            }
+            // Small tier stays on the 8-bit retention build (gated until the
+            // QAT-4bit-vs-8bit bounce A/B clears).
+            #expect(pick(8) == "OsaurusAI/gemma-4-E4B-it-8bit")
+            // Mainstream tiers: the dense 12B QAT default.
+            #expect(pick(16) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
+            #expect(pick(18) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
+            #expect(pick(24) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
+            // Large tiers: the dense 31B QAT ceiling.
+            #expect(pick(32) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
+            #expect(pick(36) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
+            #expect(pick(48) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
+            #expect(pick(64) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
         }
-        func pick(_ gb: Double) -> String? {
-            ConfigureAIState.recommendedLocalPick(from: candidates, totalMemoryGB: gb)?.id
-        }
-        // Small tier stays on the 8-bit retention build (gated until the
-        // QAT-4bit-vs-8bit bounce A/B clears).
-        #expect(pick(8) == "OsaurusAI/gemma-4-E4B-it-8bit")
-        // Mainstream tiers: the dense 12B QAT default.
-        #expect(pick(16) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-        #expect(pick(18) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-        #expect(pick(24) == "OsaurusAI/gemma-4-12B-it-qat-MXFP4")
-        // Large tiers: the dense 31B QAT ceiling.
-        #expect(pick(32) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-        #expect(pick(36) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-        #expect(pick(48) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
-        #expect(pick(64) == "OsaurusAI/gemma-4-31B-it-qat-MXFP4")
     }
 
-    @Test @MainActor func onboardingDefault_neverAutoSelectsMoEorLargerFlagship() {
-        let candidates = withIsolatedModelSizeCache {
-            ModelManager().suggestedModels.filter(\.isTopSuggestion)
-        }
-        let excluded: Set<String> = [
-            "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
-            "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8",
-            "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
-            "OsaurusAI/Qwen3.6-27B-MXFP8-MTP",
-        ]
-        for gb in stride(from: 8.0, through: 128.0, by: 2.0) {
-            let id = ConfigureAIState.recommendedLocalPick(
-                from: candidates,
-                totalMemoryGB: gb
-            )?.id
-            if let id {
-                #expect(!excluded.contains(id), "auto-default \(id) at \(gb)GB must not be a MoE/flagship")
+    @Test @MainActor func onboardingDefault_neverAutoSelectsMoEorLargerFlagship() async {
+        await withIsolatedModelSizeCache {
+            let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
+            let excluded: Set<String> = [
+                "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
+                "OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8",
+                "OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP",
+                "OsaurusAI/Qwen3.6-27B-MXFP8-MTP",
+            ]
+            for gb in stride(from: 8.0, through: 128.0, by: 2.0) {
+                let id = ConfigureAIState.recommendedLocalPick(
+                    from: candidates,
+                    totalMemoryGB: gb
+                )?.id
+                if let id {
+                    #expect(!excluded.contains(id), "auto-default \(id) at \(gb)GB must not be a MoE/flagship")
+                }
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelSizeCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelSizeCacheTests.swift
@@ -15,8 +15,8 @@ struct ModelSizeCacheTests {
 
     /// Point `OsaurusPaths` at a throwaway root and clear the in-memory
     /// cache so each test starts from a clean, isolated state.
-    private func withTempRoot(_ body: (URL) throws -> Void) rethrows {
-        try OsaurusTestGlobals.withPathsLock {
+    private func withTempRoot(_ body: @Sendable (URL) -> Void) async {
+        await OsaurusTestGlobals.withPathsLock {
             let previous = OsaurusPaths.overrideRoot
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("osaurus-size-cache-\(UUID().uuidString)", isDirectory: true)
@@ -27,12 +27,12 @@ struct ModelSizeCacheTests {
                 ModelSizeCache.invalidateInMemory()
                 try? FileManager.default.removeItem(at: root)
             }
-            try body(root)
+            body(root)
         }
     }
 
-    @Test func record_thenReadBack_matchingRevision() throws {
-        try withTempRoot { _ in
+    @Test func record_thenReadBack_matchingRevision() async {
+        await withTempRoot { _ in
             ModelSizeCache.record(id: "Org/Repo", bytes: 12_345, revision: "rev-a")
 
             // Exact id (case-insensitive) + matching revision returns bytes.
@@ -42,8 +42,8 @@ struct ModelSizeCacheTests {
         }
     }
 
-    @Test func persistsAcrossInMemoryReset() throws {
-        try withTempRoot { _ in
+    @Test func persistsAcrossInMemoryReset() async {
+        await withTempRoot { _ in
             ModelSizeCache.record(id: "Org/Repo", bytes: 999, revision: "r1")
             // Drop the in-memory copy; the next read must re-hydrate from disk.
             ModelSizeCache.invalidateInMemory()
@@ -51,23 +51,23 @@ struct ModelSizeCacheTests {
         }
     }
 
-    @Test func revisionlessEntry_servedWithoutRevision() throws {
-        try withTempRoot { _ in
+    @Test func revisionlessEntry_servedWithoutRevision() async {
+        await withTempRoot { _ in
             ModelSizeCache.record(id: "a/b", bytes: 4_096, revision: nil)
             // No revision supplied -> any non-expired entry is accepted.
             #expect(ModelSizeCache.bytes(forId: "a/b") == 4_096)
         }
     }
 
-    @Test func zeroBytes_notRecorded() throws {
-        try withTempRoot { _ in
+    @Test func zeroBytes_notRecorded() async {
+        await withTempRoot { _ in
             ModelSizeCache.record(id: "a/b", bytes: 0, revision: "r")
             #expect(ModelSizeCache.bytes(forId: "a/b") == nil)
         }
     }
 
-    @Test func concreteRevisionEntry_servedWhenNoRevisionRequested() throws {
-        try withTempRoot { _ in
+    @Test func concreteRevisionEntry_servedWhenNoRevisionRequested() async {
+        await withTempRoot { _ in
             ModelSizeCache.record(id: "a/b", bytes: 77, revision: "rev")
             // A concrete-revision entry is trusted even without a comparison
             // revision (revisions only change when the repo changes).

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -157,8 +157,8 @@ struct ExternalModelLocatorTests {
 
     // MARK: - HF cache scan + resolution (via test override)
 
-    @Test func rescan_resolvesHFCacheSnapshotAndPath() {
-        OsaurusTestGlobals.withPathsLock {
+    @Test func rescan_resolvesHFCacheSnapshotAndPath() async {
+        await OsaurusTestGlobals.withPathsLock {
             rescan_resolvesHFCacheSnapshotAndPath_body()
         }
     }
@@ -211,8 +211,8 @@ struct ExternalModelLocatorTests {
         #expect(report?.skipped.isEmpty == true)
     }
 
-    @Test func rescan_reportsHFCacheSnapshotSkipReason() {
-        OsaurusTestGlobals.withPathsLock {
+    @Test func rescan_reportsHFCacheSnapshotSkipReason() async {
+        await OsaurusTestGlobals.withPathsLock {
             rescan_reportsHFCacheSnapshotSkipReason_body()
         }
     }

--- a/Packages/OsaurusCore/Tests/Support/TestGlobalStateLock.swift
+++ b/Packages/OsaurusCore/Tests/Support/TestGlobalStateLock.swift
@@ -2,23 +2,16 @@
 //  TestGlobalStateLock.swift
 //  osaurusTests
 //
-//  swift-testing runs suites in parallel. A handful of tests mutate
-//  process-wide state — `OsaurusPaths.overrideRoot`, the static
-//  `ModelSizeCache` / `ExternalModelLocator` registries — that can't be
-//  isolated per-test. They acquire this shared lock for their full duration
-//  so they run serially relative to one another regardless of which suite
-//  they live in.
+//  Backward-compatible entrypoint for tests that predate
+//  `StoragePathsTestLock`. Keep all path/global-state mutation on the same
+//  async lock so swift-testing's parallel runner cannot interleave roots.
 //
 
 import Foundation
 
 enum OsaurusTestGlobals {
-    static let pathsLock = NSLock()
-
     /// Run `body` while holding the shared global-state lock.
-    static func withPathsLock<T>(_ body: () throws -> T) rethrows -> T {
-        pathsLock.lock()
-        defer { pathsLock.unlock() }
-        return try body()
+    static func withPathsLock<T: Sendable>(_ body: @Sendable () async throws -> T) async rethrows -> T {
+        try await StoragePathsTestLock.shared.run(body)
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3354,7 +3354,8 @@ final class ChatSession: ObservableObject {
                                     // model's intended answer in the reasoning
                                     // channel — so require thinking blank too, matching
                                     // the "No visible text was produced" condition.
-                                    return (assistantTurn.contentIsBlank
+                                    return
+                                        (assistantTurn.contentIsBlank
                                         && assistantTurn.thinkingIsBlank)
                                         ? .emptyResponse : .finalResponse
                                 }


### PR DESCRIPTION
## Summary
- Restores Swift-format parity on current main after the 0.19.20 release/appcast updates.
- Moves the legacy model-size/global-path tests onto the shared storage-path lock so swift-testing cannot interleave OsaurusPaths.overrideRoot across suites.
- Keeps ModelManagerSuggested assertions inside the locked main-actor scope, fixing the observed AttachmentSpilloverTests race where blob paths were resolved under osaurus-suggested-models-*.

## Rationale
Current main failed the canonical local gate before this branch: swift-format lint reported formatting violations in current-main files, and make ci-test failed in AttachmentSpilloverTests.largeImageIsSpilledToBlobs() because another suite changed OsaurusPaths.overrideRoot while the spillover assertion was resolving blob paths. This PR fixes the actual test isolation issue instead of weakening the spillover assertion.

## Verification
- swift-format lint --strict --recursive Packages App
- swiftlint lint --reporter github-actions-logging (existing warnings only, 0 serious)
- find scripts -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
- swift test --package-path Packages/OsaurusCLI --parallel
- make ci-test
- swift build --package-path Packages/OsaurusCore -c release
- Focused regression: swift test --package-path Packages/OsaurusCore --filter 'AttachmentSpilloverTests|ModelManagerSuggestedTests|ModelSizeCacheTests|ExternalModelLocatorTests' --parallel

Full gate: LANE_GATE_OK 2026-06-15T16:15:52Z