### PR TITLE
enable sandbox by default

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -272,7 +272,8 @@ public final class AgentManager: ObservableObject {
             maxTokens: maxTokens,
             isBuiltIn: false,
             createdAt: Date(),
-            updatedAt: Date()
+            updatedAt: Date(),
+            autonomousExec: Self.sandboxDefaultAutonomousExec
         )
         add(agent)
         return agent
@@ -552,7 +553,41 @@ public final class AgentManager: ObservableObject {
 // MARK: - Agent Configuration Helpers
 
 extension AgentManager {
+    /// Whether the sandbox (autonomous exec) toggle should default ON for the
+    /// built-in Default agent and newly created custom agents.
+    ///
+    /// Gated on sandbox availability: the chat chip is hidden and the Linux VM
+    /// cannot run on unsupported machines (pre-macOS 26), so defaulting on
+    /// there would only inject an unusable placeholder into the model's
+    /// schema. Reading the published availability (seeded synchronously from
+    /// the OS version in `SandboxManager.State`) keeps this stable from the
+    /// first frame and lets tests force a value via
+    /// `SandboxManager.State.shared.availability`.
+    @MainActor
+    public static var sandboxEnabledByDefault: Bool {
+        SandboxManager.State.shared.availability.isAvailable
+    }
+
+    /// The `autonomousExec` to apply when an agent has made no explicit choice
+    /// and the sandbox defaults ON: enabled where supported, else `nil` (off).
+    /// Used both as the Default agent's computed default (when nothing is
+    /// stored) and to seed newly created custom agents. Never applied on
+    /// edit/import/duplicate, which must preserve the source agent's value.
+    @MainActor
+    public static var sandboxDefaultAutonomousExec: AutonomousExecConfig? {
+        sandboxEnabledByDefault ? AutonomousExecConfig(enabled: true) : nil
+    }
+
     /// Get the effective sandbox execution config for an agent.
+    ///
+    /// The sandbox toggle defaults ON for the built-in Default agent on
+    /// machines where the sandbox is supported: when the Default agent has no
+    /// explicitly stored `autonomousExec` (the user has never touched the
+    /// chip), we synthesize an enabled config. An explicit choice — turning
+    /// the chip off — persists `enabled: false`, which then wins over this
+    /// computed default. Custom agents carry their own persisted value (seeded
+    /// ON at creation for new agents, left untouched for existing ones), so
+    /// they are returned as-is.
     public func effectiveAutonomousExec(for agentId: UUID) -> AutonomousExecConfig? {
         guard let agent = agent(for: agentId) else {
             return nil
@@ -560,6 +595,7 @@ extension AgentManager {
 
         if agent.id == Agent.defaultId {
             return DefaultAgentConfigurationStore.load().autonomousExec
+                ?? Self.sandboxDefaultAutonomousExec
         }
 
         return agent.autonomousExec
@@ -594,10 +630,12 @@ extension AgentManager {
         }
 
         if willBeEnabled && !wasEnabled {
-            // Toggling autonomous on is an explicit user action — clear any
-            // prior failure cool-down so the registrar's next provisioning
-            // attempt isn't suppressed.
-            SandboxToolRegistrar.shared.resetStartupFailures()
+            // Toggling the sandbox on is an explicit user opt-in: clear any
+            // prior failure cool-down and boot the container now (cold-
+            // provisioning if needed), bypassing the `setupComplete` gate that
+            // keeps the default-ON chip from auto-downloading at launch.
+            // `provisionOnDemand` resets the startup-failure tracking for us.
+            SandboxToolRegistrar.shared.provisionOnDemand(for: agentId)
         }
 
         // Mirror the per-agent egress choice onto the shared sandbox config

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -350,6 +350,15 @@ extension Agent {
 // MARK: - Autonomous Exec Configuration
 
 public struct AutonomousExecConfig: Codable, Sendable, Equatable {
+    /// Whether the agent's sandbox (autonomous code execution) is on. Note the
+    /// *effective* default is resolved in
+    /// `AgentManager.effectiveAutonomousExec`, not by this struct: the chip
+    /// defaults ON for the Default agent and newly created agents on supported
+    /// machines (`AgentManager.sandboxEnabledByDefault`). This field's own
+    /// default below stays `false` so it remains a neutral base for
+    /// `current ?? .default` mutations in the settings UI (which only flips
+    /// individual sub-toggles) and never silently turns the sandbox on for an
+    /// existing custom agent that was left unconfigured.
     public var enabled: Bool
     public var maxCommandsPerTurn: Int
     public var pluginCreate: Bool

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
@@ -67,6 +67,11 @@ public final class SandboxToolRegistrar {
     /// hitting "Retry" on the chip) to avoid silent loops.
     private var provisioningRetryScheduled: Set<UUID> = []
 
+    /// Coalesces explicit first-use provisioning kicks (`provisionOnDemand`)
+    /// so the model hammering the `sandbox_init_pending` placeholder while the
+    /// cold download runs doesn't queue a fresh `registerTools` per call.
+    private var onDemandProvisionTask: Task<Void, Never>?
+
     /// Delay before the single auto-retry on `provisioningFailed`. Kept
     /// short because most provisioning failures are transient (container
     /// settling state, brief lock during user creation) and fail fast on
@@ -208,7 +213,7 @@ public final class SandboxToolRegistrar {
     /// provisioning. Failures are recorded in `unavailability[agentId]` so the
     /// system prompt can surface a clear message to the model instead of the
     /// model silently losing access to its sandbox tools.
-    public func registerTools(for agentId: UUID) async {
+    public func registerTools(for agentId: UUID, forceStart: Bool = false) async {
         ToolRegistry.shared.unregisterAllBuiltinSandboxTools()
 
         let agent = AgentManager.shared.agent(for: agentId) ?? Agent.default
@@ -228,7 +233,7 @@ public final class SandboxToolRegistrar {
         var realToolsRegistered = false
         defer {
             if autonomousEnabled && !realToolsRegistered {
-                BuiltinSandboxTools.registerInitPending()
+                BuiltinSandboxTools.registerInitPending(agentId: agent.id)
             }
         }
 
@@ -237,6 +242,22 @@ public final class SandboxToolRegistrar {
             // Without autonomous execution there's no expectation of sandbox
             // tools — clear any prior unavailability and bail.
             guard autonomousEnabled else {
+                unavailability.removeValue(forKey: agent.id)
+                publishActiveAgentUnavailability(for: agent.id, reason: nil)
+                return
+            }
+
+            // The chip defaults ON for the Default agent and new agents, but a
+            // default-ON sandbox that was never set up must NOT cold-provision
+            // (multi-GB download) just because `registerTools` runs at launch,
+            // on agent switch, or on a status change. Defer until explicit
+            // first use: the `sandbox_init_pending` placeholder (registered by
+            // the `defer` above) calls `provisionOnDemand`, or the user starts
+            // it from the Sandbox tab. `forceStart` is that explicit opt-in;
+            // `setupComplete` allows warm restarts of an already-provisioned
+            // sandbox (no download).
+            let mayColdStart = forceStart || SandboxConfigurationStore.load().setupComplete
+            guard mayColdStart else {
                 unavailability.removeValue(forKey: agent.id)
                 publishActiveAgentUnavailability(for: agent.id, reason: nil)
                 return
@@ -489,5 +510,26 @@ public final class SandboxToolRegistrar {
     public func resetStartupFailures() {
         startupFailureCount = 0
         nextStartupRetryAfter = nil
+    }
+
+    /// Boot the sandbox for an agent on explicit first use, bypassing the
+    /// `setupComplete` cold-start gate in `registerTools`.
+    ///
+    /// This is the "boots on first sandboxed run" path: the chip defaults ON
+    /// (where supported), but a fresh, never-set-up sandbox stays un-booted at
+    /// launch so there's no surprise multi-GB download. When the model first
+    /// reaches for a sandbox tool it hits the `sandbox_init_pending`
+    /// placeholder, which calls this to start (and cold-provision) the
+    /// container. `AgentManager.updateAutonomousExec` also calls it on an
+    /// explicit OFF→ON toggle. Coalesced via `onDemandProvisionTask` so
+    /// repeated placeholder calls during the download don't pile up.
+    public func provisionOnDemand(for agentId: UUID) {
+        guard onDemandProvisionTask == nil else { return }
+        resetStartupFailures()
+        onDemandProvisionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.onDemandProvisionTask = nil }
+            await self.registerTools(for: agentId, forceStart: true)
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
+++ b/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
@@ -22,6 +22,26 @@ enum ChatHistoryTestStorage {
             )
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
 
+            // Neutralize the "sandbox enabled by default" behavior for these
+            // chat/engine/persistence tests. With the sandbox available (macOS
+            // 26+), the Default agent resolves to autonomous-ON, so every
+            // `ChatSession.send()` would run `prepareChatExecutionMode` ->
+            // `SandboxToolRegistrar.registerTools`. Depending on the global
+            // `SandboxManager.State.shared.status` left by other (serialized)
+            // sandbox suites, that can enter real container provisioning
+            // (NSXPCConnection), which stalls headlessly in CI and delays
+            // `engine.streamChat` past these tests' timeouts. Forcing the
+            // availability seam OFF (and resetting status) keeps `send()` on
+            // the no-sandbox path, matching what these tests assume. Held under
+            // `SandboxTestLock` above, so no concurrent sandbox suite observes
+            // these values; both are restored on exit.
+            let previousAvailability = SandboxManager.State.shared.availability
+            let previousStatus = SandboxManager.State.shared.status
+            SandboxManager.State.shared.availability = .unavailable(
+                reason: "sandbox neutralized for chat-history tests"
+            )
+            SandboxManager.State.shared.status = .notProvisioned
+
             let previousRoot = OsaurusPaths.overrideRoot
             OsaurusPaths.overrideRoot = root
             StorageKeyManager.shared._setKeyForTesting(
@@ -34,6 +54,8 @@ enum ChatHistoryTestStorage {
                 StorageKeyManager.shared.wipeCache()
                 OsaurusPaths.overrideRoot = previousRoot
                 AgentManager.shared.refresh()
+                SandboxManager.State.shared.availability = previousAvailability
+                SandboxManager.State.shared.status = previousStatus
                 try? FileManager.default.removeItem(at: root)
             }
 

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
@@ -1,0 +1,187 @@
+//
+//  SandboxDefaultEnablementTests.swift
+//  OsaurusCoreTests
+//
+//  Covers the "sandbox enabled by default" behavior:
+//
+//   * The built-in Default agent resolves to sandbox-ON when it has no
+//     stored `autonomousExec` and the sandbox is supported, OFF when the
+//     sandbox is unavailable, and honors an explicit disable.
+//   * Newly created custom agents are seeded ON (where supported).
+//   * Lazy provisioning: with the toggle on but the sandbox never set up,
+//     `registerTools` drops the `sandbox_init_pending` placeholder into the
+//     schema and does NOT kick a (cold-download) container start.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct SandboxDefaultEnablementTests {
+
+    // MARK: - Helpers
+
+    /// Force `SandboxManager` availability for the duration of `body`, then
+    /// restore it. The published value is the seam the production code reads
+    /// to gate the default-on behavior.
+    private func withAvailability<T>(
+        _ availability: SandboxAvailability,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let previous = SandboxManager.State.shared.availability
+        SandboxManager.State.shared.availability = availability
+        defer { SandboxManager.State.shared.availability = previous }
+        return try body()
+    }
+
+    /// Point the Default-agent config store at a throwaway directory seeded
+    /// with the given `autonomousExec`, so `effectiveAutonomousExec` reads a
+    /// known stored value (or `nil`) without touching the user's real config.
+    private func withDefaultAgentConfig<T>(
+        autonomousExec: AutonomousExecConfig?,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-sandbox-default-enable-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let previous = DefaultAgentConfigurationStore.overrideDirectory
+        DefaultAgentConfigurationStore.overrideDirectory = tmp
+        DefaultAgentConfigurationStore.resetCacheForTests()
+        if let autonomousExec {
+            var cfg = DefaultAgentConfiguration.default
+            cfg.autonomousExec = autonomousExec
+            DefaultAgentConfigurationStore.save(cfg)
+        }
+        defer {
+            DefaultAgentConfigurationStore.overrideDirectory = previous
+            DefaultAgentConfigurationStore.resetCacheForTests()
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        return try body()
+    }
+
+    // MARK: - Default agent
+
+    @Test
+    func effectiveAutonomousExec_defaultAgent_defaultsOnWhenAvailableAndUnconfigured() async {
+        await SandboxTestLock.runWithStoragePaths {
+            self.withDefaultAgentConfig(autonomousExec: nil) {
+                self.withAvailability(.available) {
+                    let config = AgentManager.shared.effectiveAutonomousExec(for: Agent.defaultId)
+                    #expect(config?.enabled == true)
+                }
+            }
+        }
+    }
+
+    @Test
+    func effectiveAutonomousExec_defaultAgent_offWhenSandboxUnavailable() async {
+        await SandboxTestLock.runWithStoragePaths {
+            self.withDefaultAgentConfig(autonomousExec: nil) {
+                self.withAvailability(.unavailable(reason: "test")) {
+                    let config = AgentManager.shared.effectiveAutonomousExec(for: Agent.defaultId)
+                    // No synthesized default on unsupported machines — the chip
+                    // is hidden and the VM can't run there.
+                    #expect(config == nil)
+                }
+            }
+        }
+    }
+
+    @Test
+    func effectiveAutonomousExec_defaultAgent_explicitDisableWinsOverComputedDefault() async {
+        await SandboxTestLock.runWithStoragePaths {
+            // The user turned the chip OFF — persisted as enabled:false. That
+            // explicit choice must survive even on a supported machine.
+            self.withDefaultAgentConfig(autonomousExec: AutonomousExecConfig(enabled: false)) {
+                self.withAvailability(.available) {
+                    let config = AgentManager.shared.effectiveAutonomousExec(for: Agent.defaultId)
+                    #expect(config?.enabled == false)
+                }
+            }
+        }
+    }
+
+    // MARK: - Seed for new agents
+
+    @Test
+    func sandboxDefaultAutonomousExec_mirrorsAvailability() async {
+        await SandboxTestLock.runWithStoragePaths {
+            self.withAvailability(.available) {
+                #expect(AgentManager.sandboxDefaultAutonomousExec?.enabled == true)
+            }
+            self.withAvailability(.unavailable(reason: "test")) {
+                #expect(AgentManager.sandboxDefaultAutonomousExec == nil)
+            }
+        }
+    }
+
+    @Test
+    func create_seedsSandboxOnWhenAvailable_offWhenUnavailable() async {
+        await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+
+            let onAgent = self.withAvailability(.available) {
+                manager.create(name: "Seed On \(UUID().uuidString)")
+            }
+            #expect(onAgent.autonomousExec?.enabled == true)
+            _ = await manager.delete(id: onAgent.id)
+
+            let offAgent = self.withAvailability(.unavailable(reason: "test")) {
+                manager.create(name: "Seed Off \(UUID().uuidString)")
+            }
+            #expect(offAgent.autonomousExec == nil)
+            _ = await manager.delete(id: offAgent.id)
+        }
+    }
+
+    // MARK: - Lazy provisioning gate
+
+    @Test
+    func registerTools_defaultOnButNeverSetUp_registersPlaceholderWithoutStarting() async {
+        await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let registry = ToolRegistry.shared
+            let originalActiveAgentId = manager.activeAgentId
+            let originalStatus = SandboxManager.State.shared.status
+            let originalSandboxConfig = SandboxConfigurationStore.load()
+
+            // A sandbox that the user never set up: setupComplete == false and
+            // the container is not provisioned.
+            var freshConfig = SandboxConfiguration.default
+            freshConfig.setupComplete = false
+            SandboxConfigurationStore.save(freshConfig)
+            SandboxManager.State.shared.status = .notProvisioned
+
+            let agent = Agent(
+                name: "Lazy Sandbox \(UUID().uuidString)",
+                agentAddress: "test-lazy-sandbox-\(UUID().uuidString)",
+                autonomousExec: AutonomousExecConfig(enabled: true)
+            )
+            manager.add(agent)
+            manager.setActiveAgent(agent.id)
+
+            registry.unregisterAllBuiltinSandboxTools()
+            await SandboxToolRegistrar.shared.registerTools(for: agent.id)
+
+            let names = registry.builtInSandboxToolNamesSnapshot
+            // Lazy: the placeholder is offered so the model has something to
+            // call (which triggers the on-demand boot), but the real exec
+            // tools are NOT registered and no cold container start happened.
+            #expect(names.contains(BuiltinSandboxTools.initPendingToolName))
+            #expect(names.contains("sandbox_exec") == false)
+            #expect(SandboxManager.State.shared.status == .notProvisioned)
+
+            registry.unregisterAllSandboxTools()
+            SandboxManager.State.shared.status = originalStatus
+            SandboxConfigurationStore.save(originalSandboxConfig)
+            manager.setActiveAgent(originalActiveAgentId)
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -130,9 +130,9 @@ enum BuiltinSandboxTools {
     /// `unregisterAllBuiltinSandboxTools()` the moment real sandbox tools
     /// come online.
     @MainActor
-    static func registerInitPending() {
+    static func registerInitPending(agentId: UUID) {
         ToolRegistry.shared.registerSandboxTool(
-            SandboxInitPendingTool(),
+            SandboxInitPendingTool(agentId: agentId),
             runtimeManaged: true
         )
     }
@@ -153,27 +153,40 @@ extension BuiltinSandboxTools {
 }
 
 /// Placeholder tool registered when sandbox is enabled but the container
-/// isn't running yet. Always returns the same "still initialising" envelope.
-/// Designed to keep the model's schema non-empty (so it has *something*
-/// to call) while the container provisions in the background.
+/// isn't running yet. Calling it kicks the on-demand boot (the sandbox chip
+/// defaults ON but a never-set-up sandbox stays un-provisioned until first
+/// use) and returns a "still initialising" envelope. Designed to keep the
+/// model's schema non-empty (so it has *something* to call) while the
+/// container provisions; the real sandbox tools register automatically once
+/// it's running.
 private struct SandboxInitPendingTool: OsaurusTool, @unchecked Sendable {
+    let agentId: UUID
     let name = BuiltinSandboxTools.initPendingToolName
     let description =
-        "Sandbox is starting in the background. Call this tool to confirm it isn't ready, "
-        + "then either reply without sandbox tools or tell the user to wait. The real "
-        + "sandbox tools (file ops, shell) appear in your schema once the container boots — "
-        + "do NOT invent or guess sandbox tool names in the meantime."
+        "Sandbox isn't running yet. Calling this tool starts it (first use can take a "
+        + "moment to provision) and confirms it isn't ready — then either reply without "
+        + "sandbox tools or tell the user to wait. The real sandbox tools (file ops, "
+        + "shell) appear in your schema once the container boots — do NOT invent or guess "
+        + "sandbox tool names in the meantime."
 
     var parameters: JSONValue? {
         .object(["type": .string("object"), "properties": .object([:])])
     }
 
     func execute(argumentsJSON: String) async throws -> String {
-        ToolErrorEnvelope(
+        // First reach for a sandbox tool is the explicit signal to boot the
+        // (default-ON, not-yet-provisioned) sandbox. Kick the on-demand
+        // provision; the status publisher re-registers the real tools once the
+        // container is running, so the model's next turn uses them.
+        await MainActor.run { [agentId] in
+            SandboxToolRegistrar.shared.provisionOnDemand(for: agentId)
+        }
+        return ToolErrorEnvelope(
             kind: .unavailable,
             reason:
-                "Sandbox is still initializing. Real sandbox tools will register on "
-                + "the next turn. Reply without sandbox tools, or wait and try again.",
+                "Sandbox is starting up (first use) — this can take a moment while it "
+                + "provisions. Real sandbox tools register automatically once it's "
+                + "running. Reply without sandbox tools, or wait and try again.",
             toolName: name,
             retryable: true
         ).toJSONString()

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -6112,6 +6112,7 @@ private struct AgentEditorSheet: View {
             isBuiltIn: false,
             createdAt: Date(),
             updatedAt: Date(),
+            autonomousExec: AgentManager.sandboxDefaultAutonomousExec,
             toolSelectionMode: draftMode,
             manualToolNames: Array(draftToolNames),
             manualSkillNames: Array(draftSkillNames),

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -1693,10 +1693,14 @@ extension FloatingInputCard {
                     Text(verbatim: accountService.formattedBalance)
                         .font(.system(size: caption - 1, weight: style.weight, design: .monospaced))
                         .foregroundColor(style.textColor)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 } else {
                     Text("Add credits", bundle: .module)
                         .font(theme.font(size: caption - 1, weight: style.weight))
                         .foregroundColor(style.textColor)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
             }
             // Chrome only appears in the low/empty attention states; the healthy
@@ -1780,11 +1784,15 @@ extension FloatingInputCard {
                 .foregroundColor(
                     warningColor ?? (isStreaming ? theme.secondaryText : theme.tertiaryText)
                 )
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
 
             if !isCompact {
                 Text("tokens", bundle: .module)
                     .font(theme.font(size: CGFloat(theme.captionSize) - 1, weight: .regular))
                     .foregroundColor(theme.tertiaryText.opacity(0.7))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
             }
         }
         .pointingHandCursor()

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
@@ -105,6 +105,7 @@ final class CreateAgentState: ObservableObject {
             systemPrompt: selectedTemplate.systemPrompt,
             createdAt: Date(),
             updatedAt: Date(),
+            autonomousExec: AgentManager.sandboxDefaultAutonomousExec,
             toolSelectionMode: .auto,
             avatar: selectedAvatar
         )

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -162,6 +162,8 @@ Sandbox-only by design — folder-mode agents are short-lived and project-bound.
 
 When the container is running, sandbox tools are automatically registered for the active agent. Read-only tools are always available. Write and execution tools require `autonomous_exec` to be enabled on the agent.
 
+> **Default ON (where supported):** On macOS 26+ the sandbox chip defaults **on** for the built-in Default agent and for newly created agents. To avoid a surprise multi-GB download for users who never touch it, the container is **not** booted eagerly — a never-set-up sandbox stays un-provisioned until first use. The first time the model reaches for a sandbox tool (the transient `sandbox_init_pending` placeholder), the container boots and provisions on demand; once `setupComplete` is recorded, later launches auto-start as normal. Provisioning the container from the Sandbox tab, or toggling the chip off→on, also boots it immediately. Existing agents that were left unconfigured keep their previous (off) state, and unsupported machines (pre-macOS 26) stay off.
+
 ### Anti-confusion cheat sheet (always prefer the dedicated tool)
 
 | Don't                                | Do                                                                                                              |


### PR DESCRIPTION
## Summary

sandbox was dsiabled by default

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
