### PR TITLE
Improve host stdio MCP command resolution

### DIFF
--- a/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
@@ -49,7 +49,7 @@
 
             let mergedEnv = Self.buildEnv(provider: provider)
             let executablePath = try Self.resolveExecutablePath(
-                command: provider.command,
+                command: Self.expandUserPath(provider.command),
                 env: mergedEnv
             )
 
@@ -65,7 +65,10 @@
             // and we surface it in the host logs (which the user can tail).
             process.standardError = FileHandle.standardError
             if let cwd = provider.workingDirectory, !cwd.isEmpty {
-                process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+                process.currentDirectoryURL = URL(
+                    fileURLWithPath: Self.expandUserPath(cwd),
+                    isDirectory: true
+                )
             }
 
             self.process = process
@@ -105,7 +108,7 @@
             if command.contains("/") {
                 return command
             }
-            let searchPath = env["PATH"] ?? "/usr/bin:/bin:/usr/local/bin"
+            let searchPath = executableSearchPath(env: env)
             guard let found = resolveOnPath(command, path: searchPath) else {
                 throw MCPStdioTransportError.commandNotFound(
                     command: command,
@@ -113,6 +116,58 @@
                 )
             }
             return found
+        }
+
+        /// GUI-launched macOS apps often inherit a sparse PATH that misses
+        /// Homebrew, MacPorts, or user-local bins. Keep the user's PATH order
+        /// first, then append safe local command directories so common MCP
+        /// launchers (`npx`, `uvx`, `python`) are discoverable without forcing
+        /// users to paste absolute paths.
+        private static func executableSearchPath(env: [String: String]) -> String {
+            var entries =
+                (env["PATH"]?.isEmpty == false ? env["PATH"] : nil)?
+                .split(separator: ":", omittingEmptySubsequences: true)
+                .map(String.init)
+                ?? []
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            for fallback in [
+                "/opt/homebrew/bin",
+                "/usr/local/bin",
+                "/opt/local/bin",
+                "\(home)/.local/bin",
+                "\(home)/bin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+            ] where !entries.contains(fallback) {
+                entries.append(fallback)
+            }
+            return entries.joined(separator: ":")
+        }
+
+        private static func expandUserPath(_ path: String) -> String {
+            guard path == "~" || path.hasPrefix("~/") else { return path }
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            if path == "~" {
+                return home
+            }
+            return home + String(path.dropFirst())
+        }
+
+        static func executableSearchPathForTesting(env: [String: String]) -> String {
+            executableSearchPath(env: env)
+        }
+
+        static func expandUserPathForTesting(_ path: String) -> String {
+            expandUserPath(path)
+        }
+
+        static func resolveExecutablePathForTesting(
+            command: String,
+            env: [String: String]
+        ) throws -> String {
+            try resolveExecutablePath(command: expandUserPath(command), env: env)
         }
 
         /// Set once a global spawn slot is held so `stop()` releases exactly

--- a/Packages/OsaurusCore/Tests/MCPOAuth/ShellArgsTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/ShellArgsTests.swift
@@ -132,3 +132,56 @@ final class MCPStdioTransportErrorTests: XCTestCase {
         XCTAssertFalse(MCPStdioTransportError.isCommandNotFoundMessage(description))
     }
 }
+
+#if canImport(Darwin)
+    final class MCPStdioHostRunnerPathTests: XCTestCase {
+        func testHostSearchPathAppendsCommonLocalBinFallbacks() throws {
+            let searchPath = MCPStdioHostRunner.executableSearchPathForTesting(
+                env: ["PATH": "/custom/bin:/usr/bin"]
+            )
+            let entries = searchPath.split(separator: ":").map(String.init)
+
+            XCTAssertEqual(entries.first, "/custom/bin")
+            XCTAssertTrue(entries.contains("/opt/homebrew/bin"))
+            XCTAssertTrue(entries.contains("/usr/local/bin"))
+            XCTAssertTrue(entries.contains("/usr/bin"))
+            XCTAssertEqual(entries.filter { $0 == "/usr/bin" }.count, 1)
+        }
+
+        func testHostResolverFindsExecutableOnPath() throws {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-mcp-path-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            defer { try? FileManager.default.removeItem(at: root) }
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let executable = root.appendingPathComponent("fake-mcp")
+            try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executable.path
+            )
+
+            let resolved = try MCPStdioHostRunner.resolveExecutablePathForTesting(
+                command: "fake-mcp",
+                env: ["PATH": root.path]
+            )
+
+            XCTAssertEqual(resolved, executable.path)
+        }
+
+        func testHostResolverExpandsUserPaths() throws {
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+
+            XCTAssertEqual(
+                MCPStdioHostRunner.expandUserPathForTesting("~/bin/mcp-server"),
+                "\(home)/bin/mcp-server"
+            )
+            XCTAssertEqual(MCPStdioHostRunner.expandUserPathForTesting("~"), home)
+            XCTAssertEqual(
+                MCPStdioHostRunner.expandUserPathForTesting("/usr/local/bin/mcp-server"),
+                "/usr/local/bin/mcp-server"
+            )
+        }
+    }
+#endif

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -247,10 +247,12 @@ Research notes for the next local-runtime compatibility wave live in
 
 **Components:**
 
-- `Models/Configuration/MCPProviderConfiguration.swift` — Provider config model (URL, none / bearer / OAuth)
+- `Models/Configuration/MCPProviderConfiguration.swift` — Provider config model (HTTP URL or stdio command, none / bearer / OAuth)
 - `Models/Configuration/MCPProviderTemplate.swift` — Hardcoded catalog of well-known providers
-- `Managers/MCPProviderManager.swift` — HTTP/SSE connection, tool discovery, OAuth refresh & 401 retry
+- `Managers/MCPProviderManager.swift` — HTTP/SSE and stdio connection, tool discovery, OAuth refresh & 401 retry
 - `Services/MCP/MCPProviderKeychain.swift` — Secure token, refresh-token, and client-secret storage
+- `Services/MCP/Stdio/MCPStdioHostTransport.swift` — Host stdio subprocess runner with PATH / `~` command resolution
+- `Services/MCP/Stdio/SandboxStdioRunner.swift` — Sandbox stdio subprocess runner for plugin-imported local MCP servers
 - `Services/MCP/OAuth/MCPOAuthService.swift` — End-to-end OAuth sign-in orchestration
 - `Services/MCP/OAuth/MCPOAuthDiscovery.swift` — RFC 9728 PRM + RFC 8414 ASM discovery (with OIDC fallback)
 - `Services/MCP/OAuth/MCPOAuthRegistration.swift` — RFC 7591 Dynamic Client Registration
@@ -269,8 +271,8 @@ Research notes for the next local-runtime compatibility wave live in
 - Manual-credentials OAuth 2.1 + PKCE for confidential-client vendors that don't publish DCR (HubSpot's MCP Auth Apps), with a fixed-port loopback redirect URI and Keychain-stored client secret
 - API-key templates for vendors without DCR (GitHub, Atlassian, Zapier)
 - Self-hosting templates (Google Workspace) that deeplink to setup docs
-- Custom Server fallback for any URL not in the catalog
-- HTTP/SSE transport for remote providers; no third-party stdio command launching
+- Custom Server fallback for any HTTP/SSE URL or local stdio command not in the catalog
+- HTTP/SSE transport for remote providers plus local stdio command launching on host or in the sandbox
 - Automatic tool discovery on connect, with namespaced tool names (`provider_toolname`)
 - Proactive OAuth token refresh + bounded 401-retry-with-refresh
 - Configurable discovery and execution timeouts
@@ -925,7 +927,7 @@ See [docs/plugins/README.md](plugins/README.md) for the full reference.
 
 - **Unified Plugins tab** — Claude plugins render as cards mixed into the same `Installed` grid as native `PluginCard`s, distinguished by an `Imported` badge; **Skills** tab is now only for user-authored and built-in skills
 - **Marketplace + per-plugin manifest** — Reads both `.claude-plugin/marketplace.json` (legacy flat skill arrays, directory-based, external `url` / `git-subdir` shapes) and `<source>/.claude-plugin/plugin.json` (displayName, version, author, homepage, repository, license, keywords, userConfig)
-- **Five artifact families** — `SKILL.md`, `agents/*.md`, `commands/*.md`, `CLAUDE.md`, `.mcp.json` (HTTP/SSE)
+- **Five artifact families** — `SKILL.md`, `agents/*.md`, `commands/*.md`, `CLAUDE.md`, `.mcp.json` (HTTP/SSE and sandbox stdio)
 - **Plugin id grouping** — Every artifact tagged `github:<owner>/<repo>/<plugin>` so the bundle reinstalls / uninstalls atomically; manifest snapshot persisted at `~/.osaurus/claude-plugins/manifests/<safe-id>.json`
 - **Idempotent re-install + Update flow** — Card and detail view both show an Update capsule when the source's `plugin.json.version` (or marketplace / source SHA) is newer than what's installed; clicking Update calls `ClaudePluginInstaller.install(replaceExisting: true)` to re-fetch and replace the artifact set
 - **`userConfig` prompt sheet** — When `plugin.json` declares `userConfig`, an in-app sheet collects values at install. Non-sensitive values land in `~/.osaurus/claude-plugins/userconfig/<safe-id>.json`; sensitive values go to the macOS Keychain (skipped under `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`)

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -438,10 +438,10 @@ Existing pre-OAuth `mcp.json` files keep working unchanged; missing fields defau
 │  ┌─────────────────────────────────────────────│───────────┐    │
 │  │              MCPProviderManager              │           │    │
 │  │  ┌─────────────────────────────────────────┴────────┐   │    │
-│  │  │       Remote MCP Client (HTTP/SSE only)           │   │    │
+│  │  │       MCP Client (HTTP/SSE + stdio)                │   │    │
 │  │  │     ├── PRM/ASM Discovery                         │   │    │
 │  │  │     ├── DCR + PKCE OAuth flow                     │   │    │
-│  │  │     ├── Loopback callback server                  │   │    │
+│  │  │     ├── Local stdio subprocess runners            │   │    │
 │  │  │     └── Token refresh + 401 retry                 │   │    │
 │  │  └─────────────────────────────────────────┬────────┘   │    │
 │  └─────────────────────────────────────────────│───────────┘    │


### PR DESCRIPTION
## Summary
- Expand `~` in host stdio MCP commands and working directories before launch.
- Preserve the inherited PATH while appending common local binary directories so GUI-launched Osaurus can find MCP launchers like `npx`, `uvx`, and Python-installed tools.
- Update MCP provider docs / feature ledger to reflect current HTTP/SSE plus stdio support.

Refs #416, #587.

## Tests
- `git diff --check`
- `swiftlint lint --strict Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift Packages/OsaurusCore/Tests/MCPOAuth/ShellArgsTests.swift`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ShellArgsTests`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter MCPProviderConfigurationMigrationTests`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter MCPStdioHostRunnerPathTests`
