### PR TITLE
Add app data location resolver and legacy fallback audit

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsDev.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsDev.swift
@@ -14,8 +14,8 @@
 import Foundation
 import OsaurusRepository
 
-private nonisolated(unsafe) var devProxyConfigFile: URL?
-private nonisolated(unsafe) var signalSource: DispatchSourceSignal?
+nonisolated(unsafe) private var devProxyConfigFile: URL?
+nonisolated(unsafe) private var signalSource: DispatchSourceSignal?
 
 public struct ToolsDev {
 
@@ -194,7 +194,7 @@ public struct ToolsDev {
                     at: pluginDir,
                     includingPropertiesForKeys: nil,
                     options: .skipsHiddenFiles
-                ).filter(\.hasDirectoryPath).first
+                ).first { $0.hasDirectoryPath }
             }
             guard let dir = versionDir else { return nil }
 
@@ -370,8 +370,7 @@ public struct ToolsDev {
 
         for case let url as URL in enumerator {
             if let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
-                let mtime = values.contentModificationDate, mtime > latest
-            {
+                let mtime = values.contentModificationDate, mtime > latest {
                 latest = mtime
             }
         }
@@ -385,8 +384,7 @@ public struct ToolsDev {
         for name in companions {
             let url = cwd.appendingPathComponent(name)
             if let values = try? url.resourceValues(forKeys: [.contentModificationDateKey]),
-                let mtime = values.contentModificationDate, mtime > latest
-            {
+                let mtime = values.contentModificationDate, mtime > latest {
                 latest = mtime
             }
         }
@@ -408,16 +406,23 @@ public struct ToolsDev {
 
     private static func setupWebProxy(pluginId: String, webProxyURL: String?) {
         guard let proxy = webProxyURL else { return }
-        let configDir = ToolsPaths.root().appendingPathComponent("config", isDirectory: true)
+        let configFile = devProxyConfigurationFile()
+        let configDir = configFile.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         let devConfig: [String: Any] = [
             "plugin_id": pluginId,
             "web_proxy": proxy,
         ]
         let data = try? JSONSerialization.data(withJSONObject: devConfig, options: .prettyPrinted)
-        let configFile = configDir.appendingPathComponent("dev-proxy.json")
         try? data?.write(to: configFile)
         devProxyConfigFile = configFile
+    }
+
+    static func devProxyConfigurationFile(
+        locations: AppDataLocationResolver.ResolvedLocations =
+            AppDataLocationResolver.resolve(overrideRoot: ToolsPaths.overrideRoot)
+    ) -> URL {
+        locations.configRoot.appendingPathComponent("dev-proxy.json")
     }
 
     private static func setupSignalHandler() {

--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/Configuration.swift
@@ -9,16 +9,9 @@ import Foundation
 import OsaurusRepository
 
 public struct Configuration {
-    /// Root data directory for Osaurus (`~/.osaurus/`)
+    /// Resolved data directory for Osaurus.
     public static func root() -> URL {
         ToolsPaths.root()
-    }
-
-    /// The previous root directory before migration to `~/.osaurus/`.
-    private static func legacyRoot() -> URL {
-        let fm = FileManager.default
-        let supportDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return supportDir.appendingPathComponent("com.dinoki.osaurus", isDirectory: true)
     }
 
     public static func resolveConfiguredPort() -> Int? {
@@ -27,16 +20,15 @@ public struct Configuration {
         }
 
         let fm = FileManager.default
-        let root = root()
-        let oldRoot = legacyRoot()
+        let locations = AppDataLocationResolver.resolve(overrideRoot: ToolsPaths.overrideRoot)
 
-        // Check ~/.osaurus/config/server.json first, then legacy Application Support locations
-        let candidates: [URL] = [
-            root.appendingPathComponent("config/server.json"),
-            root.appendingPathComponent("ServerConfiguration.json"),
-            oldRoot.appendingPathComponent("config/server.json"),
-            oldRoot.appendingPathComponent("ServerConfiguration.json"),
-        ]
+        let configCandidates = locations.configSearchDirectories.map {
+            $0.appendingPathComponent("server.json")
+        }
+        let rootCandidates = locations.dataSearchRoots.map {
+            $0.appendingPathComponent("ServerConfiguration.json")
+        }
+        let candidates = (configCandidates + rootCandidates).deduplicatedByPath()
 
         guard let configURL = candidates.first(where: { fm.fileExists(atPath: $0.path) }) else {
             return nil
@@ -54,5 +46,18 @@ public struct Configuration {
 
     public static func toolsRootDirectory() -> URL {
         ToolsPaths.toolsRootDirectory()
+    }
+}
+
+private extension Array where Element == URL {
+    func deduplicatedByPath() -> [URL] {
+        var seen: Set<String> = []
+        var result: [URL] = []
+        for url in self {
+            let path = url.standardizedFileURL.path
+            guard seen.insert(path).inserted else { continue }
+            result.append(url)
+        }
+        return result
     }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/OsaurusCLITests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/OsaurusCLITests.swift
@@ -14,4 +14,32 @@ final class OsaurusCLITests: XCTestCase {
         let root = Configuration.toolsRootDirectory()
         XCTAssertFalse(root.path.isEmpty)
     }
+
+    func testResolveConfiguredPortReadsResolvedConfigRoot() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(
+            "osaurus-cli-config-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let config = root.appendingPathComponent("config", isDirectory: true)
+        try fm.createDirectory(at: config, withIntermediateDirectories: true)
+        try #"{"port":2468}"#.write(
+            to: config.appendingPathComponent("server.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let previous = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"]
+        setenv("OSAURUS_TEST_ROOT", root.path, 1)
+        defer {
+            if let previous {
+                setenv("OSAURUS_TEST_ROOT", previous, 1)
+            } else {
+                unsetenv("OSAURUS_TEST_ROOT")
+            }
+            try? fm.removeItem(at: root)
+        }
+
+        XCTAssertEqual(Configuration.resolveConfiguredPort(), 2468)
+    }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsDevTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsDevTests.swift
@@ -45,4 +45,41 @@ final class ToolsDevTests: XCTestCase {
                 .appendingPathComponent("dev-proxy.json")
         )
     }
+
+    func testDevProxyConfigurationFileFollowsLegacyDataRootConfigFamily() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("osaurus-tools-dev-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let dirs = AppDataLocationResolver.PlatformDirectories(
+            homeDirectory: root.appendingPathComponent("home", isDirectory: true),
+            applicationSupportDirectory:
+                root.appendingPathComponent("Library/Application Support", isDirectory: true),
+            cachesDirectory: root.appendingPathComponent("Library/Caches", isDirectory: true),
+            xdgDataHome: root.appendingPathComponent("home/.local/share", isDirectory: true),
+            xdgConfigHome: root.appendingPathComponent("home/.config", isDirectory: true),
+            xdgCacheHome: root.appendingPathComponent("home/.cache", isDirectory: true)
+        )
+        let legacy = dirs.homeDirectory.appendingPathComponent(".osaurus", isDirectory: true)
+        let standardConfig = dirs.applicationSupportDirectory!
+            .appendingPathComponent("Osaurus", isDirectory: true)
+            .appendingPathComponent("config", isDirectory: true)
+        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
+        try fm.createDirectory(at: standardConfig, withIntermediateDirectories: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+        let file = ToolsDev.devProxyConfigurationFile(locations: locations)
+
+        XCTAssertEqual(
+            file,
+            legacy
+                .appendingPathComponent("config", isDirectory: true)
+                .appendingPathComponent("dev-proxy.json")
+        )
+    }
 }

--- a/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsDevTests.swift
+++ b/Packages/OsaurusCLI/Tests/OsaurusCLITests/ToolsDevTests.swift
@@ -1,0 +1,48 @@
+//
+//  ToolsDevTests.swift
+//  osaurus
+//
+//  Tests for plugin development-mode helpers.
+//
+
+import OsaurusRepository
+import XCTest
+
+@testable import OsaurusCLICore
+
+final class ToolsDevTests: XCTestCase {
+    func testDevProxyConfigurationFileUsesResolvedConfigRoot() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-tools-dev-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let dirs = AppDataLocationResolver.PlatformDirectories(
+            homeDirectory: root.appendingPathComponent("home", isDirectory: true),
+            applicationSupportDirectory: nil,
+            cachesDirectory: nil,
+            xdgDataHome: root.appendingPathComponent("xdg-data", isDirectory: true),
+            xdgConfigHome: root.appendingPathComponent("xdg-config", isDirectory: true),
+            xdgCacheHome: root.appendingPathComponent("xdg-cache", isDirectory: true)
+        )
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            platformDirectories: dirs
+        )
+
+        let file = ToolsDev.devProxyConfigurationFile(locations: locations)
+
+        XCTAssertEqual(
+            file,
+            dirs.xdgConfigHome
+                .appendingPathComponent("osaurus", isDirectory: true)
+                .appendingPathComponent("dev-proxy.json")
+        )
+        XCTAssertNotEqual(
+            file,
+            dirs.xdgDataHome
+                .appendingPathComponent("osaurus", isDirectory: true)
+                .appendingPathComponent("config", isDirectory: true)
+                .appendingPathComponent("dev-proxy.json")
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -44,6 +44,12 @@ struct RuntimePolicySourceTests {
         return String(block[revisionRange])
     }
 
+    private static func sourceMatches(_ pattern: String, in source: String) throws -> Bool {
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(source.startIndex ..< source.endIndex, in: source)
+        return regex.firstMatch(in: source, range: range) != nil
+    }
+
     private static func swiftFiles(under relativePath: String) throws -> [URL] {
         let root = packageRoot().appendingPathComponent(relativePath)
         guard
@@ -2113,15 +2119,35 @@ struct RuntimePolicySourceTests {
         #expect(standards.contains("\"candidate_locations\""))
         #expect(standards.contains("\"standard_cache_root\""))
         #expect(standards.contains("\"spec_compliant\""))
-        #expect(
-            standards.contains(
-                "legacyApplicationSupportFolderName =\n        AppDataLocationResolver.legacyApplicationSupportFolderName"
-            )
+        let legacySupportConstantUsesResolver = try Self.sourceMatches(
+            #"legacyApplicationSupportFolderName\s*=\s*AppDataLocationResolver\.legacyApplicationSupportFolderName"#,
+            in: standards
         )
+        #expect(legacySupportConstantUsesResolver)
         #expect(!standards.contains("copyItem"))
         #expect(!standards.contains("moveItem"))
         #expect(!standards.contains("removeItem"))
         #expect(!standards.contains("createDirectory"))
+    }
+
+    @Test("dev proxy reader and writer use the resolved config root")
+    func devProxyReaderAndWriterUseResolvedConfigRoot() throws {
+        let httpHandler = try Self.source("Networking/HTTPHandler.swift")
+        let toolsDev = try Self.source(
+            "../OsaurusCLI/Sources/OsaurusCLICore/Commands/Tools/ToolsDev.swift"
+        )
+
+        let reader = try Self.functionBody(
+            "private static func loadDevProxyURL(for pluginId: String)",
+            in: httpHandler
+        )
+        #expect(
+            reader.contains("OsaurusPaths.config().appendingPathComponent(\"dev-proxy.json\")")
+        )
+        #expect(!reader.contains("OsaurusPaths.root().appendingPathComponent(\"config\""))
+
+        let writer = try Self.functionBody("static func devProxyConfigurationFile(", in: toolsDev)
+        #expect(writer.contains("locations.configRoot.appendingPathComponent(\"dev-proxy.json\")"))
     }
 
     @Test("ModelRuntime does not repair reasoning parser output")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2103,11 +2103,19 @@ struct RuntimePolicySourceTests {
         // and report, never migrate. Pin both the stable reason codes and the
         // absence of any filesystem mutation in the audit module.
         #expect(standards.contains("case homeDotDirectory = \"home_dot_directory\""))
+        #expect(standards.contains("case xdgBaseDirectory = \"xdg_base_directory\""))
         #expect(standards.contains("\"root_home_dot_directory_not_apple_spec\""))
+        #expect(standards.contains("\"data_root_legacy_application_support_fallback\""))
         #expect(standards.contains("\"legacy_application_support_root_present\""))
-        #expect(standards.contains("\"migration_decision_pending\""))
+        #expect(standards.contains("\"migration_required_manual\""))
+        #expect(standards.contains("\"candidate_locations\""))
+        #expect(standards.contains("\"standard_cache_root\""))
         #expect(standards.contains("\"spec_compliant\""))
-        #expect(standards.contains("legacyApplicationSupportFolderName = \"com.dinoki.osaurus\""))
+        #expect(
+            standards.contains(
+                "legacyApplicationSupportFolderName =\n        AppDataLocationResolver.legacyApplicationSupportFolderName"
+            )
+        )
         #expect(!standards.contains("copyItem"))
         #expect(!standards.contains("moveItem"))
         #expect(!standards.contains("removeItem"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1778,6 +1778,7 @@ struct RuntimePolicySourceTests {
     @Test("live proof keychain-disabled mode keeps app startup off user Keychain")
     func liveProofKeychainDisabledModeKeepsStartupOffUserKeychain() throws {
         let paths = try Self.source("Utils/OsaurusPaths.swift")
+        let appDataResolver = try Self.source("../OsaurusRepository/AppDataLocationResolver.swift")
         let storage = try Self.source("Identity/StorageKeyManager.swift")
         let appDelegate = try Self.source("AppDelegate.swift")
         let keychainHelper = try Self.source("Services/Keychain/KeychainQueryHelpers.swift")
@@ -1786,7 +1787,8 @@ struct RuntimePolicySourceTests {
         let remoteProvider = try Self.source("Services/Provider/RemoteProviderKeychain.swift")
         let mcpProvider = try Self.source("Services/MCP/MCPProviderKeychain.swift")
 
-        #expect(paths.contains("OSAURUS_TEST_ROOT"))
+        #expect(paths.contains("AppDataLocationResolver.testRootEnvironmentVariable"))
+        #expect(appDataResolver.contains("OSAURUS_TEST_ROOT"))
         #expect(storage.contains("OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS"))
         #expect(storage.contains("generateInMemoryKey()"))
         #expect(storage.contains("if Self.disablesKeychainForProcess"))

--- a/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
@@ -20,7 +20,7 @@ struct StorageLocationStandardsTests {
     private func makeInputs(
         dataSource: AppDataLocationResolver.LocationSource = .standard,
         configSource: AppDataLocationResolver.LocationSource? = nil,
-        cacheSource: AppDataLocationResolver.LocationSource = .standard,
+        cacheSource: AppDataLocationResolver.LocationSource? = nil,
         supportPath: String? = "/Users/sam/Library/Application Support",
         standardDataPresent: Bool = false,
         standardConfigPresent: Bool = false,
@@ -43,6 +43,7 @@ struct StorageLocationStandardsTests {
         let legacyApplicationSupport = supportPath.map { "\($0)/com.dinoki.osaurus" }
 
         let resolvedConfigSource = configSource ?? dataSource
+        let resolvedCacheSource = cacheSource ?? dataSource
         let data = AppDataLocationResolver.ResolvedLocation(
             kind: .data,
             source: dataSource,
@@ -58,8 +59,8 @@ struct StorageLocationStandardsTests {
         )
         let cache = AppDataLocationResolver.ResolvedLocation(
             kind: .cache,
-            source: cacheSource,
-            url: url(pathForCache(source: cacheSource, standard: standardCache,
+            source: resolvedCacheSource,
+            url: url(pathForCache(source: resolvedCacheSource, standard: standardCache,
                                   legacyHome: legacyHome,
                                   legacyApplicationSupport: legacyApplicationSupport))
         )
@@ -155,6 +156,7 @@ struct StorageLocationStandardsTests {
             report.reasonCodes == [
                 "root_home_dot_directory_not_apple_spec",
                 "config_root_legacy_fallback",
+                "cache_root_legacy_fallback",
                 "migration_required_manual",
                 "models_root_home_visible_by_design",
             ]
@@ -181,6 +183,7 @@ struct StorageLocationStandardsTests {
                 "root_home_dot_directory_not_apple_spec",
                 "standard_location_available_legacy_active",
                 "config_root_legacy_fallback",
+                "cache_root_legacy_fallback",
                 "migration_required_manual",
             ]
         )
@@ -205,6 +208,7 @@ struct StorageLocationStandardsTests {
                 "data_root_legacy_application_support_fallback",
                 "legacy_application_support_root_present",
                 "config_root_legacy_fallback",
+                "cache_root_legacy_fallback",
                 "migration_required_manual",
             ]
         )
@@ -335,7 +339,7 @@ struct StorageLocationStandardsTests {
         #expect(json["classification"] as? String == "home_dot_directory")
         #expect(json["data_source"] as? String == "legacy_home_dot_directory")
         #expect(json["config_source"] as? String == "legacy_home_dot_directory")
-        #expect(json["cache_source"] as? String == "standard")
+        #expect(json["cache_source"] as? String == "legacy_home_dot_directory")
         #expect(json["migration_required"] as? Bool == true)
 
         let candidates = try #require(json["candidate_locations"] as? [[String: Any]])
@@ -369,7 +373,8 @@ struct StorageLocationStandardsTests {
         #expect(
             report.summary
                 == "data=legacy_home_dot_directory; config=legacy_home_dot_directory; "
-                + "cache=standard; needs-attention; migration=required; models_root=home_visible"
+                + "cache=legacy_home_dot_directory; needs-attention; migration=required; "
+                + "models_root=home_visible"
         )
         #expect(!report.summary.contains("\n"))
     }

--- a/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/StorageLocationStandardsTests.swift
@@ -1,129 +1,233 @@
 //
 //  StorageLocationStandardsTests.swift
 //
-//  Pin the #1422 storage-location audit: classification of the active
-//  app-data root, the legacy Application Support root, the models root, and
-//  the stable reason-code / JSON diagnostic surface. The classifier is a
-//  pure function over `Inputs`, so every case here is hermetic — no real
-//  home directory, no filesystem mutation, no `OsaurusPaths` global state.
+//  Pins the #1422 storage-location audit: data/config/cache resolution,
+//  compatibility fallback, stable reason codes, and JSON diagnostics.
 //
 
 import Foundation
+import OsaurusRepository
 import Testing
 
 @testable import OsaurusCore
 
 @Suite
 struct StorageLocationStandardsTests {
+    private let home = "/Users/sam"
+    private let support = "/Users/sam/Library/Application Support"
+    private let caches = "/Users/sam/Library/Caches"
 
     private func makeInputs(
-        activeRootPath: String = "/Users/sam/.osaurus",
-        rootSource: StorageLocationStandards.RootSource = .standard,
-        home: String = "/Users/sam",
-        support: String? = "/Users/sam/Library/Application Support",
-        legacyPresent: Bool = false,
-        legacyMergeMarked: Bool = false,
-        candidatePresent: Bool = false,
+        dataSource: AppDataLocationResolver.LocationSource = .standard,
+        configSource: AppDataLocationResolver.LocationSource? = nil,
+        cacheSource: AppDataLocationResolver.LocationSource = .standard,
+        supportPath: String? = "/Users/sam/Library/Application Support",
+        standardDataPresent: Bool = false,
+        standardConfigPresent: Bool = false,
+        standardCachePresent: Bool = false,
+        legacyHomePresent: Bool = false,
+        legacyHomeConfigPresent: Bool = false,
+        legacyHomeCachePresent: Bool = false,
+        legacyApplicationSupportPresent: Bool = false,
+        legacyApplicationSupportConfigPresent: Bool = false,
+        legacyApplicationSupportCachePresent: Bool = false,
         modelsRootPath: String = "/Users/sam/MLXModels"
     ) -> StorageLocationStandards.Inputs {
-        let markerPath = "\(activeRootPath)/\(OsaurusPaths.legacyApplicationSupportMergeMarkerName)"
+        let standardData =
+            supportPath.map { "\($0)/Osaurus" } ?? "\(home)/.local/share/osaurus"
+        let standardConfig =
+            supportPath.map { "\($0)/Osaurus/config" } ?? "\(home)/.config/osaurus"
+        let standardCache =
+            supportPath.map { _ in "\(caches)/Osaurus" } ?? "\(home)/.cache/osaurus"
+        let legacyHome = "\(home)/.osaurus"
+        let legacyApplicationSupport = supportPath.map { "\($0)/com.dinoki.osaurus" }
+
+        let resolvedConfigSource = configSource ?? dataSource
+        let data = AppDataLocationResolver.ResolvedLocation(
+            kind: .data,
+            source: dataSource,
+            url: url(pathForData(source: dataSource, standard: standardData, legacyHome: legacyHome,
+                                 legacyApplicationSupport: legacyApplicationSupport))
+        )
+        let config = AppDataLocationResolver.ResolvedLocation(
+            kind: .config,
+            source: resolvedConfigSource,
+            url: url(pathForConfig(source: resolvedConfigSource, standard: standardConfig,
+                                   legacyHome: legacyHome,
+                                   legacyApplicationSupport: legacyApplicationSupport))
+        )
+        let cache = AppDataLocationResolver.ResolvedLocation(
+            kind: .cache,
+            source: cacheSource,
+            url: url(pathForCache(source: cacheSource, standard: standardCache,
+                                  legacyHome: legacyHome,
+                                  legacyApplicationSupport: legacyApplicationSupport))
+        )
+
+        let candidates = makeCandidates(
+            selected: [data, config, cache],
+            standardData: standardData,
+            standardConfig: standardConfig,
+            standardCache: standardCache,
+            legacyHome: legacyHome,
+            legacyApplicationSupport: legacyApplicationSupport,
+            standardDataPresent: standardDataPresent,
+            standardConfigPresent: standardConfigPresent,
+            standardCachePresent: standardCachePresent,
+            legacyHomePresent: legacyHomePresent,
+            legacyHomeConfigPresent: legacyHomeConfigPresent,
+            legacyHomeCachePresent: legacyHomeCachePresent,
+            legacyApplicationSupportPresent: legacyApplicationSupportPresent,
+            legacyApplicationSupportConfigPresent: legacyApplicationSupportConfigPresent,
+            legacyApplicationSupportCachePresent: legacyApplicationSupportCachePresent
+        )
+        let locations = AppDataLocationResolver.ResolvedLocations(
+            data: data,
+            config: config,
+            cache: cache,
+            candidates: candidates,
+            standardDataRoot: url(standardData),
+            standardConfigRoot: url(standardConfig),
+            standardCacheRoot: url(standardCache),
+            legacyHomeRoot: url(legacyHome),
+            legacyApplicationSupportRoot: legacyApplicationSupport.map(url)
+        )
         return StorageLocationStandards.Inputs(
-            activeRootPath: activeRootPath,
-            rootSource: rootSource,
+            locations: locations,
             homeDirectoryPath: home,
-            applicationSupportPath: support,
-            legacyApplicationSupportRootPath: support.map { "\($0)/com.dinoki.osaurus" },
-            legacyApplicationSupportRootPresent: legacyPresent,
-            legacyApplicationSupportMergeMarkerPath: markerPath,
-            legacyApplicationSupportMergeMarked: legacyMergeMarked,
-            appleSpecCandidateRootPath: support.map { "\($0)/Osaurus" },
-            appleSpecCandidateRootPresent: candidatePresent,
+            applicationSupportPath: supportPath,
             modelsRootPath: modelsRootPath
         )
     }
 
     // MARK: - Root classification
 
-    @Test("Default ~/.osaurus root classifies as home dot-directory, not spec-compliant")
-    func homeDotDirectoryRoot() {
-        let report = StorageLocationStandards.audit(makeInputs())
-
-        #expect(report.classification == .homeDotDirectory)
-        #expect(!report.specCompliant)
-        #expect(
-            report.reasonCodes == [
-                "root_home_dot_directory_not_apple_spec",
-                "migration_decision_pending",
-                "models_root_home_visible_by_design",
-            ]
-        )
-        #expect(report.findings[0].severity == .warning)
-        #expect(report.findings[0].message.contains("~/Library/Application Support"))
-        #expect(report.findings[0].message.contains("~/.local/share"))
-    }
-
-    @Test("Application Support root classifies as Apple-spec compliant with no findings")
+    @Test("Standard Application Support data/config/cache locations are compliant")
     func applicationSupportRoot() {
         let report = StorageLocationStandards.audit(
             makeInputs(
-                activeRootPath: "/Users/sam/Library/Application Support/Osaurus",
+                configSource: .standard,
                 modelsRootPath: "/Users/sam/Library/Application Support/Osaurus/models"
             )
         )
 
         #expect(report.classification == .appleApplicationSupport)
         #expect(report.specCompliant)
-        #expect(report.modelsRootClassification == .applicationSupport)
-        #expect(report.findings.isEmpty)
+        #expect(report.dataSource == .standard)
+        #expect(report.configSource == .standard)
+        #expect(report.cacheSource == .standard)
         #expect(report.reasonCodes.isEmpty)
     }
 
-    @Test("Root equal to the Application Support directory itself counts as under it")
-    func rootEqualToApplicationSupport() {
-        let report = StorageLocationStandards.audit(
-            makeInputs(activeRootPath: "/Users/sam/Library/Application Support")
-        )
-
-        #expect(report.classification == .appleApplicationSupport)
-        #expect(report.specCompliant)
-    }
-
-    @Test("Dot-directory below a subfolder of home is custom, not home dot-directory")
-    func nestedDotDirectoryIsCustom() {
-        let report = StorageLocationStandards.audit(
-            makeInputs(activeRootPath: "/Users/sam/Documents/.osaurus")
-        )
-
-        #expect(report.classification == .custom)
-        #expect(!report.specCompliant)
-        #expect(report.reasonCodes.contains("root_custom_location"))
-    }
-
-    @Test("External-volume root is custom and models on the same volume are external")
-    func externalVolumeRoot() {
+    @Test("XDG fallback classifies as spec-compliant when Apple directories are unavailable")
+    func xdgFallbackRoot() {
         let report = StorageLocationStandards.audit(
             makeInputs(
-                activeRootPath: "/Volumes/External/osaurus-data",
+                configSource: .standard,
+                supportPath: nil,
                 modelsRootPath: "/Volumes/External/MLXModels"
             )
         )
 
-        #expect(report.classification == .custom)
-        #expect(report.modelsRootClassification == .externalOrCustom)
-        #expect(report.reasonCodes == ["root_custom_location"])
+        #expect(report.classification == .xdgBaseDirectory)
+        #expect(report.specCompliant)
+        #expect(report.appleSpecCandidateRootPath == nil)
+        #expect(report.standardDataRootPath == "/Users/sam/.local/share/osaurus")
+        #expect(report.standardConfigRootPath == "/Users/sam/.config/osaurus")
+        #expect(report.standardCacheRootPath == "/Users/sam/.cache/osaurus")
     }
 
-    @Test("Trailing slashes and dot segments normalize before comparison")
-    func pathNormalization() {
+    @Test("Existing ~/.osaurus root remains active and reports manual migration")
+    func homeDotDirectoryRoot() {
         let report = StorageLocationStandards.audit(
             makeInputs(
-                activeRootPath: "/Users/sam/Library/Application Support/./Osaurus/",
-                modelsRootPath: "/Users/sam/Library/Application Support/Osaurus/models"
+                dataSource: .legacyHomeDotDirectory,
+                configSource: .legacyHomeDotDirectory,
+                legacyHomePresent: true,
+                legacyHomeConfigPresent: true
+            )
+        )
+
+        #expect(report.classification == .homeDotDirectory)
+        #expect(!report.specCompliant)
+        #expect(report.migrationRequired)
+        #expect(
+            report.reasonCodes == [
+                "root_home_dot_directory_not_apple_spec",
+                "config_root_legacy_fallback",
+                "migration_required_manual",
+                "models_root_home_visible_by_design",
+            ]
+        )
+        #expect(report.findings[0].message.contains("No data is moved automatically"))
+    }
+
+    @Test("Standard candidate present does not override active legacy data")
+    func standardCandidatePresentLegacyActive() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                dataSource: .legacyHomeDotDirectory,
+                configSource: .legacyHomeDotDirectory,
+                standardDataPresent: true,
+                legacyHomePresent: true,
+                legacyHomeConfigPresent: true,
+                modelsRootPath: "/Volumes/External/MLXModels"
+            )
+        )
+
+        #expect(report.dataSource == .legacyHomeDotDirectory)
+        #expect(
+            report.reasonCodes == [
+                "root_home_dot_directory_not_apple_spec",
+                "standard_location_available_legacy_active",
+                "config_root_legacy_fallback",
+                "migration_required_manual",
+            ]
+        )
+    }
+
+    @Test("Retired Application Support root is reported as a legacy fallback")
+    func legacyApplicationSupportFallback() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                dataSource: .legacyApplicationSupport,
+                configSource: .legacyApplicationSupport,
+                legacyApplicationSupportPresent: true,
+                legacyApplicationSupportConfigPresent: true,
+                modelsRootPath: "/Volumes/External/MLXModels"
+            )
+        )
+
+        #expect(report.classification == .legacyApplicationSupport)
+        #expect(report.legacyApplicationSupportRootPresent)
+        #expect(
+            report.reasonCodes == [
+                "data_root_legacy_application_support_fallback",
+                "legacy_application_support_root_present",
+                "config_root_legacy_fallback",
+                "migration_required_manual",
+            ]
+        )
+        let legacy = report.findings.first {
+            $0.code == .legacyApplicationSupportRootPresent
+        }
+        #expect(legacy?.message.contains("does not copy, merge, or delete") == true)
+    }
+
+    @Test("Existing legacy cache fallback keeps diagnostics non-compliant")
+    func legacyCacheFallback() {
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                configSource: .standard,
+                cacheSource: .legacyHomeDotDirectory,
+                legacyHomeCachePresent: true,
+                modelsRootPath: "/Volumes/External/MLXModels"
             )
         )
 
         #expect(report.classification == .appleApplicationSupport)
-        #expect(report.specCompliant)
+        #expect(!report.specCompliant)
+        #expect(report.reasonCodes == ["cache_root_legacy_fallback", "migration_required_manual"])
     }
 
     // MARK: - Overrides
@@ -132,108 +236,31 @@ struct StorageLocationStandardsTests {
     func testOverrideClassification() {
         let report = StorageLocationStandards.audit(
             makeInputs(
-                activeRootPath: "/tmp/osaurus-test",
-                rootSource: .testOverride
+                dataSource: .testOverride,
+                configSource: .testOverride,
+                cacheSource: .testOverride,
+                modelsRootPath: "/Users/sam/MLXModels"
             )
         )
 
         #expect(report.classification == .testOverride)
         #expect(!report.specCompliant)
         #expect(report.reasonCodes == ["root_overridden_for_tests"])
-        #expect(report.findings[0].severity == .info)
     }
 
-    @Test("Environment override reports environment_override and suppresses spec assessment")
+    @Test("Environment override reports environment_override")
     func environmentOverrideClassification() {
         let report = StorageLocationStandards.audit(
             makeInputs(
-                activeRootPath: "/tmp/osaurus-test-env",
-                rootSource: .environmentOverride
+                dataSource: .environmentOverride,
+                configSource: .environmentOverride,
+                cacheSource: .environmentOverride,
+                modelsRootPath: "/Users/sam/MLXModels"
             )
         )
 
         #expect(report.classification == .environmentOverride)
         #expect(report.reasonCodes == ["root_environment_override"])
-    }
-
-    // MARK: - Legacy root
-
-    @Test("Legacy com.dinoki.osaurus root present adds a warning and the re-merge caveat")
-    func legacyRootPresent() {
-        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
-
-        #expect(report.legacyApplicationSupportRootPresent)
-        #expect(
-            report.reasonCodes == [
-                "root_home_dot_directory_not_apple_spec",
-                "legacy_application_support_root_present",
-                "migration_decision_pending",
-                "models_root_home_visible_by_design",
-            ]
-        )
-        let legacy = report.findings.first {
-            $0.code == .legacyApplicationSupportRootPresent
-        }
-        #expect(legacy?.severity == .warning)
-        #expect(legacy?.message.contains("marker") == true)
-        #expect(legacy?.message.contains("missing") == true)
-        #expect(legacy?.message.contains("com.dinoki.osaurus") == true)
-    }
-
-    @Test("Legacy root with merge marker reports as consumed, not repeatedly merged")
-    func legacyRootWithMergeMarker() {
-        let report = StorageLocationStandards.audit(
-            makeInputs(legacyPresent: true, legacyMergeMarked: true)
-        )
-
-        #expect(report.legacyApplicationSupportMergeMarked)
-        let legacy = report.findings.first {
-            $0.code == .legacyApplicationSupportRootPresent
-        }
-        #expect(legacy?.severity == .info)
-        #expect(legacy?.message.contains("will not re-merge") == true)
-    }
-
-    @Test("Legacy root present alongside a compliant root still pends the migration decision")
-    func legacyRootWithCompliantActive() {
-        let report = StorageLocationStandards.audit(
-            makeInputs(
-                activeRootPath: "/Users/sam/Library/Application Support/Osaurus",
-                legacyPresent: true,
-                modelsRootPath: "/Volumes/External/MLXModels"
-            )
-        )
-
-        #expect(report.specCompliant)
-        #expect(
-            report.reasonCodes == [
-                "legacy_application_support_root_present",
-                "migration_decision_pending",
-            ]
-        )
-    }
-
-    // MARK: - Models root
-
-    @Test("Home-visible models root is an info-level by-design finding, not a violation")
-    func modelsRootHomeVisible() {
-        let report = StorageLocationStandards.audit(makeInputs())
-        let finding = report.findings.first {
-            $0.code == .modelsRootHomeVisibleByDesign
-        }
-
-        #expect(report.modelsRootClassification == .homeVisible)
-        #expect(finding?.severity == .info)
-    }
-
-    @Test("Models finding is suppressed under test and environment overrides")
-    func modelsFindingSuppressedForOverrides() {
-        let report = StorageLocationStandards.audit(
-            makeInputs(rootSource: .testOverride)
-        )
-
-        #expect(report.modelsRootClassification == .homeVisible)
-        #expect(!report.reasonCodes.contains("models_root_home_visible_by_design"))
     }
 
     // MARK: - Diagnostic surface stability
@@ -242,11 +269,16 @@ struct StorageLocationStandardsTests {
     func reasonCodeRawValuesPinned() {
         let expected: [StorageLocationStandards.ReasonCode: String] = [
             .rootHomeDotDirectoryNotAppleSpec: "root_home_dot_directory_not_apple_spec",
+            .dataRootLegacyApplicationSupportFallback:
+                "data_root_legacy_application_support_fallback",
             .rootOverriddenForTests: "root_overridden_for_tests",
             .rootEnvironmentOverride: "root_environment_override",
             .rootCustomLocation: "root_custom_location",
+            .standardLocationAvailableLegacyActive: "standard_location_available_legacy_active",
             .legacyApplicationSupportRootPresent: "legacy_application_support_root_present",
-            .migrationDecisionPending: "migration_decision_pending",
+            .configRootLegacyFallback: "config_root_legacy_fallback",
+            .cacheRootLegacyFallback: "cache_root_legacy_fallback",
+            .migrationRequiredManual: "migration_required_manual",
             .modelsRootHomeVisibleByDesign: "models_root_home_visible_by_design",
         ]
 
@@ -256,9 +288,17 @@ struct StorageLocationStandardsTests {
         }
     }
 
-    @Test("JSON object carries the full snake_case diagnostic surface")
+    @Test("JSON object carries the snake_case diagnostic surface")
     func jsonObjectShape() throws {
-        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                dataSource: .legacyHomeDotDirectory,
+                configSource: .legacyHomeDotDirectory,
+                standardDataPresent: true,
+                legacyHomePresent: true,
+                legacyHomeConfigPresent: true
+            )
+        )
         let json = StorageLocationStandards.jsonObject(for: report)
 
         #expect(
@@ -266,12 +306,25 @@ struct StorageLocationStandardsTests {
                 "classification",
                 "spec_compliant",
                 "active_root",
+                "data_root",
+                "data_source",
+                "config_root",
+                "config_source",
+                "cache_root",
+                "cache_source",
+                "standard_data_root",
+                "standard_config_root",
+                "standard_cache_root",
                 "apple_spec_candidate_root",
                 "apple_spec_candidate_root_present",
+                "legacy_home_root",
+                "legacy_home_root_present",
                 "legacy_application_support_root",
                 "legacy_application_support_root_present",
                 "legacy_application_support_merge_marker",
                 "legacy_application_support_merge_marked",
+                "migration_required",
+                "candidate_locations",
                 "models_root",
                 "models_root_classification",
                 "reason_codes",
@@ -280,134 +333,208 @@ struct StorageLocationStandardsTests {
             ]
         )
         #expect(json["classification"] as? String == "home_dot_directory")
-        #expect(json["spec_compliant"] as? Bool == false)
-        #expect(json["legacy_application_support_root_present"] as? Bool == true)
-        #expect(json["legacy_application_support_merge_marked"] as? Bool == false)
-        #expect(json["models_root_classification"] as? String == "home_visible")
+        #expect(json["data_source"] as? String == "legacy_home_dot_directory")
+        #expect(json["config_source"] as? String == "legacy_home_dot_directory")
+        #expect(json["cache_source"] as? String == "standard")
+        #expect(json["migration_required"] as? Bool == true)
 
-        let findings = try #require(json["findings"] as? [[String: Any]])
-        #expect(findings.count == report.findings.count)
-        for entry in findings {
-            #expect(entry["code"] is String)
-            #expect(entry["severity"] is String)
-            #expect(entry["message"] is String)
-        }
-
-        // The block must serialize with the same canonical options the
-        // endpoint uses.
+        let candidates = try #require(json["candidate_locations"] as? [[String: Any]])
+        #expect(candidates.contains { $0["selected"] as? Bool == true })
+        #expect(candidates.contains { $0["source"] as? String == "standard" })
         #expect(JSONSerialization.isValidJSONObject(json))
     }
 
-    @Test("JSON object uses NSNull for absent Application Support paths")
+    @Test("JSON object uses NSNull for absent Application Support path")
     func jsonObjectNullability() {
-        let report = StorageLocationStandards.audit(makeInputs(support: nil))
+        let report = StorageLocationStandards.audit(
+            makeInputs(configSource: .standard, supportPath: nil)
+        )
         let json = StorageLocationStandards.jsonObject(for: report)
 
         #expect(json["apple_spec_candidate_root"] is NSNull)
         #expect(json["legacy_application_support_root"] is NSNull)
     }
 
-    // MARK: - Legacy Application Support merge marker
-
-    @Test("Legacy Application Support migration writes marker and skips later merges")
-    func legacyApplicationSupportMigrationIsOneShot() throws {
-        let fm = FileManager.default
-        let sandbox = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let legacy = sandbox.appendingPathComponent("Library/Application Support/com.dinoki.osaurus")
-        let active = sandbox.appendingPathComponent(".osaurus")
-        defer { try? fm.removeItem(at: sandbox) }
-
-        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
-        try "first".write(
-            to: legacy.appendingPathComponent("settings.json"),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        let first = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
-            fileManager: fm,
-            legacyRoot: legacy,
-            activeRoot: active
-        )
-        #expect(first == .copied(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
-        #expect(fm.fileExists(atPath: active.appendingPathComponent("settings.json").path))
-        #expect(
-            fm.fileExists(
-                atPath: OsaurusPaths.legacyApplicationSupportMergeMarker(for: active).path
-            )
-        )
-
-        try "second".write(
-            to: legacy.appendingPathComponent("new-after-marker.json"),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        let second = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
-            fileManager: fm,
-            legacyRoot: legacy,
-            activeRoot: active
-        )
-        #expect(second == .alreadyMarked(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
-        #expect(!fm.fileExists(atPath: active.appendingPathComponent("new-after-marker.json").path))
-    }
-
-    @Test("Legacy Application Support merge keeps newer active files before writing marker")
-    func legacyApplicationSupportMergePreservesNewerActiveFiles() throws {
-        let fm = FileManager.default
-        let sandbox = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let legacy = sandbox.appendingPathComponent("Library/Application Support/com.dinoki.osaurus")
-        let active = sandbox.appendingPathComponent(".osaurus")
-        defer { try? fm.removeItem(at: sandbox) }
-
-        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
-        try fm.createDirectory(at: active, withIntermediateDirectories: true)
-        let legacyFile = legacy.appendingPathComponent("config.json")
-        let activeFile = active.appendingPathComponent("config.json")
-        try "legacy".write(to: legacyFile, atomically: true, encoding: .utf8)
-        try "active".write(to: activeFile, atomically: true, encoding: .utf8)
-        try fm.setAttributes(
-            [.modificationDate: Date(timeIntervalSince1970: 100)],
-            ofItemAtPath: legacyFile.path
-        )
-        try fm.setAttributes(
-            [.modificationDate: Date(timeIntervalSince1970: 200)],
-            ofItemAtPath: activeFile.path
-        )
-
-        let result = OsaurusPaths.migrateLegacyApplicationSupportRootIfNeeded(
-            fileManager: fm,
-            legacyRoot: legacy,
-            activeRoot: active
-        )
-
-        #expect(result == .merged(OsaurusPaths.legacyApplicationSupportMergeMarker(for: active)))
-        #expect(try String(contentsOf: activeFile, encoding: .utf8) == "active")
-        #expect(
-            fm.fileExists(
-                atPath: OsaurusPaths.legacyApplicationSupportMergeMarker(for: active).path
-            )
-        )
-    }
-
     @Test("Summary stays one stable line")
     func summaryShape() {
-        let report = StorageLocationStandards.audit(makeInputs(legacyPresent: true))
+        let report = StorageLocationStandards.audit(
+            makeInputs(
+                dataSource: .legacyHomeDotDirectory,
+                configSource: .legacyHomeDotDirectory,
+                legacyHomePresent: true,
+                legacyHomeConfigPresent: true
+            )
+        )
 
         #expect(
             report.summary
-                == "root=home_dot_directory (non-compliant); legacy_root=present; "
-                + "models_root=home_visible"
+                == "data=legacy_home_dot_directory; config=legacy_home_dot_directory; "
+                + "cache=standard; needs-attention; migration=required; models_root=home_visible"
         )
         #expect(!report.summary.contains("\n"))
     }
 
-    @Test("Missing Application Support directory still classifies the home dot-directory")
-    func missingApplicationSupport() {
-        let report = StorageLocationStandards.audit(makeInputs(support: nil))
+    // MARK: - Helpers
 
-        #expect(report.classification == .homeDotDirectory)
-        #expect(report.appleSpecCandidateRootPath == nil)
-        #expect(!report.appleSpecCandidateRootPresent)
+    private func makeCandidates(
+        selected: [AppDataLocationResolver.ResolvedLocation],
+        standardData: String,
+        standardConfig: String,
+        standardCache: String,
+        legacyHome: String,
+        legacyApplicationSupport: String?,
+        standardDataPresent: Bool,
+        standardConfigPresent: Bool,
+        standardCachePresent: Bool,
+        legacyHomePresent: Bool,
+        legacyHomeConfigPresent: Bool,
+        legacyHomeCachePresent: Bool,
+        legacyApplicationSupportPresent: Bool,
+        legacyApplicationSupportConfigPresent: Bool,
+        legacyApplicationSupportCachePresent: Bool
+    ) -> [AppDataLocationResolver.Candidate] {
+        var candidates: [AppDataLocationResolver.Candidate] = []
+
+        func append(
+            kind: AppDataLocationResolver.LocationKind,
+            source: AppDataLocationResolver.LocationSource,
+            path: String,
+            exists: Bool
+        ) {
+            let candidateURL = url(path)
+            candidates.append(
+                AppDataLocationResolver.Candidate(
+                    kind: kind,
+                    source: source,
+                    url: candidateURL,
+                    exists: exists,
+                    isSelected: selected.contains {
+                        $0.kind == kind
+                            && $0.source == source
+                            && $0.url.standardizedFileURL.path
+                                == candidateURL.standardizedFileURL.path
+                    }
+                )
+            )
+        }
+
+        append(kind: .data, source: .standard, path: standardData, exists: standardDataPresent)
+        append(
+            kind: .data,
+            source: .legacyHomeDotDirectory,
+            path: legacyHome,
+            exists: legacyHomePresent
+        )
+        if let legacyApplicationSupport {
+            append(
+                kind: .data,
+                source: .legacyApplicationSupport,
+                path: legacyApplicationSupport,
+                exists: legacyApplicationSupportPresent
+            )
+        }
+
+        append(
+            kind: .config,
+            source: .standard,
+            path: standardConfig,
+            exists: standardConfigPresent
+        )
+        append(
+            kind: .config,
+            source: .legacyHomeDotDirectory,
+            path: "\(legacyHome)/config",
+            exists: legacyHomeConfigPresent
+        )
+        if let legacyApplicationSupport {
+            append(
+                kind: .config,
+                source: .legacyApplicationSupport,
+                path: "\(legacyApplicationSupport)/config",
+                exists: legacyApplicationSupportConfigPresent
+            )
+        }
+
+        append(kind: .cache, source: .standard, path: standardCache, exists: standardCachePresent)
+        append(
+            kind: .cache,
+            source: .legacyHomeDotDirectory,
+            path: "\(legacyHome)/cache",
+            exists: legacyHomeCachePresent
+        )
+        if let legacyApplicationSupport {
+            append(
+                kind: .cache,
+                source: .legacyApplicationSupport,
+                path: "\(legacyApplicationSupport)/cache",
+                exists: legacyApplicationSupportCachePresent
+            )
+        }
+
+        return candidates
+    }
+
+    private func pathForData(
+        source: AppDataLocationResolver.LocationSource,
+        standard: String,
+        legacyHome: String,
+        legacyApplicationSupport: String?
+    ) -> String {
+        switch source {
+        case .standard:
+            return standard
+        case .legacyHomeDotDirectory:
+            return legacyHome
+        case .legacyApplicationSupport:
+            return legacyApplicationSupport ?? standard
+        case .testOverride:
+            return "/tmp/osaurus-test-root"
+        case .environmentOverride:
+            return "/tmp/osaurus-env-root"
+        }
+    }
+
+    private func pathForConfig(
+        source: AppDataLocationResolver.LocationSource,
+        standard: String,
+        legacyHome: String,
+        legacyApplicationSupport: String?
+    ) -> String {
+        switch source {
+        case .standard:
+            return standard
+        case .legacyHomeDotDirectory:
+            return "\(legacyHome)/config"
+        case .legacyApplicationSupport:
+            return legacyApplicationSupport.map { "\($0)/config" } ?? standard
+        case .testOverride:
+            return "/tmp/osaurus-test-root/config"
+        case .environmentOverride:
+            return "/tmp/osaurus-env-root/config"
+        }
+    }
+
+    private func pathForCache(
+        source: AppDataLocationResolver.LocationSource,
+        standard: String,
+        legacyHome: String,
+        legacyApplicationSupport: String?
+    ) -> String {
+        switch source {
+        case .standard:
+            return standard
+        case .legacyHomeDotDirectory:
+            return "\(legacyHome)/cache"
+        case .legacyApplicationSupport:
+            return legacyApplicationSupport.map { "\($0)/cache" } ?? standard
+        case .testOverride:
+            return "/tmp/osaurus-test-root/cache"
+        case .environmentOverride:
+            return "/tmp/osaurus-env-root/cache"
+        }
+    }
+
+    private func url(_ path: String) -> URL {
+        URL(fileURLWithPath: path, isDirectory: true)
     }
 }

--- a/Packages/OsaurusCore/Utils/OsaurusPaths.swift
+++ b/Packages/OsaurusCore/Utils/OsaurusPaths.swift
@@ -8,6 +8,7 @@
 
 import AppKit
 import Foundation
+import OsaurusRepository
 
 /// Centralized path management for all Osaurus app data.
 /// All stores and services should use this module for path resolution.
@@ -18,45 +19,26 @@ public enum OsaurusPaths {
 
     // MARK: - Root Directory
 
-    private static let defaultRoot: URL = {
-        let fm = FileManager.default
-        let newRoot = fm.homeDirectoryForCurrentUser.appendingPathComponent(".osaurus", isDirectory: true)
-        let supportDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let oldRoot = supportDir.appendingPathComponent("com.dinoki.osaurus", isDirectory: true)
+    private static let defaultLocations = AppDataLocationResolver.resolve()
 
-        _ = migrateLegacyApplicationSupportRootIfNeeded(
-            fileManager: fm,
-            legacyRoot: oldRoot,
-            activeRoot: newRoot
-        )
-
-        return newRoot
-    }()
-
-    /// Marker written after the legacy Application Support root has been
-    /// copied/merged into `~/.osaurus`. The legacy root is intentionally never
-    /// deleted, so this marker prevents every future launch from re-merging it.
+    /// Historical marker written by older builds after copying/merging the
+    /// retired Application Support root. New path resolution is read-only, but
+    /// diagnostics still report this marker when present.
     public static let legacyApplicationSupportMergeMarkerName =
         ".legacy-application-support-merge.done"
 
-    enum LegacyApplicationSupportMigrationResult: Equatable {
-        case legacyRootAbsent
-        case alreadyMarked(URL)
-        case copied(URL)
-        case merged(URL)
+    /// The resolved root data directory for Osaurus.
+    public static func root() -> URL {
+        resolvedLocations().dataRoot
     }
 
-    /// The root data directory for Osaurus: `~/.osaurus/`
-    public static func root() -> URL {
-        if let override = overrideRoot {
-            return override
+    /// Resolved data/config/cache locations for diagnostics and callers that
+    /// need the whole location set.
+    public static func resolvedLocations() -> AppDataLocationResolver.ResolvedLocations {
+        if overrideRoot != nil || testRootEnvironmentOverridePresent() {
+            return AppDataLocationResolver.resolve(overrideRoot: overrideRoot)
         }
-        if let envRoot = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"],
-            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
-            return URL(fileURLWithPath: envRoot, isDirectory: true)
-        }
-        return defaultRoot
+        return defaultLocations
     }
 
     /// Returns the marker path for a resolved root without triggering another
@@ -65,11 +47,20 @@ public enum OsaurusPaths {
         root.appendingPathComponent(legacyApplicationSupportMergeMarkerName)
     }
 
+    private static func testRootEnvironmentOverridePresent() -> Bool {
+        guard let raw = ProcessInfo.processInfo.environment[
+            AppDataLocationResolver.testRootEnvironmentVariable
+        ] else {
+            return false
+        }
+        return !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     // MARK: - Directory Paths
 
     /// Configuration files directory
     public static func config() -> URL {
-        root().appendingPathComponent("config", isDirectory: true)
+        resolvedLocations().configRoot
     }
 
     /// Voice-related configuration directory
@@ -139,7 +130,7 @@ public enum OsaurusPaths {
 
     /// Cache directory
     public static func cache() -> URL {
-        root().appendingPathComponent("cache", isDirectory: true)
+        resolvedLocations().cacheRoot
     }
 
     /// Disk KV cache directory used by vmlx-swift's `DiskCache` (L2 tier).
@@ -172,8 +163,7 @@ public enum OsaurusPaths {
     public static func volumeFreeBytes(forPath path: String) -> Int64? {
         var legacyFree: Int64?
         if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
-            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
-        {
+            let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value {
             legacyFree = free
         }
         if let legacyFree, legacyFree > 0 {
@@ -184,8 +174,7 @@ public enum OsaurusPaths {
         var importantCapacity: Int64?
         let keys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
         if let values = try? url.resourceValues(forKeys: keys),
-            let capacity = values.volumeAvailableCapacityForImportantUsage
-        {
+            let capacity = values.volumeAvailableCapacityForImportantUsage {
             importantCapacity = capacity
         }
         return resolvedVolumeFreeBytes(
@@ -214,13 +203,11 @@ public enum OsaurusPaths {
         let url = URL(fileURLWithPath: path)
         let keys: Set<URLResourceKey> = [.volumeTotalCapacityKey]
         if let values = try? url.resourceValues(forKeys: keys),
-            let capacity = values.volumeTotalCapacity
-        {
+            let capacity = values.volumeTotalCapacity {
             return Int64(capacity)
         }
         if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path),
-            let total = (attrs[.systemSize] as? NSNumber)?.int64Value
-        {
+            let total = (attrs[.systemSize] as? NSNumber)?.int64Value {
             return total
         }
         return nil
@@ -274,7 +261,7 @@ public enum OsaurusPaths {
         root().appendingPathComponent("methods", isDirectory: true)
     }
 
-    /// On-device Osaurus Router billing ledger directory (`~/.osaurus/billing/`).
+    /// On-device Osaurus Router billing ledger directory (`<data root>/billing/`).
     public static func billing() -> URL {
         root().appendingPathComponent("billing", isDirectory: true)
     }
@@ -286,13 +273,13 @@ public enum OsaurusPaths {
 
     // MARK: - Agent DB + Self-Scheduling (Agent DB feature)
 
-    /// Per-agent feature directory: `~/.osaurus/agents/<uuid>/`.
+    /// Per-agent feature directory: `<data root>/agents/<uuid>/`.
     /// Sibling to the agent's JSON file (which lives directly under `agents()`).
     public static func agentDirectory(for id: UUID) -> URL {
         agents().appendingPathComponent(id.uuidString, isDirectory: true)
     }
 
-    /// Per-agent SQLite database file: `~/.osaurus/agents/<uuid>/db.sqlite`.
+    /// Per-agent SQLite database file: `<data root>/agents/<uuid>/db.sqlite`.
     /// Encrypted via `EncryptedSQLiteOpener` with the shared storage key.
     public static func agentDatabaseFile(for id: UUID) -> URL {
         agentDirectory(for: id).appendingPathComponent("db.sqlite")
@@ -304,20 +291,20 @@ public enum OsaurusPaths {
         agentDirectory(for: id).appendingPathComponent("schema.sql")
     }
 
-    /// Per-agent migrations directory: `~/.osaurus/agents/<uuid>/migrations/`.
+    /// Per-agent migrations directory: `<data root>/agents/<uuid>/migrations/`.
     /// Each `db.create_table`/`db.alter_table`/`db.migrate` call writes a
     /// numbered up + down SQL pair here.
     public static func agentMigrationsDirectory(for id: UUID) -> URL {
         agentDirectory(for: id).appendingPathComponent("migrations", isDirectory: true)
     }
 
-    /// Per-agent saved-views directory: `~/.osaurus/agents/<uuid>/views/`.
+    /// Per-agent saved-views directory: `<data root>/agents/<uuid>/views/`.
     /// Auto-synced with the `_views` system table for portability.
     public static func agentViewsDirectory(for id: UUID) -> URL {
         agentDirectory(for: id).appendingPathComponent("views", isDirectory: true)
     }
 
-    /// Per-agent run-trace directory: `~/.osaurus/agents/<uuid>/runs/`.
+    /// Per-agent run-trace directory: `<data root>/agents/<uuid>/runs/`.
     /// One JSON file per run with the full prompt, tool calls, and output.
     public static func agentRunsDirectory(for id: UUID) -> URL {
         agentDirectory(for: id).appendingPathComponent("runs", isDirectory: true)
@@ -329,42 +316,42 @@ public enum OsaurusPaths {
     }
 
     /// Host-side record of which sandbox packages have been installed for
-    /// an agent: `~/.osaurus/agents/<uuid>/installed-packages.json`. Seeded
+    /// an agent: `<data root>/agents/<uuid>/installed-packages.json`. Seeded
     /// by `SandboxAgentProvisioner` (lazy reconcile) and appended to by
     /// `sandbox_install`; surfaced as a compact line in the system prompt.
     public static func agentPackageManifestFile(for id: UUID) -> URL {
         agentDirectory(for: id).appendingPathComponent("installed-packages.json")
     }
 
-    /// Cross-agent scheduler database: `~/.osaurus/scheduler.sqlite`.
+    /// Cross-agent scheduler database: `<data root>/scheduler.sqlite`.
     /// Owns `agent_next_run`, `agent_runs`, `agent_pause`. Encrypted.
     public static func schedulerDatabaseFile() -> URL {
         root().appendingPathComponent("scheduler.sqlite")
     }
 
-    /// Plugin binaries directory (`~/.osaurus/Tools/`)
+    /// Plugin binaries directory (`<data root>/Tools/`)
     public static func tools() -> URL {
         root().appendingPathComponent("Tools", isDirectory: true)
     }
 
-    /// Plugin specifications directory (`~/.osaurus/PluginSpecs/`)
+    /// Plugin specifications directory (`<data root>/PluginSpecs/`)
     public static func toolSpecs() -> URL {
         root().appendingPathComponent("PluginSpecs", isDirectory: true)
     }
 
-    /// Central sandbox plugin library (`~/.osaurus/sandbox-plugins/`)
+    /// Central sandbox plugin library (`<data root>/sandbox-plugins/`)
     public static func sandboxPluginLibrary() -> URL {
         root().appendingPathComponent("sandbox-plugins", isDirectory: true)
     }
 
     // MARK: - Container / Sandbox Paths
 
-    /// Container root: `~/.osaurus/container/`
+    /// Container root: `<data root>/container/`
     public static func container() -> URL {
         root().appendingPathComponent("container", isDirectory: true)
     }
 
-    /// Kernel binary directory: `~/.osaurus/container/kernel/`
+    /// Kernel binary directory: `<data root>/container/kernel/`
     public static func containerKernelDir() -> URL {
         container().appendingPathComponent("kernel", isDirectory: true)
     }
@@ -374,7 +361,7 @@ public enum OsaurusPaths {
         containerKernelDir().appendingPathComponent("vmlinux")
     }
 
-    /// Path to the init filesystem image: `~/.osaurus/container/initfs.ext4`
+    /// Path to the init filesystem image: `<data root>/container/initfs.ext4`
     public static func containerInitFSFile() -> URL {
         container().appendingPathComponent("initfs.ext4")
     }
@@ -401,12 +388,12 @@ public enum OsaurusPaths {
 
     // MARK: - Shared Artifacts
 
-    /// Root directory for all shared artifacts: `~/.osaurus/artifacts/`
+    /// Root directory for all shared artifacts: `<data root>/artifacts/`
     public static func artifactsDir() -> URL {
         root().appendingPathComponent("artifacts", isDirectory: true)
     }
 
-    /// Per-context artifacts directory: `~/.osaurus/artifacts/{contextId}/`
+    /// Per-context artifacts directory: `<data root>/artifacts/{contextId}/`
     public static func contextArtifactsDir(contextId: String) -> URL {
         artifactsDir().appendingPathComponent(contextId, isDirectory: true)
     }
@@ -461,7 +448,7 @@ public enum OsaurusPaths {
         chatHistory().appendingPathComponent("history.sqlite")
     }
     public static func methodsDatabaseFile() -> URL { methods().appendingPathComponent("methods.sqlite") }
-    /// Encrypted on-device Osaurus Router billing ledger: `~/.osaurus/billing/ledger.sqlite`.
+    /// Encrypted on-device Osaurus Router billing ledger: `<data root>/billing/ledger.sqlite`.
     public static func billingLedgerDatabaseFile() -> URL { billing().appendingPathComponent("ledger.sqlite") }
     public static func toolIndexDatabaseFile() -> URL { toolIndex().appendingPathComponent("tool_index.sqlite") }
     public static func memoryConfigFile() -> URL { config().appendingPathComponent("memory.json") }
@@ -501,31 +488,31 @@ public enum OsaurusPaths {
     // MARK: - Claude plugins (imported via GitHub)
 
     /// Root directory for Claude-plugin metadata and per-plugin storage:
-    /// `~/.osaurus/claude-plugins/`.
+    /// `<data root>/claude-plugins/`.
     public static func claudePluginsRoot() -> URL {
         root().appendingPathComponent("claude-plugins", isDirectory: true)
     }
 
     /// Per-plugin manifest snapshot directory:
-    /// `~/.osaurus/claude-plugins/manifests/`.
+    /// `<data root>/claude-plugins/manifests/`.
     public static func claudePluginsManifestsDir() -> URL {
         claudePluginsRoot().appendingPathComponent("manifests", isDirectory: true)
     }
 
     /// Per-plugin user-config (non-sensitive) JSON directory:
-    /// `~/.osaurus/claude-plugins/userconfig/`.
+    /// `<data root>/claude-plugins/userconfig/`.
     public static func claudePluginsUserConfigDir() -> URL {
         claudePluginsRoot().appendingPathComponent("userconfig", isDirectory: true)
     }
 
     /// Per-plugin data directory parent (`CLAUDE_PLUGIN_DATA` root):
-    /// `~/.osaurus/claude-plugins/data/`.
+    /// `<data root>/claude-plugins/data/`.
     public static func claudePluginsDataDir() -> URL {
         claudePluginsRoot().appendingPathComponent("data", isDirectory: true)
     }
 
     /// Per-plugin synthesised source cache (`CLAUDE_PLUGIN_ROOT` target):
-    /// `~/.osaurus/claude-plugins/cache/`. Currently a placeholder so the
+    /// `<data root>/claude-plugins/cache/`. Currently a placeholder so the
     /// variable expander can hand out a stable path even though we don't
     /// keep a full plugin checkout.
     public static func claudePluginsCacheDir() -> URL {
@@ -533,21 +520,21 @@ public enum OsaurusPaths {
     }
 
     /// Per-plugin manifest snapshot file:
-    /// `~/.osaurus/claude-plugins/manifests/<safeId>.json`.
+    /// `<data root>/claude-plugins/manifests/<safeId>.json`.
     public static func claudePluginManifestFile(for pluginId: String) -> URL {
         claudePluginsManifestsDir()
             .appendingPathComponent("\(claudePluginSafeId(pluginId)).json")
     }
 
     /// Per-plugin user-config JSON file:
-    /// `~/.osaurus/claude-plugins/userconfig/<safeId>.json`.
+    /// `<data root>/claude-plugins/userconfig/<safeId>.json`.
     public static func claudePluginUserConfigFile(for pluginId: String) -> URL {
         claudePluginsUserConfigDir()
             .appendingPathComponent("\(claudePluginSafeId(pluginId)).json")
     }
 
     /// Per-plugin data directory:
-    /// `~/.osaurus/claude-plugins/data/<safeId>/`. Created lazily on first
+    /// `<data root>/claude-plugins/data/<safeId>/`. Created lazily on first
     /// reference by `ClaudePluginVariableExpander`.
     public static func claudePluginDataDir(for pluginId: String) -> URL {
         claudePluginsDataDir()
@@ -555,7 +542,7 @@ public enum OsaurusPaths {
     }
 
     /// Per-plugin synthesised source cache directory:
-    /// `~/.osaurus/claude-plugins/cache/<safeId>/`.
+    /// `<data root>/claude-plugins/cache/<safeId>/`.
     public static func claudePluginCacheDir(for pluginId: String) -> URL {
         claudePluginsCacheDir()
             .appendingPathComponent(claudePluginSafeId(pluginId), isDirectory: true)
@@ -649,108 +636,6 @@ public enum OsaurusPaths {
         return total
     }
 
-    // MARK: - Migration
-
-    /// Copies or merges the retired Application Support root into the active
-    /// root once, then writes a marker in the active root. The legacy root is
-    /// left untouched so users can inspect or delete it manually.
-    @discardableResult
-    static func migrateLegacyApplicationSupportRootIfNeeded(
-        fileManager fm: FileManager = .default,
-        legacyRoot oldRoot: URL,
-        activeRoot newRoot: URL
-    ) -> LegacyApplicationSupportMigrationResult {
-        var isLegacyDirectory = ObjCBool(false)
-        guard fm.fileExists(atPath: oldRoot.path, isDirectory: &isLegacyDirectory),
-            isLegacyDirectory.boolValue
-        else {
-            return .legacyRootAbsent
-        }
-
-        let marker = legacyApplicationSupportMergeMarker(for: newRoot)
-        if fm.fileExists(atPath: marker.path) {
-            print("[Osaurus] Legacy data migration already marked at \(marker.path); skipping")
-            return .alreadyMarked(marker)
-        }
-
-        if !fm.fileExists(atPath: newRoot.path) {
-            do {
-                try fm.copyItem(at: oldRoot, to: newRoot)
-                writeLegacyApplicationSupportMergeMarker(
-                    marker,
-                    legacyRoot: oldRoot,
-                    activeRoot: newRoot
-                )
-                print("[Osaurus] Copied data from \(oldRoot.path) to \(newRoot.path)")
-                return .copied(marker)
-            } catch {
-                print("[Osaurus] Copy failed, falling back to merge: \(error)")
-            }
-        }
-
-        mergeDirectory(from: oldRoot, into: newRoot)
-        writeLegacyApplicationSupportMergeMarker(
-            marker,
-            legacyRoot: oldRoot,
-            activeRoot: newRoot
-        )
-        print("[Osaurus] Merged data from \(oldRoot.path) into \(newRoot.path)")
-        return .merged(marker)
-    }
-
-    private static func writeLegacyApplicationSupportMergeMarker(
-        _ marker: URL,
-        legacyRoot: URL,
-        activeRoot: URL
-    ) {
-        let payload = """
-            legacy_application_support_migrated=1
-            legacy_root=\(legacyRoot.path)
-            active_root=\(activeRoot.path)
-
-            """
-        do {
-            try ensureExists(marker.deletingLastPathComponent())
-            try Data(payload.utf8).write(to: marker, options: .atomic)
-        } catch {
-            print("[Osaurus] Failed to write legacy data migration marker \(marker.path): \(error)")
-        }
-    }
-
-    /// Recursively copy the contents of `src` into `dest` (never deletes from `src`).
-    /// When both source and destination files exist, the newer one wins.
-    private static func mergeDirectory(from src: URL, into dest: URL) {
-        let fm = FileManager.default
-        ensureExistsSilent(dest)
-        let keys: Set<URLResourceKey> = [.isDirectoryKey, .contentModificationDateKey]
-        guard let contents = try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: Array(keys)) else {
-            return
-        }
-        for item in contents {
-            let target = dest.appendingPathComponent(item.lastPathComponent)
-            let isDir = (try? item.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
-
-            if fm.fileExists(atPath: target.path) {
-                if isDir {
-                    mergeDirectory(from: item, into: target)
-                } else {
-                    let srcDate =
-                        (try? item.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
-                        ?? .distantPast
-                    let destDate =
-                        (try? target.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
-                        ?? .distantPast
-                    if srcDate > destDate {
-                        try? fm.removeItem(at: target)
-                        try? fm.copyItem(at: item, to: target)
-                    }
-                }
-            } else {
-                try? fm.copyItem(at: item, to: target)
-            }
-        }
-    }
-
     // MARK: - Legacy Personas -> agents migration
 
     /// Result of the one-time legacy `Personas` -> `agents` agent-JSON
@@ -835,8 +720,7 @@ public enum OsaurusPaths {
         // Best-effort cleanup: only remove the legacy directory once empty so
         // we never discard unexpected non-JSON contents.
         if let remaining = try? fm.contentsOfDirectory(at: legacy, includingPropertiesForKeys: nil),
-            remaining.isEmpty
-        {
+            remaining.isEmpty {
             try? fm.removeItem(at: legacy)
         }
 

--- a/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
+++ b/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
@@ -334,13 +334,17 @@ public enum StorageLocationStandards {
         }
 
         if isLegacy(locations.cache.source) {
+            let cacheReason =
+                locations.usesLegacyDataRoot
+                ? "to stay with the resolved legacy data root family."
+                : "because an existing cache directory was found."
             findings.append(
                 Finding(
                     code: .cacheRootLegacyFallback,
                     severity: .info,
                     message:
                         "Cache root \(locations.cacheRoot.path) is a legacy location "
-                        + "because an existing cache directory was found."
+                        + cacheReason
                 )
             )
         }

--- a/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
+++ b/Packages/OsaurusCore/Utils/StorageLocationStandards.swift
@@ -4,46 +4,29 @@
 //
 //  Storage-location standards audit for issue #1422.
 //
-//  Osaurus currently keeps its app data in `~/.osaurus/` (see
-//  `OsaurusPaths`), which follows neither Apple's file-system guidance
-//  (`~/Library/Application Support/...`) nor the XDG base-directory spec
-//  (`~/.local/share/...`). Relocating the root is a data-safety decision —
-//  the Keychain data-encryption key is paired with the existing tree, the
-//  HKDF salt sidecar lives inside it, sandbox tooling references
-//  `~/.osaurus` literally, and plugin/container trees can be large — so this
-//  module deliberately performs **no migration**. It only classifies the
-//  current layout and reports stable reason codes through
-//  `/admin/cache-stats` so users and maintainers can see exactly where data
-//  lives and why. Classification is a pure function over `Inputs`; the live
-//  probe is read-only and never mutates the filesystem.
-//
 
 import Foundation
+import OsaurusRepository
 
+/// Read-only storage-location audit. Path resolution lives in
+/// `AppDataLocationResolver`; this module turns the resolved data/config/cache
+/// roots into a stable diagnostic surface for `/admin/cache-stats`.
 public enum StorageLocationStandards {
 
     // MARK: - Model
 
-    /// Where the active app-data root was resolved from.
-    public enum RootSource: String, Sendable {
-        case standard
-        case testOverride = "test_override"
-        case environmentOverride = "environment_override"
-    }
-
-    /// Classification of the active app-data root against platform
-    /// storage-location conventions.
     public enum RootClassification: String, Sendable {
         case appleApplicationSupport = "apple_application_support"
+        case xdgBaseDirectory = "xdg_base_directory"
         case homeDotDirectory = "home_dot_directory"
+        case legacyApplicationSupport = "legacy_application_support"
         case testOverride = "test_override"
         case environmentOverride = "environment_override"
         case custom
     }
 
     /// Classification of the model-weights root, reported separately from
-    /// the app-data root because user-managed weights are home-visible by
-    /// design today.
+    /// app data because user-managed weights remain home-visible by design.
     public enum ModelsRootClassification: String, Sendable {
         case applicationSupport = "application_support"
         case homeVisible = "home_visible"
@@ -51,14 +34,19 @@ public enum StorageLocationStandards {
     }
 
     /// Stable, machine-readable reason codes. These are part of the
-    /// diagnostic surface — do not rename existing raw values.
+    /// diagnostic surface; avoid renaming existing raw values.
     public enum ReasonCode: String, CaseIterable, Sendable {
         case rootHomeDotDirectoryNotAppleSpec = "root_home_dot_directory_not_apple_spec"
+        case dataRootLegacyApplicationSupportFallback =
+            "data_root_legacy_application_support_fallback"
         case rootOverriddenForTests = "root_overridden_for_tests"
         case rootEnvironmentOverride = "root_environment_override"
         case rootCustomLocation = "root_custom_location"
+        case standardLocationAvailableLegacyActive = "standard_location_available_legacy_active"
         case legacyApplicationSupportRootPresent = "legacy_application_support_root_present"
-        case migrationDecisionPending = "migration_decision_pending"
+        case configRootLegacyFallback = "config_root_legacy_fallback"
+        case cacheRootLegacyFallback = "cache_root_legacy_fallback"
+        case migrationRequiredManual = "migration_required_manual"
         case modelsRootHomeVisibleByDesign = "models_root_home_visible_by_design"
     }
 
@@ -83,41 +71,26 @@ public enum StorageLocationStandards {
     /// Everything the pure classifier needs. Built by `currentInputs()` in
     /// production; built by hand in tests.
     public struct Inputs: Equatable, Sendable {
-        public let activeRootPath: String
-        public let rootSource: RootSource
+        public let locations: AppDataLocationResolver.ResolvedLocations
         public let homeDirectoryPath: String
         public let applicationSupportPath: String?
-        public let legacyApplicationSupportRootPath: String?
-        public let legacyApplicationSupportRootPresent: Bool
         public let legacyApplicationSupportMergeMarkerPath: String?
         public let legacyApplicationSupportMergeMarked: Bool
-        public let appleSpecCandidateRootPath: String?
-        public let appleSpecCandidateRootPresent: Bool
         public let modelsRootPath: String
 
         public init(
-            activeRootPath: String,
-            rootSource: RootSource,
+            locations: AppDataLocationResolver.ResolvedLocations,
             homeDirectoryPath: String,
             applicationSupportPath: String?,
-            legacyApplicationSupportRootPath: String?,
-            legacyApplicationSupportRootPresent: Bool,
-            legacyApplicationSupportMergeMarkerPath: String?,
-            legacyApplicationSupportMergeMarked: Bool,
-            appleSpecCandidateRootPath: String?,
-            appleSpecCandidateRootPresent: Bool,
+            legacyApplicationSupportMergeMarkerPath: String? = nil,
+            legacyApplicationSupportMergeMarked: Bool = false,
             modelsRootPath: String
         ) {
-            self.activeRootPath = activeRootPath
-            self.rootSource = rootSource
+            self.locations = locations
             self.homeDirectoryPath = homeDirectoryPath
             self.applicationSupportPath = applicationSupportPath
-            self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
-            self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
             self.legacyApplicationSupportMergeMarkerPath = legacyApplicationSupportMergeMarkerPath
             self.legacyApplicationSupportMergeMarked = legacyApplicationSupportMergeMarked
-            self.appleSpecCandidateRootPath = appleSpecCandidateRootPath
-            self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
             self.modelsRootPath = modelsRootPath
         }
     }
@@ -126,52 +99,93 @@ public enum StorageLocationStandards {
     public struct Report: Equatable, Sendable {
         public let classification: RootClassification
         public let specCompliant: Bool
-        public let activeRootPath: String
+        public let dataRootPath: String
+        public let dataSource: AppDataLocationResolver.LocationSource
+        public let configRootPath: String
+        public let configSource: AppDataLocationResolver.LocationSource
+        public let cacheRootPath: String
+        public let cacheSource: AppDataLocationResolver.LocationSource
+        public let standardDataRootPath: String
+        public let standardConfigRootPath: String
+        public let standardCacheRootPath: String
         public let appleSpecCandidateRootPath: String?
         public let appleSpecCandidateRootPresent: Bool
+        public let legacyHomeRootPath: String
+        public let legacyHomeRootPresent: Bool
         public let legacyApplicationSupportRootPath: String?
         public let legacyApplicationSupportRootPresent: Bool
         public let legacyApplicationSupportMergeMarkerPath: String?
         public let legacyApplicationSupportMergeMarked: Bool
+        public let migrationRequired: Bool
+        public let candidateLocations: [AppDataLocationResolver.Candidate]
         public let modelsRootPath: String
         public let modelsRootClassification: ModelsRootClassification
         public let findings: [Finding]
+
+        /// Backward-compatible alias for the active data root.
+        public var activeRootPath: String { dataRootPath }
 
         public var reasonCodes: [String] {
             findings.map { $0.code.rawValue }
         }
 
         public var summary: String {
-            let compliance = specCompliant ? "apple-spec" : "non-compliant"
-            let legacy = legacyApplicationSupportRootPresent ? "present" : "absent"
-            return "root=\(classification.rawValue) (\(compliance)); "
-                + "legacy_root=\(legacy); "
+            let compliance = specCompliant ? "spec-compliant" : "needs-attention"
+            let migration = migrationRequired ? "required" : "not_required"
+            return "data=\(dataSource.rawValue); "
+                + "config=\(configSource.rawValue); "
+                + "cache=\(cacheSource.rawValue); "
+                + "\(compliance); migration=\(migration); "
                 + "models_root=\(modelsRootClassification.rawValue)"
         }
 
         public init(
             classification: RootClassification,
             specCompliant: Bool,
-            activeRootPath: String,
+            dataRootPath: String,
+            dataSource: AppDataLocationResolver.LocationSource,
+            configRootPath: String,
+            configSource: AppDataLocationResolver.LocationSource,
+            cacheRootPath: String,
+            cacheSource: AppDataLocationResolver.LocationSource,
+            standardDataRootPath: String,
+            standardConfigRootPath: String,
+            standardCacheRootPath: String,
             appleSpecCandidateRootPath: String?,
             appleSpecCandidateRootPresent: Bool,
+            legacyHomeRootPath: String,
+            legacyHomeRootPresent: Bool,
             legacyApplicationSupportRootPath: String?,
             legacyApplicationSupportRootPresent: Bool,
             legacyApplicationSupportMergeMarkerPath: String?,
             legacyApplicationSupportMergeMarked: Bool,
+            migrationRequired: Bool,
+            candidateLocations: [AppDataLocationResolver.Candidate],
             modelsRootPath: String,
             modelsRootClassification: ModelsRootClassification,
             findings: [Finding]
         ) {
             self.classification = classification
             self.specCompliant = specCompliant
-            self.activeRootPath = activeRootPath
+            self.dataRootPath = dataRootPath
+            self.dataSource = dataSource
+            self.configRootPath = configRootPath
+            self.configSource = configSource
+            self.cacheRootPath = cacheRootPath
+            self.cacheSource = cacheSource
+            self.standardDataRootPath = standardDataRootPath
+            self.standardConfigRootPath = standardConfigRootPath
+            self.standardCacheRootPath = standardCacheRootPath
             self.appleSpecCandidateRootPath = appleSpecCandidateRootPath
             self.appleSpecCandidateRootPresent = appleSpecCandidateRootPresent
+            self.legacyHomeRootPath = legacyHomeRootPath
+            self.legacyHomeRootPresent = legacyHomeRootPresent
             self.legacyApplicationSupportRootPath = legacyApplicationSupportRootPath
             self.legacyApplicationSupportRootPresent = legacyApplicationSupportRootPresent
             self.legacyApplicationSupportMergeMarkerPath = legacyApplicationSupportMergeMarkerPath
             self.legacyApplicationSupportMergeMarked = legacyApplicationSupportMergeMarked
+            self.migrationRequired = migrationRequired
+            self.candidateLocations = candidateLocations
             self.modelsRootPath = modelsRootPath
             self.modelsRootClassification = modelsRootClassification
             self.findings = findings
@@ -180,51 +194,25 @@ public enum StorageLocationStandards {
 
     // MARK: - Live probe (read-only)
 
-    /// Name of the legacy pre-`~/.osaurus` root under Application Support.
-    public static let legacyApplicationSupportFolderName = "com.dinoki.osaurus"
+    public static let legacyApplicationSupportFolderName =
+        AppDataLocationResolver.legacyApplicationSupportFolderName
+    public static let appleSpecCandidateFolderName =
+        AppDataLocationResolver.standardApplicationSupportFolderName
 
-    /// Proposed Apple-spec folder name under Application Support. Reported
-    /// as a candidate only; nothing is created or moved.
-    public static let appleSpecCandidateFolderName = "Osaurus"
-
-    /// Gather live inputs. Read-only: performs `fileExists` probes plus the
-    /// same root resolution `OsaurusPaths.root()` already performed for the
-    /// running process; it never creates, copies, or deletes anything.
+    /// Gather live inputs. Read-only: reports the same resolved locations used
+    /// by `OsaurusPaths` and never creates, copies, moves, or deletes anything.
     public static func currentInputs(fileManager fm: FileManager = .default) -> Inputs {
-        let testRootOverride = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let rootSource: RootSource
-        if OsaurusPaths.overrideRoot != nil {
-            rootSource = .testOverride
-        } else if testRootOverride?.isEmpty == false {
-            rootSource = .environmentOverride
-        } else {
-            rootSource = .standard
-        }
+        let locations = OsaurusPaths.resolvedLocations()
+        let mergeMarker = OsaurusPaths.legacyApplicationSupportMergeMarker(
+            for: locations.dataRoot
+        )
         let support = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        let legacy = support?.appendingPathComponent(
-            legacyApplicationSupportFolderName,
-            isDirectory: true
-        )
-        let candidate = support?.appendingPathComponent(
-            appleSpecCandidateFolderName,
-            isDirectory: true
-        )
-        let activeRoot = OsaurusPaths.root()
-        let mergeMarker = OsaurusPaths.legacyApplicationSupportMergeMarker(for: activeRoot)
         return Inputs(
-            activeRootPath: activeRoot.path,
-            rootSource: rootSource,
+            locations: locations,
             homeDirectoryPath: fm.homeDirectoryForCurrentUser.path,
             applicationSupportPath: support?.path,
-            legacyApplicationSupportRootPath: legacy?.path,
-            legacyApplicationSupportRootPresent: legacy.map { fm.fileExists(atPath: $0.path) }
-                ?? false,
             legacyApplicationSupportMergeMarkerPath: mergeMarker.path,
             legacyApplicationSupportMergeMarked: fm.fileExists(atPath: mergeMarker.path),
-            appleSpecCandidateRootPath: candidate?.path,
-            appleSpecCandidateRootPresent: candidate.map { fm.fileExists(atPath: $0.path) }
-                ?? false,
             modelsRootPath: DirectoryPickerService.effectiveModelsDirectory().path
         )
     }
@@ -237,12 +225,14 @@ public enum StorageLocationStandards {
     // MARK: - Pure classification
 
     public static func audit(_ inputs: Inputs) -> Report {
+        let locations = inputs.locations
         let classification = classifyRoot(inputs)
         let modelsClassification = classifyModelsRoot(inputs)
+        let migrationRequired = requiresManualMigration(locations)
         var findings: [Finding] = []
 
         switch classification {
-        case .appleApplicationSupport:
+        case .appleApplicationSupport, .xdgBaseDirectory:
             break
         case .homeDotDirectory:
             findings.append(
@@ -250,10 +240,21 @@ public enum StorageLocationStandards {
                     code: .rootHomeDotDirectoryNotAppleSpec,
                     severity: .warning,
                     message:
-                        "App data root \(inputs.activeRootPath) is a home dot-directory. "
-                        + "Apple's file-system guidance places app data under "
-                        + "~/Library/Application Support; the XDG equivalent is "
-                        + "~/.local/share. See docs/STORAGE.md (Storage Location Standards)."
+                        "Using legacy app data root \(locations.dataRoot.path) because it "
+                        + "already exists. New installs use "
+                        + "\(locations.standardDataRoot.path). No data is moved automatically; "
+                        + "back up or export data before a manual migration."
+                )
+            )
+        case .legacyApplicationSupport:
+            findings.append(
+                Finding(
+                    code: .dataRootLegacyApplicationSupportFallback,
+                    severity: .warning,
+                    message:
+                        "Using retired Application Support root \(locations.dataRoot.path) "
+                        + "because it already exists and no newer data root was selected. "
+                        + "No data is moved automatically."
                 )
             )
         case .testOverride:
@@ -282,59 +283,84 @@ public enum StorageLocationStandards {
                     code: .rootCustomLocation,
                     severity: .info,
                     message:
-                        "Storage root \(inputs.activeRootPath) is neither the default home "
-                        + "dot-directory nor under Application Support."
+                        "Storage root \(locations.dataRoot.path) is neither a standard "
+                        + "Apple/XDG location nor a known legacy location."
                 )
             )
         }
 
-        if inputs.legacyApplicationSupportRootPresent {
-            let legacyPath =
-                inputs.legacyApplicationSupportRootPath
-                ?? legacyApplicationSupportFolderName
-            let markerPath =
-                inputs.legacyApplicationSupportMergeMarkerPath
-                ?? OsaurusPaths.legacyApplicationSupportMergeMarkerName
-            let severity: Severity = inputs.legacyApplicationSupportMergeMarked ? .info : .warning
-            let message: String
-            if inputs.legacyApplicationSupportMergeMarked {
-                message =
-                    "Legacy root \(legacyPath) still exists, but one-shot migration marker "
-                    + "\(markerPath) is present. OsaurusPaths will not re-merge it into "
-                    + "the active root on future launches."
-            } else {
-                message =
-                    "Legacy root \(legacyPath) still exists and one-shot migration marker "
-                    + "\(markerPath) is missing. OsaurusPaths will copy or merge it into "
-                    + "the active root once, then write the marker so future launches do "
-                    + "not resurrect stale legacy files."
-            }
+        if locations.usesLegacyDataRoot && candidateExists(locations, kind: .data, source: .standard) {
+            findings.append(
+                Finding(
+                    code: .standardLocationAvailableLegacyActive,
+                    severity: .info,
+                    message:
+                        "Standard data root \(locations.standardDataRoot.path) exists, but "
+                        + "legacy root \(locations.dataRoot.path) remains active to avoid "
+                        + "silently switching away from existing user data."
+                )
+            )
+        }
+
+        let legacySupportPresent = candidateExists(
+            locations,
+            kind: .data,
+            source: .legacyApplicationSupport
+        )
+        if legacySupportPresent {
             findings.append(
                 Finding(
                     code: .legacyApplicationSupportRootPresent,
-                    severity: severity,
-                    message: message
+                    severity: locations.data.source == .legacyApplicationSupport ? .warning : .info,
+                    message:
+                        "Retired Application Support root "
+                        + "\(locations.legacyApplicationSupportRoot?.path ?? legacyApplicationSupportFolderName) "
+                        + "still exists. The resolver reports it as a legacy fallback and "
+                        + "does not copy, merge, or delete it."
                 )
             )
         }
 
-        if classification == .homeDotDirectory || inputs.legacyApplicationSupportRootPresent {
+        if isLegacy(locations.config.source) {
             findings.append(
                 Finding(
-                    code: .migrationDecisionPending,
-                    severity: .info,
+                    code: .configRootLegacyFallback,
+                    severity: .warning,
                     message:
-                        "Relocating the storage root is deferred pending a maintainer "
-                        + "decision: the Keychain data-encryption key is paired with the "
-                        + "current tree, the HKDF salt sidecar lives inside it, sandbox "
-                        + "tooling references ~/.osaurus literally, and plugin/container "
-                        + "trees can be large."
+                        "Configuration root \(locations.configRoot.path) is a legacy "
+                        + "location selected for compatibility with existing files."
                 )
             )
         }
 
-        let usesStandardRoot = classification != .testOverride && classification != .environmentOverride
-        if usesStandardRoot && modelsClassification == .homeVisible {
+        if isLegacy(locations.cache.source) {
+            findings.append(
+                Finding(
+                    code: .cacheRootLegacyFallback,
+                    severity: .info,
+                    message:
+                        "Cache root \(locations.cacheRoot.path) is a legacy location "
+                        + "because an existing cache directory was found."
+                )
+            )
+        }
+
+        if migrationRequired {
+            findings.append(
+                Finding(
+                    code: .migrationRequiredManual,
+                    severity: .info,
+                    message:
+                        "A manual migration is required before all app data can use "
+                        + "standard Apple/XDG locations. The resolver only selects safe "
+                        + "fallbacks and never moves user data."
+                )
+            )
+        }
+
+        let usesOverride =
+            locations.data.source == .testOverride || locations.data.source == .environmentOverride
+        if !usesOverride && modelsClassification == .homeVisible {
             findings.append(
                 Finding(
                     code: .modelsRootHomeVisibleByDesign,
@@ -347,16 +373,38 @@ public enum StorageLocationStandards {
             )
         }
 
+        let mergeMarkerPath = inputs.legacyApplicationSupportMergeMarkerPath
+            ?? OsaurusPaths.legacyApplicationSupportMergeMarker(for: locations.dataRoot).path
         return Report(
             classification: classification,
-            specCompliant: classification == .appleApplicationSupport,
-            activeRootPath: inputs.activeRootPath,
-            appleSpecCandidateRootPath: inputs.appleSpecCandidateRootPath,
-            appleSpecCandidateRootPresent: inputs.appleSpecCandidateRootPresent,
-            legacyApplicationSupportRootPath: inputs.legacyApplicationSupportRootPath,
-            legacyApplicationSupportRootPresent: inputs.legacyApplicationSupportRootPresent,
-            legacyApplicationSupportMergeMarkerPath: inputs.legacyApplicationSupportMergeMarkerPath,
+            specCompliant: isSpecCompliant(classification, locations),
+            dataRootPath: locations.dataRoot.path,
+            dataSource: locations.data.source,
+            configRootPath: locations.configRoot.path,
+            configSource: locations.config.source,
+            cacheRootPath: locations.cacheRoot.path,
+            cacheSource: locations.cache.source,
+            standardDataRootPath: locations.standardDataRoot.path,
+            standardConfigRootPath: locations.standardConfigRoot.path,
+            standardCacheRootPath: locations.standardCacheRoot.path,
+            appleSpecCandidateRootPath: appleCandidatePath(inputs, locations: locations),
+            appleSpecCandidateRootPresent: candidateExists(
+                locations,
+                kind: .data,
+                source: .standard
+            ),
+            legacyHomeRootPath: locations.legacyHomeRoot.path,
+            legacyHomeRootPresent: candidateExists(
+                locations,
+                kind: .data,
+                source: .legacyHomeDotDirectory
+            ),
+            legacyApplicationSupportRootPath: locations.legacyApplicationSupportRoot?.path,
+            legacyApplicationSupportRootPresent: legacySupportPresent,
+            legacyApplicationSupportMergeMarkerPath: mergeMarkerPath,
             legacyApplicationSupportMergeMarked: inputs.legacyApplicationSupportMergeMarked,
+            migrationRequired: migrationRequired,
+            candidateLocations: locations.candidates,
             modelsRootPath: inputs.modelsRootPath,
             modelsRootClassification: modelsClassification,
             findings: findings
@@ -372,14 +420,35 @@ public enum StorageLocationStandards {
             "classification": report.classification.rawValue,
             "spec_compliant": report.specCompliant,
             "active_root": report.activeRootPath,
+            "data_root": report.dataRootPath,
+            "data_source": report.dataSource.rawValue,
+            "config_root": report.configRootPath,
+            "config_source": report.configSource.rawValue,
+            "cache_root": report.cacheRootPath,
+            "cache_source": report.cacheSource.rawValue,
+            "standard_data_root": report.standardDataRootPath,
+            "standard_config_root": report.standardConfigRootPath,
+            "standard_cache_root": report.standardCacheRootPath,
             "apple_spec_candidate_root": report.appleSpecCandidateRootPath as Any? ?? NSNull(),
             "apple_spec_candidate_root_present": report.appleSpecCandidateRootPresent,
+            "legacy_home_root": report.legacyHomeRootPath,
+            "legacy_home_root_present": report.legacyHomeRootPresent,
             "legacy_application_support_root": report.legacyApplicationSupportRootPath as Any?
                 ?? NSNull(),
             "legacy_application_support_root_present": report.legacyApplicationSupportRootPresent,
             "legacy_application_support_merge_marker":
                 report.legacyApplicationSupportMergeMarkerPath as Any? ?? NSNull(),
             "legacy_application_support_merge_marked": report.legacyApplicationSupportMergeMarked,
+            "migration_required": report.migrationRequired,
+            "candidate_locations": report.candidateLocations.map { candidate in
+                [
+                    "kind": candidate.kind.rawValue,
+                    "source": candidate.source.rawValue,
+                    "path": candidate.url.path,
+                    "exists": candidate.exists,
+                    "selected": candidate.isSelected,
+                ]
+            },
             "models_root": report.modelsRootPath,
             "models_root_classification": report.modelsRootClassification.rawValue,
             "reason_codes": report.reasonCodes,
@@ -397,32 +466,31 @@ public enum StorageLocationStandards {
     // MARK: - Helpers
 
     private static func classifyRoot(_ inputs: Inputs) -> RootClassification {
-        switch inputs.rootSource {
+        let locations = inputs.locations
+        switch locations.data.source {
         case .testOverride:
             return .testOverride
         case .environmentOverride:
             return .environmentOverride
-        case .standard:
-            break
-        }
-        let activeRootIsInApplicationSupport =
-            inputs.applicationSupportPath.map { isSubpath(inputs.activeRootPath, of: $0) } ?? false
-        if activeRootIsInApplicationSupport {
-            return .appleApplicationSupport
-        }
-        let root = URL(fileURLWithPath: normalizedPath(inputs.activeRootPath))
-        let rootParentPath = root.deletingLastPathComponent().path
-        let normalizedHomePath = normalizedPath(inputs.homeDirectoryPath)
-        if root.lastPathComponent.hasPrefix(".") && rootParentPath == normalizedHomePath {
+        case .legacyHomeDotDirectory:
             return .homeDotDirectory
+        case .legacyApplicationSupport:
+            return .legacyApplicationSupport
+        case .standard:
+            if let support = inputs.applicationSupportPath,
+                isSubpath(locations.dataRoot.path, of: support) {
+                return .appleApplicationSupport
+            }
+            if samePath(locations.dataRoot.path, locations.standardDataRoot.path) {
+                return .xdgBaseDirectory
+            }
+            return .custom
         }
-        return .custom
     }
 
     private static func classifyModelsRoot(_ inputs: Inputs) -> ModelsRootClassification {
-        let modelsRootIsInApplicationSupport =
-            inputs.applicationSupportPath.map { isSubpath(inputs.modelsRootPath, of: $0) } ?? false
-        if modelsRootIsInApplicationSupport {
+        if let support = inputs.applicationSupportPath,
+            isSubpath(inputs.modelsRootPath, of: support) {
             return .applicationSupport
         }
         if isSubpath(inputs.modelsRootPath, of: inputs.homeDirectoryPath) {
@@ -431,13 +499,62 @@ public enum StorageLocationStandards {
         return .externalOrCustom
     }
 
-    private static func normalizedPath(_ path: String) -> String {
-        URL(fileURLWithPath: path).standardizedFileURL.path
+    private static func isSpecCompliant(
+        _ classification: RootClassification,
+        _ locations: AppDataLocationResolver.ResolvedLocations
+    ) -> Bool {
+        switch classification {
+        case .appleApplicationSupport, .xdgBaseDirectory:
+            return locations.data.source == .standard
+                && locations.config.source == .standard
+                && locations.cache.source == .standard
+        case .homeDotDirectory,
+             .legacyApplicationSupport,
+             .testOverride,
+             .environmentOverride,
+             .custom:
+            return false
+        }
+    }
+
+    private static func requiresManualMigration(
+        _ locations: AppDataLocationResolver.ResolvedLocations
+    ) -> Bool {
+        locations.usesLegacyDataRoot
+            || isLegacy(locations.config.source)
+            || isLegacy(locations.cache.source)
+    }
+
+    private static func candidateExists(
+        _ locations: AppDataLocationResolver.ResolvedLocations,
+        kind: AppDataLocationResolver.LocationKind,
+        source: AppDataLocationResolver.LocationSource
+    ) -> Bool {
+        locations.candidates.contains {
+            $0.kind == kind && $0.source == source && $0.exists
+        }
+    }
+
+    private static func isLegacy(_ source: AppDataLocationResolver.LocationSource) -> Bool {
+        source == .legacyHomeDotDirectory || source == .legacyApplicationSupport
+    }
+
+    private static func appleCandidatePath(
+        _ inputs: Inputs,
+        locations: AppDataLocationResolver.ResolvedLocations
+    ) -> String? {
+        guard inputs.applicationSupportPath != nil else { return nil }
+        return locations.standardDataRoot.path
+    }
+
+    private static func samePath(_ lhs: String, _ rhs: String) -> Bool {
+        URL(fileURLWithPath: lhs).standardizedFileURL.path
+            == URL(fileURLWithPath: rhs).standardizedFileURL.path
     }
 
     private static func isSubpath(_ path: String, of parent: String) -> Bool {
-        let child = normalizedPath(path)
-        let base = normalizedPath(parent)
+        let child = URL(fileURLWithPath: path).standardizedFileURL.path
+        let base = URL(fileURLWithPath: parent).standardizedFileURL.path
         if child == base {
             return true
         }

--- a/Packages/OsaurusRepository/AppDataLocationResolver.swift
+++ b/Packages/OsaurusRepository/AppDataLocationResolver.swift
@@ -297,24 +297,45 @@ public enum AppDataLocationResolver {
             let legacyHomeCache = legacyHome.appendingPathComponent("cache", isDirectory: true)
             let legacySupportCache = legacySupport?.appendingPathComponent("cache", isDirectory: true)
 
-            if directoryExists(standardCache, fileManager: fm) {
-                return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
-            }
-            if directoryExists(legacyHomeCache, fileManager: fm) {
+            switch dataSource {
+            case .legacyHomeDotDirectory:
                 return ResolvedLocation(
                     kind: .cache,
                     source: .legacyHomeDotDirectory,
                     url: legacyHomeCache
                 )
-            }
-            if let legacySupportCache, directoryExists(legacySupportCache, fileManager: fm) {
+            case .legacyApplicationSupport:
                 return ResolvedLocation(
                     kind: .cache,
                     source: .legacyApplicationSupport,
-                    url: legacySupportCache
+                    url: legacySupportCache ?? standardCache
+                )
+            case .standard:
+                if directoryExists(standardCache, fileManager: fm) {
+                    return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
+                }
+                if directoryExists(legacyHomeCache, fileManager: fm) {
+                    return ResolvedLocation(
+                        kind: .cache,
+                        source: .legacyHomeDotDirectory,
+                        url: legacyHomeCache
+                    )
+                }
+                if let legacySupportCache, directoryExists(legacySupportCache, fileManager: fm) {
+                    return ResolvedLocation(
+                        kind: .cache,
+                        source: .legacyApplicationSupport,
+                        url: legacySupportCache
+                    )
+                }
+                return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
+            case .testOverride, .environmentOverride:
+                return ResolvedLocation(
+                    kind: .cache,
+                    source: dataSource,
+                    url: dataRoot.appendingPathComponent("cache", isDirectory: true)
                 )
             }
-            return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
         }()
 
         let data = ResolvedLocation(kind: .data, source: dataSource, url: dataRoot)

--- a/Packages/OsaurusRepository/AppDataLocationResolver.swift
+++ b/Packages/OsaurusRepository/AppDataLocationResolver.swift
@@ -1,0 +1,531 @@
+//
+//  AppDataLocationResolver.swift
+//  osaurus
+//
+//  Shared app data/config/cache location resolution.
+//
+
+import Foundation
+
+/// Resolves Osaurus storage locations from Apple/XDG-standard candidates with
+/// read-only fallback to existing legacy locations.
+public enum AppDataLocationResolver {
+    public static let testRootEnvironmentVariable = "OSAURUS_TEST_ROOT"
+    public static let standardApplicationSupportFolderName = "Osaurus"
+    public static let standardCacheFolderName = "Osaurus"
+    public static let xdgFolderName = "osaurus"
+    public static let legacyHomeFolderName = ".osaurus"
+    public static let legacyApplicationSupportFolderName = "com.dinoki.osaurus"
+
+    public enum LocationKind: String, CaseIterable, Sendable {
+        case data
+        case config
+        case cache
+    }
+
+    public enum LocationSource: String, Sendable {
+        case standard
+        case legacyHomeDotDirectory = "legacy_home_dot_directory"
+        case legacyApplicationSupport = "legacy_application_support"
+        case testOverride = "test_override"
+        case environmentOverride = "environment_override"
+    }
+
+    public struct Candidate: Equatable, Sendable {
+        public let kind: LocationKind
+        public let source: LocationSource
+        public let url: URL
+        public let exists: Bool
+        public let isSelected: Bool
+
+        public init(
+            kind: LocationKind,
+            source: LocationSource,
+            url: URL,
+            exists: Bool,
+            isSelected: Bool
+        ) {
+            self.kind = kind
+            self.source = source
+            self.url = url
+            self.exists = exists
+            self.isSelected = isSelected
+        }
+    }
+
+    public struct ResolvedLocation: Equatable, Sendable {
+        public let kind: LocationKind
+        public let source: LocationSource
+        public let url: URL
+
+        public init(kind: LocationKind, source: LocationSource, url: URL) {
+            self.kind = kind
+            self.source = source
+            self.url = url
+        }
+    }
+
+    public struct ResolvedLocations: Equatable, Sendable {
+        public let data: ResolvedLocation
+        public let config: ResolvedLocation
+        public let cache: ResolvedLocation
+        public let candidates: [Candidate]
+        public let standardDataRoot: URL
+        public let standardConfigRoot: URL
+        public let standardCacheRoot: URL
+        public let legacyHomeRoot: URL
+        public let legacyApplicationSupportRoot: URL?
+
+        public var dataRoot: URL { data.url }
+        public var configRoot: URL { config.url }
+        public var cacheRoot: URL { cache.url }
+
+        public var usesLegacyDataRoot: Bool {
+            data.source == .legacyHomeDotDirectory || data.source == .legacyApplicationSupport
+        }
+
+        public func candidates(for kind: LocationKind) -> [Candidate] {
+            candidates.filter { $0.kind == kind }
+        }
+
+        public var dataSearchRoots: [URL] {
+            searchURLs(for: .data)
+        }
+
+        public var configSearchDirectories: [URL] {
+            searchURLs(for: .config)
+        }
+
+        public var cacheSearchDirectories: [URL] {
+            searchURLs(for: .cache)
+        }
+
+        public init(
+            data: ResolvedLocation,
+            config: ResolvedLocation,
+            cache: ResolvedLocation,
+            candidates: [Candidate],
+            standardDataRoot: URL,
+            standardConfigRoot: URL,
+            standardCacheRoot: URL,
+            legacyHomeRoot: URL,
+            legacyApplicationSupportRoot: URL?
+        ) {
+            self.data = data
+            self.config = config
+            self.cache = cache
+            self.candidates = candidates
+            self.standardDataRoot = standardDataRoot
+            self.standardConfigRoot = standardConfigRoot
+            self.standardCacheRoot = standardCacheRoot
+            self.legacyHomeRoot = legacyHomeRoot
+            self.legacyApplicationSupportRoot = legacyApplicationSupportRoot
+        }
+
+        private func searchURLs(for kind: LocationKind) -> [URL] {
+            let selected: URL
+            switch kind {
+            case .data:
+                selected = data.url
+            case .config:
+                selected = config.url
+            case .cache:
+                selected = cache.url
+            }
+
+            var urls = [selected]
+            for candidate in candidates where candidate.kind == kind {
+                if !urls.contains(where: { samePath($0, candidate.url) }) {
+                    urls.append(candidate.url)
+                }
+            }
+            return urls
+        }
+    }
+
+    public struct PlatformDirectories: Equatable, Sendable {
+        public let homeDirectory: URL
+        public let applicationSupportDirectory: URL?
+        public let cachesDirectory: URL?
+        public let xdgDataHome: URL
+        public let xdgConfigHome: URL
+        public let xdgCacheHome: URL
+
+        public init(
+            homeDirectory: URL,
+            applicationSupportDirectory: URL?,
+            cachesDirectory: URL?,
+            xdgDataHome: URL,
+            xdgConfigHome: URL,
+            xdgCacheHome: URL
+        ) {
+            self.homeDirectory = homeDirectory
+            self.applicationSupportDirectory = applicationSupportDirectory
+            self.cachesDirectory = cachesDirectory
+            self.xdgDataHome = xdgDataHome
+            self.xdgConfigHome = xdgConfigHome
+            self.xdgCacheHome = xdgCacheHome
+        }
+    }
+
+    public static func platformDirectories(
+        fileManager fm: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> PlatformDirectories {
+        let home = fm.homeDirectoryForCurrentUser
+        return PlatformDirectories(
+            homeDirectory: home,
+            applicationSupportDirectory:
+                fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first,
+            cachesDirectory: fm.urls(for: .cachesDirectory, in: .userDomainMask).first,
+            xdgDataHome: xdgDirectory(
+                environmentName: "XDG_DATA_HOME",
+                fallback: home.appendingPathComponent(".local/share", isDirectory: true),
+                environment: environment
+            ),
+            xdgConfigHome: xdgDirectory(
+                environmentName: "XDG_CONFIG_HOME",
+                fallback: home.appendingPathComponent(".config", isDirectory: true),
+                environment: environment
+            ),
+            xdgCacheHome: xdgDirectory(
+                environmentName: "XDG_CACHE_HOME",
+                fallback: home.appendingPathComponent(".cache", isDirectory: true),
+                environment: environment
+            )
+        )
+    }
+
+    public static func resolve(
+        overrideRoot: URL? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager fm: FileManager = .default,
+        platformDirectories directories: PlatformDirectories? = nil
+    ) -> ResolvedLocations {
+        let dirs = directories ?? platformDirectories(fileManager: fm, environment: environment)
+
+        if let overrideRoot {
+            return overrideLocations(
+                root: overrideRoot,
+                source: .testOverride,
+                fileManager: fm,
+                directories: dirs
+            )
+        }
+        if let envRoot = testRoot(from: environment) {
+            return overrideLocations(
+                root: envRoot,
+                source: .environmentOverride,
+                fileManager: fm,
+                directories: dirs
+            )
+        }
+
+        let standardData = standardDataRoot(in: dirs)
+        let standardConfig = standardConfigRoot(in: dirs)
+        let standardCache = standardCacheRoot(in: dirs)
+        let legacyHome = dirs.homeDirectory.appendingPathComponent(
+            legacyHomeFolderName,
+            isDirectory: true
+        )
+        let legacySupport = dirs.applicationSupportDirectory?.appendingPathComponent(
+            legacyApplicationSupportFolderName,
+            isDirectory: true
+        )
+
+        let dataSource: LocationSource
+        let dataRoot: URL
+        if directoryExists(legacyHome, fileManager: fm) {
+            dataSource = .legacyHomeDotDirectory
+            dataRoot = legacyHome
+        } else if directoryExists(standardData, fileManager: fm) {
+            dataSource = .standard
+            dataRoot = standardData
+        } else if let legacySupport, directoryExists(legacySupport, fileManager: fm) {
+            dataSource = .legacyApplicationSupport
+            dataRoot = legacySupport
+        } else {
+            dataSource = .standard
+            dataRoot = standardData
+        }
+
+        let config: ResolvedLocation = {
+            let legacyHomeConfig = legacyHome.appendingPathComponent("config", isDirectory: true)
+            let legacySupportConfig = legacySupport?.appendingPathComponent(
+                "config",
+                isDirectory: true
+            )
+
+            switch dataSource {
+            case .legacyHomeDotDirectory:
+                return ResolvedLocation(
+                    kind: .config,
+                    source: .legacyHomeDotDirectory,
+                    url: legacyHomeConfig
+                )
+            case .legacyApplicationSupport:
+                return ResolvedLocation(
+                    kind: .config,
+                    source: .legacyApplicationSupport,
+                    url: legacySupportConfig ?? standardConfig
+                )
+            case .standard:
+                if directoryExists(standardConfig, fileManager: fm) {
+                    return ResolvedLocation(kind: .config, source: .standard, url: standardConfig)
+                }
+                if directoryExists(legacyHomeConfig, fileManager: fm) {
+                    return ResolvedLocation(
+                        kind: .config,
+                        source: .legacyHomeDotDirectory,
+                        url: legacyHomeConfig
+                    )
+                }
+                if let legacySupportConfig, directoryExists(legacySupportConfig, fileManager: fm) {
+                    return ResolvedLocation(
+                        kind: .config,
+                        source: .legacyApplicationSupport,
+                        url: legacySupportConfig
+                    )
+                }
+                return ResolvedLocation(kind: .config, source: .standard, url: standardConfig)
+            case .testOverride, .environmentOverride:
+                return ResolvedLocation(kind: .config, source: dataSource, url: dataRoot)
+            }
+        }()
+
+        let cache: ResolvedLocation = {
+            let legacyHomeCache = legacyHome.appendingPathComponent("cache", isDirectory: true)
+            let legacySupportCache = legacySupport?.appendingPathComponent("cache", isDirectory: true)
+
+            if directoryExists(standardCache, fileManager: fm) {
+                return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
+            }
+            if directoryExists(legacyHomeCache, fileManager: fm) {
+                return ResolvedLocation(
+                    kind: .cache,
+                    source: .legacyHomeDotDirectory,
+                    url: legacyHomeCache
+                )
+            }
+            if let legacySupportCache, directoryExists(legacySupportCache, fileManager: fm) {
+                return ResolvedLocation(
+                    kind: .cache,
+                    source: .legacyApplicationSupport,
+                    url: legacySupportCache
+                )
+            }
+            return ResolvedLocation(kind: .cache, source: .standard, url: standardCache)
+        }()
+
+        let data = ResolvedLocation(kind: .data, source: dataSource, url: dataRoot)
+        return ResolvedLocations(
+            data: data,
+            config: config,
+            cache: cache,
+            candidates: selectedCandidates(
+                selected: [data, config, cache],
+                standardData: standardData,
+                standardConfig: standardConfig,
+                standardCache: standardCache,
+                legacyHome: legacyHome,
+                legacySupport: legacySupport,
+                fileManager: fm
+            ),
+            standardDataRoot: standardData,
+            standardConfigRoot: standardConfig,
+            standardCacheRoot: standardCache,
+            legacyHomeRoot: legacyHome,
+            legacyApplicationSupportRoot: legacySupport
+        )
+    }
+
+    private static func overrideLocations(
+        root: URL,
+        source: LocationSource,
+        fileManager fm: FileManager,
+        directories: PlatformDirectories
+    ) -> ResolvedLocations {
+        let data = ResolvedLocation(kind: .data, source: source, url: root)
+        let config = ResolvedLocation(
+            kind: .config,
+            source: source,
+            url: root.appendingPathComponent("config", isDirectory: true)
+        )
+        let cache = ResolvedLocation(
+            kind: .cache,
+            source: source,
+            url: root.appendingPathComponent("cache", isDirectory: true)
+        )
+        let standardData = standardDataRoot(in: directories)
+        let standardConfig = standardConfigRoot(in: directories)
+        let standardCache = standardCacheRoot(in: directories)
+        return ResolvedLocations(
+            data: data,
+            config: config,
+            cache: cache,
+            candidates: [
+                Candidate(
+                    kind: .data,
+                    source: source,
+                    url: root,
+                    exists: directoryExists(root, fileManager: fm),
+                    isSelected: true
+                ),
+                Candidate(
+                    kind: .config,
+                    source: source,
+                    url: config.url,
+                    exists: directoryExists(config.url, fileManager: fm),
+                    isSelected: true
+                ),
+                Candidate(
+                    kind: .cache,
+                    source: source,
+                    url: cache.url,
+                    exists: directoryExists(cache.url, fileManager: fm),
+                    isSelected: true
+                ),
+            ],
+            standardDataRoot: standardData,
+            standardConfigRoot: standardConfig,
+            standardCacheRoot: standardCache,
+            legacyHomeRoot: directories.homeDirectory.appendingPathComponent(
+                legacyHomeFolderName,
+                isDirectory: true
+            ),
+            legacyApplicationSupportRoot:
+                directories.applicationSupportDirectory?.appendingPathComponent(
+                    legacyApplicationSupportFolderName,
+                    isDirectory: true
+                )
+        )
+    }
+
+    private static func selectedCandidates(
+        selected: [ResolvedLocation],
+        standardData: URL,
+        standardConfig: URL,
+        standardCache: URL,
+        legacyHome: URL,
+        legacySupport: URL?,
+        fileManager fm: FileManager
+    ) -> [Candidate] {
+        var candidates: [Candidate] = []
+
+        func append(kind: LocationKind, source: LocationSource, url: URL) {
+            let chosen = selected.contains { location in
+                location.kind == kind
+                    && location.source == source
+                    && samePath(location.url, url)
+            }
+            candidates.append(
+                Candidate(
+                    kind: kind,
+                    source: source,
+                    url: url,
+                    exists: directoryExists(url, fileManager: fm),
+                    isSelected: chosen
+                )
+            )
+        }
+
+        append(kind: .data, source: .standard, url: standardData)
+        append(kind: .data, source: .legacyHomeDotDirectory, url: legacyHome)
+        if let legacySupport {
+            append(kind: .data, source: .legacyApplicationSupport, url: legacySupport)
+        }
+
+        append(kind: .config, source: .standard, url: standardConfig)
+        append(
+            kind: .config,
+            source: .legacyHomeDotDirectory,
+            url: legacyHome.appendingPathComponent("config", isDirectory: true)
+        )
+        if let legacySupport {
+            append(
+                kind: .config,
+                source: .legacyApplicationSupport,
+                url: legacySupport.appendingPathComponent("config", isDirectory: true)
+            )
+        }
+
+        append(kind: .cache, source: .standard, url: standardCache)
+        append(
+            kind: .cache,
+            source: .legacyHomeDotDirectory,
+            url: legacyHome.appendingPathComponent("cache", isDirectory: true)
+        )
+        if let legacySupport {
+            append(
+                kind: .cache,
+                source: .legacyApplicationSupport,
+                url: legacySupport.appendingPathComponent("cache", isDirectory: true)
+            )
+        }
+
+        return candidates
+    }
+
+    private static func standardDataRoot(in directories: PlatformDirectories) -> URL {
+        if let applicationSupportDirectory = directories.applicationSupportDirectory {
+            return applicationSupportDirectory.appendingPathComponent(
+                standardApplicationSupportFolderName,
+                isDirectory: true
+            )
+        }
+        return directories.xdgDataHome.appendingPathComponent(xdgFolderName, isDirectory: true)
+    }
+
+    private static func standardConfigRoot(in directories: PlatformDirectories) -> URL {
+        if let applicationSupportDirectory = directories.applicationSupportDirectory {
+            return applicationSupportDirectory
+                .appendingPathComponent(standardApplicationSupportFolderName, isDirectory: true)
+                .appendingPathComponent("config", isDirectory: true)
+        }
+        return directories.xdgConfigHome.appendingPathComponent(xdgFolderName, isDirectory: true)
+    }
+
+    private static func standardCacheRoot(in directories: PlatformDirectories) -> URL {
+        if let cachesDirectory = directories.cachesDirectory {
+            return cachesDirectory.appendingPathComponent(
+                standardCacheFolderName,
+                isDirectory: true
+            )
+        }
+        return directories.xdgCacheHome.appendingPathComponent(xdgFolderName, isDirectory: true)
+    }
+
+    private static func testRoot(from environment: [String: String]) -> URL? {
+        guard let raw = environment[testRootEnvironmentVariable]?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !raw.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true)
+    }
+
+    private static func xdgDirectory(
+        environmentName: String,
+        fallback: URL,
+        environment: [String: String]
+    ) -> URL {
+        guard let raw = environment[environmentName]?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !raw.isEmpty else {
+            return fallback
+        }
+        let expanded = (raw as NSString).expandingTildeInPath
+        guard expanded.hasPrefix("/") else { return fallback }
+        return URL(fileURLWithPath: expanded, isDirectory: true)
+    }
+
+    private static func directoryExists(_ url: URL, fileManager fm: FileManager) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fm.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+}
+
+private func samePath(_ lhs: URL, _ rhs: URL) -> Bool {
+    lhs.standardizedFileURL.path == rhs.standardizedFileURL.path
+}

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/AppDataLocationResolverTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/AppDataLocationResolverTests.swift
@@ -1,0 +1,219 @@
+//
+//  AppDataLocationResolverTests.swift
+//  OsaurusRepository
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusRepository
+
+final class AppDataLocationResolverTests: XCTestCase {
+    private var sandbox: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sandbox = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-location-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let sandbox {
+            try? FileManager.default.removeItem(at: sandbox)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testNewInstallUsesAppleStandardLocationsWithoutCreatingThem() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(
+            locations.dataRoot,
+            dirs.applicationSupportDirectory!.appendingPathComponent("Osaurus", isDirectory: true)
+        )
+        XCTAssertEqual(
+            locations.configRoot,
+            dirs.applicationSupportDirectory!
+                .appendingPathComponent("Osaurus", isDirectory: true)
+                .appendingPathComponent("config", isDirectory: true)
+        )
+        XCTAssertEqual(
+            locations.cacheRoot,
+            dirs.cachesDirectory!.appendingPathComponent("Osaurus", isDirectory: true)
+        )
+        XCTAssertEqual(locations.data.source, .standard)
+        XCTAssertEqual(locations.config.source, .standard)
+        XCTAssertEqual(locations.cache.source, .standard)
+        XCTAssertFalse(fm.fileExists(atPath: locations.dataRoot.path))
+        XCTAssertFalse(fm.fileExists(atPath: locations.cacheRoot.path))
+    }
+
+    func testExistingHomeDotDirectoryKeepsDataAndConfigInLegacyRoot() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let legacy = dirs.homeDirectory.appendingPathComponent(".osaurus", isDirectory: true)
+        try fm.createDirectory(
+            at: legacy.appendingPathComponent("config", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, legacy)
+        XCTAssertEqual(locations.data.source, .legacyHomeDotDirectory)
+        XCTAssertEqual(
+            locations.configRoot,
+            legacy.appendingPathComponent("config", isDirectory: true)
+        )
+        XCTAssertEqual(locations.config.source, .legacyHomeDotDirectory)
+        XCTAssertEqual(locations.cache.source, .standard)
+        XCTAssertFalse(fm.fileExists(atPath: locations.standardDataRoot.path))
+    }
+
+    func testExistingLegacyCacheFallsBackForCompatibility() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let legacyCache = dirs.homeDirectory
+            .appendingPathComponent(".osaurus", isDirectory: true)
+            .appendingPathComponent("cache", isDirectory: true)
+        try fm.createDirectory(at: legacyCache, withIntermediateDirectories: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.cacheRoot, legacyCache)
+        XCTAssertEqual(locations.cache.source, .legacyHomeDotDirectory)
+    }
+
+    func testStandardRootWinsOverRetiredApplicationSupportWhenHomeLegacyIsAbsent() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let standard = dirs.applicationSupportDirectory!.appendingPathComponent(
+            "Osaurus",
+            isDirectory: true
+        )
+        let retired = dirs.applicationSupportDirectory!.appendingPathComponent(
+            "com.dinoki.osaurus",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: standard, withIntermediateDirectories: true)
+        try fm.createDirectory(at: retired, withIntermediateDirectories: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, standard)
+        XCTAssertEqual(locations.data.source, .standard)
+        XCTAssertTrue(
+            locations.candidates.contains {
+                $0.kind == .data && $0.source == .legacyApplicationSupport && $0.exists
+            }
+        )
+    }
+
+    func testRetiredApplicationSupportIsReadOnlyFallbackWhenItIsTheOnlyExistingRoot() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let retired = dirs.applicationSupportDirectory!.appendingPathComponent(
+            "com.dinoki.osaurus",
+            isDirectory: true
+        )
+        try fm.createDirectory(
+            at: retired.appendingPathComponent("config", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, retired)
+        XCTAssertEqual(locations.data.source, .legacyApplicationSupport)
+        XCTAssertEqual(
+            locations.configRoot,
+            retired.appendingPathComponent("config", isDirectory: true)
+        )
+        XCTAssertEqual(locations.config.source, .legacyApplicationSupport)
+        XCTAssertFalse(fm.fileExists(atPath: locations.standardDataRoot.path))
+    }
+
+    func testEnvironmentOverrideCollapsesLocationsUnderTestRoot() throws {
+        let dirs = platformDirectories()
+        let root = sandbox.appendingPathComponent("override-root", isDirectory: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [AppDataLocationResolver.testRootEnvironmentVariable: root.path],
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, root)
+        XCTAssertEqual(locations.configRoot, root.appendingPathComponent("config", isDirectory: true))
+        XCTAssertEqual(locations.cacheRoot, root.appendingPathComponent("cache", isDirectory: true))
+        XCTAssertEqual(locations.data.source, .environmentOverride)
+        XCTAssertEqual(locations.config.source, .environmentOverride)
+        XCTAssertEqual(locations.cache.source, .environmentOverride)
+    }
+
+    func testXDGDirectoriesAreUsedWhenAppleDirectoriesAreUnavailable() throws {
+        let dirs = AppDataLocationResolver.PlatformDirectories(
+            homeDirectory: sandbox.appendingPathComponent("home", isDirectory: true),
+            applicationSupportDirectory: nil,
+            cachesDirectory: nil,
+            xdgDataHome: sandbox.appendingPathComponent("xdg-data", isDirectory: true),
+            xdgConfigHome: sandbox.appendingPathComponent("xdg-config", isDirectory: true),
+            xdgCacheHome: sandbox.appendingPathComponent("xdg-cache", isDirectory: true)
+        )
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(
+            locations.dataRoot,
+            dirs.xdgDataHome.appendingPathComponent("osaurus", isDirectory: true)
+        )
+        XCTAssertEqual(
+            locations.configRoot,
+            dirs.xdgConfigHome.appendingPathComponent("osaurus", isDirectory: true)
+        )
+        XCTAssertEqual(
+            locations.cacheRoot,
+            dirs.xdgCacheHome.appendingPathComponent("osaurus", isDirectory: true)
+        )
+    }
+
+    private func platformDirectories() -> AppDataLocationResolver.PlatformDirectories {
+        AppDataLocationResolver.PlatformDirectories(
+            homeDirectory: sandbox.appendingPathComponent("home", isDirectory: true),
+            applicationSupportDirectory:
+                sandbox.appendingPathComponent("Library/Application Support", isDirectory: true),
+            cachesDirectory: sandbox.appendingPathComponent("Library/Caches", isDirectory: true),
+            xdgDataHome: sandbox.appendingPathComponent("home/.local/share", isDirectory: true),
+            xdgConfigHome: sandbox.appendingPathComponent("home/.config", isDirectory: true),
+            xdgCacheHome: sandbox.appendingPathComponent("home/.cache", isDirectory: true)
+        )
+    }
+}

--- a/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/AppDataLocationResolverTests.swift
+++ b/Packages/OsaurusRepository/Tests/OsaurusRepositoryTests/AppDataLocationResolverTests.swift
@@ -58,7 +58,7 @@ final class AppDataLocationResolverTests: XCTestCase {
         XCTAssertFalse(fm.fileExists(atPath: locations.cacheRoot.path))
     }
 
-    func testExistingHomeDotDirectoryKeepsDataAndConfigInLegacyRoot() throws {
+    func testExistingHomeDotDirectoryKeepsDataConfigAndCacheInLegacyRoot() throws {
         let fm = FileManager.default
         let dirs = platformDirectories()
         let legacy = dirs.homeDirectory.appendingPathComponent(".osaurus", isDirectory: true)
@@ -80,8 +80,50 @@ final class AppDataLocationResolverTests: XCTestCase {
             legacy.appendingPathComponent("config", isDirectory: true)
         )
         XCTAssertEqual(locations.config.source, .legacyHomeDotDirectory)
-        XCTAssertEqual(locations.cache.source, .standard)
+        XCTAssertEqual(
+            locations.cacheRoot,
+            legacy.appendingPathComponent("cache", isDirectory: true)
+        )
+        XCTAssertEqual(locations.cache.source, .legacyHomeDotDirectory)
+        XCTAssertEqual(locations.configSearchDirectories.first, locations.configRoot)
+        XCTAssertEqual(locations.cacheSearchDirectories.first, locations.cacheRoot)
         XCTAssertFalse(fm.fileExists(atPath: locations.standardDataRoot.path))
+        XCTAssertFalse(fm.fileExists(atPath: locations.cacheRoot.path))
+    }
+
+    func testExistingHomeDotDirectoryKeepsConfigAndCacheWhenStandardCandidatesExist() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let legacy = dirs.homeDirectory.appendingPathComponent(".osaurus", isDirectory: true)
+        let standardConfig = dirs.applicationSupportDirectory!
+            .appendingPathComponent("Osaurus", isDirectory: true)
+            .appendingPathComponent("config", isDirectory: true)
+        let standardCache = dirs.cachesDirectory!.appendingPathComponent(
+            "Osaurus",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: legacy, withIntermediateDirectories: true)
+        try fm.createDirectory(at: standardConfig, withIntermediateDirectories: true)
+        try fm.createDirectory(at: standardCache, withIntermediateDirectories: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, legacy)
+        XCTAssertEqual(locations.data.source, .legacyHomeDotDirectory)
+        XCTAssertEqual(
+            locations.configRoot,
+            legacy.appendingPathComponent("config", isDirectory: true)
+        )
+        XCTAssertEqual(locations.config.source, .legacyHomeDotDirectory)
+        XCTAssertEqual(
+            locations.cacheRoot,
+            legacy.appendingPathComponent("cache", isDirectory: true)
+        )
+        XCTAssertEqual(locations.cache.source, .legacyHomeDotDirectory)
     }
 
     func testExistingLegacyCacheFallsBackForCompatibility() throws {
@@ -156,7 +198,42 @@ final class AppDataLocationResolverTests: XCTestCase {
             retired.appendingPathComponent("config", isDirectory: true)
         )
         XCTAssertEqual(locations.config.source, .legacyApplicationSupport)
+        XCTAssertEqual(
+            locations.cacheRoot,
+            retired.appendingPathComponent("cache", isDirectory: true)
+        )
+        XCTAssertEqual(locations.cache.source, .legacyApplicationSupport)
         XCTAssertFalse(fm.fileExists(atPath: locations.standardDataRoot.path))
+    }
+
+    func testRetiredApplicationSupportKeepsCacheWhenStandardCacheExists() throws {
+        let fm = FileManager.default
+        let dirs = platformDirectories()
+        let retired = dirs.applicationSupportDirectory!.appendingPathComponent(
+            "com.dinoki.osaurus",
+            isDirectory: true
+        )
+        let standardCache = dirs.cachesDirectory!.appendingPathComponent(
+            "Osaurus",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: retired, withIntermediateDirectories: true)
+        try fm.createDirectory(at: standardCache, withIntermediateDirectories: true)
+
+        let locations = AppDataLocationResolver.resolve(
+            environment: [:],
+            fileManager: fm,
+            platformDirectories: dirs
+        )
+
+        XCTAssertEqual(locations.dataRoot, retired)
+        XCTAssertEqual(locations.data.source, .legacyApplicationSupport)
+        XCTAssertEqual(
+            locations.cacheRoot,
+            retired.appendingPathComponent("cache", isDirectory: true)
+        )
+        XCTAssertEqual(locations.cache.source, .legacyApplicationSupport)
+        XCTAssertEqual(locations.cacheSearchDirectories.first, locations.cacheRoot)
     }
 
     func testEnvironmentOverrideCollapsesLocationsUnderTestRoot() throws {

--- a/Packages/OsaurusRepository/ToolsPaths.swift
+++ b/Packages/OsaurusRepository/ToolsPaths.swift
@@ -3,7 +3,7 @@
 //  osaurus
 //
 //  Path management for plugin storage and specifications.
-//  Mirrors OsaurusPaths.root() for use in the OsaurusRepository package.
+//  Mirrors the shared app-data resolver for use in the OsaurusRepository package.
 //
 
 import Foundation
@@ -11,25 +11,19 @@ import Foundation
 public enum ToolsPaths {
     /// Optional root directory override for tests
     /// Note: nonisolated(unsafe) since this is only set during test setup before any concurrent access
-    public nonisolated(unsafe) static var overrideRoot: URL?
+    nonisolated(unsafe) public static var overrideRoot: URL?
 
-    /// The root data directory for Osaurus: `~/.osaurus/`
+    /// The resolved root data directory for Osaurus.
     public static func root() -> URL {
-        if let override = overrideRoot {
-            return override
-        }
-        let fm = FileManager.default
-        return fm.homeDirectoryForCurrentUser.appendingPathComponent(".osaurus", isDirectory: true)
+        AppDataLocationResolver.resolve(overrideRoot: overrideRoot).dataRoot
     }
 
     /// Tools directory (plugins)
-    /// `~/.osaurus/Tools/`
     public static func toolsRootDirectory() -> URL {
         root().appendingPathComponent("Tools", isDirectory: true)
     }
 
     /// Plugin specifications directory
-    /// `~/.osaurus/PluginSpecs/`
     public static func pluginSpecsRoot() -> URL {
         root().appendingPathComponent("PluginSpecs", isDirectory: true)
     }

--- a/Packages/OsaurusRepository/ToolsPaths.swift
+++ b/Packages/OsaurusRepository/ToolsPaths.swift
@@ -18,6 +18,11 @@ public enum ToolsPaths {
         AppDataLocationResolver.resolve(overrideRoot: overrideRoot).dataRoot
     }
 
+    /// Configuration directory resolved from the shared app-data resolver.
+    public static func configRootDirectory() -> URL {
+        AppDataLocationResolver.resolve(overrideRoot: overrideRoot).configRoot
+    }
+
     /// Tools directory (plugins)
     public static func toolsRootDirectory() -> URL {
         root().appendingPathComponent("Tools", isDirectory: true)

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -279,7 +279,7 @@ Issue [#1422](https://github.com/osaurus-ai/osaurus/issues/1422) is right: the h
 |---|---|---|
 | App data | `~/Library/Application Support/Osaurus/` | `~/.osaurus/`, then `~/Library/Application Support/com.dinoki.osaurus/` when those already exist |
 | Config | `~/Library/Application Support/Osaurus/config/` | Matching legacy data root's `config/` directory |
-| Cache | `~/Library/Caches/Osaurus/` | Existing `~/.osaurus/cache/` or retired Application Support cache |
+| Cache | `~/Library/Caches/Osaurus/` | Matching legacy data root's `cache/` directory |
 | XDG fallback | `~/.local/share/osaurus/`, `~/.config/osaurus/`, `~/.cache/osaurus/` | Used only when Apple directory APIs are unavailable |
 | Model weights | `~/MLXModels/` (legacy `~/Documents/MLXModels/`, env override, or user-picked folder) | Separate decision — weights are user-managed and home-visible by design |
 
@@ -295,7 +295,7 @@ The resolver does **not** move user data automatically. Existing legacy roots re
 - Sandbox tooling and plugin/container trees can be many gigabytes; a silent move on upgrade is not acceptable.
 - If a standard root and a legacy root both exist, the resolver keeps the legacy root active to avoid switching away from existing user data. The diagnostic report surfaces this with `standard_location_available_legacy_active`.
 
-The contract is: paths resolve through `AppDataLocationResolver` via `OsaurusPaths` / `ToolsPaths`, the audit reports reality instead of hiding it, and no code should invent a storage root directly.
+The contract is: paths resolve through `AppDataLocationResolver` via `OsaurusPaths` / `ToolsPaths`, preserved legacy data roots keep their config/cache siblings, the audit reports reality instead of hiding it, and no code should invent a storage root directly.
 
 ---
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,6 +1,6 @@
 # Storage
 
-Osaurus stores your local data — chats, memory, methods, tool indexes, plugin databases, and large attachments — under `~/.osaurus/`. As of 0.21.0, that data is stored **as plaintext SQLite by default**, relying on macOS **FileVault** for at-rest protection, with **SQLCipher whole-database encryption available as an explicit opt-in** in **Settings → Storage**.
+Osaurus stores your local data — chats, memory, methods, tool indexes, plugin databases, and large attachments — under the resolved app-data root. Fresh installs use `~/Library/Application Support/Osaurus/`; existing installs continue to use `~/.osaurus/` or the retired `~/Library/Application Support/com.dinoki.osaurus/` when those roots already exist. As of 0.21.0, that data is stored **as plaintext SQLite by default**, relying on macOS **FileVault** for at-rest protection, with **SQLCipher whole-database encryption available as an explicit opt-in** in **Settings → Storage**.
 
 This is a deliberate change from the earlier always-on encryption model. The "why" is documented in [Why encryption is opt-in](#why-encryption-is-opt-in) below — the short version is reliability: an always-required Keychain key coupled every store's ability to open to a secret that breaks on Mac migration, app re-signing, or a Keychain wipe, and when it broke it failed closed with no recovery.
 
@@ -28,12 +28,12 @@ This document covers how data is stored, how opening is decided per-file, how to
 
 ## Overview
 
-Everything Osaurus persists lives under `~/.osaurus/`:
+Everything Osaurus persists lives under the resolved app-data root:
 
 - **Default (plaintext).** Every SQLite database is a normal SQLite file, and large attachments / `.osec`-class artifacts are written as plaintext. On a modern Mac, **FileVault** already encrypts the entire disk at rest, so plaintext-on-disk is still protected when the Mac is powered off or logged out — without depending on an app-managed key that can go missing.
 - **Opt-in (encrypted).** When you enable encryption in **Settings → Storage**, every SQLite database is converted to a [SQLCipher 4.6.1](https://www.zetetic.net/sqlcipher/) database keyed with a 32-byte symmetric key, and app-layer artifacts are written as AES-GCM `.osec` files. The data-encryption key (DEK) lives in the macOS Keychain, scoped to your account on this device.
 
-The posture (plaintext vs. encrypted) is your choice and is persisted in a small, deliberately **non-encrypted** marker file (`~/.osaurus/.storage-encryption.json`). It cannot itself be encrypted — that would reintroduce the chicken-and-egg key dependency this design removes.
+The posture (plaintext vs. encrypted) is your choice and is persisted in a small, deliberately **non-encrypted** marker file (`<data root>/.storage-encryption.json`). It cannot itself be encrypted — that would reintroduce the chicken-and-egg key dependency this design removes.
 
 ---
 
@@ -46,7 +46,7 @@ In the always-on model, every store's ability to open depended on a Keychain DEK
 - Migrating to a new Mac without iCloud Keychain sync.
 - Re-signing the app (different team/identity) so the Keychain ACL no longer matches.
 - Wiping or resetting the login Keychain.
-- Restoring `~/.osaurus/` into a different user account than the one the key was paired with.
+- Restoring a different app-data root into a different user account than the one the key was paired with.
 
 When that happened, `StorageKeyManager.currentKey()` threw `keyUnavailableForExistingData`, the database refused to open, and the app **failed closed with an opaque error** — silently bricking memory and search for real users, with no recovery path. Reliability is the priority, and FileVault already provides full-disk at-rest encryption on modern macOS. So the default is now plaintext, and SQLCipher is an explicit, reversible opt-in.
 
@@ -55,12 +55,12 @@ When that happened, `StorageKeyManager.currentKey()` threw `keyUnavailableForExi
 | Threat | Plaintext + FileVault (default) | Opt-in SQLCipher |
 |---|---|---|
 | Lost/stolen Mac, powered off | Protected by FileVault full-disk encryption | Protected (FileVault **and** SQLCipher) |
-| Another logged-in user on the same Mac reading your files | Filesystem permissions only (`~/.osaurus` is user-owned); **not** cryptographically separated | Cryptographically separated — the DEK is scoped to your account |
+| Another logged-in user on the same Mac reading your files | Filesystem permissions only (the app-data root is user-owned); **not** cryptographically separated | Cryptographically separated — the DEK is scoped to your account |
 | You don't use FileVault | Data is readable from the raw disk | Encrypted at rest regardless of FileVault |
-| Backups / Time Machine / cloud sync of `~/.osaurus` | Copied as plaintext | Copied as ciphertext |
+| Backups / Time Machine / cloud sync of the app-data root | Copied as plaintext | Copied as ciphertext |
 | Keychain key lost (migration, re-sign, wipe) | **No impact** — nothing depends on the key | Encrypted stores can't be opened until the key is restored or the store is reset |
 
-Plain-language summary: **plaintext is the most reliable option and is well-protected if FileVault is on.** Turn on SQLCipher if you share the Mac account, don't run FileVault, or sync/back up `~/.osaurus` to a place you don't fully trust — and keep a plaintext backup in case the key is ever lost.
+Plain-language summary: **plaintext is the most reliable option and is well-protected if FileVault is on.** Turn on SQLCipher if you share the Mac account, don't run FileVault, or sync/back up the app-data root to a place you don't fully trust — and keep a plaintext backup in case the key is ever lost.
 
 ---
 
@@ -82,7 +82,7 @@ The consequence: in the default (plaintext) world, `currentKey()` is **never cal
 
 Nothing to configure. On first launch of a fresh install:
 
-1. The posture marker is created in plaintext mode (`~/.osaurus/.storage-encryption.json`).
+1. The posture marker is created in plaintext mode (`<data root>/.storage-encryption.json`).
 2. Each database is created as a plaintext SQLite file on first open via [`OsaurusStorageOpener`](../Packages/OsaurusCore/Storage/OsaurusStorageOpener.swift).
 
 If you upgraded from a version that used always-on encryption, your existing encrypted data is **migrated automatically and invisibly on first launch** (see [Migration and Convergence](#migration-and-convergence)): it is decrypted to plaintext when macOS FileVault is enabled, or kept encrypted when FileVault is off so the migration never silently removes its only at-rest protection. There is no prompt or notice — the change is seamless, and you can always flip the posture later from **Settings → Storage**.
@@ -97,15 +97,15 @@ To back up your data in plaintext (for example, before reinstalling macOS), open
 
 | Artifact | Default (plaintext) | Opt-in (encrypted) | On-disk location |
 |---|---|---|---|
-| Chat history | SQLite | SQLCipher | `~/.osaurus/chat-history/history.sqlite` |
-| Router billing ledger | SQLite | SQLCipher | `~/.osaurus/billing/ledger.sqlite` |
-| Memory (identity, pinned facts, episodes, transcript, FTS5 mirrors) | SQLite | SQLCipher | `~/.osaurus/memory/memory.sqlite` |
-| Methods catalog | SQLite | SQLCipher | `~/.osaurus/methods/methods.sqlite` |
-| Tool index | SQLite | SQLCipher | `~/.osaurus/tool-index/tool_index.sqlite` |
-| Per-plugin databases | SQLite | SQLCipher | `~/.osaurus/Tools/<plugin-id>/data/data.db` |
-| Per-agent database (opt-in feature) | SQLite | SQLCipher | `~/.osaurus/agents/<uuid>/db.sqlite` |
-| Self-scheduling slots | SQLite | SQLCipher | `~/.osaurus/scheduler.sqlite` |
-| Large chat attachments | plaintext blob | AES-GCM (`.osec`) | `~/.osaurus/chat-history/blobs/<sha256>` |
+| Chat history | SQLite | SQLCipher | `<data root>/chat-history/history.sqlite` |
+| Router billing ledger | SQLite | SQLCipher | `<data root>/billing/ledger.sqlite` |
+| Memory (identity, pinned facts, episodes, transcript, FTS5 mirrors) | SQLite | SQLCipher | `<data root>/memory/memory.sqlite` |
+| Methods catalog | SQLite | SQLCipher | `<data root>/methods/methods.sqlite` |
+| Tool index | SQLite | SQLCipher | `<data root>/tool-index/tool_index.sqlite` |
+| Per-plugin databases | SQLite | SQLCipher | `<data root>/Tools/<plugin-id>/data/data.db` |
+| Per-agent database (opt-in feature) | SQLite | SQLCipher | `<data root>/agents/<uuid>/db.sqlite` |
+| Self-scheduling slots | SQLite | SQLCipher | `<data root>/scheduler.sqlite` |
+| Large chat attachments | plaintext blob | AES-GCM (`.osec`) | `<data root>/chat-history/blobs/<sha256>` |
 
 **Attachment spillover.** Every `Attachment.image` or `Attachment.document` payload greater than or equal to **16 KB** is hashed (SHA-256, content-addressed so duplicates dedup) and written to its own file via [`AttachmentBlobStore`](../Packages/OsaurusCore/Storage/AttachmentBlobStore.swift). In plaintext mode the blob is written raw; in encrypted mode it is written as an AES-GCM `.osec` twin. Reads are detection-first (sniff the file, prefer the plaintext twin, fall back to `.osec`) via [`EncryptedFileStore`](../Packages/OsaurusCore/Storage/EncryptedFileStore.swift), so a posture change never strands existing blobs. The chat row stores only `{ "ref": "<sha256>", ... }`. Smaller payloads stay inline in the row.
 
@@ -113,10 +113,10 @@ To back up your data in plaintext (for example, before reinstalling macOS), open
 
 **Always plaintext, by design.** A few artifacts stay plaintext in both modes:
 
-- The encryption posture marker `~/.osaurus/.storage-encryption.json` (it cannot be encrypted — see [Overview](#overview)).
-- JSON config under `~/.osaurus/config/`, `agents/`, `themes/`, `providers/`, `schedules/`, `watchers/`, `skills/` that is read as raw JSON by various consumers. (In encrypted mode, sensitive app-layer artifacts that go through `EncryptedFileStore` are wrapped; pure config that must be world-readable JSON stays plaintext.)
-- Plugin manifests under `~/.osaurus/sandbox-plugins/`.
-- Vector index files under `~/.osaurus/memory/vectura/<agentId>/`. These are rebuilt from the SQLite source on demand; see [Limitations](#limitations-and-trade-offs).
+- The encryption posture marker `<data root>/.storage-encryption.json` (it cannot be encrypted — see [Overview](#overview)).
+- JSON config under the resolved config root plus `<data root>/agents/`, `themes/`, `providers/`, `schedules/`, `watchers/`, and `skills/` that is read as raw JSON by various consumers. (In encrypted mode, sensitive app-layer artifacts that go through `EncryptedFileStore` are wrapped; pure config that must be world-readable JSON stays plaintext.)
+- Plugin manifests under `<data root>/sandbox-plugins/`.
+- Vector index files under `<data root>/memory/vectura/<agentId>/`. These are rebuilt from the SQLite source on demand; see [Limitations](#limitations-and-trade-offs).
 
 ---
 
@@ -158,7 +158,7 @@ Convergence **never auto-deletes data**. If a store can't be converted or opened
 Recovery actions are provided by [`StorageRecoveryService`](../Packages/OsaurusCore/Storage/StorageRecoveryService.swift):
 
 - **Retry** re-attempts the open (e.g. after you restore the Keychain key or fix signing) and clears the recorded issue on success.
-- **Reset** quarantines the unreadable file to `~/.osaurus/quarantine/` (it is **moved, never deleted**), removes the `-wal`/`-shm` sidecars via [`StorageFile`](../Packages/OsaurusCore/Storage/StorageFile.swift), and recreates an empty store in the current posture so the feature works again. Resetting the memory store also rebuilds its VecturaKit vector index from the fresh (empty) source.
+- **Reset** quarantines the unreadable file to `<data root>/quarantine/` (it is **moved, never deleted**), removes the `-wal`/`-shm` sidecars via [`StorageFile`](../Packages/OsaurusCore/Storage/StorageFile.swift), and recreates an empty store in the current posture so the feature works again. Resetting the memory store also rebuilds its VecturaKit vector index from the fresh (empty) source.
 
 Because the original file is only quarantined, a user who later recovers the key can still export the old data from the quarantined copy.
 
@@ -190,7 +190,7 @@ Code that needs to know whether it can safely persist checks `StorageKeyManager.
 
 ### Optional: derive from the master key
 
-For users who want their DEK reproducible across devices via the iCloud-synced Identity master key, `StorageKeyManager.deriveFromMasterKey(context:)` replaces the Keychain entry with `HKDF-SHA256(masterKeyBytes, salt, "osaurus-storage-v1")`. The salt is persisted in the Keychain (`com.osaurus.storage` / `data-encryption-salt`) and in a sidecar file at `~/.osaurus/.storage-key.salt` so it travels with a manual restore. The salt is harmless without the master key (HKDF is one-way).
+For users who want their DEK reproducible across devices via the iCloud-synced Identity master key, `StorageKeyManager.deriveFromMasterKey(context:)` replaces the Keychain entry with `HKDF-SHA256(masterKeyBytes, salt, "osaurus-storage-v1")`. The salt is persisted in the Keychain (`com.osaurus.storage` / `data-encryption-salt`) and in a sidecar file at `<data root>/.storage-key.salt` so it travels with a manual restore. The salt is harmless without the master key (HKDF is one-way).
 
 ### Rotation and reset
 
@@ -217,7 +217,7 @@ The panel includes a plain-language trade-offs section covering FileVault relian
 
 ### Export plaintext backup
 
-Writes a plaintext copy of every database, attachment, and config under `~/.osaurus/` to a folder you pick. In encrypted mode this decrypts on the way out; in plaintext mode it copies as-is. Use it **before** reinstalling macOS, migrating Macs, rotating the key, or wiping state. Export never changes anything on disk.
+Writes a plaintext copy of every database, attachment, and config under the resolved app-data root to a folder you pick. In encrypted mode this decrypts on the way out; in plaintext mode it copies as-is. Use it **before** reinstalling macOS, migrating Macs, rotating the key, or wiping state. Export never changes anything on disk.
 
 ### Rotate storage key (encrypted mode only)
 
@@ -239,7 +239,7 @@ Appears only when one or more stores failed to open this session. Lists each deg
 | `PRAGMA wal_checkpoint(TRUNCATE)` | every 7 days | Bounds the size of the `-wal` sidecar. |
 | `VACUUM` | every 30 days | Reclaims space after large deletes. |
 
-State is persisted in `~/.osaurus/.storage-maintenance.json`. The first load stamps "last run" to now, so the first tick never triggers a 30-day-old VACUUM. The ticker is started from [`AppDelegate`](../Packages/OsaurusCore/AppDelegate.swift) during launch.
+State is persisted in `<data root>/.storage-maintenance.json`. The first load stamps "last run" to now, so the first tick never triggers a 30-day-old VACUUM. The ticker is started from [`AppDelegate`](../Packages/OsaurusCore/AppDelegate.swift) during launch.
 
 **Plugin databases are intentionally not registered.** With hundreds of installed plugins, a global maintenance pass would thrash IO. Plugin DBs are still maintained by the plugin host, not the maintenance ticker.
 
@@ -249,52 +249,61 @@ State is persisted in `~/.osaurus/.storage-maintenance.json`. The first load sta
 
 | Path | Description |
 |---|---|
-| `~/.osaurus/.storage-encryption.json` | Desired at-rest posture marker (always plaintext) |
-| `~/.osaurus/.storage-maintenance.json` | Last `optimize` / `checkpoint` / `vacuum` timestamps |
-| `~/.osaurus/.storage-key.salt` | HKDF salt sidecar (only present when DEK is master-derived) |
-| `~/.osaurus/quarantine/` | Unreadable stores moved here by Reset recovery (never deleted) |
-| `~/.osaurus/billing/ledger.sqlite` | Router billing ledger (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/chat-history/history.sqlite` | Chat database (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/chat-history/blobs/<sha256>` | Spilled attachments (plaintext blob, or `.osec` when encrypted) |
-| `~/.osaurus/memory/memory.sqlite` | Memory database (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/memory/vectura/<agentId>/` | Per-agent VecturaKit vector index (plaintext, see Limitations) |
-| `~/.osaurus/methods/methods.sqlite` | Methods catalog (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/tool-index/tool_index.sqlite` | Tool index (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/Tools/<plugin-id>/data/data.db` | Per-plugin database (SQLite, or SQLCipher when encrypted) |
-| `~/.osaurus/agents/<uuid>/db.sqlite` | Per-agent database (see [Agent DB & Self-Scheduling](AGENT_DB.md)) |
-| `~/.osaurus/scheduler.sqlite` | Cross-agent next-run + pause slots (SQLite, or SQLCipher when encrypted) |
+| `<data root>/.storage-encryption.json` | Desired at-rest posture marker (always plaintext) |
+| `<data root>/.storage-maintenance.json` | Last `optimize` / `checkpoint` / `vacuum` timestamps |
+| `<data root>/.storage-key.salt` | HKDF salt sidecar (only present when DEK is master-derived) |
+| `<data root>/quarantine/` | Unreadable stores moved here by Reset recovery (never deleted) |
+| `<data root>/billing/ledger.sqlite` | Router billing ledger (SQLite, or SQLCipher when encrypted) |
+| `<data root>/chat-history/history.sqlite` | Chat database (SQLite, or SQLCipher when encrypted) |
+| `<data root>/chat-history/blobs/<sha256>` | Spilled attachments (plaintext blob, or `.osec` when encrypted) |
+| `<data root>/memory/memory.sqlite` | Memory database (SQLite, or SQLCipher when encrypted) |
+| `<data root>/memory/vectura/<agentId>/` | Per-agent VecturaKit vector index (plaintext, see Limitations) |
+| `<data root>/methods/methods.sqlite` | Methods catalog (SQLite, or SQLCipher when encrypted) |
+| `<data root>/tool-index/tool_index.sqlite` | Tool index (SQLite, or SQLCipher when encrypted) |
+| `<data root>/Tools/<plugin-id>/data/data.db` | Per-plugin database (SQLite, or SQLCipher when encrypted) |
+| `<data root>/agents/<uuid>/db.sqlite` | Per-agent database (see [Agent DB & Self-Scheduling](AGENT_DB.md)) |
+| `<data root>/scheduler.sqlite` | Cross-agent next-run + pause slots (SQLite, or SQLCipher when encrypted) |
+| `<config root>/server.json` | Server configuration |
 
-When encryption is on, the DEK lives in macOS Keychain, **not** in `~/.osaurus/`.
+When encryption is on, the DEK lives in macOS Keychain, **not** in the app-data root.
 
 ---
 
 ## Storage Location Standards
 
-Issue [#1422](https://github.com/osaurus-ai/osaurus/issues/1422) is right: the app-data root `~/.osaurus/` follows neither [Apple's file-system guidance](https://developer.apple.com/documentation/foundation/using-the-file-system-effectively) (app data belongs under `~/Library/Application Support/`) nor the [XDG base-directory spec](https://specifications.freedesktop.org/basedir/latest/). Historically the data deliberately moved *out of* `~/Library/Application Support/com.dinoki.osaurus/` *into* `~/.osaurus/` (see `OsaurusPaths.defaultRoot`), so this is a known trade-off, not an accident.
+Issue [#1422](https://github.com/osaurus-ai/osaurus/issues/1422) is right: the historical app-data root `~/.osaurus/` follows neither [Apple's file-system guidance](https://developer.apple.com/documentation/foundation/using-the-file-system-effectively) (app data belongs under `~/Library/Application Support/`) nor the [XDG base-directory spec](https://specifications.freedesktop.org/basedir/latest/) (`~/.local/share/`, `~/.config/`, `~/.cache/`). Path resolution now prefers Apple locations for fresh installs while preserving read-only fallback to existing legacy locations.
 
 ### Where things stand
 
-| Root | Current location | Spec-compliant target |
+| Root | Fresh-install location | Legacy fallback |
 |---|---|---|
-| App data | `~/.osaurus/` | `~/Library/Application Support/Osaurus/` |
-| Legacy app data | `~/Library/Application Support/com.dinoki.osaurus/` (copied/merged once into `~/.osaurus/` when the marker is missing; never deleted) | n/a — retired by `~/.osaurus/.legacy-application-support-merge.done` |
-| Model weights | `~/MLXModels/` (legacy `~/Documents/MLXModels/`, env override, or user-picked folder) | separate decision — weights are user-managed and home-visible by design |
+| App data | `~/Library/Application Support/Osaurus/` | `~/.osaurus/`, then `~/Library/Application Support/com.dinoki.osaurus/` when those already exist |
+| Config | `~/Library/Application Support/Osaurus/config/` | Matching legacy data root's `config/` directory |
+| Cache | `~/Library/Caches/Osaurus/` | Existing `~/.osaurus/cache/` or retired Application Support cache |
+| XDG fallback | `~/.local/share/osaurus/`, `~/.config/osaurus/`, `~/.cache/osaurus/` | Used only when Apple directory APIs are unavailable |
+| Model weights | `~/MLXModels/` (legacy `~/Documents/MLXModels/`, env override, or user-picked folder) | Separate decision — weights are user-managed and home-visible by design |
 
 ### The audit surface
 
-`GET /admin/cache-stats` returns a read-only `storage_locations` block (built by [`StorageLocationStandards`](../Packages/OsaurusCore/Utils/StorageLocationStandards.swift)) reporting: the active root and its classification, `spec_compliant`, whether the legacy `com.dinoki.osaurus` root still exists, whether the one-shot merge marker is present, the models root classification, and stable snake_case `reason_codes`. The audit never creates, copies, moves, or deletes anything.
+`GET /admin/cache-stats` returns a read-only `storage_locations` block (built by [`StorageLocationStandards`](../Packages/OsaurusCore/Utils/StorageLocationStandards.swift)) reporting: active data/config/cache roots, each root's source (`standard`, `legacy_home_dot_directory`, `legacy_application_support`, `test_override`, or `environment_override`), standard candidate roots, legacy candidate roots, candidate presence/selection, `migration_required`, the model root classification, and stable snake_case `reason_codes` with human-readable findings. The audit never creates, copies, moves, or deletes anything.
 
-### Why the root has not moved (yet)
+### Migration policy
 
-Relocating `~/.osaurus/` is a data-safety decision pending an explicit maintainer call, because the (optional) Keychain DEK and HKDF salt sidecar are paired with the existing tree, sandbox tooling references `~/.osaurus/` literally, and plugin/container trees can be many gigabytes. Until that decision, paths resolve exclusively through `OsaurusPaths`, and no code outside `OsaurusPaths` may invent a storage root.
+The resolver does **not** move user data automatically. Existing legacy roots remain active until a user or a future explicit migration flow moves the full tree safely. This is deliberate because:
+
+- The Keychain DEK is paired with the existing tree when encryption is enabled, and the HKDF salt sidecar (`<data root>/.storage-key.salt`) must travel with the data it unlocks (see Key Management above).
+- Sandbox tooling and plugin/container trees can be many gigabytes; a silent move on upgrade is not acceptable.
+- If a standard root and a legacy root both exist, the resolver keeps the legacy root active to avoid switching away from existing user data. The diagnostic report surfaces this with `standard_location_available_legacy_active`.
+
+The contract is: paths resolve through `AppDataLocationResolver` via `OsaurusPaths` / `ToolsPaths`, the audit reports reality instead of hiding it, and no code should invent a storage root directly.
 
 ---
 
 ## Limitations and Trade-offs
 
 - **Plaintext default relies on FileVault.** In the default mode, on-disk files are plaintext; their at-rest protection comes from FileVault full-disk encryption. If FileVault is off, the raw disk and any backups of `~/.osaurus/` are readable. Turn on FileVault, or opt in to SQLCipher, if that matters for your threat model. See [Why encryption is opt-in](#why-encryption-is-opt-in).
-- **Encrypted mode is device-bound and key-loss is unrecoverable.** When you opt in, the Keychain entry is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` and is **not** synced to iCloud. There is no escrow key. If you wipe the Keychain, restore a different `~/.osaurus/` than the one your Keychain was paired with, or migrate Macs without bringing the key, the encrypted stores can't be opened — Reset recovery quarantines them and recreates empty stores. Export a plaintext backup before any risky migration.
+- **Encrypted mode is device-bound and key-loss is unrecoverable.** When you opt in, the Keychain entry is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` and is **not** synced to iCloud. There is no escrow key. If you wipe the Keychain, restore a different app-data root than the one your Keychain was paired with, or migrate Macs without bringing the key, the encrypted stores can't be opened — Reset recovery quarantines them and recreates empty stores. Export a plaintext backup before any risky migration.
 - **`kdf_iter = 256000`.** SQLCipher's PBKDF2 round count is the SQLCipher 4 default. We use a CSPRNG key, so the PBKDF2 work is largely overhead, but the safer default stays. This only affects encrypted mode.
-- **VecturaKit indexes are plaintext in both modes.** The vector index files under `~/.osaurus/memory/vectura/<agentId>/` are written by VecturaKit, which doesn't support pluggable storage encryption. They are rebuilt from the SQLite source via `MemorySearchService.shared.rebuildIndex()`. The vectors leak some information (clustering, approximate counts) but no raw text.
+- **VecturaKit indexes are plaintext in both modes.** The vector index files under `<data root>/memory/vectura/<agentId>/` are written by VecturaKit, which doesn't support pluggable storage encryption. They are rebuilt from the SQLite source via `MemorySearchService.shared.rebuildIndex()`. The vectors leak some information (clustering, approximate counts) but no raw text.
 - **Plugin database maintenance is per-plugin.** Skipping global `StorageMaintenance` registration means plugin DBs can grow large `-wal` files if a plugin opens a transaction it never commits. Plugin authors should run `PRAGMA wal_checkpoint` on long-lived connections.
 - **Recovery requires the data itself, plus the Keychain entry only in encrypted mode.** In plaintext mode nothing extra is needed. In encrypted mode, recovery requires either the Keychain entry or a plaintext backup. See [`SECURITY.md`](SECURITY.md) for the recovery posture.

--- a/docs/plugins/FAQ.md
+++ b/docs/plugins/FAQ.md
@@ -92,7 +92,7 @@ Browsers can't add the `X-Osaurus-Agent-Id` header to top-level navigation. Use 
 
 ### Does the dev proxy work with Vite HMR?
 
-Yes. The proxy now forwards the original method, headers, and body — POSTs, HMR pings, fetch calls all flow through. Set `~/Library/Application Support/Osaurus/Config/dev-proxy.json` per [ROUTES_AND_WEB.md#dev-proxy](ROUTES_AND_WEB.md#dev-proxy).
+Yes. The proxy now forwards the original method, headers, and body — POSTs, HMR pings, fetch calls all flow through. Set `dev-proxy.json` in the resolved Osaurus config directory per [ROUTES_AND_WEB.md#dev-proxy](ROUTES_AND_WEB.md#dev-proxy).
 
 ### Are paths case-sensitive?
 

--- a/docs/plugins/ROUTES_AND_WEB.md
+++ b/docs/plugins/ROUTES_AND_WEB.md
@@ -210,7 +210,8 @@ http://127.0.0.1:1338/plugins/dev.example.MyPlugin/ui?osr_agent=<agent_uuid>
 
 During development you often want to run a Vite / Next.js / webpack dev server with HMR rather than rebuilding the plugin every time the UI changes.
 
-Create `~/Library/Application Support/Osaurus/Config/dev-proxy.json`:
+Create `dev-proxy.json` in the resolved Osaurus config directory, such as
+`~/Library/Application Support/Osaurus/config/dev-proxy.json` on macOS:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Add a shared app data resolver for Apple/XDG data, config, and cache locations, with read-only fallback to existing legacy roots.
- Wire core paths, repository tooling, and CLI server-config lookup through the resolver.
- Expand storage-location diagnostics, docs, and tests for migration-required reporting without automatic data moves.

## Validation
- swift test --package-path Packages/OsaurusRepository --filter AppDataLocationResolverTests
- swift test --package-path Packages/OsaurusCore --filter 'StorageLocationStandardsTests|RuntimePolicySourceTests/adminCacheStatsExposesStorageLocationStandards'
- swift test --package-path Packages/OsaurusCLI
- git diff --check
