### PR TITLE
Route MCP OAuth through global proxy

### DIFF
--- a/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
+++ b/Packages/OsaurusCore/Networking/GlobalProxySettings.swift
@@ -32,9 +32,7 @@ public enum GlobalProxySettings {
     /// that need a custom delegate (download progress, redirect policy) must
     /// build and own their own session.
     public static func sharedSession() -> URLSession {
-        let key =
-            diskBackedServerConfiguration()?.globalProxyURL?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let key = currentProxyCacheKey()
         return sharedSessionBox.withLock { state in
             if let state, state.proxyKey == key {
                 return state.session
@@ -47,6 +45,15 @@ public enum GlobalProxySettings {
             return session
         }
     }
+
+    /// Cache key for shared network clients that need to rebuild when the
+    /// persisted proxy endpoint changes, including clients with custom
+    /// delegates that cannot use `sharedSession()`.
+    static func currentProxyCacheKey() -> String {
+        diskBackedServerConfiguration()?.globalProxyURL?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+
     /// Read the persisted server configuration and return the validated proxy
     /// endpoint. Invalid or missing values fail closed to normal networking so
     /// a stale config file cannot break all outbound traffic.

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift
@@ -415,7 +415,7 @@ public actor MCPOAuthDiscovery {
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 15
-        let (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+        let (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw MCPOAuthDiscoveryError.transport("non-HTTP response")
         }

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift
@@ -6,17 +6,39 @@
 //
 
 import Foundation
+import os
 
 enum MCPOAuthHTTPTransport {
-    static let noRedirectSession: URLSession = {
+    private struct NoRedirectSessionState {
+        let proxyKey: String
+        let session: URLSession
+    }
+
+    private static let noRedirectSessionBox = OSAllocatedUnfairLock<NoRedirectSessionState?>(initialState: nil)
+
+    static func noRedirectSession() -> URLSession {
+        let key = GlobalProxySettings.currentProxyCacheKey()
+        return noRedirectSessionBox.withLock { state in
+            if let state, state.proxyKey == key {
+                return state.session
+            }
+
+            state?.session.finishTasksAndInvalidate()
+            let session = makeNoRedirectSession()
+            state = NoRedirectSessionState(proxyKey: key, session: session)
+            return session
+        }
+    }
+
+    private static func makeNoRedirectSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.waitsForConnectivity = true
-        return URLSession(
-            configuration: configuration,
+        return GlobalProxySettings.makeSession(
+            base: configuration,
             delegate: MCPOAuthNoRedirectDelegate.shared,
             delegateQueue: nil
         )
-    }()
+    }
 
     /// OAuth endpoints carry code/token material, so redirects must be visible to the
     /// caller instead of followed by Foundation with the original request context.
@@ -72,7 +94,7 @@ enum MCPOAuthURLPolicy {
     static func isAbsoluteHTTPURL(_ url: URL) -> Bool {
         guard
             let scheme = url.scheme?.lowercased(),
-            (scheme == "http" || scheme == "https"),
+            scheme == "http" || scheme == "https",
             url.host != nil
         else {
             return false
@@ -107,10 +129,11 @@ enum MCPOAuthURLPolicy {
             .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
 
         guard !normalized.isEmpty else { return true }
-        if normalized == "localhost"
+        let isLocalDomain =
+            normalized == "localhost"
             || normalized.hasSuffix(".localhost")
             || normalized.hasSuffix(".local")
-        {
+        if isLocalDomain {
             return true
         }
 

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift
@@ -118,7 +118,7 @@ public enum MCPOAuthRegistration {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         } catch {
             throw MCPOAuthRegistrationError.transport(error.localizedDescription)
         }

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -483,7 +483,7 @@ public enum MCPOAuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         } catch {
             throw MCPOAuthError.transport(error.localizedDescription)
         }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
@@ -5,6 +5,7 @@
 //  RFC 7591 Dynamic Client Registration request/response shape.
 //
 
+import CFNetwork
 import Foundation
 import XCTest
 
@@ -26,6 +27,53 @@ final class MCPOAuthRegistrationTests: XCTestCase {
         )
 
         XCTAssertNil(request)
+    }
+
+    func testOAuthTransportUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try makeTemporaryOAuthProxyRoot()
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                _ = MCPOAuthHTTPTransport.noRedirectSession()
+            }
+
+            try writeOAuthProxyServerConfiguration(proxyURL: "https://proxy.example.com:8443")
+
+            let session = MCPOAuthHTTPTransport.noRedirectSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int, 1)
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String, "proxy.example.com")
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int, 8443)
+        }
+    }
+
+    func testOAuthTransportRebuildsWhenGlobalProxyChanges() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try makeTemporaryOAuthProxyRoot()
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                _ = MCPOAuthHTTPTransport.noRedirectSession()
+            }
+
+            try writeOAuthProxyServerConfiguration(proxyURL: "http://proxy-one.example.com:8080")
+            let first = MCPOAuthHTTPTransport.noRedirectSession()
+
+            try writeOAuthProxyServerConfiguration(proxyURL: "socks5://proxy-two.example.com:1080")
+            let second = MCPOAuthHTTPTransport.noRedirectSession()
+            let dictionary = second.configuration.connectionProxyDictionary
+
+            XCTAssertFalse(first === second)
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int, 1)
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String, "proxy-two.example.com")
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int, 1080)
+        }
     }
 
     func testRegistrationRequestHasNativePublicClientShape() async throws {
@@ -76,6 +124,27 @@ final class MCPOAuthRegistrationTests: XCTestCase {
             XCTAssertTrue(error is MCPOAuthRegistrationError)
         }
     }
+}
+
+private func makeTemporaryOAuthProxyRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "osaurus-mcp-oauth-proxy-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+}
+
+private func writeOAuthProxyServerConfiguration(proxyURL: String?) throws {
+    try OsaurusPaths.ensureExists(OsaurusPaths.config())
+    var configuration = ServerConfiguration.default
+    configuration.globalProxyURL = proxyURL
+    let data = try JSONEncoder().encode(configuration)
+    try data.write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
 }
 
 private final class OAuthRegistrationCapture: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Route MCP OAuth discovery, dynamic registration, token exchange, and refresh requests through the persisted global proxy setting.
- Keep the OAuth no-redirect policy intact by building a proxy-aware custom `URLSession` with the existing redirect delegate.
- Rebuild the cached MCP OAuth transport session when the global proxy endpoint changes.
- Add regression coverage for proxy dictionary wiring and session rebuilds across proxy changes.

## Validation
- `git diff --check`
- `swiftlint lint --strict Packages/OsaurusCore/Networking/GlobalProxySettings.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-mcp-oauth-proxy swift test --package-path Packages/OsaurusCore --filter 'MCPOAuthRegistrationTests|MCPOAuthServiceTests|MCPOAuthDiscoveryTests|GlobalProxyConfigurationTests'`

Notes: the live-network MCP OAuth discovery test remains intentionally skipped in the local focused lane. This complements #1530 by covering the MCP OAuth transport path rather than provider OAuth services.

Refs #1091, #232.
