### PR TITLE
[codex] Route MCP OAuth transport through global proxy

### DIFF
--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift
@@ -415,7 +415,7 @@ public actor MCPOAuthDiscovery {
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 15
-        let (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+        let (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw MCPOAuthDiscoveryError.transport("non-HTTP response")
         }

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift
@@ -6,17 +6,43 @@
 //
 
 import Foundation
+import os
 
 enum MCPOAuthHTTPTransport {
-    static let noRedirectSession: URLSession = {
+    private struct TransportSessionState {
+        let proxyKey: String
+        let session: URLSession
+    }
+
+    private static let noRedirectSessionBox = OSAllocatedUnfairLock<TransportSessionState?>(initialState: nil)
+
+    static func noRedirectSession() -> URLSession {
+        let proxyKey = currentTransportProxyKey()
+        return noRedirectSessionBox.withLock { state in
+            if let state, state.proxyKey == proxyKey {
+                return state.session
+            }
+
+            state?.session.finishTasksAndInvalidate()
+            let session = makeNoRedirectSession()
+            state = TransportSessionState(proxyKey: proxyKey, session: session)
+            return session
+        }
+    }
+
+    private static func currentTransportProxyKey() -> String {
+        GlobalProxySettings.currentConfiguration()?.redactedDescription ?? ""
+    }
+
+    private static func makeNoRedirectSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.waitsForConnectivity = true
-        return URLSession(
-            configuration: configuration,
+        return GlobalProxySettings.makeSession(
+            base: configuration,
             delegate: MCPOAuthNoRedirectDelegate.shared,
             delegateQueue: nil
         )
-    }()
+    }
 
     /// OAuth endpoints carry code/token material, so redirects must be visible to the
     /// caller instead of followed by Foundation with the original request context.
@@ -72,7 +98,7 @@ enum MCPOAuthURLPolicy {
     static func isAbsoluteHTTPURL(_ url: URL) -> Bool {
         guard
             let scheme = url.scheme?.lowercased(),
-            (scheme == "http" || scheme == "https"),
+            scheme == "http" || scheme == "https",
             url.host != nil
         else {
             return false
@@ -107,10 +133,11 @@ enum MCPOAuthURLPolicy {
             .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
 
         guard !normalized.isEmpty else { return true }
-        if normalized == "localhost"
+        let isLocalNamedHost =
+            normalized == "localhost"
             || normalized.hasSuffix(".localhost")
             || normalized.hasSuffix(".local")
-        {
+        if isLocalNamedHost {
             return true
         }
 

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift
@@ -118,7 +118,7 @@ public enum MCPOAuthRegistration {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         } catch {
             throw MCPOAuthRegistrationError.transport(error.localizedDescription)
         }

--- a/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
+++ b/Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift
@@ -483,7 +483,7 @@ public enum MCPOAuthService {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession.data(for: request)
+            (data, response) = try await MCPOAuthHTTPTransport.noRedirectSession().data(for: request)
         } catch {
             throw MCPOAuthError.transport(error.localizedDescription)
         }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
@@ -6,11 +6,41 @@
 //
 
 import Foundation
+import CFNetwork
 import XCTest
 
 @testable import OsaurusCore
 
 final class MCPOAuthRegistrationTests: XCTestCase {
+    func testOAuthTransportUsesGlobalProxySetting() async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-mcp-oauth-proxy-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                _ = MCPOAuthHTTPTransport.noRedirectSession()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            var configuration = ServerConfiguration.default
+            configuration.globalProxyURL = "https://proxy.example.com:8443"
+            try JSONEncoder().encode(configuration).write(to: OsaurusPaths.serverConfigFile(), options: .atomic)
+
+            let session = MCPOAuthHTTPTransport.noRedirectSession()
+            let dictionary = session.configuration.connectionProxyDictionary
+
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSEnable)] as? Int, 1)
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSProxy)] as? String, "proxy.example.com")
+            XCTAssertEqual(dictionary?[proxyKey(kCFNetworkProxiesHTTPSPort)] as? Int, 8443)
+        }
+    }
+
     func testOAuthTransportDoesNotFollowRedirects() {
         let response = HTTPURLResponse(
             url: URL(string: "https://auth.example.com/register")!,
@@ -76,6 +106,10 @@ final class MCPOAuthRegistrationTests: XCTestCase {
             XCTAssertTrue(error is MCPOAuthRegistrationError)
         }
     }
+}
+
+private func proxyKey(_ value: CFString) -> AnyHashable {
+    AnyHashable(value as String)
 }
 
 private final class OAuthRegistrationCapture: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- routes MCP OAuth discovery, dynamic client registration, and token exchange through the global proxy setting
- preserves the existing no-redirect delegate so OAuth redirects remain visible to callers
- caches the transport session and rebuilds it when the active proxy setting changes
- adds a focused transport test for the proxy session configuration

## Validation
- xcrun swift-format format -i Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
- git diff --check
- swiftlint lint Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthHTTPTransport.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthDiscovery.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthRegistration.swift Packages/OsaurusCore/Services/MCP/OAuth/MCPOAuthService.swift Packages/OsaurusCore/Tests/MCPOAuth/MCPOAuthRegistrationTests.swift
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter MCPOAuthRegistrationTests

Head commit: b38c1d40
