### PR TITLE
Route markdown image downloads through global proxy

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/MarkdownRemoteImageGlobalProxyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MarkdownRemoteImageGlobalProxyTests.swift
@@ -1,0 +1,67 @@
+//
+//  MarkdownRemoteImageGlobalProxyTests.swift
+//  OsaurusCoreTests
+//
+
+import CFNetwork
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct MarkdownRemoteImageGlobalProxyTests {
+    @Test func swiftUIRemoteImageLoaderUsesGlobalProxySetting() async throws {
+        try await withMarkdownImageProxyRoot(proxyURL: "socks5://proxy.example.com:1080") {
+            let session = ImageLoader.makeRemoteImageSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesSOCKSPort)] as? Int == 1080)
+        }
+    }
+
+    @Test func nativeRemoteImageLoaderUsesGlobalProxySetting() async throws {
+        try await withMarkdownImageProxyRoot(proxyURL: "https://proxy.example.com:8443") {
+            let session = NativeMarkdownView.makeRemoteImageSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int == 1)
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String == "proxy.example.com")
+            #expect(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int == 8443)
+        }
+    }
+}
+
+private func withMarkdownImageProxyRoot(
+    proxyURL: String,
+    _ body: @Sendable () throws -> Void
+) async throws {
+    try await StoragePathsTestLock.shared.run {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-markdown-image-proxy-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let previousRoot = OsaurusPaths.overrideRoot
+        OsaurusPaths.overrideRoot = root
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            _ = ImageLoader.makeRemoteImageSession()
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        try OsaurusPaths.ensureExists(OsaurusPaths.config())
+        var configuration = ServerConfiguration.default
+        configuration.globalProxyURL = proxyURL
+        let data = try JSONEncoder().encode(configuration)
+        try data.write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+        try body()
+    }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
+}

--- a/Packages/OsaurusCore/Views/Chat/MarkdownImageView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MarkdownImageView.swift
@@ -207,7 +207,7 @@ struct MarkdownImageView: View {
 
 // MARK: - Image Loader (non-actor-isolated)
 
-private enum ImageLoader {
+enum ImageLoader {
     static func load(from urlString: String) async throws -> NSImage {
         if urlString.hasPrefix("data:image/") {
             return try loadBase64(urlString)
@@ -247,7 +247,7 @@ private enum ImageLoader {
         guard let url = URL(string: urlString) else {
             throw ImageLoadError.invalidURL
         }
-        let (data, response) = try await URLSession.shared.data(from: url)
+        let (data, response) = try await makeRemoteImageSession().data(from: url)
         guard let httpResponse = response as? HTTPURLResponse,
             (200 ... 299).contains(httpResponse.statusCode)
         else {
@@ -257,6 +257,10 @@ private enum ImageLoader {
             throw ImageLoadError.corruptedImage
         }
         return image
+    }
+
+    static func makeRemoteImageSession() -> URLSession {
+        GlobalProxySettings.sharedSession()
     }
 }
 

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -23,6 +23,10 @@ final class NativeMarkdownView: NSView {
     override var acceptsFirstResponder: Bool { true }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
+    nonisolated static func makeRemoteImageSession() -> URLSession {
+        GlobalProxySettings.sharedSession()
+    }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
         if let sub = super.hitTest(point) { return sub }
         // when the container is taller than the laid-out text (or timing leaves super.hitTest nil),
@@ -955,7 +959,7 @@ final class NativeMarkdownView: NSView {
                 }.value
             } else {
                 do {
-                    let (d, _) = try await URLSession.shared.data(from: url)
+                    let (d, _) = try await Self.makeRemoteImageSession().data(from: url)
                     data = d
                 } catch {
                     data = nil


### PR DESCRIPTION
## Summary
- routes remote markdown image downloads through GlobalProxySettings.sharedSession()
- covers both SwiftUI MarkdownImageView and the native AppKit markdown renderer
- adds focused proxy wiring tests that avoid real image network I/O

## Validation
- xcrun swift-format format -i Packages/OsaurusCore/Views/Chat/MarkdownImageView.swift Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift Packages/OsaurusCore/Tests/Chat/MarkdownRemoteImageGlobalProxyTests.swift
- git diff --check
- swiftlint lint Packages/OsaurusCore/Views/Chat/MarkdownImageView.swift Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift Packages/OsaurusCore/Tests/Chat/MarkdownRemoteImageGlobalProxyTests.swift (exit 0; reports pre-existing warnings in MarkdownImageView.swift and NativeMarkdownView.swift)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter MarkdownRemoteImageGlobalProxyTests

Head commit: f3dda1d4
