### PR TITLE
Route theme API through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/Themes/ThemesAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Themes/ThemesAPIClient.swift
@@ -123,7 +123,10 @@ public actor ThemesAPIClient {
 
     public init(baseURL: URL = ThemesAPIClient.defaultBaseURL) {
         self.baseURL = baseURL
+        self.session = Self.makeSession()
+    }
 
+    static func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 60
@@ -131,7 +134,7 @@ public actor ThemesAPIClient {
         config.httpAdditionalHeaders = [
             "Accept": "application/json"
         ]
-        self.session = URLSession(configuration: config)
+        return GlobalProxySettings.makeSession(base: config)
     }
 
     // MARK: - POST /auth/challenge
@@ -234,9 +237,7 @@ public actor ThemesAPIClient {
             let error: String?
             let message: String?
         }
-        if let envelope = try? decodeJSON(ErrorEnvelope.self, from: data),
-            let code = envelope.error
-        {
+        if let envelope = try? decodeJSON(ErrorEnvelope.self, from: data), let code = envelope.error {
             throw ThemesAPIError.from(
                 code: code,
                 message: envelope.message,

--- a/Packages/OsaurusCore/Tests/Theme/ThemesAPIClientGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemesAPIClientGlobalProxyTests.swift
@@ -1,0 +1,48 @@
+//
+//  ThemesAPIClientGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct ThemesAPIClientGlobalProxyTests {
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-themes-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = ThemesAPIClient.makeSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+            #expect(session.configuration.timeoutIntervalForRequest == 30)
+            #expect(session.configuration.httpAdditionalHeaders?["Accept"] as? String == "application/json")
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Business rationale

Theme sharing and importing calls `https://themes.osaurus.ai` directly. Users who configure the app-wide HTTP/SOCKS proxy for outbound traffic expect that service path to follow the same network route as providers, model downloads, and plugin HTTP transport. This closes one remaining direct-session gap for issues #1091 and #232.

## Coding rationale

The theme client keeps its existing ephemeral session, timeout, connectivity, and `Accept` header behavior, but constructs the session through `GlobalProxySettings.makeSession(base:)` so the persisted server proxy setting is applied at creation time. The change is intentionally limited to the theme API client; local loopback and LAN pairing flows are not routed through this path.

## Acceptance criteria

- [x] Theme API sessions inherit the persisted global proxy setting.
- [x] Existing theme API timeout and header configuration is preserved.
- [x] No local-only networking path is changed.

## Quality gate

- [x] `swiftlint lint Packages/OsaurusCore/Services/Themes/ThemesAPIClient.swift Packages/OsaurusCore/Tests/Theme/ThemesAPIClientGlobalProxyTests.swift`
- [x] `git diff --check`
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter ThemesAPIClientGlobalProxyTests`
- [x] Gate head SHA: 4f247820

## Debug evidence

`ThemesAPIClientGlobalProxyTests.defaultSessionUsesGlobalProxySetting` writes a temporary server config with `https://proxy.example.com:8443`, builds the default theme API session, and asserts the HTTPS proxy dictionary plus the existing timeout/header settings.

## Self-review

### Regression review

Touched call site: `ThemesAPIClient.init`, used by `ThemesAPIClient.shared` and test-created clients. Existing request construction and response handling are unchanged; the new test covers proxy inheritance and preservation of session settings.

### Performance review

No algorithmic change. Session creation still happens once per client actor and only adds the existing config lookup already used by other network clients. No new per-request I/O or allocations were added.

## Rollback

Revert commit `4f247820` to restore the direct ephemeral URLSession construction.