### PR TITLE
Route OAuth requests through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -307,8 +307,7 @@ public enum OpenAICodexOAuthService {
     }
 
     public static func exchangeAuthorizationCode(_ code: String, verifier: String) async throws
-        -> RemoteProviderOAuthTokens
-    {
+        -> RemoteProviderOAuthTokens {
         try await requestTokens(
             form: [
                 "grant_type": "authorization_code",
@@ -365,7 +364,7 @@ public enum OpenAICodexOAuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
         } catch {
             let message = "Network error: \(error.localizedDescription)"
             switch operation {

--- a/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift
@@ -170,7 +170,7 @@ public enum OpenRouterOAuthService {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .osaurusCanonical)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw OpenRouterOAuthError.invalidKeyResponse
         }

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -257,7 +257,7 @@ public enum XAIOAuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
         } catch {
             throw XAIOAuthError.discoveryFailed("Network error: \(error.localizedDescription)")
         }
@@ -359,7 +359,7 @@ public enum XAIOAuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
         } catch {
             throw XAIOAuthError.tokenRequestFailed("Network error: \(error.localizedDescription)")
         }

--- a/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/GlobalProxyConfigurationTests.swift
@@ -139,6 +139,45 @@ struct GlobalProxyConfigurationTests {
         }
     }
 
+    @Test func sharedSessionRebuildsWhenPersistedProxyChanges() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-shared-proxy-session-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                _ = GlobalProxySettings.sharedSession()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "http://proxy-a.example.com:8080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let first = GlobalProxySettings.sharedSession()
+            #expect(
+                first.configuration.connectionProxyDictionary?[key(kCFNetworkProxiesHTTPProxy)] as? String
+                    == "proxy-a.example.com"
+            )
+
+            configuration.globalProxyURL = "socks5://proxy-b.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let second = GlobalProxySettings.sharedSession()
+            #expect(first !== second)
+            #expect(
+                second.configuration.connectionProxyDictionary?[key(kCFNetworkProxiesSOCKSProxy)] as? String
+                    == "proxy-b.example.com"
+            )
+            #expect(second.configuration.connectionProxyDictionary?[key(kCFNetworkProxiesHTTPProxy)] == nil)
+        }
+    }
+
     @Test func rejectsUnsafeProxyURLInput() {
         let cases: [(String, GlobalProxyConfiguration.ValidationError)] = [
             ("", .empty),


### PR DESCRIPTION
## Summary
- route external Codex, OpenRouter, and xAI OAuth HTTP requests through GlobalProxySettings.sharedSession()
- keep local loopback callback traffic direct; only external discovery/token/key-exchange calls are changed
- add a proxy-session regression test proving the shared session rebuilds when the persisted proxy URL changes

## Why
#1091/#232 ask for global proxy coverage for all network access. Provider/model traffic was already mostly proxy-aware, but external OAuth sign-in requests still used URLSession.shared and bypassed the persisted proxy endpoint.

## Validation
- `git diff --check`
- `SCRIPT_INPUT_FILE_COUNT=3 SCRIPT_INPUT_FILE_0=Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift SCRIPT_INPUT_FILE_1=Packages/OsaurusCore/Services/Provider/OpenRouterOAuthService.swift SCRIPT_INPUT_FILE_2=Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift swiftlint lint --strict --use-script-input-files`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter 'GlobalProxyConfigurationTests|OpenAICodexOAuthServiceTests|OpenRouterOAuthServiceTests|XAIOAuthServiceTests'`\n\nRefs #1091\nRefs #232