### PR TITLE
Add access key management console

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Status.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Status.swift
@@ -13,19 +13,25 @@ public struct StatusCommand: Command {
     public static func execute(args: [String]) async {
         let port = Configuration.resolveConfiguredPort() ?? 1337
 
-        guard let url = URL(string: "http://127.0.0.1:\(port)/health") else {
-            fputs("Invalid URL for health check\n", stderr)
+        guard
+            let healthURL = URL(string: "http://127.0.0.1:\(port)/health"),
+            let statusURL = URL(string: "http://127.0.0.1:\(port)/admin/status")
+        else {
+            fputs("Invalid URL for status check\n", stderr)
             exit(EXIT_FAILURE)
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 0.6
+        var healthRequest = URLRequest(url: healthURL)
+        healthRequest.httpMethod = "GET"
+        healthRequest.timeoutInterval = 0.6
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await URLSession.shared.data(for: healthRequest)
             if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                let payload = try? JSONDecoder().decode(StatusHealthPayload.self, from: data)
+                var statusRequest = URLRequest(url: statusURL)
+                statusRequest.httpMethod = "GET"
+                statusRequest.timeoutInterval = 0.6
+                let payload = try? await fetchStatusPayload(request: statusRequest)
                 print(formatRunningStatus(port: port, health: payload))
                 exit(EXIT_SUCCESS)
             } else {
@@ -36,6 +42,14 @@ public struct StatusCommand: Command {
             print("stopped")
             exit(EXIT_FAILURE)
         }
+    }
+
+    private static func fetchStatusPayload(request: URLRequest) async throws -> StatusHealthPayload? {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return nil
+        }
+        return try JSONDecoder().decode(StatusHealthPayload.self, from: data)
     }
 
     static func formatRunningStatus(port: Int, health: StatusHealthPayload?) -> String {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Status.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Status.swift
@@ -23,9 +23,10 @@ public struct StatusCommand: Command {
         request.timeoutInterval = 0.6
 
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                print("running (port \(port))")
+                let payload = try? JSONDecoder().decode(StatusHealthPayload.self, from: data)
+                print(formatRunningStatus(port: port, health: payload))
                 exit(EXIT_SUCCESS)
             } else {
                 print("stopped")
@@ -35,5 +36,53 @@ public struct StatusCommand: Command {
             print("stopped")
             exit(EXIT_FAILURE)
         }
+    }
+
+    static func formatRunningStatus(port: Int, health: StatusHealthPayload?) -> String {
+        var lines = ["running (port \(port))"]
+        if let auth = health?.auth {
+            lines.append("auth: \(auth.summary)")
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+struct StatusHealthPayload: Decodable, Equatable {
+    let auth: StatusAuthPayload?
+}
+
+struct StatusAuthPayload: Decodable, Equatable {
+    let localAuthPolicy: String
+    let loopbackTrusted: Bool
+    let networkExposure: Bool
+    let accessKeysLoaded: Bool
+    let accessKeyCount: Int?
+    let activeAccessKeyCount: Int?
+    let revokedAccessKeyCount: Int?
+    let expiredAccessKeyCount: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case localAuthPolicy = "local_auth_policy"
+        case loopbackTrusted = "loopback_trusted"
+        case networkExposure = "network_exposure"
+        case accessKeysLoaded = "access_keys_loaded"
+        case accessKeyCount = "access_key_count"
+        case activeAccessKeyCount = "active_access_key_count"
+        case revokedAccessKeyCount = "revoked_access_key_count"
+        case expiredAccessKeyCount = "expired_access_key_count"
+    }
+
+    var summary: String {
+        let local = loopbackTrusted ? "localhost keyless" : "localhost requires key"
+        let exposure = networkExposure ? "network exposed" : "local only"
+        let keys: String
+        if accessKeysLoaded {
+            keys =
+                "keys active \(activeAccessKeyCount ?? 0), revoked \(revokedAccessKeyCount ?? 0), "
+                + "expired \(expiredAccessKeyCount ?? 0)"
+        } else {
+            keys = "key metadata not loaded"
+        }
+        return "\(local); \(exposure); \(keys)"
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/OsaurusCLITests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/OsaurusCLITests.swift
@@ -14,4 +14,56 @@ final class OsaurusCLITests: XCTestCase {
         let root = Configuration.toolsRootDirectory()
         XCTAssertFalse(root.path.isEmpty)
     }
+
+    func testStatusFormatsAuthSummaryWhenHealthIncludesLoadedKeys() throws {
+        let json = """
+            {
+              "auth": {
+                "local_auth_policy": "always_allow",
+                "loopback_trusted": true,
+                "network_exposure": true,
+                "access_keys_loaded": true,
+                "access_key_count": 4,
+                "active_access_key_count": 2,
+                "revoked_access_key_count": 1,
+                "expired_access_key_count": 1
+              }
+            }
+            """
+        let payload = try JSONDecoder().decode(StatusHealthPayload.self, from: Data(json.utf8))
+
+        XCTAssertEqual(
+            StatusCommand.formatRunningStatus(port: 1337, health: payload),
+            """
+            running (port 1337)
+            auth: localhost keyless; network exposed; keys active 2, revoked 1, expired 1
+            """
+        )
+    }
+
+    func testStatusFormatsUnloadedKeyMetadata() throws {
+        let json = """
+            {
+              "auth": {
+                "local_auth_policy": "local_only",
+                "loopback_trusted": false,
+                "network_exposure": true,
+                "access_keys_loaded": false,
+                "access_key_count": null,
+                "active_access_key_count": null,
+                "revoked_access_key_count": null,
+                "expired_access_key_count": null
+              }
+            }
+            """
+        let payload = try JSONDecoder().decode(StatusHealthPayload.self, from: Data(json.utf8))
+
+        XCTAssertEqual(
+            StatusCommand.formatRunningStatus(port: 8080, health: payload),
+            """
+            running (port 8080)
+            auth: localhost requires key; network exposed; key metadata not loaded
+            """
+        )
+    }
 }

--- a/Packages/OsaurusCore/Identity/APIKeyManager.swift
+++ b/Packages/OsaurusCore/Identity/APIKeyManager.swift
@@ -131,10 +131,11 @@ public final class APIKeyManager: @unchecked Sendable {
 
         queue.sync(flags: .barrier) {
             let currentCounter = CounterStore.shared.current
+            let revokedAt = Date()
             RevocationStore.shared.revokeAllBefore(address: address, counter: currentCounter)
             keys = keys.map { key in
                 guard key.iss.lowercased() == address.lowercased(), !key.revoked else { return key }
-                return key.withRevoked()
+                return key.withRevoked(at: revokedAt)
             }
             Self.saveToKeychain(keys)
         }
@@ -160,6 +161,12 @@ public final class APIKeyManager: @unchecked Sendable {
 
     public func listKeys() -> [AccessKeyInfo] {
         queue.sync { keys }
+    }
+
+    public func listKeysIfLoaded() -> [AccessKeyInfo]? {
+        queue.sync {
+            didLoadFromKeychain ? keys : nil
+        }
     }
 
     /// Return all access keys whose audience matches `audience` (case-insensitive).

--- a/Packages/OsaurusCore/Identity/IdentityModels.swift
+++ b/Packages/OsaurusCore/Identity/IdentityModels.swift
@@ -104,6 +104,12 @@ public enum AccessKeyExpiration: String, Codable, CaseIterable, Sendable {
     }
 }
 
+public enum AccessKeyStatus: String, Codable, Sendable, Equatable {
+    case active
+    case expired
+    case revoked
+}
+
 /// The signed payload embedded inside an osk-v1 access key.
 /// Keys are sorted alphabetically for canonical JSON encoding.
 public struct AccessKeyPayload: Codable, Sendable {
@@ -148,17 +154,75 @@ public struct AccessKeyInfo: Codable, Identifiable, Sendable {
     public let expiration: AccessKeyExpiration
     public let expiresAt: Date?
     public let revoked: Bool
+    public let revokedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case label
+        case prefix
+        case nonce
+        case cnt
+        case iss
+        case aud
+        case createdAt
+        case expiration
+        case expiresAt
+        case revoked
+        case revokedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.label = try container.decode(String.self, forKey: .label)
+        self.prefix = try container.decode(String.self, forKey: .prefix)
+        self.nonce = try container.decode(String.self, forKey: .nonce)
+        self.cnt = try container.decode(UInt64.self, forKey: .cnt)
+        self.iss = try container.decode(OsaurusID.self, forKey: .iss)
+        self.aud = try container.decode(OsaurusID.self, forKey: .aud)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.expiration = try container.decode(AccessKeyExpiration.self, forKey: .expiration)
+        self.expiresAt = try container.decodeIfPresent(Date.self, forKey: .expiresAt)
+        self.revoked = try container.decodeIfPresent(Bool.self, forKey: .revoked) ?? false
+        self.revokedAt = try container.decodeIfPresent(Date.self, forKey: .revokedAt)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(label, forKey: .label)
+        try container.encode(prefix, forKey: .prefix)
+        try container.encode(nonce, forKey: .nonce)
+        try container.encode(cnt, forKey: .cnt)
+        try container.encode(iss, forKey: .iss)
+        try container.encode(aud, forKey: .aud)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(expiration, forKey: .expiration)
+        try container.encodeIfPresent(expiresAt, forKey: .expiresAt)
+        try container.encode(revoked, forKey: .revoked)
+        try container.encodeIfPresent(revokedAt, forKey: .revokedAt)
+    }
+
+    public func status(at date: Date = Date()) -> AccessKeyStatus {
+        if revoked { return .revoked }
+        if let expiresAt, date > expiresAt { return .expired }
+        return .active
+    }
 
     public var isExpired: Bool {
-        guard let expiresAt else { return false }
-        return Date() > expiresAt
+        status() == .expired
     }
 
     public var isActive: Bool {
-        !revoked && !isExpired
+        status() == .active
     }
 
-    public func withRevoked() -> AccessKeyInfo {
+    public var redactedDisplay: String {
+        let nonceTail = nonce.suffix(6)
+        return "\(prefix)...\(nonceTail)"
+    }
+
+    public func withRevoked(at revokedAt: Date = Date()) -> AccessKeyInfo {
         AccessKeyInfo(
             id: id,
             label: label,
@@ -170,7 +234,8 @@ public struct AccessKeyInfo: Codable, Identifiable, Sendable {
             createdAt: createdAt,
             expiration: expiration,
             expiresAt: expiresAt,
-            revoked: true
+            revoked: true,
+            revokedAt: revokedAt
         )
     }
 
@@ -185,7 +250,8 @@ public struct AccessKeyInfo: Codable, Identifiable, Sendable {
         createdAt: Date,
         expiration: AccessKeyExpiration,
         expiresAt: Date?,
-        revoked: Bool = false
+        revoked: Bool = false,
+        revokedAt: Date? = nil
     ) {
         self.id = id
         self.label = label
@@ -198,6 +264,7 @@ public struct AccessKeyInfo: Codable, Identifiable, Sendable {
         self.expiration = expiration
         self.expiresAt = expiresAt
         self.revoked = revoked
+        self.revokedAt = revokedAt
     }
 }
 

--- a/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfiguration.swift
@@ -22,6 +22,23 @@ public enum AppearanceMode: String, Codable, CaseIterable, Sendable {
     }
 }
 
+public enum ServerLocalAuthPolicy: String, Codable, CaseIterable, Sendable, Equatable {
+    case localOnly = "local_only"
+    case requireAccessKey = "require_access_key"
+    case alwaysAllow = "always_allow"
+
+    public func trustsLoopback(exposeToNetwork: Bool) -> Bool {
+        switch self {
+        case .localOnly:
+            return !exposeToNetwork
+        case .requireAccessKey:
+            return false
+        case .alwaysAllow:
+            return true
+        }
+    }
+}
+
 /// Configuration settings for the server
 public struct ServerConfiguration: Codable, Equatable, Sendable {
     public static let defaultModelLoadRAMSoftThreshold = 0.70
@@ -32,6 +49,9 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
 
     /// Expose the server to the local network (0.0.0.0) or keep it on localhost (127.0.0.1)
     public var exposeToNetwork: Bool
+
+    /// Whether loopback callers may skip Bearer authentication.
+    public var localAuthPolicy: ServerLocalAuthPolicy
 
     /// Start Osaurus automatically at login
     public var startAtLogin: Bool
@@ -88,6 +108,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case port
         case exposeToNetwork
+        case localAuthPolicy
         case startAtLogin
         case hideDockIcon
         case appearanceMode
@@ -110,6 +131,9 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         self.port = try container.decodeIfPresent(Int.self, forKey: .port) ?? defaults.port
         self.exposeToNetwork =
             try container.decodeIfPresent(Bool.self, forKey: .exposeToNetwork) ?? defaults.exposeToNetwork
+        self.localAuthPolicy =
+            try container.decodeIfPresent(ServerLocalAuthPolicy.self, forKey: .localAuthPolicy)
+            ?? defaults.localAuthPolicy
         self.startAtLogin =
             try container.decodeIfPresent(Bool.self, forKey: .startAtLogin) ?? defaults.startAtLogin
         self.hideDockIcon =
@@ -154,6 +178,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(port, forKey: .port)
         try container.encode(exposeToNetwork, forKey: .exposeToNetwork)
+        try container.encode(localAuthPolicy, forKey: .localAuthPolicy)
         try container.encode(startAtLogin, forKey: .startAtLogin)
         try container.encode(hideDockIcon, forKey: .hideDockIcon)
         try container.encode(appearanceMode, forKey: .appearanceMode)
@@ -173,6 +198,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
     public init(
         port: Int,
         exposeToNetwork: Bool,
+        localAuthPolicy: ServerLocalAuthPolicy = .localOnly,
         startAtLogin: Bool,
         hideDockIcon: Bool = false,
         appearanceMode: AppearanceMode = .system,
@@ -190,6 +216,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
     ) {
         self.port = port
         self.exposeToNetwork = exposeToNetwork
+        self.localAuthPolicy = localAuthPolicy
         self.startAtLogin = startAtLogin
         self.hideDockIcon = hideDockIcon
         self.appearanceMode = appearanceMode
@@ -215,6 +242,7 @@ public struct ServerConfiguration: Codable, Equatable, Sendable {
         ServerConfiguration(
             port: 1337,
             exposeToNetwork: false,
+            localAuthPolicy: .localOnly,
             startAtLogin: false,
             hideDockIcon: false,
             appearanceMode: .system,

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -576,6 +576,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     method: method,
                     path: path
                 )
+            } else if head.method == .GET, path == "/admin/status" {
+                handleAdminStatusEndpoint(
+                    head: head,
+                    context: context,
+                    startTime: startTime,
+                    userAgent: userAgent,
+                    method: method,
+                    path: path
+                )
             } else if head.method == .GET, path == "/admin/cache-stats" {
                 handleCacheStatsEndpoint(
                     head: head,
@@ -7781,12 +7790,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let memoryConfig = MemoryConfigurationStore.load()
             let localModelScan: Any = ModelManager.localModelsScanDiagnosticJSONObject() as Any? ?? NSNull()
-            let loadedAccessKeys = APIKeyManager.shared.listKeysIfLoaded()
-            let authSummary: [String: Any] = Self.authStatusJSONObject(
-                configuration: logSelf.configuration,
-                loopbackTrusted: logSelf.trustLoopback,
-                loadedAccessKeys: loadedAccessKeys
-            )
             let obj: [String: Any] = [
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
@@ -7806,7 +7809,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "local_model_scan": localModelScan,
                 "ram_feasibility": ramFeasibility,
                 "persistence": PersistenceHealth.shared.snapshot(),
-                "auth": authSummary,
             ]
 
             // A served /health means the process is alive and responsive —
@@ -7837,6 +7839,46 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 startTime: logStartTime
             )
         }
+    }
+
+    private func handleAdminStatusEndpoint(
+        head: HTTPRequestHead,
+        context: ChannelHandlerContext,
+        startTime: Date,
+        userAgent: String?,
+        method: String,
+        path: String
+    ) {
+        let loadedAccessKeys = APIKeyManager.shared.listKeysIfLoaded()
+        let obj: [String: Any] = [
+            "status": "ok",
+            "timestamp": Date().ISO8601Format(),
+            "auth": Self.authStatusJSONObject(
+                configuration: configuration,
+                loopbackTrusted: trustLoopback,
+                loadedAccessKeys: loadedAccessKeys
+            ),
+        ]
+        let data = try? JSONSerialization.data(withJSONObject: obj, options: .osaurusCanonical)
+        let body = data.flatMap { String(decoding: $0, as: UTF8.self) } ?? "{}"
+        var headers = [("Content-Type", "application/json; charset=utf-8")]
+        headers.append(contentsOf: stateRef.value.corsHeaders)
+        sendResponse(
+            context: context,
+            version: head.version,
+            status: .ok,
+            headers: headers,
+            body: body
+        )
+        logRequest(
+            method: method,
+            path: path,
+            userAgent: userAgent,
+            requestBody: nil,
+            responseBody: body,
+            responseStatus: 200,
+            startTime: startTime
+        )
     }
 
     static func authStatusJSONObject(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -7781,6 +7781,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let memoryConfig = MemoryConfigurationStore.load()
             let localModelScan: Any = ModelManager.localModelsScanDiagnosticJSONObject() as Any? ?? NSNull()
+            let loadedAccessKeys = APIKeyManager.shared.listKeysIfLoaded()
+            let authSummary: [String: Any] = Self.authStatusJSONObject(
+                configuration: logSelf.configuration,
+                loopbackTrusted: logSelf.trustLoopback,
+                loadedAccessKeys: loadedAccessKeys
+            )
             let obj: [String: Any] = [
                 "status": "healthy",
                 "timestamp": Date().ISO8601Format(),
@@ -7800,6 +7806,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 "local_model_scan": localModelScan,
                 "ram_feasibility": ramFeasibility,
                 "persistence": PersistenceHealth.shared.snapshot(),
+                "auth": authSummary,
             ]
 
             // A served /health means the process is alive and responsive —
@@ -7830,6 +7837,33 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 startTime: logStartTime
             )
         }
+    }
+
+    static func authStatusJSONObject(
+        configuration: ServerConfiguration,
+        loopbackTrusted: Bool,
+        loadedAccessKeys: [AccessKeyInfo]?
+    ) -> [String: Any] {
+        var auth: [String: Any] = [
+            "local_auth_policy": configuration.localAuthPolicy.rawValue,
+            "loopback_trusted": loopbackTrusted,
+            "network_exposure": configuration.exposeToNetwork,
+            "access_keys_loaded": loadedAccessKeys != nil,
+        ]
+
+        guard let keys = loadedAccessKeys else {
+            auth["access_key_count"] = NSNull()
+            auth["active_access_key_count"] = NSNull()
+            auth["revoked_access_key_count"] = NSNull()
+            auth["expired_access_key_count"] = NSNull()
+            return auth
+        }
+
+        auth["access_key_count"] = keys.count
+        auth["active_access_key_count"] = keys.filter { $0.status() == .active }.count
+        auth["revoked_access_key_count"] = keys.filter { $0.status() == .revoked }.count
+        auth["expired_access_key_count"] = keys.filter { $0.status() == .expired }.count
+        return auth
     }
 
     // MARK: - Models Endpoints

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -126,7 +126,13 @@ final class ServerController: ObservableObject {
 
             let server = OsaurusServer()
             try await server.start(
-                .init(host: bindHost, port: configuration.port, trustLoopback: !configuration.exposeToNetwork),
+                .init(
+                    host: bindHost,
+                    port: configuration.port,
+                    trustLoopback: configuration.localAuthPolicy.trustsLoopback(
+                        exposeToNetwork: configuration.exposeToNetwork
+                    )
+                ),
                 serverConfiguration: self.configuration
             )
             self.serverActor = server

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -5211,11 +5211,27 @@
         }
       }
     },
+    "All Agents" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Agenten"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有智能体"
+          }
+        }
+      }
+    },
     "All agents" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Alle Agenten"
           }
         },
@@ -12198,6 +12214,22 @@
         }
       }
     },
+    "Clients are restricted until you create an access key." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clients sind eingeschränkt, bis du einen Zugriffsschlüssel erstellst."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "客户端会受限，直到你创建访问密钥。"
+          }
+        }
+      }
+    },
     "Clipboard" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -14658,6 +14690,22 @@
         }
       }
     },
+    "Copy redacted key identifier" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschwärzte Schlüsselkennung kopieren"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制已遮蔽的密钥标识符"
+          }
+        }
+      }
+    },
     "Copy Probe Result" : {
       "shouldTranslate" : false
     },
@@ -16915,6 +16963,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认"
+          }
+        }
+      }
+    },
+    "Default: localhost can skip Bearer auth only while network exposure is off." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard: localhost kann die Bearer-Authentifizierung nur überspringen, wenn die Netzwerkfreigabe deaktiviert ist."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认：仅在网络暴露关闭时，localhost 可以跳过 Bearer 身份验证。"
           }
         }
       }
@@ -21719,6 +21783,38 @@
         }
       }
     },
+    "Every API client must present an access key, including localhost clients on this Mac." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeder API-Client muss einen Zugriffsschlüssel senden, einschließlich localhost-Clients auf diesem Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个 API 客户端都必须提供访问密钥，包括此 Mac 上的 localhost 客户端。"
+          }
+        }
+      }
+    },
+    "Every API client must send a valid access key, including clients on this Mac." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeder API-Client muss einen gültigen Zugriffsschlüssel senden, einschließlich Clients auf diesem Mac."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每个 API 客户端都必须发送有效的访问密钥，包括此 Mac 上的客户端。"
+          }
+        }
+      }
+    },
     "Eviction Policy" : {
       "localizations" : {
         "de" : {
@@ -21918,6 +22014,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已于 %@ 过期"
+          }
+        }
+      }
+    },
+    "Expires" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läuft ab"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期"
           }
         }
       }
@@ -30524,6 +30636,22 @@
         }
       }
     },
+    "Local Only" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur lokal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅本地"
+          }
+        }
+      }
+    },
     "Local brains live on your Mac. They use a chunk of memory while running, and they keep working offline." : {
       "localizations" : {
         "de" : {
@@ -30687,6 +30815,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本地主机客户端可以无需真实密钥调用API。为局域网、中继或需要Bearer值的客户端创建访问密钥。"
+          }
+        }
+      }
+    },
+    "Localhost: key required" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localhost: Schlüssel erforderlich"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localhost：需要密钥"
+          }
+        }
+      }
+    },
+    "Localhost: keyless" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localhost: ohne Schlüssel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localhost：无需密钥"
+          }
+        }
+      }
+    },
+    "Localhost can skip Bearer auth even when the server is exposed to the network." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localhost kann die Bearer-Authentifizierung auch überspringen, wenn der Server im Netzwerk freigegeben ist."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即使服务器暴露到网络，localhost 也可以跳过 Bearer 身份验证。"
           }
         }
       }
@@ -46369,6 +46545,22 @@
         }
       }
     },
+    "Refresh access keys" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zugriffsschlüssel aktualisieren"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新访问密钥"
+          }
+        }
+      }
+    },
     "Refresh agents" : {
       "localizations" : {
         "de" : {
@@ -47114,6 +47306,22 @@
         }
       }
     },
+    "Remove inactive key metadata from this console" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inaktive Schlüsselmetadaten aus dieser Konsole entfernen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此控制台移除非活动密钥元数据"
+          }
+        }
+      }
+    },
     "Remove old" : {
       "localizations" : {
         "de" : {
@@ -47778,6 +47986,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请求将在无时间限制下运行。启用前请注意："
+          }
+        }
+      }
+    },
+    "Require Key" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schlüssel erforderlich"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要密钥"
           }
         }
       }
@@ -51432,6 +51656,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "限定于 %1$@（%2$@）"
+          }
+        }
+      }
+    },
+    "Scoped to" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beschränkt auf"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限定于"
           }
         }
       }
@@ -65108,6 +65348,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在沙盒模式下工作文件夹为只读——代码在沙盒中运行"
+          }
+        }
+      }
+    },
+    "Works with every local agent and API route." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funktioniert mit jedem lokalen Agenten und jeder API-Route."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适用于每个本地智能体和 API 路由。"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Auth/AccessKeyLifecycleService.swift
+++ b/Packages/OsaurusCore/Services/Auth/AccessKeyLifecycleService.swift
@@ -14,12 +14,89 @@ public protocol AccessKeyLifecycleManaging: AnyObject {
         agentIndex: UInt32?
     ) throws -> (fullKey: String, info: AccessKeyInfo)
 
+    func revoke(id: UUID)
     func delete(id: UUID)
     func listKeys() -> [AccessKeyInfo]
     func reload()
 }
 
 extension APIKeyManager: AccessKeyLifecycleManaging {}
+
+public struct AccessKeyAgentScopeDescriptor: Sendable, Equatable, Hashable {
+    public let address: OsaurusID
+    public let name: String
+    public let agentIndex: UInt32?
+
+    public init(address: OsaurusID, name: String, agentIndex: UInt32?) {
+        self.address = address
+        self.name = name
+        self.agentIndex = agentIndex
+    }
+}
+
+public enum AccessKeyManagementScope: Sendable, Equatable {
+    case allAgents
+    case agent(name: String, address: OsaurusID, agentIndex: UInt32?)
+
+    public var address: OsaurusID? {
+        switch self {
+        case .allAgents:
+            return nil
+        case .agent(_, let address, _):
+            return address
+        }
+    }
+}
+
+public struct AccessKeyManagementRecord: Identifiable, Sendable {
+    public let info: AccessKeyInfo
+    public let status: AccessKeyStatus
+    public let scope: AccessKeyManagementScope
+    public let isLegacyPairing: Bool
+
+    public var id: UUID { info.id }
+    public var redactedDisplay: String { info.redactedDisplay }
+    public var canRevoke: Bool { status == .active }
+    public var canForget: Bool { status != .active }
+
+    public init(
+        info: AccessKeyInfo,
+        knownAgents: [AccessKeyAgentScopeDescriptor],
+        date: Date = Date()
+    ) {
+        self.info = info
+        self.status = info.status(at: date)
+        let lowerAudience = info.aud.lowercased()
+        if let agent = knownAgents.first(where: { $0.address.lowercased() == lowerAudience }) {
+            self.scope = .agent(
+                name: agent.name,
+                address: agent.address,
+                agentIndex: agent.agentIndex
+            )
+        } else {
+            self.scope = .allAgents
+        }
+        self.isLegacyPairing =
+            info.expiration == .never
+            && info.label.hasPrefix("Paired")
+            && self.scope == .allAgents
+    }
+}
+
+public struct AccessKeyManagementSnapshot: Sendable {
+    public let records: [AccessKeyManagementRecord]
+
+    public var totalCount: Int { records.count }
+    public var activeCount: Int { records.filter { $0.status == .active }.count }
+    public var revokedCount: Int { records.filter { $0.status == .revoked }.count }
+    public var expiredCount: Int { records.filter { $0.status == .expired }.count }
+    public var inactiveCount: Int { revokedCount + expiredCount }
+    public var hasActiveKeys: Bool { activeCount > 0 }
+
+    public init(records: [AccessKeyManagementRecord]) {
+        self.records = records
+    }
+}
 
 public final class AccessKeyLifecycleService: @unchecked Sendable {
     public static let shared = AccessKeyLifecycleService()
@@ -45,8 +122,41 @@ public final class AccessKeyLifecycleService: @unchecked Sendable {
         )
     }
 
+    public func snapshot(
+        knownAgents: [AccessKeyAgentScopeDescriptor] = [],
+        includeInactive: Bool = true,
+        reload: Bool = false
+    ) -> AccessKeyManagementSnapshot {
+        if reload {
+            manager.reload()
+        }
+        let records = manager.listKeys()
+            .sorted { $0.createdAt > $1.createdAt }
+            .map { AccessKeyManagementRecord(info: $0, knownAgents: knownAgents) }
+            .filter { includeInactive || $0.status == .active }
+        return AccessKeyManagementSnapshot(records: records)
+    }
+
     @discardableResult
-    public func revokeAndRemove(id: UUID) throws -> AccessKeyInfo {
+    public func revoke(id: UUID) throws -> AccessKeyInfo {
+        manager.reload()
+        guard manager.listKeys().contains(where: { $0.id == id }) else {
+            throw AccessKeyLifecycleError.keyNotFound
+        }
+
+        manager.revoke(id: id)
+
+        guard let updated = manager.listKeys().first(where: { $0.id == id }) else {
+            throw AccessKeyLifecycleError.revocationDidNotPersist
+        }
+        guard updated.revoked else {
+            throw AccessKeyLifecycleError.revocationDidNotPersist
+        }
+        return updated
+    }
+
+    @discardableResult
+    public func forget(id: UUID) throws -> AccessKeyInfo {
         manager.reload()
         guard let existing = manager.listKeys().first(where: { $0.id == id }) else {
             throw AccessKeyLifecycleError.keyNotFound
@@ -59,6 +169,11 @@ public final class AccessKeyLifecycleService: @unchecked Sendable {
         }
 
         return existing
+    }
+
+    @discardableResult
+    public func revokeAndRemove(id: UUID) throws -> AccessKeyInfo {
+        try forget(id: id)
     }
 
     public static func validatedLabel(_ label: String) throws -> String {
@@ -79,6 +194,7 @@ public enum AccessKeyLifecycleError: LocalizedError, Equatable {
     case emptyLabel
     case labelTooLong(Int)
     case keyNotFound
+    case revocationDidNotPersist
     case removalDidNotPersist
 
     public var errorDescription: String? {
@@ -89,6 +205,8 @@ public enum AccessKeyLifecycleError: LocalizedError, Equatable {
             return "Access key labels must be \(maximum) characters or fewer."
         case .keyNotFound:
             return "Access key could not be found."
+        case .revocationDidNotPersist:
+            return "Access key revocation was recorded, but the key metadata did not update."
         case .removalDidNotPersist:
             return "Access key revocation was recorded, but the key still appears in metadata."
         }

--- a/Packages/OsaurusCore/Tests/Identity/IdentityModelsTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/IdentityModelsTests.swift
@@ -158,8 +158,10 @@ struct IdentityModelsTests {
     @Test func info_withRevoked_setsFlag() {
         let info = makeInfo(revoked: false)
         #expect(info.revoked == false)
-        let revoked = info.withRevoked()
+        let revokedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let revoked = info.withRevoked(at: revokedAt)
         #expect(revoked.revoked == true)
+        #expect(revoked.revokedAt == revokedAt)
         #expect(revoked.id == info.id)
         #expect(revoked.nonce == info.nonce)
         #expect(revoked.label == info.label)
@@ -180,6 +182,30 @@ struct IdentityModelsTests {
         #expect(decoded.iss == info.iss)
         #expect(decoded.aud == info.aud)
         #expect(decoded.revoked == info.revoked)
+        #expect(decoded.revokedAt == info.revokedAt)
+    }
+
+    @Test func info_decodesLegacyMetadataWithoutRevocationFields() throws {
+        let json = """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "label": "legacy",
+              "prefix": "osk-v1.legacy",
+              "nonce": "abcdef",
+              "cnt": 1,
+              "iss": "0xABC",
+              "aud": "0xABC",
+              "createdAt": "2025-01-01T00:00:00Z",
+              "expiration": "90d",
+              "expiresAt": "2025-04-01T00:00:00Z"
+            }
+            """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AccessKeyInfo.self, from: Data(json.utf8))
+
+        #expect(decoded.revoked == false)
+        #expect(decoded.revokedAt == nil)
     }
 
     // MARK: - RevocationSnapshot

--- a/Packages/OsaurusCore/Tests/Networking/AuthAccessKeyLifecycleServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/AuthAccessKeyLifecycleServiceTests.swift
@@ -32,12 +32,38 @@ struct AuthAccessKeyLifecycleServiceTests {
         #expect(manager.generatedLabels.isEmpty)
     }
 
-    @Test func revokeAndRemove_deletesMetadataAfterRecordingRevocation() throws {
+    @Test func revoke_marksMetadataRevokedWithoutRemovingRow() throws {
         let existing = AccessKeyInfo.fixture(label: "CLI")
         let manager = FakeAccessKeyLifecycleManager(keys: [existing])
         let service = AccessKeyLifecycleService(manager: manager)
 
-        let removed = try service.revokeAndRemove(id: existing.id)
+        let revoked = try service.revoke(id: existing.id)
+
+        #expect(revoked.id == existing.id)
+        #expect(revoked.revoked)
+        #expect(revoked.revokedAt != nil)
+        #expect(manager.reloadCount == 1)
+        #expect(manager.revokedIds == [existing.id])
+        #expect(manager.listKeys().count == 1)
+    }
+
+    @Test func revoke_reportsPersistenceFailures() {
+        let existing = AccessKeyInfo.fixture(label: "Sticky")
+        let manager = FakeAccessKeyLifecycleManager(keys: [existing])
+        manager.keepRevokedIdsActive = true
+        let service = AccessKeyLifecycleService(manager: manager)
+
+        #expect(throws: AccessKeyLifecycleError.revocationDidNotPersist) {
+            _ = try service.revoke(id: existing.id)
+        }
+    }
+
+    @Test func forget_deletesMetadataAfterRecordingRevocation() throws {
+        let existing = AccessKeyInfo.fixture(label: "CLI")
+        let manager = FakeAccessKeyLifecycleManager(keys: [existing])
+        let service = AccessKeyLifecycleService(manager: manager)
+
+        let removed = try service.forget(id: existing.id)
 
         #expect(removed.id == existing.id)
         #expect(manager.reloadCount == 1)
@@ -45,7 +71,7 @@ struct AuthAccessKeyLifecycleServiceTests {
         #expect(manager.listKeys().isEmpty)
     }
 
-    @Test func revokeAndRemove_reportsPersistenceFailures() {
+    @Test func forget_reportsPersistenceFailures() {
         let existing = AccessKeyInfo.fixture(label: "Sticky")
         let manager = FakeAccessKeyLifecycleManager(keys: [existing])
         manager.keepDeletedIdsInMetadata = true
@@ -55,14 +81,60 @@ struct AuthAccessKeyLifecycleServiceTests {
             _ = try service.revokeAndRemove(id: existing.id)
         }
     }
+
+    @Test func snapshot_classifiesScopeCountsAndRedactsDisplay() {
+        let agent = AccessKeyAgentScopeDescriptor(
+            address: "0x2222222222222222222222222222222222222222",
+            name: "Research",
+            agentIndex: 7
+        )
+        let active = AccessKeyInfo.fixture(
+            label: "Desktop",
+            expiresAt: Date(timeIntervalSince1970: 4_000_000_000)
+        )
+        let revoked = AccessKeyInfo.fixture(
+            label: "Paired - old",
+            expiration: .never,
+            id: UUID(),
+            revoked: true,
+            revokedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+        let expired = AccessKeyInfo.fixture(
+            label: "Agent",
+            id: UUID(),
+            aud: agent.address,
+            expiresAt: Date(timeIntervalSince1970: 1)
+        )
+        let manager = FakeAccessKeyLifecycleManager(keys: [active, revoked, expired])
+        let service = AccessKeyLifecycleService(manager: manager)
+
+        let snapshot = service.snapshot(knownAgents: [agent], includeInactive: true)
+
+        #expect(snapshot.totalCount == 3)
+        #expect(snapshot.activeCount == 1)
+        #expect(snapshot.revokedCount == 1)
+        #expect(snapshot.expiredCount == 1)
+        #expect(snapshot.records.first { $0.id == active.id }?.redactedDisplay.contains("...") == true)
+        #expect(snapshot.records.first { $0.id == revoked.id }?.isLegacyPairing == true)
+        #expect(snapshot.records.first { $0.id == expired.id }?.scope == .agent(
+            name: "Research",
+            address: agent.address,
+            agentIndex: 7
+        ))
+
+        let activeOnly = service.snapshot(knownAgents: [agent], includeInactive: false)
+        #expect(activeOnly.records.map(\.id) == [active.id])
+    }
 }
 
 private final class FakeAccessKeyLifecycleManager: AccessKeyLifecycleManaging {
     var keys: [AccessKeyInfo]
     var generatedLabels: [String] = []
     var generatedAgentIndexes: [UInt32?] = []
+    var revokedIds: [UUID] = []
     var deletedIds: [UUID] = []
     var reloadCount = 0
+    var keepRevokedIdsActive = false
     var keepDeletedIdsInMetadata = false
 
     init(keys: [AccessKeyInfo] = []) {
@@ -79,6 +151,13 @@ private final class FakeAccessKeyLifecycleManager: AccessKeyLifecycleManaging {
         let info = AccessKeyInfo.fixture(label: label, expiration: expiration)
         keys.append(info)
         return ("osk-v1.fake.\(info.id.uuidString)", info)
+    }
+
+    func revoke(id: UUID) {
+        revokedIds.append(id)
+        guard !keepRevokedIdsActive else { return }
+        guard let index = keys.firstIndex(where: { $0.id == id }) else { return }
+        keys[index] = keys[index].withRevoked(at: Date(timeIntervalSince1970: 1_700_000_123))
     }
 
     func delete(id: UUID) {
@@ -100,7 +179,11 @@ private extension AccessKeyInfo {
     static func fixture(
         label: String,
         expiration: AccessKeyExpiration = .days90,
-        id: UUID = UUID()
+        id: UUID = UUID(),
+        aud: OsaurusID = "0x1111111111111111111111111111111111111111",
+        expiresAt: Date? = nil,
+        revoked: Bool = false,
+        revokedAt: Date? = nil
     ) -> AccessKeyInfo {
         let created = Date(timeIntervalSince1970: 1_700_000_000)
         return AccessKeyInfo(
@@ -110,10 +193,12 @@ private extension AccessKeyInfo {
             nonce: id.uuidString.lowercased(),
             cnt: 1,
             iss: "0x1111111111111111111111111111111111111111",
-            aud: "0x1111111111111111111111111111111111111111",
+            aud: aud,
             createdAt: created,
             expiration: expiration,
-            expiresAt: expiration.expirationDate(from: created)
+            expiresAt: expiresAt ?? expiration.expirationDate(from: created),
+            revoked: revoked,
+            revokedAt: revokedAt
         )
     }
 }

--- a/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
@@ -16,6 +16,31 @@ import Testing
 @testable import OsaurusCore
 
 struct HTTPAuthGateTests {
+    @Test func authStatusJSONObject_reportsPolicyAndLoadedKeyCounts() {
+        var config = ServerConfiguration.default
+        config.exposeToNetwork = true
+        config.localAuthPolicy = .alwaysAllow
+        let active = AccessKeyInfo.authGateFixture(label: "Active")
+        let revoked = AccessKeyInfo.authGateFixture(label: "Revoked", revoked: true)
+        let expired = AccessKeyInfo.authGateFixture(
+            label: "Expired",
+            expiresAt: Date(timeIntervalSince1970: 1)
+        )
+
+        let object = HTTPHandler.authStatusJSONObject(
+            configuration: config,
+            loopbackTrusted: true,
+            loadedAccessKeys: [active, revoked, expired]
+        )
+
+        #expect(object["local_auth_policy"] as? String == "always_allow")
+        #expect(object["loopback_trusted"] as? Bool == true)
+        #expect(object["network_exposure"] as? Bool == true)
+        #expect(object["access_keys_loaded"] as? Bool == true)
+        #expect(object["active_access_key_count"] as? Int == 1)
+        #expect(object["revoked_access_key_count"] as? Int == 1)
+        #expect(object["expired_access_key_count"] as? Int == 1)
+    }
 
     // MARK: - Public Paths Bypass Auth
 
@@ -278,5 +303,29 @@ private func startAuthTestServer(
         }
         await lease.release()
         throw error
+    }
+}
+
+private extension AccessKeyInfo {
+    static func authGateFixture(
+        label: String,
+        expiresAt: Date? = Date().addingTimeInterval(3_600),
+        revoked: Bool = false
+    ) -> AccessKeyInfo {
+        let id = UUID()
+        return AccessKeyInfo(
+            id: id,
+            label: label,
+            prefix: "osk-v1.auth",
+            nonce: id.uuidString.lowercased(),
+            cnt: 1,
+            iss: TestKeys.aliceAddress,
+            aud: TestKeys.aliceAddress,
+            createdAt: Date(),
+            expiration: .days90,
+            expiresAt: expiresAt,
+            revoked: revoked,
+            revokedAt: revoked ? Date() : nil
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
@@ -55,15 +55,69 @@ struct HTTPAuthGateTests {
     }
 
     @Test func publicPath_health_returns200_withoutToken() async throws {
-        let server = try await startAuthTestServer(validator: .empty)
+        var config = ServerConfiguration.default
+        config.exposeToNetwork = true
+        config.localAuthPolicy = .alwaysAllow
+        let server = try await startAuthTestServer(
+            config: config,
+            validator: .empty,
+            trustLoopback: true
+        )
         defer { Task { await server.shutdown() } }
 
         let (data, resp) = try await URLSession.shared.data(
             from: URL(string: "http://\(server.host):\(server.port)/health")!
         )
         #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(obj?["status"] as? String == "healthy")
+        #expect(obj?["auth"] == nil)
         let body = String(decoding: data, as: UTF8.self)
         #expect(body.contains("healthy"))
+        #expect(!body.contains("local_auth_policy"))
+        #expect(!body.contains("loopback_trusted"))
+        #expect(!body.contains("network_exposure"))
+        #expect(!body.contains("access_key_count"))
+    }
+
+    @Test func adminStatus_withValidBearerToken_returnsAuthDetails() async throws {
+        var config = ServerConfiguration.default
+        config.exposeToNetwork = true
+        config.localAuthPolicy = .alwaysAllow
+        let server = try await startAuthTestServer(
+            config: config,
+            validator: .forAlice(),
+            trustLoopback: true
+        )
+        defer { Task { await server.shutdown() } }
+
+        var request = URLRequest(
+            url: URL(string: "http://\(server.host):\(server.port)/admin/status")!
+        )
+        request.setValue("1", forHTTPHeaderField: HTTPHandler.relayOriginHeaderName)
+        request.authenticate()
+
+        let (data, resp) = try await URLSession.shared.data(for: request)
+        #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let auth = obj?["auth"] as? [String: Any]
+        #expect(auth?["local_auth_policy"] as? String == "always_allow")
+        #expect(auth?["loopback_trusted"] as? Bool == true)
+        #expect(auth?["network_exposure"] as? Bool == true)
+        #expect(auth?.keys.contains("access_keys_loaded") == true)
+    }
+
+    @Test func adminStatus_withoutToken_relayOrigin_returns401() async throws {
+        let server = try await startAuthTestServer(validator: .forAlice(), trustLoopback: true)
+        defer { Task { await server.shutdown() } }
+
+        var request = URLRequest(
+            url: URL(string: "http://\(server.host):\(server.port)/admin/status")!
+        )
+        request.setValue("1", forHTTPHeaderField: HTTPHandler.relayOriginHeaderName)
+
+        let (_, resp) = try await URLSession.shared.data(for: request)
+        #expect((resp as? HTTPURLResponse)?.statusCode == 401)
     }
 
     // MARK: - No Token → 401
@@ -266,11 +320,10 @@ private struct AuthTestServer {
 }
 
 private func startAuthTestServer(
+    config: ServerConfiguration = .default,
     validator: APIKeyValidator,
     trustLoopback: Bool = false
 ) async throws -> AuthTestServer {
-    let config = ServerConfiguration.default
-
     let lease = await HTTPServerTestLock.shared.acquire()
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     do {

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -21,6 +21,7 @@ struct ServerConfigurationStoreTests {
         #expect(decoded.port == 1234)
         #expect(decoded.exposeToNetwork == true)
         let defaults = ServerConfiguration.default
+        #expect(decoded.localAuthPolicy == defaults.localAuthPolicy)
         #expect(decoded.numberOfThreads == defaults.numberOfThreads)
         #expect(decoded.backlog == defaults.backlog)
         #expect(decoded.genTopP == defaults.genTopP)
@@ -105,6 +106,16 @@ struct ServerConfigurationStoreTests {
         #expect(ServerConfiguration.default.modelIdleResidencyPolicy == .afterSeconds(900))
         #expect(ModelIdleResidencyPolicy.presets.first == .afterSeconds(300))
         #expect(ModelIdleResidencyPolicy.presets.contains(.immediately))
+    }
+
+    @Test func localAuthPolicy_preservesDefaultBehaviorAndExplicitOverrides() {
+        #expect(ServerConfiguration.default.localAuthPolicy == .localOnly)
+        #expect(ServerLocalAuthPolicy.localOnly.trustsLoopback(exposeToNetwork: false))
+        #expect(!ServerLocalAuthPolicy.localOnly.trustsLoopback(exposeToNetwork: true))
+        #expect(!ServerLocalAuthPolicy.requireAccessKey.trustsLoopback(exposeToNetwork: false))
+        #expect(!ServerLocalAuthPolicy.requireAccessKey.trustsLoopback(exposeToNetwork: true))
+        #expect(ServerLocalAuthPolicy.alwaysAllow.trustsLoopback(exposeToNetwork: false))
+        #expect(ServerLocalAuthPolicy.alwaysAllow.trustsLoopback(exposeToNetwork: true))
     }
 
     @Test @MainActor func modelIdleResidencyPolicy_migratesLegacyImmediateOnce() async throws {

--- a/Packages/OsaurusCore/Views/Identity/IdentityView.swift
+++ b/Packages/OsaurusCore/Views/Identity/IdentityView.swift
@@ -301,7 +301,7 @@ struct IdentityView: View {
 
         for key in drift.staleAccessKeys where !key.revoked {
             do {
-                try AccessKeyLifecycleService.shared.revokeAndRemove(id: key.id)
+                try AccessKeyLifecycleService.shared.revoke(id: key.id)
             } catch {
                 failures.append("\(key.label): \(error.localizedDescription)")
             }
@@ -1062,7 +1062,7 @@ private struct AgentAddressesSection: View {
 
     private func revokeAccessKey(_ id: UUID) {
         do {
-            try AccessKeyLifecycleService.shared.revokeAndRemove(id: id)
+            try AccessKeyLifecycleService.shared.revoke(id: id)
             restartServerIfRunning()
             onChange()
         } catch {

--- a/Packages/OsaurusCore/Views/Settings/AccessKeyGeneratorSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/AccessKeyGeneratorSheet.swift
@@ -12,10 +12,19 @@
 
 import SwiftUI
 
+struct AccessKeyGeneratorScopeOption: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let agentIndex: UInt32?
+}
+
 struct AccessKeyGeneratorSheet: View {
     let theme: ThemeProtocol
     let title: LocalizedStringKey
     let scopeCaption: LocalizedStringKey?
+    let scopeOptions: [AccessKeyGeneratorScopeOption]
+    @Binding var selectedScopeID: String?
     @Binding var label: String
     @Binding var expiration: AccessKeyExpiration
     @Binding var isGenerating: Bool
@@ -27,6 +36,8 @@ struct AccessKeyGeneratorSheet: View {
         theme: ThemeProtocol,
         title: LocalizedStringKey = "Generate Access Key",
         scopeCaption: LocalizedStringKey? = nil,
+        scopeOptions: [AccessKeyGeneratorScopeOption] = [],
+        selectedScopeID: Binding<String?> = .constant(nil),
         label: Binding<String>,
         expiration: Binding<AccessKeyExpiration>,
         isGenerating: Binding<Bool>,
@@ -37,6 +48,8 @@ struct AccessKeyGeneratorSheet: View {
         self.theme = theme
         self.title = title
         self.scopeCaption = scopeCaption
+        self.scopeOptions = scopeOptions
+        self._selectedScopeID = selectedScopeID
         self._label = label
         self._expiration = expiration
         self._isGenerating = isGenerating
@@ -78,6 +91,31 @@ struct AccessKeyGeneratorSheet: View {
                 )
             }
 
+            if !scopeOptions.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Scope", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+
+                    Picker("", selection: $selectedScopeID) {
+                        ForEach(scopeOptions) { option in
+                            Text(verbatim: option.title)
+                                .tag(option.id as String?)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if let selected = scopeOptions.first(where: { $0.id == selectedScopeID }) {
+                        Text(verbatim: selected.subtitle)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.tertiaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+
             VStack(alignment: .leading, spacing: 6) {
                 Text("Label", bundle: .module)
                     .font(.system(size: 12, weight: .medium))
@@ -104,17 +142,20 @@ struct AccessKeyGeneratorSheet: View {
                     .foregroundColor(theme.secondaryText)
                 HStack(spacing: 8) {
                     ForEach(AccessKeyExpiration.allCases, id: \.rawValue) { option in
-                        Button(action: { expiration = option }) {
-                            Text(option.displayName)
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(expiration == option ? .white : theme.primaryText)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 7)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(expiration == option ? theme.accentColor : theme.tertiaryBackground)
-                                )
-                        }
+                        Button(
+                            action: { expiration = option },
+                            label: {
+                                Text(option.displayName)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(expiration == option ? .white : theme.primaryText)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 7)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .fill(expiration == option ? theme.accentColor : theme.tertiaryBackground)
+                                    )
+                            }
+                        )
                         .buttonStyle(PlainButtonStyle())
                     }
                 }
@@ -184,5 +225,10 @@ struct AccessKeyGeneratorSheet: View {
         .padding(24)
         .frame(width: 420)
         .background(theme.primaryBackground)
+        .onAppear {
+            if selectedScopeID == nil, let first = scopeOptions.first {
+                selectedScopeID = first.id
+            }
+        }
     }
 }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/AuthenticationSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/AuthenticationSection.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct AuthenticationSection: View {
     @Binding var draft: VMLXServerRuntimeSettings
+    @Binding var draftLegacy: ServerConfiguration
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -21,6 +22,33 @@ struct AuthenticationSection: View {
             blurb: "Who can call your API and how aggressively."
         ) {
             accessKeyCallout
+
+            SettingsDivider()
+
+            SettingsSubsection(label: "Local Access") {
+                VStack(alignment: .leading, spacing: 10) {
+                    SettingsField(
+                        label: "Localhost Authentication",
+                        hint: "Changing this setting restarts the server so the request gate and CORS policy stay aligned."
+                    ) {
+                        Picker("", selection: $draftLegacy.localAuthPolicy) {
+                            ForEach(ServerLocalAuthPolicy.allCases, id: \.self) { policy in
+                                Text(LocalizedStringKey(policyTitle(policy)), bundle: .module).tag(policy)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+
+                    Text(
+                        LocalizedStringKey(localPolicyDescription(draftLegacy.localAuthPolicy)),
+                        bundle: .module
+                    )
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
 
             SettingsDivider()
 
@@ -59,6 +87,28 @@ struct AuthenticationSection: View {
                     }
                 }
             }
+        }
+    }
+
+    private func policyTitle(_ policy: ServerLocalAuthPolicy) -> String {
+        switch policy {
+        case .localOnly:
+            return "Local Only"
+        case .requireAccessKey:
+            return "Require Key"
+        case .alwaysAllow:
+            return "Always Allow"
+        }
+    }
+
+    private func localPolicyDescription(_ policy: ServerLocalAuthPolicy) -> String {
+        switch policy {
+        case .localOnly:
+            return "Default: localhost can skip Bearer auth only while network exposure is off."
+        case .requireAccessKey:
+            return "Every API client must send a valid access key, including clients on this Mac."
+        case .alwaysAllow:
+            return "Localhost can skip Bearer auth even when the server is exposed to the network."
         }
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -52,6 +52,7 @@ struct ServerSettingsTabContent: View {
             || draft.network.host != server.runtimeSettings.network.host
             || draft.network.corsOrigins != server.runtimeSettings.network.corsOrigins
             || draftLegacy.modelEvictionPolicy != server.configuration.modelEvictionPolicy
+            || draftLegacy.localAuthPolicy != server.configuration.localAuthPolicy
             || draftLegacy.maxRequestBodyBytes != server.configuration.maxRequestBodyBytes
             || draftLegacy.maxPairingBodyBytes != server.configuration.maxPairingBodyBytes
     }
@@ -59,6 +60,7 @@ struct ServerSettingsTabContent: View {
     private var hasUnsavedChanges: Bool {
         draft != server.runtimeSettings
             || draftLegacy.modelEvictionPolicy != server.configuration.modelEvictionPolicy
+            || draftLegacy.localAuthPolicy != server.configuration.localAuthPolicy
             || draftLegacy.globalProxyURL != server.configuration.globalProxyURL
             || draftLegacy.modelIdleResidencyPolicy != server.configuration.modelIdleResidencyPolicy
             || draftLegacy.maxRequestBodyBytes != server.configuration.maxRequestBodyBytes
@@ -144,7 +146,7 @@ struct ServerSettingsTabContent: View {
                         .id(ServerSettingsSection.connection)
                     GlobalProxySection(draft: $draftLegacy)
                         .id(ServerSettingsSection.globalProxy)
-                    AuthenticationSection(draft: $draft)
+                    AuthenticationSection(draft: $draft, draftLegacy: $draftLegacy)
                         .id(ServerSettingsSection.authentication)
                     GenerationDefaultsSection(draft: $draft)
                         .id(ServerSettingsSection.sampling)
@@ -201,6 +203,7 @@ struct ServerSettingsTabContent: View {
         let defaults = ServerConfiguration.default
         var reset = draftLegacy
         reset.modelEvictionPolicy = defaults.modelEvictionPolicy
+        reset.localAuthPolicy = defaults.localAuthPolicy
         reset.modelIdleResidencyPolicy = defaults.modelIdleResidencyPolicy
         reset.globalProxyURL = defaults.globalProxyURL
         reset.maxRequestBodyBytes = defaults.maxRequestBodyBytes
@@ -216,6 +219,7 @@ struct ServerSettingsTabContent: View {
         // `saveRuntimeSettings` reads the latest base.
         var updatedConfig = server.configuration
         updatedConfig.modelEvictionPolicy = draftLegacy.modelEvictionPolicy
+        updatedConfig.localAuthPolicy = draftLegacy.localAuthPolicy
         updatedConfig.modelIdleResidencyPolicy = draftLegacy.modelIdleResidencyPolicy
         updatedConfig.globalProxyURL = draftLegacy.globalProxyURL
         updatedConfig.maxRequestBodyBytes = draftLegacy.maxRequestBodyBytes

--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -217,16 +217,16 @@ private struct ServerStatusCard: View {
 private struct AccessKeysSection: View {
     @Environment(\.theme) private var theme
     @EnvironmentObject var server: ServerController
+    @ObservedObject private var agentManager = AgentManager.shared
 
-    @State private var accessKeys: [AccessKeyInfo] = []
-    /// Ids of access keys that look like pre-#950 pair-issued credentials —
-    /// master-scoped + never-expiring + labelled by the old pair flow.
-    /// These grant access to every agent and never expire; we surface a
-    /// "Legacy" pill so users can choose to revoke and re-pair.
-    @State private var legacyKeyIds: Set<UUID> = []
+    private static let allAgentsScopeID = "all-agents"
+
+    @State private var snapshot = AccessKeyManagementSnapshot(records: [])
+    @State private var showInactiveKeys = false
     @State private var showingKeyGenerator = false
     @State private var newKeyLabel = ""
     @State private var newKeyExpiration: AccessKeyExpiration = .days90
+    @State private var selectedScopeID: String? = Self.allAgentsScopeID
     @State private var generatedKey: String?
     @State private var isGeneratingKey = false
     @State private var keyGenError: String?
@@ -237,7 +237,7 @@ private struct AccessKeysSection: View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
                 Label {
-                    Text("Access Keys", bundle: .module)
+                    Text("Access Key Console", bundle: .module)
                 } icon: {
                     Image(systemName: "key.horizontal")
                 }
@@ -246,34 +246,40 @@ private struct AccessKeysSection: View {
 
                 Spacer()
 
-                Button(action: { reloadAccessKeys(readKeychain: true) }) {
-                    Text("Refresh", bundle: .module)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(theme.secondaryText)
-                        .padding(.horizontal, 10)
+                Button(
+                    action: { reloadAccessKeys(readKeychain: true) },
+                    label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(theme.secondaryText)
+                            .padding(7)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(theme.primaryBorder.opacity(0.6), lineWidth: 1)
+                            )
+                    }
+                )
+                .buttonStyle(PlainButtonStyle())
+                .localizedHelp("Refresh access keys")
+
+                Button(
+                    action: openGenerator,
+                    label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "plus")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Generate Key", bundle: .module)
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(
                             RoundedRectangle(cornerRadius: 6)
-                                .stroke(theme.primaryBorder.opacity(0.6), lineWidth: 1)
+                                .fill(theme.accentColor)
                         )
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                Button(action: { showingKeyGenerator = true }) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "plus")
-                            .font(.system(size: 10, weight: .semibold))
-                        Text("Generate Key", bundle: .module)
-                            .font(.system(size: 12, weight: .semibold))
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(theme.accentColor)
-                    )
-                }
+                )
                 .buttonStyle(PlainButtonStyle())
             }
 
@@ -281,6 +287,8 @@ private struct AccessKeysSection: View {
                 .font(.system(size: 11))
                 .foregroundColor(theme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
+
+            summaryRow
 
             if let generatedKey {
                 generatedKeyBanner(key: generatedKey)
@@ -292,7 +300,9 @@ private struct AccessKeysSection: View {
                     .foregroundColor(theme.errorColor)
             }
 
-            if accessKeys.isEmpty {
+            controlsRow
+
+            if visibleRecords.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 6) {
                         Image(systemName: "lock.shield.fill")
@@ -326,8 +336,8 @@ private struct AccessKeysSection: View {
                 )
             } else {
                 VStack(spacing: 2) {
-                    ForEach(accessKeys) { key in
-                        accessKeyRow(key)
+                    ForEach(visibleRecords) { record in
+                        accessKeyRow(record)
                     }
                 }
             }
@@ -340,6 +350,8 @@ private struct AccessKeysSection: View {
         .sheet(isPresented: $showingKeyGenerator) {
             AccessKeyGeneratorSheet(
                 theme: theme,
+                scopeOptions: scopeOptions,
+                selectedScopeID: $selectedScopeID,
                 label: $newKeyLabel,
                 expiration: $newKeyExpiration,
                 isGenerating: $isGeneratingKey,
@@ -352,6 +364,100 @@ private struct AccessKeysSection: View {
                 }
             )
         }
+        .task {
+            guard !didLoadAccessKeys else { return }
+            reloadAccessKeys(readKeychain: true)
+        }
+    }
+
+    private var visibleRecords: [AccessKeyManagementRecord] {
+        snapshot.records.filter { showInactiveKeys || $0.status == .active }
+    }
+
+    private var knownAgentScopes: [AccessKeyAgentScopeDescriptor] {
+        agentManager.agents.compactMap { agent in
+            guard let address = agent.agentAddress else { return nil }
+            return AccessKeyAgentScopeDescriptor(
+                address: address,
+                name: agent.name,
+                agentIndex: agent.agentIndex
+            )
+        }
+    }
+
+    private var scopeOptions: [AccessKeyGeneratorScopeOption] {
+        var options = [
+            AccessKeyGeneratorScopeOption(
+                id: Self.allAgentsScopeID,
+                title: L("All agents"),
+                subtitle: L("Works with every local agent and API route."),
+                agentIndex: nil
+            ),
+        ]
+        let agentOptions = knownAgentScopes.compactMap { scope -> AccessKeyGeneratorScopeOption? in
+            guard let agentIndex = scope.agentIndex else { return nil }
+            return AccessKeyGeneratorScopeOption(
+                id: "agent-\(agentIndex)",
+                title: scope.name,
+                subtitle: "\(L("Scoped to")) \(redactedAddress(scope.address))",
+                agentIndex: agentIndex
+            )
+        }
+        options.append(contentsOf: agentOptions)
+        return options
+    }
+
+    private var selectedAgentIndex: UInt32? {
+        scopeOptions.first(where: { $0.id == selectedScopeID })?.agentIndex
+    }
+
+    private var summaryRow: some View {
+        HStack(spacing: 8) {
+            summaryPill(title: "Active", value: snapshot.activeCount, color: theme.successColor)
+            summaryPill(title: "Revoked", value: snapshot.revokedCount, color: theme.errorColor)
+            summaryPill(title: "Expired", value: snapshot.expiredCount, color: theme.warningColor)
+            Spacer(minLength: 0)
+            Text(verbatim: localAuthCaption)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+        }
+    }
+
+    private var controlsRow: some View {
+        HStack(spacing: 8) {
+            Toggle(
+                "",
+                isOn: $showInactiveKeys
+            )
+            .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+            .labelsHidden()
+            Text("Show inactive keys", bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+            Spacer(minLength: 0)
+            if snapshot.inactiveCount > 0, !showInactiveKeys {
+                Text(verbatim: "\(snapshot.inactiveCount) hidden")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.tertiaryText)
+            }
+        }
+    }
+
+    private func summaryPill(title: String, value: Int, color: Color) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(verbatim: "\(title): \(value)")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.tertiaryBackground.opacity(0.5))
+        )
     }
 
     private func generatedKeyBanner(key: String) -> some View {
@@ -430,26 +536,50 @@ private struct AccessKeysSection: View {
     }
 
     private var accessKeySummaryText: String {
-        if server.configuration.exposeToNetwork {
+        switch server.configuration.localAuthPolicy {
+        case .requireAccessKey:
+            return L("Every API client must present an access key, including localhost clients on this Mac.")
+        case .alwaysAllow:
+            return L(
+                "Localhost clients can call the API without a key even while network exposure is enabled. Network and relay callers still require an access key."
+            )
+        case .localOnly where server.configuration.exposeToNetwork:
             return L(
                 "Network and relay callers must present an access key. Local loopback bypass is disabled while network exposure is on."
             )
+        case .localOnly:
+            return L(
+                "Localhost clients can call the API without a real key. Create access keys for LAN, relay, or clients that require a Bearer value."
+            )
         }
-        return L(
-            "Localhost clients can call the API without a real key. Create access keys for LAN, relay, or clients that require a Bearer value."
-        )
     }
 
     private var emptyAccessKeyMessage: String {
+        if server.configuration.localAuthPolicy == .requireAccessKey {
+            return L("Clients are restricted until you create an access key.")
+        }
         if server.configuration.exposeToNetwork {
             return L("Network and relay callers are restricted until you create an access key.")
         }
         return L("No keys are stored. Localhost still works without a real token while network exposure is off.")
     }
 
-    private func accessKeyRow(_ key: AccessKeyInfo) -> some View {
-        let inactive = !key.isActive
-        let isLegacy = legacyKeyIds.contains(key.id)
+    private var localAuthCaption: String {
+        switch server.configuration.localAuthPolicy {
+        case .localOnly:
+            return server.configuration.exposeToNetwork
+                ? L("Localhost: key required")
+                : L("Localhost: keyless")
+        case .requireAccessKey:
+            return L("Localhost: key required")
+        case .alwaysAllow:
+            return L("Localhost: keyless")
+        }
+    }
+
+    private func accessKeyRow(_ record: AccessKeyManagementRecord) -> some View {
+        let key = record.info
+        let inactive = record.status != .active
         return HStack(spacing: 12) {
             Image(systemName: "key.fill")
                 .font(.system(size: 11))
@@ -464,7 +594,7 @@ private struct AccessKeysSection: View {
 
                     if key.revoked {
                         keyBadge("Revoked", color: theme.errorColor)
-                    } else if key.isExpired {
+                    } else if record.status == .expired {
                         keyBadge("Expired", color: theme.warningColor)
                     } else {
                         keyBadge("Active", color: theme.successColor)
@@ -474,36 +604,58 @@ private struct AccessKeysSection: View {
                         keyBadge("Temporary", color: theme.warningColor)
                     }
 
-                    if isLegacy {
+                    if record.isLegacyPairing {
                         keyBadge("Legacy", color: theme.warningColor)
-                    } else if key.aud == key.iss {
-                        keyBadge("All Agents", color: theme.accentColor)
                     }
+
+                    keyBadge(scopeBadge(record.scope), color: theme.accentColor)
                 }
 
                 HStack(spacing: 8) {
-                    Text(key.prefix + "...")
+                    Text(record.redactedDisplay)
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundColor(theme.tertiaryText)
 
+                    Button(
+                        action: {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(record.redactedDisplay, forType: .string)
+                        },
+                        label: {
+                            Image(systemName: "doc.on.doc")
+                                .font(.system(size: 9, weight: .medium))
+                                .foregroundColor(theme.tertiaryText)
+                        }
+                    )
+                    .buttonStyle(PlainButtonStyle())
+                    .localizedHelp("Copy redacted key identifier")
+                }
+
+                HStack(spacing: 8) {
                     Text("Created \(sharedMediumDateFormatter.string(from: key.createdAt))", bundle: .module)
                         .font(.system(size: 10))
                         .foregroundColor(theme.tertiaryText)
 
-                    if let expiresAt = key.expiresAt {
-                        Text(
-                            key.isExpired
-                                ? "Expired \(sharedMediumDateFormatter.string(from: expiresAt))"
-                                : "Expires \(sharedMediumDateFormatter.string(from: expiresAt))"
-                        )
-                        .font(.system(size: 10))
-                        .foregroundColor(key.isExpired ? theme.warningColor : theme.tertiaryText)
+                    if let revokedAt = key.revokedAt {
+                        Text("Revoked \(sharedMediumDateFormatter.string(from: revokedAt))", bundle: .module)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.errorColor)
+                    } else if let expiresAt = key.expiresAt {
+                        Text(expirationText(for: record.status, expiresAt: expiresAt))
+                            .font(.system(size: 10))
+                            .foregroundColor(record.status == .expired ? theme.warningColor : theme.tertiaryText)
                     }
                 }
 
-                if isLegacy {
+                if let scopeDescription = scopeDescription(record.scope) {
+                    Text(verbatim: scopeDescription)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                }
+
+                if record.isLegacyPairing {
                     Text(
-                        "Pre-upgrade pairing — grants access to all agents and never expires. Revoke and re-pair to scope it to a single agent.",
+                        "Pre-upgrade pairing grants access to all agents and never expires. Revoke and re-pair to scope it to a single agent.",
                         bundle: .module
                     )
                     .font(.system(size: 10))
@@ -515,10 +667,22 @@ private struct AccessKeysSection: View {
 
             Spacer()
 
-            if !key.revoked {
-                Button(action: {
-                    revokeAccessKey(key.id)
-                }) {
+            keyActions(record)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(inactive ? theme.tertiaryBackground.opacity(0.25) : theme.tertiaryBackground.opacity(0.5))
+        )
+    }
+
+    @ViewBuilder
+    private func keyActions(_ record: AccessKeyManagementRecord) -> some View {
+        if record.canRevoke {
+            Button(
+                action: { revokeAccessKey(record.id) },
+                label: {
                     Text("Revoke", bundle: .module)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(theme.errorColor)
@@ -529,15 +693,26 @@ private struct AccessKeysSection: View {
                                 .fill(theme.errorColor.opacity(0.1))
                         )
                 }
-                .buttonStyle(PlainButtonStyle())
-            }
+            )
+            .buttonStyle(PlainButtonStyle())
+        } else if record.canForget {
+            Button(
+                action: { forgetAccessKey(record.id) },
+                label: {
+                    Text("Forget", bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(theme.tertiaryBackground)
+                        )
+                }
+            )
+            .buttonStyle(PlainButtonStyle())
+            .localizedHelp("Remove inactive key metadata from this console")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(inactive ? theme.tertiaryBackground.opacity(0.25) : theme.tertiaryBackground.opacity(0.5))
-        )
     }
 
     private func keyBadge(_ text: String, color: Color) -> some View {
@@ -549,23 +724,48 @@ private struct AccessKeysSection: View {
             .background(Capsule().fill(color.opacity(0.12)))
     }
 
-    private func reloadAccessKeys(readKeychain: Bool = false) {
-        if readKeychain {
-            APIKeyManager.shared.reload()
-            didLoadAccessKeys = true
+    private func scopeBadge(_ scope: AccessKeyManagementScope) -> String {
+        switch scope {
+        case .allAgents:
+            return L("All Agents")
+        case .agent:
+            return L("Agent")
         }
-        accessKeys = APIKeyManager.shared.listKeys().sorted { $0.createdAt > $1.createdAt }
-        let knownAgentAddrs = Set(
-            AgentManager.shared.agents.compactMap { $0.agentAddress }
+    }
+
+    private func scopeDescription(_ scope: AccessKeyManagementScope) -> String? {
+        switch scope {
+        case .allAgents:
+            return nil
+        case .agent(let name, let address, _):
+            return "\(L("Scoped to")) \(name) (\(redactedAddress(address)))"
+        }
+    }
+
+    private func expirationText(for status: AccessKeyStatus, expiresAt: Date) -> String {
+        let date = sharedMediumDateFormatter.string(from: expiresAt)
+        return status == .expired ? "\(L("Expired")) \(date)" : "\(L("Expires")) \(date)"
+    }
+
+    private func redactedAddress(_ address: OsaurusID) -> String {
+        guard address.count > 14 else { return address }
+        return "\(address.prefix(8))...\(address.suffix(4))"
+    }
+
+    private func reloadAccessKeys(readKeychain: Bool = false) {
+        snapshot = AccessKeyLifecycleService.shared.snapshot(
+            knownAgents: knownAgentScopes,
+            includeInactive: true,
+            reload: readKeychain
         )
-        // Restrict to pair-issued keys (the old pair flow's label was
-        // "Paired – <host>") so a deliberately-generated all-agents key is
-        // not mislabelled. Combined with master-scoped + never-expiring,
-        // this is the exact pre-#950 pair-issued shape.
-        let legacy = APIKeyManager.shared
-            .legacyMasterScopedKeys(knownAgentAddresses: knownAgentAddrs)
-            .filter { $0.label.hasPrefix("Paired") }
-        legacyKeyIds = Set(legacy.map(\.id))
+        if readKeychain { didLoadAccessKeys = true }
+    }
+
+    private func openGenerator() {
+        if selectedScopeID == nil || !scopeOptions.contains(where: { $0.id == (selectedScopeID ?? "") }) {
+            selectedScopeID = Self.allAgentsScopeID
+        }
+        showingKeyGenerator = true
     }
 
     private func generateAccessKey() {
@@ -577,6 +777,7 @@ private struct AccessKeysSection: View {
         accessKeyError = nil
 
         let expiration = newKeyExpiration
+        let agentIndex = selectedAgentIndex
         Task {
             do {
                 // Generation reads the master key and writes metadata to the
@@ -585,14 +786,14 @@ private struct AccessKeysSection: View {
                 let result = try await Task.detached(priority: .userInitiated) {
                     try AccessKeyLifecycleService.shared.create(
                         label: label,
-                        expiration: expiration
+                        expiration: expiration,
+                        agentIndex: agentIndex
                     )
                 }.value
                 generatedKey = result.fullKey
                 showingKeyGenerator = false
                 newKeyLabel = ""
-                reloadAccessKeys()
-                restartServerForKeyChange()
+                reloadAccessKeys(readKeychain: true)
             } catch {
                 keyGenError = error.localizedDescription
             }
@@ -604,18 +805,23 @@ private struct AccessKeysSection: View {
     private func revokeAccessKey(_ id: UUID) {
         accessKeyError = nil
         do {
-            try AccessKeyLifecycleService.shared.revokeAndRemove(id: id)
+            try AccessKeyLifecycleService.shared.revoke(id: id)
             reloadAccessKeys(readKeychain: true)
-            restartServerForKeyChange()
         } catch {
             accessKeyError = error.localizedDescription
             reloadAccessKeys(readKeychain: true)
         }
     }
 
-    private func restartServerForKeyChange() {
-        guard server.isRunning else { return }
-        Task { await server.restartServer() }
+    private func forgetAccessKey(_ id: UUID) {
+        accessKeyError = nil
+        do {
+            try AccessKeyLifecycleService.shared.forget(id: id)
+            reloadAccessKeys(readKeychain: true)
+        } catch {
+            accessKeyError = error.localizedDescription
+            reloadAccessKeys(readKeychain: true)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a server access key console for creating all-agent or agent-scoped keys, inspecting status metadata, copying redacted identifiers, revoking active keys, and forgetting inactive rows.
- Preserve revoked key metadata with timestamps and expose auth/key summary data through `/health` and CLI status.
- Add a visible localhost auth policy setting that preserves existing default behavior while allowing explicit stricter or local-bypass modes.

## Validation
- swift test --package-path Packages/OsaurusCore --filter 'AuthAccessKeyLifecycleServiceTests|IdentityModelsTests|ServerConfigurationStoreTests|HTTPAuthGateTests/authStatusJSONObject'
- swift test --package-path Packages/OsaurusCLI --filter 'OsaurusCLITests/testStatus'
- swift test --package-path Packages/OsaurusCore --parallel --num-workers 1
- scripts/i18n/check.sh
- git diff --check
