### PR TITLE
Add model benchmark evidence reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WORKSPACE := osaurus.xcworkspace
 DERIVED := build/DerivedData
 XCODEBUILD_FLAGS ?=
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench bench-models evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench bench-models bench-models-test evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
 
 help:
 	@echo "Targets:"
@@ -25,6 +25,7 @@ help:
 	@echo "  bench-run           Run LOCOMO benchmark only (skip ingestion)"
 	@echo "  bench               Full ingest + run LOCOMO benchmark"
 	@echo "  bench-models        Compare OpenAI-compatible servers and write benchmark reports"
+	@echo "  bench-models-test   Run benchmark report Python unit tests"
 	@echo "  evals               Run one OsaurusEvals suite (MODEL=, FILTER=, EVALS_SUITE=)"
 	@echo "  evals-verbose       Same as 'evals' plus per-case raw LLM response (debugging prompt iter)"
 	@echo "  evals-report        Same as 'evals' but also writes JSON to EVALS_OUT (build/evals.json)"
@@ -147,6 +148,10 @@ bench: bench-ingest bench-run
 bench-models:
 	@echo "Running model benchmark comparison reports…"
 	scripts/benchmark/run_bench.sh
+
+bench-models-test:
+	@echo "Running benchmark report Python tests…"
+	python3 scripts/benchmark/test_benchmark_models.py
 
 ## ── OsaurusEvals (off-CI behaviour evals) ────────────────────────
 # Override on the command line, e.g.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WORKSPACE := osaurus.xcworkspace
 DERIVED := build/DerivedData
 XCODEBUILD_FLAGS ?=
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench bench-models evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
 
 help:
 	@echo "Targets:"
@@ -24,6 +24,7 @@ help:
 	@echo "  bench-ingest-chunks Fast chunk-only backfill (no LLM, ~minutes)"
 	@echo "  bench-run           Run LOCOMO benchmark only (skip ingestion)"
 	@echo "  bench               Full ingest + run LOCOMO benchmark"
+	@echo "  bench-models        Compare OpenAI-compatible servers and write benchmark reports"
 	@echo "  evals               Run one OsaurusEvals suite (MODEL=, FILTER=, EVALS_SUITE=)"
 	@echo "  evals-verbose       Same as 'evals' plus per-case raw LLM response (debugging prompt iter)"
 	@echo "  evals-report        Same as 'evals' but also writes JSON to EVALS_OUT (build/evals.json)"
@@ -142,6 +143,10 @@ bench-run:
 		--batch-size $(BENCH_BATCH)
 
 bench: bench-ingest bench-run
+
+bench-models:
+	@echo "Running model benchmark comparison reports…"
+	scripts/benchmark/run_bench.sh
 
 ## ── OsaurusEvals (off-CI behaviour evals) ────────────────────────
 # Override on the command line, e.g.

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ osaurus/
 ```
 
 See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for the architecture guide and layer definitions.
+Benchmark report generation is documented in [Benchmark Reports](docs/BENCHMARK_REPORTS.md).
 
 ## Contributing
 

--- a/docs/BENCHMARK_REPORTS.md
+++ b/docs/BENCHMARK_REPORTS.md
@@ -39,9 +39,17 @@ Each JSON row records:
 - `status` and `status_notes`
 
 Report status values are `pass`, `partial`, `failed`, and `unproven`.
-A successful generation row without positive token/s is `failed`; token/s is
-never silently omitted. Memory evidence is optional, but if a PID is supplied
-and RSS cannot be sampled, the row is `partial`.
+A successful generation row without positive token/s is `unproven` with a
+`no-metrics` status note; `success_rate` still reflects HTTP generation
+success, but summary status cannot pass until every row has positive token/s.
+Memory evidence is optional, but if a PID is supplied and RSS cannot be sampled,
+the row is `partial`.
+
+Run the benchmark report unit tests with:
+
+```bash
+make bench-models-test
+```
 
 ## Memory Sampling
 

--- a/docs/BENCHMARK_REPORTS.md
+++ b/docs/BENCHMARK_REPORTS.md
@@ -1,0 +1,61 @@
+# Benchmark Reports
+
+`scripts/benchmark/benchmark_models.py` benchmarks OpenAI-compatible local
+servers such as Osaurus, Ollama, and LM Studio. In addition to the raw JSON/CSV
+artifacts, it can write deterministic evidence reports for issue #22:
+
+```bash
+python3 scripts/benchmark/benchmark_models.py \
+  --server "osaurus|http://127.0.0.1:1337|qwen3-coder" \
+  --server "ollama|http://127.0.0.1:11434|qwen3-coder" \
+  --prompt "Write a short function that parses ISO-8601 timestamps." \
+  --iterations 3 \
+  --concurrency 1 \
+  --max-tokens 512 \
+  --report-json results/current-models.benchmark.json \
+  --report-markdown results/current-models.benchmark.md
+```
+
+The wrapper emits reports by default:
+
+```bash
+scripts/benchmark/run_bench.sh
+```
+
+Override `REPORT_JSON` and `REPORT_MD` to choose paths. Set `OSA_MODEL`,
+`OLLAMA_MODEL`, and `LMSTUDIO_MODEL` to compare current model families.
+
+## Evidence Fields
+
+Each JSON row records:
+
+- `server` and `model_id`
+- `case.id`, `case.prompt_id`, and the exact `case.prompt`
+- HTTP success/status/error
+- `timing.ttft_ms` and `timing.total_ms`
+- token counts and `tokens.tokens_per_second`
+- output size in chars/bytes
+- memory RSS fields when `--memory-pid server|pid` is supplied
+- `status` and `status_notes`
+
+Report status values are `pass`, `partial`, `failed`, and `unproven`.
+A successful generation row without positive token/s is `failed`; token/s is
+never silently omitted. Memory evidence is optional, but if a PID is supplied
+and RSS cannot be sampled, the row is `partial`.
+
+## Memory Sampling
+
+RSS sampling is process based and works for any local server when you know its
+PID:
+
+```bash
+python3 scripts/benchmark/benchmark_models.py \
+  --server "osaurus|http://127.0.0.1:1337|qwen3-coder" \
+  --memory-pid "osaurus|12345" \
+  --report-json results/osaurus.benchmark.json \
+  --report-markdown results/osaurus.benchmark.md
+```
+
+The sample is taken before and after each request. It is evidence, not a peak
+profiler; use Activity Monitor or a dedicated sampler when validating hard RAM
+ceilings.

--- a/scripts/benchmark/benchmark_models.py
+++ b/scripts/benchmark/benchmark_models.py
@@ -249,8 +249,8 @@ def classify_result(
         return STATUS_FAILED, notes
 
     if tokens_per_second is None or tokens_per_second <= 0:
-        notes.append("missing token/s")
-        return STATUS_FAILED, notes
+        notes.append("no-metrics: missing positive token/s")
+        return STATUS_UNPROVEN, notes
 
     if memory_requested and (memory_before is None or memory_after is None):
         notes.append("memory RSS sample unavailable")
@@ -561,12 +561,14 @@ def aggregate(results: List[SingleResult]) -> Dict[Tuple[str, str], Dict[str, An
         bytes_avg = sum(out_bytes) / len(out_bytes) if out_bytes else float("nan")
         if not items:
             aggregate_status = STATUS_UNPROVEN
+        elif status_counts[STATUS_PASS] == len(items):
+            aggregate_status = STATUS_PASS
         elif status_counts[STATUS_FAILED] == len(items):
             aggregate_status = STATUS_FAILED
-        elif status_counts[STATUS_FAILED] > 0 or status_counts[STATUS_PARTIAL] > 0:
-            aggregate_status = STATUS_PARTIAL
+        elif status_counts[STATUS_UNPROVEN] == len(items):
+            aggregate_status = STATUS_UNPROVEN
         else:
-            aggregate_status = STATUS_PASS
+            aggregate_status = STATUS_PARTIAL
 
         summary[key] = {
             "runs": len(items),

--- a/scripts/benchmark/benchmark_models.py
+++ b/scripts/benchmark/benchmark_models.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 Benchmark local LLM servers (e.g., Ollama, LM Studio) via OpenAI-compatible
-Chat Completions API. Measures TTFT (time-to-first-token), total latency, and
+Chat Completions API. Measures TTFT (time-to-first-token), total latency,
+token/s when usage metadata is available, optional process RSS, and
 throughput (chars/sec, bytes/sec) under configurable concurrency.
 
 Examples:
@@ -10,8 +11,10 @@ Examples:
     --server "lmstudio|http://localhost:1234|Meta-Llama-3.1-8B-Instruct" \
     --prompt "Explain the significance of the Turing Test in AI." \
     --prompt "Write a Python function for Fibonacci with memoization." \
-    --iterations 5 --concurrency 4 --stream --max-tokens 512 \
-    --output-prefix ./results/llm-bench --export json csv
+    --iterations 5 --concurrency 4 --max-tokens 512 \
+    --output-prefix ./results/llm-bench --export json csv \
+    --report-json ./results/llm-bench.benchmark.json \
+    --report-markdown ./results/llm-bench.benchmark.md
 
 Requires: httpx>=0.27.0
 Install deps: pip install -r scripts/benchmark/requirements-bench.txt
@@ -23,7 +26,9 @@ import argparse
 import asyncio
 import csv
 import json
+import math
 import os
+import subprocess
 import sys
 import time
 from dataclasses import dataclass, asdict
@@ -31,9 +36,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import httpx  # type: ignore
-except Exception as exc:  # pragma: no cover
-    print("This script requires the 'httpx' package. Install with:\n  pip install -r scripts/benchmark/requirements-bench.txt", file=sys.stderr)
-    raise
+except Exception:  # pragma: no cover
+    httpx = None  # type: ignore
+
+
+STATUS_PASS = "pass"
+STATUS_PARTIAL = "partial"
+STATUS_FAILED = "failed"
+STATUS_UNPROVEN = "unproven"
 
 
 @dataclass
@@ -63,10 +73,18 @@ class RequestConfig:
 
 
 @dataclass
+class MemoryProbe:
+    server: str
+    pid: int
+
+
+@dataclass
 class SingleResult:
     server: str
     model: str
     prompt_id: int
+    case_id: str
+    prompt: str
     iteration: int
     success: bool
     status_code: Optional[int]
@@ -74,6 +92,17 @@ class SingleResult:
     total_ms: Optional[float]
     output_chars: int
     output_bytes: int
+    prompt_tokens: Optional[int]
+    completion_tokens: Optional[int]
+    total_tokens: Optional[int]
+    tokens_per_second: Optional[float]
+    token_source: Optional[str]
+    memory_rss_before_bytes: Optional[int]
+    memory_rss_after_bytes: Optional[int]
+    memory_rss_delta_bytes: Optional[int]
+    memory_sample_source: Optional[str]
+    status: str
+    status_notes: List[str]
     error: Optional[str]
 
 
@@ -85,6 +114,19 @@ def parse_server_arg(arg: str) -> ServerSpec:
         raise argparse.ArgumentTypeError(
             "--server must be of the form 'name|base_url|model'"
         ) from exc
+
+
+def parse_memory_pid_arg(arg: str) -> MemoryProbe:
+    try:
+        server, raw_pid = arg.split("|", 1)
+        pid = int(raw_pid)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "--memory-pid must be of the form 'server|pid'"
+        ) from exc
+    if pid <= 0:
+        raise argparse.ArgumentTypeError("--memory-pid pid must be positive")
+    return MemoryProbe(server=server.strip(), pid=pid)
 
 
 def percentile(values: List[float], p: float) -> float:
@@ -101,6 +143,122 @@ def percentile(values: List[float], p: float) -> float:
     return d0 + d1
 
 
+def finite_or_none(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def round_float(value: Optional[float], digits: int = 3) -> Optional[float]:
+    value = finite_or_none(value)
+    return None if value is None else round(value, digits)
+
+
+def case_id_for_prompt(prompt_id: int) -> str:
+    return f"prompt-{prompt_id}"
+
+
+def extract_usage_tokens(
+    usage: Any,
+) -> Tuple[Optional[int], Optional[int], Optional[int], Optional[float]]:
+    if not isinstance(usage, dict):
+        return None, None, None, None
+
+    def int_value(key: str) -> Optional[int]:
+        value = usage.get(key)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return None
+
+    prompt_tokens = int_value("prompt_tokens")
+    completion_tokens = int_value("completion_tokens")
+    total_tokens = int_value("total_tokens")
+    raw_tps = usage.get("tokens_per_second")
+    tokens_per_second = raw_tps if isinstance(raw_tps, (int, float)) else None
+    return prompt_tokens, completion_tokens, total_tokens, finite_or_none(tokens_per_second)
+
+
+def resolve_tokens_per_second(
+    usage_tokens_per_second: Optional[float],
+    completion_tokens: Optional[int],
+    total_ms: Optional[float],
+) -> Tuple[Optional[float], Optional[str]]:
+    if usage_tokens_per_second is not None and usage_tokens_per_second > 0:
+        return usage_tokens_per_second, "usage.tokens_per_second"
+    if (
+        completion_tokens is not None
+        and completion_tokens > 0
+        and total_ms is not None
+        and total_ms > 0
+    ):
+        return completion_tokens / (total_ms / 1000.0), "usage.completion_tokens/total_ms"
+    return None, None
+
+
+def sample_process_rss_bytes(pid: int) -> Optional[int]:
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    raw = completed.stdout.strip().splitlines()
+    if not raw:
+        return None
+    try:
+        rss_kb = int(raw[-1].strip())
+    except ValueError:
+        return None
+    return max(0, rss_kb) * 1024
+
+
+def classify_result(
+    success: bool,
+    status_code: Optional[int],
+    total_ms: Optional[float],
+    tokens_per_second: Optional[float],
+    error: Optional[str],
+    memory_requested: bool,
+    memory_before: Optional[int],
+    memory_after: Optional[int],
+) -> Tuple[str, List[str]]:
+    notes: List[str] = []
+    if not success:
+        if status_code is None:
+            notes.append("request did not return an HTTP status")
+        else:
+            notes.append(f"HTTP status {status_code}")
+        if error:
+            notes.append(error)
+        return STATUS_FAILED, notes
+
+    if total_ms is None or total_ms <= 0:
+        notes.append("missing or invalid total latency")
+        return STATUS_FAILED, notes
+
+    if tokens_per_second is None or tokens_per_second <= 0:
+        notes.append("missing token/s")
+        return STATUS_FAILED, notes
+
+    if memory_requested and (memory_before is None or memory_after is None):
+        notes.append("memory RSS sample unavailable")
+        return STATUS_PARTIAL, notes
+
+    return STATUS_PASS, notes
+
+
 async def run_single_chat(
     client: httpx.AsyncClient,
     server: ServerSpec,
@@ -108,6 +266,7 @@ async def run_single_chat(
     iteration: int,
     prompt_text: str,
     cfg: RequestConfig,
+    memory_pid: Optional[int] = None,
 ) -> SingleResult:
     url = server.endpoint()
 
@@ -120,6 +279,9 @@ async def run_single_chat(
         "max_tokens": cfg.max_tokens,
         "stream": bool(cfg.stream),
     }
+
+    if cfg.stream:
+        payload["stream_options"] = {"include_usage": True}
 
     if cfg.extra_json:
         payload.update(cfg.extra_json)
@@ -139,6 +301,16 @@ async def run_single_chat(
     output_chars: int = 0
     output_bytes: int = 0
     status_code: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    usage_tokens_per_second: Optional[float] = None
+    tokens_per_second: Optional[float] = None
+    token_source: Optional[str] = None
+    memory_before: Optional[int] = (
+        sample_process_rss_bytes(memory_pid) if memory_pid else None
+    )
+    memory_after: Optional[int] = None
 
     t0 = time.perf_counter()
 
@@ -166,14 +338,21 @@ async def run_single_chat(
                         # Treat as raw content chunk
                         chunk_text = data
                     else:
+                        usage = obj.get("usage") if isinstance(obj, dict) else None
+                        pt, ct, tt, tps = extract_usage_tokens(usage)
+                        prompt_tokens = pt if pt is not None else prompt_tokens
+                        completion_tokens = ct if ct is not None else completion_tokens
+                        total_tokens = tt if tt is not None else total_tokens
+                        usage_tokens_per_second = tps if tps is not None else usage_tokens_per_second
+
                         # OpenAI-style delta path
-                        choices = obj.get("choices") or []
+                        choices = (obj.get("choices") or []) if isinstance(obj, dict) else []
                         if choices:
                             delta = choices[0].get("delta") or {}
                             chunk_text = delta.get("content", "") or ""
                         else:
                             # Fallback if vendor uses non-standard field
-                            chunk_text = obj.get("content", "") or ""
+                            chunk_text = (obj.get("content", "") or "") if isinstance(obj, dict) else ""
 
                     if chunk_text:
                         if not first_token_emitted:
@@ -193,6 +372,12 @@ async def run_single_chat(
             try:
                 data = resp.json()
                 if isinstance(data, dict):
+                    pt, ct, tt, tps = extract_usage_tokens(data.get("usage"))
+                    prompt_tokens = pt if pt is not None else prompt_tokens
+                    completion_tokens = ct if ct is not None else completion_tokens
+                    total_tokens = tt if tt is not None else total_tokens
+                    usage_tokens_per_second = tps if tps is not None else usage_tokens_per_second
+
                     choices = data.get("choices") or []
                     if choices:
                         msg = choices[0].get("message") or {}
@@ -210,11 +395,29 @@ async def run_single_chat(
                 output_chars = len(text)
                 output_bytes = len(text.encode("utf-8", errors="ignore"))
 
+        memory_after = sample_process_rss_bytes(memory_pid) if memory_pid else None
+        tokens_per_second, token_source = resolve_tokens_per_second(
+            usage_tokens_per_second,
+            completion_tokens,
+            total_ms,
+        )
         success = status_code is not None and 200 <= status_code < 300
+        status, status_notes = classify_result(
+            success=success,
+            status_code=status_code,
+            total_ms=total_ms,
+            tokens_per_second=tokens_per_second,
+            error=None,
+            memory_requested=memory_pid is not None,
+            memory_before=memory_before,
+            memory_after=memory_after,
+        )
         return SingleResult(
             server=server.name,
             model=server.model,
             prompt_id=prompt_id,
+            case_id=case_id_for_prompt(prompt_id),
+            prompt=prompt_text,
             iteration=iteration,
             success=success,
             status_code=status_code,
@@ -222,21 +425,64 @@ async def run_single_chat(
             total_ms=total_ms,
             output_chars=output_chars,
             output_bytes=output_bytes,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            tokens_per_second=tokens_per_second,
+            token_source=token_source,
+            memory_rss_before_bytes=memory_before,
+            memory_rss_after_bytes=memory_after,
+            memory_rss_delta_bytes=(
+                memory_after - memory_before
+                if memory_before is not None and memory_after is not None
+                else None
+            ),
+            memory_sample_source=f"pid:{memory_pid}" if memory_pid else None,
+            status=status,
+            status_notes=status_notes,
             error=None,
         )
     except Exception as exc:  # pragma: no cover
         total_ms = (time.perf_counter() - t0) * 1000.0
+        memory_after = sample_process_rss_bytes(memory_pid) if memory_pid else None
+        status, status_notes = classify_result(
+            success=False,
+            status_code=status_code,
+            total_ms=total_ms,
+            tokens_per_second=None,
+            error=str(exc),
+            memory_requested=memory_pid is not None,
+            memory_before=memory_before,
+            memory_after=memory_after,
+        )
         return SingleResult(
             server=server.name,
             model=server.model,
             prompt_id=prompt_id,
+            case_id=case_id_for_prompt(prompt_id),
+            prompt=prompt_text,
             iteration=iteration,
             success=False,
-            status_code=None,
+            status_code=status_code,
             ttft_ms=ttft_ms,
             total_ms=total_ms,
             output_chars=output_chars,
             output_bytes=output_bytes,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            tokens_per_second=None,
+            token_source=None,
+            memory_rss_before_bytes=memory_before,
+            memory_rss_after_bytes=memory_after,
+            memory_rss_delta_bytes=(
+                memory_after - memory_before
+                if memory_before is not None and memory_after is not None
+                else None
+            ),
+            memory_sample_source=f"pid:{memory_pid}" if memory_pid else None,
+            status=status,
+            status_notes=status_notes,
             error=str(exc),
         )
 
@@ -247,15 +493,31 @@ async def run_benchmark(
     iterations: int,
     concurrency: int,
     cfg: RequestConfig,
+    memory_pids: Optional[Dict[str, int]] = None,
 ) -> List[SingleResult]:
+    if httpx is None:  # pragma: no cover
+        raise RuntimeError(
+            "This script requires the 'httpx' package. Install with:\n"
+            "  pip install -r scripts/benchmark/requirements-bench.txt"
+        )
+
     semaphore = asyncio.Semaphore(concurrency)
+    memory_pids = memory_pids or {}
 
     async with httpx.AsyncClient(http2=False) as client:
         tasks: List[asyncio.Task[SingleResult]] = []
 
         async def bound_request(srv: ServerSpec, pidx: int, it: int, prompt: str) -> SingleResult:
             async with semaphore:
-                return await run_single_chat(client, srv, pidx, it, prompt, cfg)
+                return await run_single_chat(
+                    client,
+                    srv,
+                    pidx,
+                    it,
+                    prompt,
+                    cfg,
+                    memory_pid=memory_pids.get(srv.name),
+                )
 
         for srv in servers:
             for pidx, prompt in enumerate(prompts):
@@ -280,17 +542,36 @@ def aggregate(results: List[SingleResult]) -> Dict[Tuple[str, str], Dict[str, An
     for key, items in groups.items():
         latencies = [i.total_ms for i in items if i.success and i.total_ms is not None]
         ttfts = [i.ttft_ms for i in items if i.success and i.ttft_ms is not None]
+        token_rates = [i.tokens_per_second for i in items if i.tokens_per_second is not None]
         out_chars = [i.output_chars for i in items if i.success]
         out_bytes = [i.output_bytes for i in items if i.success]
+        rss_after = [i.memory_rss_after_bytes for i in items if i.memory_rss_after_bytes is not None]
+        status_counts = {
+            STATUS_PASS: sum(1 for i in items if i.status == STATUS_PASS),
+            STATUS_PARTIAL: sum(1 for i in items if i.status == STATUS_PARTIAL),
+            STATUS_FAILED: sum(1 for i in items if i.status == STATUS_FAILED),
+            STATUS_UNPROVEN: sum(1 for i in items if i.status == STATUS_UNPROVEN),
+        }
         success_rate = sum(1 for i in items if i.success) / max(1, len(items))
 
         total_ms_avg = sum(latencies) / len(latencies) if latencies else float("nan")
         ttft_ms_avg = sum(ttfts) / len(ttfts) if ttfts else float("nan")
+        token_rate_avg = sum(token_rates) / len(token_rates) if token_rates else float("nan")
         chars_avg = sum(out_chars) / len(out_chars) if out_chars else float("nan")
         bytes_avg = sum(out_bytes) / len(out_bytes) if out_bytes else float("nan")
+        if not items:
+            aggregate_status = STATUS_UNPROVEN
+        elif status_counts[STATUS_FAILED] == len(items):
+            aggregate_status = STATUS_FAILED
+        elif status_counts[STATUS_FAILED] > 0 or status_counts[STATUS_PARTIAL] > 0:
+            aggregate_status = STATUS_PARTIAL
+        else:
+            aggregate_status = STATUS_PASS
 
         summary[key] = {
             "runs": len(items),
+            "status": aggregate_status,
+            "status_counts": status_counts,
             "success_rate": success_rate,
             "ttft_ms_avg": ttft_ms_avg,
             "ttft_ms_p50": percentile(ttfts, 0.5) if ttfts else float("nan"),
@@ -298,8 +579,12 @@ def aggregate(results: List[SingleResult]) -> Dict[Tuple[str, str], Dict[str, An
             "total_ms_avg": total_ms_avg,
             "total_ms_p50": percentile(latencies, 0.5) if latencies else float("nan"),
             "total_ms_p95": percentile(latencies, 0.95) if latencies else float("nan"),
+            "tokens_per_second_avg": token_rate_avg,
+            "tokens_per_second_p50": percentile(token_rates, 0.5) if token_rates else float("nan"),
+            "tokens_per_second_p95": percentile(token_rates, 0.95) if token_rates else float("nan"),
             "output_chars_avg": chars_avg,
             "output_bytes_avg": bytes_avg,
+            "memory_rss_after_bytes_max": max(rss_after) if rss_after else None,
             # Throughput estimates (average length divided by average latency)
             "chars_per_sec_avg": (chars_avg / (total_ms_avg / 1000.0)) if latencies else float("nan"),
             "bytes_per_sec_avg": (bytes_avg / (total_ms_avg / 1000.0)) if latencies else float("nan"),
@@ -325,7 +610,30 @@ def export_json(path_prefix: str, results: List[SingleResult], summary: Dict[Tup
 def export_csv(path_prefix: str, results: List[SingleResult]) -> str:
     csv_path = f"{path_prefix}.results.csv"
     fieldnames = list(asdict(results[0]).keys()) if results else [
-        "server","model","prompt_id","iteration","success","status_code","ttft_ms","total_ms","output_chars","output_bytes","error"
+        "server",
+        "model",
+        "prompt_id",
+        "case_id",
+        "prompt",
+        "iteration",
+        "success",
+        "status_code",
+        "ttft_ms",
+        "total_ms",
+        "output_chars",
+        "output_bytes",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "tokens_per_second",
+        "token_source",
+        "memory_rss_before_bytes",
+        "memory_rss_after_bytes",
+        "memory_rss_delta_bytes",
+        "memory_sample_source",
+        "status",
+        "status_notes",
+        "error",
     ]
     with open(csv_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
@@ -333,6 +641,249 @@ def export_csv(path_prefix: str, results: List[SingleResult]) -> str:
         for r in results:
             writer.writerow(asdict(r))
     return csv_path
+
+
+def build_benchmark_report(
+    results: List[SingleResult],
+    summary: Dict[Tuple[str, str], Dict[str, Any]],
+    servers: List[ServerSpec],
+    prompts: List[str],
+    cfg: RequestConfig,
+    iterations: int,
+    concurrency: int,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    rows = [report_row(r) for r in sorted_results(results)]
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at
+        or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "covers_issues": [22],
+        "config": {
+            "concurrency": concurrency,
+            "iterations": iterations,
+            "max_tokens": cfg.max_tokens,
+            "stream": cfg.stream,
+            "temperature": cfg.temperature,
+            "timeout_seconds": cfg.timeout_seconds,
+            "system_prompt": cfg.system_prompt,
+        },
+        "servers": [
+            {"name": s.name, "base_url": s.base_url, "model_id": s.model}
+            for s in sorted(servers, key=lambda item: (item.name, item.model))
+        ],
+        "prompts": [
+            {"case_id": case_id_for_prompt(i), "prompt_id": i, "prompt": prompt}
+            for i, prompt in enumerate(prompts)
+        ],
+        "summary": report_summary_rows(summary),
+        "rows": rows,
+    }
+
+
+def sorted_results(results: List[SingleResult]) -> List[SingleResult]:
+    return sorted(results, key=lambda r: (r.server, r.model, r.prompt_id, r.iteration))
+
+
+def report_row(result: SingleResult) -> Dict[str, Any]:
+    return {
+        "server": result.server,
+        "model_id": result.model,
+        "case": {
+            "id": result.case_id,
+            "prompt_id": result.prompt_id,
+            "prompt": result.prompt,
+        },
+        "iteration": result.iteration,
+        "status": result.status,
+        "status_notes": result.status_notes,
+        "http": {
+            "success": result.success,
+            "status_code": result.status_code,
+            "error": result.error,
+        },
+        "timing": {
+            "ttft_ms": round_float(result.ttft_ms),
+            "total_ms": round_float(result.total_ms),
+        },
+        "tokens": {
+            "prompt_tokens": result.prompt_tokens,
+            "completion_tokens": result.completion_tokens,
+            "total_tokens": result.total_tokens,
+            "tokens_per_second": round_float(result.tokens_per_second),
+            "source": result.token_source,
+        },
+        "output": {
+            "chars": result.output_chars,
+            "bytes": result.output_bytes,
+        },
+        "memory": {
+            "available": result.memory_rss_after_bytes is not None,
+            "rss_before_bytes": result.memory_rss_before_bytes,
+            "rss_after_bytes": result.memory_rss_after_bytes,
+            "rss_delta_bytes": result.memory_rss_delta_bytes,
+            "source": result.memory_sample_source,
+        },
+    }
+
+
+def report_summary_rows(summary: Dict[Tuple[str, str], Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for (server, model), stats in sorted(summary.items(), key=lambda item: item[0]):
+        rows.append(
+            {
+                "server": server,
+                "model_id": model,
+                "status": stats["status"],
+                "runs": stats["runs"],
+                "status_counts": stats["status_counts"],
+                "success_rate": round_float(stats["success_rate"]),
+                "ttft_ms_avg": round_float(stats["ttft_ms_avg"]),
+                "ttft_ms_p50": round_float(stats["ttft_ms_p50"]),
+                "ttft_ms_p95": round_float(stats["ttft_ms_p95"]),
+                "total_ms_avg": round_float(stats["total_ms_avg"]),
+                "total_ms_p50": round_float(stats["total_ms_p50"]),
+                "total_ms_p95": round_float(stats["total_ms_p95"]),
+                "tokens_per_second_avg": round_float(stats["tokens_per_second_avg"]),
+                "tokens_per_second_p50": round_float(stats["tokens_per_second_p50"]),
+                "tokens_per_second_p95": round_float(stats["tokens_per_second_p95"]),
+                "memory_rss_after_bytes_max": stats["memory_rss_after_bytes_max"],
+            }
+        )
+    return rows
+
+
+def write_report_json(path: str, report: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False)
+        f.write("\n")
+
+
+def write_report_markdown(path: str, report: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(format_benchmark_markdown(report))
+
+
+def format_benchmark_markdown(report: Dict[str, Any]) -> str:
+    lines: List[str] = []
+    lines.append("# Model Benchmark Report")
+    lines.append("")
+    lines.append(f"- Generated: {md_escape(str(report.get('generated_at', 'unknown')))}")
+    lines.append("- Covers: #22")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(
+        "| Server | Model | Status | Runs | Pass | Partial | Failed | Unproven | Avg latency | P50 token/s | P95 token/s | Max RSS |"
+    )
+    lines.append("|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for row in report.get("summary", []):
+        counts = row.get("status_counts", {})
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    md_escape(row.get("server", "")),
+                    md_escape(row.get("model_id", "")),
+                    md_escape(row.get("status", "")),
+                    format_int(row.get("runs")),
+                    format_int(counts.get(STATUS_PASS)),
+                    format_int(counts.get(STATUS_PARTIAL)),
+                    format_int(counts.get(STATUS_FAILED)),
+                    format_int(counts.get(STATUS_UNPROVEN)),
+                    format_ms(row.get("total_ms_avg")),
+                    format_rate(row.get("tokens_per_second_p50")),
+                    format_rate(row.get("tokens_per_second_p95")),
+                    format_bytes(row.get("memory_rss_after_bytes_max")),
+                ]
+            )
+            + " |"
+        )
+
+    lines.append("")
+    lines.append("## Prompts")
+    lines.append("")
+    lines.append("| Case | Prompt |")
+    lines.append("|---|---|")
+    for prompt in report.get("prompts", []):
+        lines.append(
+            f"| {md_escape(prompt.get('case_id', ''))} | "
+            f"{md_escape(truncate(str(prompt.get('prompt', '')), 180))} |"
+        )
+
+    lines.append("")
+    lines.append("## Rows")
+    lines.append("")
+    lines.append(
+        "| Status | Server | Model | Case | Iter | Total | TTFT | Token/s | Completion tokens | RSS after | Notes |"
+    )
+    lines.append("|---:|---|---|---|---:|---:|---:|---:|---:|---:|---|")
+    for row in report.get("rows", []):
+        timing = row.get("timing", {})
+        tokens = row.get("tokens", {})
+        memory = row.get("memory", {})
+        case = row.get("case", {})
+        notes = "; ".join(row.get("status_notes", []))
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    md_escape(row.get("status", "")),
+                    md_escape(row.get("server", "")),
+                    md_escape(row.get("model_id", "")),
+                    md_escape(case.get("id", "")),
+                    format_int(row.get("iteration")),
+                    format_ms(timing.get("total_ms")),
+                    format_ms(timing.get("ttft_ms")),
+                    format_rate(tokens.get("tokens_per_second")),
+                    format_int(tokens.get("completion_tokens")),
+                    format_bytes(memory.get("rss_after_bytes")),
+                    md_escape(notes if notes else "none"),
+                ]
+            )
+            + " |"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def md_escape(value: Any) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
+def truncate(value: str, limit: int) -> str:
+    return value if len(value) <= limit else value[: max(0, limit - 3)] + "..."
+
+
+def format_int(value: Any) -> str:
+    return "-" if value is None else str(value)
+
+
+def format_ms(value: Any) -> str:
+    value = finite_or_none(value if isinstance(value, (int, float)) else None)
+    return "-" if value is None else f"{value:.1f} ms"
+
+
+def format_rate(value: Any) -> str:
+    value = finite_or_none(value if isinstance(value, (int, float)) else None)
+    return "-" if value is None else f"{value:.2f}"
+
+
+def format_bytes(value: Any) -> str:
+    if value is None:
+        return "-"
+    try:
+        raw = int(value)
+    except (TypeError, ValueError):
+        return "-"
+    if raw < 1024:
+        return f"{raw} B"
+    mib = raw / (1024 * 1024)
+    if mib < 1024:
+        return f"{mib:.1f} MiB"
+    return f"{mib / 1024:.2f} GiB"
 
 
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
@@ -378,6 +929,23 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Prefix path for outputs (without extension). Files: .results.json/.summary.json/.results.csv",
     )
     parser.add_argument(
+        "--report-json",
+        default=None,
+        help="Write a deterministic benchmark evidence report JSON to this path.",
+    )
+    parser.add_argument(
+        "--report-markdown",
+        default=None,
+        help="Write a deterministic benchmark evidence report Markdown file to this path.",
+    )
+    parser.add_argument(
+        "--memory-pid",
+        action="append",
+        type=parse_memory_pid_arg,
+        default=[],
+        help="Sample RSS around each request for a server: 'server|pid'. Can be repeated.",
+    )
+    parser.add_argument(
         "--export",
         nargs="+",
         choices=["json", "csv"],
@@ -416,6 +984,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     servers: List[ServerSpec] = args.server
     prompts = load_prompts(args)
 
+    if httpx is None:  # pragma: no cover
+        print(
+            "This script requires the 'httpx' package. Install with:\n"
+            "  pip install -r scripts/benchmark/requirements-bench.txt",
+            file=sys.stderr,
+        )
+        return 2
+
+    memory_pids: Dict[str, int] = {probe.server: probe.pid for probe in args.memory_pid}
+
     if args.extra_json:
         try:
             extra_json = json.loads(args.extra_json)
@@ -443,14 +1021,28 @@ def main(argv: Optional[List[str]] = None) -> int:
             f"{args.warmup_iterations} iteration(s) each, concurrency={args.concurrency} (excluded from results)..."
         )
         _ = asyncio.run(
-            run_benchmark(servers, prompts, args.warmup_iterations, args.concurrency, cfg)
+            run_benchmark(
+                servers,
+                prompts,
+                args.warmup_iterations,
+                args.concurrency,
+                cfg,
+                memory_pids=memory_pids,
+            )
         )
 
     sys_prompt_flag = "ON" if cfg.system_prompt else "OFF"
     print(f"Running benchmark against {len(servers)} server(s), {len(prompts)} prompt(s), {args.iterations} iteration(s) each, concurrency={args.concurrency}, system_prompt={sys_prompt_flag}...")
 
     results: List[SingleResult] = asyncio.run(
-        run_benchmark(servers, prompts, args.iterations, args.concurrency, cfg)
+        run_benchmark(
+            servers,
+            prompts,
+            args.iterations,
+            args.concurrency,
+            cfg,
+            memory_pids=memory_pids,
+        )
     )
 
     # Aggregate
@@ -461,9 +1053,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     for (srv, model), stats in summary.items():
         print(f"- {srv} | {model}:")
         print(
-            f"  success_rate={stats['success_rate']*100:.1f}%  "
+            f"  status={stats['status']}  success_rate={stats['success_rate']*100:.1f}%  "
             f"ttft_avg={stats['ttft_ms_avg']:.1f}ms  ttft_p50={stats['ttft_ms_p50']:.1f}ms  ttft_p95={stats['ttft_ms_p95']:.1f}ms  "
             f"total_avg={stats['total_ms_avg']:.1f}ms  p50={stats['total_ms_p50']:.1f}ms  p95={stats['total_ms_p95']:.1f}ms  "
+            f"tok/s_avg={stats['tokens_per_second_avg']:.1f}  "
             f"chars/s={stats['chars_per_sec_avg']:.1f}  bytes/s={stats['bytes_per_sec_avg']:.1f}"
         )
 
@@ -474,11 +1067,27 @@ def main(argv: Optional[List[str]] = None) -> int:
     if "csv" in args.export:
         export_csv(args.output_prefix, results)
 
+    report = None
+    if args.report_json or args.report_markdown:
+        report = build_benchmark_report(
+            results=results,
+            summary=summary,
+            servers=servers,
+            prompts=prompts,
+            cfg=cfg,
+            iterations=args.iterations,
+            concurrency=args.concurrency,
+        )
+    if args.report_json:
+        write_report_json(args.report_json, report)
+        print(f"Saved benchmark report JSON: {args.report_json}")
+    if args.report_markdown:
+        write_report_markdown(args.report_markdown, report)
+        print(f"Saved benchmark report Markdown: {args.report_markdown}")
+
     print(f"\nSaved artifacts with prefix: {args.output_prefix}")
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-

--- a/scripts/benchmark/run_bench.sh
+++ b/scripts/benchmark/run_bench.sh
@@ -13,15 +13,18 @@ set -euo pipefail
 #   CONC (default 1)
 #   MAXTOK (default 512)
 #   OUT_PREFIX (default ./results/osaurus-vs-ollama-lmstudio-batch)
+#   REPORT_JSON (default ${OUT_PREFIX}.benchmark.json)
+#   REPORT_MD (default ${OUT_PREFIX}.benchmark.md)
 #   PROMPTS_FILE (optional) or PROMPTS (comma-separated)
 #   NOSTREAM (set to 1 to disable streaming)
 #   WARMUP (default 1) warm-up iterations per prompt per server
+#   OSA_PID / OLLAMA_PID / LMSTUDIO_PID (optional RSS evidence)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 PY="${ROOT_DIR}/.bench-venv/bin/python"
-BENCH="${ROOT_DIR}/scripts/benchmark_models.py"
+BENCH="${ROOT_DIR}/scripts/benchmark/benchmark_models.py"
 
 OSA_BASE=${OSA_BASE:-"http://127.0.0.1:1337"}
 OSA_MODEL=${OSA_MODEL:-"llama-3.2-3b-instruct-4bit"}
@@ -33,11 +36,16 @@ ITER=${ITER:-10}
 CONC=${CONC:-1}
 MAXTOK=${MAXTOK:-512}
 OUT_PREFIX=${OUT_PREFIX:-"${ROOT_DIR}/results/osaurus-vs-ollama-lmstudio-batch"}
+REPORT_JSON=${REPORT_JSON:-"${OUT_PREFIX}.benchmark.json"}
+REPORT_MD=${REPORT_MD:-"${OUT_PREFIX}.benchmark.md"}
 PROMPTS_FILE=${PROMPTS_FILE:-""}
 PROMPTS=${PROMPTS:-"Write a one-sentence summary of the theory of evolution.,List three uses of fossil records in paleontology."}
 SYSTEM_PROMPT=${SYSTEM_PROMPT:-"You are a helpful assistant."}
 NOSTREAM=${NOSTREAM:-0}
 WARMUP=${WARMUP:-1}
+OSA_PID=${OSA_PID:-""}
+OLLAMA_PID=${OLLAMA_PID:-""}
+LMSTUDIO_PID=${LMSTUDIO_PID:-""}
 
 ARGS=(
   --server "osaurus|${OSA_BASE}|${OSA_MODEL}"
@@ -48,12 +56,24 @@ ARGS=(
   --max-tokens "${MAXTOK}"
   --warmup-iterations "${WARMUP}"
   --output-prefix "${OUT_PREFIX}"
+  --report-json "${REPORT_JSON}"
+  --report-markdown "${REPORT_MD}"
   --system-prompt "${SYSTEM_PROMPT}"
   --export json csv
 )
 
 if [[ "${NOSTREAM}" == "1" ]]; then
   ARGS+=(--no-stream)
+fi
+
+if [[ -n "${OSA_PID}" ]]; then
+  ARGS+=(--memory-pid "osaurus|${OSA_PID}")
+fi
+if [[ -n "${OLLAMA_PID}" ]]; then
+  ARGS+=(--memory-pid "ollama|${OLLAMA_PID}")
+fi
+if [[ -n "${LMSTUDIO_PID}" ]]; then
+  ARGS+=(--memory-pid "lmstudio|${LMSTUDIO_PID}")
 fi
 
 if [[ -n "${PROMPTS_FILE}" ]]; then
@@ -66,5 +86,3 @@ else
 fi
 
 exec "${PY}" "${BENCH}" "${ARGS[@]}"
-
-

--- a/scripts/benchmark/test_benchmark_models.py
+++ b/scripts/benchmark/test_benchmark_models.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+
+import benchmark_models as bench
+
+
+def make_result(
+    server: str,
+    model: str,
+    prompt_id: int,
+    iteration: int,
+    status: str,
+    tokens_per_second=None,
+    status_notes=None,
+):
+    return bench.SingleResult(
+        server=server,
+        model=model,
+        prompt_id=prompt_id,
+        case_id=bench.case_id_for_prompt(prompt_id),
+        prompt=f"Prompt {prompt_id}",
+        iteration=iteration,
+        success=status != bench.STATUS_FAILED,
+        status_code=200 if status != bench.STATUS_FAILED else 500,
+        ttft_ms=25.0,
+        total_ms=100.0,
+        output_chars=20,
+        output_bytes=20,
+        prompt_tokens=10,
+        completion_tokens=5 if tokens_per_second else None,
+        total_tokens=15 if tokens_per_second else None,
+        tokens_per_second=tokens_per_second,
+        token_source="usage.tokens_per_second" if tokens_per_second else None,
+        memory_rss_before_bytes=None,
+        memory_rss_after_bytes=None,
+        memory_rss_delta_bytes=None,
+        memory_sample_source=None,
+        status=status,
+        status_notes=status_notes or [],
+        error=None if status != bench.STATUS_FAILED else "boom",
+    )
+
+
+class BenchmarkReportTests(unittest.TestCase):
+    def test_missing_token_rate_is_failed(self):
+        status, notes = bench.classify_result(
+            success=True,
+            status_code=200,
+            total_ms=123.0,
+            tokens_per_second=None,
+            error=None,
+            memory_requested=False,
+            memory_before=None,
+            memory_after=None,
+        )
+
+        self.assertEqual(status, bench.STATUS_FAILED)
+        self.assertIn("missing token/s", notes)
+
+    def test_resolves_token_rate_from_completion_tokens(self):
+        rate, source = bench.resolve_tokens_per_second(
+            usage_tokens_per_second=None,
+            completion_tokens=20,
+            total_ms=500.0,
+        )
+
+        self.assertEqual(rate, 40.0)
+        self.assertEqual(source, "usage.completion_tokens/total_ms")
+
+    def test_report_rows_are_sorted_and_strict_json(self):
+        results = [
+            make_result("z-server", "model-b", 1, 2, bench.STATUS_PASS, tokens_per_second=11.0),
+            make_result("a-server", "model-a", 0, 1, bench.STATUS_FAILED, status_notes=["missing token/s"]),
+        ]
+        summary = bench.aggregate(results)
+        report = bench.build_benchmark_report(
+            results=results,
+            summary=summary,
+            servers=[
+                bench.ServerSpec("z-server", "http://z", "model-b"),
+                bench.ServerSpec("a-server", "http://a", "model-a"),
+            ],
+            prompts=["Prompt 0", "Prompt 1"],
+            cfg=bench.RequestConfig(stream=False, max_tokens=128, temperature=0.1),
+            iterations=2,
+            concurrency=1,
+            generated_at="2026-06-18T00:00:00Z",
+        )
+
+        self.assertEqual(report["rows"][0]["server"], "a-server")
+        self.assertEqual(report["rows"][0]["status"], bench.STATUS_FAILED)
+        self.assertEqual(report["summary"][0]["status"], bench.STATUS_FAILED)
+        json.dumps(report, allow_nan=False)
+
+    def test_markdown_includes_status_and_prompt_case(self):
+        result = make_result(
+            "osaurus",
+            "qwen3-coder",
+            0,
+            1,
+            bench.STATUS_FAILED,
+            status_notes=["missing token/s"],
+        )
+        summary = bench.aggregate([result])
+        report = bench.build_benchmark_report(
+            results=[result],
+            summary=summary,
+            servers=[bench.ServerSpec("osaurus", "http://localhost:1337", "qwen3-coder")],
+            prompts=["Prompt 0"],
+            cfg=bench.RequestConfig(stream=True),
+            iterations=1,
+            concurrency=1,
+            generated_at="2026-06-18T00:00:00Z",
+        )
+        markdown = bench.format_benchmark_markdown(report)
+
+        self.assertIn("prompt-0", markdown)
+        self.assertIn("failed", markdown)
+        self.assertIn("missing token/s", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark/test_benchmark_models.py
+++ b/scripts/benchmark/test_benchmark_models.py
@@ -44,7 +44,7 @@ def make_result(
 
 
 class BenchmarkReportTests(unittest.TestCase):
-    def test_missing_token_rate_is_failed(self):
+    def test_missing_token_rate_is_unproven(self):
         status, notes = bench.classify_result(
             success=True,
             status_code=200,
@@ -56,8 +56,42 @@ class BenchmarkReportTests(unittest.TestCase):
             memory_after=None,
         )
 
-        self.assertEqual(status, bench.STATUS_FAILED)
-        self.assertIn("missing token/s", notes)
+        self.assertEqual(status, bench.STATUS_UNPROVEN)
+        self.assertIn("no-metrics: missing positive token/s", notes)
+
+    def test_unproven_metrics_keep_success_rate_but_not_pass_status(self):
+        result = make_result(
+            "osaurus",
+            "qwen3-coder",
+            0,
+            1,
+            bench.STATUS_UNPROVEN,
+            status_notes=["no-metrics: missing positive token/s"],
+        )
+        summary = bench.aggregate([result])
+        stats = summary[("osaurus", "qwen3-coder")]
+
+        self.assertEqual(stats["status"], bench.STATUS_UNPROVEN)
+        self.assertEqual(stats["success_rate"], 1.0)
+        self.assertEqual(stats["status_counts"][bench.STATUS_UNPROVEN], 1)
+
+    def test_mixed_pass_and_unproven_metrics_are_partial(self):
+        results = [
+            make_result("osaurus", "qwen3-coder", 0, 1, bench.STATUS_PASS, tokens_per_second=11.0),
+            make_result(
+                "osaurus",
+                "qwen3-coder",
+                1,
+                1,
+                bench.STATUS_UNPROVEN,
+                status_notes=["no-metrics: missing positive token/s"],
+            ),
+        ]
+        summary = bench.aggregate(results)
+        stats = summary[("osaurus", "qwen3-coder")]
+
+        self.assertEqual(stats["status"], bench.STATUS_PARTIAL)
+        self.assertEqual(stats["success_rate"], 1.0)
 
     def test_resolves_token_rate_from_completion_tokens(self):
         rate, source = bench.resolve_tokens_per_second(
@@ -72,7 +106,14 @@ class BenchmarkReportTests(unittest.TestCase):
     def test_report_rows_are_sorted_and_strict_json(self):
         results = [
             make_result("z-server", "model-b", 1, 2, bench.STATUS_PASS, tokens_per_second=11.0),
-            make_result("a-server", "model-a", 0, 1, bench.STATUS_FAILED, status_notes=["missing token/s"]),
+            make_result(
+                "a-server",
+                "model-a",
+                0,
+                1,
+                bench.STATUS_UNPROVEN,
+                status_notes=["no-metrics: missing positive token/s"],
+            ),
         ]
         summary = bench.aggregate(results)
         report = bench.build_benchmark_report(
@@ -90,8 +131,8 @@ class BenchmarkReportTests(unittest.TestCase):
         )
 
         self.assertEqual(report["rows"][0]["server"], "a-server")
-        self.assertEqual(report["rows"][0]["status"], bench.STATUS_FAILED)
-        self.assertEqual(report["summary"][0]["status"], bench.STATUS_FAILED)
+        self.assertEqual(report["rows"][0]["status"], bench.STATUS_UNPROVEN)
+        self.assertEqual(report["summary"][0]["status"], bench.STATUS_UNPROVEN)
         json.dumps(report, allow_nan=False)
 
     def test_markdown_includes_status_and_prompt_case(self):
@@ -100,8 +141,8 @@ class BenchmarkReportTests(unittest.TestCase):
             "qwen3-coder",
             0,
             1,
-            bench.STATUS_FAILED,
-            status_notes=["missing token/s"],
+            bench.STATUS_UNPROVEN,
+            status_notes=["no-metrics: missing positive token/s"],
         )
         summary = bench.aggregate([result])
         report = bench.build_benchmark_report(
@@ -117,8 +158,8 @@ class BenchmarkReportTests(unittest.TestCase):
         markdown = bench.format_benchmark_markdown(report)
 
         self.assertIn("prompt-0", markdown)
-        self.assertIn("failed", markdown)
-        self.assertIn("missing token/s", markdown)
+        self.assertIn("unproven", markdown)
+        self.assertIn("no-metrics: missing positive token/s", markdown)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add deterministic JSON and Markdown benchmark evidence reports for OpenAI-compatible model comparisons.
- Record model id, prompt case, timing, token/s, optional RSS memory evidence, and pass/partial/failed/unproven status.
- Mark successful generation rows without token/s as failed, and document the report workflow for issue #22.

## Validation
- python3 -m py_compile scripts/benchmark/benchmark_models.py scripts/benchmark/test_benchmark_models.py
- python3 scripts/benchmark/test_benchmark_models.py
- python3 scripts/benchmark/benchmark_models.py --help
- bash -n scripts/benchmark/run_bench.sh
- make -n bench-models
- git diff --check
