### PR TITLE
Surface local model cache imports in Models

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -385,8 +385,20 @@ struct ExternalModelLocatorTests {
 
         ExternalModelLocator.testRootsOverride = [(root: hfRoot, source: .huggingFaceCache)]
         ExternalModelLocator.rescan()
-        #expect(FileManager.default.fileExists(atPath: OsaurusPaths.externalModelsManifestFile().path))
+        let manifestFile = OsaurusPaths.externalModelsManifestFile()
+        #expect(FileManager.default.fileExists(atPath: manifestFile.path))
+        let manifestData = try? Data(contentsOf: manifestFile)
+        let manifestJSON =
+            manifestData.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        let persistedModels = manifestJSON?["models"] as? [[String: Any]]
+        #expect(
+            persistedModels?.contains {
+                $0["id"] as? String == "org/persisted"
+                    && $0["bundlePath"] as? String == snapshot.standardizedFileURL.path
+            } == true
+        )
 
+        ExternalModelLocator.testRootsOverride = []
         ExternalModelLocator.invalidateInMemory()
         let models = ExternalModelLocator.models()
         guard let reloaded = models.first(where: { $0.id == "org/persisted" }) else {

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -353,6 +353,55 @@ struct ExternalModelLocatorTests {
         #expect(report?.skipped.isEmpty == true)
     }
 
+    @Test func manifestReloadsHFCacheModelsWithoutCopyingFiles() async {
+        await OsaurusTestGlobals.withPathsLock {
+            manifestReloadsHFCacheModelsWithoutCopyingFiles_body()
+        }
+    }
+
+    private func manifestReloadsHFCacheModelsWithoutCopyingFiles_body() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        let previousOverride = ExternalModelLocator.testRootsOverride
+        let manifestRoot = makeTempDir()
+        let hfRoot = makeTempDir()
+        OsaurusPaths.overrideRoot = manifestRoot
+        ExternalModelLocator.invalidateInMemory()
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            ExternalModelLocator.testRootsOverride = previousOverride
+            ExternalModelLocator.invalidateInMemory()
+            try? FileManager.default.removeItem(at: manifestRoot)
+            try? FileManager.default.removeItem(at: hfRoot)
+        }
+
+        let fm = FileManager.default
+        let rev = "persisted123"
+        let modelDir = hfRoot.appendingPathComponent("models--org--persisted", isDirectory: true)
+        let refsDir = modelDir.appendingPathComponent("refs", isDirectory: true)
+        try? fm.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try? Data(rev.utf8).write(to: refsDir.appendingPathComponent("main"))
+        let snapshot = modelDir.appendingPathComponent("snapshots/\(rev)", isDirectory: true)
+        writeBundle(at: snapshot)
+
+        ExternalModelLocator.testRootsOverride = [(root: hfRoot, source: .huggingFaceCache)]
+        ExternalModelLocator.rescan()
+        #expect(FileManager.default.fileExists(atPath: OsaurusPaths.externalModelsManifestFile().path))
+
+        ExternalModelLocator.invalidateInMemory()
+        let models = ExternalModelLocator.models()
+        guard let reloaded = models.first(where: { $0.id == "org/persisted" }) else {
+            Issue.record("expected persisted HF cache model to reload from manifest")
+            return
+        }
+
+        #expect(reloaded.externalSource == ExternalModelLocator.Source.huggingFaceCache.rawValue)
+        #expect(reloaded.bundleDirectory?.standardizedFileURL.path == snapshot.standardizedFileURL.path)
+        #expect(
+            ExternalModelLocator.path(forId: "org/persisted")?.standardizedFileURL.path
+                == snapshot.standardizedFileURL.path
+        )
+    }
+
     @Test func rescan_reportsHFCacheSnapshotSkipReason() async {
         await OsaurusTestGlobals.withPathsLock {
             rescan_reportsHFCacheSnapshotSkipReason_body()

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -115,6 +115,7 @@ struct ModelDownloadView: View {
 
     /// Import-from-Hugging-Face sheet state
     @State private var showImportSheet = false
+    @State private var showExternalModelsPanel = false
 
     /// Index of the leading Top Picks card the edge arrows scroll to. Desktop
     /// mice can't scroll horizontally, so the carousel is driven by these
@@ -975,7 +976,10 @@ struct ModelDownloadView: View {
     }
 
     private var externalModelsImportPanel: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        DisclosureGroup(isExpanded: $showExternalModelsPanel) {
+            ExternalModelsSettingsView()
+                .padding(.top, 10)
+        } label: {
             HStack(spacing: 8) {
                 Image(systemName: "externaldrive.badge.plus")
                     .font(.system(size: 13, weight: .semibold))
@@ -988,8 +992,6 @@ struct ModelDownloadView: View {
 
                 Spacer()
             }
-
-            ExternalModelsSettingsView()
         }
         .padding(14)
         .background(

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -933,6 +933,10 @@ struct ModelDownloadView: View {
                                 deprecationBanner
                             }
 
+                            if selectedTab == .downloaded {
+                                externalModelsImportPanel
+                            }
+
                             if lists.displayed.isEmpty {
                                 emptyState
                             } else {
@@ -968,6 +972,34 @@ struct ModelDownloadView: View {
                 }
             }
         }
+    }
+
+    private var externalModelsImportPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "externaldrive.badge.plus")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+
+                Text("External models", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                    .textCase(.uppercase)
+
+                Spacer()
+            }
+
+            ExternalModelsSettingsView()
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.primaryBorder.opacity(0.16), lineWidth: 1)
+                )
+        )
     }
 
     // MARK: - Sort / Filter Bar

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -216,7 +216,7 @@ Research notes for the next local-runtime compatibility wave live in
 
 | Request | User-visible status | Next implementation step | Runtime owner |
 | --- | --- | --- | --- |
-| Hugging Face cache import | Implemented as read-only discovery for verified MLX snapshots; Settings now shows skipped candidate reasons. | Add manifest/digest verification before load if cache mutation protection becomes required. | Osaurus host discovery/storage. |
+| Hugging Face cache import | Implemented as read-only discovery for verified MLX snapshots; Models > On Device and Settings show skipped candidate reasons. | Add manifest/digest verification before load if cache mutation protection becomes required. | Osaurus host discovery/storage. |
 | Hunyuan `hunyuan_v1_dense` | Blocked with an explicit unsupported-family diagnostic until vmlx has a native Hunyuan Dense factory. | Enable only after real-model validation lands upstream. | vmlx model factory and Osaurus diagnostics. |
 | DFlash speculative decoding | Research-only; no draft/target local generation contract exists today. | Define a feature-flagged draft-model API and benchmark harness. | vmlx or dedicated MLX speculative adapter. |
 | LongCat Flash/Next | Blocked with an explicit unsupported-family diagnostic; current public repos require custom LongCat code paths and large multimodal runtimes. | Wait for native runtime support and multimodal proof before local picker enablement. | vmlx model family support. |

--- a/docs/MODEL_COMPATIBILITY_RESEARCH.md
+++ b/docs/MODEL_COMPATIBILITY_RESEARCH.md
@@ -50,7 +50,7 @@ Current source map:
 
 | Request | Current status | First shippable step | Runtime boundary |
 | --- | --- | --- | --- |
-| Hugging Face local cache (#443) | Read-only HF cache and LM Studio discovery are implemented for verified MLX safetensors bundles; skipped candidates now have Settings diagnostics. | Add optional manifest/digest verification before load if mutation protection is required. | Host-only discovery/storage work; no vmlx change if the snapshot already loads as MLX. |
+| Hugging Face local cache (#443) | Read-only HF cache and LM Studio discovery are implemented for verified MLX safetensors bundles; skipped candidates now have Models > On Device and Settings diagnostics. | Add optional manifest/digest verification before load if mutation protection is required. | Host-only discovery/storage work; no vmlx change if the snapshot already loads as MLX. |
 | Hunyuan `hunyuan_v1_dense` (#358) | `mlx-community/HY-MT1.5-7B-bf16` advertises `model_type: hunyuan_v1_dense`; Osaurus now reports it as unsupported until vmlx has a native factory. | Enable catalog/runtime only after vmlx support and live validation land. | vmlx must own config mapping, weights, tokenizer/template behavior, and generation tests. |
 | DFlash speculative decoding (#1065) | Osaurus has one target model per local generation request and no draft-model contract. | Design a feature-flagged draft/target request shape plus benchmark evidence requirements. | vmlx or a dedicated MLX adapter must own the speculative loop and acceptance verification. |
 | LongCat Flash/Next (#886) | LongCat repos use custom code and new LongCat config shapes; LongCat-Next is a 74B any-to-any model that documents at least three 80GB GPUs for Transformers usage. Osaurus now reports LongCat local bundles as unsupported. | Keep local catalog entries hidden or blocked until native support and multimodal proof exist. | Native LongCat model classes, multimodal processors, lazy decoder paths, and cache geometry belong upstream. |
@@ -73,10 +73,13 @@ Implementation shape:
 3. Register a snapshot only if it satisfies the same minimum shape as
    `MLXModel.isDownloaded`: `config.json`, tokenizer assets, and
    `*.safetensors`.
-4. Store an Osaurus-local manifest keyed by repo id, revision, relative file
-   path, file size, and SHA-256 for every file the runtime will load.
-5. Before `ModelRuntime` loads a cache-backed model, verify the manifest still
-   matches. If a file changed, mark the model as stale and require a rescan.
+4. Store an Osaurus-local manifest keyed by repo id, revision, source, and the
+   absolute snapshot path so imported models reappear on launch before a
+   background rescan finishes.
+5. Before `ModelRuntime` loads a cache-backed model, resolve the external path
+   through `ExternalModelLocator` and keep the files in place. Full file digest
+   verification is a future hardening step, not part of the current import
+   contract.
 6. Never mutate the HF cache from Osaurus. Delete/uninstall controls should
    clearly say "remove from Osaurus catalog" unless the implementation later
    adds an explicit cache-management mode.


### PR DESCRIPTION
## Summary
- Adds Hugging Face cache path configuration and import visibility in the Models view.
- Lets users point Osaurus at pre-downloaded local model folders without redownloading them.
- Keeps incomplete or imported-model status available behind a collapsed panel so the default Models view stays quiet.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter 'ExternalModelLocatorTests|HuggingFaceDownloadPathTests|ModelDownloadServiceStorageTests'` — 32 tests passed after rebase onto current `origin/main`.
- `bash scripts/i18n/check.sh` — passed.
- `git diff --check` — passed.
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"` — attempted locally; the CLI target completed and the app target stalled idle in Xcode/SwiftBuild after dependency compilation, so the run was interrupted and GitHub CI is the current build signal.
- GitHub CI — green; merge state CLEAN.

## Notes
- The external model details remain available for debugging/import flows, but are collapsed by default to avoid noisy model-library rows for users with many incomplete local downloads.
- This branch was rebased onto current `origin/main` to replace the previous unrelated `test-core` failure with a fresh CI run.