### PR TITLE
Route privacy model downloads through global proxy

### DIFF
--- a/Packages/OsaurusCore/PrivacyFilter/Model/PrivacyFilterModelDownloader.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Model/PrivacyFilterModelDownloader.swift
@@ -179,11 +179,7 @@ public final class PrivacyFilterModelDownloader: NSObject, ObservableObject {
         let bytesTotal = wanted.reduce(Int64(0)) { $0 + $1.size }
         var bytesDownloaded: Int64 = 0
 
-        let session = URLSession(
-            configuration: .default,
-            delegate: self,
-            delegateQueue: nil
-        )
+        let session = Self.makeDownloadSession(delegate: self)
         self.session = session
 
         for (index, file) in wanted.enumerated() {
@@ -266,6 +262,10 @@ public final class PrivacyFilterModelDownloader: NSObject, ObservableObject {
         for (_, observer) in inflightObservers { observer.invalidate() }
         inflightObservers.removeAll()
         inflightContinuations.removeAll()
+    }
+
+    nonisolated static func makeDownloadSession(delegate: URLSessionDownloadDelegate) -> URLSession {
+        GlobalProxySettings.makeSession(base: .default, delegate: delegate, delegateQueue: nil)
     }
 
     private func runVerify() async {
@@ -437,7 +437,7 @@ private enum HuggingFaceTreeService {
         var req = URLRequest(url: url)
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         do {
-            let (data, response) = try await URLSession.shared.data(for: req)
+            let (data, response) = try await GlobalProxySettings.sharedSession().data(for: req)
             guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
                 return nil
             }

--- a/Packages/OsaurusCore/Tests/PrivacyFilter/PrivacyFilterModelDownloaderGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/PrivacyFilter/PrivacyFilterModelDownloaderGlobalProxyTests.swift
@@ -1,0 +1,55 @@
+//
+//  PrivacyFilterModelDownloaderGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct PrivacyFilterModelDownloaderGlobalProxyTests {
+    @Test func downloadSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-privacy-downloader-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let delegate = DownloadDelegate()
+            let session = PrivacyFilterModelDownloader.makeDownloadSession(delegate: delegate)
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+        }
+    }
+}
+
+private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {}
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Business rationale

The privacy filter bootstrap downloads Hugging Face tree metadata and model bundle files independently from the normal model downloader. Before this change, that path bypassed the app-wide proxy, so privacy-filter setup could fail on networks where other Osaurus downloads/providers were correctly proxied. This closes another #1091/#232 outbound coverage gap.

## Coding rationale

The delegated download session now uses `GlobalProxySettings.makeSession(base:delegate:delegateQueue:)`, preserving the existing `URLSessionDownloadDelegate` progress/completion behavior. The Hugging Face tree metadata request now uses `GlobalProxySettings.sharedSession()`. Bundle filtering, manifest synthesis, hash verification, and cancellation behavior are unchanged.

## Acceptance criteria

- [x] Privacy filter model download sessions inherit the persisted global proxy setting.
- [x] Hugging Face tree metadata requests use the shared global-proxy session.
- [x] Existing delegated progress and verification behavior is preserved.

## Quality gate

- [x] `git diff --check`
- [x] `swiftlint lint Packages/OsaurusCore/PrivacyFilter/Model/PrivacyFilterModelDownloader.swift Packages/OsaurusCore/Tests/PrivacyFilter/PrivacyFilterModelDownloaderGlobalProxyTests.swift` exits 0; the downloader file still reports pre-existing warnings unrelated to this diff.
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter PrivacyFilterModelDownloaderGlobalProxyTests`
- [x] Gate head SHA: e9de1396

## Debug evidence

`PrivacyFilterModelDownloaderGlobalProxyTests.downloadSessionUsesGlobalProxySetting` writes a temporary server config with `https://proxy.example.com:8443`, builds the delegated download session factory, and asserts the HTTPS proxy dictionary.

## Self-review

### Regression review

Touched call sites: privacy filter tree metadata fetch and delegated bundle file download session creation. Existing filtering, progress bookkeeping, continuation cleanup, file moves, manifest writing, and hash verification are untouched; the new test covers proxy inheritance for the delegated session factory.

### Performance review

No algorithmic change. The same metadata request and sequential file downloads occur; only their URLSession source changes. No new per-file loops, extra disk reads, or unbounded memory allocations were added.

## Rollback

Revert commit `e9de1396` to restore direct `URLSession.shared` metadata calls and direct default download-session construction.