### PR TITLE
Add OpenAI-compatible FIM request handling

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -597,7 +597,16 @@ extension ChatMessage {
 /// tools (Continue, etc.) rely on for `<|fim_*|>` prompts.
 struct CompletionRequest: Decodable, Sendable {
     let model: String
+    /// Raw prompt sent to the generation path. For OpenAI insertion/FIM
+    /// clients that send `prefix` instead of `prompt`, this falls back to the
+    /// prefix because the local raw completion contract accepts one string.
     let prompt: String
+    /// OpenAI-compatible FIM/insertion request fields. `suffix` and `middle`
+    /// are decoded so callers get a precise compatibility error instead of the
+    /// field being silently ignored by the raw left-to-right completion path.
+    let prefix: String?
+    let suffix: String?
+    let middle: String?
     let maxTokens: Int?
     let temperature: Float?
     let topP: Float?
@@ -606,7 +615,7 @@ struct CompletionRequest: Decodable, Sendable {
     let stream: Bool?
 
     private enum CodingKeys: String, CodingKey {
-        case model, prompt, temperature, stop, stream
+        case model, prompt, prefix, suffix, middle, temperature, stop, stream
         case maxTokens = "max_tokens"
         case topP = "top_p"
         case topK = "top_k"
@@ -615,15 +624,15 @@ struct CompletionRequest: Decodable, Sendable {
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         model = (try? c.decode(String.self, forKey: .model)) ?? ""
+        let decodedPrefix = Self.decodeStringOrFirstArray(from: c, forKey: .prefix)
+        prefix = decodedPrefix
+        suffix = Self.decodeStringOrFirstArray(from: c, forKey: .suffix)
+        middle = Self.decodeStringOrFirstArray(from: c, forKey: .middle)
         // `prompt` may be a string or an array of strings. FIM clients send a
-        // single string; for an array we take the first entry.
-        if let s = try? c.decode(String.self, forKey: .prompt) {
-            prompt = s
-        } else if let arr = try? c.decode([String].self, forKey: .prompt) {
-            prompt = arr.first ?? ""
-        } else {
-            prompt = ""
-        }
+        // single string; for an array we take the first entry. Some OpenAI-
+        // compatible insertion clients use `prefix` instead of `prompt`; treat
+        // that as the raw prompt only when `prompt` is absent.
+        prompt = Self.decodeStringOrFirstArray(from: c, forKey: .prompt) ?? decodedPrefix ?? ""
         maxTokens = try? c.decodeIfPresent(Int.self, forKey: .maxTokens)
         temperature = try? c.decodeIfPresent(Float.self, forKey: .temperature)
         topP = try? c.decodeIfPresent(Float.self, forKey: .topP)
@@ -639,10 +648,44 @@ struct CompletionRequest: Decodable, Sendable {
         stream = try? c.decodeIfPresent(Bool.self, forKey: .stream)
     }
 
+    private static func decodeStringOrFirstArray(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> String? {
+        if let s = try? container.decode(String.self, forKey: key) {
+            return s
+        }
+        if let arr = try? container.decode([String].self, forKey: key) {
+            return arr.first
+        }
+        return nil
+    }
+
     /// FIM completions are short; default generously when the client omits
     /// `max_tokens` (OpenAI's legacy default of 16 is too small for most
     /// autocomplete use).
     var resolvedMaxTokens: Int { maxTokens ?? 256 }
+
+    /// The current local raw-completion generation contract accepts one prompt
+    /// string. A prompt that already contains model-native FIM tokens is routed
+    /// verbatim; separate `suffix` / `middle` fields cannot be honored without
+    /// a runtime-level suffix channel, so reject them explicitly instead of
+    /// ignoring suffix context and generating a misleading left-to-right
+    /// continuation.
+    var unsupportedFIMReason: String? {
+        var unsupportedFields: [String] = []
+        if let suffix, !suffix.isEmpty {
+            unsupportedFields.append("suffix")
+        }
+        if let middle, !middle.isEmpty {
+            unsupportedFields.append("middle")
+        }
+        guard !unsupportedFields.isEmpty else { return nil }
+        let fields = unsupportedFields.map { "'\($0)'" }.joined(separator: ", ")
+        return "FIM fields \(fields) are not supported by the local /v1/completions runtime. "
+            + "Send a single raw prompt containing the model's native FIM tokens, or omit "
+            + "separate suffix/middle fields."
+    }
 }
 
 struct ChatCompletionRequest: Codable, Sendable {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5631,9 +5631,55 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             requestBodyString = nil
         }
 
-        guard let req = try? JSONDecoder().decode(CompletionRequest.self, from: data),
-            !req.prompt.isEmpty
-        else {
+        guard let req = try? JSONDecoder().decode(CompletionRequest.self, from: data) else {
+            let body = Self.errorBody(
+                .openai(type: "invalid_request_error"),
+                message: "Invalid request format: 'prompt' is required"
+            )
+            sendResponse(
+                context: context,
+                version: head.version,
+                status: .badRequest,
+                headers: [("Content-Type", "application/json; charset=utf-8")],
+                body: body
+            )
+            logRequest(
+                method: "POST",
+                path: "/completions",
+                userAgent: userAgent,
+                requestBody: requestBodyString,
+                responseStatus: 400,
+                startTime: startTime,
+                errorMessage: "Invalid completions request"
+            )
+            return
+        }
+
+        if let unsupported = req.unsupportedFIMReason {
+            let body = Self.errorBody(
+                .openai(type: "invalid_request_error"),
+                message: unsupported
+            )
+            sendResponse(
+                context: context,
+                version: head.version,
+                status: .badRequest,
+                headers: [("Content-Type", "application/json; charset=utf-8")],
+                body: body
+            )
+            logRequest(
+                method: "POST",
+                path: "/completions",
+                userAgent: userAgent,
+                requestBody: requestBodyString,
+                responseStatus: 400,
+                startTime: startTime,
+                errorMessage: unsupported
+            )
+            return
+        }
+
+        guard !req.prompt.isEmpty else {
             let body = Self.errorBody(
                 .openai(type: "invalid_request_error"),
                 message: "Invalid request format: 'prompt' is required"

--- a/Packages/OsaurusCore/Tests/Networking/CompletionRequestTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/CompletionRequestTests.swift
@@ -35,6 +35,10 @@ struct CompletionRequestTests {
         )
         #expect(req.model == "qwen2.5-coder-1.5b-instruct-4bit")
         #expect(req.prompt.contains("<|fim_prefix|>"))
+        #expect(req.prefix == nil)
+        #expect(req.suffix == nil)
+        #expect(req.middle == nil)
+        #expect(req.unsupportedFIMReason == nil)
         #expect(req.maxTokens == 50)
         #expect(req.resolvedMaxTokens == 50)
         #expect(req.temperature == 0.2)
@@ -64,5 +68,74 @@ struct CompletionRequestTests {
         #expect(req.stop.isEmpty)
         #expect(req.stream == nil)
         #expect(req.temperature == nil)
+    }
+
+    @Test func decodesPrefixAsPromptFallback() throws {
+        let req = try decode(
+            #"""
+            {
+              "model": "m",
+              "prefix": "func f() -> Int {\n    ",
+              "max_tokens": 24
+            }
+            """#
+        )
+        #expect(req.prompt == "func f() -> Int {\n    ")
+        #expect(req.prefix == "func f() -> Int {\n    ")
+        #expect(req.suffix == nil)
+        #expect(req.middle == nil)
+        #expect(req.unsupportedFIMReason == nil)
+    }
+
+    @Test func decodesOpenAIInsertionSuffixAndRejectsUnsupportedSeparateContext() throws {
+        let req = try decode(
+            #"""
+            {
+              "model": "m",
+              "prompt": "func f() -> Int {\n    ",
+              "suffix": "\n}",
+              "max_tokens": 24
+            }
+            """#
+        )
+        #expect(req.prompt == "func f() -> Int {\n    ")
+        #expect(req.suffix == "\n}")
+        let reason = try #require(req.unsupportedFIMReason)
+        #expect(reason.contains("suffix"))
+        #expect(reason.contains("/v1/completions"))
+    }
+
+    @Test func decodesPrefixSuffixMiddleFieldsAndRejectsUnsupportedMiddle() throws {
+        let req = try decode(
+            #"""
+            {
+              "model": "m",
+              "prefix": "before",
+              "suffix": "after",
+              "middle": "existing edit"
+            }
+            """#
+        )
+        #expect(req.prompt == "before")
+        #expect(req.prefix == "before")
+        #expect(req.suffix == "after")
+        #expect(req.middle == "existing edit")
+        let reason = try #require(req.unsupportedFIMReason)
+        #expect(reason.contains("suffix"))
+        #expect(reason.contains("middle"))
+    }
+
+    @Test func emptySuffixDoesNotRejectPlainPrefixCompletion() throws {
+        let req = try decode(
+            #"""
+            {
+              "model": "m",
+              "prefix": "continue from here",
+              "suffix": ""
+            }
+            """#
+        )
+        #expect(req.prompt == "continue from here")
+        #expect(req.unsupportedFIMReason == nil)
     }
 }

--- a/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/RequestValidationTests.swift
@@ -76,4 +76,50 @@ struct RequestValidationTests {
         #expect(reason != nil)
         #expect((reason ?? "").contains("json_schema"))
     }
+
+    @Test func chatRequestIgnoresFIMFieldsWithoutDroppingTools() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "default",
+              "messages": [{"role": "user", "content": "hello"}],
+              "suffix": "ignored by chat",
+              "middle": "ignored by chat",
+              "tools": [
+                {
+                  "type": "function",
+                  "function": {
+                    "name": "lookup",
+                    "description": "Lookup a thing",
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "query": {"type": "string"}
+                      },
+                      "required": ["query"]
+                    }
+                  }
+                }
+              ],
+              "tool_choice": "auto"
+            }
+            """#.utf8
+        )
+
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: data)
+        #expect(HTTPHandler.unsupportedSamplerReason(req) == nil)
+        #expect(req.messages.count == 1)
+        #expect(req.tools?.first?.function.name == "lookup")
+        guard case .auto? = req.tool_choice else {
+            Issue.record("Expected tool_choice auto to survive decoding")
+            return
+        }
+
+        let encoded = try JSONEncoder().encode(req)
+        let payload = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(payload["suffix"] == nil)
+        #expect(payload["middle"] == nil)
+        #expect(payload["tools"] != nil)
+        #expect(payload["tool_choice"] != nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Decode completion-style fill-in-middle fields on `/v1/completions`.
- Route prompt and prefix-only completion requests through the existing raw generation path.
- Return an explicit OpenAI-shaped unsupported error for separate suffix or middle context instead of silently ignoring it.
- Add focused request decoding and chat/tool compatibility tests.

## Validation
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-a5 swift test --package-path Packages/OsaurusCore --filter 'CompletionRequestTests|RequestValidationTests'
- OSAURUS_TEST_ROOT=/tmp/osaurus-full-a5b make test
- git diff --check
