### PR TITLE
Add MCP Server Hub

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4725,6 +4725,22 @@
         }
       }
     },
+    "Attention" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Achtung"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "注意"
+          }
+        }
+      }
+    },
     "Allow" : {
       "localizations" : {
         "de" : {
@@ -12766,6 +12782,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制"
+          }
+        }
+      }
+    },
+    "Copy diagnostics" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Diagnose kopieren"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "复制诊断"
           }
         }
       }
@@ -22029,6 +22061,28 @@
         }
       }
     },
+    "Global proxy: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Globaler Proxy: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Global proxy: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全局代理：%@"
+          }
+        }
+      }
+    },
     "Global Proxy" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -23621,6 +23675,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "忽略"
+          }
+        }
+      }
+    },
+    "Ignored - %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ignoriert - %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ignored - %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已忽略 - %@"
           }
         }
       }
@@ -28456,6 +28532,22 @@
         }
       }
     },
+    "MCP Server Hub diagnostics" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "MCP Server Hub-Diagnose"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "MCP Server Hub 诊断"
+          }
+        }
+      }
+    },
     "MCP server health check" : {
       "localizations" : {
         "de" : {
@@ -30175,6 +30267,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要权限"
+          }
+        }
+      }
+    },
+    "Needs attention" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benötigt Aufmerksamkeit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要注意"
           }
         }
       }
@@ -39825,6 +39933,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "探测完成 初始化/工具列表，共找到 %lld 个工具。"
+          }
+        }
+      }
+    },
+    "Probe" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Testen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "探测"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
@@ -48,8 +48,8 @@ public enum MCPLocalProviderDiagnostics {
             severity: result.succeeded ? .ok : .blocked,
             detail: result.succeeded
                 ? L("\(result.toolCount) tool(s) discovered via \(snapshot.transportSummary).")
-                : result.message,
-            action: result.action
+                : result.redactedMessage,
+            action: result.redactedAction
         )
     }
 

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -77,21 +77,35 @@ public struct MCPProviderProbeResult: Codable, Identifiable, Sendable, Equatable
         self.action = action
     }
 
+    public var redactedTransportSummary: String {
+        MCPProviderProbeRedactor.safeDiagnosticFragment(transportSummary, maxLength: 500)
+    }
+
+    public var redactedMessage: String {
+        MCPProviderProbeRedactor.safeDiagnosticFragment(message, maxLength: 280)
+    }
+
+    public var redactedAction: String? {
+        guard let action, !action.isEmpty else { return nil }
+        let redacted = MCPProviderProbeRedactor.safeDiagnosticFragment(action, maxLength: 280)
+        return redacted.isEmpty ? nil : redacted
+    }
+
     public var pasteboardText: String {
         var lines = [
             "MCP provider probe",
             "Provider: \(providerName)",
-            "Transport: \(transportSummary)",
+            "Transport: \(redactedTransportSummary)",
             "Status: \(succeeded ? "succeeded" : "failed")",
             "Reason: \(reasonCode.rawValue)",
             "Stage: \(stage.rawValue)",
             "Tools: \(toolCount)",
-            "Message: \(message)",
+            "Message: \(redactedMessage)",
         ]
         if !toolNames.isEmpty {
             lines.append("Tool names: \(toolNames.joined(separator: ", "))")
         }
-        if let action, !action.isEmpty {
+        if let action = redactedAction {
             lines.append("Action: \(action)")
         }
         return lines.joined(separator: "\n")
@@ -137,9 +151,50 @@ public struct MCPProviderProbeResult: Codable, Identifiable, Sendable, Equatable
             reasonCode: reasonCode,
             toolCount: 0,
             toolNames: [],
-            message: OpenAICodexOAuthService.safeDiagnosticFragment(message, maxLength: 280),
-            action: action
+            message: MCPProviderProbeRedactor.safeDiagnosticFragment(message, maxLength: 280),
+            action: action.map { MCPProviderProbeRedactor.safeDiagnosticFragment($0, maxLength: 280) }
         )
+    }
+}
+
+private extension String {
+    func mcpReplacingMatches(of pattern: String, with template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return self }
+        let range = NSRange(startIndex..., in: self)
+        return regex.stringByReplacingMatches(in: self, range: range, withTemplate: template)
+    }
+}
+
+enum MCPProviderProbeRedactor {
+    static func safeDiagnosticFragment(_ raw: String, maxLength: Int = 280) -> String {
+        var value = raw
+        let replacements: [(pattern: String, template: String)] = [
+            (#"(?i)authorization\s*[:=]\s*(?:bearer\s+)?[^\s,;}]+\"?"#, "credential=***"),
+            (#"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"#, "credential=***"),
+            (
+                #"(?i)\"(access_token|refresh_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token)\"\s*:\s*\"[^\"]*\""#,
+                #""$1":"***""#
+            ),
+            (
+                #"(?i)\b(access_token|refresh_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token)=([^&\s,;}]+)"#,
+                "$1=***"
+            ),
+            (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
+        ]
+        for replacement in replacements {
+            value = value.mcpReplacingMatches(of: replacement.pattern, with: replacement.template)
+        }
+
+        value = value.replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.contains("  ") {
+            value = value.replacingOccurrences(of: "  ", with: " ")
+        }
+        if value.count > maxLength {
+            return String(value.prefix(maxLength)) + "..."
+        }
+        return value
     }
 }
 

--- a/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
@@ -1,0 +1,261 @@
+//
+//  MCPServerHub.swift
+//  OsaurusCore
+//
+//  Aggregates MCP provider health for the Management provider dashboard.
+//
+
+import Foundation
+
+public struct MCPProviderCredentialPresence: Sendable, Equatable {
+    public var bearerTokenPresent: Bool
+    public var oauthTokensPresent: Bool
+
+    public init(bearerTokenPresent: Bool = false, oauthTokensPresent: Bool = false) {
+        self.bearerTokenPresent = bearerTokenPresent
+        self.oauthTokensPresent = oauthTokensPresent
+    }
+}
+
+public enum MCPServerHubStatus: String, Sendable, Equatable, CaseIterable {
+    case connected
+    case connecting
+    case needsAttention
+    case disabled
+    case idle
+
+    public var displayName: String {
+        switch self {
+        case .connected: return L("Connected")
+        case .connecting: return L("Connecting")
+        case .needsAttention: return L("Needs attention")
+        case .disabled: return L("Disabled")
+        case .idle: return L("Ready")
+        }
+    }
+}
+
+public enum MCPServerHubFilter: String, Sendable, Equatable, CaseIterable {
+    case all
+    case attention
+    case connected
+    case stdio
+    case http
+    case disabled
+
+    public var displayName: String {
+        switch self {
+        case .all: return L("All")
+        case .attention: return L("Attention")
+        case .connected: return L("Connected")
+        case .stdio: return L("Stdio")
+        case .http: return L("HTTP")
+        case .disabled: return L("Disabled")
+        }
+    }
+
+    public func includes(_ report: MCPServerHubProviderReport) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .attention:
+            return report.hasAttention
+        case .connected:
+            return report.status == .connected
+        case .stdio:
+            return report.provider.transport == .stdio
+        case .http:
+            return report.provider.transport == .http
+        case .disabled:
+            return report.status == .disabled
+        }
+    }
+}
+
+public struct MCPServerHubProviderReport: Identifiable, Sendable {
+    public let id: UUID
+    public let provider: MCPProvider
+    public let state: MCPProviderState?
+    public let diagnostics: ProviderDiagnosticReport
+    public let healthSnapshot: MCPProviderHealthSnapshot?
+    public let status: MCPServerHubStatus
+    public let highestSeverity: ProviderDiagnosticSeverity
+    public let summary: String
+    public let recommendedAction: String?
+    public let toolCount: Int
+
+    public var hasAttention: Bool {
+        status == .needsAttention
+            || (provider.enabled && (highestSeverity == .blocked || highestSeverity == .warning))
+    }
+}
+
+public struct MCPServerHubSnapshot: Sendable {
+    public let reports: [MCPServerHubProviderReport]
+    public let proxy: GlobalProxyDiagnosticState
+
+    public var totalCount: Int { reports.count }
+    public var enabledCount: Int { reports.filter { $0.provider.enabled }.count }
+    public var connectedCount: Int { reports.filter { $0.status == .connected }.count }
+    public var connectingCount: Int { reports.filter { $0.status == .connecting }.count }
+    public var attentionCount: Int { reports.filter(\.hasAttention).count }
+    public var disabledCount: Int { reports.filter { $0.status == .disabled }.count }
+    public var httpCount: Int { reports.filter { $0.provider.transport == .http }.count }
+    public var stdioCount: Int { reports.filter { $0.provider.transport == .stdio }.count }
+    public var hostStdioCount: Int {
+        reports.filter { $0.provider.transport == .stdio && $0.provider.executionHost == .host }.count
+    }
+    public var sandboxStdioCount: Int {
+        reports.filter { $0.provider.transport == .stdio && $0.provider.executionHost == .sandbox }.count
+    }
+    public var toolCount: Int { reports.reduce(0) { $0 + $1.toolCount } }
+
+    public var highestSeverity: ProviderDiagnosticSeverity {
+        let actionableReports = reports.filter(\.hasAttention)
+        guard !actionableReports.isEmpty else {
+            return connectedCount > 0 ? .ok : .info
+        }
+        return actionableReports.map(\.highestSeverity).max(by: mcpSeverityLessThan) ?? .info
+    }
+
+    public func filtered(by filter: MCPServerHubFilter) -> [MCPServerHubProviderReport] {
+        reports.filter { filter.includes($0) }
+    }
+
+    public var pasteboardText: String {
+        var lines = [
+            L("MCP Server Hub diagnostics"),
+            L(
+                "\(connectedCount)/\(totalCount) connected, \(attentionCount) attention, \(toolCount) tools, \(stdioCount) stdio provider(s)"
+            ),
+            L("Global proxy: \(proxy.summaryText)"),
+        ]
+
+        for report in reports {
+            lines.append("")
+            lines.append(report.diagnostics.pasteboardText)
+            if let probe = report.healthSnapshot?.lastProbe {
+                lines.append("")
+                lines.append(probe.pasteboardText)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+public enum MCPServerHub {
+    public static func snapshot(
+        providers: [MCPProvider],
+        states: [UUID: MCPProviderState],
+        proxy: GlobalProxyDiagnosticState,
+        credentialsByProvider: [UUID: MCPProviderCredentialPresence],
+        healthSnapshots: [UUID: MCPProviderHealthSnapshot]
+    ) -> MCPServerHubSnapshot {
+        let reports = providers.map { provider in
+            providerReport(
+                provider: provider,
+                state: states[provider.id],
+                proxy: proxy,
+                credentialPresence: credentialsByProvider[provider.id] ?? MCPProviderCredentialPresence(),
+                healthSnapshot: healthSnapshots[provider.id]
+            )
+        }
+        return MCPServerHubSnapshot(reports: reports, proxy: proxy)
+    }
+
+    public static func providerReport(
+        provider: MCPProvider,
+        state: MCPProviderState?,
+        proxy: GlobalProxyDiagnosticState,
+        credentialPresence: MCPProviderCredentialPresence,
+        healthSnapshot: MCPProviderHealthSnapshot?
+    ) -> MCPServerHubProviderReport {
+        let baseReport = ProviderNetworkDiagnostics.mcpProviderReport(
+            provider: provider,
+            state: state,
+            proxy: proxy,
+            bearerTokenPresent: credentialPresence.bearerTokenPresent,
+            oauthTokensPresent: credentialPresence.oauthTokensPresent
+        )
+        let diagnostics = MCPLocalProviderDiagnostics.augment(
+            report: baseReport,
+            provider: provider,
+            healthSnapshot: healthSnapshot
+        )
+        let severity = diagnostics.rows.map(\.severity).max(by: mcpSeverityLessThan) ?? .info
+        let status = status(for: provider, state: state, highestSeverity: severity)
+        let firstActionableRow = diagnostics.rows.first { $0.severity == .blocked }
+            ?? diagnostics.rows.first { provider.enabled && $0.severity == .warning }
+        let summaryRow = firstActionableRow
+            ?? diagnostics.rows.first { $0.id == "local-health" }
+            ?? diagnostics.rows.first { $0.id == "connection" }
+
+        return MCPServerHubProviderReport(
+            id: provider.id,
+            provider: provider,
+            state: state,
+            diagnostics: diagnostics,
+            healthSnapshot: healthSnapshot,
+            status: status,
+            highestSeverity: severity,
+            summary: summary(for: summaryRow, fallback: status.displayName),
+            recommendedAction: firstActionableRow?.action,
+            toolCount: state?.discoveredToolCount ?? healthSnapshot?.lastProbe.toolCount ?? 0
+        )
+    }
+
+    private static func status(
+        for provider: MCPProvider,
+        state: MCPProviderState?,
+        highestSeverity: ProviderDiagnosticSeverity
+    ) -> MCPServerHubStatus {
+        guard provider.enabled else { return .disabled }
+        if state?.isConnecting == true { return .connecting }
+        if state?.isConnected == true { return .connected }
+        if state?.requiresAuth == true
+            || state?.lastError?.isEmpty == false
+            || highestSeverity == .blocked
+            || highestSeverity == .warning {
+            return .needsAttention
+        }
+        return .idle
+    }
+
+    private static func summary(for row: ProviderDiagnosticRow?, fallback: String) -> String {
+        guard let row else { return fallback }
+        if let detail = row.detail, !detail.isEmpty {
+            return "\(row.title): \(row.value) - \(detail)"
+        }
+        return "\(row.title): \(row.value)"
+    }
+}
+
+private func mcpSeverityLessThan(_ lhs: ProviderDiagnosticSeverity, _ rhs: ProviderDiagnosticSeverity) -> Bool {
+    mcpSeverityRank(lhs) < mcpSeverityRank(rhs)
+}
+
+private func mcpSeverityRank(_ severity: ProviderDiagnosticSeverity) -> Int {
+    switch severity {
+    case .ok:
+        return 0
+    case .info:
+        return 1
+    case .warning:
+        return 2
+    case .blocked:
+        return 3
+    }
+}
+
+private extension GlobalProxyDiagnosticState {
+    var summaryText: String {
+        switch self {
+        case .disabled:
+            return L("Disabled")
+        case .active(let url):
+            return url
+        case .invalid(let reason):
+            return L("Ignored - \(reason)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -105,6 +105,53 @@ struct MCPProviderProbeServiceTests {
         #expect(decision.denialReason == .backgroundCaptureDenied)
     }
 
+    @Test func probePasteboardTextRedactsCredentialFragments() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Secretive MCP",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "node",
+            args: ["server.js", "--token=secret-token"]
+        )
+        let result = MCPProviderProbeResult.failure(
+            provider: provider,
+            startedAt: Date(),
+            stage: .connect,
+            reasonCode: .authRequired,
+            message: #"HTTP 401 {"access_token":"secret-token","client_secret":"secret-code"} Authorization: Bearer raw-token"#,
+            action: "Retry after rotating password=hunter2."
+        )
+
+        #expect(!result.pasteboardText.contains("secret-token"))
+        #expect(!result.pasteboardText.contains("secret-code"))
+        #expect(!result.pasteboardText.contains("raw-token"))
+        #expect(!result.pasteboardText.contains("hunter2"))
+        #expect(result.pasteboardText.contains("client_secret"))
+        #expect(result.pasteboardText.contains("***"))
+
+        let legacyRawResult = MCPProviderProbeResult(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "stdio host node server.js --client_secret=legacy-secret",
+            startedAt: Date(),
+            finishedAt: Date(),
+            succeeded: false,
+            stage: .connect,
+            reasonCode: .authRequired,
+            toolCount: 0,
+            toolNames: [],
+            message: "legacy access_token=legacy-token",
+            action: "legacy password=legacy-password"
+        )
+
+        #expect(!legacyRawResult.pasteboardText.contains("legacy-secret"))
+        #expect(!legacyRawResult.pasteboardText.contains("legacy-token"))
+        #expect(!legacyRawResult.pasteboardText.contains("legacy-password"))
+    }
+
     @Test func diagnosticsAppendHealthAndCaptureRows() {
         let provider = MCPProvider(
             id: UUID(),

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPServerHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPServerHubTests.swift
@@ -1,0 +1,161 @@
+//
+//  MCPServerHubTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MCP Server Hub")
+struct MCPServerHubTests {
+    @Test func snapshotClassifiesProvidersAndBuildsSanitizedReport() {
+        let connected = MCPProvider(
+            id: UUID(),
+            name: "Linear",
+            url: "https://mcp.linear.app/mcp",
+            authType: .oauth,
+            transport: .http
+        )
+        let failed = MCPProvider(
+            id: UUID(),
+            name: "Filesystem",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem"]
+        )
+        var disabled = MCPProvider(
+            id: UUID(),
+            name: "Zapier",
+            url: "https://mcp.zapier.com/api/mcp/mcp",
+            authType: .bearerToken,
+            transport: .http
+        )
+        disabled.enabled = false
+
+        var connectedState = MCPProviderState(providerId: connected.id)
+        connectedState.isConnected = true
+        connectedState.discoveredToolCount = 2
+        connectedState.discoveredToolNames = ["linear_search", "linear_issue"]
+
+        var failedState = MCPProviderState(providerId: failed.id)
+        failedState.lastError = #"process failed with {"access_token":"secret-token"}"#
+
+        let failedProbe = MCPProviderProbeResult.failure(
+            provider: failed,
+            startedAt: Date(timeIntervalSince1970: 10),
+            stage: .spawn,
+            reasonCode: .commandNotFound,
+            message: #"spawn failed with client_secret=secret-code"#,
+            action: "Use a full executable path."
+        )
+        let failedSnapshot = MCPProviderHealthSnapshot(
+            providerId: failed.id,
+            providerName: failed.name,
+            transportSummary: "stdio host npx -y @modelcontextprotocol/server-filesystem",
+            lastProbe: failedProbe,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+
+        let snapshot = MCPServerHub.snapshot(
+            providers: [connected, failed, disabled],
+            states: [
+                connected.id: connectedState,
+                failed.id: failedState,
+            ],
+            proxy: .active("https://proxy.example.com:8443"),
+            credentialsByProvider: [
+                connected.id: MCPProviderCredentialPresence(oauthTokensPresent: true),
+                disabled.id: MCPProviderCredentialPresence(bearerTokenPresent: false),
+            ],
+            healthSnapshots: [
+                failed.id: failedSnapshot,
+            ]
+        )
+
+        #expect(snapshot.totalCount == 3)
+        #expect(snapshot.connectedCount == 1)
+        #expect(snapshot.attentionCount == 1)
+        #expect(snapshot.disabledCount == 1)
+        #expect(snapshot.httpCount == 2)
+        #expect(snapshot.stdioCount == 1)
+        #expect(snapshot.hostStdioCount == 1)
+        #expect(snapshot.toolCount == 2)
+        #expect(snapshot.filtered(by: .connected).map(\.provider.name) == ["Linear"])
+        #expect(snapshot.filtered(by: .stdio).map(\.provider.name) == ["Filesystem"])
+        #expect(snapshot.filtered(by: .disabled).map(\.provider.name) == ["Zapier"])
+        #expect(snapshot.filtered(by: .attention).map(\.provider.name) == ["Filesystem"])
+        #expect(snapshot.pasteboardText.contains("MCP Server Hub diagnostics"))
+        #expect(snapshot.pasteboardText.contains("https://proxy.example.com:8443"))
+        #expect(snapshot.pasteboardText.contains("commandNotFound"))
+        #expect(!snapshot.pasteboardText.contains("secret-token"))
+        #expect(!snapshot.pasteboardText.contains("secret-code"))
+    }
+
+    @Test func failedProbeMakesEnabledProviderNeedAttention() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Local Search",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .sandbox,
+            command: "uvx",
+            args: ["local-search-mcp"]
+        )
+        let probe = MCPProviderProbeResult.failure(
+            provider: provider,
+            startedAt: Date(),
+            stage: .connect,
+            reasonCode: .protocolError,
+            message: "not MCP JSON-RPC",
+            action: "Verify the process speaks MCP JSON-RPC on stdin/stdout."
+        )
+        let health = MCPProviderHealthSnapshot(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "stdio sandbox uvx local-search-mcp",
+            lastProbe: probe
+        )
+
+        let report = MCPServerHub.providerReport(
+            provider: provider,
+            state: nil,
+            proxy: .disabled,
+            credentialPresence: MCPProviderCredentialPresence(),
+            healthSnapshot: health
+        )
+
+        #expect(report.status == .needsAttention)
+        #expect(report.hasAttention)
+        #expect(report.summary.contains("Last probe"))
+        #expect(report.recommendedAction?.contains("JSON-RPC") == true)
+    }
+
+    @Test func disabledProviderDoesNotDriveHubAttentionSeverity() {
+        var provider = MCPProvider(
+            id: UUID(),
+            name: "Disabled Token Provider",
+            url: "https://mcp.example.com/mcp",
+            authType: .bearerToken,
+            transport: .http
+        )
+        provider.enabled = false
+
+        let snapshot = MCPServerHub.snapshot(
+            providers: [provider],
+            states: [:],
+            proxy: .disabled,
+            credentialsByProvider: [:],
+            healthSnapshots: [:]
+        )
+
+        #expect(snapshot.attentionCount == 0)
+        #expect(snapshot.highestSeverity == .info)
+        #expect(snapshot.filtered(by: .attention).isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -15,6 +15,12 @@ struct ProvidersView: View {
     @State private var showAddSheet = false
     @State private var editingProvider: MCPProvider?
     @State private var hasAppeared = false
+    @State private var providerFilter: MCPServerHubFilter = .all
+    @State private var credentialPresence: [UUID: MCPProviderCredentialPresence] = [:]
+    @State private var healthSnapshots: [UUID: MCPProviderHealthSnapshot] = MCPProviderHealthSnapshotStore.load()
+    @State private var reconnectingAll = false
+    @State private var probingAll = false
+    @State private var probingProviderIds: Set<UUID> = []
 
     var body: some View {
         ScrollView {
@@ -25,24 +31,29 @@ struct ProvidersView: View {
                 if manager.configuration.providers.isEmpty {
                     emptyState
                 } else {
-                    ForEach(Array(manager.configuration.providers.enumerated()), id: \.element.id) {
-                        index,
-                        provider in
+                    hubPanel
+
+                    ForEach(Array(visibleProviderReports.enumerated()), id: \.element.id) { index, report in
                         ProviderCard(
-                            provider: provider,
-                            state: manager.providerStates[provider.id],
+                            report: report,
                             animationIndex: index,
-                            onEdit: { editingProvider = provider },
-                            onDelete: { manager.removeProvider(id: provider.id) },
-                            onConnect: { Task { try? await manager.connect(providerId: provider.id) } },
-                            onDisconnect: { manager.disconnect(providerId: provider.id) },
+                            isTesting: probingProviderIds.contains(report.id),
+                            onEdit: { editingProvider = report.provider },
+                            onDelete: { manager.removeProvider(id: report.id) },
+                            onConnect: { Task { try? await manager.connect(providerId: report.id) } },
+                            onDisconnect: { manager.disconnect(providerId: report.id) },
+                            onTest: { probeProvider(report.provider) },
+                            onCopyDiagnostics: { copyDiagnostics(report.diagnostics) },
                             onToggleEnabled: { enabled in
-                                manager.setEnabled(enabled, for: provider.id)
+                                manager.setEnabled(enabled, for: report.id)
                             },
                             onSignIn: {
                                 Task {
                                     do {
-                                        _ = try await manager.oauthSignIn(providerId: provider.id)
+                                        _ = try await manager.oauthSignIn(providerId: report.id)
+                                        await MainActor.run {
+                                            refreshCredentialPresence()
+                                        }
                                     } catch {
                                         // The manager already wrote the error into
                                         // `MCPProviderState.lastError`, so the inline
@@ -50,7 +61,7 @@ struct ProvidersView: View {
                                         // toast it so the user notices even if their
                                         // card is scrolled off-screen.
                                         await MainActor.run {
-                                            ToastManager.shared.error(
+                                            _ = ToastManager.shared.error(
                                                 L("OAuth sign-in failed"),
                                                 message: error.localizedDescription
                                             )
@@ -61,17 +72,18 @@ struct ProvidersView: View {
                             onSaveBearerToken: { token in
                                 // Persist directly to Keychain (the provider record
                                 // itself doesn't change) and immediately retry.
-                                _ = MCPProviderKeychain.saveToken(token, for: provider.id)
+                                _ = MCPProviderKeychain.saveToken(token, for: report.id)
+                                refreshCredentialPresence()
                                 // Enable the provider so the retry connect doesn't no-op.
-                                if !provider.enabled {
-                                    manager.setEnabled(true, for: provider.id)
+                                if !report.provider.enabled {
+                                    manager.setEnabled(true, for: report.id)
                                 }
                                 Task {
                                     do {
-                                        try await manager.connect(providerId: provider.id)
+                                        try await manager.connect(providerId: report.id)
                                     } catch {
                                         await MainActor.run {
-                                            ToastManager.shared.error(
+                                            _ = ToastManager.shared.error(
                                                 L("Couldn't connect with new token"),
                                                 message: error.localizedDescription
                                             )
@@ -90,19 +102,31 @@ struct ProvidersView: View {
             withAnimation(.easeOut(duration: 0.25).delay(0.1)) {
                 hasAppeared = true
             }
+            refreshCredentialPresence()
+            refreshHealthSnapshots()
             applyPendingEditRequest()
         }
         .onChange(of: managementState.pendingMCPProviderEditId) { _, _ in
             applyPendingEditRequest()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: Foundation.Notification.Name.mcpProviderHealthSnapshotChanged
+            )
+        ) { _ in
+            refreshHealthSnapshots()
+        }
         .sheet(isPresented: $showAddSheet) {
             ProviderEditSheet(provider: nil) { provider, token in
                 manager.addProvider(provider, token: token)
+                refreshCredentialPresence()
             }
         }
         .sheet(item: $editingProvider) { provider in
             ProviderEditSheet(provider: provider) { updatedProvider, token in
                 manager.updateProvider(updatedProvider, token: token)
+                refreshCredentialPresence()
+                refreshHealthSnapshots()
             }
         }
     }
@@ -116,6 +140,150 @@ struct ProvidersView: View {
             editingProvider = provider
         }
         managementState.pendingMCPProviderEditId = nil
+    }
+
+    private var hubSnapshot: MCPServerHubSnapshot {
+        MCPServerHub.snapshot(
+            providers: manager.configuration.providers,
+            states: manager.providerStates,
+            proxy: GlobalProxySettings.currentDiagnostic(),
+            credentialsByProvider: credentialPresence,
+            healthSnapshots: healthSnapshots
+        )
+    }
+
+    private var visibleProviderReports: [MCPServerHubProviderReport] {
+        hubSnapshot.filtered(by: providerFilter)
+    }
+
+    private var hubPanel: some View {
+        MCPServerHubPanel(
+            snapshot: hubSnapshot,
+            filter: $providerFilter,
+            isReconnecting: reconnectingAll,
+            isProbing: probingAll,
+            onReconnectAll: reconnectEnabledProviders,
+            onProbeAll: probeEnabledProviders,
+            onCopyReport: copyHubReport
+        )
+    }
+
+    private func refreshCredentialPresence() {
+        let providers = manager.configuration.providers
+        Task {
+            var next: [UUID: MCPProviderCredentialPresence] = [:]
+            for provider in providers {
+                let providerID = provider.id
+                let presence = await Task.detached(priority: .utility) {
+                    MCPProviderCredentialPresence(
+                        bearerTokenPresent: MCPProviderKeychain.hasToken(for: providerID),
+                        oauthTokensPresent: MCPProviderKeychain.hasOAuthTokens(for: providerID)
+                    )
+                }.value
+                next[providerID] = presence
+            }
+            await MainActor.run {
+                credentialPresence = next
+            }
+        }
+    }
+
+    private func refreshHealthSnapshots() {
+        healthSnapshots = MCPProviderHealthSnapshotStore.load()
+    }
+
+    private func reconnectEnabledProviders() {
+        let targets = manager.configuration.providers.filter(\.enabled)
+        guard !targets.isEmpty else { return }
+        reconnectingAll = true
+        Task {
+            for provider in targets {
+                do {
+                    try await manager.connect(providerId: provider.id)
+                } catch {
+                    // Row state keeps the user-facing diagnostic.
+                }
+            }
+            await MainActor.run {
+                reconnectingAll = false
+            }
+        }
+    }
+
+    private func probeEnabledProviders() {
+        let targets = manager.configuration.providers.filter(\.enabled)
+        guard !targets.isEmpty else { return }
+        probingAll = true
+        probingProviderIds.formUnion(targets.map(\.id))
+        Task {
+            for provider in targets {
+                let result = await probeResult(for: provider)
+                MCPProviderHealthSnapshotStore.record(result, for: provider)
+            }
+            await MainActor.run {
+                refreshHealthSnapshots()
+                probingProviderIds.subtract(targets.map(\.id))
+                probingAll = false
+            }
+        }
+    }
+
+    private func probeProvider(_ provider: MCPProvider) {
+        guard !probingProviderIds.contains(provider.id) else { return }
+        probingProviderIds.insert(provider.id)
+        Task {
+            let result = await probeResult(for: provider)
+            MCPProviderHealthSnapshotStore.record(result, for: provider)
+            await MainActor.run {
+                refreshHealthSnapshots()
+                _ = probingProviderIds.remove(provider.id)
+            }
+        }
+    }
+
+    private func probeResult(for provider: MCPProvider) async -> MCPProviderProbeResult {
+        switch provider.transport {
+        case .http:
+            let credentials = await Task.detached(priority: .utility) {
+                let token: String? = switch provider.authType {
+                case .bearerToken:
+                    MCPProviderKeychain.getToken(for: provider.id)
+                case .oauth:
+                    MCPProviderKeychain.getOAuthTokens(for: provider.id)?.accessToken
+                case .none:
+                    nil
+                }
+                return (
+                    token,
+                    provider.resolvedHeaders()
+                )
+            }.value
+            return await MCPProviderProbeService.probeHTTP(
+                providerId: provider.id,
+                name: provider.name,
+                url: provider.url,
+                token: credentials.0,
+                headers: credentials.1,
+                streamingEnabled: provider.streamingEnabled,
+                discoveryTimeout: provider.discoveryTimeout
+            )
+        case .stdio:
+            return await MCPProviderProbeService.probeStdio(provider: provider)
+        }
+    }
+
+    private func copyHubReport() {
+        copyText(hubSnapshot.pasteboardText)
+    }
+
+    private func copyDiagnostics(_ report: ProviderDiagnosticReport) {
+        copyText(report.pasteboardText)
+    }
+
+    private func copyText(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
     }
 
     private var headerSection: some View {
@@ -179,17 +347,192 @@ struct ProvidersView: View {
     }
 }
 
+// MARK: - MCP Server Hub Panel
+
+private struct MCPServerHubPanel: View {
+    @Environment(\.theme) private var theme
+
+    let snapshot: MCPServerHubSnapshot
+    @Binding var filter: MCPServerHubFilter
+    let isReconnecting: Bool
+    let isProbing: Bool
+    let onReconnectAll: () -> Void
+    let onProbeAll: () -> Void
+    let onCopyReport: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                HStack(spacing: 10) {
+                    Image(systemName: iconName)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(statusColor)
+                        .frame(width: 30, height: 30)
+                        .background(Circle().fill(statusColor.opacity(0.12)))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("MCP Server Hub", bundle: .module)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                            .lineLimit(1)
+                        Text(summaryText)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.secondaryText)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+
+                Spacer()
+
+                hubIconButton(
+                    systemName: "antenna.radiowaves.left.and.right",
+                    isBusy: isProbing,
+                    isDisabled: isProbing || snapshot.enabledCount == 0,
+                    help: "Probe enabled",
+                    action: onProbeAll
+                )
+
+                hubIconButton(
+                    systemName: "arrow.clockwise",
+                    isBusy: isReconnecting,
+                    isDisabled: isReconnecting || snapshot.enabledCount == 0,
+                    help: "Reconnect enabled",
+                    action: onReconnectAll
+                )
+
+                hubIconButton(
+                    systemName: "doc.on.doc",
+                    isBusy: false,
+                    isDisabled: snapshot.totalCount == 0,
+                    help: "Copy diagnostics",
+                    action: onCopyReport
+                )
+            }
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 86), spacing: 8, alignment: .leading)],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                MCPServerHubMetricPill(title: L("Connected"), value: "\(snapshot.connectedCount)", color: theme.successColor)
+                MCPServerHubMetricPill(title: L("Attention"), value: "\(snapshot.attentionCount)", color: theme.warningColor)
+                MCPServerHubMetricPill(title: L("Tools"), value: "\(snapshot.toolCount)", color: theme.accentColor)
+                MCPServerHubMetricPill(title: L("Stdio"), value: "\(snapshot.stdioCount)", color: theme.infoColor)
+                MCPServerHubMetricPill(title: L("Host"), value: "\(snapshot.hostStdioCount)", color: Color.orange)
+            }
+
+            Picker("", selection: $filter) {
+                ForEach(MCPServerHubFilter.allCases, id: \.self) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(statusColor.opacity(0.35), lineWidth: 1)
+                )
+        )
+    }
+
+    private func hubIconButton(
+        systemName: String,
+        isBusy: Bool,
+        isDisabled: Bool,
+        help: LocalizedStringKey,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            if isBusy {
+                ProgressView()
+                    .scaleEffect(0.55)
+                    .frame(width: 28, height: 28)
+            } else {
+                Image(systemName: systemName)
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 28, height: 28)
+            }
+        }
+        .buttonStyle(PlainButtonStyle())
+        .foregroundColor(theme.secondaryText)
+        .background(Circle().fill(theme.tertiaryBackground))
+        .disabled(isDisabled)
+        .localizedHelp(help)
+    }
+
+    private var statusColor: Color {
+        switch snapshot.highestSeverity {
+        case .ok:
+            return theme.successColor
+        case .info:
+            return theme.infoColor
+        case .warning:
+            return theme.warningColor
+        case .blocked:
+            return theme.errorColor
+        }
+    }
+
+    private var iconName: String {
+        switch snapshot.highestSeverity {
+        case .ok:
+            return "checkmark.seal.fill"
+        case .info:
+            return "server.rack"
+        case .warning:
+            return "exclamationmark.triangle.fill"
+        case .blocked:
+            return "xmark.octagon.fill"
+        }
+    }
+
+    private var summaryText: String {
+        L(
+            "\(snapshot.connectedCount)/\(snapshot.totalCount) connected - \(snapshot.attentionCount) attention - \(snapshot.toolCount) tools"
+        )
+    }
+}
+
+private struct MCPServerHubMetricPill: View {
+    @Environment(\.theme) private var theme
+
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(value)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(color)
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(color.opacity(0.1)))
+    }
+}
+
 // MARK: - Provider Card
 
 private struct ProviderCard: View {
     @Environment(\.theme) private var theme
-    let provider: MCPProvider
-    let state: MCPProviderState?
+    let report: MCPServerHubProviderReport
     var animationIndex: Int = 0
+    let isTesting: Bool
     let onEdit: () -> Void
     let onDelete: () -> Void
     let onConnect: () -> Void
     let onDisconnect: () -> Void
+    let onTest: () -> Void
+    let onCopyDiagnostics: () -> Void
     let onToggleEnabled: (Bool) -> Void
     let onSignIn: () -> Void
     /// Inline "Add API token" submit for bearer-token providers that hit a 401.
@@ -203,9 +546,9 @@ private struct ProviderCard: View {
     @State private var showDeleteConfirm = false
     /// Inline secure-field text for the bearer-token 401 banner. Cleared on submit.
     @State private var inlineBearerToken: String = ""
-    @State private var bearerTokenPresent = false
-    @State private var oauthTokensPresent = false
-    @State private var healthSnapshot: MCPProviderHealthSnapshot?
+
+    private var provider: MCPProvider { report.provider }
+    private var state: MCPProviderState? { report.state }
 
     private var isConnected: Bool {
         state?.isConnected ?? false
@@ -220,35 +563,7 @@ private struct ProviderCard: View {
     }
 
     private var diagnosticsReport: ProviderDiagnosticReport {
-        let baseReport = ProviderNetworkDiagnostics.mcpProviderReport(
-            provider: provider,
-            state: state,
-            proxy: GlobalProxySettings.currentDiagnostic(),
-            bearerTokenPresent: bearerTokenPresent,
-            oauthTokensPresent: oauthTokensPresent
-        )
-        return MCPLocalProviderDiagnostics.augment(
-            report: baseReport,
-            provider: provider,
-            healthSnapshot: healthSnapshot
-        )
-    }
-
-    @MainActor
-    private func refreshCredentialState() async {
-        let providerID = provider.id
-        let credentials = await Task.detached(priority: .utility) {
-            (
-                MCPProviderKeychain.hasToken(for: providerID),
-                MCPProviderKeychain.hasOAuthTokens(for: providerID)
-            )
-        }.value
-        bearerTokenPresent = credentials.0
-        oauthTokensPresent = credentials.1
-    }
-
-    private func refreshHealthSnapshot() {
-        healthSnapshot = MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id)
+        report.diagnostics
     }
 
     var body: some View {
@@ -295,6 +610,14 @@ private struct ProviderCard: View {
                                 .truncationMode(
                                     provider.transport == .stdio ? .middle : .tail
                                 )
+
+                            if report.hasAttention {
+                                Text(report.summary)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(theme.secondaryText)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
                         }
 
                         Spacer()
@@ -355,6 +678,39 @@ private struct ProviderCard: View {
                                     ? theme.errorColor.opacity(0.1) : (isConnecting ? Color.clear : theme.accentColor)
                             )
                     )
+
+                    Button(action: onTest) {
+                        if isTesting {
+                            ProgressView()
+                                .scaleEffect(0.55)
+                                .frame(width: 28, height: 28)
+                        } else {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(theme.secondaryText)
+                                .frame(width: 28, height: 28)
+                        }
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(theme.tertiaryBackground)
+                    )
+                    .disabled(isTesting)
+                    .localizedHelp("Probe")
+
+                    Button(action: onCopyDiagnostics) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(theme.secondaryText)
+                            .frame(width: 28, height: 28)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(theme.tertiaryBackground)
+                    )
+                    .localizedHelp("Copy diagnostics")
 
                     Menu {
                         Button(action: onEdit) {
@@ -455,23 +811,6 @@ private struct ProviderCard: View {
         .background(cardBackground)
         .animation(.easeOut(duration: 0.15), value: isHovering)
         .onHover { hovering in isHovering = hovering }
-        .task(id: provider.id) {
-            await refreshCredentialState()
-            refreshHealthSnapshot()
-        }
-        .onChange(of: provider.authType) { _, _ in
-            Task { await refreshCredentialState() }
-        }
-        .onReceive(
-            NotificationCenter.default.publisher(
-                for: Foundation.Notification.Name.mcpProviderHealthSnapshotChanged
-            )
-        ) { notification in
-            guard let changedId = notification.object as? UUID else { return }
-            if changedId == provider.id {
-                refreshHealthSnapshot()
-            }
-        }
         .opacity(hasAppeared ? 1 : 0)
         .onAppear {
             let delay = Double(animationIndex) * 0.03
@@ -1861,12 +2200,12 @@ private struct ProviderEditSheet: View {
                     probeChip(title: "Tools", value: "\(result.toolCount)")
                 }
 
-                Text(result.message)
+                Text(result.redactedMessage)
                     .font(.system(size: 12))
                     .foregroundColor(themeManager.currentTheme.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
 
-                if let action = result.action, !action.isEmpty {
+                if let action = result.redactedAction {
                     Text(action)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(themeManager.currentTheme.accentColor)

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -169,6 +169,13 @@ repro path. The copied text is safe to paste in an issue or Discord thread; it
 does not include bearer tokens, OAuth tokens, request bodies, env values, or raw
 headers.
 
+The top of the Providers page includes an **MCP Server Hub** summary when at
+least one provider exists. It aggregates connected, attention, tool, stdio, and
+host-stdio counts, and the segmented filter lets you narrow the row list to all,
+attention, connected, stdio, HTTP, or disabled providers. The hub actions can
+probe every enabled provider, reconnect every enabled provider, or copy a single
+redacted support report for the whole provider set.
+
 For stdio providers, diagnostics distinguish sandbox vs host execution and point
 command-not-found failures at the executable path/PATH fix. For HTTP/SSE
 providers, diagnostics show whether the global proxy is active, disabled, or


### PR DESCRIPTION
## Summary
- Add an MCP Server Hub summary to Management -> Providers with health counts, filters, bulk probe/reconnect actions, and copyable provider-set diagnostics.
- Move provider cards onto shared hub reports so credential presence, proxy policy, connection state, and saved probe health are evaluated consistently.
- Harden MCP probe diagnostics so copied probe reports and legacy saved probe snapshots redact token, client secret, bearer, password, and JWT fragments.

## Validation
- swift test --package-path Packages/OsaurusCore --filter 'MCPServerHubTests|MCPProviderProbeServiceTests'\n- bash scripts/i18n/check.sh\n- swiftlint lint --strict --config .swiftlint.yml Packages/OsaurusCore/Services/MCP/MCPServerHub.swift Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift Packages/OsaurusCore/Tests/MCPOAuth/MCPServerHubTests.swift Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift\n- swiftlint lint --reporter github-actions-logging\n- git diff --check\n- make test\n- make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"