### PR TITLE
Route remote agent invites through global proxy

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteAgentManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteAgentManager.swift
@@ -243,17 +243,21 @@ public final class RemoteAgentManager: ObservableObject {
     /// Use an ephemeral URLSession so the deeplink path never races shared
     /// connection state (cookies, persistent connections from other features).
     private func postWithBackgroundSession(_ request: URLRequest) async throws -> (Data, URLResponse) {
-        let cfg = URLSessionConfiguration.ephemeral
-        cfg.waitsForConnectivity = true
-        cfg.timeoutIntervalForRequest = 30
-        cfg.timeoutIntervalForResource = 60
-        let session = URLSession(configuration: cfg)
+        let session = Self.makePairInviteSession()
         defer { session.finishTasksAndInvalidate() }
         do {
             return try await session.data(for: request)
         } catch {
             throw RemoteAgentPairError.networkFailed(error.localizedDescription)
         }
+    }
+
+    nonisolated static func makePairInviteSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.waitsForConnectivity = true
+        cfg.timeoutIntervalForRequest = 30
+        cfg.timeoutIntervalForResource = 60
+        return GlobalProxySettings.makeSession(base: cfg)
     }
 
     private func decodeErrorMessage(_ data: Data) -> String? {

--- a/Packages/OsaurusCore/Tests/Networking/RemoteAgentManagerGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RemoteAgentManagerGlobalProxyTests.swift
@@ -1,0 +1,49 @@
+//
+//  RemoteAgentManagerGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct RemoteAgentManagerGlobalProxyTests {
+    @Test func pairInviteSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-remote-agent-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "socks5://proxy.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = RemoteAgentManager.makePairInviteSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+            #expect(session.configuration.waitsForConnectivity == true)
+            #expect(session.configuration.timeoutIntervalForRequest == 30)
+            #expect(session.configuration.timeoutIntervalForResource == 60)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Business rationale

Remote-agent share deeplinks post accepted invites back through the relay with `/pair-invite`. That is an outbound relay call, so it should honor the same app-wide proxy setting as other remote network access. This closes another targeted #1091/#232 proxy coverage gap while leaving LAN Bonjour pairing untouched.

## Coding rationale

`RemoteAgentManager` now uses a small `makePairInviteSession()` factory for the existing ephemeral pair-invite session. The factory preserves `waitsForConnectivity` and timeout behavior, then applies `GlobalProxySettings.makeSession(base:)`. Request body construction, HPKE sealing, response decoding, remote-provider persistence, and local pairing code are unchanged.

## Acceptance criteria

- [x] Pair-invite relay sessions inherit the persisted global proxy setting.
- [x] Existing pair-invite timeout/connectivity settings are preserved.
- [x] Local LAN pairing paths are not changed.

## Quality gate

- [x] `swiftlint lint Packages/OsaurusCore/Managers/RemoteAgentManager.swift Packages/OsaurusCore/Tests/Networking/RemoteAgentManagerGlobalProxyTests.swift`
- [x] `git diff --check`
- [x] `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RemoteAgentManagerGlobalProxyTests`
- [x] Gate head SHA: 3fe84eb9

## Debug evidence

`RemoteAgentManagerGlobalProxyTests.pairInviteSessionUsesGlobalProxySetting` writes a temporary server config with `socks5://proxy.example.com:1080`, builds the pair-invite session factory, and asserts the SOCKS proxy dictionary plus the existing timeout/connectivity values.

## Self-review

### Regression review

Touched call site: share-deeplink `postWithBackgroundSession` for `/pair-invite`. The local Bonjour pairing client in `ChatView` is not modified. Existing invite cryptography, persistence, and error decoding are untouched; the new test covers proxy inheritance for the relay session.

### Performance review

No algorithmic change. Session creation remains one-shot per invite POST and no new per-byte or per-agent loops were added. The proxy configuration lookup is bounded and reused from central networking code.

## Rollback

Revert commit `3fe84eb9` to restore direct ephemeral URLSession construction for pair invites.