### PR TITLE
Add native audio file attachments for capable local models

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -230,6 +230,7 @@ final class ModelManager: NSObject, ObservableObject {
         NotificationCenter.default.publisher(for: .localModelsChanged)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                ModelMediaCapabilities.invalidateComposerDescriptorCache()
                 self?.refreshDownloadStates()
             }
             .store(in: &cancellables)
@@ -1638,6 +1639,7 @@ extension ModelManager {
         localModelsCacheCondition.unlock()
         LocalReasoningCapability.invalidate()
         LocalGenerationDefaults.invalidate()
+        ModelMediaCapabilities.invalidateComposerDescriptorCache()
     }
 
     nonisolated static func localModelsScanDiagnosticJSONObject() -> [String: Any]? {

--- a/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
+++ b/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
@@ -17,9 +17,8 @@ this:
 | Loaded model | Drop zone accepts | File picker shows |
 |---|---|---|
 | Nemotron-3-Nano-Omni (any quant tier) | image + audio + video | image + docs + audio + video |
-| Installed Gemma 4 bundles with audio tensors in the weight map | image + audio | image + docs + audio |
 | Qwen 2/2.5/3 VL, Qwen 3.5/3.6 MoE VL, Holo3 VL, SmolVLM 2 | image + video | image + docs + video |
-| Image-only VLMs (PaliGemma, Idefics3, FastVLM, Pixtral standalone, GLM OCR, LFM2-VL, Gemma 3, Gemma 4 bundles without audio tensors, Mistral 3/3.5/4) | image | image + docs |
+| Image-only VLMs (PaliGemma, Idefics3, FastVLM, Pixtral standalone, GLM OCR, LFM2-VL, Gemma 3, Gemma 4, Mistral 3/3.5/4) | image | image + docs |
 | Dense LLMs (gpt-oss, Laguna, MiniMax text, Kimi, etc.) | (no media) | docs |
 
 When a user drops a file the current model can't consume, the host
@@ -39,15 +38,16 @@ Pinned to the regex/substring matcher in
 - Any future bundle whose id matches regex `nemotron-3-nano-omni|nemotron[_-]h[_-]omni`
 - Locally-installed bundles with a `config_omni.json` sidecar — `from(directory:modelId:)` reads this directly
 
-### Audio + image (installed bundle proof required)
+### Gemma 4 audio diagnostics (partial/blocked)
 
-- Gemma 4 checkpoints whose installed `model.safetensors.index.json`
-  contains `embed_audio.embedding_projection`, or single-file bundles
-  whose `config.json` includes a non-null `audio_config`.
-- Name-only Gemma 4 detection remains proof-required for audio so the
-  composer does not advertise audio before it can inspect the local
-  checkpoint. Installed 26B-A4B / 31B-style bundles without
-  `embed_audio` or `audio_tower` are image-only and produce a typed
+- Gemma 4 checkpoints remain image-only for attachment acceptance.
+- If an installed Gemma 4 bundle exposes `embed_audio` / `audio_tower`
+  markers, Osaurus reports audio as `partial` and keeps the audio picker/drop
+  path blocked until live Osaurus/vMLX runtime proof exists.
+- If a single-file bundle exposes only `audio_config`, Osaurus reports audio as
+  `partial` but still blocks audio input because the weight map cannot prove
+  the tensors.
+- Installed Gemma 4 bundles without audio markers produce a typed
   unsupported-audio rejection.
 
 ### Image + video (no audio)
@@ -62,8 +62,7 @@ Pinned to the regex/substring matcher in
 - PaliGemma, Idefics 3, FastVLM, Llava-Qwen2
 - Pixtral standalone (NOT the Mistral 3 wrapper — that's matched separately)
 - GLM-OCR, LFM2-VL
-- Gemma 3, plus Gemma 4 name-only detection and installed Gemma 4
-  bundles that do not prove audio tensors.
+- Gemma 3 and Gemma 4.
 - Mistral 3 / Mistral 3.5 (image only via Pixtral wrapper) — regex `mistral[-_](3|medium-3)`
 - Mistral 4 VL — regex `mistral[-_]?4.*[-_]vl`
 
@@ -84,7 +83,7 @@ text, Laguna, Cascade-2 text, etc.)
 
 ## 3. Format extensions accepted
 
-### Audio (Nemotron-3-Nano-Omni + proven Gemma 4 bundles)
+### Audio (Nemotron-3-Nano-Omni)
 
 | Extension | UTType bucket | vmlx canonicalization |
 |---|---|---|
@@ -283,7 +282,8 @@ print(caps.summary)
 
 print(descriptor.audio.status.rawValue)
 // → "supported"  (Nemotron Omni)
-// → "unproven"   (Gemma4 VLM audio before live proof)
+// → "partial"    (installed Gemma4 bundle has audio markers but remains blocked)
+// → "unproven"   (Gemma4 VLM audio before bundle inspection/live proof)
 // → "unsupported" (text/image/video-only families)
 ```
 
@@ -300,8 +300,8 @@ This reads `config_omni.json` + `config.json` directly, so
 ambiguous IDs that the regex can't disambiguate (e.g. some
 community-renamed bundles) resolve correctly via the on-disk config.
 For chat composer gating, use `composerDescriptor(modelId:fallbackSupportsImages:localDirectory:)`
-so installed Gemma 4 bundles can upgrade audio from local bundle facts while
-name-only Gemma 4 stays proof-required.
+so installed Gemma 4 bundles report partial/blocked audio evidence from local
+bundle facts while name-only Gemma 4 stays proof-required.
 
 ---
 
@@ -310,9 +310,9 @@ name-only Gemma 4 stays proof-required.
 | Layer | Test file | Cases |
 |---|---|---|
 | Capability detection (regex/substring + modality status) | `Tests/Model/ModelMediaCapabilitiesMCDCTests.swift` | MC/DC-shaped + descriptor cases |
-| Chat composer model switching + installed bundle proof | `Tests/Chat/LocalModelDetectionTests.swift` | Gemma 4 audio-capable and no-audio bundle fixtures |
+| Chat composer model switching + installed bundle proof | `Tests/Chat/LocalModelDetectionTests.swift` | Gemma 4 partial-audio and no-audio bundle fixtures |
 | Audio file classification | `Tests/Documents/DocumentParserShimTests.swift` | native audio extension normalization + picker buckets |
-| Local runtime media policy | `Tests/Service/MLXServiceRuntimePolicyTests.swift` | audio blocked for unsupported models and allowed for proven Gemma 4 bundles |
+| Local runtime media policy | `Tests/Service/MLXServiceRuntimePolicyTests.swift` | audio blocked for unsupported models and Gemma 4 partial-audio bundles |
 | API content-part round-trip | `Tests/Model/MultimodalContentPartTests.swift` | 9 |
 | Data URL materialization audit fix | `Tests/Model/MaterializeMediaDataUrlMCDCTests.swift` | 11 MC/DC |
 | Hybrid-cache substring matcher | `Tests/Service/IsKnownHybridModelMCDCTests.swift` | 14 MC/DC |

--- a/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
+++ b/Packages/OsaurusCore/Models/Chat/MEDIA-ATTACHMENT-USER-GUIDE.md
@@ -17,8 +17,9 @@ this:
 | Loaded model | Drop zone accepts | File picker shows |
 |---|---|---|
 | Nemotron-3-Nano-Omni (any quant tier) | image + audio + video | image + docs + audio + video |
+| Installed Gemma 4 bundles with audio tensors in the weight map | image + audio | image + docs + audio |
 | Qwen 2/2.5/3 VL, Qwen 3.5/3.6 MoE VL, Holo3 VL, SmolVLM 2 | image + video | image + docs + video |
-| Image-only VLMs (PaliGemma, Idefics3, FastVLM, Pixtral standalone, GLM OCR, LFM2-VL, Gemma 3/4, Mistral 3/3.5/4) | image | image + docs |
+| Image-only VLMs (PaliGemma, Idefics3, FastVLM, Pixtral standalone, GLM OCR, LFM2-VL, Gemma 3, Gemma 4 bundles without audio tensors, Mistral 3/3.5/4) | image | image + docs |
 | Dense LLMs (gpt-oss, Laguna, MiniMax text, Kimi, etc.) | (no media) | docs |
 
 When a user drops a file the current model can't consume, the host
@@ -38,6 +39,17 @@ Pinned to the regex/substring matcher in
 - Any future bundle whose id matches regex `nemotron-3-nano-omni|nemotron[_-]h[_-]omni`
 - Locally-installed bundles with a `config_omni.json` sidecar — `from(directory:modelId:)` reads this directly
 
+### Audio + image (installed bundle proof required)
+
+- Gemma 4 checkpoints whose installed `model.safetensors.index.json`
+  contains `embed_audio.embedding_projection`, or single-file bundles
+  whose `config.json` includes a non-null `audio_config`.
+- Name-only Gemma 4 detection remains proof-required for audio so the
+  composer does not advertise audio before it can inspect the local
+  checkpoint. Installed 26B-A4B / 31B-style bundles without
+  `embed_audio` or `audio_tower` are image-only and produce a typed
+  unsupported-audio rejection.
+
 ### Image + video (no audio)
 
 - Qwen 2 VL / 2.5 VL / 3 VL — regex `qwen[2-3](\.\d+|_\d+)?[-_]?vl`
@@ -50,9 +62,8 @@ Pinned to the regex/substring matcher in
 - PaliGemma, Idefics 3, FastVLM, Llava-Qwen2
 - Pixtral standalone (NOT the Mistral 3 wrapper — that's matched separately)
 - GLM-OCR, LFM2-VL
-- Gemma 3, Gemma 4 (the `-it` VLM variants). Gemma4 audio is a
-  proof-required status, not a supported status, until live model routing
-  evidence exists.
+- Gemma 3, plus Gemma 4 name-only detection and installed Gemma 4
+  bundles that do not prove audio tensors.
 - Mistral 3 / Mistral 3.5 (image only via Pixtral wrapper) — regex `mistral[-_](3|medium-3)`
 - Mistral 4 VL — regex `mistral[-_]?4.*[-_]vl`
 
@@ -73,7 +84,7 @@ text, Laguna, Cascade-2 text, etc.)
 
 ## 3. Format extensions accepted
 
-### Audio (Nemotron-3-Nano-Omni only)
+### Audio (Nemotron-3-Nano-Omni + proven Gemma 4 bundles)
 
 | Extension | UTType bucket | vmlx canonicalization |
 |---|---|---|
@@ -288,6 +299,9 @@ let caps = ModelMediaCapabilities.from(
 This reads `config_omni.json` + `config.json` directly, so
 ambiguous IDs that the regex can't disambiguate (e.g. some
 community-renamed bundles) resolve correctly via the on-disk config.
+For chat composer gating, use `composerDescriptor(modelId:fallbackSupportsImages:localDirectory:)`
+so installed Gemma 4 bundles can upgrade audio from local bundle facts while
+name-only Gemma 4 stays proof-required.
 
 ---
 
@@ -296,6 +310,9 @@ community-renamed bundles) resolve correctly via the on-disk config.
 | Layer | Test file | Cases |
 |---|---|---|
 | Capability detection (regex/substring + modality status) | `Tests/Model/ModelMediaCapabilitiesMCDCTests.swift` | MC/DC-shaped + descriptor cases |
+| Chat composer model switching + installed bundle proof | `Tests/Chat/LocalModelDetectionTests.swift` | Gemma 4 audio-capable and no-audio bundle fixtures |
+| Audio file classification | `Tests/Documents/DocumentParserShimTests.swift` | native audio extension normalization + picker buckets |
+| Local runtime media policy | `Tests/Service/MLXServiceRuntimePolicyTests.swift` | audio blocked for unsupported models and allowed for proven Gemma 4 bundles |
 | API content-part round-trip | `Tests/Model/MultimodalContentPartTests.swift` | 9 |
 | Data URL materialization audit fix | `Tests/Model/MaterializeMediaDataUrlMCDCTests.swift` | 11 MC/DC |
 | Hybrid-cache substring matcher | `Tests/Service/IsKnownHybridModelMCDCTests.swift` | 14 MC/DC |

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -16,8 +16,8 @@
 //   - Per-family video support is config-parametric. Mistral 3 / 3.5
 //     have a vision_config but no video preprocessor. Qwen 3 VL hardcodes
 //     `targetFPS=2` in the model class.
-//   - Audio support today is exclusively Nemotron-3-Nano-Omni — gated by
-//     the `config_omni.json` sidecar.
+//   - Audio support is bundle-fact-driven: Nemotron-3-Nano-Omni is gated by
+//     `config_omni.json`, and Gemma4 is gated by installed audio tensors.
 //
 //  The matrix here mirrors `vmlx-swift/Libraries/MLXLMCommon/
 //  BatchEngine/MEDIA-MODEL-MATRIX.md`. Keep them in sync — when vmlx
@@ -159,8 +159,8 @@ public enum ModelMediaCapabilities {
     public static func from(modelId: String) -> Capabilities {
         let lower = modelId.lowercased()
 
-        // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — only family with
-        // native audio today.
+        // Nemotron-3-Nano-Omni / Nemotron-Omni-Nano — native audio +
+        // image + video via the omni runtime.
         // Matches:
         //   OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4 / -JANGTQ4 / -JANGTQ
         //   nemotron-3-nano-omni-* (case-folded picker form)
@@ -261,12 +261,20 @@ public enum ModelMediaCapabilities {
     /// granting audio or video.
     public static func composerCapabilities(
         modelId: String?,
-        fallbackSupportsImages: Bool
+        fallbackSupportsImages: Bool,
+        localDirectory: URL? = nil
     ) -> Capabilities {
         guard let modelId,
             !modelId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
             return fallbackSupportsImages ? .imageOnly : .textOnly
+        }
+
+        if let inspected = inspectedBundleCapabilities(
+            modelId: modelId,
+            localDirectory: localDirectory
+        ) {
+            return inspected
         }
 
         let detected = from(modelId: modelId)
@@ -296,10 +304,21 @@ public enum ModelMediaCapabilities {
 
     public static func composerDescriptor(
         modelId: String?,
-        fallbackSupportsImages: Bool
+        fallbackSupportsImages: Bool,
+        localDirectory: URL? = nil
     ) -> Descriptor {
         let normalized = modelId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let displayId = normalized.isEmpty ? "unspecified model" : normalized
+        if let inspected = inspectedBundleCapabilities(
+            modelId: normalized,
+            localDirectory: localDirectory
+        ) {
+            return buildDescriptor(
+                modelId: displayId,
+                capabilities: inspected,
+                source: "bundle config"
+            )
+        }
         let capabilities = composerCapabilities(
             modelId: modelId,
             fallbackSupportsImages: fallbackSupportsImages
@@ -314,6 +333,20 @@ public enum ModelMediaCapabilities {
             capabilities: capabilities,
             source: source
         )
+    }
+
+    private static func inspectedBundleCapabilities(
+        modelId: String,
+        localDirectory: URL?
+    ) -> Capabilities? {
+        let normalized = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, let localDirectory else { return nil }
+        guard FileManager.default.fileExists(
+            atPath: localDirectory.appendingPathComponent("config.json").path
+        ) else {
+            return nil
+        }
+        return from(directory: localDirectory, modelId: normalized)
     }
 
     /// Resolve capabilities by inspecting the locally-installed bundle.

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -335,6 +335,27 @@ public enum ModelMediaCapabilities {
         )
     }
 
+    /// Cached descriptor surface for SwiftUI composer hot paths. The miss path
+    /// accepts a provider so repeated body evaluations can return before
+    /// calling `ModelManager.findInstalledMLXModel` or reading bundle files.
+    static func cachedComposerDescriptor(
+        modelId: String?,
+        fallbackSupportsImages: Bool,
+        localDirectoryCacheKey: String?,
+        localDirectory: () -> URL?
+    ) -> Descriptor {
+        composerDescriptorCache.descriptor(
+            modelId: modelId,
+            fallbackSupportsImages: fallbackSupportsImages,
+            localDirectoryCacheKey: localDirectoryCacheKey,
+            localDirectory: localDirectory
+        )
+    }
+
+    static func invalidateComposerDescriptorCache() {
+        composerDescriptorCache.invalidate()
+    }
+
     private static func inspectedBundleCapabilities(
         modelId: String,
         localDirectory: URL?
@@ -564,6 +585,7 @@ public enum ModelMediaCapabilities {
     // compilation is slow enough under memory pressure to register as
     // a main-thread hang.
     private static let regexCache = RegexCache()
+    private static let composerDescriptorCache = ComposerDescriptorCache()
 
     private final class RegexCache: @unchecked Sendable {
         private var storage: [String: NSRegularExpression] = [:]
@@ -576,6 +598,65 @@ public enum ModelMediaCapabilities {
             guard let re = try? NSRegularExpression(pattern: pattern) else { return nil }
             storage[pattern] = re
             return re
+        }
+    }
+
+    private struct ComposerDescriptorCacheKey: Hashable {
+        let normalizedModelId: String
+        let fallbackSupportsImages: Bool
+        let localDirectoryCacheKey: String
+    }
+
+    private final class ComposerDescriptorCache: @unchecked Sendable {
+        private var storage: [ComposerDescriptorCacheKey: Descriptor] = [:]
+        private var generation: UInt64 = 0
+        private let lock = NSLock()
+
+        func descriptor(
+            modelId: String?,
+            fallbackSupportsImages: Bool,
+            localDirectoryCacheKey: String?,
+            localDirectory: () -> URL?
+        ) -> Descriptor {
+            let key = ComposerDescriptorCacheKey(
+                normalizedModelId: modelId?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                    ?? "",
+                fallbackSupportsImages: fallbackSupportsImages,
+                localDirectoryCacheKey: localDirectoryCacheKey ?? "none"
+            )
+
+            while true {
+                lock.lock()
+                let observedGeneration = generation
+                if let hit = storage[key] {
+                    lock.unlock()
+                    return hit
+                }
+                lock.unlock()
+
+                let descriptor = ModelMediaCapabilities.composerDescriptor(
+                    modelId: modelId,
+                    fallbackSupportsImages: fallbackSupportsImages,
+                    localDirectory: localDirectory()
+                )
+
+                lock.lock()
+                if generation == observedGeneration {
+                    storage[key] = descriptor
+                    lock.unlock()
+                    return descriptor
+                }
+                lock.unlock()
+            }
+        }
+
+        func invalidate() {
+            lock.lock()
+            generation &+= 1
+            storage.removeAll()
+            lock.unlock()
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMediaCapabilities.swift
@@ -17,7 +17,9 @@
 //     have a vision_config but no video preprocessor. Qwen 3 VL hardcodes
 //     `targetFPS=2` in the model class.
 //   - Audio support is bundle-fact-driven: Nemotron-3-Nano-Omni is gated by
-//     `config_omni.json`, and Gemma4 is gated by installed audio tensors.
+//     `config_omni.json`. Gemma4 bundle markers are reported as partial until
+//     the live Osaurus/vMLX path has production proof; they do not open the
+//     attachment gate.
 //
 //  The matrix here mirrors `vmlx-swift/Libraries/MLXLMCommon/
 //  BatchEngine/MEDIA-MODEL-MATRIX.md`. Keep them in sync — when vmlx
@@ -41,6 +43,7 @@ public enum ModelMediaCapabilities {
         case supported
         case unsupported
         case unproven
+        case partial
         case disabled
 
         public var isUsable: Bool {
@@ -63,6 +66,8 @@ public enum ModelMediaCapabilities {
                 return "\(modality.label): unsupported"
             case .unproven:
                 return "\(modality.label): proof required"
+            case .partial:
+                return "\(modality.label): partial"
             case .disabled:
                 return "\(modality.label): disabled"
             }
@@ -166,8 +171,7 @@ public enum ModelMediaCapabilities {
         //   nemotron-3-nano-omni-* (case-folded picker form)
         //   local crack bundles like Nemotron-Omni-Nano-JANGTQ-CRACK
         if ModelFamilyNames.isNemotronOmniFamily(modelId)
-            || regexMatches(lower, pattern: #"nemotron-3-nano-omni|nemotron[_-]h[_-]omni"#)
-        {
+            || regexMatches(lower, pattern: #"nemotron-3-nano-omni|nemotron[_-]h[_-]omni"#) {
             return .omni
         }
 
@@ -280,8 +284,7 @@ public enum ModelMediaCapabilities {
         let detected = from(modelId: modelId)
         if detected == .textOnly,
             ModelFamilyNames.isNemotronThinkingFamily(modelId),
-            !ModelFamilyNames.isNemotronOmniFamily(modelId)
-        {
+            !ModelFamilyNames.isNemotronOmniFamily(modelId) {
             return .textOnly
         }
         guard fallbackSupportsImages, !detected.supportsImage else {
@@ -309,14 +312,18 @@ public enum ModelMediaCapabilities {
     ) -> Descriptor {
         let normalized = modelId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let displayId = normalized.isEmpty ? "unspecified model" : normalized
-        if let inspected = inspectedBundleCapabilities(
+        if let localDirectory,
+            let inspected = inspectedBundleCapabilities(
             modelId: normalized,
             localDirectory: localDirectory
         ) {
             return buildDescriptor(
                 modelId: displayId,
                 capabilities: inspected,
-                source: "bundle config"
+                source: "bundle config",
+                gemma4Evidence: isGemma4Bundle(localDirectory, modelId: normalized)
+                    ? gemma4AudioEvidence(directory: localDirectory)
+                    : nil
             )
         }
         let capabilities = composerCapabilities(
@@ -391,8 +398,7 @@ public enum ModelMediaCapabilities {
         }
 
         if ModelFamilyNames.isNemotronThinkingFamily(modelId)
-            && !ModelFamilyNames.isNemotronOmniFamily(modelId)
-        {
+            && !ModelFamilyNames.isNemotronOmniFamily(modelId) {
             return .textOnly
         }
 
@@ -413,23 +419,12 @@ public enum ModelMediaCapabilities {
             return .imageOnly
         }
 
-        // Gemma4: audio capability is checkpoint-fact-driven, not
-        // name-driven. The same family ships three different audio
-        // realities (verified against the OsaurusAI QAT weight maps):
-        //   12B (gemma4_unified)  — encoder-free `embed_audio` raw-frame
-        //                           projection; vMLX decodes raw audio
-        //                           natively via unified chunking.
-        //   E2B/E4B (gemma4)      — mel + conformer `audio_tower` plus
-        //                           `embed_audio`.
-        //   26B-A4B / 31B         — NO audio tensors in the checkpoint;
-        //                           audio is impossible there, not
-        //                           "unwired", so it stays unsupported.
+        // Gemma4: image-capable, but audio remains a partial/blocked row in
+        // Osaurus until live vMLX + Osaurus proof exists. Some checkpoints ship
+        // `embed_audio` / `audio_tower` markers; those markers are reported via
+        // the descriptor for diagnostics, not promoted to usable capability.
         if modelType.hasPrefix("gemma4") {
-            return Capabilities(
-                supportsImage: true,
-                supportsVideo: false,
-                supportsAudio: gemma4BundleSupportsAudio(directory: directory)
-            )
+            return .imageOnly
         }
 
         // Cross-check the family-by-model_type for video support.
@@ -455,34 +450,51 @@ public enum ModelMediaCapabilities {
         buildDescriptor(
             modelId: modelId,
             capabilities: from(directory: directory, modelId: modelId),
-            source: "bundle config"
+            source: "bundle config",
+            gemma4Evidence: isGemma4Bundle(directory, modelId: modelId)
+                ? gemma4AudioEvidence(directory: directory)
+                : nil
         )
     }
 
-    /// True when a locally-installed Gemma4 bundle ships the audio input
-    /// tensors the runtime needs. Checks the safetensors weight map for
-    /// `embed_audio.embedding_projection` — present in the 12B unified
-    /// (raw-frame) and E2B/E4B (mel + `audio_tower`) checkpoints, absent
-    /// from 26B-A4B / 31B. A raw byte scan is used instead of full JSON
-    /// decoding because the 12B index is multi-MB and this runs on the
-    /// capability-resolution path.
-    private static func gemma4BundleSupportsAudio(directory: URL) -> Bool {
+    private enum Gemma4AudioEvidence: Equatable {
+        case noAudioMarkers
+        case tensorMarkers
+        case configOnly
+    }
+
+    /// Local Gemma4 audio evidence. This does not imply usable audio support;
+    /// it only lets descriptors distinguish a partial/blocked row from a
+    /// checkpoint that has no audio input markers at all.
+    private static func gemma4AudioEvidence(directory: URL) -> Gemma4AudioEvidence {
         let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
         if let data = try? Data(contentsOf: indexURL, options: .mappedIfSafe) {
-            return data.range(of: Data("embed_audio.embedding_projection".utf8)) != nil
+            if data.range(of: Data("embed_audio.embedding_projection".utf8)) != nil
+                || data.range(of: Data("audio_tower.".utf8)) != nil {
+                return .tensorMarkers
+            }
+            return .noAudioMarkers
         }
-        // Single-file bundles: fall back to the config's audio marker.
-        // Gemma4 configs always carry audio_token_id, so use audio_config
-        // presence (E-series) only; without an index we cannot prove the
-        // unified embed_audio tensor exists, so stay conservative.
+        // Single-file bundles can advertise audio metadata without a weight map.
+        // Treat that as partial evidence only; do not promote it to support.
         let configURL = directory.appendingPathComponent("config.json")
         if let data = try? Data(contentsOf: configURL),
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let audioConfig = json["audio_config"], !(audioConfig is NSNull)
-        {
+            let audioConfig = json["audio_config"], !(audioConfig is NSNull) {
+            return .configOnly
+        }
+        return .noAudioMarkers
+    }
+
+    private static func isGemma4Bundle(_ directory: URL, modelId: String) -> Bool {
+        let configURL = directory.appendingPathComponent("config.json")
+        if let data = try? Data(contentsOf: configURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let modelType = (json["model_type"] as? String)?.lowercased(),
+            modelType.hasPrefix("gemma4") {
             return true
         }
-        return false
+        return isGemma4VisionFamily(modelId, capabilities: from(modelId: modelId))
     }
 
     // MARK: - Helpers
@@ -490,7 +502,8 @@ public enum ModelMediaCapabilities {
     private static func buildDescriptor(
         modelId: String,
         capabilities: Capabilities,
-        source: String
+        source: String,
+        gemma4Evidence: Gemma4AudioEvidence? = nil
     ) -> Descriptor {
         Descriptor(
             modelId: modelId,
@@ -512,7 +525,8 @@ public enum ModelMediaCapabilities {
             audio: audioDescriptor(
                 modelId: modelId,
                 capabilities: capabilities,
-                source: source
+                source: source,
+                gemma4Evidence: gemma4Evidence
             )
         )
     }
@@ -520,7 +534,8 @@ public enum ModelMediaCapabilities {
     private static func audioDescriptor(
         modelId: String,
         capabilities: Capabilities,
-        source: String
+        source: String,
+        gemma4Evidence: Gemma4AudioEvidence?
     ) -> ModalityDescriptor {
         if capabilities.supportsAudio {
             return ModalityDescriptor(
@@ -530,14 +545,31 @@ public enum ModelMediaCapabilities {
             )
         }
         if isGemma4VisionFamily(modelId, capabilities: capabilities) {
-            // Bundle-fact gate: `from(directory:)` only reports audio for
-            // Gemma4 bundles whose weight map actually ships
-            // `embed_audio.embedding_projection`. When detection ran against
-            // the installed bundle, reaching here means this checkpoint has
-            // no audio input tensors (26B-A4B / 31B) — audio is impossible
-            // for the checkpoint, not pending runtime wiring. Name-only
-            // detection cannot see the weight map, so it must not claim
-            // checkpoint facts.
+            if let gemma4Evidence {
+                switch gemma4Evidence {
+                case .tensorMarkers:
+                    return ModalityDescriptor(
+                        modality: .audio,
+                        status: .partial,
+                        reason:
+                            "This Gemma4 checkpoint ships audio tensor markers, but Osaurus keeps Gemma4 audio input blocked until the live vMLX/Osaurus path has production proof."
+                    )
+                case .configOnly:
+                    return ModalityDescriptor(
+                        modality: .audio,
+                        status: .partial,
+                        reason:
+                            "This Gemma4 checkpoint advertises audio_config but has no inspectable audio weight-map proof; Osaurus keeps Gemma4 audio input blocked until live runtime proof exists."
+                    )
+                case .noAudioMarkers:
+                    return ModalityDescriptor(
+                        modality: .audio,
+                        status: .unsupported,
+                        reason:
+                            "This Gemma4 checkpoint ships no audio input tensors (no embed_audio/audio_tower in the weight map); audio input is not possible for this bundle."
+                    )
+                }
+            }
             if source == "bundle config" {
                 return ModalityDescriptor(
                     modality: .audio,
@@ -550,7 +582,7 @@ public enum ModelMediaCapabilities {
                 modality: .audio,
                 status: .unproven,
                 reason:
-                    "Gemma4 audio is enabled per-bundle from the installed weight map (12B unified and E-series ship audio tensors; 26B-A4B/31B do not). Install the model so the bundle can be inspected."
+                    "Gemma4 audio remains blocked until installed bundle evidence and live Osaurus/vMLX runtime proof exist. Install the model so the bundle can be inspected."
             )
         }
         return ModalityDescriptor(

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -13,6 +13,7 @@ import Foundation
 private struct LocalModelRef {
     let name: String
     let modelId: String
+    let directory: URL?
 }
 
 actor MLXService: ToolCapableService {
@@ -50,9 +51,12 @@ actor MLXService: ToolCapableService {
         return ModelManager.installedModelNames()
     }
 
-    fileprivate nonisolated static func findModel(named name: String) -> LocalModelRef? {
-        if let found = ModelManager.findInstalledModel(named: name) {
-            return LocalModelRef(name: found.name, modelId: found.id)
+    nonisolated fileprivate static func findModel(named name: String) -> LocalModelRef? {
+        if let found = ModelManager.findInstalledMLXModel(named: name) {
+            let repo =
+                found.id.split(separator: "/").last.map(String.init)?.lowercased()
+                ?? name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return LocalModelRef(name: repo, modelId: found.id, directory: found.localDirectory)
         }
         return nil
     }
@@ -72,7 +76,8 @@ actor MLXService: ToolCapableService {
             messages: messages,
             parameters: parameters,
             tools: [],
-            runtime: ServerRuntimeSettingsStore.snapshot()
+            runtime: ServerRuntimeSettingsStore.snapshot(),
+            modelDirectory: model.directory
         )
         return try await ModelRuntime.shared.streamWithTools(
             messages: messages,
@@ -132,7 +137,8 @@ actor MLXService: ToolCapableService {
             messages: [],
             parameters: parameters,
             tools: [],
-            runtime: ServerRuntimeSettingsStore.snapshot()
+            runtime: ServerRuntimeSettingsStore.snapshot(),
+            modelDirectory: model.directory
         )
         return try await ModelRuntime.shared.streamRawText(
             prompt: prompt,
@@ -160,7 +166,8 @@ actor MLXService: ToolCapableService {
             messages: messages,
             parameters: parameters,
             tools: tools,
-            runtime: ServerRuntimeSettingsStore.snapshot()
+            runtime: ServerRuntimeSettingsStore.snapshot(),
+            modelDirectory: model.directory
         )
         return try await ModelRuntime.shared.respondWithTools(
             messages: messages,
@@ -188,7 +195,8 @@ actor MLXService: ToolCapableService {
             messages: messages,
             parameters: parameters,
             tools: tools,
-            runtime: ServerRuntimeSettingsStore.snapshot()
+            runtime: ServerRuntimeSettingsStore.snapshot(),
+            modelDirectory: model.directory
         )
         return try await ModelRuntime.shared.streamWithTools(
             messages: messages,
@@ -519,15 +527,11 @@ actor MLXService: ToolCapableService {
             // external-bundle metadata reads.
             return ModelMediaCapabilities.descriptor(modelId: modelId)
         }
-        let localDirectory =
-            modelDirectory
-            ?? modelId.split(separator: "/").map(String.init).reduce(
-                DirectoryPickerService.effectiveModelsDirectory()
-            ) {
-                $0.appendingPathComponent($1, isDirectory: true)
-            }
-        if FileManager.default.fileExists(atPath: localDirectory.path) {
-            return ModelMediaCapabilities.descriptor(directory: localDirectory, modelId: modelId)
+        if let localDirectory = modelDirectory ?? localModelDirectory(modelId: modelId) {
+            return ModelMediaCapabilities.descriptor(
+                directory: localDirectory,
+                modelId: modelId
+            )
         }
         return ModelMediaCapabilities.descriptor(modelId: modelId)
     }

--- a/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
@@ -154,4 +154,82 @@ struct LocalModelDetectionTests {
             }
         }
     }
+
+    @Test
+    func selectedModelMediaCapabilitiesUseInstalledGemma4BundleFacts() async throws {
+        try await ChatHistoryTestStorage.run {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-gemma4-media-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let audioBundle = try Self.makeGemma4Bundle(
+                under: root,
+                name: "audio",
+                supportsAudio: true
+            )
+            let noAudioBundle = try Self.makeGemma4Bundle(
+                under: root,
+                name: "no-audio",
+                supportsAudio: false
+            )
+            let models = [
+                MLXModel(
+                    id: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+                    name: "Gemma 4 12B",
+                    description: "fixture-audio",
+                    downloadURL: "https://example.invalid/gemma4-audio",
+                    bundleDirectory: audioBundle
+                ),
+                MLXModel(
+                    id: "OsaurusAI/Gemma-4-26B-A4B-it-MXFP4",
+                    name: "Gemma 4 26B",
+                    description: "fixture-no-audio",
+                    downloadURL: "https://example.invalid/gemma4-no-audio",
+                    bundleDirectory: noAudioBundle
+                ),
+            ]
+
+            try withCatalog(models) {
+                let session = ChatSession()
+
+                session.selectedModel = "Gemma-4-12B-it-MXFP4"
+                #expect(session.selectedModelSupportsImages)
+                #expect(session.selectedModelSupportsAudio)
+                #expect(session.selectedModelMediaDescriptor.audio.status == .supported)
+
+                session.selectedModel = "Gemma-4-26B-A4B-it-MXFP4"
+                #expect(session.selectedModelSupportsImages)
+                #expect(!session.selectedModelSupportsAudio)
+                #expect(session.selectedModelMediaDescriptor.audio.status == .unsupported)
+            }
+        }
+    }
+
+    private static func makeGemma4Bundle(
+        under root: URL,
+        name: String,
+        supportsAudio: Bool
+    ) throws -> URL {
+        let bundle = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        let config: [String: Any] = [
+            "model_type": "gemma4",
+            "vision_config": ["image_size": 896],
+        ]
+        let configData = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try configData.write(to: bundle.appendingPathComponent("config.json"))
+
+        if supportsAudio {
+            let index: [String: Any] = [
+                "weight_map": [
+                    "embed_audio.embedding_projection.weight": "model-00001-of-00001.safetensors"
+                ]
+            ]
+            let indexData = try JSONSerialization.data(withJSONObject: index, options: [.sortedKeys])
+            try indexData.write(to: bundle.appendingPathComponent("model.safetensors.index.json"))
+        }
+
+        return bundle
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/LocalModelDetectionTests.swift
@@ -195,8 +195,8 @@ struct LocalModelDetectionTests {
 
                 session.selectedModel = "Gemma-4-12B-it-MXFP4"
                 #expect(session.selectedModelSupportsImages)
-                #expect(session.selectedModelSupportsAudio)
-                #expect(session.selectedModelMediaDescriptor.audio.status == .supported)
+                #expect(!session.selectedModelSupportsAudio)
+                #expect(session.selectedModelMediaDescriptor.audio.status == .partial)
 
                 session.selectedModel = "Gemma-4-26B-A4B-it-MXFP4"
                 #expect(session.selectedModelSupportsImages)

--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -141,6 +141,35 @@ struct DocumentParserShimTests {
         #expect(supported.contains(potx))
     }
 
+    @Test func audioFormat_normalizesNativeAudioExtensions() {
+        let cases: [(String, String)] = [
+            ("voice.wav", "wav"),
+            ("voice.wave", "wav"),
+            ("song.MP3", "mp3"),
+            ("podcast.mpeg", "mp3"),
+            ("clip.m4a", "m4a"),
+            ("lossless.flac", "flac"),
+            ("sample.aif", "aiff"),
+        ]
+
+        for (filename, expectedFormat) in cases {
+            let url = URL(fileURLWithPath: "/tmp/\(filename)")
+            #expect(DocumentParser.isAudioFile(url: url), "\(filename) should classify as audio")
+            #expect(DocumentParser.audioFormat(for: url) == expectedFormat)
+        }
+
+        #expect(!DocumentParser.isAudioFile(url: URL(fileURLWithPath: "/tmp/readme.md")))
+        #expect(DocumentParser.audioFormat(for: URL(fileURLWithPath: "/tmp/readme.md")) == nil)
+    }
+
+    @Test func supportedAudioTypes_includePickerBuckets() throws {
+        let supported = Set(DocumentParser.supportedAudioTypes)
+        #expect(supported.contains(.audio))
+        #expect(supported.contains(.mp3))
+        #expect(supported.contains(.wav))
+        #expect(supported.contains(.mpeg4Audio))
+    }
+
     // MARK: - Fixtures
 
     private func writeFile(content: String, ext: String) throws -> URL {

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -415,6 +415,89 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(descriptor.audio.reason.contains("no audio input tensors"))
     }
 
+    @Test("Cached composer descriptor reuses bundle inspection until invalidated")
+    func cachedComposerDescriptor_reusesBundleInspectionUntilInvalidated() throws {
+        let audioBundle = try makeGemma4Bundle(supportsAudio: true)
+        let imageOnlyBundle = try makeGemma4Bundle(supportsAudio: false)
+        defer {
+            try? FileManager.default.removeItem(at: audioBundle)
+            try? FileManager.default.removeItem(at: imageOnlyBundle)
+            ModelMediaCapabilities.invalidateComposerDescriptorCache()
+        }
+
+        ModelMediaCapabilities.invalidateComposerDescriptorCache()
+        var providerCalls = 0
+
+        let first = ModelMediaCapabilities.cachedComposerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectoryCacheKey: "local"
+        ) {
+            providerCalls += 1
+            return audioBundle
+        }
+
+        let second = ModelMediaCapabilities.cachedComposerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectoryCacheKey: "local"
+        ) {
+            providerCalls += 1
+            return imageOnlyBundle
+        }
+
+        #expect(providerCalls == 1)
+        #expect(first == second)
+        #expect(second.capabilities.supportsAudio)
+
+        ModelMediaCapabilities.invalidateComposerDescriptorCache()
+        let afterInvalidation = ModelMediaCapabilities.cachedComposerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectoryCacheKey: "local"
+        ) {
+            providerCalls += 1
+            return imageOnlyBundle
+        }
+
+        #expect(providerCalls == 2)
+        #expect(!afterInvalidation.capabilities.supportsAudio)
+    }
+
+    @Test("Cached composer descriptor rechecks when picker source changes")
+    func cachedComposerDescriptor_rechecksWhenPickerSourceChanges() throws {
+        let audioBundle = try makeGemma4Bundle(supportsAudio: true)
+        defer {
+            try? FileManager.default.removeItem(at: audioBundle)
+            ModelMediaCapabilities.invalidateComposerDescriptorCache()
+        }
+
+        ModelMediaCapabilities.invalidateComposerDescriptorCache()
+        var providerCalls = 0
+
+        let remoteDescriptor = ModelMediaCapabilities.cachedComposerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectoryCacheKey: "remote-provider"
+        ) {
+            providerCalls += 1
+            return nil
+        }
+
+        let localDescriptor = ModelMediaCapabilities.cachedComposerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectoryCacheKey: "local"
+        ) {
+            providerCalls += 1
+            return audioBundle
+        }
+
+        #expect(providerCalls == 2)
+        #expect(!remoteDescriptor.capabilities.supportsAudio)
+        #expect(localDescriptor.capabilities.supportsAudio)
+    }
+
     private func makeGemma4Bundle(supportsAudio: Bool) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-media-cap-gemma4-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -380,4 +380,63 @@ struct ModelMediaCapabilitiesMCDCTests {
             ) == .omni
         )
     }
+
+    @Test("Composer descriptor upgrades Gemma4 audio from installed bundle facts")
+    func composerDescriptor_usesInstalledGemma4AudioFacts() throws {
+        let bundle = try makeGemma4Bundle(supportsAudio: true)
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
+        let descriptor = ModelMediaCapabilities.composerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectory: bundle
+        )
+
+        #expect(descriptor.capabilities.supportsImage)
+        #expect(descriptor.capabilities.supportsAudio)
+        #expect(descriptor.audio.status == .supported)
+        #expect(descriptor.audio.reason.contains("bundle config"))
+    }
+
+    @Test("Composer descriptor reports installed Gemma4 bundles without audio tensors as unsupported")
+    func composerDescriptor_rejectsGemma4BundleWithoutAudioFacts() throws {
+        let bundle = try makeGemma4Bundle(supportsAudio: false)
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
+        let descriptor = ModelMediaCapabilities.composerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-26B-A4B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectory: bundle
+        )
+
+        #expect(descriptor.capabilities.supportsImage)
+        #expect(!descriptor.capabilities.supportsAudio)
+        #expect(descriptor.audio.status == .unsupported)
+        #expect(descriptor.audio.reason.contains("no audio input tensors"))
+    }
+
+    private func makeGemma4Bundle(supportsAudio: Bool) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-media-cap-gemma4-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let config: [String: Any] = [
+            "model_type": "gemma4",
+            "vision_config": ["image_size": 896],
+        ]
+        let configData = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try configData.write(to: directory.appendingPathComponent("config.json"))
+
+        if supportsAudio {
+            let index: [String: Any] = [
+                "weight_map": [
+                    "embed_audio.embedding_projection.weight": "model-00001-of-00001.safetensors"
+                ]
+            ]
+            let indexData = try JSONSerialization.data(withJSONObject: index, options: [.sortedKeys])
+            try indexData.write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+        }
+
+        return directory
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -339,7 +339,7 @@ struct ModelMediaCapabilitiesMCDCTests {
         #expect(descriptor.image.status == .supported)
         #expect(descriptor.audio.status == .unproven)
         #expect(!descriptor.audio.isUsable)
-        #expect(descriptor.rejectionMessage(for: .audio).contains("Gemma4 audio is enabled per-bundle"))
+        #expect(descriptor.rejectionMessage(for: .audio).contains("Gemma4 audio remains blocked"))
     }
 
     @Test("Descriptor keeps Nemotron Omni audio supported")
@@ -381,8 +381,8 @@ struct ModelMediaCapabilitiesMCDCTests {
         )
     }
 
-    @Test("Composer descriptor upgrades Gemma4 audio from installed bundle facts")
-    func composerDescriptor_usesInstalledGemma4AudioFacts() throws {
+    @Test("Composer descriptor reports Gemma4 audio tensor evidence as partial/blocked")
+    func composerDescriptor_reportsInstalledGemma4AudioFactsAsPartial() throws {
         let bundle = try makeGemma4Bundle(supportsAudio: true)
         defer { try? FileManager.default.removeItem(at: bundle) }
 
@@ -393,9 +393,28 @@ struct ModelMediaCapabilitiesMCDCTests {
         )
 
         #expect(descriptor.capabilities.supportsImage)
-        #expect(descriptor.capabilities.supportsAudio)
-        #expect(descriptor.audio.status == .supported)
-        #expect(descriptor.audio.reason.contains("bundle config"))
+        #expect(!descriptor.capabilities.supportsAudio)
+        #expect(descriptor.audio.status == .partial)
+        #expect(!descriptor.audio.isUsable)
+        #expect(descriptor.audio.reason.contains("audio tensor markers"))
+        #expect(descriptor.audio.reason.contains("blocked"))
+    }
+
+    @Test("Composer descriptor reports Gemma4 audio_config-only bundles as partial/blocked")
+    func composerDescriptor_reportsGemma4AudioConfigOnlyAsPartial() throws {
+        let bundle = try makeGemma4Bundle(supportsAudio: false, audioConfigOnly: true)
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
+        let descriptor = ModelMediaCapabilities.composerDescriptor(
+            modelId: "OsaurusAI/Gemma-4-E2B-it-MXFP4",
+            fallbackSupportsImages: false,
+            localDirectory: bundle
+        )
+
+        #expect(descriptor.capabilities == .imageOnly)
+        #expect(descriptor.audio.status == .partial)
+        #expect(!descriptor.audio.isUsable)
+        #expect(descriptor.audio.reason.contains("audio_config"))
     }
 
     @Test("Composer descriptor reports installed Gemma4 bundles without audio tensors as unsupported")
@@ -448,7 +467,8 @@ struct ModelMediaCapabilitiesMCDCTests {
 
         #expect(providerCalls == 1)
         #expect(first == second)
-        #expect(second.capabilities.supportsAudio)
+        #expect(!second.capabilities.supportsAudio)
+        #expect(second.audio.status == .partial)
 
         ModelMediaCapabilities.invalidateComposerDescriptorCache()
         let afterInvalidation = ModelMediaCapabilities.cachedComposerDescriptor(
@@ -462,6 +482,7 @@ struct ModelMediaCapabilitiesMCDCTests {
 
         #expect(providerCalls == 2)
         #expect(!afterInvalidation.capabilities.supportsAudio)
+        #expect(afterInvalidation.audio.status == .unsupported)
     }
 
     @Test("Cached composer descriptor rechecks when picker source changes")
@@ -495,18 +516,26 @@ struct ModelMediaCapabilitiesMCDCTests {
 
         #expect(providerCalls == 2)
         #expect(!remoteDescriptor.capabilities.supportsAudio)
-        #expect(localDescriptor.capabilities.supportsAudio)
+        #expect(remoteDescriptor.audio.status == .unproven)
+        #expect(!localDescriptor.capabilities.supportsAudio)
+        #expect(localDescriptor.audio.status == .partial)
     }
 
-    private func makeGemma4Bundle(supportsAudio: Bool) throws -> URL {
+    private func makeGemma4Bundle(
+        supportsAudio: Bool,
+        audioConfigOnly: Bool = false
+    ) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-media-cap-gemma4-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
-        let config: [String: Any] = [
+        var config: [String: Any] = [
             "model_type": "gemma4",
             "vision_config": ["image_size": 896],
         ]
+        if audioConfigOnly {
+            config["audio_config"] = ["model_type": "gemma4_audio"]
+        }
         let configData = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
         try configData.write(to: directory.appendingPathComponent("config.json"))
 

--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -22,7 +22,7 @@ import Testing
 
 @testable import OsaurusCore
 
-@Suite("ModelMediaCapabilities — MC/DC coverage")
+@Suite("ModelMediaCapabilities — MC/DC coverage", .serialized)
 struct ModelMediaCapabilitiesMCDCTests {
 
     // MARK: - D1: Nemotron-3 omni (audio + video + image)

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -142,6 +142,30 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
+    @Test func modelCapabilityAllowsGemma4AudioWhenBundleFactsProveIt() throws {
+        let bundle = try Self.makeGemma4AudioBundle()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+
+        let message = ChatMessage(
+            role: "user",
+            content: "hear this",
+            contentParts: [
+                .text("hear this"),
+                .audioInput(data: "AAAA", format: "wav"),
+            ]
+        )
+
+        try MLXService.validateRuntimePolicy(
+            modelName: "gemma-4-12b-it-mxfp4",
+            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+            messages: [message],
+            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+            tools: [],
+            runtime: VMLXServerRuntimeSettings(),
+            modelDirectory: bundle
+        )
+    }
+
     @Test func policyRejectsKnownBadZayaVLJANGTQKDiagnosticArtifact() {
         #expect(throws: MLXService.RuntimePolicyError.self) {
             try MLXService.validateRuntimePolicy(
@@ -360,6 +384,29 @@ struct MLXServiceRuntimePolicyTests {
         }
         let data = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
         try data.write(to: directory.appendingPathComponent("config.json"))
+        return directory
+    }
+
+    private static func makeGemma4AudioBundle() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-gemma4-audio-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let config: [String: Any] = [
+            "model_type": "gemma4",
+            "vision_config": ["image_size": 896],
+        ]
+        let configData = try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+        try configData.write(to: directory.appendingPathComponent("config.json"))
+
+        let index: [String: Any] = [
+            "weight_map": [
+                "embed_audio.embedding_projection.weight": "model-00001-of-00001.safetensors"
+            ]
+        ]
+        let indexData = try JSONSerialization.data(withJSONObject: index, options: [.sortedKeys])
+        try indexData.write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+
         return directory
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -136,13 +136,13 @@ struct MLXServiceRuntimePolicyTests {
             Issue.record("Gemma4 audio must stay rejected when bundle facts are unavailable.")
         } catch let error as MLXService.RuntimePolicyError {
             let description = error.errorDescription ?? ""
-            #expect(description.contains("Gemma4 audio is enabled per-bundle"))
+            #expect(description.contains("Gemma4 audio remains blocked"))
         } catch {
             Issue.record("Unexpected error type: \(error)")
         }
     }
 
-    @Test func modelCapabilityAllowsGemma4AudioWhenBundleFactsProveIt() throws {
+    @Test func modelCapabilityRejectsGemma4AudioEvenWhenBundleHasPartialEvidence() throws {
         let bundle = try Self.makeGemma4AudioBundle()
         defer { try? FileManager.default.removeItem(at: bundle) }
 
@@ -155,15 +155,24 @@ struct MLXServiceRuntimePolicyTests {
             ]
         )
 
-        try MLXService.validateRuntimePolicy(
-            modelName: "gemma-4-12b-it-mxfp4",
-            modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
-            messages: [message],
-            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
-            tools: [],
-            runtime: VMLXServerRuntimeSettings(),
-            modelDirectory: bundle
-        )
+        do {
+            try MLXService.validateRuntimePolicy(
+                modelName: "gemma-4-12b-it-mxfp4",
+                modelId: "OsaurusAI/Gemma-4-12B-it-MXFP4",
+                messages: [message],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [],
+                runtime: VMLXServerRuntimeSettings(),
+                modelDirectory: bundle
+            )
+            Issue.record("Gemma4 audio must remain blocked until live Osaurus/vMLX proof exists.")
+        } catch let error as MLXService.RuntimePolicyError {
+            let description = error.errorDescription ?? ""
+            #expect(description.contains("audio tensor markers"))
+            #expect(description.contains("blocked"))
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
     }
 
     @Test func policyRejectsKnownBadZayaVLJANGTQKDiagnosticArtifact() {

--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 enum DocumentParser {
 
     static let maxParsedTextLength = 500_000  // ~500KB of text
+    static let maxAudioFileSize = 50 * 1024 * 1024
 
     /// Hard byte cap applied before the file is read into memory. The post-read
     /// `maxParsedTextLength` trim only bounds the *decoded* text, so a crafted
@@ -125,6 +126,25 @@ enum DocumentParser {
         return utType.conforms(to: .image)
     }
 
+    static func isAudioFile(url: URL) -> Bool {
+        audioFormat(for: url) != nil
+    }
+
+    static func audioFormat(for url: URL) -> String? {
+        let ext = url.pathExtension
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        guard !ext.isEmpty else { return nil }
+        if let normalized = audioFormatByExtension[ext] {
+            return normalized
+        }
+        guard let utType = UTType(filenameExtension: ext), utType.conforms(to: .audio) else {
+            return nil
+        }
+        return ext
+    }
+
     static var supportedDocumentTypes: [UTType] {
         [
             .plainText, .utf8PlainText,
@@ -140,6 +160,21 @@ enum DocumentParser {
             UTType("com.netscape.javascript-source") ?? .data,
             UTType("public.shell-script") ?? .data,
         ].compactMap { $0 } + structuredDocumentTypes
+    }
+
+    static var supportedAudioTypes: [UTType] {
+        [
+            .audio,
+            .mp3,
+            .wav,
+            .mpeg4Audio,
+            UTType(filenameExtension: "flac"),
+            UTType(filenameExtension: "ogg"),
+            UTType(filenameExtension: "opus"),
+            UTType(filenameExtension: "aac"),
+            UTType(filenameExtension: "aiff"),
+            UTType(filenameExtension: "caf"),
+        ].compactMap { $0 }
     }
 
     private static let structuredDocumentTypes: [UTType] = [
@@ -166,6 +201,27 @@ enum DocumentParser {
 
     private static let richDocumentExtensions: Set<String> = [
         "pdf", "docx", "doc", "rtf", "rtfd", "html", "htm",
+    ]
+
+    private static let audioFormatByExtension: [String: String] = [
+        "wav": "wav",
+        "wave": "wav",
+        "mp3": "mp3",
+        "mpeg": "mp3",
+        "mpga": "mp3",
+        "m4a": "m4a",
+        "x-m4a": "m4a",
+        "m4b": "m4b",
+        "flac": "flac",
+        "ogg": "ogg",
+        "oga": "ogg",
+        "opus": "opus",
+        "aac": "aac",
+        "wma": "wma",
+        "aif": "aiff",
+        "aiff": "aiff",
+        "caf": "caf",
+        "amr": "amr",
     ]
 
     private static func isPlainText(ext: String) -> Bool {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -782,11 +782,13 @@ final class ChatSession: ObservableObject {
     }
 
     private func mediaDescriptor(for model: String?) -> ModelMediaCapabilities.Descriptor {
-        ModelMediaCapabilities.composerDescriptor(
+        ModelMediaCapabilities.cachedComposerDescriptor(
             modelId: model,
             fallbackSupportsImages: imageFallbackSupport(for: model),
-            localDirectory: localModelDirectory(for: model)
-        )
+            localDirectoryCacheKey: modelSourceCacheKey(for: model)
+        ) {
+            self.localModelDirectory(for: model)
+        }
     }
 
     private func imageFallbackSupport(for model: String?) -> Bool {
@@ -803,6 +805,11 @@ final class ChatSession: ObservableObject {
             guard case .local = option.source else { return nil }
         }
         return ModelManager.findInstalledMLXModel(named: model)?.localDirectory
+    }
+
+    private func modelSourceCacheKey(for model: String?) -> String? {
+        guard let model else { return nil }
+        return pickerItems.first(where: { $0.id == model })?.source.uniqueKey
     }
 
     /// Get the currently selected ModelPickerItem

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -551,11 +551,13 @@ final class ChatSession: ObservableObject {
 
                 self.loadActiveModelOptions(for: model)
 
-                // Clear pending image attachments when switching to a non-VLM
-                // model. Computed against the NEW model id, since `@Published`
-                // emits before `selectedModel` updates.
-                if !Self.modelSupportsImages(modelId: model, pickerItems: self.pickerItems) {
-                    self.pendingAttachments = []
+                // Clear media attachments the new model cannot consume.
+                // Document attachments stay usable for text-only models.
+                let newCapabilities = self.mediaDescriptor(for: model).capabilities
+                self.pendingAttachments.removeAll { attachment in
+                    (attachment.isImage && !newCapabilities.supportsImage)
+                        || (attachment.isAudio && !newCapabilities.supportsAudio)
+                        || (attachment.isVideo && !newCapabilities.supportsVideo)
                 }
 
                 Task { @MainActor in
@@ -764,31 +766,43 @@ final class ChatSession: ObservableObject {
 
     /// Check if the currently selected model supports images (VLM)
     var selectedModelSupportsImages: Bool {
-        guard let model = selectedModel else { return false }
-        return Self.modelSupportsImages(modelId: model, pickerItems: pickerItems)
-    }
-
-    /// Whether `modelId` can accept image input. Remote models are NOT assumed
-    /// vision-capable: a plain remote provider (incl. a Mode 1 `.osaurus`
-    /// device) exposes a flat model list with no capability metadata, so a
-    /// remote item's `isVLM` is false unless the id-based heuristic matched or
-    /// router metadata set it — sending images to a non-VLM remote model just
-    /// gets rejected upstream.
-    static func modelSupportsImages(modelId: String, pickerItems: [ModelPickerItem]) -> Bool {
-        if modelId.lowercased() == "foundation" { return false }
-        if ModelMediaCapabilities.from(modelId: modelId).supportsImage { return true }
-        guard let option = pickerItems.first(where: { $0.id == modelId }) else { return false }
-        return option.isVLM
+        selectedModelMediaDescriptor.capabilities.supportsImage
     }
 
     var selectedModelSupportsAudio: Bool {
-        guard let model = selectedModel else { return false }
-        return ModelMediaCapabilities.from(modelId: model).supportsAudio
+        selectedModelMediaDescriptor.capabilities.supportsAudio
     }
 
     var selectedModelSupportsVideo: Bool {
-        guard let model = selectedModel else { return false }
-        return ModelMediaCapabilities.from(modelId: model).supportsVideo
+        selectedModelMediaDescriptor.capabilities.supportsVideo
+    }
+
+    var selectedModelMediaDescriptor: ModelMediaCapabilities.Descriptor {
+        mediaDescriptor(for: selectedModel)
+    }
+
+    private func mediaDescriptor(for model: String?) -> ModelMediaCapabilities.Descriptor {
+        ModelMediaCapabilities.composerDescriptor(
+            modelId: model,
+            fallbackSupportsImages: imageFallbackSupport(for: model),
+            localDirectory: localModelDirectory(for: model)
+        )
+    }
+
+    private func imageFallbackSupport(for model: String?) -> Bool {
+        guard let model else { return false }
+        if model.lowercased() == "foundation" { return false }
+        if ModelMediaCapabilities.from(modelId: model).supportsImage { return true }
+        guard let option = pickerItems.first(where: { $0.id == model }) else { return false }
+        return option.isVLM
+    }
+
+    private func localModelDirectory(for model: String?) -> URL? {
+        guard let model else { return nil }
+        if let option = pickerItems.first(where: { $0.id == model }) {
+            guard case .local = option.source else { return nil }
+        }
+        return ModelManager.findInstalledMLXModel(named: model)?.localDirectory
     }
 
     /// Get the currently selected ModelPickerItem

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3228,12 +3228,21 @@ extension FloatingInputCard {
     private var mediaCapabilityDescriptor: ModelMediaCapabilities.Descriptor {
         ModelMediaCapabilities.composerDescriptor(
             modelId: selectedModel,
-            fallbackSupportsImages: supportsImages
+            fallbackSupportsImages: supportsImages,
+            localDirectory: selectedLocalModelDirectory
         )
     }
 
     private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
         mediaCapabilityDescriptor.capabilities
+    }
+
+    private var selectedLocalModelDirectory: URL? {
+        guard let selectedModel else { return nil }
+        if let option = pickerItems.first(where: { $0.id == selectedModel }) {
+            guard case .local = option.source else { return nil }
+        }
+        return ModelManager.findInstalledMLXModel(named: selectedModel)?.localDirectory
     }
 
     /// UTTypes the drop zone advertises. `fileURL` stays enabled for
@@ -3246,12 +3255,7 @@ extension FloatingInputCard {
             types.append(.image)
         }
         if cap.supportsAudio {
-            types.append(.audio)
-            // explicit common audio formats so HEIF-style "any audio"
-            // type negotiation doesn't miss specific containers
-            types.append(.mp3)
-            types.append(.wav)
-            types.append(.mpeg4Audio)
+            types.append(contentsOf: DocumentParser.supportedAudioTypes)
         }
         if cap.supportsVideo {
             types.append(.movie)
@@ -3274,10 +3278,7 @@ extension FloatingInputCard {
         }
         types.append(contentsOf: DocumentParser.supportedDocumentTypes)
         if cap.supportsAudio {
-            types.append(.audio)
-            types.append(.mp3)
-            types.append(.wav)
-            types.append(.mpeg4Audio)
+            types.append(contentsOf: DocumentParser.supportedAudioTypes)
         }
         if cap.supportsVideo {
             types.append(.movie)
@@ -3344,8 +3345,9 @@ extension FloatingInputCard {
             return
         }
 
-        // Audio path — only for omni models.
-        if audioExtensions.contains(ext) {
+        // Audio path — only for models whose installed/runtime capability
+        // descriptor proves native audio input.
+        if let audioFormat = DocumentParser.audioFormat(for: url) {
             guard cap.supportsAudio else {
                 ToastManager.shared.error(
                     L("Cannot attach \(url.lastPathComponent)"),
@@ -3353,7 +3355,7 @@ extension FloatingInputCard {
                 )
                 return
             }
-            attachAudio(url: url, ext: ext)
+            attachAudio(url: url, format: audioFormat)
             return
         }
 
@@ -3386,15 +3388,10 @@ extension FloatingInputCard {
         )
     }
 
-    private static let audioExtensions: Set<String> = [
-        "wav", "mp3", "m4a", "flac", "ogg", "opus", "aac", "wma",
-    ]
-
     private static let videoExtensions: Set<String> = [
         "mp4", "mov", "m4v", "qt", "webm", "mkv", "avi",
     ]
 
-    private var audioExtensions: Set<String> { Self.audioExtensions }
     private var videoExtensions: Set<String> { Self.videoExtensions }
 
     /// Attach audio bytes from a file URL. Reads inline; spillover to
@@ -3403,7 +3400,7 @@ extension FloatingInputCard {
     /// the turn is committed. Format string is the lowercased file
     /// extension and flows directly into
     /// `MessageContentPart.audioInput.format`.
-    private func attachAudio(url: URL, ext: String) {
+    private func attachAudio(url: URL, format: String) {
         guard let data = try? Data(contentsOf: url) else {
             ToastManager.shared.error(
                 L("Could not read \(url.lastPathComponent)"),
@@ -3413,14 +3410,14 @@ extension FloatingInputCard {
         }
         // Cap inline audio at 50 MB — beyond that the user is sending
         // multi-minute clips that should go through a streaming API.
-        guard data.count <= 50 * 1024 * 1024 else {
+        guard data.count <= DocumentParser.maxAudioFileSize else {
             ToastManager.shared.errorLocalized(
                 "Audio file too large",
                 message: "Files larger than 50 MB are not supported in chat attachments."
             )
             return
         }
-        appendAttachment(.audio(data, format: ext, filename: url.lastPathComponent))
+        appendAttachment(.audio(data, format: format, filename: url.lastPathComponent))
     }
 
     /// Attach video bytes from a file URL. Same lifecycle as audio,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3226,11 +3226,13 @@ extension FloatingInputCard {
     /// substring/regex matcher; tests pin the boundary at
     /// `ModelMediaCapabilitiesMCDCTests`.
     private var mediaCapabilityDescriptor: ModelMediaCapabilities.Descriptor {
-        ModelMediaCapabilities.composerDescriptor(
+        ModelMediaCapabilities.cachedComposerDescriptor(
             modelId: selectedModel,
             fallbackSupportsImages: supportsImages,
-            localDirectory: selectedLocalModelDirectory
-        )
+            localDirectoryCacheKey: selectedModelSourceCacheKey
+        ) {
+            selectedLocalModelDirectory
+        }
     }
 
     private var mediaCapabilities: ModelMediaCapabilities.Capabilities {
@@ -3243,6 +3245,11 @@ extension FloatingInputCard {
             guard case .local = option.source else { return nil }
         }
         return ModelManager.findInstalledMLXModel(named: selectedModel)?.localDirectory
+    }
+
+    private var selectedModelSourceCacheKey: String? {
+        guard let selectedModel else { return nil }
+        return pickerItems.first(where: { $0.id == selectedModel })?.source.uniqueKey
     }
 
     /// UTTypes the drop zone advertises. `fileURL` stays enabled for


### PR DESCRIPTION
## Summary
- Enable audio file attachments only when local bundle facts prove native audio input support.
- Keep name-only, unsupported, and unproven audio models gated with visible typed errors instead of advertising capability.
- Keep Gemma4 audio blocked as `partial`/diagnostic evidence until live Osaurus/vMLX runtime proof exists, even when installed bundle metadata contains `embed_audio`, `audio_tower`, or `audio_config` markers.
- Centralize audio file classification, picker/drop UTTypes, format normalization, and attachment size limits.
- Thread local model directories into runtime policy so audio requests are accepted only with capability evidence.

Fixes #1183.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-a10 swift test --package-path Packages/OsaurusCore --filter 'ModelMediaCapabilitiesMCDCTests|MLXServiceRuntimePolicyTests|DocumentParserShimTests|LocalModelDetectionTests|ChatAttachmentSecurityTests|MultimodalContentPartTests'`
- `git diff --check`
- `scripts/i18n/check.sh`

## Maintainer Feedback Addressed
- Gemma4 multimodal audio is no longer promoted to usable support from metadata alone. Installed Gemma4 audio markers now surface as partial/blocked diagnostics until there is live runtime proof.
