### PR TITLE
Add Codex OAuth diagnostic context

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -10918,6 +10918,22 @@
         }
       }
     },
+    "Codex subscription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Codex-Abonnement"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Codex 订阅"
+          }
+        }
+      }
+    },
     "Coding" : {
       "localizations" : {
         "de" : {
@@ -12892,6 +12908,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制探测结果并检查提供者日志。"
+          }
+        }
+      }
+    },
+    "Copy diagnostics after a failed sign-in attempt and include this row in the issue." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kopiere die Diagnosedaten nach einem fehlgeschlagenen Anmeldeversuch und füge diese Zeile in das Issue ein."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "登录尝试失败后复制诊断信息，并在问题中包含此行。"
           }
         }
       }
@@ -32708,6 +32740,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "OAuth"
+          }
+        }
+      }
+    },
+    "OAuth context" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OAuth-Kontext"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OAuth 上下文"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -88,21 +88,34 @@ public enum ProviderNetworkDiagnostics {
         apiKeyPresent: Bool,
         oauthTokensPresent: Bool
     ) -> ProviderDiagnosticReport {
-        ProviderDiagnosticReport(
-            title: "Remote provider diagnostics",
-            subtitle: "\(provider.name) | \(provider.displayEndpoint)",
-            rows: [
-                remoteStateRow(provider: provider, state: state),
-                remoteAuthRow(
-                    provider: provider,
-                    state: state,
-                    apiKeyPresent: apiKeyPresent,
-                    oauthTokensPresent: oauthTokensPresent
-                ),
+        var rows = [
+            remoteStateRow(provider: provider, state: state),
+            remoteAuthRow(
+                provider: provider,
+                state: state,
+                apiKeyPresent: apiKeyPresent,
+                oauthTokensPresent: oauthTokensPresent
+            ),
+        ]
+        if let oauthContext = remoteOAuthContextRow(
+            provider: provider,
+            state: state,
+            oauthTokensPresent: oauthTokensPresent
+        ) {
+            rows.append(oauthContext)
+        }
+        rows.append(
+            contentsOf: [
                 remoteModelDiscoveryRow(provider: provider),
                 remoteRequestFormatRow(provider: provider),
                 proxyRow(proxy, appliesTo: "Remote provider requests"),
             ]
+        )
+
+        return ProviderDiagnosticReport(
+            title: "Remote provider diagnostics",
+            subtitle: "\(provider.name) | \(provider.displayEndpoint)",
+            rows: rows
         )
     }
 
@@ -353,6 +366,36 @@ public enum ProviderNetworkDiagnostics {
                 detail: L("Fetches the signed router /models endpoint and hides stale prices.")
             )
         }
+    }
+
+    private static func remoteOAuthContextRow(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        oauthTokensPresent: Bool
+    ) -> ProviderDiagnosticRow? {
+        guard provider.authType == .openAICodexOAuth || provider.providerType == .openAICodex else {
+            return nil
+        }
+
+        var details = [
+            "providerType=\(provider.providerType.rawValue)",
+            "authType=\(provider.authType.rawValue)",
+            "redirectURI=\(OpenAICodexOAuthService.redirectURI)",
+            "callbackPort=1455",
+            "tokens=\(oauthTokensPresent ? "present" : "missing")",
+        ]
+        if let error = state?.lastError, !error.isEmpty {
+            details.append("lastError=\(safeDiagnostic(error))")
+        }
+
+        return ProviderDiagnosticRow(
+            id: "oauth-context",
+            title: L("OAuth context"),
+            value: L("Codex subscription"),
+            severity: oauthTokensPresent ? .info : .warning,
+            detail: details.joined(separator: "; "),
+            action: L("Copy diagnostics after a failed sign-in attempt and include this row in the issue.")
+        )
     }
 
     private static func remoteRequestFormatRow(provider: RemoteProvider) -> ProviderDiagnosticRow {

--- a/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift
@@ -29,7 +29,36 @@ struct ProviderNetworkDiagnosticsTests {
         #expect(auth.severity == .blocked)
         #expect(auth.value == L("ChatGPT sign-in required"))
         #expect(report.pasteboardText.contains(L("ChatGPT sign-in required")))
+
+        let oauth = row("oauth-context", in: report)
+        #expect(oauth.severity == .warning)
+        #expect(oauth.value == L("Codex subscription"))
+        #expect(oauth.detail?.contains("providerType=openAICodex") == true)
+        #expect(oauth.detail?.contains("authType=openAICodexOAuth") == true)
+        #expect(oauth.detail?.contains("redirectURI=http://localhost:1455/auth/callback") == true)
+        #expect(oauth.detail?.contains("callbackPort=1455") == true)
+        #expect(oauth.detail?.contains("tokens=missing") == true)
         #expect(!report.pasteboardText.contains("secret-token"))
+    }
+
+    @Test func codexOAuthReportShowsSignedInContextWithoutSecrets() {
+        let provider = OpenAICodexOAuthService.makeProvider(id: UUID())
+        var state = RemoteProviderState(providerId: provider.id)
+        state.lastError = #"previous callback code=secret-code"#
+
+        let report = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: .disabled,
+            apiKeyPresent: false,
+            oauthTokensPresent: true
+        )
+
+        let oauth = row("oauth-context", in: report)
+        #expect(oauth.severity == .info)
+        #expect(oauth.detail?.contains("tokens=present") == true)
+        #expect(oauth.detail?.contains("lastError=previous callback code=***") == true)
+        #expect(!report.pasteboardText.contains("secret-code"))
     }
 
     @Test func xaiOAuthReportFlagsMissingTokensWithoutLeakingSecrets() {


### PR DESCRIPTION
## Summary
- add a copyable Codex OAuth context row to remote provider diagnostics
- include provider/auth type, fixed redirect URI, callback port, token-presence state, and sanitized last error for subscription sign-in reports
- add regression coverage that the diagnostic row is present and does not leak OAuth callback secrets

## Why
Issue #1225 is still missing actionable repro logs for a ChatGPT/Codex subscription sign-in failure. This does not claim live OAuth is fixed; it makes the diagnostics report include the exact callback/auth context maintainers need after a failed sign-in attempt.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `SCRIPT_INPUT_FILE_COUNT=2 SCRIPT_INPUT_FILE_0=Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift SCRIPT_INPUT_FILE_1=Packages/OsaurusCore/Tests/Provider/ProviderNetworkDiagnosticsTests.swift swiftlint lint --strict --use-script-input-files`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ProviderNetworkDiagnosticsTests`

Refs #1225