### PR TITLE
Add local model compatibility preflight

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -16988,6 +16988,22 @@
         }
       }
     },
+    "DFlash speculative decoding incomplete" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "DFlash spekulatives Decodieren unvollständig"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DFlash推测解码不完整"
+          }
+        }
+      }
+    },
     "Diagnostic / Custom" : {
       "localizations" : {
         "de" : {
@@ -39794,6 +39810,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打印"
+          }
+        }
+      }
+    },
+    "Preflight" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Preflight"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预检"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/ModelCompatibilityDiagnostics.swift
@@ -16,11 +16,13 @@ enum ModelCompatibilityDiagnostics {
         let source: SourceStatus
         let localBundle: LocalBundleStatus
         let runtime: RuntimeStatus
+        let preflight: PreflightStatus
         let benchmark: BenchmarkStatus
         let featureHooks: [FeatureHook]
+        let evidence: [Evidence]
 
-        var primaryTitle: String { runtime.title }
-        var primaryDetail: String { runtime.detail }
+        var primaryTitle: String { preflight.title }
+        var primaryDetail: String { preflight.detail }
     }
 
     struct SourceStatus: Equatable {
@@ -56,16 +58,34 @@ enum ModelCompatibilityDiagnostics {
         let hasVisionConfig: Bool
         let hasJANGConfig: Bool
         let hasJANGTQSidecar: Bool
+        let tokenizer: TokenizerSummary?
+        let generation: GenerationSummary?
 
         var displayModelType: String? {
             modelType ?? textModelType
         }
     }
 
+    struct TokenizerSummary: Equatable {
+        let tokenizerClass: String?
+        let modelMaxLength: Int?
+        let chatTemplatePresent: Bool
+        let specialTokenKeys: [String]
+        let hasDFlashReference: Bool
+    }
+
+    struct GenerationSummary: Equatable {
+        let keys: [String]
+        let maxNewTokens: Int?
+        let topK: Int?
+        let hasDFlashReference: Bool
+    }
+
     struct RuntimeStatus: Equatable {
         enum Kind: String {
             case ready
             case blocked
+            case partial
             case needsDownload
             case unproven
         }
@@ -78,12 +98,57 @@ enum ModelCompatibilityDiagnostics {
             case incompleteBundle
             case unsupportedHunyuanDense
             case unsupportedLongCat
+            case partialDFlashSpeculativeDecoding
         }
 
         let kind: Kind
         let reason: ReasonCode
         let title: String
         let detail: String
+    }
+
+    struct PreflightStatus: Equatable {
+        enum Status: String {
+            case supported
+            case partial
+            case unsupported
+            case unproven
+        }
+
+        let status: Status
+        let reason: RuntimeStatus.ReasonCode
+        let title: String
+        let detail: String
+
+        var blocksRuntimeLoad: Bool {
+            status == .unsupported || status == .partial
+        }
+    }
+
+    struct Evidence: Equatable, Identifiable {
+        let source: String
+        let key: String
+        let value: String
+
+        var id: String { "\(source):\(key):\(value)" }
+    }
+
+    struct PreflightError: LocalizedError, Sendable, Equatable {
+        let modelId: String
+        let modelName: String
+        let status: String
+        let reason: String
+        let title: String
+        let detail: String
+        let evidence: [String]
+
+        var errorDescription: String? {
+            var message = "\(title): \(detail)"
+            if !evidence.isEmpty {
+                message += " Evidence: \(evidence.joined(separator: "; "))"
+            }
+            return message
+        }
     }
 
     struct BenchmarkStatus: Equatable {
@@ -142,14 +207,40 @@ enum ModelCompatibilityDiagnostics {
             localBundle: localBundle,
             config: config
         )
+        let evidence = evidenceRows(
+            modelId: modelId,
+            modelName: modelName,
+            modelTypeHint: modelTypeHint,
+            source: source,
+            localBundle: localBundle,
+            config: config
+        )
+        let preflight = preflightStatus(runtime: runtime)
         let benchmark = benchmarkStatus(runtime: runtime, localBundle: localBundle)
         return Report(
             modelId: modelId,
             source: source,
             localBundle: localBundle,
             runtime: runtime,
+            preflight: preflight,
             benchmark: benchmark,
-            featureHooks: runtime.kind == .blocked ? [] : futureHooks(for: localBundle)
+            featureHooks: runtime.kind == .blocked || runtime.kind == .partial
+                ? []
+                : futureHooks(for: localBundle),
+            evidence: evidence
+        )
+    }
+
+    static func validateLoadAllowed(_ report: Report, modelName: String) throws {
+        guard report.preflight.blocksRuntimeLoad else { return }
+        throw PreflightError(
+            modelId: report.modelId,
+            modelName: modelName,
+            status: report.preflight.status.rawValue,
+            reason: report.preflight.reason.rawValue,
+            title: report.preflight.title,
+            detail: report.preflight.detail,
+            evidence: report.evidence.map { "\($0.source).\($0.key)=\($0.value)" }
         )
     }
 
@@ -267,6 +358,26 @@ enum ModelCompatibilityDiagnostics {
         }
     }
 
+    private static func preflightStatus(runtime: RuntimeStatus) -> PreflightStatus {
+        let status: PreflightStatus.Status
+        switch runtime.kind {
+        case .ready:
+            status = .supported
+        case .partial:
+            status = .partial
+        case .blocked:
+            status = .unsupported
+        case .needsDownload, .unproven:
+            status = .unproven
+        }
+        return PreflightStatus(
+            status: status,
+            reason: runtime.reason,
+            title: runtime.title,
+            detail: runtime.detail
+        )
+    }
+
     private static func unsupportedFamilyStatus(
         modelId: String,
         modelName: String,
@@ -281,6 +392,18 @@ enum ModelCompatibilityDiagnostics {
 
         let architectures = config?.architectures.map { $0.lowercased() } ?? []
         let names = [modelId, modelName].map { $0.lowercased() }
+
+        if isDFlashStyleBundle(modelTypes: modelTypes, architectures: architectures, config: config, names: names) {
+            return RuntimeStatus(
+                kind: .partial,
+                reason: .partialDFlashSpeculativeDecoding,
+                title: L("DFlash speculative decoding incomplete"),
+                detail:
+                    L(
+                        "This bundle advertises DFlash/speculative-decoding metadata, but local generation has no target/draft acceptance contract or benchmark proof yet. Use it only after native runtime support lands."
+                    )
+            )
+        }
 
         let isHunyuanDense =
             modelTypes.contains("hunyuan_v1_dense")
@@ -317,6 +440,35 @@ enum ModelCompatibilityDiagnostics {
         return nil
     }
 
+    private static func isDFlashStyleBundle(
+        modelTypes: [String],
+        architectures: [String],
+        config: ConfigSummary?,
+        names: [String]
+    ) -> Bool {
+        let directHints =
+            modelTypes.contains(where: isDFlashToken)
+            || architectures.contains(where: isDFlashToken)
+            || names.contains(where: isDFlashToken)
+        if directHints { return true }
+
+        if config?.tokenizer?.hasDFlashReference == true { return true }
+        if config?.generation?.hasDFlashReference == true { return true }
+        return false
+    }
+
+    private static func isDFlashToken(_ value: String) -> Bool {
+        let normalized =
+            value
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        return normalized == "dflash"
+            || normalized.contains("_dflash")
+            || normalized.contains("dflash_")
+            || normalized.contains("d_flash")
+    }
+
     private static func benchmarkStatus(
         runtime: RuntimeStatus,
         localBundle: LocalBundleStatus
@@ -330,7 +482,7 @@ enum ModelCompatibilityDiagnostics {
         }
 
         switch runtime.kind {
-        case .blocked:
+        case .blocked, .partial:
             return BenchmarkStatus(
                 kind: .notApplicable,
                 title: L("Blocked"),
@@ -346,6 +498,138 @@ enum ModelCompatibilityDiagnostics {
                     )
             )
         }
+    }
+
+    private static func evidenceRows(
+        modelId: String,
+        modelName: String,
+        modelTypeHint: String?,
+        source: SourceStatus,
+        localBundle: LocalBundleStatus,
+        config: ConfigSummary?
+    ) -> [Evidence] {
+        var rows: [Evidence] = [
+            Evidence(source: "model", key: "id", value: modelId),
+            Evidence(source: "model", key: "name", value: modelName),
+            Evidence(source: "source", key: "kind", value: source.kind.rawValue),
+            Evidence(source: "bundle", key: "status", value: localBundle.kind.rawValue),
+        ]
+        if let path = localBundle.path {
+            rows.append(Evidence(source: "bundle", key: "path", value: path))
+        }
+        if let modelTypeHint {
+            rows.append(Evidence(source: "catalog", key: "model_type", value: modelTypeHint))
+        }
+        guard let config else { return rows }
+
+        appendOptional(&rows, source: "config.json", key: "model_type", value: config.modelType)
+        appendOptional(
+            &rows,
+            source: "config.json",
+            key: "text_config.model_type",
+            value: config.textModelType
+        )
+        if !config.architectures.isEmpty {
+            rows.append(
+                Evidence(
+                    source: "config.json",
+                    key: "architectures",
+                    value: config.architectures.joined(separator: ", ")
+                )
+            )
+        }
+        rows.append(
+            Evidence(
+                source: "config.json",
+                key: "vision_config",
+                value: config.hasVisionConfig ? "present" : "absent"
+            )
+        )
+        rows.append(
+            Evidence(
+                source: "jang_config.json",
+                key: "file",
+                value: config.hasJANGConfig ? "present" : "absent"
+            )
+        )
+        rows.append(
+            Evidence(
+                source: "jangtq_runtime.safetensors",
+                key: "file",
+                value: config.hasJANGTQSidecar ? "present" : "absent"
+            )
+        )
+
+        if let tokenizer = config.tokenizer {
+            appendOptional(
+                &rows,
+                source: "tokenizer_config.json",
+                key: "tokenizer_class",
+                value: tokenizer.tokenizerClass
+            )
+            if let maxLength = tokenizer.modelMaxLength {
+                rows.append(
+                    Evidence(
+                        source: "tokenizer_config.json",
+                        key: "model_max_length",
+                        value: "\(maxLength)"
+                    )
+                )
+            }
+            rows.append(
+                Evidence(
+                    source: "tokenizer_config.json",
+                    key: "chat_template",
+                    value: tokenizer.chatTemplatePresent ? "present" : "absent"
+                )
+            )
+            if !tokenizer.specialTokenKeys.isEmpty {
+                rows.append(
+                    Evidence(
+                        source: "tokenizer_config.json",
+                        key: "special_tokens",
+                        value: tokenizer.specialTokenKeys.joined(separator: ", ")
+                    )
+                )
+            }
+        }
+
+        if let generation = config.generation {
+            if !generation.keys.isEmpty {
+                rows.append(
+                    Evidence(
+                        source: "generation_config.json",
+                        key: "keys",
+                        value: generation.keys.joined(separator: ", ")
+                    )
+                )
+            }
+            if let maxNewTokens = generation.maxNewTokens {
+                rows.append(
+                    Evidence(
+                        source: "generation_config.json",
+                        key: "max_new_tokens",
+                        value: "\(maxNewTokens)"
+                    )
+                )
+            }
+            if let topK = generation.topK {
+                rows.append(
+                    Evidence(source: "generation_config.json", key: "top_k", value: "\(topK)")
+                )
+            }
+        }
+        return rows
+    }
+
+    private static func appendOptional(
+        _ rows: inout [Evidence],
+        source: String,
+        key: String,
+        value: String?
+    ) {
+        guard let value else { return }
+        rows.append(Evidence(source: source, key: key, value: value))
     }
 
     private static func futureHooks(for localBundle: LocalBundleStatus) -> [FeatureHook] {
@@ -392,13 +676,74 @@ enum ModelCompatibilityDiagnostics {
             ),
             hasJANGTQSidecar: FileManager.default.fileExists(
                 atPath: bundleURL.appendingPathComponent("jangtq_runtime.safetensors").path
-            )
+            ),
+            tokenizer: readTokenizerSummary(at: bundleURL),
+            generation: readGenerationSummary(at: bundleURL)
         )
+    }
+
+    private static func readTokenizerSummary(at bundleURL: URL) -> TokenizerSummary? {
+        let url = bundleURL.appendingPathComponent("tokenizer_config.json")
+        guard let object = readJSONObject(at: url) else { return nil }
+        let specialTokenKeys = object.keys.filter { key in
+            key.hasSuffix("_token") || key.hasSuffix("_token_id")
+        }.sorted()
+        return TokenizerSummary(
+            tokenizerClass: stringValue(object["tokenizer_class"]),
+            modelMaxLength: intValue(object["model_max_length"]),
+            chatTemplatePresent: stringValue(object["chat_template"]) != nil
+                || object["chat_template"] is [Any]
+                || object["chat_template"] is [String: Any],
+            specialTokenKeys: specialTokenKeys,
+            hasDFlashReference: containsDFlashReference(object)
+        )
+    }
+
+    private static func readGenerationSummary(at bundleURL: URL) -> GenerationSummary? {
+        let url = bundleURL.appendingPathComponent("generation_config.json")
+        guard let object = readJSONObject(at: url) else { return nil }
+        return GenerationSummary(
+            keys: object.keys.sorted(),
+            maxNewTokens: intValue(object["max_new_tokens"]),
+            topK: intValue(object["top_k"]),
+            hasDFlashReference: containsDFlashReference(object)
+        )
+    }
+
+    private static func readJSONObject(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return object
     }
 
     private static func stringValue(_ value: Any?) -> String? {
         guard let value = value as? String else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let string = stringValue(value) { return Int(string) }
+        return nil
+    }
+
+    private static func containsDFlashReference(_ value: Any) -> Bool {
+        if let string = value as? String {
+            return isDFlashToken(string)
+        }
+        if let array = value as? [Any] {
+            return array.contains(where: containsDFlashReference)
+        }
+        if let object = value as? [String: Any] {
+            return object.contains { key, nested in
+                isDFlashToken(key) || containsDFlashReference(nested)
+            }
+        }
+        return false
     }
 }

--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -95,6 +95,9 @@ final class ModelDownloadService: ObservableObject {
         filePath: String? = nil
     ) -> DownloadAlertInfo {
         let lower = rawError.lowercased()
+        let isCompatibilityPreflight = lower.contains("compatibility preflight")
+            || lower.contains("unsupported local model type")
+            || lower.contains("speculative decoding")
         let title: String
         let message: String
         if lower.contains("not enough disk space") || lower.contains("no space") {
@@ -112,6 +115,9 @@ final class ModelDownloadService: ObservableObject {
             || lower.contains("network") || lower.contains("timed out")
         {
             title = "Network error"
+            message = rawError
+        } else if isCompatibilityPreflight {
+            title = "Model not runnable"
             message = rawError
         } else if lower.contains("size mismatch") {
             title = "Downloaded file corrupted"
@@ -447,6 +453,16 @@ final class ModelDownloadService: ObservableObject {
                             "Download incomplete: \(missing.count) of \(files.count) files are missing or have wrong size"
                     )
                 }
+                let compatibilityReport =
+                    isComplete
+                    ? ModelCompatibilityDiagnostics.report(
+                        modelId: model.id,
+                        modelName: model.name,
+                        modelTypeHint: model.modelType,
+                        bundleURL: model.localDirectory,
+                        externalSource: model.externalSource
+                    )
+                    : nil
                 await MainActor.run {
                     let didFinalize = self.finalizeOrchestration(
                         modelId: model.id,
@@ -456,6 +472,19 @@ final class ModelDownloadService: ObservableObject {
                         failureFilePath: missing.first
                     )
                     if didFinalize && isComplete {
+                        if let compatibilityReport {
+                            if compatibilityReport.preflight.blocksRuntimeLoad {
+                                self.downloadAlert = Self.makeAlert(
+                                    modelId: model.id,
+                                    rawError:
+                                        "Compatibility preflight: \(compatibilityReport.preflight.title). \(compatibilityReport.preflight.detail)",
+                                    stage: "compatibility-preflight"
+                                )
+                                ModelManager.invalidateLocalModelsCache()
+                                NotificationCenter.default.post(name: .localModelsChanged, object: nil)
+                                return
+                            }
+                        }
                         NotificationService.shared.postModelReady(
                             modelId: model.id,
                             modelName: model.name

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1225,6 +1225,24 @@ public actor ModelRuntime {
             "loadContainer: local directory model=\(name, privacy: .public) path=\(localURL.path, privacy: .public)"
         )
 
+        let installedModel =
+            ModelManager.findInstalledMLXModel(named: id)
+            ?? ModelManager.findInstalledMLXModel(named: name)
+        let compatibilityReport = ModelCompatibilityDiagnostics.report(
+            modelId: id,
+            modelName: name,
+            modelTypeHint: installedModel?.modelType,
+            bundleURL: localURL,
+            externalSource: installedModel?.externalSource
+        )
+        try ModelCompatibilityDiagnostics.validateLoadAllowed(
+            compatibilityReport,
+            modelName: name
+        )
+        genLog.info(
+            "loadContainer: compatibility preflight model=\(name, privacy: .public) status=\(compatibilityReport.preflight.status.rawValue, privacy: .public) reason=\(compatibilityReport.preflight.reason.rawValue, privacy: .public)"
+        )
+
         let probe = MLXModel(id: id, name: name, description: "", downloadURL: "")
         let completeVerified = await ModelDownloadService.ensureComplete(for: probe, directory: localURL)
         if !completeVerified {

--- a/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelCompatibilityDiagnosticsTests.swift
@@ -19,12 +19,24 @@ struct ModelCompatibilityDiagnosticsTests {
     private func writeBundle(
         at dir: URL,
         config: String = #"{"model_type":"qwen3"}"#,
+        tokenizerConfig: String? = nil,
+        generationConfig: String? = nil,
         tokenizer: Bool = true,
         weights: Bool = true
     ) {
         let fm = FileManager.default
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
         try? Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        if let tokenizerConfig {
+            try? Data(tokenizerConfig.utf8).write(
+                to: dir.appendingPathComponent("tokenizer_config.json")
+            )
+        }
+        if let generationConfig {
+            try? Data(generationConfig.utf8).write(
+                to: dir.appendingPathComponent("generation_config.json")
+            )
+        }
         if tokenizer {
             try? Data("{}".utf8).write(to: dir.appendingPathComponent("tokenizer.json"))
         }
@@ -48,6 +60,8 @@ struct ModelCompatibilityDiagnosticsTests {
 
         #expect(report.source.kind == .external)
         #expect(report.localBundle.kind == .available)
+        #expect(report.preflight.status == .unproven)
+        #expect(report.preflight.blocksRuntimeLoad == false)
         #expect(report.runtime.reason == .externalBundleUnproven)
         #expect(report.benchmark.kind == .missingProof)
         #expect(report.featureHooks.map(\.code) == [.dflashSpeculativeDecoding, .tensorParallelism])
@@ -94,6 +108,37 @@ struct ModelCompatibilityDiagnosticsTests {
         #expect(report.runtime.reason == .externalBundleUnproven)
     }
 
+    @Test func supportedLocalBundle_reportsSupportedPreflightWithEvidence() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"qwen3","architectures":["Qwen3ForCausalLM"]}"#,
+            tokenizerConfig:
+                #"{"tokenizer_class":"Qwen2Tokenizer","model_max_length":32768,"chat_template":"{{ messages }}","eos_token":"<|end|>"}"#,
+            generationConfig: #"{"top_k":20,"max_new_tokens":4096}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/qwen",
+            modelName: "qwen",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.preflight.status == .supported)
+        #expect(report.preflight.reason == .localBundleReady)
+        #expect(report.preflight.blocksRuntimeLoad == false)
+        #expect(report.evidence.contains {
+            $0.source == "tokenizer_config.json" && $0.key == "chat_template"
+                && $0.value == "present"
+        })
+        #expect(report.evidence.contains {
+            $0.source == "generation_config.json" && $0.key == "top_k" && $0.value == "20"
+        })
+    }
+
     @Test func hunyuanDenseConfig_reportsUnsupportedFamily() {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -113,6 +158,8 @@ struct ModelCompatibilityDiagnosticsTests {
 
         #expect(report.runtime.kind == .blocked)
         #expect(report.runtime.reason == .unsupportedHunyuanDense)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
         #expect(report.benchmark.kind == .notApplicable)
     }
 
@@ -134,6 +181,7 @@ struct ModelCompatibilityDiagnosticsTests {
 
         #expect(report.runtime.kind == .blocked)
         #expect(report.runtime.reason == .unsupportedHunyuanDense)
+        #expect(report.preflight.status == .unsupported)
     }
 
     @Test func longCatConfig_reportsUnsupportedFamily() {
@@ -154,6 +202,99 @@ struct ModelCompatibilityDiagnosticsTests {
 
         #expect(report.runtime.kind == .blocked)
         #expect(report.runtime.reason == .unsupportedLongCat)
+        #expect(report.preflight.status == .unsupported)
+        #expect(report.preflight.blocksRuntimeLoad)
+    }
+
+    @Test func dflashConfig_reportsPartialAndBlocksRuntimeLoad() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config:
+                #"{"model_type":"dflash","architectures":["DFlashForCausalLM"]}"#,
+            tokenizerConfig: #"{"tokenizer_class":"DFlashTokenizer","chat_template":"{{ messages }}"}"#,
+            generationConfig:
+                #"{"speculative_decoding":{"method":"dflash","draft_model":"org/draft"},"max_new_tokens":512}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/dflash-target",
+            modelName: "DFlash Target",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .partial)
+        #expect(report.runtime.reason == .partialDFlashSpeculativeDecoding)
+        #expect(report.preflight.status == .partial)
+        #expect(report.preflight.blocksRuntimeLoad)
+        #expect(report.featureHooks.isEmpty)
+        #expect(report.evidence.contains {
+            $0.source == "generation_config.json" && $0.key == "keys"
+                && $0.value.contains("speculative_decoding")
+        })
+    }
+
+    @Test func dflashGenerationConfigReference_reportsPartialEvenWhenModelTypeIsGeneric() {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        writeBundle(
+            at: root,
+            config: #"{"model_type":"qwen3","architectures":["Qwen3ForCausalLM"]}"#,
+            generationConfig: #"{"draft":{"method":"dflash","max_draft_tokens":4}}"#
+        )
+
+        let report = ModelCompatibilityDiagnostics.report(
+            modelId: "org/speculative",
+            modelName: "Speculative",
+            modelTypeHint: nil,
+            bundleURL: root,
+            externalSource: nil
+        )
+
+        #expect(report.runtime.kind == .partial)
+        #expect(report.runtime.reason == .partialDFlashSpeculativeDecoding)
+    }
+
+    @Test func validateLoadAllowedThrowsForPartialAndUnsupportedReports() {
+        let partialRoot = makeTempDir()
+        let unsupportedRoot = makeTempDir()
+        defer {
+            try? FileManager.default.removeItem(at: partialRoot)
+            try? FileManager.default.removeItem(at: unsupportedRoot)
+        }
+        writeBundle(
+            at: partialRoot,
+            config: #"{"model_type":"dflash","architectures":["DFlashForCausalLM"]}"#
+        )
+        writeBundle(
+            at: unsupportedRoot,
+            config: #"{"model_type":"longcat_next"}"#
+        )
+
+        let partial = ModelCompatibilityDiagnostics.report(
+            modelId: "org/dflash",
+            modelName: "DFlash",
+            modelTypeHint: nil,
+            bundleURL: partialRoot,
+            externalSource: nil
+        )
+        let unsupported = ModelCompatibilityDiagnostics.report(
+            modelId: "org/longcat",
+            modelName: "LongCat",
+            modelTypeHint: nil,
+            bundleURL: unsupportedRoot,
+            externalSource: nil
+        )
+
+        #expect(throws: ModelCompatibilityDiagnostics.PreflightError.self) {
+            try ModelCompatibilityDiagnostics.validateLoadAllowed(partial, modelName: "DFlash")
+        }
+        #expect(throws: ModelCompatibilityDiagnostics.PreflightError.self) {
+            try ModelCompatibilityDiagnostics.validateLoadAllowed(unsupported, modelName: "LongCat")
+        }
     }
 
     @Test func catalogEntryWithoutBundle_reportsDownloadRequired() {

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -398,10 +398,41 @@ struct ModelDetailView: View, Identifiable {
             ) {
                 DiagnosticFact(label: L("Source"), value: report.source.title)
                 DiagnosticFact(label: L("Bundle"), value: report.localBundle.title)
+                DiagnosticFact(
+                    label: L("Preflight"),
+                    value: report.preflight.status.rawValue.capitalized
+                )
                 if let modelType = report.localBundle.config?.displayModelType {
                     DiagnosticFact(label: L("Model Type"), value: modelType)
                 }
                 DiagnosticFact(label: L("Benchmark proof"), value: report.benchmark.title)
+            }
+
+            if !report.evidence.isEmpty {
+                Divider()
+                    .background(theme.cardBorder)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Evidence", bundle: .module)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(theme.tertiaryText)
+                        .textCase(.uppercase)
+
+                    ForEach(Array(report.evidence.prefix(6))) { item in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text("\(item.source).\(item.key)")
+                                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                .foregroundColor(theme.tertiaryText)
+                                .lineLimit(1)
+                            Text(item.value)
+                                .font(.system(size: 10))
+                                .foregroundColor(theme.secondaryText)
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
             }
 
             if !report.featureHooks.isEmpty {
@@ -438,7 +469,7 @@ struct ModelDetailView: View, Identifiable {
         switch kind {
         case .ready: return theme.successColor
         case .blocked: return theme.errorColor
-        case .needsDownload, .unproven: return theme.warningColor
+        case .partial, .needsDownload, .unproven: return theme.warningColor
         }
     }
 
@@ -446,6 +477,7 @@ struct ModelDetailView: View, Identifiable {
         switch kind {
         case .ready: return "checkmark.shield.fill"
         case .blocked: return "xmark.octagon.fill"
+        case .partial: return "exclamationmark.triangle.fill"
         case .needsDownload: return "arrow.down.circle.fill"
         case .unproven: return "exclamationmark.triangle.fill"
         }


### PR DESCRIPTION
## Summary
- Add a metadata-backed model compatibility preflight that classifies local bundles as supported, partial, unsupported, or unproven with evidence from config, tokenizer, and generation metadata.
- Block unsupported and partial local loads before vMLX materialization, including Hunyuan Dense, LongCat, and DFlash/speculative-decoding cases.
- Surface the preflight status and evidence in model details, and prevent “model ready” download notifications for bundles that are not runnable.

## Validation
- OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-a8 swift test --package-path Packages/OsaurusCore --filter ModelCompatibilityDiagnosticsTests
- git diff --check
- scripts/i18n/check.sh
