### PR TITLE
Route sandbox artifact downloads through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
@@ -1627,7 +1627,7 @@
                     }
                 }
             }
-            let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+            let session = Self.makeArtifactDownloadSession(delegate: delegate)
             defer { session.finishTasksAndInvalidate() }
 
             var lastError: Error?
@@ -1683,6 +1683,10 @@
             throw SandboxError.provisionFailed(
                 "Download failed: \(lastError?.localizedDescription ?? "all URLs failed")"
             )
+        }
+
+        nonisolated static func makeArtifactDownloadSession(delegate: URLSessionDownloadDelegate) -> URLSession {
+            GlobalProxySettings.makeSession(base: .default, delegate: delegate, delegateQueue: nil)
         }
 
         /// `verifySHA256` wrapped in a detached task. Lets actor-isolated

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxArtifactDownloadGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxArtifactDownloadGlobalProxyTests.swift
@@ -1,0 +1,59 @@
+//
+//  SandboxArtifactDownloadGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+#if os(macOS)
+
+    import CFNetwork
+    import Foundation
+    import Testing
+
+    @testable import OsaurusCore
+
+    @Suite
+    struct SandboxArtifactDownloadGlobalProxyTests {
+        @Test func artifactDownloadSessionUsesGlobalProxySetting() async throws {
+            try await StoragePathsTestLock.shared.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-sandbox-artifact-proxy-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                try OsaurusPaths.ensureExists(OsaurusPaths.config())
+                var configuration = ServerConfiguration.default
+                configuration.globalProxyURL = "https://proxy.example.com:8443"
+                try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+                let delegate = DownloadDelegate()
+                let session = SandboxManager.makeArtifactDownloadSession(delegate: delegate)
+                defer { session.invalidateAndCancel() }
+
+                let dictionary = session.configuration.connectionProxyDictionary
+                #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+                #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+                #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+            }
+        }
+    }
+
+    private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate {
+        func urlSession(
+            _ session: URLSession,
+            downloadTask: URLSessionDownloadTask,
+            didFinishDownloadingTo location: URL
+        ) {}
+    }
+
+    private func proxyKey(_ value: CFString) -> AnyHashable {
+        AnyHashable(value as String)
+    }
+
+#endif


### PR DESCRIPTION
## Business rationale

Sandbox provisioning downloads the pinned Kata kernel archive and initfs artifact before verifying their SHA-256 digests. Those remote artifact downloads should follow the app-wide proxy setting on restricted networks; otherwise sandbox setup can fail even when other Osaurus remote traffic is proxied. This advances the #1091/#232 all-network-access coverage without weakening artifact integrity checks.

## Coding rationale

The existing download delegate/progress path is preserved, but the URLSession is now created through SandboxManager.makeArtifactDownloadSession(), which applies GlobalProxySettings while retaining the delegate and delegate queue. Source selection, HTTP status handling, digest verification, size bounds, temp-file cleanup, and fail-closed behavior are unchanged.

## Acceptance criteria

- [x] Sandbox artifact download sessions inherit the persisted global proxy setting.
- [x] Existing delegated progress reporting remains intact.
- [x] Artifact SHA-256 and max-size verification behavior is unchanged.

## Quality gate

- [x] swiftlint lint Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift Packages/OsaurusCore/Tests/Sandbox/SandboxArtifactDownloadGlobalProxyTests.swift exits 0; SandboxManager still reports pre-existing warnings unrelated to this diff.
- [x] git diff --check
- [x] OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter SandboxArtifactDownloadGlobalProxyTests
- [x] Gate head SHA: d8b773ec

## Debug evidence

SandboxArtifactDownloadGlobalProxyTests.artifactDownloadSessionUsesGlobalProxySetting writes a temporary server config with https://proxy.example.com:8443, builds the artifact download session factory with a dummy download delegate, and asserts the HTTPS proxy dictionary.

## Self-review

### Regression review

Touched call site: SandboxManager.downloadFile session creation for provisioning artifact downloads. The download loop, mirror fallback for transport errors, integrity failure handling, SHA-256 verification, max-size bound, progress reporting callback, and destination move are unchanged. The new test covers proxy inheritance for the delegated session factory.

### Performance review

No algorithmic change. Downloads and hashing keep the same streaming/constant-memory behavior; proxy configuration is applied once when creating the download session. No new per-byte or per-file overhead was added.

## Rollback

Revert commit d8b773ec to restore direct URLSession construction for sandbox provisioning downloads.
