### PR TITLE
Route router API through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/Router/OsaurusRouterAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Router/OsaurusRouterAPIClient.swift
@@ -18,12 +18,16 @@ actor OsaurusRouterAPIClient {
         self.baseURL = baseURL
         self.signer = signer
         self.authOverride = authOverride
+        self.session = session ?? Self.makeSession()
+        self.decoder = JSONDecoder()
+    }
+
+    static func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 120
         config.waitsForConnectivity = false
-        self.session = session ?? URLSession(configuration: config)
-        self.decoder = JSONDecoder()
+        return GlobalProxySettings.makeSession(base: config)
     }
 
     func health() async throws {

--- a/Packages/OsaurusCore/Tests/Router/OsaurusRouterAPIClientTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/OsaurusRouterAPIClientTests.swift
@@ -1,10 +1,42 @@
 import Foundation
+import CFNetwork
 import Testing
 
 @testable import OsaurusCore
 
 @Suite("Osaurus router API client", .serialized)
 struct OsaurusRouterAPIClientTests {
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-router-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "socks5://proxy.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = OsaurusRouterAPIClient.makeSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+            #expect(session.configuration.timeoutIntervalForRequest == 30)
+            #expect(session.configuration.timeoutIntervalForResource == 120)
+        }
+    }
+
     @Test func balance_decodesMicroStringAndSendsAuthHeaders() async throws {
         let client = try makeClient { request in
             #expect(request.url?.path == "/credits/balance")
@@ -149,4 +181,8 @@ private extension URLRequest {
         }
         return data
     }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
 }


### PR DESCRIPTION
## Business rationale

The Osaurus router client calls the hosted router API for balance, checkout, model, and usage requests. With the app-wide global proxy setting enabled, those outbound requests should use the same proxy route as providers and downloads. This closes another direct-session gap for issues #1091 and #232.

## Coding rationale

The client already accepts an injected `URLSession` for tests. This PR preserves that injection path and changes only the default live session construction to call `GlobalProxySettings.makeSession(base:)` after applying the router client timeouts. Request signing, URLs, decoding, and injected test transports are unchanged.

## Acceptance criteria

- [x] Default router API sessions inherit a persisted SOCKS/HTTP global proxy.
- [x] Existing timeout settings are preserved.
- [x] Injected sessions used by tests and custom callers still bypass the default construction path.

## Quality gate

- [x] `swiftlint lint Packages/OsaurusCore/Services/Router/OsaurusRouterAPIClient.swift Packages/OsaurusCore/Tests/Router/OsaurusRouterAPIClientTests.swift`
- [x] `git diff --check`
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter OsaurusRouterAPIClientTests`
- [x] Gate head SHA: eb8b4744

## Debug evidence

`OsaurusRouterAPIClientTests.defaultSessionUsesGlobalProxySetting` writes a temporary server config with `socks5://proxy.example.com:1080`, builds the default router session, and asserts the SOCKS proxy dictionary plus the existing timeout values. The rest of the router client suite still passes.

## Self-review

### Regression review

Touched call site: default `OsaurusRouterAPIClient.init` session creation. Existing injected-session tests cover request path, body, auth headers, and error decoding; the new test covers proxy inheritance on the live default path.

### Performance review

No request-path complexity change. Session construction remains one-time per client instance and reuses the central proxy configuration code already used by provider network paths. No new hot-loop work or synchronous per-request I/O was added.

## Rollback

Revert commit `eb8b4744` to restore the direct ephemeral URLSession construction.