### PR TITLE
Add Business Document Studio service

### DIFF
--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -667,15 +667,15 @@ public struct BusinessDocumentStudioService: Sendable {
         guard url.isFileURL else {
             throw BusinessDocumentStudioError.destinationIsNotFileURL(url)
         }
-        if !policy.allowOverwrite, FileManager.default.fileExists(atPath: url.path) {
-            throw BusinessDocumentStudioError.destinationAlreadyExists(url)
-        }
         if let allowedDirectory = policy.allowedDirectory {
             let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
             let parent = url.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().path
             guard parent == root || parent.hasPrefix(root + "/") else {
                 throw BusinessDocumentStudioError.destinationOutsideAllowedDirectory(url)
             }
+        }
+        if !policy.allowOverwrite, FileManager.default.fileExists(atPath: url.path) {
+            throw BusinessDocumentStudioError.destinationAlreadyExists(url)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -1,0 +1,921 @@
+//
+//  BusinessDocumentStudioService.swift
+//  osaurus
+//
+//  Format-neutral orchestration for business-file workflows. The existing
+//  adapters and format-specific workflow services keep owning parse/export
+//  fidelity; this layer gives UI, plugins, and attachment surfaces one bounded
+//  entry point for inspect, preview, and explicit export checks.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+public struct BusinessDocumentStudioPolicy: Equatable, Sendable {
+    public let csvPreview: CSVTablePreviewPolicy
+    public let workbookPreview: BusinessDocumentWorkbookPreviewPolicy
+    public let workbookExport: WorkbookExportPolicy
+    public let pdfPPTXPreview: PDFPPTXPreviewPolicy
+    public let textPreview: BusinessDocumentTextPreviewPolicy
+
+    public init(
+        csvPreview: CSVTablePreviewPolicy = .standard,
+        workbookPreview: BusinessDocumentWorkbookPreviewPolicy = .standard,
+        workbookExport: WorkbookExportPolicy = .xlsxExport,
+        pdfPPTXPreview: PDFPPTXPreviewPolicy = .standard,
+        textPreview: BusinessDocumentTextPreviewPolicy = .standard
+    ) {
+        self.csvPreview = csvPreview
+        self.workbookPreview = workbookPreview
+        self.workbookExport = workbookExport
+        self.pdfPPTXPreview = pdfPPTXPreview
+        self.textPreview = textPreview
+    }
+
+    public static let standard = BusinessDocumentStudioPolicy()
+}
+
+public struct BusinessDocumentWorkbookPreviewPolicy: Codable, Equatable, Sendable {
+    public let maxSheets: Int
+    public let maxRowsPerSheet: Int
+    public let maxColumnsPerSheet: Int
+    public let maxCellTextUTF16Units: Int
+
+    public init(
+        maxSheets: Int = 3,
+        maxRowsPerSheet: Int = 20,
+        maxColumnsPerSheet: Int = 12,
+        maxCellTextUTF16Units: Int = 256
+    ) {
+        self.maxSheets = max(1, maxSheets)
+        self.maxRowsPerSheet = max(1, maxRowsPerSheet)
+        self.maxColumnsPerSheet = max(1, maxColumnsPerSheet)
+        self.maxCellTextUTF16Units = max(1, maxCellTextUTF16Units)
+    }
+
+    public static let standard = BusinessDocumentWorkbookPreviewPolicy()
+}
+
+public struct BusinessDocumentTextPreviewPolicy: Codable, Equatable, Sendable {
+    public let maxTextUTF16Units: Int
+    public let maxRichBlocks: Int
+    public let maxBlockTextUTF16Units: Int
+
+    public init(
+        maxTextUTF16Units: Int = 4_000,
+        maxRichBlocks: Int = 20,
+        maxBlockTextUTF16Units: Int = 500
+    ) {
+        self.maxTextUTF16Units = max(1, maxTextUTF16Units)
+        self.maxRichBlocks = max(1, maxRichBlocks)
+        self.maxBlockTextUTF16Units = max(1, maxBlockTextUTF16Units)
+    }
+
+    public static let standard = BusinessDocumentTextPreviewPolicy()
+}
+
+public struct BusinessDocumentStudioExportPolicy: Equatable, Sendable {
+    public let allowedDirectory: URL?
+    public let allowOverwrite: Bool
+    public let maxTextExportUTF8Bytes: Int
+
+    public init(
+        allowedDirectory: URL? = nil,
+        allowOverwrite: Bool = false,
+        maxTextExportUTF8Bytes: Int = 5 * 1024 * 1024
+    ) {
+        self.allowedDirectory = allowedDirectory
+        self.allowOverwrite = allowOverwrite
+        self.maxTextExportUTF8Bytes = max(1, maxTextExportUTF8Bytes)
+    }
+
+    public static let standard = BusinessDocumentStudioExportPolicy()
+}
+
+public struct BusinessDocumentStudioInspection: Codable, Equatable, Sendable {
+    public let summary: BusinessDocumentStudioSummary
+    public let registryRoles: [DocumentFormatRegistrationRole]
+    public let parseLimitBytes: Int64
+    public let security: DocumentSecurityMetadata
+    public let preview: BusinessDocumentStudioPreview
+    public let exportOptions: [BusinessDocumentStudioExportOption]
+}
+
+public struct BusinessDocumentStudioSummary: Codable, Equatable, Sendable {
+    public let filename: String
+    public let formatId: String
+    public let representationFormatId: String
+    public let fileExtension: String?
+    public let kind: BusinessDocumentKind
+    public let fileSize: Int64
+    public let structureSummary: DocumentStructureSummary
+    public let textFallbackUTF16Length: Int
+    public let createdAt: Date
+
+    public init(document: StructuredDocument) {
+        let fileExtension =
+            document.security.fileExtension
+            ?? URL(fileURLWithPath: document.filename).pathExtension.lowercasedNonEmpty
+        self.filename = document.filename
+        self.formatId = document.formatId
+        self.representationFormatId = document.representation.formatId
+        self.fileExtension = fileExtension
+        self.kind = BusinessDocumentKind.infer(formatId: document.formatId, fileExtension: fileExtension)
+        self.fileSize = document.fileSize
+        self.structureSummary = document.structure.businessSummary
+        self.textFallbackUTF16Length = document.textFallback.utf16.count
+        self.createdAt = document.createdAt
+    }
+}
+
+public enum BusinessDocumentStudioPreview: Codable, Equatable, Sendable {
+    case table(CSVTablePreview)
+    case workbook(BusinessDocumentWorkbookPreview)
+    case pdf(BusinessDocumentPDFPreview)
+    case presentation(BusinessDocumentPresentationPreview)
+    case richText(BusinessDocumentRichTextPreview)
+    case text(BusinessDocumentTextPreview)
+}
+
+public struct BusinessDocumentWorkbookPreview: Codable, Equatable, Sendable {
+    public let inspection: WorkbookWorkflowInspection
+    public let sheets: [BusinessDocumentWorkbookSheetPreview]
+    public let isSheetSampleTruncated: Bool
+}
+
+public struct BusinessDocumentWorkbookSheetPreview: Codable, Equatable, Sendable {
+    public let name: String
+    public let index: Int
+    public let rowCount: Int
+    public let cellCount: Int
+    public let formulaCellCount: Int
+    public let mergedRangeCount: Int
+    public let maxColumn: Int
+    public let sampleRows: [BusinessDocumentWorkbookRowPreview]
+    public let isRowSampleTruncated: Bool
+    public let isColumnSampleTruncated: Bool
+}
+
+public struct BusinessDocumentWorkbookRowPreview: Codable, Equatable, Sendable {
+    public let number: Int
+    public let cells: [BusinessDocumentWorkbookCellPreview]
+    public let isCellSampleTruncated: Bool
+}
+
+public struct BusinessDocumentWorkbookCellPreview: Codable, Equatable, Sendable {
+    public let reference: String
+    public let rowNumber: Int
+    public let columnNumber: Int
+    public let text: BusinessDocumentTextPreview
+    public let hasFormula: Bool
+    public let anchorId: String
+}
+
+public struct BusinessDocumentPDFPreview: Codable, Equatable, Sendable {
+    public let filename: String
+    public let pageCount: Int
+    public let sampledPageCount: Int
+    public let totalTextUTF16Units: Int
+    public let tableCount: Int
+    public let tableCellCount: Int
+    public let pages: [BusinessDocumentPDFPagePreview]
+    public let isPageSampleTruncated: Bool
+    public let creationAvailability: BusinessDocumentCreationAvailability
+}
+
+public struct BusinessDocumentPDFPagePreview: Codable, Equatable, Sendable {
+    public let pageIndex: Int
+    public let anchorId: String
+    public let bounds: DocumentBoundingBox?
+    public let text: BusinessDocumentTextPreview
+    public let tableCount: Int
+    public let tables: [BusinessDocumentTablePreview]
+    public let isTableSampleTruncated: Bool
+}
+
+public struct BusinessDocumentPresentationPreview: Codable, Equatable, Sendable {
+    public let filename: String
+    public let kind: PresentationDocumentKind
+    public let slideCount: Int
+    public let sampledSlideCount: Int
+    public let hiddenSlideCount: Int
+    public let speakerNotesCount: Int
+    public let totalTextUTF16Units: Int
+    public let tableCount: Int
+    public let tableCellCount: Int
+    public let slides: [BusinessDocumentPresentationSlidePreview]
+    public let isSlideSampleTruncated: Bool
+    public let creationAvailability: BusinessDocumentCreationAvailability
+}
+
+public struct BusinessDocumentPresentationSlidePreview: Codable, Equatable, Sendable {
+    public let slideIndex: Int
+    public let slideNumber: Int
+    public let label: String
+    public let sourcePart: String
+    public let isHidden: Bool
+    public let text: BusinessDocumentTextPreview
+    public let speakerNotes: BusinessDocumentTextPreview?
+    public let tableCount: Int
+    public let tables: [BusinessDocumentTablePreview]
+    public let isTableSampleTruncated: Bool
+}
+
+public struct BusinessDocumentTablePreview: Codable, Equatable, Sendable {
+    public let sourceKind: BusinessDocumentTableSourceKind
+    public let sourceIndex: Int
+    public let index: Int
+    public let anchorId: String
+    public let rowCount: Int
+    public let columnCount: Int
+    public let cellCount: Int
+    public let bounds: DocumentBoundingBox?
+    public let sampleRows: [BusinessDocumentTableRowPreview]
+    public let isRowSampleTruncated: Bool
+    public let isColumnSampleTruncated: Bool
+}
+
+public enum BusinessDocumentTableSourceKind: String, Codable, Equatable, Sendable {
+    case pdfPage
+    case presentationSlide
+}
+
+public struct BusinessDocumentTableRowPreview: Codable, Equatable, Sendable {
+    public let index: Int
+    public let cells: [BusinessDocumentTableCellPreview]
+    public let isCellSampleTruncated: Bool
+}
+
+public struct BusinessDocumentTableCellPreview: Codable, Equatable, Sendable {
+    public let rowIndex: Int
+    public let columnIndex: Int
+    public let text: BusinessDocumentTextPreview
+    public let anchorId: String
+}
+
+public struct BusinessDocumentRichTextPreview: Codable, Equatable, Sendable {
+    public let sourceFormat: RichDocumentSourceFormat
+    public let sourceLabel: String
+    public let text: BusinessDocumentTextPreview
+    public let sampledBlocks: [BusinessDocumentRichTextBlockPreview]
+    public let blockCount: Int
+    public let isBlockSampleTruncated: Bool
+}
+
+public struct BusinessDocumentRichTextBlockPreview: Codable, Equatable, Sendable {
+    public let kind: RichDocumentBlock.Kind
+    public let text: BusinessDocumentTextPreview
+    public let sourceIndex: Int
+    public let headingLevel: Int?
+    public let listDepth: Int?
+    public let anchorId: String
+}
+
+public struct BusinessDocumentTextPreview: Codable, Equatable, Sendable {
+    public let text: String
+    public let fullUTF16Length: Int
+    public let isTruncated: Bool
+}
+
+public struct BusinessDocumentCreationAvailability: Codable, Equatable, Sendable {
+    public let formatId: String
+    public let reasonCode: BusinessDocumentCreationReasonCode
+    public let emitterFormatId: String?
+    public let message: String
+
+    public var isAvailable: Bool { reasonCode == .available }
+}
+
+public enum BusinessDocumentCreationReasonCode: String, Codable, Equatable, Sendable {
+    case available
+    case missingEmitter
+    case unsupportedFormat
+}
+
+public struct BusinessDocumentStudioExportOption: Codable, Equatable, Sendable {
+    public let targetFormatId: String
+    public let fileExtension: String
+    public let label: String
+    public let canExport: Bool
+    public let reason: BusinessDocumentStudioExportReason
+    public let message: String
+}
+
+public enum BusinessDocumentStudioExportReason: String, Codable, Equatable, Sendable {
+    case available
+    case missingEmitter
+    case validationFailed
+    case unsupportedFormat
+    case textFallbackAvailable
+    case textFallbackTooLarge
+}
+
+public struct BusinessDocumentStudioExportResult: Codable, Equatable, Sendable {
+    public let url: URL
+    public let sourceFormatId: String
+    public let targetFormatId: String
+    public let bytesWritten: Int64
+    public let message: String
+}
+
+public enum BusinessDocumentStudioError: LocalizedError, Sendable {
+    case unsupportedFormat(fileExtension: String)
+    case adapterReturnedUnexpectedFormat(expected: String, actual: String)
+    case unsupportedExport(sourceFormatId: String, targetFormatId: String)
+    case destinationOutsideAllowedDirectory(URL)
+    case destinationAlreadyExists(URL)
+    case destinationIsNotFileURL(URL)
+    case unsafeTextPackageTarget(fileExtension: String)
+    case packageTargetExtensionMismatch(targetFormatId: String, fileExtension: String)
+    case textExportTooLarge(actual: Int, limit: Int)
+    case writeFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat(let fileExtension):
+            return "No document adapter is registered for .\(fileExtension)."
+        case .adapterReturnedUnexpectedFormat(let expected, let actual):
+            return "Document adapter '\(expected)' returned unexpected format '\(actual)'."
+        case .unsupportedExport(let sourceFormatId, let targetFormatId):
+            return "Cannot export document format '\(sourceFormatId)' as '\(targetFormatId)'."
+        case .destinationOutsideAllowedDirectory(let url):
+            return "Export destination is outside the allowed directory: \(url.path)"
+        case .destinationAlreadyExists(let url):
+            return "Export destination already exists: \(url.path)"
+        case .destinationIsNotFileURL(let url):
+            return "Export destination must be a local file URL: \(url.absoluteString)"
+        case .unsafeTextPackageTarget(let fileExtension):
+            return "Text fallback export cannot write structured package target .\(fileExtension)."
+        case .packageTargetExtensionMismatch(let targetFormatId, let fileExtension):
+            return "Export target '\(targetFormatId)' cannot write package extension .\(fileExtension)."
+        case .textExportTooLarge(let actual, let limit):
+            return "Text fallback export is \(actual) bytes, limit is \(limit) bytes."
+        case .writeFailed(let message):
+            return "Business document export failed: \(message)"
+        }
+    }
+}
+
+public struct BusinessDocumentStudioService: Sendable {
+    private let registry: DocumentFormatRegistry
+
+    public init(registry: DocumentFormatRegistry = .shared) {
+        self.registry = registry
+    }
+
+    public func parse(url: URL) async throws -> StructuredDocument {
+        let (adapter, limit) = try adapterAndLimit(for: url)
+        return try await parse(url: url, adapter: adapter, limit: limit)
+    }
+
+    private func parse(
+        url: URL,
+        adapter: any DocumentFormatAdapter,
+        limit: Int64
+    ) async throws -> StructuredDocument {
+        let document = try await adapter.parse(url: url, sizeLimit: limit)
+        if document.formatId.lowercased() != adapter.formatId.lowercased() {
+            throw BusinessDocumentStudioError.adapterReturnedUnexpectedFormat(
+                expected: adapter.formatId,
+                actual: document.formatId
+            )
+        }
+        return document
+    }
+
+    public func inspect(
+        url: URL,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) async throws -> BusinessDocumentStudioInspection {
+        let (adapter, limit) = try adapterAndLimit(for: url)
+        let document = try await parse(url: url, adapter: adapter, limit: limit)
+        return try inspect(document, parseLimitBytes: limit, policy: policy)
+    }
+
+    private func adapterAndLimit(for url: URL) throws -> (adapter: any DocumentFormatAdapter, limit: Int64) {
+        if registry === DocumentFormatRegistry.shared {
+            DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        }
+
+        let uti = UTType(filenameExtension: url.pathExtension.lowercased())?.identifier
+        guard let adapter = registry.adapter(for: url, uti: uti) else {
+            throw BusinessDocumentStudioError.unsupportedFormat(fileExtension: url.pathExtension.lowercased())
+        }
+
+        let limit = DocumentLimits.limit(forFormatId: adapter.formatId)
+        return (adapter, limit)
+    }
+
+    public func inspect(
+        _ document: StructuredDocument,
+        parseLimitBytes: Int64? = nil,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) throws -> BusinessDocumentStudioInspection {
+        let roles = registry.registrationRoles(forFormatId: document.formatId)
+            .sorted { $0.rawValue < $1.rawValue }
+        return BusinessDocumentStudioInspection(
+            summary: BusinessDocumentStudioSummary(document: document),
+            registryRoles: roles,
+            parseLimitBytes: parseLimitBytes ?? DocumentLimits.limit(forFormatId: document.formatId),
+            security: document.security,
+            preview: try preview(for: document, policy: policy),
+            exportOptions: exportOptions(for: document, policy: policy)
+        )
+    }
+
+    public func export(
+        _ document: StructuredDocument,
+        as targetFormatId: String,
+        to url: URL,
+        policy: BusinessDocumentStudioExportPolicy = .standard
+    ) async throws -> BusinessDocumentStudioExportResult {
+        let normalizedTarget = targetFormatId.trimmedLowercased
+        try validateDestination(url, targetFormatId: normalizedTarget, policy: policy)
+
+        switch normalizedTarget {
+        case "csv", "tsv":
+            let delimiter: CSVDelimiter = normalizedTarget == "tsv" ? .tab : .comma
+            let result = try await CSVTableWorkflowService.export(document, to: url, delimiter: delimiter)
+            return BusinessDocumentStudioExportResult(
+                url: result.url,
+                sourceFormatId: document.formatId,
+                targetFormatId: result.formatId,
+                bytesWritten: result.bytesWritten,
+                message: "Exported \(result.rowCount) row(s) and \(result.columnCount) column(s)."
+            )
+
+        case "xlsx":
+            let result = try await WorkbookWorkflowService.export(document, to: url, registry: registry)
+            return BusinessDocumentStudioExportResult(
+                url: result.url,
+                sourceFormatId: document.formatId,
+                targetFormatId: result.formatId,
+                bytesWritten: result.bytesWritten,
+                message: "Exported workbook through the registered '\(result.formatId)' emitter."
+            )
+
+        case "txt", "text", "plaintext":
+            return try exportTextFallback(document, to: url, policy: policy)
+
+        default:
+            guard let emitter = registry.emitter(for: document),
+                emitter.formatId.lowercased() == normalizedTarget
+            else {
+                throw BusinessDocumentStudioError.unsupportedExport(
+                    sourceFormatId: document.formatId,
+                    targetFormatId: normalizedTarget
+                )
+            }
+            do {
+                try await emitter.emit(document, to: url)
+                return BusinessDocumentStudioExportResult(
+                    url: url,
+                    sourceFormatId: document.formatId,
+                    targetFormatId: emitter.formatId,
+                    bytesWritten: Self.fileSize(url),
+                    message: "Exported document through the registered '\(emitter.formatId)' emitter."
+                )
+            } catch {
+                throw BusinessDocumentStudioError.writeFailed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func preview(
+        for document: StructuredDocument,
+        policy: BusinessDocumentStudioPolicy
+    ) throws -> BusinessDocumentStudioPreview {
+        if document.representation.underlying is CSVDocument {
+            return .table(try CSVTableWorkflowService.preview(document, policy: policy.csvPreview))
+        }
+
+        if let workbook = document.representation.underlying as? Workbook {
+            let inspection = try WorkbookWorkflowService.inspect(
+                document,
+                registry: registry,
+                policy: policy.workbookExport
+            )
+            return .workbook(
+                workbookPreview(
+                    workbook,
+                    inspection: inspection,
+                    policy: policy.workbookPreview
+                )
+            )
+        }
+
+        if let pdfPPTX = try? PDFPPTXWorkflowService(registry: registry)
+            .preview(document, policy: policy.pdfPPTXPreview) {
+            switch pdfPPTX {
+            case .pdf(let preview):
+                return .pdf(Self.pdfPreview(preview))
+            case .presentation(let preview):
+                return .presentation(Self.presentationPreview(preview))
+            }
+        }
+
+        if let richText = document.representation.underlying as? RichDocumentRepresentation {
+            return .richText(Self.richTextPreview(richText, policy: policy.textPreview))
+        }
+
+        return .text(Self.textPreview(document.textFallback, maxUTF16Units: policy.textPreview.maxTextUTF16Units))
+    }
+
+    private func exportOptions(
+        for document: StructuredDocument,
+        policy: BusinessDocumentStudioPolicy
+    ) -> [BusinessDocumentStudioExportOption] {
+        var options: [BusinessDocumentStudioExportOption] = []
+
+        if let csv = document.representation.underlying as? CSVDocument {
+            let issues = CSVTableWorkflowService.validationIssues(for: csv)
+            let canExport = issues.isEmpty
+            let reason: BusinessDocumentStudioExportReason = canExport ? .available : .validationFailed
+            let message =
+                canExport
+                ? "CSV/TSV table can be exported through the delimited-text emitter."
+                : "CSV/TSV export is blocked by \(issues.count) validation issue(s)."
+            options.append(
+                BusinessDocumentStudioExportOption(
+                    targetFormatId: "csv",
+                    fileExtension: "csv",
+                    label: "CSV",
+                    canExport: canExport,
+                    reason: reason,
+                    message: message
+                )
+            )
+            options.append(
+                BusinessDocumentStudioExportOption(
+                    targetFormatId: "tsv",
+                    fileExtension: "tsv",
+                    label: "TSV",
+                    canExport: canExport,
+                    reason: reason,
+                    message: message
+                )
+            )
+        }
+
+        if document.representation.underlying is Workbook {
+            let availability =
+                (try? WorkbookWorkflowService.inspect(
+                    document,
+                    registry: registry,
+                    policy: policy.workbookExport
+                ).exportAvailability)
+                ?? WorkbookExportAvailability(
+                    reason: .missingEmitter,
+                    formatId: document.formatId,
+                    message: "Workbook export availability could not be inspected."
+                )
+            options.append(
+                BusinessDocumentStudioExportOption(
+                    targetFormatId: "xlsx",
+                    fileExtension: "xlsx",
+                    label: "XLSX workbook",
+                    canExport: availability.canExport,
+                    reason: Self.workbookReason(availability.reason),
+                    message: availability.message
+                )
+            )
+        }
+
+        let pdfPPTXAvailability = PDFPPTXWorkflowService(registry: registry).creationAvailability(for: document)
+        if pdfPPTXAvailability.reasonCode != .unsupportedFormat {
+            options.append(
+                BusinessDocumentStudioExportOption(
+                    targetFormatId: pdfPPTXAvailability.formatId,
+                    fileExtension: pdfPPTXAvailability.formatId,
+                    label: pdfPPTXAvailability.formatId.uppercased(),
+                    canExport: pdfPPTXAvailability.isAvailable,
+                    reason: Self.exportReason(pdfPPTXAvailability.reasonCode),
+                    message: pdfPPTXAvailability.message
+                )
+            )
+        }
+
+        let fallbackSize = document.textFallback.utf8.count
+        options.append(
+            BusinessDocumentStudioExportOption(
+                targetFormatId: "txt",
+                fileExtension: "txt",
+                label: "Text fallback",
+                canExport: fallbackSize <= BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes,
+                reason: fallbackSize <= BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes
+                    ? .textFallbackAvailable
+                    : .textFallbackTooLarge,
+                message: "Exports the bounded text fallback carried by the parsed document."
+            )
+        )
+
+        return options
+    }
+
+    private func workbookPreview(
+        _ workbook: Workbook,
+        inspection: WorkbookWorkflowInspection,
+        policy: BusinessDocumentWorkbookPreviewPolicy
+    ) -> BusinessDocumentWorkbookPreview {
+        let sheets = workbook.sheets.prefix(policy.maxSheets).map { sheet in
+            let sampledRows = sheet.rows.prefix(policy.maxRowsPerSheet).map { row in
+                let cells = row.cells.prefix(policy.maxColumnsPerSheet).map { cell in
+                    BusinessDocumentWorkbookCellPreview(
+                        reference: cell.reference,
+                        rowNumber: cell.rowNumber,
+                        columnNumber: cell.columnNumber,
+                        text: Self.textPreview(cell.value.fallbackText, maxUTF16Units: policy.maxCellTextUTF16Units),
+                        hasFormula: cell.formula != nil,
+                        anchorId: cell.anchor.id
+                    )
+                }
+                return BusinessDocumentWorkbookRowPreview(
+                    number: row.number,
+                    cells: Array(cells),
+                    isCellSampleTruncated: row.cells.count > policy.maxColumnsPerSheet
+                )
+            }
+            let allCells = sheet.rows.flatMap(\.cells)
+            return BusinessDocumentWorkbookSheetPreview(
+                name: sheet.name,
+                index: sheet.index,
+                rowCount: sheet.rows.count,
+                cellCount: allCells.count,
+                formulaCellCount: allCells.filter { $0.formula != nil }.count,
+                mergedRangeCount: sheet.mergedRanges.count,
+                maxColumn: allCells.map(\.columnNumber).max() ?? 0,
+                sampleRows: Array(sampledRows),
+                isRowSampleTruncated: sheet.rows.count > policy.maxRowsPerSheet,
+                isColumnSampleTruncated: sheet.rows.contains { $0.cells.count > policy.maxColumnsPerSheet }
+            )
+        }
+
+        return BusinessDocumentWorkbookPreview(
+            inspection: inspection,
+            sheets: Array(sheets),
+            isSheetSampleTruncated: workbook.sheets.count > policy.maxSheets
+        )
+    }
+
+    private func validateDestination(
+        _ url: URL,
+        targetFormatId: String,
+        policy: BusinessDocumentStudioExportPolicy
+    ) throws {
+        guard url.isFileURL else {
+            throw BusinessDocumentStudioError.destinationIsNotFileURL(url)
+        }
+        if !policy.allowOverwrite, FileManager.default.fileExists(atPath: url.path) {
+            throw BusinessDocumentStudioError.destinationAlreadyExists(url)
+        }
+        if let allowedDirectory = policy.allowedDirectory {
+            let root = allowedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
+            let parent = url.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().path
+            guard parent == root || parent.hasPrefix(root + "/") else {
+                throw BusinessDocumentStudioError.destinationOutsideAllowedDirectory(url)
+            }
+        }
+        let extensionName = url.pathExtension.lowercased()
+        guard Self.structuredPackageExtensions.contains(extensionName) else { return }
+        guard let allowedExtensions = Self.structuredTargetExtensions[targetFormatId] else {
+            throw BusinessDocumentStudioError.unsafeTextPackageTarget(fileExtension: extensionName)
+        }
+        guard allowedExtensions.contains(extensionName) else {
+            throw BusinessDocumentStudioError.packageTargetExtensionMismatch(
+                targetFormatId: targetFormatId,
+                fileExtension: extensionName
+            )
+        }
+    }
+
+    private func exportTextFallback(
+        _ document: StructuredDocument,
+        to url: URL,
+        policy: BusinessDocumentStudioExportPolicy
+    ) throws -> BusinessDocumentStudioExportResult {
+        let data = Data(document.textFallback.utf8)
+        guard data.count <= policy.maxTextExportUTF8Bytes else {
+            throw BusinessDocumentStudioError.textExportTooLarge(
+                actual: data.count,
+                limit: policy.maxTextExportUTF8Bytes
+            )
+        }
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+            return BusinessDocumentStudioExportResult(
+                url: url,
+                sourceFormatId: document.formatId,
+                targetFormatId: "txt",
+                bytesWritten: Int64(data.count),
+                message: "Exported document text fallback."
+            )
+        } catch {
+            throw BusinessDocumentStudioError.writeFailed(error.localizedDescription)
+        }
+    }
+
+    private static func pdfPreview(_ preview: PDFWorkflowPreview) -> BusinessDocumentPDFPreview {
+        BusinessDocumentPDFPreview(
+            filename: preview.filename,
+            pageCount: preview.pageCount,
+            sampledPageCount: preview.sampledPageCount,
+            totalTextUTF16Units: preview.totalTextUTF16Units,
+            tableCount: preview.tableCount,
+            tableCellCount: preview.tableCellCount,
+            pages: preview.pages.map { page in
+                BusinessDocumentPDFPagePreview(
+                    pageIndex: page.pageIndex,
+                    anchorId: page.anchorId,
+                    bounds: page.bounds,
+                    text: textPreview(page.text),
+                    tableCount: page.tableCount,
+                    tables: page.tables.map(tablePreview),
+                    isTableSampleTruncated: page.isTableSampleTruncated
+                )
+            },
+            isPageSampleTruncated: preview.isPageSampleTruncated,
+            creationAvailability: creationAvailability(preview.creationAvailability)
+        )
+    }
+
+    private static func presentationPreview(
+        _ preview: PresentationWorkflowPreview
+    ) -> BusinessDocumentPresentationPreview {
+        BusinessDocumentPresentationPreview(
+            filename: preview.filename,
+            kind: preview.kind,
+            slideCount: preview.slideCount,
+            sampledSlideCount: preview.sampledSlideCount,
+            hiddenSlideCount: preview.hiddenSlideCount,
+            speakerNotesCount: preview.speakerNotesCount,
+            totalTextUTF16Units: preview.totalTextUTF16Units,
+            tableCount: preview.tableCount,
+            tableCellCount: preview.tableCellCount,
+            slides: preview.slides.map { slide in
+                BusinessDocumentPresentationSlidePreview(
+                    slideIndex: slide.slideIndex,
+                    slideNumber: slide.slideNumber,
+                    label: slide.label,
+                    sourcePart: slide.sourcePart,
+                    isHidden: slide.isHidden,
+                    text: textPreview(slide.text),
+                    speakerNotes: slide.speakerNotes.map(textPreview),
+                    tableCount: slide.tableCount,
+                    tables: slide.tables.map(tablePreview),
+                    isTableSampleTruncated: slide.isTableSampleTruncated
+                )
+            },
+            isSlideSampleTruncated: preview.isSlideSampleTruncated,
+            creationAvailability: creationAvailability(preview.creationAvailability)
+        )
+    }
+
+    private static func tablePreview(_ preview: PDFPPTXTablePreview) -> BusinessDocumentTablePreview {
+        BusinessDocumentTablePreview(
+            sourceKind: preview.sourceKind == .pdfPage ? .pdfPage : .presentationSlide,
+            sourceIndex: preview.sourceIndex,
+            index: preview.index,
+            anchorId: preview.anchorId,
+            rowCount: preview.rowCount,
+            columnCount: preview.columnCount,
+            cellCount: preview.cellCount,
+            bounds: preview.bounds,
+            sampleRows: preview.sampleRows.map { row in
+                BusinessDocumentTableRowPreview(
+                    index: row.index,
+                    cells: row.cells.map { cell in
+                        BusinessDocumentTableCellPreview(
+                            rowIndex: cell.rowIndex,
+                            columnIndex: cell.columnIndex,
+                            text: textPreview(cell.text),
+                            anchorId: cell.anchorId
+                        )
+                    },
+                    isCellSampleTruncated: row.isCellSampleTruncated
+                )
+            },
+            isRowSampleTruncated: preview.isRowSampleTruncated,
+            isColumnSampleTruncated: preview.isColumnSampleTruncated
+        )
+    }
+
+    private static func richTextPreview(
+        _ richText: RichDocumentRepresentation,
+        policy: BusinessDocumentTextPreviewPolicy
+    ) -> BusinessDocumentRichTextPreview {
+        let blocks = richText.blocks.prefix(policy.maxRichBlocks).map { block in
+            BusinessDocumentRichTextBlockPreview(
+                kind: block.kind,
+                text: textPreview(block.text, maxUTF16Units: policy.maxBlockTextUTF16Units),
+                sourceIndex: block.sourceIndex,
+                headingLevel: block.headingLevel,
+                listDepth: block.listDepth,
+                anchorId: block.anchorId
+            )
+        }
+        return BusinessDocumentRichTextPreview(
+            sourceFormat: richText.sourceFormat,
+            sourceLabel: richText.sourceLabel,
+            text: textPreview(richText.text, maxUTF16Units: policy.maxTextUTF16Units),
+            sampledBlocks: Array(blocks),
+            blockCount: richText.blocks.count,
+            isBlockSampleTruncated: richText.blocks.count > policy.maxRichBlocks
+        )
+    }
+
+    private static func textPreview(_ preview: PDFPPTXTextPreview) -> BusinessDocumentTextPreview {
+        BusinessDocumentTextPreview(
+            text: preview.text,
+            fullUTF16Length: preview.fullUTF16Length,
+            isTruncated: preview.isTruncated
+        )
+    }
+
+    private static func textPreview(_ text: String, maxUTF16Units: Int) -> BusinessDocumentTextPreview {
+        let fullLength = text.utf16.count
+        guard fullLength > maxUTF16Units else {
+            return BusinessDocumentTextPreview(text: text, fullUTF16Length: fullLength, isTruncated: false)
+        }
+
+        var clipped = ""
+        var units = 0
+        for character in text {
+            let nextUnits = String(character).utf16.count
+            guard units + nextUnits <= maxUTF16Units else { break }
+            clipped.append(character)
+            units += nextUnits
+        }
+        return BusinessDocumentTextPreview(text: clipped, fullUTF16Length: fullLength, isTruncated: true)
+    }
+
+    private static func creationAvailability(
+        _ availability: PDFPPTXCreationAvailability
+    ) -> BusinessDocumentCreationAvailability {
+        BusinessDocumentCreationAvailability(
+            formatId: availability.formatId,
+            reasonCode: Self.creationReason(availability.reasonCode),
+            emitterFormatId: availability.emitterFormatId,
+            message: availability.message
+        )
+    }
+
+    private static func creationReason(
+        _ reason: PDFPPTXCreationReasonCode
+    ) -> BusinessDocumentCreationReasonCode {
+        switch reason {
+        case .available: return .available
+        case .missingEmitter: return .missingEmitter
+        case .unsupportedFormat: return .unsupportedFormat
+        }
+    }
+
+    private static func exportReason(
+        _ reason: PDFPPTXCreationReasonCode
+    ) -> BusinessDocumentStudioExportReason {
+        switch reason {
+        case .available: return .available
+        case .missingEmitter: return .missingEmitter
+        case .unsupportedFormat: return .unsupportedFormat
+        }
+    }
+
+    private static func workbookReason(
+        _ reason: WorkbookExportAvailability.Reason
+    ) -> BusinessDocumentStudioExportReason {
+        switch reason {
+        case .available: return .available
+        case .missingEmitter, .notChecked: return .missingEmitter
+        case .invalidWorkbook: return .validationFailed
+        }
+    }
+
+    private static func fileSize(_ url: URL) -> Int64 {
+        Int64((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+    }
+
+    private static let structuredPackageExtensions: Set<String> = [
+        "xlsx", "xlsm", "xltx", "xltm", "pdf", "pptx", "pptm", "potx", "potm", "ppsx", "ppsm",
+    ]
+
+    private static let structuredTargetExtensions: [String: Set<String>] = [
+        "xlsx": ["xlsx"],
+        "pdf": ["pdf"],
+        "pptx": ["pptx", "pptm", "potx", "potm", "ppsx", "ppsm"],
+        "potx": ["pptx", "potx"],
+    ]
+}
+
+private extension String {
+    var trimmedLowercased: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    var lowercasedNonEmpty: String? {
+        let value = trimmedLowercased
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
+++ b/Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift
@@ -430,10 +430,11 @@ public struct BusinessDocumentStudioService: Sendable {
         policy: BusinessDocumentStudioExportPolicy = .standard
     ) async throws -> BusinessDocumentStudioExportResult {
         let normalizedTarget = targetFormatId.trimmedLowercased
-        try validateDestination(url, targetFormatId: normalizedTarget, policy: policy)
+        try validateDestination(url, policy: policy)
 
         switch normalizedTarget {
         case "csv", "tsv":
+            try rejectTextExportPackageTarget(url)
             let delimiter: CSVDelimiter = normalizedTarget == "tsv" ? .tab : .comma
             let result = try await CSVTableWorkflowService.export(document, to: url, delimiter: delimiter)
             return BusinessDocumentStudioExportResult(
@@ -445,6 +446,7 @@ public struct BusinessDocumentStudioService: Sendable {
             )
 
         case "xlsx":
+            try validateStructuredPackageTarget(url, targetFormatId: normalizedTarget)
             let result = try await WorkbookWorkflowService.export(document, to: url, registry: registry)
             return BusinessDocumentStudioExportResult(
                 url: result.url,
@@ -466,6 +468,7 @@ public struct BusinessDocumentStudioService: Sendable {
                     targetFormatId: normalizedTarget
                 )
             }
+            try validateEmitterPackageTarget(url, targetFormatId: emitter.formatId.trimmedLowercased)
             do {
                 try await emitter.emit(document, to: url)
                 return BusinessDocumentStudioExportResult(
@@ -659,7 +662,6 @@ public struct BusinessDocumentStudioService: Sendable {
 
     private func validateDestination(
         _ url: URL,
-        targetFormatId: String,
         policy: BusinessDocumentStudioExportPolicy
     ) throws {
         guard url.isFileURL else {
@@ -675,6 +677,20 @@ public struct BusinessDocumentStudioService: Sendable {
                 throw BusinessDocumentStudioError.destinationOutsideAllowedDirectory(url)
             }
         }
+    }
+
+    private func rejectTextExportPackageTarget(_ url: URL) throws {
+        let extensionName = url.pathExtension.lowercased()
+        guard Self.structuredPackageExtensions.contains(extensionName) else {
+            return
+        }
+        throw BusinessDocumentStudioError.unsafeTextPackageTarget(fileExtension: extensionName)
+    }
+
+    private func validateStructuredPackageTarget(
+        _ url: URL,
+        targetFormatId: String
+    ) throws {
         let extensionName = url.pathExtension.lowercased()
         guard Self.structuredPackageExtensions.contains(extensionName) else { return }
         guard let allowedExtensions = Self.structuredTargetExtensions[targetFormatId] else {
@@ -688,11 +704,22 @@ public struct BusinessDocumentStudioService: Sendable {
         }
     }
 
+    private func validateEmitterPackageTarget(
+        _ url: URL,
+        targetFormatId: String
+    ) throws {
+        guard Self.structuredTargetExtensions[targetFormatId] != nil else {
+            return
+        }
+        try validateStructuredPackageTarget(url, targetFormatId: targetFormatId)
+    }
+
     private func exportTextFallback(
         _ document: StructuredDocument,
         to url: URL,
         policy: BusinessDocumentStudioExportPolicy
     ) throws -> BusinessDocumentStudioExportResult {
+        try rejectTextExportPackageTarget(url)
         let data = Data(document.textFallback.utf8)
         guard data.count <= policy.maxTextExportUTF8Bytes else {
             throw BusinessDocumentStudioError.textExportTooLarge(

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -197,6 +197,39 @@ struct BusinessDocumentStudioServiceTests {
         }
     }
 
+    @Test func outsideAllowedDestinationDoesNotDiscloseExistingTarget() async throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let document = Self.plainTextDocument()
+        let outputDirectory = try Self.temporaryDirectory()
+        let outsideDirectory = try Self.temporaryDirectory()
+        let existingOutside = outsideDirectory.appendingPathComponent("existing.txt")
+        let missingOutside = outsideDirectory.appendingPathComponent("missing.txt")
+        try "private".write(to: existingOutside, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: outputDirectory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        for target in [existingOutside, missingOutside] {
+            do {
+                _ = try await service.export(
+                    document,
+                    as: "txt",
+                    to: target,
+                    policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+                )
+                Issue.record("Expected outside destination to be rejected")
+            } catch BusinessDocumentStudioError.destinationOutsideAllowedDirectory(let url) {
+                #expect(url == target)
+            } catch {
+                Issue.record("Expected destinationOutsideAllowedDirectory, got \(error)")
+            }
+        }
+
+        #expect(try String(contentsOf: existingOutside, encoding: .utf8) == "private")
+        #expect(!FileManager.default.fileExists(atPath: missingOutside.path))
+    }
+
     @Test func inspectPDFWrapsPreviewAndMissingEmitterExportOption() throws {
         let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         let inspection = try service.inspect(Self.pdfDocument())

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -138,6 +138,27 @@ struct BusinessDocumentStudioServiceTests {
         }
     }
 
+    @Test func exportRegisteredEmitterCanOwnStructuredPackageExtension() async throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: StubPackageEmitter(formatId: "pptm"))
+        let service = BusinessDocumentStudioService(registry: registry)
+        let document = Self.pdfDocument()
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("slides.pptm")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let result = try await service.export(
+            document,
+            as: "pptm",
+            to: target,
+            policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+        )
+
+        #expect(result.targetFormatId == "pptm")
+        #expect(result.bytesWritten > 0)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "emitted:pptm")
+    }
+
     @Test func exportTextFallbackRejectsPackageTargetsAndDirectoryEscape() async throws {
         let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
         let document = Self.plainTextDocument()
@@ -332,5 +353,17 @@ struct BusinessDocumentStudioServiceTests {
                 ]
             )
         )
+    }
+}
+
+private struct StubPackageEmitter: DocumentFormatEmitter {
+    let formatId: String
+
+    func canEmit(_ document: StructuredDocument) -> Bool {
+        true
+    }
+
+    func emit(_ document: StructuredDocument, to url: URL) async throws {
+        try Data("emitted:\(formatId)".utf8).write(to: url, options: .atomic)
     }
 }

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift
@@ -1,0 +1,336 @@
+//
+//  BusinessDocumentStudioServiceTests.swift
+//  osaurusTests
+//
+//  Covers the format-neutral document studio orchestration layer.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Business document studio service")
+struct BusinessDocumentStudioServiceTests {
+
+    @Test func inspectCSVWrapsPreviewRolesAndSafeDelimitedExports() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let service = BusinessDocumentStudioService(registry: registry)
+        let source = try Self.write(
+            """
+            name,age,active
+            Ada,37,true
+            Ben,41,false
+            """,
+            filename: "people.csv"
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("people.tsv")
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: outputDirectory)
+        }
+
+        let document = try await service.parse(url: source)
+        let inspection = try await service.inspect(url: source)
+
+        #expect(document.formatId == "csv")
+        #expect(inspection.summary.kind == .table)
+        #expect(inspection.summary.filename.hasSuffix("people.csv"))
+        #expect(inspection.registryRoles == [.adapter, .emitter])
+        #expect(inspection.exportOptions.contains { $0.targetFormatId == "csv" && $0.canExport })
+        #expect(inspection.exportOptions.contains { $0.targetFormatId == "tsv" && $0.canExport })
+
+        guard case let .table(preview) = inspection.preview else {
+            Issue.record("Expected table preview")
+            return
+        }
+        #expect(preview.hasHeader)
+        #expect(preview.columns.map(\.name) == ["name", "age", "active"])
+        #expect(preview.columns.map(\.inferredType) == [.string, .integer, .boolean])
+
+        let encoded = try JSONEncoder().encode(inspection)
+        let decoded = try JSONDecoder().decode(BusinessDocumentStudioInspection.self, from: encoded)
+        #expect(decoded.summary.filename == inspection.summary.filename)
+
+        let result = try await service.export(
+            document,
+            as: "tsv",
+            to: target,
+            policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+        )
+
+        #expect(result.targetFormatId == "tsv")
+        #expect(result.bytesWritten > 0)
+        let parsed = try await CSVAdapter(delimiter: .tab).parse(url: target, sizeLimit: 0)
+        let table = try #require(parsed.representation.underlying as? CSVDocument)
+        #expect(table.delimiter == .tab)
+        #expect(table.rows[1].cells.map(\.text) == ["Ada", "37", "true"])
+    }
+
+    @Test func inspectWorkbookSamplesCellsAndReportsValidationBlockedExport() async throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let service = BusinessDocumentStudioService(registry: registry)
+        let document = Self.workbookDocument(includeFormula: true)
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("workbook.xlsx")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let inspection = try service.inspect(document)
+
+        #expect(inspection.summary.kind == .workbook)
+        #expect(inspection.exportOptions.contains { option in
+            option.targetFormatId == "xlsx"
+                && option.canExport == false
+                && option.reason == .validationFailed
+        })
+        guard case let .workbook(preview) = inspection.preview else {
+            Issue.record("Expected workbook preview")
+            return
+        }
+        #expect(preview.inspection.formulaCellCount == 1)
+        #expect(preview.inspection.validationIssues.contains { $0.code == .formulaNotWritable })
+        #expect(preview.sheets.first?.sampleRows[1].cells[1].hasFormula == true)
+        #expect(preview.sheets.first?.sampleRows[1].cells[1].text.text == "1200")
+
+        do {
+            _ = try await service.export(
+                document,
+                as: "xlsx",
+                to: target,
+                policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+            )
+            Issue.record("Expected formula validation to block XLSX export")
+        } catch WorkbookWorkflowError.validationFailed(let issues) {
+            #expect(issues.map(\.code).contains(.formulaNotWritable))
+            #expect(!FileManager.default.fileExists(atPath: target.path))
+        } catch {
+            Issue.record("Expected WorkbookWorkflowError.validationFailed, got \(error)")
+        }
+    }
+
+    @Test func exportStructuredPackageRejectsMismatchedPackageExtension() async throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let service = BusinessDocumentStudioService(registry: registry)
+        let document = Self.workbookDocument()
+        let outputDirectory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        do {
+            _ = try await service.export(
+                document,
+                as: "xlsx",
+                to: outputDirectory.appendingPathComponent("workbook.pdf"),
+                policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+            )
+            Issue.record("Expected package extension mismatch to be rejected")
+        } catch BusinessDocumentStudioError.packageTargetExtensionMismatch(
+            let targetFormatId,
+            let fileExtension
+        ) {
+            #expect(targetFormatId == "xlsx")
+            #expect(fileExtension == "pdf")
+        } catch {
+            Issue.record("Expected packageTargetExtensionMismatch, got \(error)")
+        }
+    }
+
+    @Test func exportTextFallbackRejectsPackageTargetsAndDirectoryEscape() async throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let document = Self.plainTextDocument()
+        let outputDirectory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        do {
+            _ = try await service.export(
+                document,
+                as: "txt",
+                to: outputDirectory.appendingPathComponent("fake.xlsx"),
+                policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+            )
+            Issue.record("Expected text fallback package target to be rejected")
+        } catch BusinessDocumentStudioError.unsafeTextPackageTarget(let fileExtension) {
+            #expect(fileExtension == "xlsx")
+        } catch {
+            Issue.record("Expected unsafeTextPackageTarget, got \(error)")
+        }
+
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("studio-outside-\(UUID().uuidString).txt")
+        do {
+            _ = try await service.export(
+                document,
+                as: "txt",
+                to: outside,
+                policy: BusinessDocumentStudioExportPolicy(allowedDirectory: outputDirectory)
+            )
+            Issue.record("Expected destination containment to reject outside path")
+        } catch BusinessDocumentStudioError.destinationOutsideAllowedDirectory(let url) {
+            #expect(url == outside)
+            #expect(!FileManager.default.fileExists(atPath: outside.path))
+        } catch {
+            Issue.record("Expected destinationOutsideAllowedDirectory, got \(error)")
+        }
+    }
+
+    @Test func inspectPDFWrapsPreviewAndMissingEmitterExportOption() throws {
+        let service = BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        let inspection = try service.inspect(Self.pdfDocument())
+
+        #expect(inspection.summary.kind == .pdf)
+        #expect(inspection.exportOptions.contains { option in
+            option.targetFormatId == "pdf"
+                && option.canExport == false
+                && option.reason == .missingEmitter
+        })
+        guard case let .pdf(preview) = inspection.preview else {
+            Issue.record("Expected PDF preview")
+            return
+        }
+        #expect(preview.pageCount == 1)
+        #expect(preview.pages.first?.text.text == "Quarterly report")
+        #expect(preview.creationAvailability.reasonCode == .missingEmitter)
+    }
+
+    // MARK: - Fixtures
+
+    private static func write(_ content: String, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("business-document-studio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func plainTextDocument() -> StructuredDocument {
+        StructuredDocument(
+            formatId: "plaintext",
+            filename: "notes.txt",
+            fileSize: 11,
+            representation: AnyStructuredRepresentation(
+                formatId: "plaintext",
+                underlying: PlainTextRepresentation(text: "hello world")
+            ),
+            security: .notInspected(
+                formatId: "plaintext",
+                fileExtension: "txt",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "hello world"
+        )
+    }
+
+    private static func pdfDocument() -> StructuredDocument {
+        let page = PDFPageRepresentation(
+            pageIndex: 0,
+            text: "Quarterly report",
+            anchor: DocumentAnchor(
+                kind: .page,
+                path: [.init(kind: .page, index: 0)],
+                label: "Page 1"
+            )
+        )
+        return StructuredDocument(
+            formatId: "pdf",
+            filename: "report.pdf",
+            fileSize: 128,
+            representation: AnyStructuredRepresentation(
+                formatId: "pdf",
+                underlying: PDFDocumentRepresentation(pages: [page])
+            ),
+            security: .notInspected(
+                formatId: "pdf",
+                fileExtension: "pdf",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Quarterly report"
+        )
+    }
+
+    private static func workbookDocument(includeFormula: Bool = false) -> StructuredDocument {
+        let workbook = Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            cells: [
+                                cell("A1", row: 1, column: 1, value: .string("Month")),
+                                cell("B1", row: 1, column: 2, value: .string("Amount")),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            cells: [
+                                cell("A2", row: 2, column: 1, value: .string("January")),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .number(1200),
+                                    formula: includeFormula ? "SUM(B2:B2)" : nil
+                                ),
+                            ]
+                        ),
+                    ],
+                    anchor: DocumentAnchor(kind: .sheet, path: [.init(kind: .sheet, index: 0)])
+                ),
+            ]
+        )
+
+        return StructuredDocument(
+            formatId: "xlsx",
+            filename: "workbook.xlsx",
+            fileSize: 256,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Month\tAmount\nJanuary\t1200"
+        )
+    }
+
+    private static func row(number: Int, cells: [Workbook.Cell]) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(kind: .row, path: [.init(kind: .row, index: number - 1)])
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        formula: String? = nil
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            formula: formula,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .row, index: row - 1),
+                    .init(kind: .cell, index: column - 1),
+                ]
+            )
+        )
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -327,6 +327,7 @@ This command bridge is for external clients connecting to Osaurus. If Server > N
 - `Services/Documents/CSVAdapter.swift` — CSV and TSV table parsing with bounded input handling.
 - `Services/Documents/CSVEmitter.swift` — explicit CSV/TSV delimited-text export.
 - `Services/Documents/CSVTableWorkflowService.swift` — schema previews, bounded samples, and safe CSV/TSV conversion/export validation.
+- `Services/Documents/BusinessDocumentStudioService.swift` — one bounded inspect/preview/export orchestration layer across CSV/TSV, XLSX, PDF/PPTX, rich text, and text fallback workflows.
 - `Services/Documents/XLSXAdapter.swift` — XLSX workbook parsing from Office Open XML packages.
 - `Services/Documents/XLSXEmitter.swift` — XLSX workbook emission for round-trip workflows.
 - `Services/Documents/WorkbookWorkflowService.swift` — workbook inspection, export availability, validation issues, and explicit emitter-backed save flow.
@@ -340,6 +341,7 @@ This command bridge is for external clients connecting to Osaurus. If Server > N
 
 - CSV and TSV tables preserve headers, rows, delimiters, and source metadata. Explicit table workflow previews infer schema types from bounded samples, cap large-file reads, and validate CSV/TSV conversion/export before writing.
 - XLSX workbooks preserve sheets, cells, formulas, merged ranges, shared strings, relationships, and export availability metadata. Explicit workbook save flows validate bounds, formulas, non-finite numbers, XML-safe text, merged ranges, and emitter availability before writing a minimal valid `.xlsx` package.
+- Business Document Studio wraps registry lookup, bounded previews, export availability, safe destination containment, and text-fallback export into one service so UI, plugins, and attachment flows do not reimplement format-specific routing.
 - PPTX/POTX decks preserve slide grouping, text runs, notes, slide tables, and relationships.
 - PDFs preserve page boundaries, anchors, and simple text-layer tables so citations can point back to pages and detected table cells.
 - PDF/PPTX workflow previews expose page/slide/table/notes metadata and report missing structured emitters instead of treating text writes as valid binary output.

--- a/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
+++ b/docs/HIGH_FIDELITY_OUTPUT_SAFETY_AUDIT.md
@@ -31,6 +31,13 @@ reports whether a structured emitter is registered for a typed PDF/PPTX
 document; on current main it returns `missingEmitter`, keeping fake binary
 packages off the text-only `file_write` path.
 
+Business Document Studio is the format-neutral orchestration layer above these
+services. It parses through `DocumentFormatRegistry`, returns bounded CSV,
+workbook, PDF/PPTX, rich-text, or text previews, reports export availability,
+contains explicit export destinations when a caller supplies an allowed
+directory, and rejects text-fallback writes to structured package extensions.
+It does not add a default agent tool or an arbitrary-path HTTP file endpoint.
+
 Tool exposure stays narrow. Folder plugin hints only bias installed spreadsheet
 plugins, preflight injection respects installed plugin ids and per-agent
 allowlists, and default-agent `capabilities_load` cannot load plugin tools.
@@ -50,6 +57,7 @@ No workbook writer is added to the default schema.
 | XLSX bounds | Empty exports, whitespace-only exports, overlong cell text, invalid names/references, non-finite numbers, and ZIP32 overflows are rejected before package write | `XLSXEmitterTests`, `XLSXAdapterTests` |
 | PDF/PPTX creation diagnostics | Typed PDF/PPTX workflows report registered emitters or `missingEmitter` and do not route creation through text writes | `PDFPPTXWorkflowServiceTests` |
 | Workbook workflow | Workbook inspection reports sheet/cell/formula/merged-range counts, validation reason codes, and missing-emitter state before export | `WorkbookWorkflowServiceTests` |
+| Business Document Studio | Unified inspect/export path wraps CSV/TSV, XLSX, PDF/PPTX, rich text, and text fallback workflows without adding default tools or unsafe package-shaped text writes | `BusinessDocumentStudioServiceTests` |
 | Tool exposure | XLSX plugin injection is bias-only, installed-plugin gated, and allowlist-respecting | `PreflightCapabilitySearchTests.folderInjection_*`, `FolderPluginHintsTests` |
 
 ## Follow-Up Lanes


### PR DESCRIPTION
## Summary

Adds `BusinessDocumentStudioService`, a format-neutral core service for inspecting, previewing, and explicitly exporting business documents through the existing document registry and workflow services.

This consolidates CSV/TSV, XLSX, PDF/PPTX, rich-text, and text-fallback routing behind one Codable inspection surface so UI, plugin, and attachment flows do not each need to reimplement format-specific preview/export decisions.

## What changed

- Added a bounded Business Document Studio inspection model with summary, registry roles, security metadata, previews, and export options.
- Routed CSV/TSV previews and exports through `CSVTableWorkflowService`.
- Routed workbook inspection and XLSX export through `WorkbookWorkflowService`, with bounded sheet/row/cell samples.
- Wrapped PDF/PPTX workflow previews and missing-emitter diagnostics without pretending text writes are binary package creation.
- Added guarded text fallback export with destination containment, overwrite protection, byte limits, and structured package target rejection.
- Documented the service in the features and high-fidelity output safety audit docs.

## Safety notes

- No default agent tool is added.
- No arbitrary-path HTTP endpoint is added.
- Structured package extensions are rejected for text fallback writes, and package export target extensions must match the requested structured format.
- Preview sizes are capped by policy and format-specific parsing still uses the existing document limits.

## Validation

- `swiftlint lint Packages/OsaurusCore/Services/Documents/BusinessDocumentStudioService.swift Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioServiceTests.swift`
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter BusinessDocumentStudioServiceTests`
- `swift test --package-path Packages/OsaurusCore --filter 'BusinessDocumentStudioServiceTests|CSVTableWorkflowServiceTests|WorkbookWorkflowServiceTests|PDFPPTXWorkflowServiceTests|DocumentFormatRegistryTests'`
- `OSAURUS_TEST_ROOT=/tmp/osaurus-business-document-studio-test make test` — 3763 tests passed
- `make cli`
- `swift build --package-path Packages/OsaurusCore -c release`

Note: the keychain-disabled full-suite mode still fails an existing keychain lifecycle expectation where the bystander secret is nil under disabled keychain mode. The normal full core suite passed.

## Rollback

Revert commit `d6138991`.
