### PR TITLE
Add configurable Hugging Face cache path

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -10123,6 +10123,22 @@
         }
       }
     },
+    "Choose Hugging Face cache folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hugging-Face-Cache-Ordner auswählen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "选择 Hugging Face 缓存文件夹"
+          }
+        }
+      }
+    },
     "Choose how much to add. You'll finish payment in your browser." : {
       "comment" : "Subtitle of the add-credits amount picker sheet.",
       "localizations" : {
@@ -56172,6 +56188,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用你的 ChatGPT Plus/Pro 订阅。"
+          }
+        }
+      }
+    },
+    "Use default Hugging Face cache locations" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Standard-Hugging-Face-Cache-Orte verwenden"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "使用默认 Hugging Face 缓存位置"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -110,6 +110,7 @@ enum ExternalModelLocator {
 
     static let importHFCacheDefaultsKey = "ExternalModelImportHFCache"
     static let importLMStudioDefaultsKey = "ExternalModelImportLMStudio"
+    static let customHFCachePathDefaultsKey = "ExternalModelCustomHFCachePath"
 
     /// Both sources default ON so models from other tools are picked up
     /// automatically — the explicitly-requested "use models in all
@@ -119,6 +120,12 @@ enum ExternalModelLocator {
     }
     static var isLMStudioImportEnabled: Bool {
         UserDefaults.standard.object(forKey: importLMStudioDefaultsKey) as? Bool ?? true
+    }
+
+    static var customHFCachePath: String? {
+        let raw = UserDefaults.standard.string(forKey: customHFCachePathDefaultsKey) ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     // MARK: - Registry state
@@ -292,7 +299,9 @@ enum ExternalModelLocator {
         }
 
         if isHFCacheImportEnabled {
-            reports.append(contentsOf: huggingFaceCacheRoots().map(scanHuggingFaceCacheReport(root:)))
+            reports.append(
+                contentsOf: huggingFaceCacheRoots().map(scanHuggingFaceCacheReport(root:))
+            )
         }
         if isLMStudioImportEnabled {
             reports.append(contentsOf: lmStudioRoots().map { scanReport(root: $0, source: .lmStudio) })
@@ -302,28 +311,51 @@ enum ExternalModelLocator {
 
     // MARK: - Roots
 
-    private static func huggingFaceCacheRoots() -> [URL] {
-        let fm = FileManager.default
-        let env = ProcessInfo.processInfo.environment
+    static func huggingFaceCacheRoots(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        customPath: String? = ExternalModelLocator.customHFCachePath,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> [URL] {
         var roots: [URL] = []
-        func add(_ url: URL) {
+
+        func add(_ url: URL, requireExisting: Bool = true) {
             let standardized = url.standardizedFileURL
+            if requireExisting, !fileExists(standardized.path) { return }
             if !roots.contains(standardized) { roots.append(standardized) }
         }
-        if let hubCache = env["HF_HUB_CACHE"], !hubCache.isEmpty {
-            add(URL(fileURLWithPath: (hubCache as NSString).expandingTildeInPath, isDirectory: true))
+
+        if let customPath {
+            add(Self.fileURL(fromUserPath: customPath, homeDirectory: homeDirectory), requireExisting: false)
         }
-        if let hfHome = env["HF_HOME"], !hfHome.isEmpty {
+        if let hubCache = environment["HF_HUB_CACHE"], !hubCache.isEmpty {
+            add(Self.fileURL(fromUserPath: hubCache, homeDirectory: homeDirectory))
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.isEmpty {
             add(
-                URL(fileURLWithPath: (hfHome as NSString).expandingTildeInPath, isDirectory: true)
+                Self.fileURL(fromUserPath: hfHome, homeDirectory: homeDirectory)
                     .appendingPathComponent("hub", isDirectory: true)
             )
         }
         add(
-            fm.homeDirectoryForCurrentUser
+            homeDirectory
                 .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
         )
-        return roots.filter { fm.fileExists(atPath: $0.path) }
+        return roots
+    }
+
+    private static func fileURL(fromUserPath path: String, homeDirectory: URL) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "~" {
+            return homeDirectory
+        }
+        if trimmed.hasPrefix("~/") {
+            return homeDirectory.appendingPathComponent(String(trimmed.dropFirst(2)), isDirectory: true)
+        }
+        return URL(
+            fileURLWithPath: (trimmed as NSString).expandingTildeInPath,
+            isDirectory: true
+        )
     }
 
     private static func lmStudioRoots() -> [URL] {

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -53,6 +53,72 @@ struct ExternalModelLocatorTests {
         #expect(ExternalModelLocator.repoId(fromCacheFolder: "random") == nil)
     }
 
+    @Test func huggingFaceCacheRoots_includesCustomPathEvenWhenMissing() {
+        let home = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let custom = home.appendingPathComponent("external-hf/hub", isDirectory: true)
+
+        let roots = ExternalModelLocator.huggingFaceCacheRoots(
+            environment: [:],
+            homeDirectory: home,
+            customPath: custom.path,
+            fileExists: { _ in false }
+        )
+
+        #expect(roots == [custom.standardizedFileURL])
+    }
+
+    @Test func huggingFaceCacheRoots_expandsTildeAgainstHomeAndDeduplicatesDefault() {
+        let home = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let defaultRoot = home.appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+        try? FileManager.default.createDirectory(at: defaultRoot, withIntermediateDirectories: true)
+
+        let roots = ExternalModelLocator.huggingFaceCacheRoots(
+            environment: [:],
+            homeDirectory: home,
+            customPath: "~/.cache/huggingface/hub",
+            fileExists: { $0 == defaultRoot.standardizedFileURL.path }
+        )
+
+        #expect(roots == [defaultRoot.standardizedFileURL])
+    }
+
+    @Test func huggingFaceCacheRoots_prefersCustomBeforeEnvironmentAndDefaultRoots() {
+        let home = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let custom = home.appendingPathComponent("custom-hf/hub", isDirectory: true)
+        let envHub = home.appendingPathComponent("env-hub", isDirectory: true)
+        let envHomeHub = home.appendingPathComponent("env-home/hub", isDirectory: true)
+        let defaultRoot = home.appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+        for root in [custom, envHub, envHomeHub, defaultRoot] {
+            try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+
+        let roots = ExternalModelLocator.huggingFaceCacheRoots(
+            environment: [
+                "HF_HUB_CACHE": envHub.path,
+                "HF_HOME": home.appendingPathComponent("env-home", isDirectory: true).path,
+            ],
+            homeDirectory: home,
+            customPath: custom.path,
+            fileExists: { path in
+                [custom, envHub, envHomeHub, defaultRoot]
+                    .map { $0.standardizedFileURL.path }
+                    .contains(path)
+            }
+        )
+
+        #expect(
+            roots == [
+                custom.standardizedFileURL,
+                envHub.standardizedFileURL,
+                envHomeHub.standardizedFileURL,
+                defaultRoot.standardizedFileURL,
+            ]
+        )
+    }
+
     // MARK: - Bundle validation
 
     @Test func isMLXBundle_acceptsSafetensorsBundle() {

--- a/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
@@ -19,10 +19,14 @@ struct ExternalModelsSettingsView: View {
     @AppStorage(ExternalModelLocator.importLMStudioDefaultsKey)
     private var importLMStudio: Bool = true
 
+    @AppStorage(ExternalModelLocator.customHFCachePathDefaultsKey)
+    private var customHFCachePath: String = ""
+
     @State private var hfCount: Int = 0
     @State private var lmStudioCount: Int = 0
     @State private var scanReport: ExternalModelLocator.ScanReport?
     @State private var isScanning: Bool = false
+    @State private var showHFCachePicker: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -41,6 +45,10 @@ struct ExternalModelsSettingsView: View {
                 badge: importHFCache && hfCount > 0 ? "\(hfCount)" : nil,
                 isOn: $importHFCache
             )
+
+            if importHFCache {
+                hfCachePathControl
+            }
 
             SettingsToggle(
                 title: L("LM Studio"),
@@ -106,9 +114,82 @@ struct ExternalModelsSettingsView: View {
         .onAppear { refreshCounts() }
         .onChange(of: importHFCache) { _, _ in rescan() }
         .onChange(of: importLMStudio) { _, _ in rescan() }
+        .onChange(of: customHFCachePath) { _, _ in refreshCounts() }
         .onReceive(NotificationCenter.default.publisher(for: .localModelsChanged)) { _ in
             refreshCounts()
         }
+        .fileImporter(
+            isPresented: $showHFCachePicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
+                customHFCachePath = url.path
+                rescan()
+            }
+        }
+    }
+
+    private var hfCachePathControl: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("HF cache path", bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+
+            HStack(spacing: 8) {
+                TextField(defaultHFCacheDisplayPath, text: $customHFCachePath)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .onSubmit { rescan() }
+
+                Button(
+                    action: { showHFCachePicker = true },
+                    label: {
+                        Image(systemName: "folder.badge.gearshape")
+                            .font(.system(size: 11, weight: .semibold))
+                            .frame(width: 22, height: 22)
+                    }
+                )
+                .buttonStyle(.plain)
+                .localizedHelp("Choose Hugging Face cache folder")
+
+                if !customHFCachePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button(
+                        action: {
+                            customHFCachePath = ""
+                            rescan()
+                        },
+                        label: {
+                            Image(systemName: "arrow.counterclockwise")
+                                .font(.system(size: 11, weight: .semibold))
+                                .frame(width: 22, height: 22)
+                        }
+                    )
+                    .buttonStyle(.plain)
+                    .localizedHelp("Use default Hugging Face cache locations")
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(theme.inputBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
+
+            Text(
+                "Empty scans HF_HUB_CACHE, HF_HOME/hub, and ~/.cache/huggingface/hub.",
+                bundle: .module
+            )
+            .font(.system(size: 10))
+            .foregroundColor(theme.tertiaryText)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.leading, 8)
     }
 
     private func refreshCounts() {
@@ -139,5 +220,12 @@ struct ExternalModelsSettingsView: View {
     private func skippedSummary(_ item: ExternalModelLocator.Skipped) -> String {
         let name = item.repoId ?? URL(fileURLWithPath: item.path).lastPathComponent
         return "\(name): \(item.reason.title)"
+    }
+
+    private var defaultHFCacheDisplayPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+            .path
+            .replacingOccurrences(of: NSHomeDirectory(), with: "~")
     }
 }


### PR DESCRIPTION
## Summary
- add a persisted custom Hugging Face cache path for external model discovery
- scan the custom path before HF_HUB_CACHE, HF_HOME/hub, and ~/.cache/huggingface/hub while deduplicating equivalent roots
- expose a settings text field, folder picker, and reset affordance for the HF cache source

## Why
Main already has HF cache and LM Studio external model discovery, but #443 specifically asks for a configurable local Hugging Face cache path. This keeps the existing discovery/import behavior and makes non-standard cache locations explicit without copying or re-downloading models.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `SCRIPT_INPUT_FILE_COUNT=3 SCRIPT_INPUT_FILE_0=Packages/OsaurusCore/Services/ExternalModelLocator.swift SCRIPT_INPUT_FILE_1=Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift SCRIPT_INPUT_FILE_2=Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift swiftlint lint --strict --use-script-input-files`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ExternalModelLocatorTests`

Refs #443

Note: this PR claims discovery/configuration coverage only; it does not claim live model-load proof for any external cached bundle.