### PR TITLE
Allow manual provider models during connection tests

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -578,6 +578,7 @@ public final class RemoteProviderManager: ObservableObject {
 
     /// Test seam: when set, used in place of `RemoteProviderService.fetchModels`.
     var testFetchModelsOverride: (@MainActor (RemoteProvider) async throws -> [String])?
+    var testConnectionTransportOverride: (@MainActor (URLRequest) async throws -> (Data, URLResponse))?
 
     /// Re-query `/models` for one connected provider without tearing down its
     /// service, flipping `isConnecting`, or refreshing OAuth.
@@ -769,7 +770,8 @@ public final class RemoteProviderManager: ObservableObject {
         authType: RemoteProviderAuthType,
         providerType: RemoteProviderType = .openaiLegacy,
         apiKey: String?,
-        headers: [String: String]
+        headers: [String: String],
+        manualModelIds: [String] = []
     ) async throws -> [String] {
         if authType == .openAICodexOAuth && providerType == .openAICodex {
             // testConnection runs before sign-in (no OAuth tokens exist yet), so
@@ -797,7 +799,8 @@ public final class RemoteProviderManager: ObservableObject {
             providerType: providerType,
             enabled: true,
             autoConnect: false,
-            timeout: 30
+            timeout: 30,
+            manualModelIds: manualModelIds
         )
 
         // Manually add API key to headers for test (since it's not in Keychain)
@@ -857,7 +860,12 @@ public final class RemoteProviderManager: ObservableObject {
         }
 
         do {
-            let (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
+            let (data, response): (Data, URLResponse)
+            if let override = testConnectionTransportOverride {
+                (data, response) = try await override(request)
+            } else {
+                (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
+            }
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 print("[Osaurus] Test Connection: Invalid response type")
@@ -866,14 +874,14 @@ public final class RemoteProviderManager: ObservableObject {
 
             print("[Osaurus] Test Connection: HTTP \(httpResponse.statusCode)")
 
-            if httpResponse.statusCode >= 400 {
-                let errorMessage = extractErrorMessage(from: data, statusCode: httpResponse.statusCode)
-                print("[Osaurus] Test Connection: Error response: \(errorMessage)")
-                throw RemoteProviderError.connectionFailed(errorMessage)
-            }
-
             // Parse models response based on provider type
             if providerType == .gemini {
+                if httpResponse.statusCode >= 400 {
+                    let errorMessage = extractErrorMessage(from: data, statusCode: httpResponse.statusCode)
+                    print("[Osaurus] Test Connection: Error response: \(errorMessage)")
+                    throw RemoteProviderError.connectionFailed(errorMessage)
+                }
+
                 let modelsResponse = try JSONDecoder().decode(GeminiModelsResponse.self, from: data)
                 let models = (modelsResponse.models ?? [])
                     .filter { model in
@@ -884,9 +892,13 @@ public final class RemoteProviderManager: ObservableObject {
                 print("[Osaurus] Test Connection (Gemini): Success - found \(models.count) models")
                 return models
             } else {
-                let modelsResponse = try JSONDecoder().decode(ModelsResponse.self, from: data)
-                print("[Osaurus] Test Connection: Success - found \(modelsResponse.data.count) models")
-                return modelsResponse.data.map { $0.id }
+                let models = try RemoteProviderService.decodeOpenAICompatibleModelsResponse(
+                    data: data,
+                    statusCode: httpResponse.statusCode,
+                    provider: tempProvider
+                )
+                print("[Osaurus] Test Connection: Success - found \(models.count) models")
+                return models
             }
         } catch let error as RemoteProviderError {
             throw error
@@ -1021,6 +1033,7 @@ public final class RemoteProviderManager: ObservableObject {
         refreshConnectedTask = nil
         osaurusRouterModelCatalog = [:]
         testFetchModelsOverride = nil
+        testConnectionTransportOverride = nil
         testIdentityExistsOverride = nil
         testRetrySleepOverride = nil
     }

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerTestConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerTestConnectionTests.swift
@@ -1,0 +1,45 @@
+//
+//  RemoteProviderManagerTestConnectionTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct RemoteProviderManagerTestConnectionTests {
+    @Test func testConnectionUsesManualModelsWhenModelsEndpointIsMissing() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            defer { manager._testRemoveProviders(ids: []) }
+
+            manager.testConnectionTransportOverride = { request in
+                #expect(request.url?.absoluteString == "https://api.example.test/v1/models")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (Data(#"{"error":{"message":"not found"}}"#.utf8), response)
+            }
+
+            let models = try await manager.testConnection(
+                host: "api.example.test",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/v1",
+                authType: .none,
+                providerType: .openaiLegacy,
+                apiKey: nil,
+                headers: [:],
+                manualModelIds: [" direct-chat ", "DIRECT-CHAT", ""]
+            )
+
+            #expect(models == ["direct-chat"])
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
@@ -685,17 +685,17 @@ struct ProviderCredentialPromptSheet: View {
         let host = trimmed(extraFieldValue(for: "host"))
         let deployment = trimmed(extraFieldValue(for: "deployment"))
         let effectiveHost = host.isEmpty ? defaults.host : host
+        let deploymentModelIds = deployment
+            .split(whereSeparator: { $0 == "\n" || $0 == "," })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
         let basePath: String = {
             guard providerType == .azureOpenAI, !deployment.isEmpty else { return defaults.basePath }
             // The deployment field accepts a comma/newline-separated list
             // (persisted to `manualModelIds` on save). The inline connection
             // test only needs one valid deployment in the path — embedding the
             // whole raw string would corrupt it.
-            let first =
-                deployment
-                .split(whereSeparator: { $0 == "\n" || $0 == "," })
-                .first
-                .map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
+            let first = deploymentModelIds.first ?? ""
             return first.isEmpty ? defaults.basePath : "/openai/deployments/\(first)/v1"
         }()
 
@@ -721,7 +721,8 @@ struct ProviderCredentialPromptSheet: View {
                     authType: request.instructions.storageAuthType,
                     providerType: providerType,
                     apiKey: key,
-                    headers: testHeaders
+                    headers: testHeaders,
+                    manualModelIds: providerType == .azureOpenAI ? deploymentModelIds : []
                 )
                 testSucceededModelCount = models.count
             } catch {

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -1366,7 +1366,8 @@ private struct AddProviderFlow: View {
                         authType: .apiKey,
                         providerType: config.providerType,
                         apiKey: key,
-                        headers: HeaderEntry.buildHeaders(from: customHeaders)
+                        headers: HeaderEntry.buildHeaders(from: customHeaders),
+                        manualModelIds: parseManualModelIds(manualModelIdsText)
                     )
                 } else if selectedOAuthKind == .xai {
                     // Grok sign-in returns access/refresh tokens; stash them so
@@ -1388,7 +1389,8 @@ private struct AddProviderFlow: View {
                         authType: .apiKey,
                         providerType: config.providerType,
                         apiKey: apiKey,
-                        headers: HeaderEntry.buildHeaders(from: customHeaders)
+                        headers: HeaderEntry.buildHeaders(from: customHeaders),
+                        manualModelIds: parseManualModelIds(manualModelIdsText)
                     )
                 }
                 await MainActor.run {
@@ -1481,7 +1483,8 @@ private struct AddProviderFlow: View {
                     authType: customAuthType,
                     providerType: .openaiLegacy,
                     apiKey: testApiKey,
-                    headers: HeaderEntry.buildHeaders(from: customHeaders)
+                    headers: HeaderEntry.buildHeaders(from: customHeaders),
+                    manualModelIds: parseManualModelIds(manualModelIdsText)
                 )
                 await MainActor.run {
                     withAnimation {
@@ -2470,7 +2473,8 @@ private struct EditProviderFlow: View {
                     authType: authType,
                     providerType: providerType,
                     apiKey: testApiKey,
-                    headers: HeaderEntry.buildHeaders(from: customHeaders)
+                    headers: HeaderEntry.buildHeaders(from: customHeaders),
+                    manualModelIds: parseManualModelIds(manualModelIdsText)
                 )
                 await MainActor.run {
                     testResult = .success(models)


### PR DESCRIPTION
## Summary
- lets RemoteProviderManager.testConnection carry user-entered manual model IDs into the temporary provider shape
- allows OpenAI-compatible providers without a usable /models endpoint to pass the connection test when manual model IDs are supplied
- wires manual model IDs through add/edit provider flows and Azure credential prompts
- adds a focused manager test that simulates /models returning 404 and verifies the manual model fallback

## Validation
- git diff --check
- swiftlint lint Packages/OsaurusCore/Managers/RemoteProviderManager.swift Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerTestConnectionTests.swift (exit 0; reports pre-existing warnings in RemoteProviderManager.swift)
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RemoteProviderManagerTestConnectionTests
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test swift test --package-path Packages/OsaurusCore --filter RemoteProviderModelDiscoveryTests

Head commit: 78f54b5a
