### PR TITLE
Expose theme button colors in editor preview

### DIFF
--- a/Packages/OsaurusCore/Tests/Theme/ThemeEditorSourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeEditorSourceTests.swift
@@ -1,0 +1,32 @@
+// Copyright © 2026 osaurus.
+
+import Foundation
+import Testing
+
+@Suite("Theme editor source")
+struct ThemeEditorSourceTests {
+    private static func packageRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Theme/
+        cursor.deleteLastPathComponent()  // Tests/
+        return cursor.deletingLastPathComponent()  // OsaurusCore/
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = packageRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("theme editor exposes button colors and previews affected controls")
+    func buttonColorsAreEditableAndPreviewed() throws {
+        let source = try Self.source("Views/Theme/ThemeEditorView.swift")
+
+        #expect(source.contains(#"colorRow("Button BG", hex: $editingTheme.colors.buttonBackground)"#))
+        #expect(source.contains(#"colorRow("Button Border", hex: $editingTheme.colors.buttonBorder)"#))
+        #expect(source.contains("previewButtonTray"))
+        #expect(source.contains("theme.colors.buttonBackground"))
+        #expect(source.contains("theme.colors.buttonBorder"))
+        #expect(source.contains("previewToast"))
+        #expect(source.contains("struct ThemeSample"))
+    }
+}

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -347,6 +347,8 @@ struct ThemeEditorView: View {
                 .textCase(.uppercase)
                 colorRow("Card BG", hex: $editingTheme.colors.cardBackground)
                 colorRow("Card Border", hex: $editingTheme.colors.cardBorder)
+                colorRow("Button BG", hex: $editingTheme.colors.buttonBackground)
+                colorRow("Button Border", hex: $editingTheme.colors.buttonBorder)
                 colorRow("Input BG", hex: $editingTheme.colors.inputBackground)
                 colorRow("Input Border", hex: $editingTheme.colors.inputBorder)
             }
@@ -1196,6 +1198,8 @@ struct ThemeChatPreview: View {
                     .foregroundColor(c(theme.colors.primaryText))
 
                 previewCodeBlock
+                previewButtonTray
+                previewToast
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
@@ -1215,8 +1219,13 @@ struct ThemeChatPreview: View {
 
     private var previewCodeBlock: some View {
         let themeProtocol = CustomizableTheme(config: theme)
-        let sampleCode = "print(\"Hello, World!\")"
-        let _ = ensureHighlightrTheme(for: themeProtocol)
+        let sampleCode = [
+            "struct ThemeSample {",
+            "    let accent = \"button\"",
+            "    func render() { print(accent) }",
+            "}",
+        ].joined(separator: "\n")
+        ensureHighlightrTheme(for: themeProtocol)
         let bgColor = highlightrThemeBackgroundColor()
 
         return VStack(alignment: .leading, spacing: 0) {
@@ -1245,13 +1254,63 @@ struct ThemeChatPreview: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
             }
-            .frame(height: 36)
+            .frame(height: 84)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8).fill(bgColor)
         )
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var previewButtonTray: some View {
+        HStack(spacing: 8) {
+            previewControlButton("Primary", foreground: c(theme.colors.primaryText))
+            previewControlButton("Success", foreground: c(theme.colors.successColor))
+            previewControlButton("Delete", foreground: c(theme.colors.errorColor))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func previewControlButton(_ title: LocalizedStringKey, foreground: Color) -> some View {
+        Text(title, bundle: .module)
+            .font(primaryFont(size: captionSize, weight: .semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .foregroundColor(foreground)
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(c(theme.colors.buttonBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(c(theme.colors.buttonBorder), lineWidth: 1)
+            )
+    }
+
+    private var previewToast: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(c(theme.colors.successColor))
+            Text("Success action preview", bundle: .module)
+                .font(primaryFont(size: captionSize))
+                .lineLimit(1)
+                .foregroundColor(c(theme.colors.primaryText))
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 32)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(c(theme.colors.cardBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(c(theme.colors.cardBorder), lineWidth: 1)
+        )
     }
 
     // MARK: - Background


### PR DESCRIPTION
## Summary
- Add editable Button BG and Button Border controls to the theme editor component color section.
- Expand the live chat preview with button and toast surfaces so those colors have immediate visible feedback.
- Grow the code preview into a multi-line Swift sample for better syntax theme review.

Refs #1503.

## Rationale
The theme editor already stored button background and border colors, but users could not edit or preview those surfaces directly. This exposes the existing theme fields without changing the persistence model, and keeps the raw JSON editor requested in #1503 as a separate follow-up because that path needs validation and error handling.

## Validation
- `$(xcrun --find swift-format) lint --configuration .swift-format --strict --recursive Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift Packages/OsaurusCore/Tests/Theme/ThemeEditorSourceTests.swift`
- `git diff --check`
- `swiftlint lint --config .swiftlint.yml --force-exclude Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift Packages/OsaurusCore/Tests/Theme/ThemeEditorSourceTests.swift` (passes with 7 pre-existing ThemeEditorView trailing-closure warnings)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-theme-editor swift test --package-path Packages/OsaurusCore --filter ThemeEditorSourceTests`

## Notes
This PR intentionally does not introduce raw JSON editing. That should land separately with parse errors, schema validation, save-state handling, and accessibility coverage.