### PR TITLE
Add agent defaults and team API

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/AgentCreationDefaults.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentCreationDefaults.swift
@@ -1,0 +1,58 @@
+//
+//  AgentCreationDefaults.swift
+//  osaurus
+//
+//  Persisted defaults used when creating custom agents from API/UI flows.
+//
+
+import Foundation
+
+public struct AgentCreationDefaults: Codable, Equatable, Sendable {
+    public var defaultModel: String?
+    public var temperature: Float?
+    public var maxTokens: Int?
+    public var toolSelectionMode: ToolSelectionMode?
+    public var manualToolNames: [String]?
+    public var manualSkillNames: [String]?
+    // swiftlint:disable:next discouraged_optional_boolean
+    public var autoSpeak: Bool?
+    public var ttsVoice: String?
+
+    public init(
+        defaultModel: String? = nil,
+        temperature: Float? = nil,
+        maxTokens: Int? = nil,
+        toolSelectionMode: ToolSelectionMode? = nil,
+        manualToolNames: [String]? = nil,
+        manualSkillNames: [String]? = nil,
+        // swiftlint:disable:next discouraged_optional_boolean
+        autoSpeak: Bool? = nil,
+        ttsVoice: String? = nil
+    ) {
+        self.defaultModel = defaultModel
+        self.temperature = temperature
+        self.maxTokens = maxTokens
+        self.toolSelectionMode = toolSelectionMode
+        self.manualToolNames = manualToolNames
+        self.manualSkillNames = manualSkillNames
+        self.autoSpeak = autoSpeak
+        self.ttsVoice = ttsVoice
+    }
+
+    public static var `default`: AgentCreationDefaults {
+        AgentCreationDefaults()
+    }
+
+    public func merging(_ overrides: AgentCreationDefaults) -> AgentCreationDefaults {
+        AgentCreationDefaults(
+            defaultModel: overrides.defaultModel ?? defaultModel,
+            temperature: overrides.temperature ?? temperature,
+            maxTokens: overrides.maxTokens ?? maxTokens,
+            toolSelectionMode: overrides.toolSelectionMode ?? toolSelectionMode,
+            manualToolNames: overrides.manualToolNames ?? manualToolNames,
+            manualSkillNames: overrides.manualSkillNames ?? manualSkillNames,
+            autoSpeak: overrides.autoSpeak ?? autoSpeak,
+            ttsVoice: overrides.ttsVoice ?? ttsVoice
+        )
+    }
+}

--- a/Packages/OsaurusCore/Models/Agent/AgentTeamConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentTeamConfiguration.swift
@@ -1,0 +1,193 @@
+//
+//  AgentTeamConfiguration.swift
+//  osaurus
+//
+//  Named agent groups plus group-targeted creation defaults.
+//
+
+import Foundation
+
+public struct AgentTeamConfiguration: Codable, Equatable, Identifiable, Sendable {
+    public var id: String
+    public var name: String
+    public var description: String
+    public var memberAgentIds: [UUID]
+    public var defaults: AgentCreationDefaults
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: String,
+        name: String,
+        description: String = "",
+        memberAgentIds: [UUID] = [],
+        defaults: AgentCreationDefaults = .default,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.memberAgentIds = memberAgentIds
+        self.defaults = defaults
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+private struct AgentTeamConfigurationEnvelope: Codable, Equatable, Sendable {
+    var teams: [AgentTeamConfiguration]
+
+    static var empty: AgentTeamConfigurationEnvelope {
+        AgentTeamConfigurationEnvelope(teams: [])
+    }
+}
+
+@MainActor
+public enum AgentTeamConfigurationStore {
+    public static var overrideDirectory: URL?
+
+    private static var cached: [AgentTeamConfiguration]?
+
+    public static func load() -> [AgentTeamConfiguration] {
+        if let cached { return cached }
+        let loaded = loadFromDisk()
+        cached = loaded
+        return loaded
+    }
+
+    public static func save(_ teams: [AgentTeamConfiguration]) {
+        let normalized = normalize(teams)
+        cached = normalized
+        saveToDisk(normalized)
+        NotificationCenter.default.post(name: .appConfigurationChanged, object: nil)
+    }
+
+    public static func team(id: String) -> AgentTeamConfiguration? {
+        load().first { $0.id == id }
+    }
+
+    public static func upsert(_ team: AgentTeamConfiguration) {
+        var teams = load()
+        if let index = teams.firstIndex(where: { $0.id == team.id }) {
+            var updated = team
+            updated.createdAt = teams[index].createdAt
+            updated.updatedAt = Date()
+            teams[index] = updated
+        } else {
+            teams.append(team)
+        }
+        save(teams)
+    }
+
+    public static func assign(agentId: UUID, toTeamId teamId: String) {
+        var teams = load()
+        guard let index = teams.firstIndex(where: { $0.id == teamId }) else { return }
+        guard !teams[index].memberAgentIds.contains(agentId) else { return }
+        teams[index].memberAgentIds.append(agentId)
+        teams[index].updatedAt = Date()
+        save(teams)
+    }
+
+    public static func teamIds(containing agentId: UUID) -> [String] {
+        load()
+            .filter { $0.memberAgentIds.contains(agentId) }
+            .map(\.id)
+            .sorted()
+    }
+
+    public static func setTeamIds(_ teamIds: [String], for agentId: UUID) {
+        let requested = Set(teamIds)
+        var teams = load()
+        var changed = false
+        for index in teams.indices {
+            let shouldContain = requested.contains(teams[index].id)
+            let contains = teams[index].memberAgentIds.contains(agentId)
+            if shouldContain && !contains {
+                teams[index].memberAgentIds.append(agentId)
+                teams[index].updatedAt = Date()
+                changed = true
+            } else if !shouldContain && contains {
+                teams[index].memberAgentIds.removeAll { $0 == agentId }
+                teams[index].updatedAt = Date()
+                changed = true
+            }
+        }
+        if changed {
+            save(teams)
+        }
+    }
+
+    public static func resetCacheForTests() {
+        cached = nil
+    }
+
+    nonisolated public static func isValidTeamId(_ id: String) -> Bool {
+        guard !id.isEmpty, id.count <= 64 else { return false }
+        return id.allSatisfy { character in
+            character.isASCII
+                && (character.isLetter || character.isNumber || character == "-" || character == "_")
+        }
+    }
+
+    private static func normalize(_ teams: [AgentTeamConfiguration]) -> [AgentTeamConfiguration] {
+        var seen = Set<String>()
+        return teams
+            .filter { seen.insert($0.id).inserted }
+            .map { team in
+                var normalized = team
+                normalized.memberAgentIds = Array(Set(team.memberAgentIds)).sorted {
+                    $0.uuidString < $1.uuidString
+                }
+                return normalized
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private static func configFileURL() -> URL {
+        if let dir = overrideDirectory {
+            return dir.appendingPathComponent("agent-teams.json")
+        }
+        return OsaurusPaths.config().appendingPathComponent("agent-teams.json")
+    }
+
+    private static func loadFromDisk() -> [AgentTeamConfiguration] {
+        let url = configFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+        guard let data = try? Data(contentsOf: url) else { return [] }
+
+        if let envelope = try? JSONDecoder().decode(AgentTeamConfigurationEnvelope.self, from: data) {
+            return normalize(envelope.teams)
+        }
+        if let legacyArray = try? JSONDecoder().decode([AgentTeamConfiguration].self, from: data) {
+            return normalize(legacyArray)
+        }
+
+        print("[Osaurus] Failed to decode agent-teams.json - using empty teams (file preserved)")
+        ToastManager.shared.warning(
+            L("Agent teams unreadable"),
+            message: L("Using no saved agent teams; your saved file was left untouched.")
+        )
+        return []
+    }
+
+    private static func saveToDisk(_ teams: [AgentTeamConfiguration]) {
+        let url = configFileURL()
+        do {
+            let dir = url.deletingLastPathComponent()
+            if !FileManager.default.fileExists(atPath: dir.path) {
+                try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            }
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(AgentTeamConfigurationEnvelope(teams: teams))
+                .write(to: url, options: .atomic)
+        } catch {
+            print("[Osaurus] Failed to save agent-teams.json: \(error)")
+            ToastManager.shared.error(
+                L("Couldn't save agent teams"),
+                message: error.localizedDescription
+            )
+        }
+    }
+}

--- a/Packages/OsaurusCore/Models/Agent/DefaultAgentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Agent/DefaultAgentConfiguration.swift
@@ -69,6 +69,12 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
     /// `manualToolNames` for skills.
     public var manualSkillNames: [String]?
 
+    /// Defaults used when creating new custom agents from API-driven
+    /// create-from-defaults flows. These do not clone the Default agent's
+    /// privileged persona; they only seed model/generation, tool grants, and
+    /// voice fields that custom agents already persist.
+    public var creationDefaults: AgentCreationDefaults
+
     public init(
         systemPrompt: String = "",
         defaultModel: String? = nil,
@@ -78,7 +84,8 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         autonomousExec: AutonomousExecConfig? = nil,
         toolSelectionMode: ToolSelectionMode? = nil,
         manualToolNames: [String]? = nil,
-        manualSkillNames: [String]? = nil
+        manualSkillNames: [String]? = nil,
+        creationDefaults: AgentCreationDefaults = .default
     ) {
         self.systemPrompt = systemPrompt
         self.defaultModel = defaultModel
@@ -89,6 +96,7 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         self.toolSelectionMode = toolSelectionMode
         self.manualToolNames = manualToolNames
         self.manualSkillNames = manualSkillNames
+        self.creationDefaults = creationDefaults
     }
 
     public init(from decoder: Decoder) throws {
@@ -102,6 +110,7 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         toolSelectionMode = try c.decodeIfPresent(ToolSelectionMode.self, forKey: .toolSelectionMode)
         manualToolNames = try c.decodeIfPresent([String].self, forKey: .manualToolNames)
         manualSkillNames = try c.decodeIfPresent([String].self, forKey: .manualSkillNames)
+        creationDefaults = try c.decodeIfPresent(AgentCreationDefaults.self, forKey: .creationDefaults) ?? .default
     }
 
     public static var `default`: DefaultAgentConfiguration {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -662,10 +662,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 handlePairInviteEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
             } else if head.method == .POST, path == "/secure/session" {
                 handleSecureSessionEndpoint(head: head, context: context, startTime: startTime, userAgent: userAgent)
-            } else if head.method == .GET, path == "/agents" {
-                handleListAgents(head: head, context: context, startTime: startTime, userAgent: userAgent)
-            } else if head.method == .GET, path.hasPrefix("/agents/") {
-                handleGetAgentEndpoint(
+            } else if Self.isAgentConfigurationAPIRequest(method: head.method, path: path) {
+                handleAgentConfigurationAPIEndpoint(
                     head: head,
                     context: context,
                     path: path,
@@ -3114,11 +3112,91 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     // MARK: - Agents
 
+    private static func isAgentConfigurationAPIRequest(method: HTTPMethod, path: String) -> Bool {
+        if path == "/agents" {
+            return method == .GET || method == .POST
+        }
+        if path == "/agents/teams" {
+            return method == .GET
+        }
+        if path.hasPrefix("/agents/teams/") {
+            return method == .GET || method == .PUT
+        }
+        if path == "/agents/default" {
+            return method == .GET || method == .PUT || method == .PATCH
+        }
+        guard path.hasPrefix("/agents/") else { return false }
+        guard !path.hasSuffix("/run"), !path.hasSuffix("/dispatch") else { return false }
+        return method == .GET || method == .PUT || method == .PATCH
+    }
+
+    private struct AgentDefaultsPayload: Codable {
+        let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
+        let tool_selection_mode: ToolSelectionMode?
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let auto_speak: Bool?
+        let tts_voice: String?
+
+        init(
+            default_model: String? = nil,
+            temperature: Float? = nil,
+            max_tokens: Int? = nil,
+            tool_selection_mode: ToolSelectionMode? = nil,
+            manual_tool_names: [String]? = nil,
+            manual_skill_names: [String]? = nil,
+            // swiftlint:disable:next discouraged_optional_boolean
+            auto_speak: Bool? = nil,
+            tts_voice: String? = nil
+        ) {
+            self.default_model = default_model
+            self.temperature = temperature
+            self.max_tokens = max_tokens
+            self.tool_selection_mode = tool_selection_mode
+            self.manual_tool_names = manual_tool_names
+            self.manual_skill_names = manual_skill_names
+            self.auto_speak = auto_speak
+            self.tts_voice = tts_voice
+        }
+
+        init(_ defaults: AgentCreationDefaults) {
+            self.init(
+                default_model: defaults.defaultModel,
+                temperature: defaults.temperature,
+                max_tokens: defaults.maxTokens,
+                tool_selection_mode: defaults.toolSelectionMode,
+                manual_tool_names: defaults.manualToolNames,
+                manual_skill_names: defaults.manualSkillNames,
+                auto_speak: defaults.autoSpeak,
+                tts_voice: defaults.ttsVoice
+            )
+        }
+
+        var domain: AgentCreationDefaults {
+            AgentCreationDefaults(
+                defaultModel: default_model,
+                temperature: temperature,
+                maxTokens: max_tokens,
+                toolSelectionMode: tool_selection_mode,
+                manualToolNames: manual_tool_names,
+                manualSkillNames: manual_skill_names,
+                autoSpeak: auto_speak,
+                ttsVoice: tts_voice
+            )
+        }
+    }
+
     private struct AgentListItem: Codable {
         let id: String
         let name: String
         let description: String
+        let system_prompt: String?
         let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
         /// Server-resolved model id, known before the first streamed chunk.
         let effective_model: String?
         /// True when the resolved model has a `disableThinking` ModelProfile
@@ -3126,6 +3204,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let supports_thinking: Bool
         let supports_vision: Bool
         let is_built_in: Bool
+        let tools_enabled: Bool
+        let memory_enabled: Bool
+        let tool_selection_mode: ToolSelectionMode
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let auto_speak: Bool?
+        let tts_voice: String?
+        let agent_address: String?
+        let team_ids: [String]
+        let creation_defaults: AgentDefaultsPayload?
         let memory_entry_count: Int
         let created_at: String
         let updated_at: String
@@ -3133,6 +3222,88 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     private struct AgentListResponse: Codable {
         let agents: [AgentListItem]
+    }
+
+    private struct AgentCreateRequest: Codable {
+        let name: String?
+        let description: String?
+        let system_prompt: String?
+        let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
+        let tool_selection_mode: ToolSelectionMode?
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let auto_speak: Bool?
+        let tts_voice: String?
+        let team_id: String?
+        let team_ids: [String]?
+
+        var defaultsOverride: AgentCreationDefaults {
+            AgentCreationDefaults(
+                defaultModel: default_model,
+                temperature: temperature,
+                maxTokens: max_tokens,
+                toolSelectionMode: tool_selection_mode,
+                manualToolNames: manual_tool_names,
+                manualSkillNames: manual_skill_names,
+                autoSpeak: auto_speak,
+                ttsVoice: tts_voice
+            )
+        }
+    }
+
+    private struct AgentUpdateRequest: Codable {
+        let name: String?
+        let description: String?
+        let system_prompt: String?
+        let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let tools_enabled: Bool?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let memory_enabled: Bool?
+        let tool_selection_mode: ToolSelectionMode?
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let auto_speak: Bool?
+        let tts_voice: String?
+        let team_ids: [String]?
+        // swiftlint:disable:next discouraged_optional_boolean
+        let disable_tools: Bool?
+        let creation_defaults: AgentDefaultsPayload?
+    }
+
+    private struct AgentItemResponse: Codable {
+        let agent: AgentListItem
+    }
+
+    private struct AgentTeamItem: Codable {
+        let id: String
+        let name: String
+        let description: String
+        let member_agent_ids: [String]
+        let defaults: AgentDefaultsPayload
+        let created_at: String
+        let updated_at: String
+    }
+
+    private struct AgentTeamListResponse: Codable {
+        let teams: [AgentTeamItem]
+    }
+
+    private struct AgentTeamMutationRequest: Codable {
+        let name: String?
+        let description: String?
+        let member_agent_ids: [String]?
+        let defaults: AgentDefaultsPayload?
+    }
+
+    private struct AgentTeamItemResponse: Codable {
+        let team: AgentTeamItem
     }
 
     // MARK: - Pair Endpoint
@@ -4078,96 +4249,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
     }
 
-    private func handleListAgents(
-        head: HTTPRequestHead,
-        context: ChannelHandlerContext,
-        startTime: Date,
-        userAgent: String?
-    ) {
-        let loop = context.eventLoop
-        let ctx = NIOLoopBound(context, eventLoop: loop)
-        let cors = stateRef.value.corsHeaders
-        let hop = Self.makeHop(channel: context.channel, loop: loop)
-        let logSelf = self
-        let logStartTime = startTime
-        let logUserAgent = userAgent
-
-        runRequestTask(priority: .userInitiated) {
-            // Built-in agents (the Default agent) live only in-app; the
-            // listing endpoint must not advertise them so external clients
-            // can never even attempt to address them.
-            let agents = await MainActor.run {
-                AgentManager.shared.agents.filter { !$0.isBuiltIn }
-            }
-
-            let db = MemoryDatabase.shared
-            var memoryCounts: [String: Int] = [:]
-            if db.isOpen, let counts = try? db.agentIdsWithPinnedFacts() {
-                for (agentId, count) in counts {
-                    memoryCounts[agentId] = count
-                }
-            }
-
-            let formatter = ISO8601DateFormatter()
-            let effectiveModels = await MainActor.run {
-                Dictionary(
-                    uniqueKeysWithValues: agents.map {
-                        ($0.id, AgentManager.shared.effectiveModel(for: $0.id))
-                    }
-                )
-            }
-            let items = agents.map { agent in
-                let modelId = effectiveModels[agent.id] ?? agent.defaultModel
-                let supportsVision = modelId.map { VLMDetection.isVLM(modelId: $0) } ?? false
-                let supportsThinking =
-                    modelId.flatMap { ModelProfileRegistry.profile(for: $0)?.thinkingOption } != nil
-                return AgentListItem(
-                    id: agent.id.uuidString,
-                    name: agent.name,
-                    description: agent.description,
-                    default_model: agent.defaultModel,
-                    effective_model: modelId,
-                    supports_thinking: supportsThinking,
-                    supports_vision: supportsVision,
-                    is_built_in: agent.isBuiltIn,
-                    memory_entry_count: memoryCounts[agent.id.uuidString] ?? 0,
-                    created_at: formatter.string(from: agent.createdAt),
-                    updated_at: formatter.string(from: agent.updatedAt)
-                )
-            }
-
-            let response = AgentListResponse(agents: items)
-            let json =
-                (try? JSONEncoder.osaurusCanonical().encode(response)).map { String(decoding: $0, as: UTF8.self) }
-                ?? #"{"agents":[]}"#
-
-            hop {
-                var headers = [("Content-Type", "application/json; charset=utf-8")]
-                headers.append(contentsOf: cors)
-                self.sendResponse(
-                    context: ctx.value,
-                    version: head.version,
-                    status: .ok,
-                    headers: headers,
-                    body: json
-                )
-            }
-            logSelf.logRequest(
-                method: "GET",
-                path: "/agents",
-                userAgent: logUserAgent,
-                requestBody: nil,
-                responseBody: json,
-                responseStatus: 200,
-                startTime: logStartTime
-            )
-        }
-    }
-
-    // MARK: - Agent Info & Run Endpoints
-
-    /// GET /agents/{id} — return info for a single agent
-    private func handleGetAgentEndpoint(
+    private func handleAgentConfigurationAPIEndpoint(
         head: HTTPRequestHead,
         context: ChannelHandlerContext,
         path: String,
@@ -4181,120 +4263,320 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logSelf = self
         let logStartTime = startTime
         let logUserAgent = userAgent
-
-        // Extract agent ID: /agents/{id}. Resolve the path id as a UUID or a
-        // crypto address (the stable identity a paired remote peer knows),
-        // mirroring /agents/{id}/run so remote model discovery resolves the
-        // agent instead of falling back to ["default"].
-        let components = path.split(separator: "/")
-        let resolvedAgentId: UUID? =
-            components.count == 2
-            ? (UUID(uuidString: String(components[1]))
-                ?? AgentIdentityRegistry.shared.agentId(forAddress: String(components[1])))
+        let method = head.method.rawValue
+        let requestBody = (head.method == .POST || head.method == .PUT || head.method == .PATCH)
+            ? readRequestBody()
             : nil
-        guard components.count == 2, components[0] == "agents", let agentId = resolvedAgentId
-        else {
-            hop {
-                var headers = [("Content-Type", "application/json; charset=utf-8")]
-                headers.append(contentsOf: cors)
-                self.sendResponse(
-                    context: ctx.value,
-                    version: head.version,
-                    status: .badRequest,
-                    headers: headers,
-                    body: #"{"error":"invalid_agent_id","message":"Invalid agent UUID in path"}"#
-                )
-            }
-            return
-        }
-
-        // Confine agent-scoped keys to their own agent: a key minted by
-        // `/pair` / `/pair-invite` for agent A must not read another agent's
-        // metadata (name, description, effective_model). Mirrors the
-        // `/agents/{id}/run` scope gate. Loopback callers (authedAudience ==
-        // nil) and master-scoped keys are unaffected. Read `stateRef` here on
-        // the event loop, before the detached `runRequestTask`.
-        if let rejection = agentScopeRejection(forAgentId: agentId) {
-            hop {
-                var headers = [("Content-Type", "application/json; charset=utf-8")]
-                headers.append(contentsOf: cors)
-                self.sendResponse(
-                    context: ctx.value,
-                    version: head.version,
-                    status: .forbidden,
-                    headers: headers,
-                    body: #"{"error":"\#(rejection.code)","message":"\#(rejection.message)"}"#
-                )
-            }
-            return
-        }
+        let canManage = stateRef.value.authedAudience == nil || stateRef.value.authedScopeIsMaster
+        let authedAudience = stateRef.value.authedAudience
+        let hasGlobalScope = stateRef.value.authedScopeIsMaster
 
         runRequestTask(priority: .userInitiated) {
-            // Built-in agents are not exposed via HTTP — return 404 (not 403)
-            // so external clients learn the id is unreachable but cannot
-            // distinguish "no such agent" from "you are not allowed to see
-            // this one". This matches the listing endpoint's filter behavior.
-            guard let agent = await MainActor.run(body: { AgentManager.shared.agent(for: agentId) }),
-                !agent.isBuiltIn
-            else {
+            func sendJSON(status: HTTPResponseStatus, body: String) {
                 hop {
                     var headers = [("Content-Type", "application/json; charset=utf-8")]
                     headers.append(contentsOf: cors)
-                    self.sendResponse(
+                    logSelf.sendResponse(
                         context: ctx.value,
                         version: head.version,
-                        status: .notFound,
+                        status: status,
                         headers: headers,
-                        body: #"{"error":"agent_not_found","message":"No agent found for the given ID"}"#
+                        body: body
                     )
                 }
+                logSelf.logRequest(
+                    method: method,
+                    path: path,
+                    userAgent: logUserAgent,
+                    requestBody: requestBody?.text,
+                    responseBody: body,
+                    responseStatus: Int(status.code),
+                    startTime: logStartTime
+                )
+            }
+
+            func sendEncodable<T: Encodable>(status: HTTPResponseStatus, value: T) {
+                let body =
+                    (try? JSONEncoder.osaurusCanonical().encode(value))
+                    .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+                sendJSON(status: status, body: body)
+            }
+
+            func sendError(status: HTTPResponseStatus, code: String, message: String) {
+                let escaped = message.replacingOccurrences(of: "\"", with: "\\\"")
+                sendJSON(
+                    status: status,
+                    body: #"{"error":"\#(code)","message":"\#(escaped)"}"#
+                )
+            }
+
+            let allAgents = await MainActor.run { AgentManager.shared.agents }
+            let visibleAgents = Self.visibleAgents(
+                allAgents,
+                authedAudience: authedAudience,
+                hasGlobalScope: hasGlobalScope
+            )
+
+            if head.method == .GET, path == "/agents" {
+                let memoryCounts = Self.memoryCountsByAgentId()
+                let items = await MainActor.run {
+                    visibleAgents.map {
+                        Self.agentListItem(for: $0, memoryCounts: memoryCounts)
+                    }
+                }
+                sendEncodable(status: .ok, value: AgentListResponse(agents: items))
                 return
             }
 
-            let formatter = ISO8601DateFormatter()
-            let effectiveModelId =
-                await MainActor.run {
-                    AgentManager.shared.effectiveModel(for: agent.id)
-                } ?? agent.defaultModel
-            let supportsVision = effectiveModelId.map { VLMDetection.isVLM(modelId: $0) } ?? false
-            let supportsThinking =
-                effectiveModelId.flatMap { ModelProfileRegistry.profile(for: $0)?.thinkingOption } != nil
-            let item = AgentListItem(
-                id: agent.id.uuidString,
-                name: agent.name,
-                description: agent.description,
-                default_model: agent.defaultModel,
-                effective_model: effectiveModelId,
-                supports_thinking: supportsThinking,
-                supports_vision: supportsVision,
-                is_built_in: agent.isBuiltIn,
-                memory_entry_count: 0,
-                created_at: formatter.string(from: agent.createdAt),
-                updated_at: formatter.string(from: agent.updatedAt)
-            )
-            let json =
-                (try? JSONEncoder.osaurusCanonical().encode(item)).map { String(decoding: $0, as: UTF8.self) } ?? "{}"
-
-            hop {
-                var headers = [("Content-Type", "application/json; charset=utf-8")]
-                headers.append(contentsOf: cors)
-                self.sendResponse(
-                    context: ctx.value,
-                    version: head.version,
-                    status: .ok,
-                    headers: headers,
-                    body: json
-                )
+            if head.method == .GET, path == "/agents/teams" {
+                let scopedAgentIds = Set(visibleAgents.map(\.id))
+                let teams = await MainActor.run {
+                    AgentTeamConfigurationStore.load().filter { team in
+                        canManage || team.memberAgentIds.contains { scopedAgentIds.contains($0) }
+                    }
+                }
+                sendEncodable(status: .ok, value: AgentTeamListResponse(teams: Self.teamItems(teams)))
+                return
             }
-            logSelf.logRequest(
-                method: "GET",
-                path: path,
-                userAgent: logUserAgent,
-                requestBody: nil,
-                responseBody: json,
-                responseStatus: 200,
-                startTime: logStartTime
-            )
+
+            if path.hasPrefix("/agents/teams/") {
+                let teamId = String(path.dropFirst("/agents/teams/".count))
+                guard AgentTeamConfigurationStore.isValidTeamId(teamId) else {
+                    sendError(status: .badRequest, code: "invalid_team_id", message: "Invalid team id.")
+                    return
+                }
+                if head.method == .GET {
+                    guard let team = await MainActor.run(body: { AgentTeamConfigurationStore.team(id: teamId) })
+                    else {
+                        sendError(status: .notFound, code: "team_not_found", message: "No team found for the given id.")
+                        return
+                    }
+                    let scopedAgentIds = Set(visibleAgents.map(\.id))
+                    guard canManage || team.memberAgentIds.contains(where: { scopedAgentIds.contains($0) }) else {
+                        sendError(
+                            status: .forbidden,
+                            code: "agent_scope_denied",
+                            message: "This access key is not scoped to the requested team."
+                        )
+                        return
+                    }
+                    sendEncodable(status: .ok, value: AgentTeamItemResponse(team: Self.teamItem(team)))
+                    return
+                }
+
+                guard canManage else {
+                    sendError(
+                        status: .forbidden,
+                        code: "agent_scope_denied",
+                        message: "Only loopback or master-scoped keys can update agent teams."
+                    )
+                    return
+                }
+                guard let requestBody, !requestBody.data.isEmpty,
+                    let request = try? JSONDecoder().decode(AgentTeamMutationRequest.self, from: requestBody.data)
+                else {
+                    sendError(status: .badRequest, code: "invalid_request", message: "Team update requires JSON.")
+                    return
+                }
+                let memberIds: [UUID]
+                if let rawIds = request.member_agent_ids {
+                    memberIds = rawIds.compactMap(UUID.init(uuidString:))
+                    guard memberIds.count == rawIds.count else {
+                        sendError(status: .badRequest, code: "invalid_agent_id", message: "Invalid member agent id.")
+                        return
+                    }
+                    let customAgentIds = Set(allAgents.filter { !$0.isBuiltIn }.map(\.id))
+                    guard memberIds.allSatisfy({ customAgentIds.contains($0) }) else {
+                        sendError(
+                            status: .badRequest,
+                            code: "agent_not_found",
+                            message: "Team members must be existing custom agents."
+                        )
+                        return
+                    }
+                } else {
+                    memberIds = await MainActor.run {
+                        AgentTeamConfigurationStore.team(id: teamId)?.memberAgentIds ?? []
+                    }
+                }
+                let existing = await MainActor.run { AgentTeamConfigurationStore.team(id: teamId) }
+                let team = AgentTeamConfiguration(
+                    id: teamId,
+                    name: request.name ?? existing?.name ?? teamId,
+                    description: request.description ?? existing?.description ?? "",
+                    memberAgentIds: memberIds,
+                    defaults: request.defaults?.domain ?? existing?.defaults ?? .default,
+                    createdAt: existing?.createdAt ?? Date(),
+                    updatedAt: Date()
+                )
+                await MainActor.run { AgentTeamConfigurationStore.upsert(team) }
+                sendEncodable(status: existing == nil ? .created : .ok, value: AgentTeamItemResponse(team: Self.teamItem(team)))
+                return
+            }
+
+            if head.method == .POST, path == "/agents" {
+                guard canManage else {
+                    sendError(
+                        status: .forbidden,
+                        code: "agent_scope_denied",
+                        message: "Only loopback or master-scoped keys can create agents."
+                    )
+                    return
+                }
+                guard let requestBody, !requestBody.data.isEmpty,
+                    let request = try? JSONDecoder().decode(AgentCreateRequest.self, from: requestBody.data)
+                else {
+                    sendError(status: .badRequest, code: "invalid_request", message: "Agent create requires JSON.")
+                    return
+                }
+                let name = request.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !name.isEmpty else {
+                    sendError(status: .badRequest, code: "invalid_name", message: "Agent name is required.")
+                    return
+                }
+                let requestedTeamIds = request.team_ids ?? request.team_id.map { [$0] } ?? []
+                guard await Self.teamIdsAreValidAndKnown(requestedTeamIds) else {
+                    sendError(status: .badRequest, code: "invalid_team_id", message: "Unknown or invalid team id.")
+                    return
+                }
+                let defaults = await MainActor.run {
+                    Self.creationDefaults(forTeamIds: requestedTeamIds, requestOverrides: request.defaultsOverride)
+                }
+                let sandboxDefault = await MainActor.run {
+                    AgentManager.sandboxDefaultAutonomousExec
+                }
+                let agent = Agent(
+                    name: name,
+                    description: request.description ?? "",
+                    systemPrompt: request.system_prompt ?? "",
+                    defaultModel: defaults.defaultModel,
+                    temperature: defaults.temperature,
+                    maxTokens: defaults.maxTokens,
+                    createdAt: Date(),
+                    updatedAt: Date(),
+                    autonomousExec: sandboxDefault,
+                    toolSelectionMode: defaults.toolSelectionMode,
+                    manualToolNames: defaults.manualToolNames,
+                    manualSkillNames: defaults.manualSkillNames,
+                    autoSpeak: defaults.autoSpeak,
+                    ttsVoice: defaults.ttsVoice
+                )
+                await MainActor.run {
+                    AgentManager.shared.add(agent)
+                    for teamId in requestedTeamIds {
+                        AgentTeamConfigurationStore.assign(agentId: agent.id, toTeamId: teamId)
+                    }
+                }
+                let item = await MainActor.run {
+                    Self.agentListItem(for: AgentManager.shared.agent(for: agent.id) ?? agent, memoryCounts: [:])
+                }
+                sendEncodable(status: .created, value: AgentItemResponse(agent: item))
+                return
+            }
+
+            let identifier = String(path.dropFirst("/agents/".count))
+            let targetId = identifier.lowercased() == "default"
+                ? Agent.defaultId
+                : (UUID(uuidString: identifier) ?? AgentIdentityRegistry.shared.agentId(forAddress: identifier))
+            guard let targetId else {
+                sendError(status: .badRequest, code: "invalid_agent_id", message: "Invalid agent UUID or address in path.")
+                return
+            }
+            guard var agent = allAgents.first(where: { $0.id == targetId }) else {
+                sendError(status: .notFound, code: "agent_not_found", message: "No agent found for the given ID.")
+                return
+            }
+            if let rejection = Self.agentScopeRejection(
+                forAgentId: targetId,
+                authedAudience: authedAudience,
+                authedScopeIsMaster: hasGlobalScope
+            ) {
+                sendError(status: .forbidden, code: rejection.code, message: rejection.message)
+                return
+            }
+
+            if head.method == .GET {
+                let item = await MainActor.run {
+                    Self.agentListItem(for: agent, memoryCounts: Self.memoryCountsByAgentId())
+                }
+                sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
+                return
+            }
+
+            guard canManage else {
+                sendError(
+                    status: .forbidden,
+                    code: "agent_scope_denied",
+                    message: "Only loopback or master-scoped keys can update agent configuration."
+                )
+                return
+            }
+            guard let requestBody, !requestBody.data.isEmpty,
+                let request = try? JSONDecoder().decode(AgentUpdateRequest.self, from: requestBody.data)
+            else {
+                sendError(status: .badRequest, code: "invalid_request", message: "Agent update requires JSON.")
+                return
+            }
+
+            if targetId == Agent.defaultId {
+                let item = await MainActor.run { () -> AgentListItem in
+                    var config = DefaultAgentConfigurationStore.load()
+                    if let value = request.system_prompt { config.systemPrompt = value }
+                    if let value = request.default_model { config.defaultModel = value }
+                    if let value = request.temperature { config.temperature = value }
+                    if let value = request.max_tokens { config.maxTokens = value }
+                    if let value = request.disable_tools {
+                        config.disableTools = value
+                    } else if let value = request.tools_enabled {
+                        config.disableTools = !value
+                    }
+                    if let value = request.tool_selection_mode { config.toolSelectionMode = value }
+                    if let value = request.manual_tool_names { config.manualToolNames = value }
+                    if let value = request.manual_skill_names { config.manualSkillNames = value }
+                    if let value = request.creation_defaults { config.creationDefaults = value.domain }
+                    DefaultAgentConfigurationStore.save(config)
+                    NotificationCenter.default.post(name: .agentUpdated, object: Agent.defaultId)
+                    return Self.agentListItem(for: Agent.default, memoryCounts: [:])
+                }
+                sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
+                return
+            }
+
+            guard !agent.isBuiltIn else {
+                sendError(status: .forbidden, code: "built_in_agent", message: "Built-in agents cannot be updated here.")
+                return
+            }
+            if let value = request.name?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+                agent.name = value
+            }
+            if let value = request.description { agent.description = value }
+            if let value = request.system_prompt { agent.systemPrompt = value }
+            if let value = request.default_model { agent.defaultModel = value }
+            if let value = request.temperature { agent.temperature = value }
+            if let value = request.max_tokens { agent.maxTokens = value }
+            if let value = request.disable_tools {
+                agent.toolsEnabled = !value
+            } else if let value = request.tools_enabled {
+                agent.toolsEnabled = value
+            }
+            if let value = request.memory_enabled { agent.memoryEnabled = value }
+            if let value = request.tool_selection_mode { agent.toolSelectionMode = value }
+            if let value = request.manual_tool_names { agent.manualToolNames = value }
+            if let value = request.manual_skill_names { agent.manualSkillNames = value }
+            if let value = request.auto_speak { agent.autoSpeak = value }
+            if let value = request.tts_voice { agent.ttsVoice = value }
+            if let teamIds = request.team_ids {
+                guard await Self.teamIdsAreValidAndKnown(teamIds) else {
+                    sendError(status: .badRequest, code: "invalid_team_id", message: "Unknown or invalid team id.")
+                    return
+                }
+                await MainActor.run { AgentTeamConfigurationStore.setTeamIds(teamIds, for: agent.id) }
+            }
+            let item = await MainActor.run { () -> AgentListItem in
+                AgentManager.shared.update(agent)
+                return Self.agentListItem(for: AgentManager.shared.agent(for: agent.id) ?? agent, memoryCounts: [:])
+            }
+            sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
         }
     }
 
@@ -4318,6 +4600,113 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let context = await FolderContextService.shared.buildContext(from: url)
         return (url, context)
     }
+
+    @MainActor
+    private static func creationDefaults(
+        forTeamIds teamIds: [String],
+        requestOverrides: AgentCreationDefaults
+    ) -> AgentCreationDefaults {
+        var defaults = DefaultAgentConfigurationStore.load().creationDefaults
+        for teamId in teamIds {
+            if let team = AgentTeamConfigurationStore.team(id: teamId) {
+                defaults = defaults.merging(team.defaults)
+            }
+        }
+        return defaults.merging(requestOverrides)
+    }
+
+    @MainActor
+    private static func teamIdsAreValidAndKnown(_ teamIds: [String]) -> Bool {
+        for teamId in teamIds {
+            guard AgentTeamConfigurationStore.isValidTeamId(teamId),
+                AgentTeamConfigurationStore.team(id: teamId) != nil
+            else { return false }
+        }
+        return true
+    }
+
+    private static func visibleAgents(
+        _ agents: [Agent],
+        authedAudience: String?,
+        hasGlobalScope: Bool
+    ) -> [Agent] {
+        guard let audience = authedAudience, !hasGlobalScope else { return agents }
+        return agents.filter { agent in
+            guard !agent.isBuiltIn else { return false }
+            return agent.agentAddress?.lowercased() == audience
+        }
+    }
+
+    private static func memoryCountsByAgentId() -> [String: Int] {
+        let db = MemoryDatabase.shared
+        guard db.isOpen, let counts = try? db.agentIdsWithPinnedFacts() else { return [:] }
+        var result: [String: Int] = [:]
+        for (agentId, count) in counts {
+            result[agentId] = count
+        }
+        return result
+    }
+
+    @MainActor
+    private static func agentListItem(
+        for agent: Agent,
+        memoryCounts: [String: Int]
+    ) -> AgentListItem {
+        let formatter = ISO8601DateFormatter()
+        let manager = AgentManager.shared
+        let effectiveModelId = manager.effectiveModel(for: agent.id) ?? agent.defaultModel
+        let supportsVision = effectiveModelId.map { VLMDetection.isVLM(modelId: $0) } ?? false
+        let supportsThinking = effectiveModelId.flatMap {
+            ModelProfileRegistry.profile(for: $0)?.thinkingOption
+        } != nil
+        let capabilities = manager.effectiveCapabilities(for: agent.id)
+        let defaultConfig = agent.id == Agent.defaultId ? DefaultAgentConfigurationStore.load() : nil
+        return AgentListItem(
+            id: agent.id.uuidString,
+            name: agent.name,
+            description: agent.description,
+            system_prompt: manager.effectiveSystemPrompt(for: agent.id),
+            default_model: agent.id == Agent.defaultId ? defaultConfig?.defaultModel : agent.defaultModel,
+            temperature: agent.id == Agent.defaultId ? defaultConfig?.temperature : agent.temperature,
+            max_tokens: agent.id == Agent.defaultId ? defaultConfig?.maxTokens : agent.maxTokens,
+            effective_model: effectiveModelId,
+            supports_thinking: supportsThinking,
+            supports_vision: supportsVision,
+            is_built_in: agent.isBuiltIn,
+            tools_enabled: capabilities.toolsEnabled,
+            memory_enabled: capabilities.memoryEnabled,
+            tool_selection_mode: manager.effectiveToolSelectionMode(for: agent.id),
+            manual_tool_names: manager.effectiveEnabledToolNames(for: agent.id),
+            manual_skill_names: manager.effectiveEnabledSkillNames(for: agent.id),
+            auto_speak: agent.autoSpeak,
+            tts_voice: agent.ttsVoice,
+            agent_address: agent.agentAddress,
+            team_ids: AgentTeamConfigurationStore.teamIds(containing: agent.id),
+            creation_defaults: defaultConfig.map { AgentDefaultsPayload($0.creationDefaults) },
+            memory_entry_count: memoryCounts[agent.id.uuidString] ?? 0,
+            created_at: formatter.string(from: agent.createdAt),
+            updated_at: formatter.string(from: agent.updatedAt)
+        )
+    }
+
+    private static func teamItems(_ teams: [AgentTeamConfiguration]) -> [AgentTeamItem] {
+        teams.map(teamItem)
+    }
+
+    private static func teamItem(_ team: AgentTeamConfiguration) -> AgentTeamItem {
+        let formatter = ISO8601DateFormatter()
+        return AgentTeamItem(
+            id: team.id,
+            name: team.name,
+            description: team.description,
+            member_agent_ids: team.memberAgentIds.map(\.uuidString),
+            defaults: AgentDefaultsPayload(team.defaults),
+            created_at: formatter.string(from: team.createdAt),
+            updated_at: formatter.string(from: team.updatedAt)
+        )
+    }
+
+    // MARK: - Agent Run Endpoints
 
     /// POST /agents/{id}/run — run the full agent chat loop server-side.
     ///

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4490,16 +4490,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 sendError(status: .badRequest, code: "invalid_agent_id", message: "Invalid agent UUID or address in path.")
                 return
             }
-            guard var agent = allAgents.first(where: { $0.id == targetId }) else {
-                sendError(status: .notFound, code: "agent_not_found", message: "No agent found for the given ID.")
-                return
-            }
             if let rejection = Self.agentScopeRejection(
                 forAgentId: targetId,
                 authedAudience: authedAudience,
                 authedScopeIsMaster: hasGlobalScope
             ) {
                 sendError(status: .forbidden, code: rejection.code, message: rejection.message)
+                return
+            }
+            guard var agent = allAgents.first(where: { $0.id == targetId }) else {
+                sendError(status: .notFound, code: "agent_not_found", message: "No agent found for the given ID.")
                 return
             }
 

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4267,9 +4267,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let requestBody = (head.method == .POST || head.method == .PUT || head.method == .PATCH)
             ? readRequestBody()
             : nil
-        let canManage = stateRef.value.authedAudience == nil || stateRef.value.authedScopeIsMaster
         let authedAudience = stateRef.value.authedAudience
         let hasGlobalScope = stateRef.value.authedScopeIsMaster
+        let canManage = isLoopbackConnection(context) || hasGlobalScope
 
         runRequestTask(priority: .userInitiated) {
             func sendJSON(status: HTTPResponseStatus, body: String) {
@@ -4320,8 +4320,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             if head.method == .GET, path == "/agents" {
                 let memoryCounts = Self.memoryCountsByAgentId()
                 let items = await MainActor.run {
-                    visibleAgents.map {
-                        Self.agentListItem(for: $0, memoryCounts: memoryCounts)
+                    visibleAgents.filter { !$0.isBuiltIn }.map {
+                        Self.agentListItem(
+                            for: $0,
+                            memoryCounts: memoryCounts,
+                            includeSensitiveConfiguration: false
+                        )
                     }
                 }
                 sendEncodable(status: .ok, value: AgentListResponse(agents: items))
@@ -4468,7 +4472,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     }
                 }
                 let item = await MainActor.run {
-                    Self.agentListItem(for: AgentManager.shared.agent(for: agent.id) ?? agent, memoryCounts: [:])
+                    Self.agentListItem(
+                        for: AgentManager.shared.agent(for: agent.id) ?? agent,
+                        memoryCounts: [:],
+                        includeSensitiveConfiguration: true
+                    )
                 }
                 sendEncodable(status: .created, value: AgentItemResponse(agent: item))
                 return
@@ -4497,7 +4505,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             if head.method == .GET {
                 let item = await MainActor.run {
-                    Self.agentListItem(for: agent, memoryCounts: Self.memoryCountsByAgentId())
+                    Self.agentListItem(
+                        for: agent,
+                        memoryCounts: Self.memoryCountsByAgentId(),
+                        includeSensitiveConfiguration: true
+                    )
                 }
                 sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
                 return
@@ -4536,7 +4548,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     if let value = request.creation_defaults { config.creationDefaults = value.domain }
                     DefaultAgentConfigurationStore.save(config)
                     NotificationCenter.default.post(name: .agentUpdated, object: Agent.defaultId)
-                    return Self.agentListItem(for: Agent.default, memoryCounts: [:])
+                    return Self.agentListItem(
+                        for: Agent.default,
+                        memoryCounts: [:],
+                        includeSensitiveConfiguration: true
+                    )
                 }
                 sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
                 return
@@ -4574,7 +4590,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
             let item = await MainActor.run { () -> AgentListItem in
                 AgentManager.shared.update(agent)
-                return Self.agentListItem(for: AgentManager.shared.agent(for: agent.id) ?? agent, memoryCounts: [:])
+                return Self.agentListItem(
+                    for: AgentManager.shared.agent(for: agent.id) ?? agent,
+                    memoryCounts: [:],
+                    includeSensitiveConfiguration: true
+                )
             }
             sendEncodable(status: .ok, value: AgentItemResponse(agent: item))
         }
@@ -4650,7 +4670,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     @MainActor
     private static func agentListItem(
         for agent: Agent,
-        memoryCounts: [String: Int]
+        memoryCounts: [String: Int],
+        includeSensitiveConfiguration: Bool
     ) -> AgentListItem {
         let formatter = ISO8601DateFormatter()
         let manager = AgentManager.shared
@@ -4665,7 +4686,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             id: agent.id.uuidString,
             name: agent.name,
             description: agent.description,
-            system_prompt: manager.effectiveSystemPrompt(for: agent.id),
+            system_prompt: includeSensitiveConfiguration
+                ? manager.effectiveSystemPrompt(for: agent.id)
+                : nil,
             default_model: agent.id == Agent.defaultId ? defaultConfig?.defaultModel : agent.defaultModel,
             temperature: agent.id == Agent.defaultId ? defaultConfig?.temperature : agent.temperature,
             max_tokens: agent.id == Agent.defaultId ? defaultConfig?.maxTokens : agent.maxTokens,

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4946,6 +4946,22 @@
         }
       }
     },
+    "Agent teams unreadable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agententeams nicht lesbar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法读取智能体团队"
+          }
+        }
+      }
+    },
     "Agent traffic is protected by the Osaurus Secure Channel: forward-secret, mutually authenticated end-to-end encryption." : {
       "localizations" : {
         "de" : {
@@ -15338,6 +15354,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法打开数据库"
+          }
+        }
+      }
+    },
+    "Couldn't save agent teams" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Agententeams konnten nicht gespeichert werden"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法保存智能体团队"
           }
         }
       }
@@ -63152,6 +63184,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在使用默认值；你保存的文件未被更改。"
+          }
+        }
+      }
+    },
+    "Using no saved agent teams; your saved file was left untouched." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Es werden keine gespeicherten Agententeams verwendet; deine gespeicherte Datei bleibt unverändert."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未使用已保存的智能体团队；你保存的文件未被更改。"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Agent/AgentTeamConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentTeamConfigurationStoreTests.swift
@@ -1,0 +1,94 @@
+//
+//  AgentTeamConfigurationStoreTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct AgentTeamConfigurationStoreTests {
+
+    @MainActor
+    private static func withTempOverride<T>(
+        body: @MainActor () throws -> T
+    ) async rethrows -> T {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-agent-teams-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let previous = AgentTeamConfigurationStore.overrideDirectory
+        AgentTeamConfigurationStore.overrideDirectory = tmp
+        AgentTeamConfigurationStore.resetCacheForTests()
+        defer {
+            AgentTeamConfigurationStore.overrideDirectory = previous
+            AgentTeamConfigurationStore.resetCacheForTests()
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        return try body()
+    }
+
+    @Test
+    @MainActor
+    func roundTrip_normalizesMembershipAndDefaults() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await Self.withTempOverride {
+                let agentA = UUID()
+                let agentB = UUID()
+                let team = AgentTeamConfiguration(
+                    id: "research",
+                    name: "Research",
+                    description: "Reader agents",
+                    memberAgentIds: [agentB, agentA, agentB],
+                    defaults: AgentCreationDefaults(
+                        defaultModel: "mlx-community/Qwen3-4B-Instruct",
+                        manualToolNames: ["search_memory"],
+                        ttsVoice: "nova"
+                    )
+                )
+
+                AgentTeamConfigurationStore.save([team])
+                AgentTeamConfigurationStore.resetCacheForTests()
+
+                let reloaded = try #require(AgentTeamConfigurationStore.team(id: "research"))
+                #expect(reloaded.memberAgentIds == [agentA, agentB].sorted { $0.uuidString < $1.uuidString })
+                #expect(reloaded.defaults.defaultModel == "mlx-community/Qwen3-4B-Instruct")
+                #expect(reloaded.defaults.manualToolNames == ["search_memory"])
+                #expect(reloaded.defaults.ttsVoice == "nova")
+            }
+        }
+    }
+
+    @Test
+    @MainActor
+    func assignAgent_addsMembershipIdempotently() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await Self.withTempOverride {
+                let agentId = UUID()
+                AgentTeamConfigurationStore.upsert(
+                    AgentTeamConfiguration(id: "ops", name: "Ops")
+                )
+
+                AgentTeamConfigurationStore.assign(agentId: agentId, toTeamId: "ops")
+                AgentTeamConfigurationStore.assign(agentId: agentId, toTeamId: "ops")
+
+                #expect(AgentTeamConfigurationStore.teamIds(containing: agentId) == ["ops"])
+                let team = try #require(AgentTeamConfigurationStore.team(id: "ops"))
+                #expect(team.memberAgentIds == [agentId])
+            }
+        }
+    }
+
+    @Test
+    @MainActor
+    func teamIdValidation_allowsStableURLSafeIdsOnly() {
+        #expect(AgentTeamConfigurationStore.isValidTeamId("research-1"))
+        #expect(AgentTeamConfigurationStore.isValidTeamId("ops_team"))
+        #expect(!AgentTeamConfigurationStore.isValidTeamId(""))
+        #expect(!AgentTeamConfigurationStore.isValidTeamId("has space"))
+        #expect(!AgentTeamConfigurationStore.isValidTeamId("not/slash"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
@@ -55,7 +55,15 @@ struct DefaultAgentConfigurationStoreTests {
                     autonomousExec: nil,
                     toolSelectionMode: .manual,
                     manualToolNames: ["osaurus_status", "osaurus_list"],
-                    manualSkillNames: ["greeting"]
+                    manualSkillNames: ["greeting"],
+                    creationDefaults: AgentCreationDefaults(
+                        defaultModel: "mlx-community/Qwen3-8B",
+                        temperature: 0.2,
+                        toolSelectionMode: .manual,
+                        manualToolNames: ["search_memory"],
+                        autoSpeak: true,
+                        ttsVoice: "alloy"
+                    )
                 )
 
                 DefaultAgentConfigurationStore.save(configured)
@@ -85,5 +93,6 @@ struct DefaultAgentConfigurationStoreTests {
         #expect(decoded.toolSelectionMode == nil)
         #expect(decoded.manualToolNames == nil)
         #expect(decoded.manualSkillNames == nil)
+        #expect(decoded.creationDefaults == .default)
     }
 }

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -249,8 +249,9 @@ struct HTTPHandlerEndpointTests {
             )
             #expect((resp as? HTTPURLResponse)?.statusCode == 200)
             let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            #expect(obj?["id"] as? String == hostAgentId.uuidString)
-            #expect(obj?["default_model"] as? String == "fake-metadata-model")
+            let metadata = obj?["agent"] as? [String: Any]
+            #expect(metadata?["id"] as? String == hostAgentId.uuidString)
+            #expect(metadata?["default_model"] as? String == "fake-metadata-model")
 
             // An address with no registry mapping still fails closed.
             let unknown = "0xdead000000000000000000000000000000000000"

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -264,10 +264,60 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
-    @Test func agents_get_exposesDefaultAgentConfigurationForLoopback() async throws {
+    @Test func agents_get_omitsBuiltInsAndSystemPromptsForLoopback() async throws {
         try await withIsolatedAgentState {
             DefaultAgentConfigurationStore.save(
                 DefaultAgentConfiguration(
+                    systemPrompt: "private default prompt",
+                    defaultModel: "global-chat-model",
+                    toolSelectionMode: .manual,
+                    manualToolNames: ["global_tool"],
+                    manualSkillNames: ["global_skill"],
+                    creationDefaults: AgentCreationDefaults(
+                        defaultModel: "global-create-model",
+                        temperature: 0.25,
+                        maxTokens: 128,
+                        toolSelectionMode: .manual,
+                        manualToolNames: ["global_tool"],
+                        manualSkillNames: ["global_skill"],
+                        autoSpeak: false,
+                        ttsVoice: "global-voice"
+                    )
+                )
+            )
+            let custom = Agent(
+                name: "Listable Agent",
+                description: "Custom agent",
+                systemPrompt: "private custom prompt",
+                defaultModel: "custom-model"
+            )
+            AgentManager.shared.add(custom)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, response) = try await jsonRequest("/agents", server: server)
+
+            #expect(response.statusCode == 200)
+            let decoded = try JSONDecoder().decode(AgentListEnvelope.self, from: data)
+            #expect(decoded.agents.allSatisfy { $0.id != Agent.defaultId.uuidString })
+            let listed = try #require(decoded.agents.first { $0.id == custom.id.uuidString })
+            #expect(listed.is_built_in == false)
+            #expect(listed.default_model == "custom-model")
+
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let agents = try #require(obj?["agents"] as? [[String: Any]])
+            for agent in agents {
+                #expect(agent["system_prompt"] == nil)
+            }
+        }
+    }
+
+    @Test func agentDefault_get_exposesDefaultAgentConfigurationForLoopback() async throws {
+        try await withIsolatedAgentState {
+            DefaultAgentConfigurationStore.save(
+                DefaultAgentConfiguration(
+                    systemPrompt: "private default prompt",
                     defaultModel: "global-chat-model",
                     toolSelectionMode: .manual,
                     manualToolNames: ["global_tool"],
@@ -288,12 +338,13 @@ struct HTTPHandlerEndpointTests {
             let server = try await startServer()
             defer { Task { await server.shutdown() } }
 
-            let (data, response) = try await jsonRequest("/agents", server: server)
+            let (data, response) = try await jsonRequest("/agents/default", server: server)
 
             #expect(response.statusCode == 200)
-            let decoded = try JSONDecoder().decode(AgentListEnvelope.self, from: data)
-            let defaultAgent = try #require(decoded.agents.first { $0.id == Agent.defaultId.uuidString })
+            let defaultAgent = try JSONDecoder().decode(AgentItemEnvelope.self, from: data).agent
+            #expect(defaultAgent.id == Agent.defaultId.uuidString)
             #expect(defaultAgent.is_built_in == true)
+            #expect(defaultAgent.system_prompt == "private default prompt")
             #expect(defaultAgent.default_model == "global-chat-model")
             #expect(defaultAgent.tool_selection_mode == "manual")
             #expect(defaultAgent.manual_tool_names == ["global_tool"])
@@ -313,6 +364,48 @@ struct HTTPHandlerEndpointTests {
         let (_, response) = try await jsonRequest("/agents", server: server)
 
         #expect(response.statusCode == 401)
+    }
+
+    @Test func agents_api_deniesScopedKeyManagementWhenLoopbackTrustIsDisabled() async throws {
+        try await withIsolatedAgentState {
+            let agentAddress = try AgentKey.deriveAddress(masterKey: TestKeys.alicePrivateKey, index: 0)
+            let agentKey = AgentKey.derive(masterKey: TestKeys.alicePrivateKey, index: 0)
+            let scopedToken = try TokenBuilder.build(
+                privateKey: agentKey,
+                iss: agentAddress,
+                aud: agentAddress
+            )
+            let scopedAgent = Agent(
+                name: "Scoped Agent",
+                systemPrompt: "private scoped prompt",
+                agentAddress: agentAddress.lowercased()
+            )
+            AgentManager.shared.add(scopedAgent)
+
+            let server = try await startServer(
+                trustLoopback: false,
+                apiKeyValidator: .forAlice(agentAddress: agentAddress)
+            )
+            defer { Task { await server.shutdown() } }
+
+            let (listData, listResponse) = try await jsonRequest(
+                "/agents",
+                authorization: "Bearer \(scopedToken)",
+                server: server
+            )
+            #expect(listResponse.statusCode == 200)
+            let listed = try JSONDecoder().decode(AgentListEnvelope.self, from: listData).agents
+            #expect(listed.map(\.id) == [scopedAgent.id.uuidString])
+
+            let (_, createResponse) = try await jsonRequest(
+                "/agents",
+                method: "POST",
+                body: ["name": "Denied"],
+                authorization: "Bearer \(scopedToken)",
+                server: server
+            )
+            #expect(createResponse.statusCode == 403)
+        }
     }
 
     @Test func agents_post_appliesDefaultTeamAndRequestPrecedence() async throws {
@@ -495,7 +588,10 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
-    private func startServer(trustLoopback: Bool = true) async throws -> TestServer {
+    private func startServer(
+        trustLoopback: Bool = true,
+        apiKeyValidator: APIKeyValidator = .empty
+    ) async throws -> TestServer {
         let config = ServerConfiguration.default
         let lease = await HTTPServerTestLock.shared.acquire()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -508,7 +604,7 @@ struct HTTPHandlerEndpointTests {
                         channel.pipeline.addHandler(
                             HTTPHandler(
                                 configuration: config,
-                                apiKeyValidator: .empty,
+                                apiKeyValidator: apiKeyValidator,
                                 eventLoop: channel.eventLoop,
                                 trustLoopback: trustLoopback
                             )
@@ -547,6 +643,7 @@ struct HTTPHandlerEndpointTests {
     private struct AgentSummary: Decodable {
         let id: String
         let name: String
+        let system_prompt: String?
         let default_model: String?
         let temperature: Float?
         let max_tokens: Int?
@@ -602,10 +699,14 @@ struct HTTPHandlerEndpointTests {
         _ path: String,
         method: String = "GET",
         body: [String: Any]? = nil,
+        authorization: String? = nil,
         server: TestServer
     ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)\(path)")!)
         request.httpMethod = method
+        if let authorization {
+            request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        }
         if let body {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try JSONSerialization.data(withJSONObject: body)

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -264,6 +264,219 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
+    @Test func agents_get_exposesDefaultAgentConfigurationForLoopback() async throws {
+        try await withIsolatedAgentState {
+            DefaultAgentConfigurationStore.save(
+                DefaultAgentConfiguration(
+                    defaultModel: "global-chat-model",
+                    toolSelectionMode: .manual,
+                    manualToolNames: ["global_tool"],
+                    manualSkillNames: ["global_skill"],
+                    creationDefaults: AgentCreationDefaults(
+                        defaultModel: "global-create-model",
+                        temperature: 0.25,
+                        maxTokens: 128,
+                        toolSelectionMode: .manual,
+                        manualToolNames: ["global_tool"],
+                        manualSkillNames: ["global_skill"],
+                        autoSpeak: false,
+                        ttsVoice: "global-voice"
+                    )
+                )
+            )
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, response) = try await jsonRequest("/agents", server: server)
+
+            #expect(response.statusCode == 200)
+            let decoded = try JSONDecoder().decode(AgentListEnvelope.self, from: data)
+            let defaultAgent = try #require(decoded.agents.first { $0.id == Agent.defaultId.uuidString })
+            #expect(defaultAgent.is_built_in == true)
+            #expect(defaultAgent.default_model == "global-chat-model")
+            #expect(defaultAgent.tool_selection_mode == "manual")
+            #expect(defaultAgent.manual_tool_names == ["global_tool"])
+            #expect(defaultAgent.manual_skill_names == ["global_skill"])
+            #expect(defaultAgent.creation_defaults?.default_model == "global-create-model")
+            #expect(defaultAgent.creation_defaults?.temperature == 0.25)
+            #expect(defaultAgent.creation_defaults?.max_tokens == 128)
+            #expect(defaultAgent.creation_defaults?.auto_speak == false)
+            #expect(defaultAgent.creation_defaults?.tts_voice == "global-voice")
+        }
+    }
+
+    @Test func agents_api_requiresAccessKeyWhenLoopbackTrustIsDisabled() async throws {
+        let server = try await startServer(trustLoopback: false)
+        defer { Task { await server.shutdown() } }
+
+        let (_, response) = try await jsonRequest("/agents", server: server)
+
+        #expect(response.statusCode == 401)
+    }
+
+    @Test func agents_post_appliesDefaultTeamAndRequestPrecedence() async throws {
+        try await withIsolatedAgentState {
+            DefaultAgentConfigurationStore.save(
+                DefaultAgentConfiguration(
+                    creationDefaults: AgentCreationDefaults(
+                        defaultModel: "global-model",
+                        temperature: 0.15,
+                        maxTokens: 128,
+                        toolSelectionMode: .manual,
+                        manualToolNames: ["global_tool"],
+                        manualSkillNames: ["global_skill"],
+                        autoSpeak: false,
+                        ttsVoice: "global-voice"
+                    )
+                )
+            )
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (_, teamResponse) = try await jsonRequest(
+                "/agents/teams/research",
+                method: "PUT",
+                body: [
+                    "name": "Research",
+                    "description": "Research defaults",
+                    "defaults": [
+                        "default_model": "team-model",
+                        "manual_tool_names": ["search_memory"],
+                        "auto_speak": true,
+                    ],
+                ],
+                server: server
+            )
+            #expect(teamResponse.statusCode == 201)
+
+            let (data, createResponse) = try await jsonRequest(
+                "/agents",
+                method: "POST",
+                body: [
+                    "name": "API Defaults Test \(UUID().uuidString)",
+                    "team_id": "research",
+                    "temperature": 0.7,
+                    "tts_voice": "request-voice",
+                ],
+                server: server
+            )
+
+            #expect(createResponse.statusCode == 201)
+            let created = try JSONDecoder().decode(AgentItemEnvelope.self, from: data).agent
+            #expect(created.default_model == "team-model")
+            #expect(created.temperature == 0.7)
+            #expect(created.max_tokens == 128)
+            #expect(created.tool_selection_mode == "manual")
+            #expect(created.manual_tool_names == ["search_memory"])
+            #expect(created.manual_skill_names == ["global_skill"])
+            #expect(created.auto_speak == true)
+            #expect(created.tts_voice == "request-voice")
+            #expect(created.team_ids == ["research"])
+
+            let createdId = try #require(UUID(uuidString: created.id))
+            let persisted = try #require(AgentManager.shared.agent(for: createdId))
+            #expect(persisted.defaultModel == "team-model")
+            #expect(persisted.temperature == 0.7)
+            #expect(persisted.maxTokens == 128)
+            #expect(persisted.manualToolNames == ["search_memory"])
+            #expect(persisted.manualSkillNames == ["global_skill"])
+            #expect(AgentTeamConfigurationStore.teamIds(containing: createdId) == ["research"])
+        }
+    }
+
+    @Test func agents_patch_updatesCustomAgentAndTeamMembership() async throws {
+        try await withIsolatedAgentState {
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            for teamId in ["research", "operators"] {
+                let (_, response) = try await jsonRequest(
+                    "/agents/teams/\(teamId)",
+                    method: "PUT",
+                    body: ["name": teamId.capitalized],
+                    server: server
+                )
+                #expect(response.statusCode == 201)
+            }
+
+            let (createData, createResponse) = try await jsonRequest(
+                "/agents",
+                method: "POST",
+                body: [
+                    "name": "Patch Target \(UUID().uuidString)",
+                    "team_id": "research",
+                ],
+                server: server
+            )
+            #expect(createResponse.statusCode == 201)
+            let created = try JSONDecoder().decode(AgentItemEnvelope.self, from: createData).agent
+
+            let (patchData, patchResponse) = try await jsonRequest(
+                "/agents/\(created.id)",
+                method: "PATCH",
+                body: [
+                    "name": "Renamed Agent",
+                    "default_model": "patched-model",
+                    "tools_enabled": false,
+                    "memory_enabled": false,
+                    "tool_selection_mode": "manual",
+                    "manual_skill_names": ["planner"],
+                    "team_ids": ["operators"],
+                ],
+                server: server
+            )
+
+            #expect(patchResponse.statusCode == 200)
+            let patched = try JSONDecoder().decode(AgentItemEnvelope.self, from: patchData).agent
+            #expect(patched.name == "Renamed Agent")
+            #expect(patched.default_model == "patched-model")
+            #expect(patched.tools_enabled == false)
+            #expect(patched.memory_enabled == false)
+            #expect(patched.tool_selection_mode == "manual")
+            #expect(patched.manual_skill_names == ["planner"])
+            #expect(patched.team_ids == ["operators"])
+
+            let agentId = try #require(UUID(uuidString: created.id))
+            let persisted = try #require(AgentManager.shared.agent(for: agentId))
+            #expect(persisted.name == "Renamed Agent")
+            #expect(persisted.defaultModel == "patched-model")
+            #expect(persisted.toolsEnabled == false)
+            #expect(persisted.memoryEnabled == false)
+            #expect(persisted.manualSkillNames == ["planner"])
+            #expect(AgentTeamConfigurationStore.teamIds(containing: agentId) == ["operators"])
+        }
+    }
+
+    @Test func agentDefault_patch_persistsCreationDefaults() async throws {
+        try await withIsolatedAgentState {
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, response) = try await jsonRequest(
+                "/agents/default",
+                method: "PATCH",
+                body: [
+                    "creation_defaults": [
+                        "default_model": "patched-default-model",
+                        "manual_skill_names": ["planner"],
+                    ],
+                ],
+                server: server
+            )
+
+            #expect(response.statusCode == 200)
+            let patched = try JSONDecoder().decode(AgentItemEnvelope.self, from: data).agent
+            #expect(patched.creation_defaults?.default_model == "patched-default-model")
+            #expect(patched.creation_defaults?.manual_skill_names == ["planner"])
+
+            let saved = DefaultAgentConfigurationStore.load()
+            #expect(saved.creationDefaults.defaultModel == "patched-default-model")
+            #expect(saved.creationDefaults.manualSkillNames == ["planner"])
+        }
+    }
+
     // MARK: - Test Server Bootstrap
 
     private struct TestServer {
@@ -282,7 +495,7 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
-    private func startServer() async throws -> TestServer {
+    private func startServer(trustLoopback: Bool = true) async throws -> TestServer {
         let config = ServerConfiguration.default
         let lease = await HTTPServerTestLock.shared.acquire()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -297,7 +510,7 @@ struct HTTPHandlerEndpointTests {
                                 configuration: config,
                                 apiKeyValidator: .empty,
                                 eventLoop: channel.eventLoop,
-                                trustLoopback: true
+                                trustLoopback: trustLoopback
                             )
                         )
                     }
@@ -321,6 +534,43 @@ struct HTTPHandlerEndpointTests {
         let status: String
         let settings: VMLXServerRuntimeSettings
         let effects: RuntimeSettingsEffects?
+    }
+
+    private struct AgentListEnvelope: Decodable {
+        let agents: [AgentSummary]
+    }
+
+    private struct AgentItemEnvelope: Decodable {
+        let agent: AgentSummary
+    }
+
+    private struct AgentSummary: Decodable {
+        let id: String
+        let name: String
+        let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
+        let is_built_in: Bool
+        let tools_enabled: Bool
+        let memory_enabled: Bool
+        let tool_selection_mode: String
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        let auto_speak: Bool?
+        let tts_voice: String?
+        let team_ids: [String]
+        let creation_defaults: AgentDefaultsSummary?
+    }
+
+    private struct AgentDefaultsSummary: Decodable {
+        let default_model: String?
+        let temperature: Float?
+        let max_tokens: Int?
+        let tool_selection_mode: String?
+        let manual_tool_names: [String]?
+        let manual_skill_names: [String]?
+        let auto_speak: Bool?
+        let tts_voice: String?
     }
 
     private struct RuntimeSettingsEffects: Decodable {
@@ -348,9 +598,29 @@ struct HTTPHandlerEndpointTests {
         return try await URLSession.shared.data(for: request)
     }
 
-    private func makeTempDirectory() throws -> URL {
+    private func jsonRequest(
+        _ path: String,
+        method: String = "GET",
+        body: [String: Any]? = nil,
+        server: TestServer
+    ) async throws -> (Data, HTTPURLResponse) {
+        var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)\(path)")!)
+        request.httpMethod = method
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+        return (data, httpResponse)
+    }
+
+    private func makeTempDirectory(prefix: String = "osaurus-runtime-settings-endpoint") throws -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "osaurus-runtime-settings-endpoint-\(UUID().uuidString)",
+            "\(prefix)-\(UUID().uuidString)",
             isDirectory: true
         )
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -371,5 +641,47 @@ struct HTTPHandlerEndpointTests {
             try? FileManager.default.removeItem(at: dir)
         }
         try await body()
+    }
+
+    @MainActor
+    private func withIsolatedAgentState(
+        _ body: @MainActor @Sendable () async throws -> Void
+    ) async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let root = try makeTempDirectory(prefix: "osaurus-agent-config-endpoint")
+            let configDir = root.appendingPathComponent("config", isDirectory: true)
+
+            let previousRoot = OsaurusPaths.overrideRoot
+            let previousDefaultDirectory = DefaultAgentConfigurationStore.overrideDirectory
+            let previousTeamDirectory = AgentTeamConfigurationStore.overrideDirectory
+            let previousAvailability = SandboxManager.State.shared.availability
+            let previousStatus = SandboxManager.State.shared.status
+
+            OsaurusPaths.overrideRoot = root
+            DefaultAgentConfigurationStore.overrideDirectory = configDir
+            AgentTeamConfigurationStore.overrideDirectory = configDir
+            DefaultAgentConfigurationStore.resetCacheForTests()
+            AgentTeamConfigurationStore.resetCacheForTests()
+            SandboxManager.State.shared.availability = .unavailable(
+                reason: "sandbox disabled for agent endpoint tests"
+            )
+            SandboxManager.State.shared.status = .notProvisioned
+            AgentManager.shared.refresh()
+
+            defer {
+                AgentManager.shared.refresh()
+                DefaultAgentConfigurationStore.overrideDirectory = previousDefaultDirectory
+                AgentTeamConfigurationStore.overrideDirectory = previousTeamDirectory
+                DefaultAgentConfigurationStore.resetCacheForTests()
+                AgentTeamConfigurationStore.resetCacheForTests()
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                SandboxManager.State.shared.availability = previousAvailability
+                SandboxManager.State.shared.status = previousStatus
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try await body()
+        }
     }
 }

--- a/docs/OpenAI_API_GUIDE.md
+++ b/docs/OpenAI_API_GUIDE.md
@@ -634,19 +634,19 @@ Response:
 
 ### Agent Configuration — `/agents`
 
-Returns and updates the configured agents exposed to the local API. Use this to discover agent IDs for the `X-Osaurus-Agent-Id` header, inspect default-agent settings, and create custom agents from persisted defaults.
+Returns and updates the configured agents exposed to the local API. Use this to discover custom agent IDs for the `X-Osaurus-Agent-Id` header, inspect default-agent settings through `/agents/default`, and create custom agents from persisted defaults.
 
 ```bash
 curl http://127.0.0.1:1337/agents
 ```
 
-Loopback requests and master-scoped access keys can read and manage all agents. Agent-scoped access keys can only read the custom agent addressed by the key and any teams containing that agent. `/agents/{id}/run` and `/agents/{id}/dispatch` keep their existing execution behavior and are not configuration endpoints.
+Loopback requests and master-scoped access keys can manage all agent configuration. `GET /agents` remains a discovery endpoint for visible custom agents only; it does not advertise built-in agents or include system prompts. Use `GET /agents/default` or `GET /agents/{uuid}` to read full configuration for a specific visible agent. Agent-scoped access keys can only read the custom agent addressed by the key and any teams containing that agent. `/agents/{id}/run` and `/agents/{id}/dispatch` keep their existing execution behavior and are not configuration endpoints.
 
 Common routes:
 
 | Route | Method | Description |
 |-------|--------|-------------|
-| `/agents` | `GET` | List visible default/custom agents |
+| `/agents` | `GET` | List visible custom agents |
 | `/agents` | `POST` | Create a custom agent from default/team/request defaults |
 | `/agents/default` | `GET`, `PATCH`, `PUT` | Read or update the built-in Default agent configuration |
 | `/agents/{uuid}` | `GET`, `PATCH`, `PUT` | Read or update a custom agent configuration |
@@ -665,17 +665,16 @@ Example list response:
 {
   "agents": [
     {
-      "id": "00000000-0000-0000-0000-000000000001",
-      "name": "Osaurus",
-      "description": "Default assistant",
-      "system_prompt": "",
-      "default_model": null,
+      "id": "4B4774A8-F37E-4B6E-9376-E197B52F9579",
+      "name": "Research assistant",
+      "description": "Custom research agent",
+      "default_model": "Qwen3-8B",
       "temperature": null,
       "max_tokens": null,
-      "effective_model": null,
+      "effective_model": "Qwen3-8B",
       "supports_thinking": false,
       "supports_vision": false,
-      "is_built_in": true,
+      "is_built_in": false,
       "tools_enabled": true,
       "memory_enabled": true,
       "tool_selection_mode": "auto",
@@ -683,18 +682,8 @@ Example list response:
       "manual_skill_names": null,
       "auto_speak": null,
       "tts_voice": null,
-      "agent_address": null,
-      "team_ids": [],
-      "creation_defaults": {
-        "default_model": null,
-        "temperature": null,
-        "max_tokens": null,
-        "tool_selection_mode": null,
-        "manual_tool_names": null,
-        "manual_skill_names": null,
-        "auto_speak": null,
-        "tts_voice": null
-      },
+      "agent_address": "0xabc...",
+      "team_ids": ["research"],
       "memory_entry_count": 42,
       "created_at": "2025-01-01T00:00:00Z",
       "updated_at": "2025-01-01T00:00:00Z"

--- a/docs/OpenAI_API_GUIDE.md
+++ b/docs/OpenAI_API_GUIDE.md
@@ -632,15 +632,34 @@ Response:
 {"status": "ok", "turns_ingested": 2}
 ```
 
-### List Agents — `GET /agents`
+### Agent Configuration — `/agents`
 
-Returns all configured agents along with their pinned-fact counts. Use this to discover agent IDs for the `X-Osaurus-Agent-Id` header.
+Returns and updates the configured agents exposed to the local API. Use this to discover agent IDs for the `X-Osaurus-Agent-Id` header, inspect default-agent settings, and create custom agents from persisted defaults.
 
 ```bash
 curl http://127.0.0.1:1337/agents
 ```
 
-Example response:
+Loopback requests and master-scoped access keys can read and manage all agents. Agent-scoped access keys can only read the custom agent addressed by the key and any teams containing that agent. `/agents/{id}/run` and `/agents/{id}/dispatch` keep their existing execution behavior and are not configuration endpoints.
+
+Common routes:
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/agents` | `GET` | List visible default/custom agents |
+| `/agents` | `POST` | Create a custom agent from default/team/request defaults |
+| `/agents/default` | `GET`, `PATCH`, `PUT` | Read or update the built-in Default agent configuration |
+| `/agents/{uuid}` | `GET`, `PATCH`, `PUT` | Read or update a custom agent configuration |
+| `/agents/teams` | `GET` | List visible named agent teams |
+| `/agents/teams/{id}` | `GET`, `PUT` | Read or upsert a named team and its creation defaults |
+
+When creating a custom agent, defaults are applied in this order:
+
+1. `config/default-agent.json` `creationDefaults`
+2. each requested team's `defaults`, in request order
+3. fields supplied directly in the create request
+
+Example list response:
 
 ```json
 {
@@ -649,9 +668,33 @@ Example response:
       "id": "00000000-0000-0000-0000-000000000001",
       "name": "Osaurus",
       "description": "Default assistant",
+      "system_prompt": "",
       "default_model": null,
+      "temperature": null,
+      "max_tokens": null,
+      "effective_model": null,
+      "supports_thinking": false,
       "supports_vision": false,
       "is_built_in": true,
+      "tools_enabled": true,
+      "memory_enabled": true,
+      "tool_selection_mode": "auto",
+      "manual_tool_names": null,
+      "manual_skill_names": null,
+      "auto_speak": null,
+      "tts_voice": null,
+      "agent_address": null,
+      "team_ids": [],
+      "creation_defaults": {
+        "default_model": null,
+        "temperature": null,
+        "max_tokens": null,
+        "tool_selection_mode": null,
+        "manual_tool_names": null,
+        "manual_skill_names": null,
+        "auto_speak": null,
+        "tts_voice": null
+      },
       "memory_entry_count": 42,
       "created_at": "2025-01-01T00:00:00Z",
       "updated_at": "2025-01-01T00:00:00Z"
@@ -661,6 +704,29 @@ Example response:
 ```
 
 `supports_vision` reflects whether the agent's effective model is a VLM, so clients can show or hide image-attach UI without round-tripping the model registry.
+
+Create a team default and then create an agent from it:
+
+```bash
+curl -X PUT http://127.0.0.1:1337/agents/teams/research \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Research",
+    "defaults": {
+      "default_model": "Qwen3-8B",
+      "tool_selection_mode": "manual",
+      "manual_tool_names": ["search_memory"]
+    }
+  }'
+
+curl -X POST http://127.0.0.1:1337/agents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Research Analyst",
+    "team_id": "research",
+    "temperature": 0.3
+  }'
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- add persisted agent creation defaults to `default-agent.json` and named team defaults in `agent-teams.json`
- expand `/agents` list/get/create/update configuration routes while leaving `/agents/{id}/run` and `/dispatch` execution paths unchanged
- document default < team < request precedence and add HTTP/store coverage for auth, create, update, and team membership behavior

## Why
This is the first API/store slice for #654 and #546: the Default agent's creation defaults are discoverable, custom agents can be created from explicit defaults, and callers can group agents without adding orchestration or scheduling behavior.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `SCRIPT_INPUT_FILE_COUNT=6 ... swiftlint lint --strict --use-script-input-files`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter 'DefaultAgentConfigurationStoreTests|AgentTeamConfigurationStoreTests|agents_get_exposesDefaultAgentConfigurationForLoopback|agents_api_requiresAccessKeyWhenLoopbackTrustIsDisabled|agents_post_appliesDefaultTeamAndRequestPrecedence|agents_patch_updatesCustomAgentAndTeamMembership|agentDefault_patch_persistsCreationDefaults'`\n\nNote: a broader local `HTTPHandlerEndpointTests` run reached the existing `runtimeSettings_put_performanceChange_refreshesLoadedModel` MLX metallib failure before these new agent tests; the agent-specific endpoint tests above pass.\n\nRefs #654\nRefs #546