### PR TITLE
Route GitHub skill imports through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/GitHubSkillService.swift
+++ b/Packages/OsaurusCore/Services/GitHubSkillService.swift
@@ -867,10 +867,14 @@ public final class GitHubSkillService: ObservableObject {
     private let session: URLSession
 
     private init() {
+        self.session = Self.makeSession()
+    }
+
+    nonisolated static func makeSession() -> URLSession {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 60
-        self.session = URLSession(configuration: config)
+        return GlobalProxySettings.makeSession(base: config)
     }
 
     // MARK: - URL Parsing

--- a/Packages/OsaurusCore/Tests/Skill/GitHubSkillServiceGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/GitHubSkillServiceGlobalProxyTests.swift
@@ -1,0 +1,52 @@
+//
+//  GitHubSkillServiceGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct GitHubSkillServiceGlobalProxyTests {
+    @MainActor
+    @Test func defaultSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-github-skill-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "http://proxy.example.com:8080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = GitHubSkillService.makeSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPPort)] as? Int == 8080)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8080)
+            #expect(session.configuration.timeoutIntervalForRequest == 30)
+            #expect(session.configuration.timeoutIntervalForResource == 60)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Business rationale

GitHub skill import talks to GitHub directly when resolving and downloading repository contents. Users who configure an app-wide proxy for outbound network access need this import path to follow the same route as other remote service calls. This continues the #1091/#232 coverage sweep without changing local-only networking.

## Coding rationale

`GitHubSkillService` now builds its default session through a nonisolated `makeSession()` factory that preserves the existing default configuration and request/resource timeouts while applying `GlobalProxySettings`. URL parsing, repository validation, copy/import semantics, and GitHub response handling are unchanged. The factory is nonisolated because it has no UI state dependency and can be tested without crossing the main actor.

## Acceptance criteria

- [x] GitHub skill import sessions inherit the persisted global proxy setting.
- [x] Existing timeout behavior is preserved.
- [x] No import parsing or filesystem behavior changes.

## Quality gate

- [x] `git diff --check`
- [x] `swiftlint lint Packages/OsaurusCore/Services/GitHubSkillService.swift Packages/OsaurusCore/Tests/Skill/GitHubSkillServiceGlobalProxyTests.swift` exits 0; the service file still reports pre-existing warnings unrelated to this diff.
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter GitHubSkillServiceGlobalProxyTests`
- [x] Gate head SHA: 44fad482

## Debug evidence

`GitHubSkillServiceGlobalProxyTests.defaultSessionUsesGlobalProxySetting` writes a temporary server config with `http://proxy.example.com:8080`, builds the service session factory, and asserts both HTTP and HTTPS proxy dictionary entries plus the existing timeout settings.

## Self-review

### Regression review

Touched call site: `GitHubSkillService` default session construction used by GitHub import requests. The import state machine and parsing functions are not changed; the new test covers proxy application on the default session factory.

### Performance review

No algorithmic change. The proxy lookup happens when the service session is constructed, not per parsed file or copied asset. No new hot-loop work, unbounded allocation, or synchronous network behavior was added.

## Rollback

Revert commit `44fad482` to restore direct default URLSession construction.