### PR TITLE
Route relay tunnel traffic through global proxy

### DIFF
--- a/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
+++ b/Packages/OsaurusCore/Networking/RelayTunnelManager.swift
@@ -43,14 +43,18 @@ struct RelayPublicURLProbe: Sendable {
 
     static func live() -> RelayPublicURLProbe {
         RelayPublicURLProbe { request in
-            let config = URLSessionConfiguration.ephemeral
-            config.waitsForConnectivity = false
-            config.timeoutIntervalForRequest = timeout
-            config.timeoutIntervalForResource = timeout
-            let session = URLSession(configuration: config)
+            let session = Self.makeHealthCheckSession()
             defer { session.finishTasksAndInvalidate() }
             return try await session.data(for: request)
         }
+    }
+
+    static func makeHealthCheckSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.waitsForConnectivity = false
+        config.timeoutIntervalForRequest = timeout
+        config.timeoutIntervalForResource = timeout
+        return GlobalProxySettings.makeSession(base: config)
     }
 
     static func makeHealthRequest(baseURL: String) -> URLRequest? {
@@ -216,6 +220,10 @@ public final class RelayTunnelManager: ObservableObject {
         configuration = RelayConfigurationStore.load()
     }
 
+    nonisolated static func makeWebSocketSession() -> URLSession {
+        GlobalProxySettings.makeSession(base: .default)
+    }
+
     // MARK: - Public API
 
     /// Enable or disable tunneling for an agent. Persists the setting and connects/disconnects as needed.
@@ -315,7 +323,7 @@ public final class RelayTunnelManager: ObservableObject {
         // Re-check after the suspension: another connect may have won the race
         guard webSocketTask == nil || !isConnected else { return }
 
-        let session = URLSession(configuration: .default)
+        let session = Self.makeWebSocketSession()
         let task = session.webSocketTask(with: Self.relayURL)
         self.urlSession = session
         self.webSocketTask = task

--- a/Packages/OsaurusCore/Tests/Networking/RelayPublicURLProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RelayPublicURLProbeTests.swift
@@ -8,12 +8,74 @@
 //  through the public route.
 //
 
+import CFNetwork
 import Foundation
 import Testing
 
 @testable import OsaurusCore
 
 struct RelayPublicURLProbeTests {
+    @Test func liveHealthCheckSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-relay-health-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = RelayPublicURLProbe.makeHealthCheckSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+            #expect(session.configuration.waitsForConnectivity == false)
+            #expect(session.configuration.timeoutIntervalForRequest == 8)
+            #expect(session.configuration.timeoutIntervalForResource == 8)
+        }
+    }
+
+    @Test func websocketSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-relay-websocket-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "socks5://proxy.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = RelayTunnelManager.makeWebSocketSession()
+            defer { session.invalidateAndCancel() }
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        }
+    }
+
     @Test func healthRequestTargetsPublicHealthEndpoint() throws {
         let request = try #require(
             RelayPublicURLProbe.makeHealthRequest(baseURL: "https://0xabc.agent.osaurus.ai")
@@ -118,4 +180,8 @@ struct RelayPublicURLProbeTests {
             headerFields: ["Content-Type": "application/json"]
         )!
     }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
 }


### PR DESCRIPTION
## Business rationale

The relay tunnel uses two outbound paths: a public health probe and the WebSocket tunnel connection. Users behind a configured global proxy need both relay paths to honor that route; otherwise relay sharing can still fail even while other remote providers and downloads work. This closes a visible #1091/#232 coverage gap for public-link relay features.

## Coding rationale

RelayPublicURLProbe.live() now creates its short-lived health-check session through GlobalProxySettings, preserving the existing eight-second timeout and no-wait connectivity behavior. RelayTunnelManager now creates the WebSocket URLSession through a nonisolated factory using the same global proxy settings. Relay auth, frame handling, reconnect behavior, local server forwarding, and public-health retry logic are unchanged.

## Acceptance criteria

- [x] Relay public health-check sessions inherit the persisted global proxy setting.
- [x] Relay WebSocket sessions inherit the persisted global proxy setting.
- [x] Existing health-check timeout/connectivity settings and probe behavior are preserved.

## Quality gate

- [x] swiftlint lint Packages/OsaurusCore/Networking/RelayTunnelManager.swift Packages/OsaurusCore/Tests/Networking/RelayPublicURLProbeTests.swift exits 0; RelayTunnelManager still reports pre-existing warnings unrelated to this diff.
- [x] git diff --check
- [x] OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RelayPublicURLProbeTests
- [x] Gate head SHA: 639bd797

## Debug evidence

RelayPublicURLProbeTests.liveHealthCheckSessionUsesGlobalProxySetting asserts the HTTPS proxy dictionary and preserved health-check settings. RelayPublicURLProbeTests.websocketSessionUsesGlobalProxySetting asserts the SOCKS proxy dictionary for the tunnel WebSocket session. The existing health probe behavior tests still pass.

## Self-review

### Regression review

Touched call sites: relay public health probe session creation and relay WebSocket session creation. Existing URL validation, HTTP 200/failure handling, TLS failure reporting, tunnel auth, reconnect, and local forwarding logic are unchanged and covered by the existing relay probe tests plus the new proxy assertions.

### Performance review

No algorithmic change. The health probe still performs the same bounded attempts with the same timeout, and the WebSocket session is still created once per connect attempt. No new unbounded work or per-frame overhead was added.

## Rollback

Revert commit 639bd797 to restore direct URLSession construction for relay health checks and WebSocket connections.
