### PR TITLE
[codex] Fix MCP stdio access key auth

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift
@@ -18,7 +18,7 @@ struct OsaurusCLI {
         case show(String)
         case run(String)
         case pull(String)
-        case mcp
+        case mcp([String])
         case ui
         case tools([String])
         case manifest([String])
@@ -45,7 +45,7 @@ struct OsaurusCLI {
         case "pull":
             if let modelId = rest.first, !modelId.isEmpty { return .pull(modelId) }
             return nil
-        case "mcp": return .mcp
+        case "mcp": return .mcp(rest)
         case "ui": return .ui
         case "tools": return .tools(rest)
         case "manifest": return .manifest(rest)
@@ -80,8 +80,8 @@ struct OsaurusCLI {
             await RunCommand.execute(args: [modelId])
         case .pull(let modelId):
             await PullCommand.execute(args: [modelId])
-        case .mcp:
-            await MCPCommand.execute(args: [])
+        case .mcp(let args):
+            await MCPCommand.execute(args: args)
         case .ui:
             await UICommand.execute(args: [])
         case .tools(let args):
@@ -109,7 +109,10 @@ struct OsaurusCLI {
                                       Start the server (default: localhost only). If --expose
                                       is set, a warning prompt will appear unless --yes is provided.
               osaurus stop            Stop the server
-              osaurus mcp             Run MCP stdio server proxying to local HTTP
+              osaurus mcp [--access-key KEY]
+                                      Run MCP stdio server proxying to local HTTP. When
+                                      server network exposure is enabled, provide an
+                                      access key here or via OSAURUS_MCP_ACCESS_KEY.
               osaurus version         Show version (also: --version or -v)
               osaurus status          Check if the Osaurus server is running
               osaurus list            List available model IDs

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift
@@ -12,7 +12,19 @@ public struct MCPCommand: Command {
     public static let name = "mcp"
 
     public static func execute(args: [String]) async {
+        if args.contains("--help") || args.contains("-h") {
+            printUsage()
+            exit(EXIT_SUCCESS)
+        }
+
         fputs("[MCP] Starting MCP command...\n", stderr)
+        let credential = resolvedAccessKey(args: args)
+        if let credential {
+            fputs("[MCP] Using access key from \(credential.source)\n", stderr)
+        } else {
+            fputs("[MCP] No access key configured; relying on local loopback trust\n", stderr)
+        }
+
         // Ensure app server is up; auto-launch only if not already running
         let port = await ServerControl.ensureServerReadyOrExit(pollSeconds: 5.0)
         fputs("[MCP] Server ready on port \(port)\n", stderr)
@@ -36,10 +48,7 @@ public struct MCPCommand: Command {
                 return .init(tools: [])
             }
             fputs("[MCP] Fetching tools from \(url)\n", stderr)
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.timeoutInterval = 5.0
+            let request = makeProxyRequest(url: url, method: "GET", timeout: 5.0, credential: credential)
             do {
                 let (data, response) = try await URLSession.shared.data(for: request)
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
@@ -52,8 +61,7 @@ public struct MCPCommand: Command {
                 fputs("[MCP] Tools fetched successfully\n", stderr)
                 let tools: [MCP.Tool]
                 if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                    let arr = obj["tools"] as? [[String: Any]]
-                {
+                    let arr = obj["tools"] as? [[String: Any]] {
                     tools = arr.map { item in
                         let name = (item["name"] as? String) ?? ""
                         let description = (item["description"] as? String) ?? ""
@@ -87,13 +95,10 @@ public struct MCPCommand: Command {
                 let isError: Bool
             }
             guard let url = URL(string: "\(baseURL)/mcp/call") else {
-                return .init(content: [.text("Invalid URL")], isError: true)
+                return .init(content: [.text(text: "Invalid URL", annotations: nil, _meta: nil)], isError: true)
             }
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
+            var request = makeProxyRequest(url: url, method: "POST", timeout: 30.0, credential: credential)
             request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.timeoutInterval = 30.0
 
             do {
                 // Wrap dictionary arguments into a single MCP.Value object if present
@@ -103,10 +108,14 @@ public struct MCPCommand: Command {
 
                 let (data, response) = try await URLSession.shared.data(for: request)
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-                    let message = String(decoding: data, as: UTF8.self)
+                    let message = String(bytes: data, encoding: .utf8) ?? ""
                     return .init(
                         content: [
-                            .text("HTTP \(String(describing: (response as? HTTPURLResponse)?.statusCode)): \(message)")
+                            .text(
+                                text: "HTTP \(String(describing: (response as? HTTPURLResponse)?.statusCode)): \(message)",
+                                annotations: nil,
+                                _meta: nil
+                            )
                         ],
                         isError: true
                     )
@@ -117,11 +126,14 @@ public struct MCPCommand: Command {
                 if text.isEmpty {
                     return .init(content: [], isError: decoded.isError)
                 } else {
-                    return .init(content: [.text(text)], isError: decoded.isError)
+                    return .init(content: [.text(text: text, annotations: nil, _meta: nil)], isError: decoded.isError)
                 }
             } catch {
                 fputs("[MCP] Error calling tool: \(error)\n", stderr)
-                return .init(content: [.text(error.localizedDescription)], isError: true)
+                return .init(
+                    content: [.text(text: error.localizedDescription, annotations: nil, _meta: nil)],
+                    isError: true
+                )
             }
         }
 
@@ -140,6 +152,130 @@ public struct MCPCommand: Command {
             fputs("MCP server error: \(error.localizedDescription)\n", stderr)
             exit(EXIT_FAILURE)
         }
+    }
+
+    struct AccessKeyCredential: Equatable {
+        let token: String
+        let source: String
+    }
+
+    static func resolvedAccessKey(
+        args: [String],
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> AccessKeyCredential? {
+        for index in args.indices {
+            let arg = args[index]
+            if let value = accessKeyValue(fromInlineArgument: arg) {
+                return AccessKeyCredential(token: value, source: accessKeySource(fromInlineArgument: arg))
+            }
+            guard accessKeyOptionNames.contains(arg), args.indices.contains(index + 1) else {
+                continue
+            }
+            if let token = normalizedAccessKey(args[index + 1]) {
+                return AccessKeyCredential(token: token, source: arg)
+            }
+        }
+
+        for name in accessKeyEnvironmentNames {
+            if let token = normalizedAccessKey(environment[name]) {
+                return AccessKeyCredential(token: token, source: name)
+            }
+        }
+
+        for name in authorizationEnvironmentNames {
+            if let token = normalizedAuthorizationHeader(environment[name]) {
+                return AccessKeyCredential(token: token, source: name)
+            }
+        }
+
+        return nil
+    }
+
+    static func makeProxyRequest(
+        url: URL,
+        method: String,
+        timeout: TimeInterval,
+        credential: AccessKeyCredential?
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = timeout
+        if let credential {
+            request.setValue("Bearer \(credential.token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private static let accessKeyOptionNames: Set<String> = [
+        "--access-key",
+        "--api-key",
+        "--token",
+        "--bearer-token",
+    ]
+
+    private static let accessKeyEnvironmentNames = [
+        "OSAURUS_MCP_ACCESS_KEY",
+        "OSAURUS_ACCESS_KEY",
+        "OSAURUS_API_KEY",
+        "OSU_ACCESS_KEY",
+        "OSU_API_KEY",
+    ]
+
+    private static let authorizationEnvironmentNames = [
+        "OSAURUS_MCP_AUTHORIZATION",
+        "AUTHORIZATION",
+        "HTTP_AUTHORIZATION",
+    ]
+
+    private static func accessKeyValue(fromInlineArgument argument: String) -> String? {
+        for option in accessKeyOptionNames {
+            let prefix = option + "="
+            guard argument.hasPrefix(prefix) else { continue }
+            return normalizedAccessKey(String(argument.dropFirst(prefix.count)))
+        }
+        return nil
+    }
+
+    private static func accessKeySource(fromInlineArgument argument: String) -> String {
+        argument.split(separator: "=", maxSplits: 1).first.map(String.init) ?? "--access-key"
+    }
+
+    private static func normalizedAccessKey(_ rawValue: String?) -> String? {
+        guard var value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if value.lowercased().hasPrefix("bearer ") {
+            value = String(value.dropFirst(7)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return value.isEmpty ? nil : value
+    }
+
+    private static func normalizedAuthorizationHeader(_ rawValue: String?) -> String? {
+        guard let value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+            value.lowercased().hasPrefix("bearer ")
+        else {
+            return nil
+        }
+        return normalizedAccessKey(value)
+    }
+
+    private static func printUsage() {
+        let usage = """
+            Usage:
+              osaurus mcp [--access-key KEY]
+
+            Runs an MCP stdio server that proxies tool discovery and calls to
+            the local Osaurus HTTP server. Local-only servers can rely on
+            loopback trust. If Server > Network exposure is enabled, provide an
+            access key with --access-key or OSAURUS_MCP_ACCESS_KEY.
+
+            Accepted environment variables:
+              OSAURUS_MCP_ACCESS_KEY, OSAURUS_ACCESS_KEY, OSAURUS_API_KEY,
+              OSU_ACCESS_KEY, OSU_API_KEY, OSAURUS_MCP_AUTHORIZATION,
+              HTTP_AUTHORIZATION, AUTHORIZATION
+            """
+        print(usage)
     }
 
     // Convert loosely-typed JSON (from JSONSerialization) into MCP.Value

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPCommandAuthTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPCommandAuthTests.swift
@@ -1,0 +1,79 @@
+//
+//  MCPCommandAuthTests.swift
+//  osaurus
+//
+//  Tests the access-key plumbing used by the stdio MCP bridge before it
+//  proxies to the local authenticated HTTP MCP endpoints.
+//
+
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class MCPCommandAuthTests: XCTestCase {
+
+    func testAccessKeyFlagWinsOverEnvironment() {
+        let credential = MCPCommand.resolvedAccessKey(
+            args: ["--access-key", "osk-v1.flag.token"],
+            environment: ["OSAURUS_MCP_ACCESS_KEY": "osk-v1.env.token"]
+        )
+
+        XCTAssertEqual(credential?.token, "osk-v1.flag.token")
+        XCTAssertEqual(credential?.source, "--access-key")
+    }
+
+    func testInlineAccessKeyStripsBearerPrefix() {
+        let credential = MCPCommand.resolvedAccessKey(
+            args: ["--access-key=Bearer osk-v1.inline.token"],
+            environment: [:]
+        )
+
+        XCTAssertEqual(credential?.token, "osk-v1.inline.token")
+        XCTAssertEqual(credential?.source, "--access-key")
+    }
+
+    func testEnvironmentAccessKeySupportsClaudeDesktopAuthorizationNames() {
+        let credential = MCPCommand.resolvedAccessKey(
+            args: [],
+            environment: ["HTTP_AUTHORIZATION": "Bearer osk-v1.env.token"]
+        )
+
+        XCTAssertEqual(credential?.token, "osk-v1.env.token")
+        XCTAssertEqual(credential?.source, "HTTP_AUTHORIZATION")
+    }
+
+    func testGenericAuthorizationEnvironmentRequiresBearerValue() {
+        let credential = MCPCommand.resolvedAccessKey(
+            args: [],
+            environment: ["AUTHORIZATION": "Basic not-an-osaurus-key"]
+        )
+
+        XCTAssertNil(credential)
+    }
+
+    func testProxyRequestAddsAuthorizationWhenCredentialExists() throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:1337/mcp/tools"))
+        let request = MCPCommand.makeProxyRequest(
+            url: url,
+            method: "GET",
+            timeout: 5,
+            credential: .init(token: "osk-v1.request.token", source: "test")
+        )
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer osk-v1.request.token")
+    }
+
+    func testProxyRequestLeavesAuthorizationEmptyWithoutCredential() throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:1337/mcp/tools"))
+        let request = MCPCommand.makeProxyRequest(
+            url: url,
+            method: "GET",
+            timeout: 5,
+            credential: nil
+        )
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -149,7 +149,23 @@ Osaurus is a full MCP (Model Context Protocol) server. Give any MCP-compatible c
 }
 ```
 
-`osaurus mcp` starts a stdio MCP server for the client and proxies tool discovery/calls to your local Osaurus HTTP server. In the other direction, Osaurus can also act as an MCP client and aggregate tools from URL-based remote MCP providers. One-tap connect to ~25 well-known providers (Linear, Notion, GitHub, Vercel, Supabase, Sentry, Stripe, Cloudflare, ...) with auto OAuth 2.1 + Dynamic Client Registration, or paste an API key. The Remote MCP Providers UI is for HTTP/SSE MCP endpoints; it does not launch third-party `command`/`args` stdio providers. See the [Remote MCP Providers Guide](docs/REMOTE_MCP_PROVIDERS.md) for details.
+`osaurus mcp` starts a stdio MCP server for the client and proxies tool discovery/calls to your local Osaurus HTTP server. Local-only servers can rely on loopback trust. If Server > Network exposure is enabled, add an access key to the client environment:
+
+```json
+{
+  "mcpServers": {
+    "osaurus": {
+      "command": "osaurus",
+      "args": ["mcp"],
+      "env": {
+        "OSAURUS_MCP_ACCESS_KEY": "osk-v1..."
+      }
+    }
+  }
+}
+```
+
+In the other direction, Osaurus can also act as an MCP client and aggregate tools from URL-based remote MCP providers. One-tap connect to ~25 well-known providers (Linear, Notion, GitHub, Vercel, Supabase, Sentry, Stripe, Cloudflare, ...) with auto OAuth 2.1 + Dynamic Client Registration, or paste an API key. The Remote MCP Providers UI is for HTTP/SSE MCP endpoints; it does not launch third-party `command`/`args` stdio providers. See the [Remote MCP Providers Guide](docs/REMOTE_MCP_PROVIDERS.md) for details.
 
 ## Tools & Plugins
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -307,7 +307,7 @@ Research notes for the next local-runtime compatibility wave live in
 {"command": "osaurus", "args": ["mcp"]}
 ```
 
-This command bridge is for external clients connecting to Osaurus. It is separate from Remote MCP Providers, which only connect from Osaurus to URL-based HTTP/SSE MCP servers.
+This command bridge is for external clients connecting to Osaurus. If Server > Network exposure is enabled, provide an access key with `OSAURUS_MCP_ACCESS_KEY` in the MCP client's environment or pass `--access-key` in the `args` array. It is separate from Remote MCP Providers, which only connect from Osaurus to URL-based HTTP/SSE MCP servers.
 
 ---
 

--- a/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
+++ b/docs/OPEN_PR_BUG_DEVELOPMENT_PLAN.md
@@ -1,62 +1,50 @@
 # Open PR and Bug Development Plan
 
-Snapshot update: 2026-06-16 19:05 UTC, repo `osaurus-ai/osaurus`.
+Snapshot update: 2026-06-16 23:11 UTC, repo `osaurus-ai/osaurus`.
 
 This section is the current actionable plan. Older dated sections remain below
 as history and should not override this snapshot.
 
-## Current Live State - 2026-06-16 19:05 UTC
+## Current Live State - 2026-06-16 23:11 UTC
 
-- `origin/main` is `e8bcba8aa24eefeb2268a9b2f213ec1af2025d73`
-  (`fixed issue where model selected during onboarding not used (#1535)`).
-- Latest main remote gates are green on `e8bcba8a`:
-  - CI `27634279752`: `success`.
-  - Release Drafter `27634278864`: `success`.
-  - pages `27634275056`: `success`.
-- Recently landed work since the last active planning pass includes #1524,
-  #1525, #1526, #1534, #1535, and the 0.20.1 appcast update.
-- Author-owned review stack is green and mergeable:
-  - #1527, system prompt injection proof trace: draft, `CLEAN`, all checks
-    `SUCCESS`.
-  - #1528, pasted provider model-list URL handling: draft, `CLEAN`, all checks
-    `SUCCESS`.
-  - #1529, Codex OAuth diagnostic context: draft, `CLEAN`, all checks
-    `SUCCESS`.
-  - #1530, provider OAuth global proxy routing: draft, `CLEAN`, all checks
-    `SUCCESS`.
-  - #1531, configurable Hugging Face cache path: draft, `CLEAN`, all checks
-    `SUCCESS`.
-  - #1532, local access key lifecycle: draft, `CLEAN`, all checks `SUCCESS`.
-  - #1533, agent defaults and team API: draft, `CLEAN`, all checks `SUCCESS`.
-  - #1536, MCP OAuth global proxy routing: draft, `CLEAN`, all checks
-    `SUCCESS`.
-- Upstream #1537 is not author-owned and is still blocked on its long-running
-  `test-core` check; do not let it block review of the green author-owned
-  stack unless it lands and advances `main`.
+- `origin/main` is `b768bbcb2a86e7cf577e69fe15040c3e1ba20c22`
+  (`fixed anthropic api failing on remote providers (#1540)`).
+- The local checkout and `mimeding/osaurus` fork `main` are synced to the same
+  commit.
+- Recently landed work since the last active planning pass includes #1528,
+  #1529, #1530, #1531, #1532, #1538, #1540, and the 0.20.2 tag/appcast work.
+- Current author-owned review stack is ready and green:
+  - #1527, system prompt injection proof trace: `CLEAN`, checks `SUCCESS`.
+  - #1533, agent defaults and team API: `CLEAN`, checks `SUCCESS`.
+  - #1536, MCP OAuth global proxy routing: `CLEAN`, checks `SUCCESS`.
+  - #1475, voice input and speech output controls: `CLEAN`, checks `SUCCESS`.
+- Newly actionable bug: #1539 reports that `osaurus mcp` returns an empty tool
+  list when Server > Network exposure disables loopback auth bypass. Current
+  source confirms the stdio bridge calls `/mcp/tools` and `/mcp/call` without
+  an `Authorization` header.
 - Evidence-request comments were posted on bugs needing reporter confirmation:
   #1496, #1161, #1129, #662, #1225, #615, and #903.
 
 ## Immediate Execution Order - 2026-06-16
 
-1. Ask `tpae` to review the green stack in small groups:
-   - #1527-#1529: bug-proof and diagnostics.
-   - #1530 and #1536: global proxy coverage for provider OAuth and MCP OAuth.
-   - #1531-#1533: cache, access lifecycle, and agent/team follow-ups.
-2. Keep all issue threads awaiting reporter evidence in watch mode. Do not
+1. Publish the #1539 fix as a focused PR:
+   - Preserve zero-config behavior for local-only servers.
+   - Let `osaurus mcp` attach `Authorization: Bearer ...` from
+     `OSAURUS_MCP_ACCESS_KEY`, compatible env names, or `--access-key`.
+   - Update README / MCP docs and add CLI tests for token parsing and request
+     header construction.
+2. Ask `tpae` to review the green stack in small groups:
+   - #1527: bug-proof and runtime validation trace.
+   - #1533: agent defaults and team API.
+   - #1536: MCP OAuth global proxy coverage.
+   - #1475: voice input/output controls.
+3. Keep all issue threads awaiting reporter evidence in watch mode. Do not
    claim those bugs fixed until new reporter evidence or local reproduction
    confirms current-main behavior.
-3. Continue the global proxy lane with one narrow follow-up PR:
-   - Route plugin-host `http_request` traffic through the global proxy while
-     preserving manual redirect/SSRF checks.
-   - Keep the branch independent of #1536 by using the existing
-     `GlobalProxySettings.currentConfiguration()` and `makeSession(...)`
-     surface.
-   - Validate with focused plugin-host proxy tests, `swiftlint`, and scoped
-     OsaurusCore tests.
-4. After the plugin-host proxy PR is published, reassess remaining global proxy
-   gaps before starting new features. Likely candidates are plugin download
-   paths, repository/package fetches, and any remaining bespoke `URLSession`
-   creation outside shared proxy policy.
+4. After #1536 and the #1539 PR land, reassess remaining global proxy and MCP
+   gaps. Likely candidates are CLI pull, theme/router clients, repository
+   fetches, and any remaining bespoke `URLSession` creation outside shared
+   proxy policy.
 5. Defer broad document-stack, historical conflict, localization, voice, and
    runtime research lanes until the current green stack receives maintainer
    direction or merges into `main`.
@@ -66,13 +54,14 @@ as history and should not override this snapshot.
 Suggested message:
 
 ```text
-@tpae quick review request when you have a window: the recent author-owned stack is green and CLEAN.
+@tpae quick review request when you have a window: the current author-owned stack is green and CLEAN.
 
-- #1527-#1529: bug proof/diagnostic follow-ups for system prompt injection, provider URL handling, and Codex OAuth diagnostics.
-- #1530 + #1536: global proxy coverage for provider OAuth and MCP OAuth.
-- #1531-#1533: Hugging Face cache path, local access key lifecycle, and agent defaults/team API follow-ups.
+- #1527: system prompt injection proof trace / runtime validation evidence.
+- #1533: agent defaults and team API.
+- #1536: MCP OAuth global proxy coverage.
+- #1475: voice input and speech output controls.
 
-All listed PRs have test-core, test-cli, swiftlint, shellcheck, and release drafter green. I also posted evidence requests on the remaining blocked bug issues, so those are waiting on reporter confirmation rather than code changes right now.
+I also picked up #1539 as the next focused bug fix: `osaurus mcp` needs to pass a Bearer access key when network exposure disables loopback trust, otherwise stdio clients see an empty tools list from HTTP 401.
 ```
 
 Snapshot update: 2026-05-16 07:33 UTC, repo `osaurus-ai/osaurus`.

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -299,10 +299,19 @@ List all tools (including remote ones):
 curl http://127.0.0.1:1337/mcp/tools
 ```
 
+If Server > Network exposure is enabled, local loopback auth bypass is disabled.
+Use an access key from Settings > Server > Authentication:
+
+```bash
+curl -H "Authorization: Bearer $OSAURUS_MCP_ACCESS_KEY" \
+  http://127.0.0.1:1337/mcp/tools
+```
+
 Call a remote tool directly:
 
 ```bash
 curl http://127.0.0.1:1337/mcp/call \
+  -H "Authorization: Bearer $OSAURUS_MCP_ACCESS_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "linear_search_issues",


### PR DESCRIPTION
## Summary
- allow `osaurus mcp` to attach `Authorization: Bearer ...` when proxying `/mcp/tools` and `/mcp/call`
- resolve the access key from `--access-key`, Osaurus-specific env vars, or Bearer-style authorization env vars used by MCP clients
- document the network-exposure setup and refresh the open PR / bug development plan snapshot

## Root Cause
When Server > Network exposure is enabled, Osaurus disables loopback auth bypass. The stdio MCP bridge still called the local HTTP MCP endpoints without an Authorization header, so `/mcp/tools` returned HTTP 401 and external MCP clients saw an empty tools list.

Fixes #1539.

## Validation
- `swift test --package-path Packages/OsaurusCLI`
- `swift test --package-path Packages/OsaurusCLI --filter MCPCommandAuthTests`
- `swiftlint lint Packages/OsaurusCLI/Sources/OsaurusCLI/OsaurusCLI.swift Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/MCPCommand.swift Packages/OsaurusCLI/Tests/OsaurusCLITests/MCPCommandAuthTests.swift`
- `swift test --package-path Packages/OsaurusCore --filter AgentManagerLifecycleNotificationTests/deleteSweepsPerAgentKeychainSecrets`
- `git diff --check`
