### PR TITLE
Add raw JSON editing for themes

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift
+++ b/Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift
@@ -1,0 +1,64 @@
+//
+//  ThemeJSONEditorCodec.swift
+//  osaurus
+//
+//  Encode/decode helpers for the raw JSON theme editor.
+//
+
+import Foundation
+
+enum ThemeJSONEditorError: LocalizedError, Equatable {
+    case empty
+    case invalidUTF8
+    case decodeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .empty:
+            return "Theme JSON cannot be empty."
+        case .invalidUTF8:
+            return "Theme JSON must be valid UTF-8 text."
+        case .decodeFailed(let message):
+            return "Theme JSON is invalid: \(message)"
+        }
+    }
+}
+
+enum ThemeJSONEditorCodec {
+    static func encode(_ theme: CustomTheme) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(theme)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw ThemeJSONEditorError.invalidUTF8
+        }
+        return json
+    }
+
+    static func decode(_ json: String) throws -> CustomTheme {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ThemeJSONEditorError.empty
+        }
+        guard let data = json.data(using: .utf8) else {
+            throw ThemeJSONEditorError.invalidUTF8
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(CustomTheme.self, from: data)
+        } catch {
+            throw ThemeJSONEditorError.decodeFailed(error.localizedDescription)
+        }
+    }
+
+    static func decodePreservingEditorIdentity(_ json: String, currentTheme: CustomTheme) throws -> CustomTheme {
+        var decoded = try decode(json)
+        decoded.metadata.id = currentTheme.metadata.id
+        decoded.metadata.createdAt = currentTheme.metadata.createdAt
+        decoded.isBuiltIn = currentTheme.isBuiltIn
+        return decoded
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -40094,6 +40094,22 @@
         }
       }
     },
+    "Raw JSON" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rohes JSON"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "原始 JSON"
+          }
+        }
+      }
+    },
     "Ready" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift
@@ -1,0 +1,66 @@
+//
+//  ThemeJSONEditorCodecTests.swift
+//  osaurusTests
+//
+//  Focused coverage for the raw JSON theme editor codec.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Theme JSON editor codec")
+struct ThemeJSONEditorCodecTests {
+    @Test("encodes pretty sorted JSON and round trips")
+    func encodeRoundTripsTheme() throws {
+        var theme = CustomTheme.darkDefault
+        theme.metadata.name = "Raw JSON Theme"
+        theme.metadata.createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        theme.metadata.updatedAt = Date(timeIntervalSince1970: 1_700_000_001)
+        theme.colors.buttonBackground = "#123456"
+
+        let json = try ThemeJSONEditorCodec.encode(theme)
+        let decoded = try ThemeJSONEditorCodec.decode(json)
+
+        #expect(json.contains("\n"))
+        #expect(json.contains("\"buttonBackground\" : \"#123456\""))
+        #expect(decoded == theme)
+    }
+
+    @Test("rejects empty and malformed JSON")
+    func rejectsInvalidJSON() {
+        #expect(throws: ThemeJSONEditorError.empty) {
+            _ = try ThemeJSONEditorCodec.decode("   \n")
+        }
+
+        #expect(throws: ThemeJSONEditorError.self) {
+            _ = try ThemeJSONEditorCodec.decode(#"{"metadata": true}"#)
+        }
+    }
+
+    @Test("preserves editor identity fields when applying raw JSON")
+    func preservingEditorIdentityKeepsSaveTargetStable() throws {
+        var current = CustomTheme.darkDefault
+        current.metadata.name = "Current"
+        current.isBuiltIn = true
+
+        var pasted = CustomTheme.lightDefault
+        pasted.metadata.name = "Pasted"
+        pasted.metadata.id = UUID()
+        pasted.metadata.createdAt = Date(timeIntervalSince1970: 0)
+        pasted.isBuiltIn = false
+        pasted.colors.accentColor = "#abcdef"
+
+        let applied = try ThemeJSONEditorCodec.decodePreservingEditorIdentity(
+            ThemeJSONEditorCodec.encode(pasted),
+            currentTheme: current
+        )
+
+        #expect(applied.metadata.id == current.metadata.id)
+        #expect(applied.metadata.createdAt == current.metadata.createdAt)
+        #expect(applied.isBuiltIn == current.isBuiltIn)
+        #expect(applied.metadata.name == "Pasted")
+        #expect(applied.colors.accentColor == "#abcdef")
+    }
+}

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -30,7 +30,7 @@ struct ThemeEditorView: View {
     @State private var editingTheme: CustomTheme
     @State private var showImagePicker = false
     @State private var showSaveConfirmation = false
-    @State private var collapsedSections: Set<String> = ["Advanced Colors", "Advanced"]
+    @State private var collapsedSections: Set<String> = ["Advanced Colors", "Advanced", "Raw JSON"]
     @State private var animationPreviewTrigger = false
     @State private var showGlassPerformanceWarning = false
     /// Reverts the glass toggle the user just turned on if they cancel the
@@ -40,11 +40,15 @@ struct ThemeEditorView: View {
     /// Decoded copy of `editingTheme.background.imageData`, refreshed off
     /// the main actor whenever the base64 string changes.
     @State private var backgroundPreviewImage: NSImage?
+    @State private var rawThemeJSON: String
+    @State private var rawThemeJSONError: String?
+    @State private var rawThemeJSONIsDirty = false
 
     let onDismiss: () -> Void
 
     init(theme: CustomTheme, onDismiss: @escaping () -> Void) {
         _editingTheme = State(initialValue: theme)
+        _rawThemeJSON = State(initialValue: (try? ThemeJSONEditorCodec.encode(theme)) ?? "{}")
         self.onDismiss = onDismiss
     }
 
@@ -61,6 +65,9 @@ struct ThemeEditorView: View {
         .background(currentTheme.primaryBackground)
         .task(id: editingTheme.background.imageData) {
             backgroundPreviewImage = await decodeThemeBackgroundImage(editingTheme.background.imageData)
+        }
+        .onChange(of: editingTheme) { _, newTheme in
+            syncRawThemeJSONIfNeeded(newTheme)
         }
         .fileImporter(
             isPresented: $showImagePicker,
@@ -105,6 +112,7 @@ struct ThemeEditorView: View {
                     textAndFontsSection
                     bordersAndEffectsSection
                     advancedSection
+                    rawJSONSection
                 }
                 .padding(20)
             }
@@ -663,6 +671,90 @@ struct ThemeEditorView: View {
         }
     }
 
+    // MARK: - Section 7: Raw JSON
+
+    private var rawJSONSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            editorSection(L("Raw JSON")) {
+                VStack(alignment: .leading, spacing: 10) {
+                    TextEditor(text: rawThemeJSONBinding)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(currentTheme.primaryText)
+                        .frame(minHeight: 220)
+                        .padding(6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(currentTheme.inputBackground)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(currentTheme.inputBorder, lineWidth: 1)
+                        )
+
+                    if let rawThemeJSONError {
+                        rawJSONErrorView(rawThemeJSONError)
+                    }
+
+                    HStack(spacing: 8) {
+                        Button {
+                            refreshRawThemeJSON()
+                        } label: {
+                            Label {
+                                Text("Refresh", bundle: .module)
+                            } icon: {
+                                Image(systemName: "arrow.clockwise")
+                            }
+                        }
+                        .buttonStyle(.bordered)
+
+                        Spacer()
+
+                        Button {
+                            applyRawThemeJSON()
+                        } label: {
+                            Label {
+                                Text("Apply JSON", bundle: .module)
+                            } icon: {
+                                Image(systemName: "checkmark.circle")
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(rawThemeJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+        }
+    }
+
+    private var rawThemeJSONBinding: Binding<String> {
+        Binding(
+            get: { rawThemeJSON },
+            set: { newValue in
+                rawThemeJSON = newValue
+                rawThemeJSONIsDirty = true
+                rawThemeJSONError = nil
+            }
+        )
+    }
+
+    private func rawJSONErrorView(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(currentTheme.errorColor)
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(currentTheme.errorColor)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(currentTheme.errorColor.opacity(0.12))
+        )
+    }
+
     // MARK: - Preview Panel
 
     private var previewPanel: some View {
@@ -958,6 +1050,36 @@ struct ThemeEditorView: View {
     }
 
     // MARK: - Actions
+
+    private func syncRawThemeJSONIfNeeded(_ theme: CustomTheme) {
+        guard !rawThemeJSONIsDirty else { return }
+        rawThemeJSON = encodedThemeJSON(theme, fallback: rawThemeJSON)
+    }
+
+    private func refreshRawThemeJSON() {
+        rawThemeJSON = encodedThemeJSON(editingTheme, fallback: rawThemeJSON)
+        rawThemeJSONError = nil
+        rawThemeJSONIsDirty = false
+    }
+
+    private func applyRawThemeJSON() {
+        do {
+            let decoded = try ThemeJSONEditorCodec.decodePreservingEditorIdentity(
+                rawThemeJSON,
+                currentTheme: editingTheme
+            )
+            editingTheme = decoded
+            rawThemeJSON = encodedThemeJSON(decoded, fallback: rawThemeJSON)
+            rawThemeJSONError = nil
+            rawThemeJSONIsDirty = false
+        } catch {
+            rawThemeJSONError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func encodedThemeJSON(_ theme: CustomTheme, fallback: String) -> String {
+        (try? ThemeJSONEditorCodec.encode(theme)) ?? fallback
+    }
 
     private func saveTheme() {
         var themeToSave = editingTheme


### PR DESCRIPTION
## Summary
- Add a collapsed Raw JSON section to the theme editor with monospaced editing, refresh-from-form, and apply controls.
- Validate pasted theme JSON through a dedicated `CustomTheme` codec before updating the live preview state.
- Preserve the editor theme identity fields when applying pasted JSON so raw edits cannot silently change the save target or bypass built-in copy behavior.

Refs #1503.

## Rationale
#1503 asks for direct theme JSON editing so users can adjust keys that the structured editor does not expose yet. This keeps the raw JSON path in the app, but uses the real `CustomTheme` Codable model and the same ISO8601/sorted pretty JSON shape as theme persistence instead of patching strings in the view.

## Relationship to #1517
This PR is intentionally independent from #1517, which exposes button colors and improves the live preview. Both address #1503, but this branch is based on `main` so each slice remains reviewable on its own.

## Validation
- `scripts/i18n/check.sh`
- `$(xcrun --find swift-format) lint --configuration .swift-format --strict --recursive Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift`
- `git diff --check`
- `swiftlint lint --config .swiftlint.yml --force-exclude Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift` (passes with 7 pre-existing ThemeEditorView trailing-closure warnings)
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-theme-json swift test --package-path Packages/OsaurusCore --filter ThemeJSONEditorCodecTests`

## Notes
The first GitHub `test-core` attempt failed in `scripts/i18n/check.sh` because `Raw JSON` was missing from `Localizable.xcstrings`; head `5be07274` adds that catalog entry and the local i18n check now passes. This does not claim any changes to theme sharing or import/export. It only adds an in-editor raw JSON editing path with validation and focused codec coverage.