### PR TITLE
Repin vmlx-swift → 2bd6606f: BPE merge O(n log n) fix (#73)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
+        "revision" : "2bd6606f31ec8bc8017ef190dc983e835987e58c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
+            revision: "2bd6606f31ec8bc8017ef190dc983e835987e58c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "36aebd429dc3e691b2cfad23b89ebb7627361eb4"
+        "revision" : "2bd6606f31ec8bc8017ef190dc983e835987e58c"
       }
     },
     {


### PR DESCRIPTION
## What
Repin osaurus's vmlx-swift dependency `76047f3b → 2bd6606f` to pick up the BPE quadratic-merge fix (osaurus-ai/vmlx-swift#73).

## Why
On gemma-4-12B-it-qat with tools + sandbox, the tool-schema block renders as one ~11k-char **whitespace-free** pre-token (compact JSON). The old `BPETokenizer.bpe()` was O(n²) on a single long pre-token → **~6.3 s per tokenize**, paid every agent-loop step. #73 makes it **O(n log n)** (heap + linked list, rank-rounds to stay canonical on SentencePiece's non-monotonic whitespace ranks) → **~tens of ms**, byte-identical (locked by a differential regression test that ships in #73).

The `76047f3b..2bd6606f` delta is otherwise almost entirely inert image-gen work (vMLXFlux/ideogram/qwen proofs); the **only** osaurus-consumed change is `VMLXTokenizers`' `BPETokenizer`.

## 🚧 HOLD — do not merge yet
Build + live-prove are intentionally **pending**, held until a running gemma stress proof on the box finishes (RAM/perf isolation). Before this merges:
- [ ] SwiftPM resolve + OsaurusCore build green with the new pin.
- [ ] Live-prove: gemma-12B tools+sandbox tool-schema pre-token tokenizes in ms (was ~6.3 s); multiturn stays coherent, no regression.

Will mark ready once those are green.