### PR TITLE
[codex] Fix scrub-leaked localization fallback

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterPipeline.swift
@@ -174,23 +174,87 @@ enum PrivacyFilterPipelineError: Error, Equatable, LocalizedError {
     /// `String(localized:)` interpolation API (the same pattern used
     /// for `privacy.preview.header %lld`).
     private static func localizedCount(_ count: Int, for category: EntityCategory) -> String {
+        let rendered: String
+        let keyPrefix: String
         switch category {
         case .phone:
-            return String(localized: "privacy.error.scrubLeaked.phone \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.phone \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.phone"
         case .email:
-            return String(localized: "privacy.error.scrubLeaked.email \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.email \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.email"
         case .url:
-            return String(localized: "privacy.error.scrubLeaked.url \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.url \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.url"
         case .accountNumber:
-            return String(localized: "privacy.error.scrubLeaked.accountNumber \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.accountNumber \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.accountNumber"
         case .address:
-            return String(localized: "privacy.error.scrubLeaked.address \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.address \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.address"
         case .person:
-            return String(localized: "privacy.error.scrubLeaked.person \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.person \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.person"
         case .date:
-            return String(localized: "privacy.error.scrubLeaked.date \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.date \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.date"
         case .secret:
-            return String(localized: "privacy.error.scrubLeaked.secret \(count)", bundle: .module)
+            rendered = String(
+                localized: "privacy.error.scrubLeaked.secret \(count)",
+                bundle: .module
+            )
+            keyPrefix = "privacy.error.scrubLeaked.secret"
+        }
+
+        if renderedLooksUnresolved(rendered, keyPrefix: keyPrefix) {
+            return "\(count) \(localizedCategoryName(for: category))"
+        }
+        return rendered
+    }
+
+    private static func renderedLooksUnresolved(_ rendered: String, keyPrefix: String) -> Bool {
+        rendered == keyPrefix || rendered.hasPrefix("\(keyPrefix) ")
+    }
+
+    private static func localizedCategoryName(for category: EntityCategory) -> String {
+        switch category {
+        case .phone:
+            return String(localized: "privacy.category.phone", bundle: .module)
+        case .email:
+            return String(localized: "privacy.category.email", bundle: .module)
+        case .url:
+            return String(localized: "privacy.category.url", bundle: .module)
+        case .accountNumber:
+            return String(localized: "privacy.category.accountNumber", bundle: .module)
+        case .address:
+            return String(localized: "privacy.category.address", bundle: .module)
+        case .person:
+            return String(localized: "privacy.category.person", bundle: .module)
+        case .date:
+            return String(localized: "privacy.category.date", bundle: .module)
+        case .secret:
+            return String(localized: "privacy.category.secret", bundle: .module)
         }
     }
 


### PR DESCRIPTION
## Summary
- Preserve localized scrub-leaked plural output when it resolves.
- Fall back to count plus the localized category label when `String(localized:)` echoes a `privacy.error.scrubLeaked.*` key.
- Prevents privacy block messages from losing the actionable category name under SwiftPM/test bundle localization fallback.

## Root Cause
`String(localized:)` can return the interpolated scrub-leaked key itself for the plural count strings under `swift test`, producing messages like `privacy.error.scrubLeaked.phone 2` instead of category-bearing text. The formatter did not detect that unresolved-key path.

## Validation
- `git diff --check`
- `scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter PostScrubInvariantTests/formatScrubLeaked_singleCategory_pluralForm --filter PostScrubInvariantTests/formatScrubLeaked_twoCategories_includesBoth --filter ResolvedSecretsMergingTests/mergesDisjointKeys`
- `swift test --package-path Packages/OsaurusCore --filter ModelManagerTests/discoverLocalModels_timeoutDoesNotCacheEmptyResult`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test make test` now clears the privacy failures; one unrelated `ModelManagerTests.discoverLocalModels_timeoutDoesNotCacheEmptyResult` full-suite issue was observed and passed in isolation.

## Notes
The focused privacy failure also reproduces on clean `origin/main` before this patch, so this is a base test/runtime fallback fix rather than a voice PR regression.