### PR TITLE
Route sandbox plugin manifests through global proxy

### DIFF
--- a/Packages/OsaurusCore/Models/Plugin/SandboxPlugin.swift
+++ b/Packages/OsaurusCore/Models/Plugin/SandboxPlugin.swift
@@ -333,7 +333,7 @@ extension SandboxPlugin {
 
     /// Import from a URL (fetches JSON from a remote URL).
     public static func fromURL(_ url: URL) async throws -> SandboxPlugin {
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let (data, response) = try await makeManifestFetchSession().data(from: url)
         guard let httpResponse = response as? HTTPURLResponse,
             (200 ... 299).contains(httpResponse.statusCode)
         else {
@@ -342,6 +342,10 @@ extension SandboxPlugin {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode(SandboxPlugin.self, from: data)
+    }
+
+    static func makeManifestFetchSession() -> URLSession {
+        GlobalProxySettings.sharedSession()
     }
 
     /// Import from a GitHub repo URL (looks for osaurus.json at the root).

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxPluginGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxPluginGlobalProxyTests.swift
@@ -1,0 +1,46 @@
+//
+//  SandboxPluginGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SandboxPluginGlobalProxyTests {
+    @Test func manifestFetchSessionUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-sandbox-plugin-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                _ = SandboxPlugin.makeManifestFetchSession()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "socks5://proxy.example.com:1080"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = SandboxPlugin.makeManifestFetchSession()
+
+            let dictionary = session.configuration.connectionProxyDictionary
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        }
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}


### PR DESCRIPTION
## Summary
- routes sandbox plugin manifest imports through GlobalProxySettings.sharedSession()
- keeps GitHub plugin imports covered because fromGitHub funnels into fromURL
- adds a focused proxy wiring test that inspects the generated SOCKS session config without network I/O

## Validation
- xcrun swift-format format -i Packages/OsaurusCore/Models/Plugin/SandboxPlugin.swift Packages/OsaurusCore/Tests/Sandbox/SandboxPluginGlobalProxyTests.swift
- git diff --check
- swiftlint lint Packages/OsaurusCore/Models/Plugin/SandboxPlugin.swift Packages/OsaurusCore/Tests/Sandbox/SandboxPluginGlobalProxyTests.swift (exit 0; reports pre-existing optional-bool warnings in SandboxPlugin.swift)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter SandboxPluginGlobalProxyTests

Head commit: 6062abef
