### PR TITLE
Add legacy storage merge marker

### DIFF
--- a/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
@@ -22,16 +22,20 @@ struct StorageLocationStandardsTests {
         home: String = "/Users/sam",
         support: String? = "/Users/sam/Library/Application Support",
         legacyPresent: Bool = false,
+        legacyMergeMarked: Bool = false,
         candidatePresent: Bool = false,
         modelsRootPath: String = "/Users/sam/MLXModels"
     ) -> StorageLocationStandards.Inputs {
-        StorageLocationStandards.Inputs(
+        let markerPath = "\(activeRootPath)/\(OsaurusPaths.legacyApplicationSupportMergeMarkerName)"
+        return StorageLocationStandards.Inputs(
             activeRootPath: activeRootPath,
             rootSource: rootSource,
             homeDirectoryPath: home,
             applicationSupportPath: support,
             legacyApplicationSupportRootPath: support.map { "\($0)/com.dinoki.osaurus" },
             legacyApplicationSupportRootPresent: legacyPresent,
+            legacyApplicationSupportMergeMarkerPath: markerPath,
+            legacyApplicationSupportMergeMarked: legacyMergeMarked,
             appleSpecCandidateRootPath: support.map { "\($0)/Osaurus" },
             appleSpecCandidateRootPresent: candidatePresent,
             modelsRootPath: modelsRootPath
@@ -171,8 +175,23 @@ struct StorageLocationStandardsTests {
             $0.code == .legacyApplicationSupportRootPresent
         }
         #expect(legacy?.severity == .warning)
-        #expect(legacy?.message.contains("re-merges") == true)
+        #expect(legacy?.message.contains("marker") == true)
+        #expect(legacy?.message.contains("missing") == true)
         #expect(legacy?.message.contains("com.dinoki.osaurus") == true)
+    }
+
+    @Test("Legacy root with merge marker reports as consumed, not repeatedly merged")
+    func legacyRootWithMergeMarker() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(legacyPresent: true, legacyMergeMarked: true)
+        )
+
+        #expect(report.legacyApplicationSupportMergeMarked)
+        let legacy = report.findings.first {
+            $0.code == .legacyApplicationSupportRootPresent
+        }
+        #expect(legacy?.severity == .info)
+        #expect(legacy?.message.contains("will not re-merge") == true)
     }
 
     @Test("Legacy root present alongside a compliant root still pends the migration decision")
@@ -251,6 +270,8 @@ struct StorageLocationStandardsTests {
                 "apple_spec_candidate_root_present",
                 "legacy_application_support_root",
                 "legacy_application_support_root_present",
+                "legacy_application_support_merge_marker",
+                "legacy_application_support_merge_marked",
                 "models_root",
                 "models_root_classification",
                 "reason_codes",
@@ -261,6 +282,7 @@ struct StorageLocationStandardsTests {
         #expect(json["classification"] as? String == "home_dot_directory")
         #expect(json["spec_compliant"] as? Bool == false)
         #expect(json["legacy_application_support_root_present"] as? Bool == true)
+        #expect(json["legacy_application_support_merge_marked"] as? Bool == false)
         #expect(json["models_root_classification"] as? String == "home_visible")
 
         let findings = try #require(json["findings"] as? [[String: Any]])
@@ -283,6 +305,89 @@ struct StorageLocationStandardsTests {
 
         #expect(json["apple_spec_candidate_root"] is NSNull)
         #expect(json["legacy_application_support_root"] is NSNull)
+    }
+
+    // MARK: - Legacy Application Support merge marker
+
+    @Test("Legacy Application Support migration writes marker and skips later merges")
+    func legacyApplicationSupportMigrationIsOneShot() throws {
+        let fm = FileManager.default
+        let sandbox = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacy = sandbox.appendingPathComponent("Library/Application Support/com.dinoki.osaurus")
+        let active = sandbox.appendingPathComponent(".osaurus")
+        defer { try? fm.removeItem(at: sandbox) }
+
+        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
+        try "first".write(
+            to: legacy.appendingPathComponent("settings.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let first = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
+            fileManager: fm,
+            legacyRoot: legacy,
+            activeRoot: active
+        )
+        #expect(first == .copied(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
+        #expect(fm.fileExists(atPath: active.appendingPathComponent("settings.json").path))
+        #expect(
+            fm.fileExists(
+                atPath: OsaurusPaths.legacyApplicationSupportMergeMarker(for: active).path
+            )
+        )
+
+        try "second".write(
+            to: legacy.appendingPathComponent("new-after-marker.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let second = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
+            fileManager: fm,
+            legacyRoot: legacy,
+            activeRoot: active
+        )
+        #expect(second == .alreadyMarked(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
+        #expect(!fm.fileExists(atPath: active.appendingPathComponent("new-after-marker.json").path))
+    }
+
+    @Test("Legacy Application Support merge keeps newer active files before writing marker")
+    func legacyApplicationSupportMergePreservesNewerActiveFiles() throws {
+        let fm = FileManager.default
+        let sandbox = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacy = sandbox.appendingPathComponent("Library/Application Support/com.dinoki.osaurus")
+        let active = sandbox.appendingPathComponent(".osaurus")
+        defer { try? fm.removeItem(at: sandbox) }
+
+        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
+        try fm.createDirectory(at: active, withIntermediateDirectories: true)
+        let legacyFile = legacy.appendingPathComponent("config.json")
+        let activeFile = active.appendingPathComponent("config.json")
+        try "legacy".write(to: legacyFile, atomically: true, encoding: .utf8)
+        try "active".write(to: activeFile, atomically: true, encoding: .utf8)
+        try fm.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: legacyFile.path
+        )
+        try fm.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: activeFile.path
+        )
+
+        let result = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
+            fileManager: fm,
+            legacyRoot: legacy,
+            activeRoot: active
+        )
+
+        #expect(result == .merged(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
+        #expect(try String(contentsOf: activeFile, encoding: .utf8) == "active")
+        #expect(
+            fm.fileExists(
+                atPath: OsaurusPaths.legacyApplicationSupportMergeMarker(for: active).path
+            )
+        )
     }
 
     @Test("Summary stays one stable line")

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -14,7 +14,7 @@ import Foundation
 public enum OsaurusPaths {
     /// Optional root directory override for tests
     /// Note: nonisolated(unsafe) since this is only set during test setup before any concurrent access
-    public nonisolated(unsafe) static var overrideRoot: URL?
+    nonisolated(unsafe) public static var overrideRoot: URL?
 
     // MARK: - Root Directory
 
@@ -24,23 +24,27 @@ public enum OsaurusPaths {
         let supportDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let oldRoot = supportDir.appendingPathComponent("com.dinoki.osaurus", isDirectory: true)
 
-        // Copy data from old Application Support on first access (never deletes the original).
-        if fm.fileExists(atPath: oldRoot.path) {
-            if !fm.fileExists(atPath: newRoot.path) {
-                do {
-                    try fm.copyItem(at: oldRoot, to: newRoot)
-                    print("[Osaurus] Copied data from \(oldRoot.path) to \(newRoot.path)")
-                    return newRoot
-                } catch {
-                    print("[Osaurus] Copy failed, falling back to merge: \(error)")
-                }
-            }
-            mergeDirectory(from: oldRoot, into: newRoot)
-            print("[Osaurus] Merged data from \(oldRoot.path) into \(newRoot.path)")
-        }
+        _ = migrateLegacyApplicationSupportRootIfNeeded(
+            fileManager: fm,
+            legacyRoot: oldRoot,
+            activeRoot: newRoot
+        )
 
         return newRoot
     }()
+
+    /// Marker written after the legacy Application Support root has been
+    /// copied/merged into `~/.osaurus`. The legacy root is intentionally never
+    /// deleted, so this marker prevents every future launch from re-merging it.
+    public static let legacyApplicationSupportMergeMarkerName =
+        ".legacy-application-support-merge.done"
+
+    enum LegacyApplicationSupportMigrationResult: Equatable {
+        case legacyRootAbsent
+        case alreadyMarked(URL)
+        case copied(URL)
+        case merged(URL)
+    }
 
     /// The root data directory for Osaurus: `~/.osaurus/`
     public static func root() -> URL {
@@ -48,11 +52,16 @@ public enum OsaurusPaths {
             return override
         }
         if let envRoot = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"],
-            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
+            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return URL(fileURLWithPath: envRoot, isDirectory: true)
         }
         return defaultRoot
+    }
+
+    /// Returns the marker path for a resolved root without triggering another
+    /// root lookup when the caller already has one.
+    public static func legacyApplicationSupportMergeMarker(for root: URL) -> URL {
+        root.appendingPathComponent(legacyApplicationSupportMergeMarkerName)
     }
 
     // MARK: - Directory Paths
@@ -162,8 +171,7 @@ public enum OsaurusPaths {
     public static func volumeFreeBytes(forPath path: String) -> Int64? {
         var legacyFree: Int64?
         if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
-        {
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value {
             legacyFree = free
         }
         if let legacyFree, legacyFree > 0 {
@@ -174,8 +182,7 @@ public enum OsaurusPaths {
         var importantCapacity: Int64?
         let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
         if let values = try? url.resourceValues(forKeys: keys),
-            let capacity = values.volumeAvailableCapacityForImportantUsage
-        {
+            let capacity = values.volumeAvailableCapacityForImportantUsage {
             importantCapacity = capacity
         }
         return resolvedVolumeFreeBytes(
@@ -204,13 +211,11 @@ public enum OsaurusPaths {
         let url = URL(fileURLWithPath: path)
         let keys: Set<URLResourceKey> = [.volumeTotalCapacityKey]
         if let values = try? url.resourceValues(forKeys: keys),
-            let capacity = values.volumeTotalCapacity
-        {
+            let capacity = values.volumeTotalCapacity {
             return Int64(capacity)
         }
         if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
-            let total = (attrs[.systemSize] as? NSNumber)?.int64Value
-        {
+            let total = (attrs[.systemSize] as? NSNumber)?.int64Value {
             return total
         }
         return nil
@@ -637,6 +642,72 @@ public enum OsaurusPaths {
     }
 
     // MARK: - Migration
+
+    /// Copies or merges the retired Application Support root into the active
+    /// root once, then writes a marker in the active root. The legacy root is
+    /// left untouched so users can inspect or delete it manually.
+    @discardableResult
+    static func migrateLegacyApplicationSupportRootIfNeeded(
+        fileManager fm: FileManager = .default,
+        legacyRoot oldRoot: URL,
+        activeRoot newRoot: URL
+    ) -> LegacyApplicationSupportMigrationResult {
+        var isLegacyDirectory = ObjCBool(false)
+        guard fm.fileExists(atPath: oldRoot.path, isDirectory: &isLegacyDirectory),
+            isLegacyDirectory.boolValue
+        else {
+            return .legacyRootAbsent
+        }
+
+        let marker = legacyApplicationSupportMergeMarker(for: newRoot)
+        if fm.fileExists(atPath: marker.path) {
+            print("[Osaurus] Legacy data migration already marked at \(marker.path); skipping")
+            return .alreadyMarked(marker)
+        }
+
+        if !fm.fileExists(atPath: newRoot.path) {
+            do {
+                try fm.copyItem(at: oldRoot, to: newRoot)
+                writeLegacyApplicationSupportMergeMarker(
+                    marker,
+                    legacyRoot: oldRoot,
+                    activeRoot: newRoot
+                )
+                print("[Osaurus] Copied data from \(oldRoot.path) to \(newRoot.path)")
+                return .copied(marker)
+            } catch {
+                print("[Osaurus] Copy failed, falling back to merge: \(error)")
+            }
+        }
+
+        mergeDirectory(from: oldRoot, into: newRoot)
+        writeLegacyApplicationSupportMergeMarker(
+            marker,
+            legacyRoot: oldRoot,
+            activeRoot: newRoot
+        )
+        print("[Osaurus] Merged data from \(oldRoot.path) into \(newRoot.path)")
+        return .merged(marker)
+    }
+
+    private static func writeLegacyApplicationSupportMergeMarker(
+        _ marker: URL,
+        legacyRoot: URL,
+        activeRoot: URL
+    ) {
+        let payload = """
+        legacy_application_support_migrated=1
+        legacy_root=\(legacyRoot.path)
+        active_root=\(activeRoot.path)
+
+        """
+        do {
+            try ensureExists(marker.deletingLastPathComponent())
+            try Data(payload.utf8).write(to: marker, options: .atomic)
+        } catch {
+            print("[Osaurus] Failed to write legacy data migration marker \(marker.path): \(error)")
+        }
+    }
 
     /// Recursively copy the contents of `src` into `dest` (never deletes from `src`).
     /// When both source and destination files exist, the newer one wins.

--- a/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
+++ b/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
@@ -89,6 +89,8 @@ public enum StorageLocationStandards {
         public let applicationSupportPath: String?
         public let legacyApplicationSupportRootPath: String?
         public let legacyApplicationSupportRootPresent: Bool
+        public let legacyApplicationSupportMergeMarkerPath: String?
+        public let legacyApplicationSupportMergeMarked: Bool
         public let appleSpecCandidateRootPath: String?
         public let appleSpecCandidateRootPresent: Bool
         public let modelsRootPath: String
@@ -100,6 +102,8 @@ public enum StorageLocationStandards {
             applicationSupportPath: String?,
             legacyApplicationSupportRootPath: String?,
             legacyApplicationSupportRootPresent: Bool,
+            legacyApplicationSupportMergeMarkerPath: String?,
+            legacyApplicationSupportMergeMarked: Bool,
             appleSpecCandidateRootPath: String?,
             appleSpecCandidateRootPresent: Bool,
             modelsRootPath: String
@@ -110,6 +114,8 @@ public enum StorageLocationStandards {
             self.applicationSupportPath = applicationSupportPath
             self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
             self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
+            self.legacyApplicationSupportMergeMarkerPath = legacyApplicationSupportMergeMarkerPath
+            self.legacyApplicationSupportMergeMarked = legacyApplicationSupportMergeMarked
             self.appleSpecCandidateRootPath = appleSpecCandidateRootPath
             self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
             self.modelsRootPath = modelsRootPath
@@ -125,6 +131,8 @@ public enum StorageLocationStandards {
         public let appleSpecCandidateRootPresent: Bool
         public let legacyApplicationSupportRootPath: String?
         public let legacyApplicationSupportRootPresent: Bool
+        public let legacyApplicationSupportMergeMarkerPath: String?
+        public let legacyApplicationSupportMergeMarked: Bool
         public let modelsRootPath: String
         public let modelsRootClassification: ModelsRootClassification
         public let findings: [Finding]
@@ -149,6 +157,8 @@ public enum StorageLocationStandards {
             appleSpecCandidateRootPresent: Bool,
             legacyApplicationSupportRootPath: String?,
             legacyApplicationSupportRootPresent: Bool,
+            legacyApplicationSupportMergeMarkerPath: String?,
+            legacyApplicationSupportMergeMarked: Bool,
             modelsRootPath: String,
             modelsRootClassification: ModelsRootClassification,
             findings: [Finding]
@@ -160,6 +170,8 @@ public enum StorageLocationStandards {
             self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
             self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
             self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
+            self.legacyApplicationSupportMergeMarkerPath = legacyApplicationSupportMergeMarkerPath
+            self.legacyApplicationSupportMergeMarked = legacyApplicationSupportMergeMarked
             self.modelsRootPath = modelsRootPath
             self.modelsRootClassification = modelsRootClassification
             self.findings = findings
@@ -198,14 +210,18 @@ public enum StorageLocationStandards {
             appleSpecCandidateFolderName,
             isDirectory: true
         )
+        let activeRoot = OsaurusPaths.root()
+        let mergeMarker = OsaurusPaths.legacyApplicationSupportMergeMarker(for: activeRoot)
         return Inputs(
-            activeRootPath: OsaurusPaths.root().path,
+            activeRootPath: activeRoot.path,
             rootSource: rootSource,
             homeDirectoryPath: fm.homeDirectoryForCurrentUser.path,
             applicationSupportPath: support?.path,
             legacyApplicationSupportRootPath: legacy?.path,
             legacyApplicationSupportRootPresent: legacy.map { fm.fileExists(atPath: $0.path) }
                 ?? false,
+            legacyApplicationSupportMergeMarkerPath: mergeMarker.path,
+            legacyApplicationSupportMergeMarked: fm.fileExists(atPath: mergeMarker.path),
             appleSpecCandidateRootPath: candidate?.path,
             appleSpecCandidateRootPresent: candidate.map { fm.fileExists(atPath: $0.path) }
                 ?? false,
@@ -276,16 +292,28 @@ public enum StorageLocationStandards {
             let legacyPath =
                 inputs.legacyApplicationSupportRootPath
                 ?? legacyApplicationSupportFolderName
+            let markerPath =
+                inputs.legacyApplicationSupportMergeMarkerPath
+                ?? OsaurusPaths.legacyApplicationSupportMergeMarkerName
+            let severity: Severity = inputs.legacyApplicationSupportMergeMarked ? .info : .warning
+            let message: String
+            if inputs.legacyApplicationSupportMergeMarked {
+                message =
+                    "Legacy root \(legacyPath) still exists, but one-shot migration marker "
+                    + "\(markerPath) is present. OsaurusPaths will not re-merge it into "
+                    + "the active root on future launches."
+            } else {
+                message =
+                    "Legacy root \(legacyPath) still exists and one-shot migration marker "
+                    + "\(markerPath) is missing. OsaurusPaths will copy or merge it into "
+                    + "the active root once, then write the marker so future launches do "
+                    + "not resurrect stale legacy files."
+            }
             findings.append(
                 Finding(
                     code: .legacyApplicationSupportRootPresent,
-                    severity: .warning,
-                    message:
-                        "Legacy root \(legacyPath) still exists. OsaurusPaths re-merges it "
-                        + "into the active root on the first path access of every launch "
-                        + "(newer file wins), which can resurrect files that were since "
-                        + "changed under the active root. A one-shot migration marker is "
-                        + "pending."
+                    severity: severity,
+                    message: message
                 )
             )
         }
@@ -327,6 +355,8 @@ public enum StorageLocationStandards {
             appleSpecCandidateRootPresent: inputs.appleSpecCandidateRootPresent,
             legacyApplicationSupportRootPath: inputs.legacyApplicationSupportRootPath,
             legacyApplicationSupportRootPresent: inputs.legacyApplicationSupportRootPresent,
+            legacyApplicationSupportMergeMarkerPath: inputs.legacyApplicationSupportMergeMarkerPath,
+            legacyApplicationSupportMergeMarked: inputs.legacyApplicationSupportMergeMarked,
             modelsRootPath: inputs.modelsRootPath,
             modelsRootClassification: modelsClassification,
             findings: findings
@@ -347,6 +377,9 @@ public enum StorageLocationStandards {
             "legacy_application_support_root": report.legacyApplicationSupportRootPath as Any?
                 ?? NSNull(),
             "legacy_application_support_root_present": report.legacyApplicationSupportRootPresent,
+            "legacy_application_support_merge_marker":
+                report.legacyApplicationSupportMergeMarkerPath as Any? ?? NSNull(),
+            "legacy_application_support_merge_marked": report.legacyApplicationSupportMergeMarked,
             "models_root": report.modelsRootPath,
             "models_root_classification": report.modelsRootClassification.rawValue,
             "reason_codes": report.reasonCodes,

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -185,12 +185,12 @@ Issue [#1422](https://github.com/osaurus-ai/osaurus/issues/1422) is right: the a
 | Root | Current location | Spec-compliant target |
 |---|---|---|
 | App data | `~/.osaurus/` | `~/Library/Application Support/Osaurus/` |
-| Legacy app data | `~/Library/Application Support/com.dinoki.osaurus/` (merged into `~/.osaurus/` when present; never deleted) | n/a — retired after a one-shot migration marker lands |
+| Legacy app data | `~/Library/Application Support/com.dinoki.osaurus/` (copied/merged once into `~/.osaurus/` when the marker is missing; never deleted) | n/a — retired by `~/.osaurus/.legacy-application-support-merge.done` |
 | Model weights | `~/MLXModels/` (legacy `~/Documents/MLXModels/`, env override, or user-picked folder) | separate decision — weights are user-managed and home-visible by design |
 
 ### The audit surface
 
-`GET /admin/cache-stats` now returns a read-only `storage_locations` block (built by [`StorageLocationStandards`](../Packages/OsaurusCore/Utils/StorageLocationStandards.swift)) reporting: the active root and its classification (`apple_application_support`, `home_dot_directory`, `test_override`, `environment_override`, `custom`), `spec_compliant`, whether the legacy `com.dinoki.osaurus` root still exists, the models root classification, and stable snake_case `reason_codes` with human-readable findings. The audit never creates, copies, moves, or deletes anything.
+`GET /admin/cache-stats` now returns a read-only `storage_locations` block (built by [`StorageLocationStandards`](../Packages/OsaurusCore/Utils/StorageLocationStandards.swift)) reporting: the active root and its classification (`apple_application_support`, `home_dot_directory`, `test_override`, `environment_override`, `custom`), `spec_compliant`, whether the legacy `com.dinoki.osaurus` root still exists, whether the one-shot merge marker is present, the models root classification, and stable snake_case `reason_codes` with human-readable findings. The audit never creates, copies, moves, or deletes anything.
 
 ### Why the root has not moved (yet)
 
@@ -198,7 +198,7 @@ Relocating `~/.osaurus/` is a data-safety decision pending an explicit maintaine
 
 - The Keychain DEK is paired with the existing tree, and the HKDF salt sidecar (`~/.osaurus/.storage-key.salt`) must travel with the data it unlocks (see Key Management above).
 - Sandbox tooling references `~/.osaurus/` literally (e.g. the node workspace path), and plugin/container trees can be many gigabytes — a silent move on upgrade is not acceptable.
-- `OsaurusPaths.defaultRoot` currently **re-merges** a still-present legacy `com.dinoki.osaurus/` root into `~/.osaurus/` on the first path access of every launch (newer file wins), which can resurrect files the user has since changed. Any migration design must first add a one-shot migration marker so this loop ends.
+- `OsaurusPaths.defaultRoot` now consumes a still-present legacy `com.dinoki.osaurus/` root only when `~/.osaurus/.legacy-application-support-merge.done` is missing. The first successful copy/merge writes that marker, and future launches skip the legacy root even if the user leaves it in place.
 
 Until that decision, the contract is: paths resolve exclusively through `OsaurusPaths`, the audit reports reality instead of hiding it, and no code outside `OsaurusPaths` may invent a storage root.
 


### PR DESCRIPTION
## Summary
- add a one-shot `.legacy-application-support-merge.done` marker so the retired `~/Library/Application Support/com.dinoki.osaurus` tree is copied/merged into `~/.osaurus` only once
- expose the marker path/state in the existing `storage_locations` diagnostics returned by `/admin/cache-stats`
- update storage docs and add tests for marker skipping plus the existing newer-file-wins merge behavior

Refs #1422

## Tests
- `git diff --check`
- `swiftlint lint --strict Packages/OsaurusCore/Utils/OsaurusPaths.swift Packages/OsaurusCore/Utils/StorageLocationStandards.swift Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter StorageLocationStandardsTests`
