### PR TITLE
Add tool exposure search diagnostics

### DIFF
--- a/Packages/OsaurusCore/Models/Tool/ToolExposureDiagnostic.swift
+++ b/Packages/OsaurusCore/Models/Tool/ToolExposureDiagnostic.swift
@@ -1,0 +1,55 @@
+//
+//  ToolExposureDiagnostic.swift
+//  osaurus
+//
+//  Typed diagnostics for explaining why a named tool is or is not surfaced by
+//  capability discovery.
+//
+
+import Foundation
+
+enum ToolExposureSearchReasonCode: String, Codable, CaseIterable, Sendable {
+    case searchable
+    case indexed
+    case databaseClosedRegistryFallback = "database_closed_registry_fallback"
+    case excludedCapabilityInfrastructure = "excluded_capability_infrastructure"
+    case runtimeManaged = "runtime_managed"
+    case globallyDisabled = "globally_disabled"
+    case hiddenByAgentScope = "hidden_by_agent_scope"
+    case hiddenByExecutionMode = "hidden_by_execution_mode"
+    case notIndexed = "not_indexed"
+    case notRegistered = "not_registered"
+}
+
+struct ToolExposureDiagnostic: Equatable, Sendable {
+    struct Row: Equatable, Sendable {
+        let toolName: String
+        let availability: ToolAvailability
+        let registered: Bool
+        let globallyEnabled: Bool
+        let indexedForSearch: Bool
+        let searchableByCapabilitiesDiscover: Bool
+        let searchReasonCodes: [ToolExposureSearchReasonCode]
+
+        var compactSummary: String {
+            let searchCodes = searchReasonCodes.map(\.rawValue).joined(separator: ",")
+            return "availability=\(availability.compactSummary); indexed=\(indexedForSearch); searchable=\(searchableByCapabilitiesDiscover); search=\(searchCodes)"
+        }
+    }
+
+    let registeredToolCount: Int
+    let indexedToolCount: Int
+    let rows: [Row]
+
+    var textBlock: String {
+        guard !rows.isEmpty else { return "" }
+        var lines = [
+            "Tool exposure diagnostics:",
+            "registered_tools: \(registeredToolCount), indexed_tools: \(indexedToolCount)",
+        ]
+        for row in rows {
+            lines.append("- tool/\(row.toolName): \(row.compactSummary)")
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
@@ -127,6 +127,143 @@ public actor ToolIndexService {
         await ToolSearchService.shared.search(query: query, topK: topK)
     }
 
+    /// Explain how named tools move through the registry → search index →
+    /// capability-discovery path. This is intentionally read-only: callers
+    /// still enforce loading and execution through `ToolRegistry` and
+    /// `capabilities_load`.
+    func exposureDiagnostic(
+        forToolNames rawNames: [String],
+        agentAllowedNames: Set<String>? = nil,
+        executionMode: ExecutionMode? = nil,
+        selectedPreflightNames: Set<String>? = nil
+    ) async -> ToolExposureDiagnostic {
+        var seen = Set<String>()
+        let names =
+            rawNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+
+        let databaseOpen = ToolDatabase.shared.isOpen
+        let indexedToolCount = (try? ToolDatabase.shared.entryCount()) ?? 0
+        let indexedNames: Set<String> = {
+            guard databaseOpen,
+                let entries = try? ToolDatabase.shared.loadAllEntries()
+            else { return [] }
+            return Set(entries.map(\.name))
+        }()
+
+        struct RegistrySnapshot {
+            let registeredToolCount: Int
+            let registeredNames: Set<String>
+            let enabledNames: Set<String>
+            let runtimeManagedNames: Set<String>
+            let capabilityToolNames: Set<String>
+            let availabilityByName: [String: ToolAvailability]
+        }
+
+        let snapshot = await MainActor.run {
+            let tools = ToolRegistry.shared.listTools()
+            return RegistrySnapshot(
+                registeredToolCount: tools.count,
+                registeredNames: Set(tools.map(\.name)),
+                enabledNames: Set(tools.filter(\.enabled).map(\.name)),
+                runtimeManagedNames: ToolRegistry.shared.runtimeManagedToolNames,
+                capabilityToolNames: ToolRegistry.capabilityToolNames,
+                availabilityByName: Dictionary(
+                    uniqueKeysWithValues: names.map {
+                        (
+                            $0,
+                            ToolRegistry.shared.availability(
+                                forTool: $0,
+                                agentAllowedNames: agentAllowedNames,
+                                executionMode: executionMode,
+                                selectedPreflightNames: selectedPreflightNames
+                            )
+                        )
+                    }
+                )
+            )
+        }
+
+        let rows = names.map { name -> ToolExposureDiagnostic.Row in
+            let registered = snapshot.registeredNames.contains(name)
+            let globallyEnabled = snapshot.enabledNames.contains(name)
+            let indexedForSearch = indexedNames.contains(name)
+            let availability = snapshot.availabilityByName[name]
+                ?? ToolAvailability(
+                    toolName: name,
+                    runtime: nil,
+                    groupName: nil,
+                    reasonCodes: [.notRegistered],
+                    detail: L("tool is not registered; install or enable the plugin/provider that owns it")
+                )
+
+            var blockers: [ToolExposureSearchReasonCode] = []
+            func append(_ reason: ToolExposureSearchReasonCode) {
+                if !blockers.contains(reason) {
+                    blockers.append(reason)
+                }
+            }
+
+            if !registered {
+                append(.notRegistered)
+            }
+            if snapshot.capabilityToolNames.contains(name) {
+                append(.excludedCapabilityInfrastructure)
+            }
+            if snapshot.runtimeManagedNames.contains(name) {
+                append(.runtimeManaged)
+            }
+            if registered, !globallyEnabled {
+                append(.globallyDisabled)
+            }
+            if availability.reasonCodes.contains(.hiddenByAgentScope) {
+                append(.hiddenByAgentScope)
+            }
+            if availability.reasonCodes.contains(.hiddenByExecutionMode) {
+                append(.hiddenByExecutionMode)
+            }
+            if databaseOpen, registered, !indexedForSearch {
+                append(.notIndexed)
+            }
+
+            let hasSearchBlocker = blockers.contains { reason in
+                switch reason {
+                case .indexed, .databaseClosedRegistryFallback, .searchable:
+                    return false
+                default:
+                    return true
+                }
+            }
+            let searchable = registered
+                && !hasSearchBlocker
+                && (!databaseOpen || indexedForSearch)
+
+            var reasons: [ToolExposureSearchReasonCode] = []
+            if searchable {
+                reasons.append(.searchable)
+                reasons.append(databaseOpen ? .indexed : .databaseClosedRegistryFallback)
+            }
+            reasons.append(contentsOf: blockers)
+
+            return ToolExposureDiagnostic.Row(
+                toolName: name,
+                availability: availability,
+                registered: registered,
+                globallyEnabled: globallyEnabled,
+                indexedForSearch: indexedForSearch,
+                searchableByCapabilitiesDiscover: searchable,
+                searchReasonCodes: reasons
+            )
+        }
+
+        return ToolExposureDiagnostic(
+            registeredToolCount: snapshot.registeredToolCount,
+            indexedToolCount: indexedToolCount,
+            rows: rows
+        )
+    }
+
     /// Build a compact text index for injection into system prompt.
     /// Only includes enabled tools from the registry.
     public func buildCompactIndex() async throws -> String {

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -108,6 +108,62 @@ struct CapabilitiesDiscoverToolTests {
         #expect(result.contains("No capabilities found") || result.contains("capability"))
     }
 
+    @Test func namedToolCandidateExtractionIsConservative() {
+        let candidates = CapabilitiesDiscoverTool.namedToolCandidates(
+            in: [
+                "Can I use tool/share_artifact here?",
+                "What about capabilities_discover and zzz_missing_tool?",
+                "plain prose should stay quiet",
+            ],
+            registeredToolNames: ["share_artifact", "capabilities_discover", "notify"]
+        )
+
+        #expect(candidates == ["share_artifact", "capabilities_discover", "zzz_missing_tool"])
+    }
+
+    @Test @MainActor
+    func exposureDiagnosticSeparatesLoadedSearchableAndMissingTools() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let dbWasOpen = ToolDatabase.shared.isOpen
+            if !dbWasOpen {
+                try ToolDatabase.shared.openInMemory()
+            }
+            defer {
+                if !dbWasOpen {
+                    ToolDatabase.shared.close()
+                }
+            }
+
+            await ToolIndexService.shared.syncFromRegistry(rebuildVectorIndex: false)
+            let diagnostic = await ToolIndexService.shared.exposureDiagnostic(
+                forToolNames: [
+                    "share_artifact",
+                    "capabilities_discover",
+                    "zzz_missing_tool",
+                ]
+            )
+            let rows = Dictionary(
+                uniqueKeysWithValues: diagnostic.rows.map { ($0.toolName, $0) }
+            )
+
+            let shareArtifact = try #require(rows["share_artifact"])
+            #expect(shareArtifact.availability.reasonCodes.contains(.alreadyLoaded))
+            #expect(shareArtifact.indexedForSearch)
+            #expect(shareArtifact.searchableByCapabilitiesDiscover)
+            #expect(shareArtifact.searchReasonCodes.contains(.searchable))
+
+            let discover = try #require(rows["capabilities_discover"])
+            #expect(discover.availability.reasonCodes.contains(.alreadyLoaded))
+            #expect(!discover.searchableByCapabilitiesDiscover)
+            #expect(discover.searchReasonCodes.contains(.excludedCapabilityInfrastructure))
+
+            let missing = try #require(rows["zzz_missing_tool"])
+            #expect(missing.availability.reasonCodes == [.notRegistered])
+            #expect(!missing.searchableByCapabilitiesDiscover)
+            #expect(missing.searchReasonCodes.contains(.notRegistered))
+        }
+    }
+
     @Test @MainActor
     func searchFiltersDynamicToolsOutsideAgentGrant() async throws {
         try await StoragePathsTestLock.shared.run {

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -183,7 +183,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
 
         if hits.isEmpty {
             let queryList = queries.map { "'\($0)'" }.joined(separator: ", ")
-            let text: String
+            var text: String
             let pluginCreationAgentId = await Self.resolvePluginCreationAgentId(explicit: agentId)
             if await CapabilitySearch.canCreatePlugins(agentId: pluginCreationAgentId) {
                 text = """
@@ -195,6 +195,12 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
                     """
             } else {
                 text = "No capabilities found matching \(queryList)."
+            }
+            if let diagnostic = await Self.exposureDiagnosticForNamedTools(
+                queries: queries,
+                allowedToolNames: effectiveAllowedToolNames
+            ) {
+                text += "\n\n\(diagnostic.textBlock)"
             }
             return ToolEnvelope.success(tool: name, text: text)
         }
@@ -284,6 +290,64 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         }
     }
 
+    /// When a search misses entirely, surface diagnostics only for tool-like
+    /// names the request explicitly mentioned. This keeps normal semantic
+    /// searches concise while making exact probes such as `tool/sandbox_exec`
+    /// or `capabilities_discover` explain why they did not appear as hits.
+    private static func exposureDiagnosticForNamedTools(
+        queries: [String],
+        allowedToolNames: Set<String>?
+    ) async -> ToolExposureDiagnostic? {
+        let registeredNames = await MainActor.run {
+            Set(ToolRegistry.shared.listTools().map(\.name))
+        }
+        let candidates = namedToolCandidates(
+            in: queries,
+            registeredToolNames: registeredNames
+        )
+        guard !candidates.isEmpty else { return nil }
+        let diagnostic = await ToolIndexService.shared.exposureDiagnostic(
+            forToolNames: candidates,
+            agentAllowedNames: allowedToolNames
+        )
+        return diagnostic.rows.isEmpty ? nil : diagnostic
+    }
+
+    static func namedToolCandidates(
+        in queries: [String],
+        registeredToolNames: Set<String>
+    ) -> [String] {
+        var seen = Set<String>()
+        var candidates: [String] = []
+        let regex = try? NSRegularExpression(
+            pattern: #"(?:tool/)?[A-Za-z0-9_-]{1,64}"#,
+            options: []
+        )
+
+        for query in queries {
+            let range = NSRange(query.startIndex ..< query.endIndex, in: query)
+            let matches = regex?.matches(in: query, options: [], range: range) ?? []
+            for match in matches {
+                guard let swiftRange = Range(match.range, in: query) else { continue }
+                let raw = String(query[swiftRange])
+                let explicitTool = raw.hasPrefix("tool/")
+                let candidate = explicitTool ? String(raw.dropFirst("tool/".count)) : raw
+                let normalized = registeredToolNames.contains(candidate)
+                    ? candidate
+                    : candidate.lowercased()
+                guard explicitTool
+                    || registeredToolNames.contains(normalized)
+                    || candidate.contains("_")
+                    || candidate.contains("-")
+                else { continue }
+                if seen.insert(normalized).inserted {
+                    candidates.append(normalized)
+                }
+            }
+        }
+        return candidates
+    }
+
     /// Accept the template-safe singular `query` spelling plus older
     /// `queries` arrays. This recovery is local to the discovery tool so
     /// other array arguments keep the stricter validator behavior.
@@ -342,8 +406,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
 
         let normalized = trimmed.replacingOccurrences(of: #"<|"|>"#, with: #"""#)
         if let data = normalized.data(using: .utf8),
-            let array = try? JSONSerialization.jsonObject(with: data) as? [String]
-        {
+            let array = try? JSONSerialization.jsonObject(with: data) as? [String] {
             return array
         }
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1011,7 +1011,7 @@ Context management replaces manual per-turn tool selection with a static, sessio
 **Components:**
 
 - `Services/Tool/ToolSearchService.swift` — VecturaKit hybrid search over tools
-- `Services/Tool/ToolIndexService.swift` — Syncs ToolRegistry into searchable index
+- `Services/Tool/ToolIndexService.swift` — Syncs ToolRegistry into searchable index and exposes named-tool diagnostics
 - `Services/Context/CapabilitySearch.swift` — Index-search backend for `capabilities_discover`
 - `Storage/ToolDatabase.swift` — SQLite storage for tool index
 - `Tools/CapabilityTools.swift` — Runtime capability search and load tools
@@ -1026,6 +1026,8 @@ For on-demand discovery during a session, agents can use:
 | `capabilities_load`   | Load a capability by ID into the active session (tools become callable immediately) |
 
 When `capabilities_load` is called, new tool specs are queued in a `CapabilityLoadBuffer` and drained after the invocation. Loaded tools are callable immediately (the registry dispatches by name), but the rendered tool schema stays frozen until the next user turn — hot-patching it mid-run would rewrite the prompt prefix and bust the KV cache. The loaded names persist on the session's tool state, so the next compose includes their full schemas.
+
+When `capabilities_discover` finds no matches for a query that explicitly names a tool, it appends a typed exposure diagnostic for those names: registry availability, global enablement, index presence, and whether capability search can surface the tool. This distinguishes already-loaded built-ins from disabled, agent-hidden, runtime-managed, unindexed, or missing tools without adding new default tools.
 
 **Search Infrastructure:**
 


### PR DESCRIPTION
## Business rationale
When `capabilities_discover` misses, the current response does not tell a maintainer whether a named tool is missing, disabled, hidden by agent scope, excluded from capability search, or already loaded. That makes #823/#789/#647-style reports hard to triage because "tool not found" and "tool was never meant to be loaded through search" look the same. This PR adds typed named-tool exposure diagnostics to the existing search path without adding any new default tools.

## Coding rationale
The change reuses `ToolAvailability` as the source of truth and adds a `ToolExposureDiagnostic` value that combines registry state, global enablement, index presence, and capability-search eligibility. `capabilities_discover` only appends the diagnostic when search otherwise returns no hits and the query explicitly names a tool-like candidate, keeping normal semantic searches quiet. Out of scope: changing search ranking, adding tools, or broadening any agent grant boundary.

## Acceptance criteria
- [x] Named tool probes can distinguish already-loaded built-ins, searchable built-ins, capability infrastructure, and missing tools.
- [x] `capabilities_discover` can surface diagnostics on no-match named-tool queries without changing successful search output.
- [x] No new default tools or widened execution access.

## Quality gate
- [x] `git diff --check`
- [x] `swiftlint lint --strict Packages/OsaurusCore/Models/Tool/ToolExposureDiagnostic.swift Packages/OsaurusCore/Services/Tool/ToolIndexService.swift Packages/OsaurusCore/Tools/CapabilityTools.swift Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift`
- [x] `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter CapabilitiesDiscoverToolTests`
- [x] `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter CapabilitiesLoadToolTests`
- [x] `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ToolIndexServiceTests`
- [x] `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ToolSearchServiceTests`
- [x] Gate head SHA: 2156f85a

## Debug evidence
`CapabilitiesDiscoverToolTests` now covers conservative named-tool extraction and verifies `share_artifact` is already loaded/searchable, `capabilities_discover` is already loaded but excluded from capability search infrastructure, and `zzz_missing_tool` reports `not_registered`.

## Self-review
### Regression review
Changed call sites: `CapabilitiesDiscoverTool.execute` no-hit branch and `ToolIndexService` diagnostics. Successful searches return unchanged output. No execution or loading gate changed; `CapabilitiesLoadToolTests` and existing allowlist tests still pass. The new diagnostic reads registry/database state only.

### Performance review
The no-hit diagnostic path scans registered tool names and reads the tool index only after search returns no hits and the query contains explicit tool-like candidates. Normal successful searches and ordinary prose no-match searches avoid the extra diagnostic work. No new hot-path synchronous I/O was added to successful search or tool execution.

## Rebase notes
No conflicts; branch created from current `origin/main` `26573b24`.

## Rollback
Revert commit `2156f85a`.
