### PR TITLE
Add Provider Connectivity Center

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -62502,6 +62502,198 @@
           }
         }
       }
+    },
+    "%lld/%lld connected - %lld attention - %lld models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld/%lld connected - %lld attention - %lld models"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld/%lld connected - %lld attention - %lld models"
+          }
+        }
+      }
+    },
+    "%lld/%lld connected, %lld attention, %lld models, %lld manual-model provider(s)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld/%lld connected, %lld attention, %lld models, %lld manual-model provider(s)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld/%lld connected, %lld attention, %lld models, %lld manual-model provider(s)"
+          }
+        }
+      }
+    },
+    "Attention" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Attention"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Attention"
+          }
+        }
+      }
+    },
+    "Copy diagnostics" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copy diagnostics"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Copy diagnostics"
+          }
+        }
+      }
+    },
+    "Global proxy: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Global proxy: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Global proxy: %@"
+          }
+        }
+      }
+    },
+    "Ignored - %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignored - %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignored - %@"
+          }
+        }
+      }
+    },
+    "Manual models" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Manual models"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Manual models"
+          }
+        }
+      }
+    },
+    "Needs attention" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Needs attention"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Needs attention"
+          }
+        }
+      }
+    },
+    "Provider Connectivity" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider Connectivity"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider Connectivity"
+          }
+        }
+      }
+    },
+    "Provider connectivity diagnostics" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider connectivity diagnostics"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Provider connectivity diagnostics"
+          }
+        }
+      }
+    },
+    "Reconnect" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconnect"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconnect"
+          }
+        }
+      }
+    },
+    "Reconnect all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconnect all"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Reconnect all"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift
@@ -1,0 +1,225 @@
+//
+//  ProviderConnectivityCenter.swift
+//  OsaurusCore
+//
+//  Aggregates remote-provider health for the Settings provider dashboard.
+//
+
+import Foundation
+
+public struct RemoteProviderCredentialPresence: Sendable, Equatable {
+    public var apiKeyPresent: Bool
+    public var oauthTokensPresent: Bool
+
+    public init(apiKeyPresent: Bool = false, oauthTokensPresent: Bool = false) {
+        self.apiKeyPresent = apiKeyPresent
+        self.oauthTokensPresent = oauthTokensPresent
+    }
+}
+
+public enum ProviderConnectivityStatus: String, Sendable, Equatable, CaseIterable {
+    case connected
+    case connecting
+    case needsAttention
+    case disabled
+    case idle
+
+    public var displayName: String {
+        switch self {
+        case .connected: return L("Connected")
+        case .connecting: return L("Connecting")
+        case .needsAttention: return L("Needs attention")
+        case .disabled: return L("Disabled")
+        case .idle: return L("Ready")
+        }
+    }
+}
+
+public enum ProviderConnectivityFilter: String, Sendable, Equatable, CaseIterable {
+    case all
+    case attention
+    case connected
+    case disabled
+
+    public var displayName: String {
+        switch self {
+        case .all: return L("All")
+        case .attention: return L("Attention")
+        case .connected: return L("Connected")
+        case .disabled: return L("Disabled")
+        }
+    }
+
+    public func includes(_ report: ProviderConnectivityProviderReport) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .attention:
+            return report.status == .needsAttention
+                || report.highestSeverity == .blocked
+                || report.highestSeverity == .warning
+        case .connected:
+            return report.status == .connected
+        case .disabled:
+            return report.status == .disabled
+        }
+    }
+}
+
+public struct ProviderConnectivityProviderReport: Identifiable, Sendable {
+    public let id: UUID
+    public let provider: RemoteProvider
+    public let state: RemoteProviderState?
+    public let diagnostics: ProviderDiagnosticReport
+    public let status: ProviderConnectivityStatus
+    public let highestSeverity: ProviderDiagnosticSeverity
+    public let summary: String
+    public let recommendedAction: String?
+    public let modelCount: Int
+    public let manualModelCount: Int
+
+    public var hasAttention: Bool {
+        status == .needsAttention || highestSeverity == .blocked || highestSeverity == .warning
+    }
+}
+
+public struct ProviderConnectivitySnapshot: Sendable {
+    public let reports: [ProviderConnectivityProviderReport]
+    public let proxy: GlobalProxyDiagnosticState
+
+    public var totalCount: Int { reports.count }
+    public var enabledCount: Int { reports.filter { $0.provider.enabled }.count }
+    public var connectedCount: Int { reports.filter { $0.status == .connected }.count }
+    public var connectingCount: Int { reports.filter { $0.status == .connecting }.count }
+    public var attentionCount: Int { reports.filter(\.hasAttention).count }
+    public var disabledCount: Int { reports.filter { $0.status == .disabled }.count }
+    public var manualModelProviderCount: Int { reports.filter { $0.manualModelCount > 0 }.count }
+    public var modelCount: Int { reports.reduce(0) { $0 + $1.modelCount } }
+
+    public var highestSeverity: ProviderDiagnosticSeverity {
+        reports.map(\.highestSeverity).max(by: severityLessThan) ?? .info
+    }
+
+    public func filtered(by filter: ProviderConnectivityFilter) -> [ProviderConnectivityProviderReport] {
+        reports.filter { filter.includes($0) }
+    }
+
+    public var pasteboardText: String {
+        var lines = [
+            L("Provider connectivity diagnostics"),
+            L(
+                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(modelCount) models, \(manualModelProviderCount) manual-model provider(s)"
+            ),
+            L("Global proxy: \(proxy.summaryText)"),
+        ]
+        for report in reports {
+            lines.append("")
+            lines.append(report.diagnostics.pasteboardText)
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+public enum ProviderConnectivityCenter {
+    public static func snapshot(
+        providers: [RemoteProvider],
+        states: [UUID: RemoteProviderState],
+        proxy: GlobalProxyDiagnosticState,
+        credentialsByProvider: [UUID: RemoteProviderCredentialPresence]
+    ) -> ProviderConnectivitySnapshot {
+        let reports = providers.map { provider in
+            providerReport(
+                provider: provider,
+                state: states[provider.id],
+                proxy: proxy,
+                credentialPresence: credentialsByProvider[provider.id] ?? RemoteProviderCredentialPresence()
+            )
+        }
+        return ProviderConnectivitySnapshot(reports: reports, proxy: proxy)
+    }
+
+    public static func providerReport(
+        provider: RemoteProvider,
+        state: RemoteProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        credentialPresence: RemoteProviderCredentialPresence
+    ) -> ProviderConnectivityProviderReport {
+        let diagnostics = ProviderNetworkDiagnostics.remoteProviderReport(
+            provider: provider,
+            state: state,
+            proxy: proxy,
+            apiKeyPresent: credentialPresence.apiKeyPresent,
+            oauthTokensPresent: credentialPresence.oauthTokensPresent
+        )
+        let severity = diagnostics.rows.map(\.severity).max(by: severityLessThan) ?? .info
+        let status = status(for: provider, state: state, highestSeverity: severity)
+        let firstActionableRow = diagnostics.rows.first { $0.severity == .blocked }
+            ?? diagnostics.rows.first { $0.severity == .warning }
+        let summaryRow = firstActionableRow ?? diagnostics.rows.first { $0.id == "connection" }
+
+        return ProviderConnectivityProviderReport(
+            id: provider.id,
+            provider: provider,
+            state: state,
+            diagnostics: diagnostics,
+            status: status,
+            highestSeverity: severity,
+            summary: summary(for: summaryRow, fallback: status.displayName),
+            recommendedAction: firstActionableRow?.action,
+            modelCount: state?.modelCount ?? 0,
+            manualModelCount: provider.manualModelIds.count
+        )
+    }
+
+    private static func status(
+        for provider: RemoteProvider,
+        state: RemoteProviderState?,
+        highestSeverity: ProviderDiagnosticSeverity
+    ) -> ProviderConnectivityStatus {
+        guard provider.enabled else { return .disabled }
+        if state?.isConnecting == true { return .connecting }
+        if state?.isConnected == true { return .connected }
+        if state?.lastError?.isEmpty == false || highestSeverity == .blocked || highestSeverity == .warning {
+            return .needsAttention
+        }
+        return .idle
+    }
+
+    private static func summary(for row: ProviderDiagnosticRow?, fallback: String) -> String {
+        guard let row else { return fallback }
+        if let detail = row.detail, !detail.isEmpty {
+            return "\(row.title): \(row.value) - \(detail)"
+        }
+        return "\(row.title): \(row.value)"
+    }
+}
+
+private func severityLessThan(_ lhs: ProviderDiagnosticSeverity, _ rhs: ProviderDiagnosticSeverity) -> Bool {
+    severityRank(lhs) < severityRank(rhs)
+}
+
+private func severityRank(_ severity: ProviderDiagnosticSeverity) -> Int {
+    switch severity {
+    case .ok:
+        return 0
+    case .info:
+        return 1
+    case .warning:
+        return 2
+    case .blocked:
+        return 3
+    }
+}
+
+private extension GlobalProxyDiagnosticState {
+    var summaryText: String {
+        switch self {
+        case .disabled:
+            return L("Disabled")
+        case .active(let url):
+            return url
+        case .invalid(let reason):
+            return L("Ignored - \(reason)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
@@ -1,0 +1,164 @@
+//
+//  ProviderConnectivityCenterTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Provider connectivity center")
+struct ProviderConnectivityCenterTests {
+    @Test func snapshotClassifiesRowsAndBuildsSanitizedReport() {
+        let connected = RemoteProvider(
+            id: UUID(),
+            name: "OpenAI",
+            host: "api.openai.com",
+            authType: .apiKey,
+            providerType: .openResponses
+        )
+        let failed = RemoteProvider(
+            id: UUID(),
+            name: "Lemonade",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 8000,
+            basePath: "/api/v1",
+            authType: .none,
+            providerType: .openaiLegacy,
+            manualModelIds: ["local-chat"]
+        )
+        var disabled = RemoteProvider(
+            id: UUID(),
+            name: "Azure",
+            host: "example.openai.azure.com",
+            authType: .apiKey,
+            providerType: .azureOpenAI,
+            enabled: false,
+            manualModelIds: ["prod-chat"]
+        )
+        disabled.enabled = false
+
+        var connectedState = RemoteProviderState(providerId: connected.id)
+        connectedState.isConnected = true
+        connectedState.discoveredModels = ["gpt-5.5", "gpt-5.5-mini"]
+
+        var failedState = RemoteProviderState(providerId: failed.id)
+        failedState.lastError = #"HTTP 401: {"access_token":"secret-token"}"#
+
+        let snapshot = ProviderConnectivityCenter.snapshot(
+            providers: [connected, failed, disabled],
+            states: [
+                connected.id: connectedState,
+                failed.id: failedState,
+            ],
+            proxy: .active("https://proxy.example.com:8443"),
+            credentialsByProvider: [
+                connected.id: RemoteProviderCredentialPresence(apiKeyPresent: true),
+                disabled.id: RemoteProviderCredentialPresence(apiKeyPresent: false),
+            ]
+        )
+
+        #expect(snapshot.totalCount == 3)
+        #expect(snapshot.connectedCount == 1)
+        #expect(snapshot.modelCount == 2)
+        #expect(snapshot.manualModelProviderCount == 2)
+        #expect(snapshot.filtered(by: .connected).map(\.provider.name) == ["OpenAI"])
+        #expect(snapshot.filtered(by: .disabled).map(\.provider.name) == ["Azure"])
+        #expect(snapshot.filtered(by: .attention).contains { $0.provider.name == "Lemonade" })
+        #expect(snapshot.filtered(by: .attention).contains { $0.provider.name == "Azure" })
+        #expect(snapshot.pasteboardText.contains("Provider connectivity diagnostics"))
+        #expect(snapshot.pasteboardText.contains("https://proxy.example.com:8443"))
+        #expect(!snapshot.pasteboardText.contains("secret-token"))
+    }
+
+    @Test func attentionFilterIncludesManualModelFallbackWarnings() {
+        let provider = RemoteProvider(
+            name: "Azure",
+            host: "example.openai.azure.com",
+            authType: .apiKey,
+            providerType: .azureOpenAI,
+            manualModelIds: []
+        )
+
+        let report = ProviderConnectivityCenter.providerReport(
+            provider: provider,
+            state: nil,
+            proxy: .disabled,
+            credentialPresence: RemoteProviderCredentialPresence(apiKeyPresent: true)
+        )
+
+        #expect(report.status == .needsAttention)
+        #expect(report.highestSeverity == .warning)
+        #expect(report.summary.contains("Model discovery"))
+        #expect(report.recommendedAction?.contains("deployment") == true)
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct RemoteProviderManagerConnectivityCenterTests {
+    @Test func testConnectionUsesManualModelsWhenModelsEndpointIsMissing() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            defer { manager._testRemoveProviders(ids: []) }
+
+            manager.testConnectionTransportOverride = { request in
+                #expect(request.url?.absoluteString == "https://api.example.test/v1/models")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 404,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (Data(#"{"error":{"message":"not found"}}"#.utf8), response)
+            }
+
+            let models = try await manager.testConnection(
+                host: "api.example.test",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/v1",
+                authType: .none,
+                providerType: .openaiLegacy,
+                apiKey: nil,
+                headers: [:],
+                manualModelIds: [" direct-chat ", "DIRECT-CHAT", ""]
+            )
+
+            #expect(models == ["direct-chat"])
+        }
+    }
+
+    @Test func testConnectionStillFailsWithoutManualModelsOnServerError() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            defer { manager._testRemoveProviders(ids: []) }
+
+            manager.testConnectionTransportOverride = { request in
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 500,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (Data(#"{"error":{"message":"boom"}}"#.utf8), response)
+            }
+
+            await #expect(throws: RemoteProviderError.self) {
+                try await manager.testConnection(
+                    host: "api.example.test",
+                    providerProtocol: .https,
+                    port: nil,
+                    basePath: "/v1",
+                    authType: .none,
+                    providerType: .openaiLegacy,
+                    apiKey: nil,
+                    headers: [:],
+                    manualModelIds: ["local-chat"]
+                )
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
@@ -685,8 +685,7 @@ struct ProviderCredentialPromptSheet: View {
         let host = trimmed(extraFieldValue(for: "host"))
         let deployment = trimmed(extraFieldValue(for: "deployment"))
         let effectiveHost = host.isEmpty ? defaults.host : host
-        let deploymentModelIds =
-            deployment
+        let deploymentModelIds = deployment
             .split(whereSeparator: { $0 == "\n" || $0 == "," })
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -5,6 +5,7 @@
 //  View for managing remote API providers (OpenAI, Anthropic, etc.).
 //
 
+import AppKit
 import SwiftUI
 
 struct RemoteProvidersView: View {
@@ -18,6 +19,10 @@ struct RemoteProvidersView: View {
     @State private var editingProvider: RemoteProvider?
     @State private var showReorderSheet = false
     @State private var hasAppeared = false
+    @State private var providerFilter: ProviderConnectivityFilter = .all
+    @State private var credentialPresence: [UUID: RemoteProviderCredentialPresence] = [:]
+    @State private var reconnectingAll = false
+    @State private var reconnectingProviderIds: Set<UUID> = []
 
     private struct AddSheetConfig: Identifiable {
         let id = UUID()
@@ -41,6 +46,7 @@ struct RemoteProvidersView: View {
                     if userConfiguredProviders.isEmpty {
                         emptyStateView
                     } else {
+                        connectivityCenterView
                         providerListView
                     }
                 }
@@ -55,6 +61,7 @@ struct RemoteProvidersView: View {
             withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
                 hasAppeared = true
             }
+            refreshCredentialPresence()
         }
         .sheet(item: $addSheetConfig) { config in
             RemoteProviderEditSheet(
@@ -63,11 +70,13 @@ struct RemoteProvidersView: View {
                 startAtAPIKeyPicker: config.startAtAPIKeyPicker
             ) { provider, apiKey, oauthTokens in
                 manager.addProvider(provider, apiKey: apiKey, oauthTokens: oauthTokens)
+                refreshCredentialPresence()
             }
         }
         .sheet(item: $editingProvider) { provider in
             RemoteProviderEditSheet(provider: provider) { updatedProvider, apiKey, oauthTokens in
                 manager.updateProvider(updatedProvider, apiKey: apiKey, oauthTokens: oauthTokens)
+                refreshCredentialPresence()
             }
         }
         .sheet(isPresented: $showReorderSheet) {
@@ -120,6 +129,19 @@ struct RemoteProvidersView: View {
 
     private var userConfiguredProviders: [RemoteProvider] {
         manager.configuration.providers.filter { $0.providerType != .osaurusRouter }
+    }
+
+    private var connectivitySnapshot: ProviderConnectivitySnapshot {
+        ProviderConnectivityCenter.snapshot(
+            providers: userConfiguredProviders,
+            states: manager.providerStates,
+            proxy: GlobalProxySettings.currentDiagnostic(),
+            credentialsByProvider: credentialPresence
+        )
+    }
+
+    private var visibleProviderReports: [ProviderConnectivityProviderReport] {
+        connectivitySnapshot.filtered(by: providerFilter)
     }
 
     private func presentAPIKeyPicker() {
@@ -185,20 +207,245 @@ struct RemoteProvidersView: View {
 
     // MARK: - Provider List
 
+    private var connectivityCenterView: some View {
+        ProviderConnectivityCenterPanel(
+            snapshot: connectivitySnapshot,
+            filter: $providerFilter,
+            isReconnecting: reconnectingAll,
+            onReconnectAll: reconnectAllProviders,
+            onCopyReport: copyConnectivityReport
+        )
+    }
+
     private var providerListView: some View {
         VStack(spacing: 12) {
-            ForEach(userConfiguredProviders) { provider in
+            ForEach(visibleProviderReports) { report in
                 ProviderCardView(
-                    provider: provider,
-                    state: manager.providerStates[provider.id],
-                    onEdit: { editingProvider = provider },
-                    onDelete: { manager.removeProvider(id: provider.id) },
+                    report: report,
+                    state: report.state,
+                    isReconnecting: reconnectingProviderIds.contains(report.id),
+                    onReconnect: { reconnectProvider(report.provider) },
+                    onCopyDiagnostics: { copyDiagnostics(report.diagnostics) },
+                    onEdit: { editingProvider = report.provider },
+                    onDelete: { manager.removeProvider(id: report.id) },
                     onToggleEnabled: { enabled in
-                        manager.setEnabled(enabled, for: provider.id)
+                        manager.setEnabled(enabled, for: report.id)
                     }
                 )
             }
         }
+    }
+
+    private func refreshCredentialPresence() {
+        let providers = userConfiguredProviders
+        Task {
+            var next: [UUID: RemoteProviderCredentialPresence] = [:]
+            for provider in providers {
+                let providerID = provider.id
+                let presence = await RemoteProviderKeychain.runOffCooperativeExecutor {
+                    RemoteProviderCredentialPresence(
+                        apiKeyPresent: RemoteProviderKeychain.hasAPIKey(for: providerID),
+                        oauthTokensPresent: RemoteProviderKeychain.hasOAuthTokens(for: providerID)
+                    )
+                }
+                next[providerID] = presence
+            }
+            await MainActor.run {
+                credentialPresence = next
+            }
+        }
+    }
+
+    private func reconnectProvider(_ provider: RemoteProvider) {
+        guard provider.enabled else { return }
+        reconnectingProviderIds.insert(provider.id)
+        Task {
+            do {
+                try await manager.reconnect(providerId: provider.id)
+            } catch {
+                // RemoteProviderManager stores the user-facing failure in state.
+            }
+            await MainActor.run {
+                _ = reconnectingProviderIds.remove(provider.id)
+            }
+        }
+    }
+
+    private func reconnectAllProviders() {
+        let targets = userConfiguredProviders.filter(\.enabled)
+        guard !targets.isEmpty else { return }
+        reconnectingAll = true
+        Task {
+            for provider in targets {
+                do {
+                    try await manager.reconnect(providerId: provider.id)
+                } catch {
+                    // Individual provider rows keep their own diagnostics.
+                }
+            }
+            await MainActor.run {
+                reconnectingAll = false
+            }
+        }
+    }
+
+    private func copyConnectivityReport() {
+        copyText(connectivitySnapshot.pasteboardText)
+    }
+
+    private func copyDiagnostics(_ report: ProviderDiagnosticReport) {
+        copyText(report.pasteboardText)
+    }
+
+    private func copyText(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+}
+
+// MARK: - Provider Connectivity Center Panel
+
+private struct ProviderConnectivityCenterPanel: View {
+    @Environment(\.theme) private var theme
+
+    let snapshot: ProviderConnectivitySnapshot
+    @Binding var filter: ProviderConnectivityFilter
+    let isReconnecting: Bool
+    let onReconnectAll: () -> Void
+    let onCopyReport: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                HStack(spacing: 10) {
+                    Image(systemName: iconName)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(statusColor)
+                        .frame(width: 30, height: 30)
+                        .background(Circle().fill(statusColor.opacity(0.12)))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Provider Connectivity", bundle: .module)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                        Text(summaryText)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.secondaryText)
+                    }
+                }
+
+                Spacer()
+
+                Button(action: onReconnectAll) {
+                    if isReconnecting {
+                        ProgressView()
+                            .scaleEffect(0.55)
+                            .frame(width: 28, height: 28)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 12, weight: .semibold))
+                            .frame(width: 28, height: 28)
+                    }
+                }
+                .buttonStyle(PlainButtonStyle())
+                .foregroundColor(theme.secondaryText)
+                .background(Circle().fill(theme.tertiaryBackground))
+                .disabled(isReconnecting || snapshot.enabledCount == 0)
+                .localizedHelp("Reconnect all")
+
+                Button(action: onCopyReport) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .foregroundColor(theme.secondaryText)
+                .background(Circle().fill(theme.tertiaryBackground))
+                .localizedHelp("Copy diagnostics")
+            }
+
+            HStack(spacing: 8) {
+                ProviderConnectivityMetricPill(title: L("Connected"), value: "\(snapshot.connectedCount)", color: theme.successColor)
+                ProviderConnectivityMetricPill(title: L("Attention"), value: "\(snapshot.attentionCount)", color: theme.warningColor)
+                ProviderConnectivityMetricPill(title: L("Models"), value: "\(snapshot.modelCount)", color: theme.accentColor)
+                ProviderConnectivityMetricPill(
+                    title: L("Manual models"),
+                    value: "\(snapshot.manualModelProviderCount)",
+                    color: theme.infoColor
+                )
+            }
+
+            Picker("", selection: $filter) {
+                ForEach(ProviderConnectivityFilter.allCases, id: \.self) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(statusColor.opacity(0.35), lineWidth: 1)
+                )
+        )
+    }
+
+    private var statusColor: Color {
+        switch snapshot.highestSeverity {
+        case .ok:
+            return theme.successColor
+        case .info:
+            return theme.infoColor
+        case .warning:
+            return theme.warningColor
+        case .blocked:
+            return theme.errorColor
+        }
+    }
+
+    private var iconName: String {
+        switch snapshot.highestSeverity {
+        case .ok:
+            return "checkmark.seal.fill"
+        case .info:
+            return "network"
+        case .warning:
+            return "exclamationmark.triangle.fill"
+        case .blocked:
+            return "xmark.octagon.fill"
+        }
+    }
+
+    private var summaryText: String {
+        L(
+            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(snapshot.modelCount) models"
+        )
+    }
+}
+
+private struct ProviderConnectivityMetricPill: View {
+    @Environment(\.theme) private var theme
+
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(value)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(color)
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(color.opacity(0.1)))
     }
 }
 
@@ -206,8 +453,11 @@ struct RemoteProvidersView: View {
 
 private struct ProviderCardView: View {
     @Environment(\.theme) private var theme
-    let provider: RemoteProvider
+    let report: ProviderConnectivityProviderReport
     let state: RemoteProviderState?
+    let isReconnecting: Bool
+    let onReconnect: () -> Void
+    let onCopyDiagnostics: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
     let onToggleEnabled: (Bool) -> Void
@@ -215,6 +465,7 @@ private struct ProviderCardView: View {
     @State private var showDeleteConfirm = false
     @State private var isHovered = false
 
+    private var provider: RemoteProvider { report.provider }
     private var isConnected: Bool { state?.isConnected ?? false }
     private var isConnecting: Bool { state?.isConnecting ?? false }
 
@@ -293,6 +544,12 @@ private struct ProviderCardView: View {
                         Text("\(modelCount) model\(modelCount == 1 ? "" : "s") available", bundle: .module)
                             .font(.system(size: 12))
                             .foregroundColor(theme.secondaryText)
+                    } else if report.hasAttention {
+                        Text(report.summary)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.secondaryText)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
                     }
                 }
 
@@ -300,6 +557,39 @@ private struct ProviderCardView: View {
 
                 // Actions
                 HStack(spacing: 12) {
+                    Button(action: onReconnect) {
+                        if isReconnecting || isConnecting {
+                            ProgressView()
+                                .scaleEffect(0.55)
+                                .frame(width: 32, height: 32)
+                        } else {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 14))
+                                .foregroundColor(theme.secondaryText)
+                                .frame(width: 32, height: 32)
+                        }
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.tertiaryBackground)
+                    )
+                    .disabled(!provider.enabled || isReconnecting || isConnecting)
+                    .localizedHelp("Reconnect")
+
+                    Button(action: onCopyDiagnostics) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 14))
+                            .foregroundColor(theme.secondaryText)
+                            .frame(width: 32, height: 32)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(theme.tertiaryBackground)
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .localizedHelp("Copy diagnostics")
+
                     Button(action: onEdit) {
                         Image(systemName: "pencil")
                             .font(.system(size: 14))
@@ -312,7 +602,9 @@ private struct ProviderCardView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
 
-                    Button(action: { showDeleteConfirm = true }) {
+                    Button(
+                        action: { showDeleteConfirm = true },
+                        label: {
                         Image(systemName: "trash")
                             .font(.system(size: 14))
                             .foregroundColor(theme.errorColor.opacity(0.8))
@@ -321,7 +613,8 @@ private struct ProviderCardView: View {
                                 RoundedRectangle(cornerRadius: 8)
                                     .fill(theme.errorColor.opacity(0.1))
                             )
-                    }
+                        }
+                    )
                     .buttonStyle(PlainButtonStyle())
 
                     Toggle(
@@ -354,6 +647,12 @@ private struct ProviderCardView: View {
                 .padding(.vertical, 10)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(theme.errorColor.opacity(0.05))
+            }
+
+            if report.hasAttention {
+                Divider()
+                    .background(theme.primaryBorder)
+                ProviderDiagnosticsRowsView(report: report.diagnostics, maxRows: 3)
             }
         }
         .background(

--- a/docs/REMOTE_PROVIDERS.md
+++ b/docs/REMOTE_PROVIDERS.md
@@ -143,6 +143,26 @@ Providers can be in the following states:
 | **Disabled**     | Gray            | Manually disabled                     |
 | **Error**        | Red             | Connection failed (see error message) |
 
+### Connectivity Center
+
+The Providers screen includes a connectivity center above the provider list.
+It summarizes connected providers, attention items, discovered models, and
+providers that rely on manual model IDs. Use the segmented filter to focus on
+all providers, attention items, connected providers, or disabled providers.
+
+The center also provides:
+
+- a reconnect-all action for enabled providers
+- a safe copyable diagnostics report covering every configured provider
+- inline per-provider reconnect and copy-diagnostics actions
+- expanded diagnostics rows on providers that need attention
+
+Manual model IDs are treated as first-class connectivity evidence for
+OpenAI-compatible and Azure-style providers. If a provider's `/models` endpoint
+is missing or returns a non-OpenAI schema, a configured manual model ID can let
+the connection test and provider connect path proceed without requiring a fake
+model-list endpoint.
+
 ### Troubleshooting Connection Issues
 
 1. **Verify the endpoint** — Check host, port, and base path
@@ -153,11 +173,11 @@ Providers can be in the following states:
 
 ### Provider Diagnostics
 
-Each provider card includes a compact diagnostics section with a copy button.
-The copied report is safe to paste in GitHub or Discord: it lists connection
-state, authentication state, model-discovery path, request format, and global
-proxy state without including API keys, OAuth tokens, request bodies, callback
-URLs, or raw headers.
+Each provider card and the connectivity center include copy buttons. Copied
+reports are safe to paste in GitHub or Discord: they list connection state,
+authentication state, model-discovery path, request format, and global proxy
+state without including API keys, OAuth tokens, request bodies, callback URLs,
+or raw headers.
 
 Useful rows:
 


### PR DESCRIPTION
## Summary
- Adds a Provider Connectivity panel above remote providers with health counts, attention filtering, reconnect-all, per-provider reconnect, and copyable sanitized diagnostics.
- Adds a provider connectivity snapshot service that combines provider state, credential presence, global proxy status, model counts, and diagnostics severity.
- Extends connection tests so OpenAI-compatible and Azure providers with manual model IDs can pass when /models is unavailable or schema-incompatible, while auth/server failures still surface as errors.
- Documents the new provider troubleshooting workflow.

## Validation
- swift test --package-path Packages/OsaurusCore --filter "ProviderConnectivityCenterTests|RemoteProviderManagerConnectivityCenterTests|ProviderNetworkDiagnosticsTests|RemoteProviderModelDiscoveryTests"
- bash scripts/i18n/check.sh
- swiftlint lint --strict --config .swiftlint.yml Packages/OsaurusCore/Services/Provider/ProviderConnectivityCenter.swift Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift Packages/OsaurusCore/Tests/Provider/ProviderConnectivityCenterTests.swift
- swiftlint lint --reporter github-actions-logging
- OSAURUS_TEST_ROOT=/tmp/osaurus-provider-connectivity-center-test make test
- make cli
- xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Release -derivedDataPath build/DerivedData build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -quiet

Local signed make app is blocked on this machine by a missing Mac Development certificate for team 4W8QF9VR2F; the same app target compiles with signing disabled.