### PR TITLE
Fix pasted provider model-list URLs

### DIFF
--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderEndpointPasteTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderEndpointPasteTests.swift
@@ -1,0 +1,54 @@
+//
+//  RemoteProviderEndpointPasteTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Remote provider endpoint paste")
+struct RemoteProviderEndpointPasteTests {
+    @Test func lemonadeModelsURLPasteKeepsApiV1AsBasePath() throws {
+        let components = try #require(
+            parsePastedEndpoint("http://172.16.6.146:8000/api/v1/models")
+        )
+
+        #expect(components.providerProtocol == .http)
+        #expect(components.host == "172.16.6.146")
+        #expect(components.port == 8000)
+        #expect(components.basePath == "/api/v1")
+
+        let provider = RemoteProvider(
+            name: "Lemonade",
+            host: components.host,
+            providerProtocol: components.providerProtocol ?? .https,
+            port: components.port,
+            basePath: components.basePath ?? "/v1",
+            authType: .none,
+            providerType: .openaiLegacy
+        )
+
+        #expect(provider.url(for: "/models")?.absoluteString == "http://172.16.6.146:8000/api/v1/models")
+    }
+
+    @Test func chatCompletionsPasteKeepsV1AsBasePath() throws {
+        let components = try #require(
+            parsePastedEndpoint("https://api.example.test/v1/chat/completions")
+        )
+
+        #expect(components.providerProtocol == .https)
+        #expect(components.host == "api.example.test")
+        #expect(components.port == nil)
+        #expect(components.basePath == "/v1")
+    }
+
+    @Test func baseURLPasteKeepsPathWhenNoOperationEndpointIsPresent() throws {
+        let components = try #require(
+            parsePastedEndpoint("https://api.example.test/openai/v1")
+        )
+
+        #expect(components.basePath == "/openai/v1")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -183,6 +183,77 @@ struct RemoteProviderModelDiscoveryTests {
         #expect(models == ["Cogito-v2-llama-109B-MoE-GGUF", "Devstral-Small-2507-GGUF"])
     }
 
+    @Test func lemonadeIssuePayload_parsesMixedRecipesAndMissingSize() throws {
+        let provider = makeProvider(basePath: "/api/v1")
+        let body = Data(
+            """
+            {
+              "object": "list",
+              "data": [
+                {
+                  "checkpoint": "black-forest-labs/FLUX.2-klein-4B:flux-2-klein-4b.safetensors",
+                  "checkpoints": {
+                    "main": "black-forest-labs/FLUX.2-klein-4B:flux-2-klein-4b.safetensors",
+                    "text_encoder": "Comfy-Org/vae-text-encorder-for-flux-klein-4b:split_files/text_encoders/qwen_3_4b.safetensors",
+                    "vae": "Comfy-Org/vae-text-encorder-for-flux-klein-4b:split_files/vae/flux2-vae.safetensors"
+                  },
+                  "created": 1234567890,
+                  "downloaded": true,
+                  "id": "Flux-2-Klein-4B",
+                  "image_defaults": {"cfg_scale": 1.0, "height": 1024, "steps": 4, "width": 1024},
+                  "labels": ["image"],
+                  "object": "model",
+                  "owned_by": "lemonade",
+                  "recipe": "sd-cpp",
+                  "recipe_options": {"cfg_scale": 1.0, "height": 1024, "steps": 4, "width": 1024},
+                  "size": 16.0,
+                  "suggested": true
+                },
+                {
+                  "checkpoint": "",
+                  "checkpoints": {"main": ""},
+                  "composite_models": ["gpt-oss-20b-mxfp4-GGUF", "SDXL-Turbo"],
+                  "created": 1234567890,
+                  "downloaded": true,
+                  "id": "Lemonade Medium",
+                  "labels": [],
+                  "object": "model",
+                  "owned_by": "lemonade",
+                  "recipe": "experience",
+                  "recipe_options": {},
+                  "suggested": false
+                },
+                {
+                  "checkpoint": "ggerganov/whisper.cpp:ggml-large-v3-turbo.bin",
+                  "checkpoints": {
+                    "main": "ggerganov/whisper.cpp:ggml-large-v3-turbo.bin",
+                    "npu_cache": "amd/whisper-large-turbo-onnx-npu:ggml-large-v3-turbo-encoder-vitisai.rai"
+                  },
+                  "created": 1234567890,
+                  "downloaded": true,
+                  "id": "Whisper-Large-v3-Turbo",
+                  "labels": ["audio", "transcription", "hot"],
+                  "object": "model",
+                  "owned_by": "lemonade",
+                  "recipe": "whispercpp",
+                  "recipe_options": {},
+                  "size": 1.55,
+                  "suggested": true
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let models = try RemoteProviderService.decodeOpenAICompatibleModelsResponse(
+            data: body,
+            statusCode: 200,
+            provider: provider
+        )
+
+        #expect(models == ["Flux-2-Klein-4B", "Lemonade Medium", "Whisper-Large-v3-Turbo"])
+    }
+
     private func makeProvider(
         providerProtocol: RemoteProviderProtocol = .https,
         port: Int? = nil,

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -33,7 +33,7 @@ private func parseManualModelIds(_ text: String) -> [String] {
 /// Endpoint components recovered from a full URL pasted into a host field,
 /// so users can paste e.g. "https://api.example.com:8443/v1" and have the
 /// protocol, host, port, and base path fields filled in automatically.
-private struct PastedEndpointComponents {
+struct PastedEndpointComponents {
     var providerProtocol: RemoteProviderProtocol?
     var host: String
     var port: Int?
@@ -43,13 +43,13 @@ private struct PastedEndpointComponents {
 /// Only restructure input that was pasted (multi-character change) or that
 /// carries an explicit scheme; never mangle text the user is typing out
 /// character by character.
-private func shouldSplitHostInput(previous: String, value: String) -> Bool {
+func shouldSplitHostInput(previous: String, value: String) -> Bool {
     value.contains("://") || (value.count - previous.count > 1 && (value.contains("/") || value.contains(":")))
 }
 
 /// Parses host-field input that looks like a full URL. Returns nil when the
 /// text is already a bare host so callers leave their state untouched.
-private func parsePastedEndpoint(_ text: String) -> PastedEndpointComponents? {
+func parsePastedEndpoint(_ text: String) -> PastedEndpointComponents? {
     var remainder = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !remainder.isEmpty else { return nil }
 
@@ -76,14 +76,13 @@ private func parsePastedEndpoint(_ text: String) -> PastedEndpointComponents? {
         var path = String(remainder[slash...])
         remainder = String(remainder[..<slash])
         while path.count > 1 && path.hasSuffix("/") { path.removeLast() }
-        if path != "/" { basePath = path }
+        basePath = normalizedPastedProviderBasePath(from: path)
     }
 
     var port: Int?
     if let colon = remainder.lastIndex(of: ":"),
         // Don't treat colons inside an IPv6 literal ("[::1]") as a port separator.
-        remainder.lastIndex(of: "]").map({ colon > $0 }) ?? true
-    {
+        remainder.lastIndex(of: "]").map({ colon > $0 }) ?? true {
         port = Int(remainder[remainder.index(after: colon)...])
         remainder = String(remainder[..<colon])
     }
@@ -91,6 +90,23 @@ private func parsePastedEndpoint(_ text: String) -> PastedEndpointComponents? {
     let host = remainder.trimmingCharacters(in: .whitespaces)
     guard !host.isEmpty else { return nil }
     return PastedEndpointComponents(providerProtocol: providerProtocol, host: host, port: port, basePath: basePath)
+}
+
+private func normalizedPastedProviderBasePath(from path: String) -> String? {
+    guard path != "/" else { return nil }
+
+    let operationSuffixes = [
+        "/chat/completions",
+        "/responses",
+        "/messages",
+        "/models",
+    ]
+    for suffix in operationSuffixes where path == suffix || path.hasSuffix(suffix) {
+        let base = String(path.dropLast(suffix.count))
+        return base.isEmpty ? "" : base
+    }
+
+    return path
 }
 
 // MARK: - Main View
@@ -482,8 +498,7 @@ private struct AddProviderFlow: View {
 
                     // Help section
                     if let preset = selectedPreset, preset.isKnown, !preset.consoleURL.isEmpty,
-                        shouldShowKnownAPIKeyField
-                    {
+                        shouldShowKnownAPIKeyField {
                         helpSection(for: preset)
                     }
 


### PR DESCRIPTION
## Summary
- strip known operation endpoints when a full provider URL is pasted into the host field, so Lemonade `http://host:8000/api/v1/models` stores `/api/v1` instead of `/api/v1/models`
- add endpoint-paste regression tests for `/models` and `/chat/completions` URLs
- add a representative Lemonade mixed model-list fixture from #615 with extra metadata and missing `size` fields

## Validation
- `git diff --check`
- `SCRIPT_INPUT_FILE_COUNT=1 SCRIPT_INPUT_FILE_0=Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift swiftlint lint --strict --use-script-input-files`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RemoteProviderEndpointPasteTests`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RemoteProviderModelDiscoveryTests`

Refs #615