### PR TITLE
[codex] Route plugin host HTTP through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -70,14 +70,43 @@ final class PluginHostContext: @unchecked Sendable {
     /// than copying the struct.
     private(set) var hostAPIPtr: UnsafeMutablePointer<osr_host_api>?
 
+    private struct HTTPTransportSessionState {
+        let proxyKey: String
+        let session: URLSession
+    }
+
+    private static let noRedirectSessionBox = OSAllocatedUnfairLock<HTTPTransportSessionState?>(initialState: nil)
+
     /// Shared URLSession that suppresses redirects. `http_request`
     /// follows redirects manually so every `Location` target can pass
     /// through the same SSRF guard before the host connects.
-    private static let noRedirectSession: URLSession = {
+    static func noRedirectSession() -> URLSession {
+        let proxyKey = currentHTTPTransportProxyKey()
+        return noRedirectSessionBox.withLock { state in
+            if let state, state.proxyKey == proxyKey {
+                return state.session
+            }
+
+            state?.session.finishTasksAndInvalidate()
+            let session = makeNoRedirectSession()
+            state = HTTPTransportSessionState(proxyKey: proxyKey, session: session)
+            return session
+        }
+    }
+
+    private static func currentHTTPTransportProxyKey() -> String {
+        GlobalProxySettings.currentConfiguration()?.redactedDescription ?? ""
+    }
+
+    private static func makeNoRedirectSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.httpMaximumConnectionsPerHost = 10
-        return URLSession(configuration: config, delegate: NoRedirectDelegate.shared, delegateQueue: nil)
-    }()
+        return GlobalProxySettings.makeSession(
+            base: config,
+            delegate: NoRedirectDelegate.shared,
+            delegateQueue: nil
+        )
+    }
 
     private static let maxHTTPRedirects = 20
 
@@ -2494,7 +2523,7 @@ final class PluginHostContext: @unchecked Sendable {
                 var redirectCount = 0
 
                 while true {
-                    let (responseData, urlResponse) = try await Self.noRedirectSession.data(for: currentRequest)
+                    let (responseData, urlResponse) = try await Self.noRedirectSession().data(for: currentRequest)
                     let elapsed = Int(Date().timeIntervalSince(startTime) * 1000)
 
                     guard let httpResponse = urlResponse as? HTTPURLResponse else {

--- a/Packages/OsaurusCore/Tests/Plugin/PluginHostGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginHostGlobalProxyTests.swift
@@ -1,0 +1,84 @@
+//
+//  PluginHostGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+//  Plugin host HTTP transport should honor the app-wide proxy setting while
+//  keeping its custom no-redirect delegate for SSRF-checked redirect handling.
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct PluginHostGlobalProxyTests {
+    @Test func httpTransportUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try makeTemporaryPluginProxyRoot()
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                _ = PluginHostContext.noRedirectSession()
+            }
+
+            try writePluginProxyServerConfiguration(proxyURL: "https://proxy.example.com:8443")
+
+            let session = PluginHostContext.noRedirectSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+        }
+    }
+
+    @Test func httpTransportRebuildsWhenGlobalProxyChanges() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = try makeTemporaryPluginProxyRoot()
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+                _ = PluginHostContext.noRedirectSession()
+            }
+
+            try writePluginProxyServerConfiguration(proxyURL: "http://proxy-one.example.com:8080")
+            let first = PluginHostContext.noRedirectSession()
+
+            try writePluginProxyServerConfiguration(proxyURL: "socks5://proxy-two.example.com:1080")
+            let second = PluginHostContext.noRedirectSession()
+            let dictionary = second.configuration.connectionProxyDictionary
+
+            #expect(first !== second)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy-two.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        }
+    }
+}
+
+private func makeTemporaryPluginProxyRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "osaurus-plugin-host-proxy-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+}
+
+private func writePluginProxyServerConfiguration(proxyURL: String?) throws {
+    try OsaurusPaths.ensureExists(OsaurusPaths.config())
+    var configuration = ServerConfiguration.default
+    configuration.globalProxyURL = proxyURL
+    let data = try JSONEncoder().encode(configuration)
+    try data.write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}

--- a/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
+++ b/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
@@ -1,5 +1,80 @@
 # Open PR and Bug Development Plan
 
+Snapshot update: 2026-06-16 19:05 UTC, repo `osaurus-ai/osaurus`.
+
+This section is the current actionable plan. Older dated sections remain below
+as history and should not override this snapshot.
+
+## Current Live State - 2026-06-16 19:05 UTC
+
+- `origin/main` is `e8bcba8aa24eefeb2268a9b2f213ec1af2025d73`
+  (`fixed issue where model selected during onboarding not used (#1535)`).
+- Latest main remote gates are green on `e8bcba8a`:
+  - CI `27634279752`: `success`.
+  - Release Drafter `27634278864`: `success`.
+  - pages `27634275056`: `success`.
+- Recently landed work since the last active planning pass includes #1524,
+  #1525, #1526, #1534, #1535, and the 0.20.1 appcast update.
+- Author-owned review stack is green and mergeable:
+  - #1527, system prompt injection proof trace: draft, `CLEAN`, all checks
+    `SUCCESS`.
+  - #1528, pasted provider model-list URL handling: draft, `CLEAN`, all checks
+    `SUCCESS`.
+  - #1529, Codex OAuth diagnostic context: draft, `CLEAN`, all checks
+    `SUCCESS`.
+  - #1530, provider OAuth global proxy routing: draft, `CLEAN`, all checks
+    `SUCCESS`.
+  - #1531, configurable Hugging Face cache path: draft, `CLEAN`, all checks
+    `SUCCESS`.
+  - #1532, local access key lifecycle: draft, `CLEAN`, all checks `SUCCESS`.
+  - #1533, agent defaults and team API: draft, `CLEAN`, all checks `SUCCESS`.
+  - #1536, MCP OAuth global proxy routing: draft, `CLEAN`, all checks
+    `SUCCESS`.
+- Upstream #1537 is not author-owned and is still blocked on its long-running
+  `test-core` check; do not let it block review of the green author-owned
+  stack unless it lands and advances `main`.
+- Evidence-request comments were posted on bugs needing reporter confirmation:
+  #1496, #1161, #1129, #662, #1225, #615, and #903.
+
+## Immediate Execution Order - 2026-06-16
+
+1. Ask `tpae` to review the green stack in small groups:
+   - #1527-#1529: bug-proof and diagnostics.
+   - #1530 and #1536: global proxy coverage for provider OAuth and MCP OAuth.
+   - #1531-#1533: cache, access lifecycle, and agent/team follow-ups.
+2. Keep all issue threads awaiting reporter evidence in watch mode. Do not
+   claim those bugs fixed until new reporter evidence or local reproduction
+   confirms current-main behavior.
+3. Continue the global proxy lane with one narrow follow-up PR:
+   - Route plugin-host `http_request` traffic through the global proxy while
+     preserving manual redirect/SSRF checks.
+   - Keep the branch independent of #1536 by using the existing
+     `GlobalProxySettings.currentConfiguration()` and `makeSession(...)`
+     surface.
+   - Validate with focused plugin-host proxy tests, `swiftlint`, and scoped
+     OsaurusCore tests.
+4. After the plugin-host proxy PR is published, reassess remaining global proxy
+   gaps before starting new features. Likely candidates are plugin download
+   paths, repository/package fetches, and any remaining bespoke `URLSession`
+   creation outside shared proxy policy.
+5. Defer broad document-stack, historical conflict, localization, voice, and
+   runtime research lanes until the current green stack receives maintainer
+   direction or merges into `main`.
+
+## Discord Review Message - 2026-06-16
+
+Suggested message:
+
+```text
+@tpae quick review request when you have a window: the recent author-owned stack is green and CLEAN.
+
+- #1527-#1529: bug proof/diagnostic follow-ups for system prompt injection, provider URL handling, and Codex OAuth diagnostics.
+- #1530 + #1536: global proxy coverage for provider OAuth and MCP OAuth.
+- #1531-#1533: Hugging Face cache path, local access key lifecycle, and agent defaults/team API follow-ups.
+
+All listed PRs have test-core, test-cli, swiftlint, shellcheck, and release drafter green. I also posted evidence requests on the remaining blocked bug issues, so those are waiting on reporter confirmation rather than code changes right now.
+```
+
 Snapshot update: 2026-05-16 07:33 UTC, repo `osaurus-ai/osaurus`.
 
 This section is the current consolidated automation plan. It supersedes every


### PR DESCRIPTION
## Summary
- Route plugin-host `http_request` traffic through the persisted global proxy setting.
- Preserve the existing no-redirect session behavior so plugin redirects still go through host-side SSRF validation before the next request is sent.
- Rebuild the cached plugin-host HTTP session when the effective proxy configuration changes.
- Refresh the open PR / bug development plan with the current green review stack and the Discord review message for `tpae`.

## Why
The global proxy lane already covers provider/model paths and has separate OAuth coverage in #1530 and #1536. Plugin-host HTTP was still using a bespoke `URLSession(configuration:delegate:)`, so plugin network traffic could bypass the app-wide proxy setting even though it still needed the custom redirect delegate.

## Validation
- `git diff --check`
- `swiftlint lint --reporter github-actions-logging`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-plugin-host-proxy swift test --package-path Packages/OsaurusCore --filter 'PluginHostGlobalProxyTests|PluginHostJSONTests|SSRFProtectionTests|GlobalProxyConfigurationTests'`

Note: `swiftlint lint --strict` currently reports existing repo-wide warnings as serious on current main; the workflow-equivalent lint command above exits successfully.

Refs #1091, #232.
