### PR TITLE
Add system prompt injection proof trace

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -10,6 +10,15 @@
 import CryptoKit
 import Foundation
 
+// MARK: - PromptSectionID
+
+/// Stable IDs for sections that other proof and budget paths inspect by name.
+public enum PromptSectionID {
+    public static let platform = "platform"
+    public static let persona = "persona"
+    public static let memory = "memory"
+}
+
 // MARK: - PromptSection
 
 /// One logical block of the system prompt (e.g. base identity, sandbox, memory).
@@ -73,12 +82,12 @@ public struct PromptManifest: Sendable {
 
     /// Tokens from sections that are NOT the memory section.
     public var systemPromptTokens: Int {
-        sections.filter { $0.id != "memory" }.reduce(0) { $0 + $1.estimatedTokens }
+        sections.filter { $0.id != PromptSectionID.memory }.reduce(0) { $0 + $1.estimatedTokens }
     }
 
     /// Tokens from the memory section specifically.
     public var memoryTokens: Int {
-        section("memory")?.estimatedTokens ?? 0
+        section(PromptSectionID.memory)?.estimatedTokens ?? 0
     }
 
     public func section(_ id: String) -> PromptSection? {
@@ -126,13 +135,9 @@ public struct PromptManifest: Sendable {
     }
 
     public func systemPromptInjectionTrace(expectedPrompt: String) -> SystemPromptInjectionTrace {
-        let renderedPrompt = sections
-            .map { $0.content.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
         return systemPromptInjectionTrace(
             expectedPrompt: expectedPrompt,
-            renderedPrompt: renderedPrompt
+            renderedPrompt: PromptRenderer.render(sections)
         )
     }
 
@@ -154,7 +159,7 @@ public struct PromptManifest: Sendable {
             matchingSectionIds: matchingSectionIds,
             staticPrefixContainsExpectedPrompt: staticPrefixContent.contains(expected),
             renderedPromptContainsExpectedPrompt: renderedPrompt.contains(expected),
-            memorySectionContainsExpectedPrompt: section("memory")?.content.contains(expected) == true
+            memorySectionContainsExpectedPrompt: section(PromptSectionID.memory)?.content.contains(expected) == true
         )
     }
 }
@@ -184,7 +189,7 @@ public struct SystemPromptInjectionTrace: Sendable, Equatable {
     }
 
     public var personaSectionContainsExpectedPrompt: Bool {
-        matchingSectionIds.contains("persona")
+        matchingSectionIds.contains(PromptSectionID.persona)
     }
 
     public var passed: Bool {
@@ -218,6 +223,15 @@ public struct SystemPromptInjectionTrace: Sendable, Equatable {
             codes.append("present_in_memory_section")
         }
         return codes
+    }
+}
+
+enum PromptRenderer {
+    static func render(_ sections: [PromptSection]) -> String {
+        sections
+            .map { $0.content.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
     }
 }
 

--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -124,6 +124,101 @@ public struct PromptManifest: Sendable {
         lines.append("  Static prefix:       \(String(format: "%5d", staticPrefixTokens)) (hash: \(hash))")
         return lines.joined(separator: "\n")
     }
+
+    public func systemPromptInjectionTrace(expectedPrompt: String) -> SystemPromptInjectionTrace {
+        let renderedPrompt = sections
+            .map { $0.content.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+        return systemPromptInjectionTrace(
+            expectedPrompt: expectedPrompt,
+            renderedPrompt: renderedPrompt
+        )
+    }
+
+    public func systemPromptInjectionTrace(
+        expectedPrompt: String,
+        renderedPrompt: String
+    ) -> SystemPromptInjectionTrace {
+        let expected = expectedPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !expected.isEmpty else {
+            return SystemPromptInjectionTrace(expectedPromptWasEmpty: true)
+        }
+
+        let matchingSectionIds = sections.compactMap { section in
+            section.content.contains(expected) ? section.id : nil
+        }
+
+        return SystemPromptInjectionTrace(
+            expectedPromptWasEmpty: false,
+            matchingSectionIds: matchingSectionIds,
+            staticPrefixContainsExpectedPrompt: staticPrefixContent.contains(expected),
+            renderedPromptContainsExpectedPrompt: renderedPrompt.contains(expected),
+            memorySectionContainsExpectedPrompt: section("memory")?.content.contains(expected) == true
+        )
+    }
+}
+
+/// Source-level evidence that a configured agent prompt reached the static
+/// system prompt surface. This does not prove a model obeyed the prompt; it
+/// only proves the composer handed the expected text to the runtime path.
+public struct SystemPromptInjectionTrace: Sendable, Equatable {
+    public let expectedPromptWasEmpty: Bool
+    public let matchingSectionIds: [String]
+    public let staticPrefixContainsExpectedPrompt: Bool
+    public let renderedPromptContainsExpectedPrompt: Bool
+    public let memorySectionContainsExpectedPrompt: Bool
+
+    public init(
+        expectedPromptWasEmpty: Bool = false,
+        matchingSectionIds: [String] = [],
+        staticPrefixContainsExpectedPrompt: Bool = false,
+        renderedPromptContainsExpectedPrompt: Bool = false,
+        memorySectionContainsExpectedPrompt: Bool = false
+    ) {
+        self.expectedPromptWasEmpty = expectedPromptWasEmpty
+        self.matchingSectionIds = matchingSectionIds
+        self.staticPrefixContainsExpectedPrompt = staticPrefixContainsExpectedPrompt
+        self.renderedPromptContainsExpectedPrompt = renderedPromptContainsExpectedPrompt
+        self.memorySectionContainsExpectedPrompt = memorySectionContainsExpectedPrompt
+    }
+
+    public var personaSectionContainsExpectedPrompt: Bool {
+        matchingSectionIds.contains("persona")
+    }
+
+    public var passed: Bool {
+        !expectedPromptWasEmpty
+            && personaSectionContainsExpectedPrompt
+            && staticPrefixContainsExpectedPrompt
+            && renderedPromptContainsExpectedPrompt
+    }
+
+    public var reasonCodes: [String] {
+        var codes: [String] = []
+        if expectedPromptWasEmpty {
+            codes.append("empty_expected_prompt")
+        }
+        codes.append(
+            personaSectionContainsExpectedPrompt
+                ? "present_in_persona_section"
+                : "missing_persona_section"
+        )
+        codes.append(
+            staticPrefixContainsExpectedPrompt
+                ? "present_in_static_prefix"
+                : "missing_static_prefix"
+        )
+        codes.append(
+            renderedPromptContainsExpectedPrompt
+                ? "present_in_rendered_prompt"
+                : "missing_rendered_prompt"
+        )
+        if memorySectionContainsExpectedPrompt {
+            codes.append("present_in_memory_section")
+        }
+        return codes
+    }
 }
 
 enum PromptPrefixHasher {
@@ -186,12 +281,12 @@ struct ComposedContext: Sendable {
     /// `SessionToolState.frozenManifest` on first compose so turn 2+ can echo
     /// it back via `ComposeRequest.frozenManifest`, keeping the static
     /// system-prompt prefix byte-identical for KV-cache reuse.
-    var enabledManifest: String? = nil
+    var enabledManifest: String?
     /// Rendered SOUL.md content this compose resolved (or nil outside sandbox
     /// mode / when the file is missing or empty). Callers stash this on
     /// `SessionToolState.frozenSoul` on first compose so turn 2+ can echo it
     /// back via `ComposeRequest.frozenSoul`, so a mid-session SOUL edit can't
     /// rewrite the static prefix (the file's contract: edits apply next
     /// session).
-    var soul: String? = nil
+    var soul: String?
 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -27,10 +27,7 @@ public struct SystemPromptComposer: Sendable {
     }
 
     public func render() -> String {
-        sections
-            .map { $0.content.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
+        PromptRenderer.render(sections)
     }
 
     public func manifest() -> PromptManifest {
@@ -44,13 +41,13 @@ public struct SystemPromptComposer: Sendable {
     public mutating func appendBasePrompt(systemPrompt: String) {
         append(
             .static(
-                id: "platform",
+                id: PromptSectionID.platform,
                 label: L("Platform"),
                 content: SystemPromptTemplates.platformIdentity
             )
         )
         let effective = SystemPromptTemplates.effectivePersona(systemPrompt)
-        append(.static(id: "persona", label: L("Persona"), content: effective))
+        append(.static(id: PromptSectionID.persona, label: L("Persona"), content: effective))
     }
 
     // MARK: - Memory Assembly

--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
@@ -152,7 +152,7 @@ public struct RuntimeProofSystemPromptEvidence: Codable, Sendable, Equatable {
     }
 
     var personaSectionContainsExpectedPrompt: Bool {
-        matchingSectionIds.contains("persona")
+        matchingSectionIds.contains(PromptSectionID.persona)
     }
 
     var provesSourceTrace: Bool {

--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofValidation.swift
@@ -121,6 +121,48 @@ public struct RuntimeProofMediaEvidence: Codable, Sendable, Equatable {
     }
 }
 
+/// Source-side evidence for system-prompt injection proof. A positive source
+/// trace proves only that the configured prompt reached the composed static
+/// prompt. Runtime proof still needs a live model probe on the row itself.
+public struct RuntimeProofSystemPromptEvidence: Codable, Sendable, Equatable {
+    public var sourceTracePassed: Bool
+    public var matchingSectionIds: [String]
+    public var staticPrefixContainsExpectedPrompt: Bool
+    public var renderedPromptContainsExpectedPrompt: Bool
+
+    public init(
+        sourceTracePassed: Bool,
+        matchingSectionIds: [String],
+        staticPrefixContainsExpectedPrompt: Bool,
+        renderedPromptContainsExpectedPrompt: Bool
+    ) {
+        self.sourceTracePassed = sourceTracePassed
+        self.matchingSectionIds = matchingSectionIds
+        self.staticPrefixContainsExpectedPrompt = staticPrefixContainsExpectedPrompt
+        self.renderedPromptContainsExpectedPrompt = renderedPromptContainsExpectedPrompt
+    }
+
+    public init(trace: SystemPromptInjectionTrace) {
+        self.init(
+            sourceTracePassed: trace.passed,
+            matchingSectionIds: trace.matchingSectionIds,
+            staticPrefixContainsExpectedPrompt: trace.staticPrefixContainsExpectedPrompt,
+            renderedPromptContainsExpectedPrompt: trace.renderedPromptContainsExpectedPrompt
+        )
+    }
+
+    var personaSectionContainsExpectedPrompt: Bool {
+        matchingSectionIds.contains("persona")
+    }
+
+    var provesSourceTrace: Bool {
+        sourceTracePassed
+            && personaSectionContainsExpectedPrompt
+            && staticPrefixContainsExpectedPrompt
+            && renderedPromptContainsExpectedPrompt
+    }
+}
+
 /// One row of runtime proof evidence.
 public struct RuntimeProofRow: Codable, Sendable, Equatable {
     public var modelId: String
@@ -137,6 +179,7 @@ public struct RuntimeProofRow: Codable, Sendable, Equatable {
     public var cancellationCleanedUp: Bool
     public var cacheEvidence: RuntimeProofCacheEvidence?
     public var mediaEvidence: RuntimeProofMediaEvidence?
+    public var systemPromptEvidence: RuntimeProofSystemPromptEvidence?
     public var systemPromptProbePassed: Bool
     public var multiTurnCoherent: Bool
     public var parserMarkerLeaks: [String]
@@ -156,6 +199,7 @@ public struct RuntimeProofRow: Codable, Sendable, Equatable {
         cancellationCleanedUp: Bool = false,
         cacheEvidence: RuntimeProofCacheEvidence? = nil,
         mediaEvidence: RuntimeProofMediaEvidence? = nil,
+        systemPromptEvidence: RuntimeProofSystemPromptEvidence? = nil,
         systemPromptProbePassed: Bool = false,
         multiTurnCoherent: Bool = false,
         parserMarkerLeaks: [String] = []
@@ -174,6 +218,7 @@ public struct RuntimeProofRow: Codable, Sendable, Equatable {
         self.cancellationCleanedUp = cancellationCleanedUp
         self.cacheEvidence = cacheEvidence
         self.mediaEvidence = mediaEvidence
+        self.systemPromptEvidence = systemPromptEvidence
         self.systemPromptProbePassed = systemPromptProbePassed
         self.multiTurnCoherent = multiTurnCoherent
         self.parserMarkerLeaks = parserMarkerLeaks
@@ -309,6 +354,14 @@ public enum RuntimeProofValidator {
                     )
                 }
             case .systemPromptInjection:
+                if row.systemPromptEvidence?.provesSourceTrace != true {
+                    issues.append(
+                        blocker(
+                            .systemPromptInjection,
+                            "proven system-prompt rows require source trace into the composed static prompt"
+                        )
+                    )
+                }
                 if !row.systemPromptProbePassed {
                     issues.append(
                         blocker(

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptInjectionTraceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptInjectionTraceTests.swift
@@ -1,0 +1,69 @@
+//
+//  SystemPromptInjectionTraceTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("System prompt injection source trace")
+@MainActor
+struct SystemPromptInjectionTraceTests {
+    @Test("custom agent prompt lands in persona and static prefix")
+    func customAgentPromptLandsInPersonaStaticPrefix() {
+        let expectedPrompt = "TRACE-SYSTEM-PROMPT-\(UUID().uuidString): answer as Gerald"
+        let agentId = UUID()
+        let snapshot = AgentConfigSnapshot(
+            agentId: agentId,
+            toolsDisabled: false,
+            memoryDisabled: true,
+            autonomousConfig: nil,
+            toolMode: .auto,
+            model: nil,
+            manualToolNames: nil,
+            systemPrompt: expectedPrompt,
+            dbEnabled: false
+        )
+        let composer = SystemPromptComposer.forChat(
+            snapshot: snapshot,
+            agentId: agentId,
+            executionMode: .none
+        )
+        let manifest = composer.manifest()
+        let trace = manifest.systemPromptInjectionTrace(
+            expectedPrompt: expectedPrompt,
+            renderedPrompt: composer.render()
+        )
+
+        #expect(trace.passed)
+        #expect(trace.personaSectionContainsExpectedPrompt)
+        #expect(trace.staticPrefixContainsExpectedPrompt)
+        #expect(trace.renderedPromptContainsExpectedPrompt)
+        #expect(!trace.memorySectionContainsExpectedPrompt)
+        #expect(trace.reasonCodes.contains("present_in_persona_section"))
+    }
+
+    @Test("memory-only prompt match does not prove system injection")
+    func memoryOnlyPromptMatchDoesNotPass() {
+        let expectedPrompt = "TRACE-MEMORY-ONLY-\(UUID().uuidString)"
+        var composer = SystemPromptComposer()
+        composer.append(
+            .dynamic(
+                id: "memory",
+                label: "Memory",
+                content: "Remember this test sentinel: \(expectedPrompt)"
+            )
+        )
+        let trace = composer.manifest().systemPromptInjectionTrace(
+            expectedPrompt: expectedPrompt,
+            renderedPrompt: composer.render()
+        )
+
+        #expect(!trace.passed)
+        #expect(trace.memorySectionContainsExpectedPrompt)
+        #expect(!trace.staticPrefixContainsExpectedPrompt)
+        #expect(!trace.personaSectionContainsExpectedPrompt)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptInjectionTraceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptInjectionTraceTests.swift
@@ -37,6 +37,7 @@ struct SystemPromptInjectionTraceTests {
             renderedPrompt: composer.render()
         )
 
+        #expect(manifest.section(PromptSectionID.persona)?.content.contains(expectedPrompt) == true)
         #expect(trace.passed)
         #expect(trace.personaSectionContainsExpectedPrompt)
         #expect(trace.staticPrefixContainsExpectedPrompt)
@@ -45,13 +46,30 @@ struct SystemPromptInjectionTraceTests {
         #expect(trace.reasonCodes.contains("present_in_persona_section"))
     }
 
+    @Test("convenience trace overload uses composer render contract")
+    func convenienceTraceUsesComposerRenderContract() {
+        let expectedPrompt = "TRACE-RENDER-PATH-\(UUID().uuidString)"
+        var composer = SystemPromptComposer()
+        composer.append(.static(id: PromptSectionID.platform, label: "Platform", content: "platform"))
+        composer.append(.static(id: PromptSectionID.persona, label: "Persona", content: "\n\(expectedPrompt)\n"))
+
+        let explicitTrace = composer.manifest().systemPromptInjectionTrace(
+            expectedPrompt: expectedPrompt,
+            renderedPrompt: composer.render()
+        )
+        let convenienceTrace = composer.manifest().systemPromptInjectionTrace(expectedPrompt: expectedPrompt)
+
+        #expect(convenienceTrace == explicitTrace)
+        #expect(convenienceTrace.passed)
+    }
+
     @Test("memory-only prompt match does not prove system injection")
     func memoryOnlyPromptMatchDoesNotPass() {
         let expectedPrompt = "TRACE-MEMORY-ONLY-\(UUID().uuidString)"
         var composer = SystemPromptComposer()
         composer.append(
             .dynamic(
-                id: "memory",
+                id: PromptSectionID.memory,
                 label: "Memory",
                 content: "Remember this test sentinel: \(expectedPrompt)"
             )

--- a/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
@@ -27,7 +27,7 @@ struct RuntimeProofValidationTests {
             finishReason: "stop",
             systemPromptEvidence: RuntimeProofSystemPromptEvidence(
                 sourceTracePassed: true,
-                matchingSectionIds: ["persona"],
+                matchingSectionIds: [PromptSectionID.persona],
                 staticPrefixContainsExpectedPrompt: true,
                 renderedPromptContainsExpectedPrompt: true
             ),
@@ -155,7 +155,7 @@ struct RuntimeProofValidationTests {
             artifactPaths: ["/tmp/osaurus-proof/system-prompt.json"],
             systemPromptEvidence: RuntimeProofSystemPromptEvidence(
                 sourceTracePassed: true,
-                matchingSectionIds: ["persona"],
+                matchingSectionIds: [PromptSectionID.persona],
                 staticPrefixContainsExpectedPrompt: true,
                 renderedPromptContainsExpectedPrompt: true
             ),

--- a/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimeProofValidationTests.swift
@@ -25,6 +25,12 @@ struct RuntimeProofValidationTests {
             tokensPerSecond: 18.4,
             generationTokenCount: 42,
             finishReason: "stop",
+            systemPromptEvidence: RuntimeProofSystemPromptEvidence(
+                sourceTracePassed: true,
+                matchingSectionIds: ["persona"],
+                staticPrefixContainsExpectedPrompt: true,
+                renderedPromptContainsExpectedPrompt: true
+            ),
             systemPromptProbePassed: true,
             multiTurnCoherent: true
         )
@@ -120,6 +126,46 @@ struct RuntimeProofValidationTests {
 
         #expect(!result.isAcceptableForProvenClaim)
         #expect(result.blockers.map(\.requirement).contains(.mediaPayload))
+    }
+
+    @Test("system prompt proof requires source trace evidence")
+    func systemPromptProofRequiresSourceTrace() {
+        let row = RuntimeProofRow(
+            modelId: "local-model",
+            scenario: "configured persona probe",
+            verdict: .proven,
+            requirements: [.systemPromptInjection],
+            artifactPaths: ["/tmp/osaurus-proof/system-prompt.json"],
+            systemPromptProbePassed: true
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.systemPromptInjection))
+    }
+
+    @Test("system prompt source trace alone does not prove live injection")
+    func systemPromptSourceTraceAloneDoesNotPass() {
+        let row = RuntimeProofRow(
+            modelId: "local-model",
+            scenario: "configured persona source trace only",
+            verdict: .proven,
+            requirements: [.systemPromptInjection],
+            artifactPaths: ["/tmp/osaurus-proof/system-prompt.json"],
+            systemPromptEvidence: RuntimeProofSystemPromptEvidence(
+                sourceTracePassed: true,
+                matchingSectionIds: ["persona"],
+                staticPrefixContainsExpectedPrompt: true,
+                renderedPromptContainsExpectedPrompt: true
+            ),
+            systemPromptProbePassed: false
+        )
+
+        let result = RuntimeProofValidator.validate(row)
+
+        #expect(!result.isAcceptableForProvenClaim)
+        #expect(result.blockers.map(\.requirement).contains(.systemPromptInjection))
     }
 
     @Test("failed rows may be preserved with warnings instead of blockers")

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -106,8 +106,12 @@ evidence:
 - `visibleOutput` requires non-empty visible assistant text.
 - `noParserMarkerLeak` rejects visible/runtime marker leaks such as tool-call,
   reasoning, DSML, or streaming sentinel fragments.
-- `multiTurnCoherency` and `systemPromptInjection` require explicit positive
-  probes rather than a single happy-path answer.
+- `multiTurnCoherency` requires an explicit positive follow-up probe rather
+  than a single happy-path answer.
+- `systemPromptInjection` requires both source trace evidence showing the
+  configured agent prompt reached the composed static `persona`/prefix surface
+  and a positive live model probe showing the model obeyed that prompt. Source
+  trace alone is contract coverage, not runtime proof.
 - `ramFootprint` and `cancellation` require physical-footprint and cleanup
   evidence before a RAM or cancel row can be called proven.
 - `cacheHit` applies topology-specific checks: full-attention rows need KV,
@@ -150,7 +154,8 @@ Use `scripts/live-proof/render-runtime-proof-matrix.py` to render the latest
 [`RUNTIME_VALIDATION_STANDARD.md`](RUNTIME_VALIDATION_STANDARD.md). The renderer
 also writes a read-only JSON surface for inspection workflows, and it keeps the
 #903 system-prompt-injection and #1163 Hy3/harmony schema rows `unproven` until
-real live artifacts exist.
+real live artifacts exist. A #903 row needs both the source prompt trace and the
+live probe artifact before it can move to `proven`.
 
 osaurus deliberately does not pass `GenerateParameters.maxKVSize` -- a
 global rotating cache window forced from the app layer conflicted with

--- a/docs/RUNTIME_VALIDATION_STANDARD.md
+++ b/docs/RUNTIME_VALIDATION_STANDARD.md
@@ -14,6 +14,9 @@ real-model run.
   SHA, model bundle path, model revision, and Package.resolved entries.
 - Do not claim speed, cache, or coherence from source reading alone. Source
   tests are contract guards. Runtime claims need logs or benchmark artifacts.
+- Do not close system-prompt injection from source reading alone. A source trace
+  must show the configured agent prompt reached the composed static prompt, and
+  a live model probe must show the selected runtime obeyed it.
 - Keep cache claims topology-specific. "Cache works" is not a valid result.
   Say which cache tier was used and which model cache family was exercised.
 - Test both the direct engine path and the Osaurus app/API path when the change


### PR DESCRIPTION
## Summary
- add a source-level system prompt injection trace on PromptManifest so #903 evidence can show a configured agent prompt reached the static persona/prefix surface
- add RuntimeProofSystemPromptEvidence and require it alongside the existing live prompt probe before a system-prompt row can be marked proven
- document that source trace alone is contract coverage, not runtime proof

## Validation
- git diff --check
- SCRIPT_INPUT_FILE_COUNT=4 ... swiftlint lint --strict --use-script-input-files
- OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter SystemPromptInjectionTraceTests
- OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RuntimeProofValidationTests

Refs #903