### PR TITLE
Add MCP setup, import, and operations

### DIFF
--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -632,7 +632,7 @@ public final class MCPProviderManager: ObservableObject {
                     return nil
                 }.joined(separator: "\n")
                 let message = errorText.isEmpty ? "Tool returned error" : errorText
-                recordProviderToolCall(
+                await recordProviderToolCall(
                     provider: provider,
                     toolName: toolName,
                     argumentsJSON: argumentsJSON,
@@ -646,7 +646,7 @@ public final class MCPProviderManager: ObservableObject {
 
             // Convert content to string
             let result = MCPProviderTool.convertMCPContent(content)
-            recordProviderToolCall(
+            await recordProviderToolCall(
                 provider: provider,
                 toolName: toolName,
                 argumentsJSON: argumentsJSON,
@@ -658,7 +658,7 @@ public final class MCPProviderManager: ObservableObject {
             return result
         } catch {
             if !didRecordCall {
-                recordProviderToolCall(
+                await recordProviderToolCall(
                     provider: provider,
                     toolName: toolName,
                     argumentsJSON: argumentsJSON,
@@ -705,20 +705,21 @@ public final class MCPProviderManager: ObservableObject {
         succeeded: Bool,
         result: String? = nil,
         errorMessage: String? = nil
-    ) {
-        MCPProviderCallHistoryStore.record(
-            MCPProviderCallRecord(
-                providerId: provider.id,
-                providerName: provider.name,
-                toolName: toolName,
-                startedAt: startedAt,
-                finishedAt: Date(),
-                succeeded: succeeded,
-                argumentSummary: MCPProviderCallRecord.summarizeArguments(argumentsJSON),
-                resultSummary: result.map(MCPProviderCallRecord.summarizeResult),
-                errorMessage: errorMessage
-            )
+    ) async {
+        let record = MCPProviderCallRecord(
+            providerId: provider.id,
+            providerName: provider.name,
+            toolName: toolName,
+            startedAt: startedAt,
+            finishedAt: Date(),
+            succeeded: succeeded,
+            argumentSummary: MCPProviderCallRecord.summarizeArguments(argumentsJSON),
+            resultSummary: result.map(MCPProviderCallRecord.summarizeResult),
+            errorMessage: errorMessage
         )
+        await Task.detached(priority: .utility) {
+            MCPProviderCallHistoryStore.record(record)
+        }.value
     }
 
     #if DEBUG

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -267,7 +267,7 @@ public final class MCPProviderManager: ObservableObject {
             // stuck on "Connecting…" indefinitely. `discoverTools` already
             // uses `withTimeout` for the second leg of the handshake — we
             // mirror that for the first.
-            try await withTimeout(seconds: provider.discoveryTimeout) {
+            try await MCPAsyncTimeout.run(seconds: provider.discoveryTimeout) {
                 _ = try await client.connect(transport: transport)
             }
 
@@ -699,10 +699,10 @@ public final class MCPProviderManager: ObservableObject {
         let client = MCP.Client(name: "Osaurus", version: "1.0.0")
 
         do {
-            try await withTimeout(seconds: 10) {
+            try await MCPAsyncTimeout.run(seconds: 10) {
                 _ = try await client.connect(transport: transport)
             }
-            let tools = try await withTimeout(seconds: 10) {
+            let tools = try await MCPAsyncTimeout.run(seconds: 10) {
                 try await client.listAllTools()
             }
             stopStdioRunners(for: provider.id)
@@ -1138,7 +1138,7 @@ public final class MCPProviderManager: ObservableObject {
         // List tools with timeout, following pagination cursors so servers
         // that split tools/list across pages (e.g. Baserow, #1999) aren't
         // truncated to their first page.
-        let mcpTools = try await withTimeout(seconds: provider.discoveryTimeout) {
+        let mcpTools = try await MCPAsyncTimeout.run(seconds: provider.discoveryTimeout) {
             try await client.listAllTools()
         }
 
@@ -1185,26 +1185,6 @@ public final class MCPProviderManager: ObservableObject {
             ToolRegistry.shared.registerMCPTool(tool)
         }
         return tools
-    }
-
-    private func withTimeout<T: Sendable>(seconds: TimeInterval, operation: @escaping @Sendable () async throws -> T)
-        async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
-
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw MCPProviderError.timeout
-            }
-
-            guard let result = try await group.next() else {
-                throw MCPProviderError.timeout
-            }
-            group.cancelAll()
-            return result
-        }
     }
 
     private func notifyStatusChanged() {

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -354,9 +354,8 @@ public final class MCPProviderManager: ObservableObject {
 
             // Connect under a timeout. Without this, a stdio subprocess that
             // spawned successfully but never speaks MCP would leave the card
-            // stuck on "Connecting…" indefinitely. `discoverTools` already
-            // uses `withTimeout` for the second leg of the handshake — we
-            // mirror that for the first.
+            // stuck on "Connecting…" indefinitely. `discoverTools` uses the
+            // same cancellation-aware timeout for the second leg.
             try await MCPAsyncTimeout.run(seconds: provider.discoveryTimeout) {
                 _ = try await client.connect(transport: transport)
             }

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -174,6 +174,7 @@ public final class MCPProviderManager: ObservableObject {
         ) else { return false }
 
         configuration.add(provider)
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
         MCPProviderConfigurationStore.save(configuration)
         // KPI: a user-configured MCP tool provider. Only the transport kind
         // is captured — never the command, URL, or args.
@@ -237,6 +238,7 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         configuration.update(provider)
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
         MCPProviderConfigurationStore.save(configuration)
 
         // If the user switched away from OAuth, drop any cached tokens for this provider.
@@ -293,6 +295,7 @@ public final class MCPProviderManager: ObservableObject {
     /// When enabled is false, disconnects from the provider
     public func setEnabled(_ enabled: Bool, for providerId: UUID) {
         configuration.setEnabled(enabled, for: providerId)
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
         MCPProviderConfigurationStore.save(configuration)
 
         if enabled {
@@ -900,6 +903,7 @@ public final class MCPProviderManager: ObservableObject {
             provider.enabled = true
         }
         configuration.update(provider)
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
         MCPProviderConfigurationStore.save(configuration)
 
         // Clear the "needs sign in" badge.

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -24,9 +24,9 @@ public enum MCPProviderBearerTokenEdit: Sendable, Equatable {
         authType: MCPProviderAuthType,
         clearRequested: Bool = false
     ) -> MCPProviderBearerTokenEdit {
-        guard authType == .bearerToken else { return .preserve }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if clearRequested && trimmed.isEmpty { return .clear }
+        guard authType == .bearerToken else { return .preserve }
         return trimmed.isEmpty ? .preserve : .replace(trimmed)
     }
 
@@ -49,6 +49,50 @@ public enum MCPProviderBearerTokenEdit: Sendable, Equatable {
         case .clear:
             return delete()
         }
+    }
+}
+
+enum MCPProviderCredentialPersistence {
+    static func persist(
+        providerId: UUID,
+        tokenEdit: MCPProviderBearerTokenEdit,
+        secretWrites: [MCPProviderSecretWrite]
+    ) -> Bool {
+        persist(
+            providerId: providerId,
+            tokenEdit: tokenEdit,
+            secretWrites: secretWrites,
+            readToken: MCPProviderKeychain.getToken,
+            saveToken: MCPProviderKeychain.saveToken,
+            deleteToken: MCPProviderKeychain.deleteToken,
+            persistSecrets: MCPProviderSecretPersistence.persist
+        )
+    }
+
+    static func persist(
+        providerId: UUID,
+        tokenEdit: MCPProviderBearerTokenEdit,
+        secretWrites: [MCPProviderSecretWrite],
+        readToken: (UUID) -> String?,
+        saveToken: (String, UUID) -> Bool,
+        deleteToken: (UUID) -> Bool,
+        persistSecrets: ([MCPProviderSecretWrite], UUID) -> Bool
+    ) -> Bool {
+        let previousToken = readToken(providerId)
+        guard tokenEdit.apply(
+            save: { saveToken($0, providerId) },
+            delete: { deleteToken(providerId) }
+        ) else { return false }
+
+        guard persistSecrets(secretWrites, providerId) else {
+            if let previousToken {
+                _ = saveToken(previousToken, providerId)
+            } else {
+                _ = deleteToken(providerId)
+            }
+            return false
+        }
+        return true
     }
 }
 
@@ -106,17 +150,34 @@ public final class MCPProviderManager: ObservableObject {
     // MARK: - Provider Management
 
     /// Add a new provider
-    public func addProvider(_ provider: MCPProvider, token: String?) {
+    @discardableResult
+    public func addProvider(_ provider: MCPProvider, token: String?) -> Bool {
+        addProvider(provider, token: token, secretWrites: [])
+    }
+
+    @discardableResult
+    func addProvider(
+        _ provider: MCPProvider,
+        token: String?,
+        secretWrites: [MCPProviderSecretWrite]
+    ) -> Bool {
+        let provider = provider.scopedToActiveTransport()
+
+        let tokenEdit: MCPProviderBearerTokenEdit =
+            provider.transport == .http && provider.authType == .bearerToken
+                ? token.map(MCPProviderBearerTokenEdit.replace) ?? .preserve
+                : .preserve
+        guard MCPProviderCredentialPersistence.persist(
+            providerId: provider.id,
+            tokenEdit: tokenEdit,
+            secretWrites: secretWrites
+        ) else { return false }
+
         configuration.add(provider)
         MCPProviderConfigurationStore.save(configuration)
         // KPI: a user-configured MCP tool provider. Only the transport kind
         // is captured — never the command, URL, or args.
         FeatureTelemetry.mcpProviderAdded(transport: provider.transport.rawValue)
-
-        // Save token to Keychain if provided
-        if let token = token, !token.isEmpty {
-            MCPProviderKeychain.saveToken(token, for: provider.id)
-        }
 
         // Initialize state
         providerStates[provider.id] = MCPProviderState(providerId: provider.id)
@@ -129,28 +190,54 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         notifyStatusChanged()
+        return true
     }
 
     /// Update an existing provider
+    @discardableResult
     public func updateProvider(
         _ provider: MCPProvider,
         tokenEdit: MCPProviderBearerTokenEdit = .preserve
-    ) {
+    ) -> Bool {
+        updateProvider(provider, tokenEdit: tokenEdit, secretWrites: [])
+    }
+
+    @discardableResult
+    func updateProvider(
+        _ provider: MCPProvider,
+        tokenEdit: MCPProviderBearerTokenEdit,
+        secretWrites: [MCPProviderSecretWrite]
+    ) -> Bool {
+        let provider = provider.scopedToActiveTransport()
         let wasConnected = providerStates[provider.id]?.isConnected ?? false
+        let previous = configuration.provider(id: provider.id)
+
+        var credentialWrites = secretWrites
+        if let previous {
+            credentialWrites += Set(previous.secretHeaderKeys)
+                .subtracting(Set(provider.secretHeaderKeys))
+                .map { MCPProviderSecretWrite(storage: .header, key: $0, mutation: .delete) }
+            credentialWrites += Set(previous.secretEnvKeys)
+                .subtracting(Set(provider.secretEnvKeys))
+                .map { MCPProviderSecretWrite(storage: .environment, key: $0, mutation: .delete) }
+        }
+        let effectiveTokenEdit: MCPProviderBearerTokenEdit =
+            previous?.authType == .bearerToken && provider.authType != .bearerToken
+                ? .clear
+                : tokenEdit
+        guard MCPProviderCredentialPersistence.persist(
+            providerId: provider.id,
+            tokenEdit: effectiveTokenEdit,
+            secretWrites: credentialWrites
+        ) else { return false }
 
         // Disconnect if connected
         if wasConnected {
             disconnect(providerId: provider.id)
         }
 
-        let previous = configuration.provider(id: provider.id)
         configuration.update(provider)
         MCPProviderConfigurationStore.save(configuration)
-
-        tokenEdit.apply(
-            save: { MCPProviderKeychain.saveToken($0, for: provider.id) },
-            delete: { MCPProviderKeychain.deleteToken(for: provider.id) }
-        )
 
         // If the user switched away from OAuth, drop any cached tokens for this provider.
         if previous?.authType == .oauth && provider.authType != .oauth {
@@ -166,6 +253,7 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         notifyStatusChanged()
+        return true
     }
 
     /// Remove a provider
@@ -176,6 +264,8 @@ public final class MCPProviderManager: ObservableObject {
         // Remove from configuration (also cleans up Keychain)
         configuration.remove(id: id)
         MCPProviderConfigurationStore.save(configuration)
+        MCPProviderCallHistoryStore.clear(providerId: id)
+        MCPProviderHealthSnapshotStore.clear(providerId: id)
 
         // Clean up state
         providerStates.removeValue(forKey: id)
@@ -656,20 +746,9 @@ public final class MCPProviderManager: ObservableObject {
         arguments: [String: MCP.Value],
         timeout: TimeInterval
     ) async throws -> ([MCP.Tool.Content], Bool) {
-        try await withThrowingTaskGroup(of: ([MCP.Tool.Content], Bool).self) { group in
-            group.addTask {
-                let (content, isError) = try await client.callTool(name: toolName, arguments: arguments)
-                return (content, isError ?? false)
-            }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                throw MCPProviderError.timeout
-            }
-            guard let result = try await group.next() else {
-                throw MCPProviderError.timeout
-            }
-            group.cancelAll()
-            return result
+        try await MCPAsyncTimeout.run(seconds: timeout) {
+            let (content, isError) = try await client.callTool(name: toolName, arguments: arguments)
+            return (content, isError ?? false)
         }
     }
 

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -13,6 +13,45 @@ extension Foundation.Notification.Name {
     static let mcpProviderStatusChanged = Foundation.Notification.Name("MCPProviderStatusChanged")
 }
 
+/// Explicit edit intent for the legacy/static bearer token stored in Keychain.
+public enum MCPProviderBearerTokenEdit: Sendable, Equatable {
+    case preserve
+    case replace(String)
+    case clear
+
+    public static func fromBearerField(
+        _ value: String,
+        authType: MCPProviderAuthType,
+        clearRequested: Bool = false
+    ) -> MCPProviderBearerTokenEdit {
+        guard authType == .bearerToken else { return .preserve }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if clearRequested && trimmed.isEmpty { return .clear }
+        return trimmed.isEmpty ? .preserve : .replace(trimmed)
+    }
+
+    public var tokenForNewProvider: String? {
+        guard case .replace(let token) = self, !token.isEmpty else { return nil }
+        return token
+    }
+
+    @discardableResult
+    func apply(
+        save: (String) -> Bool,
+        delete: () -> Bool
+    ) -> Bool {
+        switch self {
+        case .preserve:
+            return true
+        case .replace(let token):
+            guard !token.isEmpty else { return true }
+            return save(token)
+        case .clear:
+            return delete()
+        }
+    }
+}
+
 /// Manages all remote MCP provider connections
 @MainActor
 public final class MCPProviderManager: ObservableObject {
@@ -44,11 +83,24 @@ public final class MCPProviderManager: ObservableObject {
 
     private init() {
         self.configuration = MCPProviderConfigurationStore.load()
+        self.providerStates = Self.initialProviderStates(for: configuration)
+    }
 
-        // Initialize states for all providers
-        for provider in configuration.providers {
-            providerStates[provider.id] = MCPProviderState(providerId: provider.id)
-        }
+    #if DEBUG
+    init(configuration: MCPProviderConfiguration) {
+        self.configuration = configuration
+        self.providerStates = Self.initialProviderStates(for: configuration)
+    }
+    #endif
+
+    private static func initialProviderStates(
+        for configuration: MCPProviderConfiguration
+    ) -> [UUID: MCPProviderState] {
+        Dictionary(
+            uniqueKeysWithValues: configuration.providers.map {
+                ($0.id, MCPProviderState(providerId: $0.id))
+            }
+        )
     }
 
     // MARK: - Provider Management
@@ -80,7 +132,10 @@ public final class MCPProviderManager: ObservableObject {
     }
 
     /// Update an existing provider
-    public func updateProvider(_ provider: MCPProvider, token: String?) {
+    public func updateProvider(
+        _ provider: MCPProvider,
+        tokenEdit: MCPProviderBearerTokenEdit = .preserve
+    ) {
         let wasConnected = providerStates[provider.id]?.isConnected ?? false
 
         // Disconnect if connected
@@ -92,14 +147,10 @@ public final class MCPProviderManager: ObservableObject {
         configuration.update(provider)
         MCPProviderConfigurationStore.save(configuration)
 
-        // Update token if provided (empty string means clear token)
-        if let token = token {
-            if token.isEmpty {
-                MCPProviderKeychain.deleteToken(for: provider.id)
-            } else {
-                MCPProviderKeychain.saveToken(token, for: provider.id)
-            }
-        }
+        tokenEdit.apply(
+            save: { MCPProviderKeychain.saveToken($0, for: provider.id) },
+            delete: { MCPProviderKeychain.deleteToken(for: provider.id) }
+        )
 
         // If the user switched away from OAuth, drop any cached tokens for this provider.
         if previous?.authType == .oauth && provider.authType != .oauth {
@@ -266,8 +317,7 @@ public final class MCPProviderManager: ObservableObject {
                         priority: .userInitiated,
                         operation: { MCPProviderKeychain.getOAuthTokens(for: providerId) }
                     ).value,
-                    tokens.refreshToken?.isEmpty == false
-                {
+                    tokens.refreshToken?.isEmpty == false {
                     do {
                         _ = try await MCPOAuthService.refresh(provider: provider, tokens: tokens)
                         // Re-enter without retry budget so we can't loop.
@@ -427,72 +477,109 @@ public final class MCPProviderManager: ObservableObject {
             throw MCPProviderError.providerNotFound
         }
 
-        // A missing client on an enabled provider (transient connect failure
-        // at launch, earlier session loss) is recoverable — reconnect instead
-        // of failing the model's tool call outright.
-        if clients[providerId] == nil, provider.enabled {
-            try await performConnect(provider: provider, allowOAuthRetry: true)
-        }
-        guard let client = clients[providerId] else {
-            throw MCPProviderError.notConnected
-        }
+        let startedAt = Date()
+        var didRecordCall = false
 
-        let arguments = try MCPProviderTool.convertArgumentsToMCPValues(argumentsJSON)
-        let timeout = provider.toolCallTimeout
-
-        // Run the network call off MainActor so it doesn't block the UI thread.
-        let (content, isError): ([MCP.Tool.Content], Bool?)
         do {
-            (content, isError) = try await Self.callMCPTool(
-                client: client,
-                toolName: toolName,
-                arguments: arguments,
-                timeout: timeout
-            )
-        } catch let error where Self.isRecoverableSessionError(error) {
-            if var reconnectState = providerStates[providerId] {
-                reconnectState.isAutoReconnecting = true
-                providerStates[providerId] = reconnectState
-                notifyStatusChanged()
+            // A missing client on an enabled provider (transient connect failure
+            // at launch, earlier session loss) is recoverable - reconnect instead
+            // of failing the model's tool call outright.
+            if clients[providerId] == nil, provider.enabled {
+                try await performConnect(provider: provider, allowOAuthRetry: true)
             }
-            defer {
-                if var finished = providerStates[providerId] {
-                    finished.isAutoReconnecting = false
-                    providerStates[providerId] = finished
-                }
-            }
-            // One reconnect + one retry; the rebuilt transport carries fresh
-            // OAuth/bearer credentials and negotiates a new session. If the
-            // reconnect fails we surface the reconnect error (it is the more
-            // actionable one: auth required, server down, ...).
-            try await performConnect(provider: provider, allowOAuthRetry: true)
-            guard let freshClient = clients[providerId] else {
+            guard let client = clients[providerId] else {
                 throw MCPProviderError.notConnected
             }
-            if var reconnected = providerStates[providerId] {
-                reconnected.lastAutoReconnectAt = Date()
-                providerStates[providerId] = reconnected
-                notifyStatusChanged()
+
+            let arguments = try MCPProviderTool.convertArgumentsToMCPValues(argumentsJSON)
+            let timeout = provider.toolCallTimeout
+
+            // Run the network call off MainActor so it doesn't block the UI thread.
+            let (content, isError): ([MCP.Tool.Content], Bool)
+            do {
+                (content, isError) = try await Self.callMCPTool(
+                    client: client,
+                    toolName: toolName,
+                    arguments: arguments,
+                    timeout: timeout
+                )
+            } catch let error where Self.isRecoverableSessionError(error) {
+                if var reconnectState = providerStates[providerId] {
+                    reconnectState.isAutoReconnecting = true
+                    providerStates[providerId] = reconnectState
+                    notifyStatusChanged()
+                }
+                defer {
+                    if var finished = providerStates[providerId] {
+                        finished.isAutoReconnecting = false
+                        providerStates[providerId] = finished
+                    }
+                }
+                // One reconnect + one retry; the rebuilt transport carries fresh
+                // OAuth/bearer credentials and negotiates a new session. If the
+                // reconnect fails we surface the reconnect error (it is the more
+                // actionable one: auth required, server down, ...).
+                try await performConnect(provider: provider, allowOAuthRetry: true)
+                guard let freshClient = clients[providerId] else {
+                    throw MCPProviderError.notConnected
+                }
+                if var reconnected = providerStates[providerId] {
+                    reconnected.lastAutoReconnectAt = Date()
+                    providerStates[providerId] = reconnected
+                    notifyStatusChanged()
+                }
+                (content, isError) = try await Self.callMCPTool(
+                    client: freshClient,
+                    toolName: toolName,
+                    arguments: arguments,
+                    timeout: timeout
+                )
             }
-            (content, isError) = try await Self.callMCPTool(
-                client: freshClient,
+
+            // Check for error
+            if isError {
+                let errorText = content.compactMap { item -> String? in
+                    if case .text(let text, _, _) = item { return text }
+                    return nil
+                }.joined(separator: "\n")
+                let message = errorText.isEmpty ? "Tool returned error" : errorText
+                recordProviderToolCall(
+                    provider: provider,
+                    toolName: toolName,
+                    argumentsJSON: argumentsJSON,
+                    startedAt: startedAt,
+                    succeeded: false,
+                    errorMessage: message
+                )
+                didRecordCall = true
+                throw MCPProviderError.toolExecutionFailed(message)
+            }
+
+            // Convert content to string
+            let result = MCPProviderTool.convertMCPContent(content)
+            recordProviderToolCall(
+                provider: provider,
                 toolName: toolName,
-                arguments: arguments,
-                timeout: timeout
+                argumentsJSON: argumentsJSON,
+                startedAt: startedAt,
+                succeeded: true,
+                result: result
             )
+            didRecordCall = true
+            return result
+        } catch {
+            if !didRecordCall {
+                recordProviderToolCall(
+                    provider: provider,
+                    toolName: toolName,
+                    argumentsJSON: argumentsJSON,
+                    startedAt: startedAt,
+                    succeeded: false,
+                    errorMessage: error.localizedDescription
+                )
+            }
+            throw error
         }
-
-        // Check for error
-        if let isError = isError, isError {
-            let errorText = content.compactMap { item -> String? in
-                if case .text(let text, _, _) = item { return text }
-                return nil
-            }.joined(separator: "\n")
-            throw MCPProviderError.toolExecutionFailed(errorText.isEmpty ? "Tool returned error" : errorText)
-        }
-
-        // Convert content to string
-        return MCPProviderTool.convertMCPContent(content)
     }
 
     /// True when a tool-call failure indicates the connection/session is
@@ -521,16 +608,58 @@ public final class MCPProviderManager: ObservableObject {
         }
     }
 
+    private func recordProviderToolCall(
+        provider: MCPProvider,
+        toolName: String,
+        argumentsJSON: String,
+        startedAt: Date,
+        succeeded: Bool,
+        result: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        MCPProviderCallHistoryStore.record(
+            MCPProviderCallRecord(
+                providerId: provider.id,
+                providerName: provider.name,
+                toolName: toolName,
+                startedAt: startedAt,
+                finishedAt: Date(),
+                succeeded: succeeded,
+                argumentSummary: MCPProviderCallRecord.summarizeArguments(argumentsJSON),
+                resultSummary: result.map(MCPProviderCallRecord.summarizeResult),
+                errorMessage: errorMessage
+            )
+        )
+    }
+
+    #if DEBUG
+    func installConnectedClientForTesting(_ client: MCP.Client, provider: MCPProvider) {
+        if configuration.provider(id: provider.id) == nil {
+            configuration.add(provider)
+        } else {
+            configuration.update(provider)
+        }
+
+        clients[provider.id] = client
+        var state = providerStates[provider.id] ?? MCPProviderState(providerId: provider.id)
+        state.isConnected = true
+        state.isConnecting = false
+        state.lastConnectedAt = Date()
+        providerStates[provider.id] = state
+    }
+    #endif
+
     /// Trampoline that runs the MCP network call outside MainActor isolation.
-    private nonisolated static func callMCPTool(
+    nonisolated private static func callMCPTool(
         client: MCP.Client,
         toolName: String,
         arguments: [String: MCP.Value],
         timeout: TimeInterval
-    ) async throws -> ([MCP.Tool.Content], Bool?) {
-        try await withThrowingTaskGroup(of: ([MCP.Tool.Content], Bool?).self) { group in
+    ) async throws -> ([MCP.Tool.Content], Bool) {
+        try await withThrowingTaskGroup(of: ([MCP.Tool.Content], Bool).self) { group in
             group.addTask {
-                try await client.callTool(name: toolName, arguments: arguments)
+                let (content, isError) = try await client.callTool(name: toolName, arguments: arguments)
+                return (content, isError ?? false)
             }
             group.addTask {
                 try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -1034,7 +1163,7 @@ public final class MCPProviderManager: ObservableObject {
     ///
     /// `registerMCPTool` auto-enables a tool only on its first registration
     /// and otherwise preserves the saved enabled state, so a per-tool disable
-    /// survives re-discovery (launch / autoConnect). Do NOT force-enable here:
+    /// survives re-discovery (launch / autoConnect). Do not force-enable here:
     /// that would overwrite the user's choice on every reconnect.
     @discardableResult
     internal func registerDiscoveredTools(
@@ -1059,8 +1188,7 @@ public final class MCPProviderManager: ObservableObject {
     }
 
     private func withTimeout<T: Sendable>(seconds: TimeInterval, operation: @escaping @Sendable () async throws -> T)
-        async throws -> T
-    {
+        async throws -> T {
         try await withThrowingTaskGroup(of: T.self) { group in
             group.addTask {
                 try await operation()

--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -13,6 +13,12 @@ extension Foundation.Notification.Name {
     static let mcpProviderStatusChanged = Foundation.Notification.Name("MCPProviderStatusChanged")
 }
 
+enum MCPProviderRuntimeErrorSanitizer {
+    static func sanitize(_ value: String) -> String {
+        MCPProviderProbeRedactor.safeDiagnosticFragment(value, maxLength: 280)
+    }
+}
+
 /// Explicit edit intent for the legacy/static bearer token stored in Keychain.
 public enum MCPProviderBearerTokenEdit: Sendable, Equatable {
     case preserve
@@ -174,7 +180,7 @@ public final class MCPProviderManager: ObservableObject {
         ) else { return false }
 
         configuration.add(provider)
-        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
+        MCPProviderHealthSnapshotStore.clear(providerId: provider.id)
         MCPProviderConfigurationStore.save(configuration)
         // KPI: a user-configured MCP tool provider. Only the transport kind
         // is captured — never the command, URL, or args.
@@ -226,6 +232,10 @@ public final class MCPProviderManager: ObservableObject {
             previous?.authType == .bearerToken && provider.authType != .bearerToken
                 ? .clear
                 : tokenEdit
+        let setupChanged =
+            previous != provider
+            || effectiveTokenEdit != .preserve
+            || !credentialWrites.isEmpty
         guard MCPProviderCredentialPersistence.persist(
             providerId: provider.id,
             tokenEdit: effectiveTokenEdit,
@@ -238,7 +248,11 @@ public final class MCPProviderManager: ObservableObject {
         }
 
         configuration.update(provider)
-        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
+        if setupChanged {
+            MCPProviderHealthSnapshotStore.clear(providerId: provider.id)
+        } else {
+            MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
+        }
         MCPProviderConfigurationStore.save(configuration)
 
         // If the user switched away from OAuth, drop any cached tokens for this provider.
@@ -295,7 +309,7 @@ public final class MCPProviderManager: ObservableObject {
     /// When enabled is false, disconnects from the provider
     public func setEnabled(_ enabled: Bool, for providerId: UUID) {
         configuration.setEnabled(enabled, for: providerId)
-        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
+        MCPProviderHealthSnapshotStore.clear(providerId: providerId)
         MCPProviderConfigurationStore.save(configuration)
 
         if enabled {
@@ -425,12 +439,16 @@ public final class MCPProviderManager: ObservableObject {
 
                 state.requiresAuth = true
                 state.resourceMetadataURL = authFailure.challenge?.resourceMetadataURL
-                state.lastError = MCPAuthFailureProbe.failureDescription(
-                    authType: provider.authType,
-                    probe: authFailure
+                state.lastError = MCPProviderRuntimeErrorSanitizer.sanitize(
+                    MCPAuthFailureProbe.failureDescription(
+                        authType: provider.authType,
+                        probe: authFailure
+                    )
                 )
             } else {
-                state.lastError = error.localizedDescription
+                state.lastError = MCPProviderRuntimeErrorSanitizer.sanitize(
+                    error.localizedDescription
+                )
             }
 
             state.isConnecting = false
@@ -885,7 +903,9 @@ public final class MCPProviderManager: ObservableObject {
             // explain what went wrong, instead of looking like a no-op. We keep
             // `requiresAuth` set so the Sign In button stays available for retry.
             if var state = providerStates[providerId] {
-                state.lastError = "Sign-in failed: \(error.localizedDescription)"
+                state.lastError = MCPProviderRuntimeErrorSanitizer.sanitize(
+                    "Sign-in failed: \(error.localizedDescription)"
+                )
                 providerStates[providerId] = state
             }
             notifyStatusChanged()
@@ -903,7 +923,7 @@ public final class MCPProviderManager: ObservableObject {
             provider.enabled = true
         }
         configuration.update(provider)
-        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
+        MCPProviderHealthSnapshotStore.clear(providerId: provider.id)
         MCPProviderConfigurationStore.save(configuration)
 
         // Clear the "needs sign in" badge.
@@ -1127,12 +1147,13 @@ public final class MCPProviderManager: ObservableObject {
             state.isConnecting = false
             state.discoveredToolCount = 0
             state.discoveredToolNames = []
-            state.lastStderrTail = stderrTail.isEmpty ? nil : stderrTail
+            let safeStderrTail = MCPProviderRuntimeErrorSanitizer.sanitize(stderrTail)
+            state.lastStderrTail = safeStderrTail.isEmpty ? nil : safeStderrTail
             let codeSuffix = exitCode >= 0 ? " (exit \(exitCode))" : ""
-            if stderrTail.isEmpty {
+            if safeStderrTail.isEmpty {
                 state.lastError = "Stdio MCP subprocess exited unexpectedly\(codeSuffix)."
             } else {
-                state.lastError = "Stdio MCP subprocess exited\(codeSuffix): \(stderrTail)"
+                state.lastError = "Stdio MCP subprocess exited\(codeSuffix): \(safeStderrTail)"
             }
             providerStates[providerId] = state
         }
@@ -1160,7 +1181,9 @@ public final class MCPProviderManager: ObservableObject {
             try await discoverTools(for: providerId, client: client, provider: provider)
         } catch {
             if var state = providerStates[providerId] {
-                state.lastError = "Tool list refresh failed: \(error.localizedDescription)"
+                state.lastError = MCPProviderRuntimeErrorSanitizer.sanitize(
+                    "Tool list refresh failed: \(error.localizedDescription)"
+                )
                 providerStates[providerId] = state
             }
             notifyStatusChanged()

--- a/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MCPProviderConfiguration.swift
@@ -274,6 +274,29 @@ public struct MCPProvider: Codable, Identifiable, Sendable, Equatable {
         return merged
     }
 
+    /// Drop fields that belong to the inactive transport before persistence.
+    /// This prevents hidden editor state and its Keychain keys from surviving a
+    /// transport switch.
+    func scopedToActiveTransport() -> MCPProvider {
+        var copy = self
+        switch transport {
+        case .http:
+            copy.command = ""
+            copy.args = []
+            copy.env = [:]
+            copy.secretEnvKeys = []
+            copy.workingDirectory = nil
+        case .stdio:
+            copy.url = ""
+            copy.customHeaders = [:]
+            copy.secretHeaderKeys = []
+            copy.authType = .none
+            copy.oauth = nil
+            copy.streamingEnabled = false
+        }
+        return copy
+    }
+
     /// Check if provider has a token stored in Keychain
     public var hasToken: Bool {
         MCPProviderKeychain.hasToken(for: id)

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,138 @@
     "" : {
       "shouldTranslate" : false
     },
+    "A local MCP provider needs an executable command before launch." : {
+      "shouldTranslate" : false
+    },
+    "A regular or secret Authorization header is configured." : {
+      "shouldTranslate" : false
+    },
+    "Add HTTP/SSE or stdio MCP providers" : {
+      "shouldTranslate" : false
+    },
+    "Arguments present (invalid JSON redacted)" : {
+      "shouldTranslate" : false
+    },
+    "Arguments present (not UTF-8)" : {
+      "shouldTranslate" : false
+    },
+    "Array with \\(array.count) item(s)" : {
+      "shouldTranslate" : false
+    },
+    "Bearer credential saved" : {
+      "shouldTranslate" : false
+    },
+    "Bearer token missing" : {
+      "shouldTranslate" : false
+    },
+    "Discovery and tool calls target \\(redactedEndpoint)." : {
+      "shouldTranslate" : false
+    },
+    "Edit the URL before testing or connecting." : {
+      "shouldTranslate" : false
+    },
+    "Empty object" : {
+      "shouldTranslate" : false
+    },
+    "Empty result" : {
+      "shouldTranslate" : false
+    },
+    "Executable path is not executable: \\(expandedCommand)." : {
+      "shouldTranslate" : false
+    },
+    "HTTP endpoint invalid" : {
+      "shouldTranslate" : false
+    },
+    "Header credential configured" : {
+      "shouldTranslate" : false
+    },
+    "Host command not found" : {
+      "shouldTranslate" : false
+    },
+    "Host stdio" : {
+      "shouldTranslate" : false
+    },
+    "JSON \\(type(of: object)) argument" : {
+      "shouldTranslate" : false
+    },
+    "Missing Keychain values for: \\(missingSecretEnvironmentKeys.joined(separator: \", \"))." : {
+      "shouldTranslate" : false
+    },
+    "No OAuth token set is saved for this provider." : {
+      "shouldTranslate" : false
+    },
+    "No arguments" : {
+      "shouldTranslate" : false
+    },
+    "No auth" : {
+      "shouldTranslate" : false
+    },
+    "No bearer token is present in Keychain." : {
+      "shouldTranslate" : false
+    },
+    "OAuth not signed in" : {
+      "shouldTranslate" : false
+    },
+    "OAuth signed in" : {
+      "shouldTranslate" : false
+    },
+    "OAuth tokens are saved and refreshed before discovery." : {
+      "shouldTranslate" : false
+    },
+    "Object keys: \\(keys.joined(separator: \", \"))" : {
+      "shouldTranslate" : false
+    },
+    "Open MCP operations hub" : {
+      "shouldTranslate" : false
+    },
+    "Osaurus will not add an Authorization header." : {
+      "shouldTranslate" : false
+    },
+    "Paste a token in the editor or inline auth prompt." : {
+      "shouldTranslate" : false
+    },
+    "Run Sign In before connecting." : {
+      "shouldTranslate" : false
+    },
+    "Sandbox stdio" : {
+      "shouldTranslate" : false
+    },
+    "Sign in again and retry discovery." : {
+      "shouldTranslate" : false
+    },
+    "Succeeded" : {
+      "shouldTranslate" : false
+    },
+    "The command runs directly on macOS and inherits the app environment plus provider env." : {
+      "shouldTranslate" : false
+    },
+    "The command runs inside the Osaurus sandbox via a short-lived stdio process." : {
+      "shouldTranslate" : false
+    },
+    "The provider URL must include a scheme, host, and MCP path." : {
+      "shouldTranslate" : false
+    },
+    "The server rejected discovery until sign-in completes." : {
+      "shouldTranslate" : false
+    },
+    "The token or secret header is stored outside the provider JSON." : {
+      "shouldTranslate" : false
+    },
+    "Working directory does not exist: \\(cwd)." : {
+      "shouldTranslate" : false
+    },
+    "\\(result.count) character(s): \\(redacted)" : {
+      "shouldTranslate" : false
+    },
+    "\\(result.count) character(s)" : {
+      "shouldTranslate" : false
+    },
+    "`\\(command)` was not found on the app PATH or common local bin directories." : {
+      "shouldTranslate" : false
+    },
+    "stdio command not set" : {
+      "shouldTranslate" : false
+    },
     " — %@" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -202,7 +202,7 @@
     "\\(result.count) character(s)" : {
       "shouldTranslate" : false
     },
-    "`\\(command)` was not found on the app PATH or common local bin directories." : {
+    "The host command was not found on the app PATH or common local bin directories." : {
       "shouldTranslate" : false
     },
     "stdio command not set" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -16,10 +16,16 @@
     "Choose JSON" : {
       "shouldTranslate" : false
     },
+    "Check Keychain access and try again." : {
+      "shouldTranslate" : false
+    },
     "Check the provider configuration and process logs, then test again." : {
       "shouldTranslate" : false
     },
     "Copy import summary" : {
+      "shouldTranslate" : false
+    },
+    "Credentials could not be saved" : {
       "shouldTranslate" : false
     },
     "No stdio command is configured." : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -58,6 +58,9 @@
     "Host paths" : {
       "shouldTranslate" : false
     },
+    "Host execution cannot override a protected environment variable." : {
+      "shouldTranslate" : false
+    },
     "Import Configuration" : {
       "shouldTranslate" : false
     },
@@ -68,6 +71,9 @@
       "shouldTranslate" : false
     },
     "Review a server before adding it" : {
+      "shouldTranslate" : false
+    },
+    "Remove the protected variable or select Sandbox." : {
       "shouldTranslate" : false
     },
     "Test this imported configuration before saving it." : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -124,7 +124,7 @@
     "Host stdio" : {
       "shouldTranslate" : false
     },
-    "JSON \\(type(of: object)) argument" : {
+    "JSON argument" : {
       "shouldTranslate" : false
     },
     "Missing Keychain values for: \\(missingSecretEnvironmentKeys.joined(separator: \", \"))." : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -109,7 +109,7 @@
     "Empty result" : {
       "shouldTranslate" : false
     },
-    "Executable path is not executable: \\(expandedCommand)." : {
+    "Executable path is not executable." : {
       "shouldTranslate" : false
     },
     "HTTP endpoint invalid" : {
@@ -166,6 +166,9 @@
     "Run Sign In before connecting." : {
       "shouldTranslate" : false
     },
+    "Resolved" : {
+      "shouldTranslate" : false
+    },
     "Sandbox stdio" : {
       "shouldTranslate" : false
     },
@@ -190,7 +193,7 @@
     "The token or secret header is stored outside the provider JSON." : {
       "shouldTranslate" : false
     },
-    "Working directory does not exist: \\(cwd)." : {
+    "Working directory does not exist." : {
       "shouldTranslate" : false
     },
     "\\(result.count) character(s): \\(redacted)" : {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -13,6 +13,63 @@
     "Add HTTP/SSE or stdio MCP providers" : {
       "shouldTranslate" : false
     },
+    "Choose JSON" : {
+      "shouldTranslate" : false
+    },
+    "Check the provider configuration and process logs, then test again." : {
+      "shouldTranslate" : false
+    },
+    "Copy import summary" : {
+      "shouldTranslate" : false
+    },
+    "No stdio command is configured." : {
+      "shouldTranslate" : false
+    },
+    "The configured stdio command was not found." : {
+      "shouldTranslate" : false
+    },
+    "The configured stdio process could not be started." : {
+      "shouldTranslate" : false
+    },
+    "The sandbox runtime is unavailable." : {
+      "shouldTranslate" : false
+    },
+    "The stdio MCP server connection failed." : {
+      "shouldTranslate" : false
+    },
+    "The stdio MCP server rejected authentication." : {
+      "shouldTranslate" : false
+    },
+    "The stdio MCP server returned an invalid protocol response." : {
+      "shouldTranslate" : false
+    },
+    "Use an absolute executable path or select Sandbox." : {
+      "shouldTranslate" : false
+    },
+    "Headers" : {
+      "shouldTranslate" : false
+    },
+    "Host paths" : {
+      "shouldTranslate" : false
+    },
+    "Import Configuration" : {
+      "shouldTranslate" : false
+    },
+    "Import MCP Configuration" : {
+      "shouldTranslate" : false
+    },
+    "MCP JSON" : {
+      "shouldTranslate" : false
+    },
+    "Review a server before adding it" : {
+      "shouldTranslate" : false
+    },
+    "Test this imported configuration before saving it." : {
+      "shouldTranslate" : false
+    },
+    "Use Configuration" : {
+      "shouldTranslate" : false
+    },
     "Arguments present (invalid JSON redacted)" : {
       "shouldTranslate" : false
     },

--- a/Packages/OsaurusCore/Services/MCP/MCPAsyncTimeout.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPAsyncTimeout.swift
@@ -1,0 +1,131 @@
+//
+//  MCPAsyncTimeout.swift
+//  OsaurusCore
+//
+
+import Foundation
+
+enum MCPAsyncTimeout {
+    static func run<T: Sendable>(
+        seconds: TimeInterval,
+        failureSignal: MCPAsyncFailureSignal? = nil,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard seconds.isFinite, seconds > 0 else { throw MCPProviderError.timeout }
+        let race = MCPTimeoutRace<T>()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.install(continuation)
+                failureSignal?.observe { [weak race] error in
+                    race?.resolve(.failure(error))
+                }
+                let operationTask = Task {
+                    do {
+                        try Task.checkCancellation()
+                        race.resolve(.success(try await operation()))
+                    } catch {
+                        race.resolve(.failure(error))
+                    }
+                }
+                let timeoutTask = Task {
+                    do {
+                        try await Task.sleep(
+                            nanoseconds: UInt64(min(seconds, 86_400) * 1_000_000_000)
+                        )
+                        race.resolve(.failure(MCPProviderError.timeout))
+                    } catch {
+                        // The winning branch cancels this task.
+                    }
+                }
+                race.setTasks(operation: operationTask, timeout: timeoutTask)
+            }
+        } onCancel: {
+            race.resolve(.failure(CancellationError()))
+        }
+    }
+}
+
+final class MCPAsyncFailureSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var failure: Error?
+    private var observer: (@Sendable (Error) -> Void)?
+
+    // One sequential operation observes this sticky signal at a time. A later
+    // stage replaces the prior stage's weak observer without losing a failure.
+    func observe(_ observer: @escaping @Sendable (Error) -> Void) {
+        lock.lock()
+        if let failure {
+            lock.unlock()
+            observer(failure)
+        } else {
+            self.observer = observer
+            lock.unlock()
+        }
+    }
+
+    func fail(_ error: Error) {
+        lock.lock()
+        guard failure == nil else {
+            lock.unlock()
+            return
+        }
+        failure = error
+        let observer = observer
+        self.observer = nil
+        lock.unlock()
+        observer?(error)
+    }
+}
+
+private final class MCPTimeoutRace<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var result: Result<T, Error>?
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    func install(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        if let result {
+            lock.unlock()
+            continuation.resume(with: result)
+        } else {
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
+
+    func setTasks(operation: Task<Void, Never>, timeout: Task<Void, Never>) {
+        lock.lock()
+        if result != nil {
+            lock.unlock()
+            operation.cancel()
+            timeout.cancel()
+        } else {
+            operationTask = operation
+            timeoutTask = timeout
+            lock.unlock()
+        }
+    }
+
+    func resolve(_ candidate: Result<T, Error>) {
+        lock.lock()
+        guard result == nil else {
+            lock.unlock()
+            return
+        }
+        result = candidate
+        let continuation = continuation
+        self.continuation = nil
+        let operationTask = operationTask
+        let timeoutTask = timeoutTask
+        self.operationTask = nil
+        self.timeoutTask = nil
+        lock.unlock()
+
+        operationTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(with: candidate)
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
@@ -515,6 +515,10 @@ struct MCPProviderProbeGate: Sendable, Equatable {
         successfulFingerprint == fingerprint
     }
 
+    func isCurrent(_ attempt: MCPProviderProbeAttempt) -> Bool {
+        attempt.generation == generation
+    }
+
     mutating func resetSuccess() {
         successfulFingerprint = nil
     }

--- a/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
@@ -1,0 +1,561 @@
+//
+//  MCPConfigurationImportService.swift
+//  OsaurusCore
+//
+//  Bounded import and preview for common mcpServers JSON configurations.
+//
+
+import CryptoKit
+import Foundation
+
+enum MCPConfigurationImportReason: String, Sendable, Equatable {
+    case invalidUTF8
+    case oversized
+    case malformedJSON
+    case duplicateKey
+    case unsupportedRoot
+    case tooManyServers
+    case invalidServer
+    case missingName
+    case mixedTransport
+    case unsupportedTransport
+    case invalidField
+    case unsafeValue
+    case invalidURL
+    case tooManyValues
+}
+
+struct MCPConfigurationImportFailure: Error, Sendable, Equatable, LocalizedError {
+    let reason: MCPConfigurationImportReason
+    let message: String
+
+    var errorDescription: String? { message }
+}
+
+struct MCPImportedConfigurationField: Identifiable, Sendable, Equatable {
+    let id: String
+    let key: String
+    let value: String
+    var isSecret: Bool
+
+    init(key: String, value: String, isSecret: Bool) {
+        self.id = key
+        self.key = key
+        self.value = value
+        self.isSecret = isSecret
+    }
+}
+
+struct MCPImportedServerConfiguration: Identifiable, Sendable, Equatable {
+    let id: String
+    let name: String
+    let transport: MCPProviderTransport
+    let url: String
+    let streamingEnabled: Bool
+    let command: String
+    let args: [String]
+    var environment: [MCPImportedConfigurationField]
+    var headers: [MCPImportedConfigurationField]
+    let workingDirectory: String?
+    let warnings: [String]
+
+    var referencesHostPaths: Bool {
+        ([command] + args + [workingDirectory ?? ""]).contains { value in
+            value.hasPrefix("/") || value.hasPrefix("~/")
+        }
+    }
+
+    var reporterSafeSummary: String {
+        [
+            "mcp-import-preview",
+            "name-present=\(!name.isEmpty)",
+            "transport=\(transport.rawValue)",
+            "streaming=\(streamingEnabled)",
+            "argument-count=\(args.count)",
+            "environment-keys=\(environment.map(\.key).sorted().joined(separator: ","))",
+            "secret-environment-keys=\(environment.filter(\.isSecret).map(\.key).sorted().joined(separator: ","))",
+            "header-keys=\(headers.map(\.key).sorted().joined(separator: ","))",
+            "secret-header-keys=\(headers.filter(\.isSecret).map(\.key).sorted().joined(separator: ","))",
+            "working-directory-present=\(workingDirectory != nil)",
+            "host-path-reference=\(referencesHostPaths)",
+            "warning-count=\(warnings.count)",
+        ].joined(separator: "\n")
+    }
+}
+
+enum MCPConfigurationImportService {
+    static let maximumBytes = 256 * 1024
+    static let maximumServers = 32
+    static let maximumArguments = 128
+    static let maximumFields = 128
+    static let maximumStringBytes = 16 * 1024
+
+    static func parse(_ data: Data) throws -> [MCPImportedServerConfiguration] {
+        guard data.count <= maximumBytes else {
+            throw failure(.oversized, "The MCP configuration is larger than 256 KB.")
+        }
+        guard String(data: data, encoding: .utf8) != nil else {
+            throw failure(.invalidUTF8, "The MCP configuration is not valid UTF-8.")
+        }
+
+        let root: Any
+        do {
+            root = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        } catch {
+            throw failure(.malformedJSON, "The MCP configuration is not valid JSON.")
+        }
+        if let duplicate = StrictJSONDuplicateKeyScanner.firstDuplicateKey(in: data) {
+            throw failure(.duplicateKey, "The MCP configuration contains the duplicate key '\(duplicate)'.")
+        }
+        try validateAggregateLimits(root)
+
+        guard let object = root as? [String: Any] else {
+            throw failure(.unsupportedRoot, "The MCP configuration must be a JSON object.")
+        }
+
+        let definitions: [(String?, [String: Any])]
+        if let wrapped = object["mcpServers"] {
+            guard let servers = wrapped as? [String: Any] else {
+                throw failure(.invalidField, "'mcpServers' must be an object keyed by server name.")
+            }
+            guard !servers.isEmpty else {
+                throw failure(.invalidServer, "The MCP configuration does not contain any servers.")
+            }
+            guard servers.count <= maximumServers else {
+                throw failure(.tooManyServers, "The MCP configuration contains more than 32 servers.")
+            }
+            definitions = try servers.keys.sorted().map { name in
+                guard let definition = servers[name] as? [String: Any] else {
+                    throw failure(.invalidServer, "The server '\(name)' must be a JSON object.")
+                }
+                return (name, definition)
+            }
+        } else if object["command"] != nil || object["url"] != nil {
+            definitions = [(object["name"] as? String, object)]
+        } else {
+            throw failure(
+                .unsupportedRoot,
+                "Use a top-level 'mcpServers' object or a single server with 'command' or 'url'."
+            )
+        }
+
+        return try definitions.map { keyName, definition in
+            try parseServer(keyName: keyName, definition: definition)
+        }
+    }
+
+    static func likelySecretKey(_ key: String, isHeader: Bool = false) -> Bool {
+        let normalized = key.uppercased().replacingOccurrences(of: "-", with: "_")
+        if isHeader {
+            return normalized == "AUTHORIZATION"
+                || normalized == "COOKIE"
+                || normalized == "PROXY_AUTHORIZATION"
+                || normalized.contains("API_KEY")
+                || normalized.contains("TOKEN")
+        }
+        let markers = ["TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "API_KEY", "AUTH"]
+        return markers.contains { normalized.contains($0) }
+            || normalized.hasSuffix("_KEY")
+            || normalized.hasSuffix("_PAT")
+            || normalized == "GH_PAT"
+    }
+
+    private static func parseServer(
+        keyName: String?,
+        definition: [String: Any]
+    ) throws -> MCPImportedServerConfiguration {
+        let explicitName = definition["name"] as? String
+        let name = (keyName ?? explicitName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw failure(.missingName, "A single-server configuration must include a non-empty 'name'.")
+        }
+        try validateSafeStructuralString(name, field: "name")
+
+        let command = try optionalString(definition["command"], field: "command")?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let rawURL = try optionalString(definition["url"], field: "url")?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard command.isEmpty || rawURL.isEmpty else {
+            throw failure(.mixedTransport, "Server '\(name)' cannot contain both 'command' and 'url'.")
+        }
+
+        let declaredType = try optionalString(definition["type"], field: "type")?.lowercased()
+        let inferredTransport: MCPProviderTransport
+        let streamingEnabled: Bool
+        switch declaredType {
+        case nil:
+            inferredTransport = command.isEmpty ? .http : .stdio
+            streamingEnabled = false
+        case "stdio":
+            guard rawURL.isEmpty else {
+                throw failure(.mixedTransport, "Server '\(name)' declares stdio but also contains a URL.")
+            }
+            inferredTransport = .stdio
+            streamingEnabled = false
+        case "http", "streamable-http":
+            guard command.isEmpty else {
+                throw failure(.mixedTransport, "Server '\(name)' declares HTTP but also contains a command.")
+            }
+            inferredTransport = .http
+            streamingEnabled = false
+        case "sse":
+            guard command.isEmpty else {
+                throw failure(.mixedTransport, "Server '\(name)' declares SSE but also contains a command.")
+            }
+            inferredTransport = .http
+            streamingEnabled = true
+        default:
+            throw failure(.unsupportedTransport, "Server '\(name)' uses an unsupported transport type.")
+        }
+
+        let args = try stringArray(definition["args"], field: "args")
+        let environment = try fields(
+            definition["env"],
+            field: "env",
+            isHeader: false
+        )
+        let headers = try fields(
+            definition["headers"],
+            field: "headers",
+            isHeader: true
+        )
+        let cwd = try coalescedWorkingDirectory(definition)
+
+        var warnings: [String] = []
+        switch inferredTransport {
+        case .stdio:
+            guard !command.isEmpty else {
+                throw failure(.invalidServer, "Server '\(name)' is missing its stdio command.")
+            }
+            try validateSafeStructuralString(command, field: "command")
+            guard rawURL.isEmpty, headers.isEmpty else {
+                throw failure(.invalidField, "Stdio server '\(name)' cannot contain HTTP headers.")
+            }
+            let referencesHostPaths = command.hasPrefix("/") || command.hasPrefix("~/")
+                || args.contains(where: { $0.hasPrefix("/") || $0.hasPrefix("~/") })
+                || (cwd?.hasPrefix("/") == true || cwd?.hasPrefix("~/") == true)
+            if referencesHostPaths {
+                warnings.append(
+                    "This definition references host paths. Keep Sandbox selected unless the server genuinely needs host files."
+                )
+            }
+        case .http:
+            guard !rawURL.isEmpty else {
+                throw failure(.invalidServer, "Server '\(name)' is missing its HTTP URL.")
+            }
+            guard args.isEmpty, environment.isEmpty, cwd == nil else {
+                throw failure(.invalidField, "HTTP server '\(name)' contains stdio-only fields.")
+            }
+            try validateHTTPURL(rawURL, name: name)
+        }
+
+        return MCPImportedServerConfiguration(
+            id: name,
+            name: name,
+            transport: inferredTransport,
+            url: rawURL,
+            streamingEnabled: streamingEnabled,
+            command: command,
+            args: args,
+            environment: environment,
+            headers: headers,
+            workingDirectory: cwd,
+            warnings: warnings
+        )
+    }
+
+    private static func stringArray(_ value: Any?, field: String) throws -> [String] {
+        guard let value else { return [] }
+        guard let array = value as? [Any] else {
+            throw failure(.invalidField, "'\(field)' must be an array of strings.")
+        }
+        guard array.count <= maximumArguments else {
+            throw failure(.tooManyValues, "'\(field)' must contain at most 128 string values.")
+        }
+        return try array.enumerated().map { index, item in
+            guard let string = item as? String else {
+                throw failure(.invalidField, "'\(field)[\(index)]' must be a string.")
+            }
+            try validateSafeStructuralString(string, field: "\(field)[\(index)]")
+            return string
+        }
+    }
+
+    private static func fields(
+        _ value: Any?,
+        field: String,
+        isHeader: Bool
+    ) throws -> [MCPImportedConfigurationField] {
+        guard let value else { return [] }
+        guard let object = value as? [String: Any] else {
+            throw failure(.invalidField, "'\(field)' must be an object with string values.")
+        }
+        guard object.count <= maximumFields else {
+            throw failure(.tooManyValues, "'\(field)' must contain at most 128 string values.")
+        }
+        return try object.keys.sorted().map { key in
+            guard let string = object[key] as? String else {
+                throw failure(.invalidField, "'\(field).\(key)' must be a string.")
+            }
+            try validateSafeStructuralString(key, field: "\(field) key")
+            try validateStringLength(string, field: "\(field).\(key)")
+            if string.unicodeScalars.contains(where: { $0.value == 0 }) {
+                throw failure(.unsafeValue, "'\(field).\(key)' contains a NUL character.")
+            }
+            if isHeader, string.unicodeScalars.contains(where: { $0.value == 10 || $0.value == 13 }) {
+                throw failure(.unsafeValue, "Header '\(key)' contains a line break.")
+            }
+            return MCPImportedConfigurationField(
+                key: key,
+                value: string,
+                isSecret: likelySecretKey(key, isHeader: isHeader)
+            )
+        }
+    }
+
+    private static func coalescedWorkingDirectory(_ definition: [String: Any]) throws -> String? {
+        let cwd = try optionalString(definition["cwd"], field: "cwd")
+        let workingDirectory = try optionalString(
+            definition["workingDirectory"],
+            field: "workingDirectory"
+        )
+        if let cwd, let workingDirectory, cwd != workingDirectory {
+            throw failure(.invalidField, "Use either 'cwd' or 'workingDirectory', not both.")
+        }
+        guard let value = (cwd ?? workingDirectory)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty
+        else { return nil }
+        try validateSafeStructuralString(value, field: "working directory")
+        return value
+    }
+
+    private static func optionalString(_ value: Any?, field: String) throws -> String? {
+        guard let value else { return nil }
+        guard let string = value as? String else {
+            throw failure(.invalidField, "'\(field)' must be a string.")
+        }
+        try validateStringLength(string, field: field)
+        return string
+    }
+
+    private static func validateHTTPURL(_ raw: String, name: String) throws {
+        try validateSafeStructuralString(raw, field: "url")
+        guard let components = URLComponents(string: raw),
+            let scheme = components.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            components.host != nil,
+            components.user == nil,
+            components.password == nil
+        else {
+            throw failure(
+                .invalidURL,
+                "Server '\(name)' must use an HTTP(S) URL without embedded credentials."
+            )
+        }
+    }
+
+    private static func validateAggregateLimits(_ value: Any) throws {
+        var stringCount = 0
+        func walk(_ item: Any) throws {
+            if let string = item as? String {
+                stringCount += 1
+                guard stringCount <= 4096 else {
+                    throw failure(.tooManyValues, "The MCP configuration contains too many values.")
+                }
+                try validateStringLength(string, field: "JSON string")
+            } else if let array = item as? [Any] {
+                guard array.count <= 4096 else {
+                    throw failure(.tooManyValues, "The MCP configuration contains an oversized array.")
+                }
+                for child in array { try walk(child) }
+            } else if let object = item as? [String: Any] {
+                guard object.count <= 4096 else {
+                    throw failure(.tooManyValues, "The MCP configuration contains an oversized object.")
+                }
+                for (key, child) in object {
+                    try validateStringLength(key, field: "JSON key")
+                    try walk(child)
+                }
+            }
+        }
+        try walk(value)
+    }
+
+    private static func validateSafeStructuralString(_ value: String, field: String) throws {
+        try validateStringLength(value, field: field)
+        if value.unicodeScalars.contains(where: { $0.value < 32 || $0.value == 127 }) {
+            throw failure(.unsafeValue, "'\(field)' contains a control character.")
+        }
+    }
+
+    private static func validateStringLength(_ value: String, field: String) throws {
+        guard value.utf8.count <= maximumStringBytes else {
+            throw failure(.oversized, "'\(field)' is longer than 16 KB.")
+        }
+    }
+
+    private static func failure(
+        _ reason: MCPConfigurationImportReason,
+        _ message: String
+    ) -> MCPConfigurationImportFailure {
+        MCPConfigurationImportFailure(reason: reason, message: message)
+    }
+}
+
+enum MCPProviderSetupFingerprint {
+    static func make(
+        provider: MCPProvider,
+        bearerToken: String?,
+        secretHeaderValues: [String: String],
+        secretEnvironmentValues: [String: String]
+    ) -> String {
+        var data = (try? JSONEncoder.sorted.encode(provider)) ?? Data()
+        append("bearer", bearerToken ?? "", to: &data)
+        append(secretHeaderValues, namespace: "header", to: &data)
+        append(secretEnvironmentValues, namespace: "environment", to: &data)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func append(
+        _ values: [String: String],
+        namespace: String,
+        to data: inout Data
+    ) {
+        for key in values.keys.sorted() {
+            append("\(namespace).\(key)", values[key] ?? "", to: &data)
+        }
+    }
+
+    private static func append(_ key: String, _ value: String, to data: inout Data) {
+        data.append(Data("\n\(key.utf8.count):\(key)\(value.utf8.count):\(value)".utf8))
+    }
+}
+
+enum MCPStdioEnvironmentResolver {
+    static func providerEnvironment(
+        provider: MCPProvider,
+        secretEnvOverrides: [String: String]
+    ) -> [String: String] {
+        var environment = provider.resolvedEnv()
+        for (key, value) in secretEnvOverrides where provider.secretEnvKeys.contains(key) {
+            environment[key] = value
+        }
+        return environment
+    }
+}
+
+struct MCPProviderProbeAttempt: Sendable, Equatable {
+    let generation: Int
+    let fingerprint: String
+}
+
+struct MCPProviderProbeGate: Sendable, Equatable {
+    private(set) var generation = 0
+    private(set) var successfulFingerprint: String?
+
+    mutating func start(fingerprint: String) -> MCPProviderProbeAttempt {
+        generation += 1
+        return MCPProviderProbeAttempt(generation: generation, fingerprint: fingerprint)
+    }
+
+    mutating func accept(
+        _ attempt: MCPProviderProbeAttempt,
+        currentFingerprint: String,
+        succeeded: Bool
+    ) -> Bool {
+        guard attempt.generation == generation,
+            attempt.fingerprint == currentFingerprint
+        else { return false }
+        if succeeded {
+            successfulFingerprint = currentFingerprint
+        } else {
+            successfulFingerprint = nil
+        }
+        return true
+    }
+
+    func hasCurrentSuccess(fingerprint: String) -> Bool {
+        successfulFingerprint == fingerprint
+    }
+
+    mutating func resetSuccess() {
+        successfulFingerprint = nil
+    }
+
+    mutating func invalidate() {
+        generation += 1
+        successfulFingerprint = nil
+    }
+}
+
+private extension JSONEncoder {
+    static var sorted: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}
+
+private enum StrictJSONDuplicateKeyScanner {
+    private struct Frame {
+        let isObject: Bool
+        var expectsKey: Bool
+        var keys: Set<String>
+    }
+
+    static func firstDuplicateKey(in data: Data) -> String? {
+        guard let source = String(data: data, encoding: .utf8) else { return nil }
+        let bytes = Array(source.utf8)
+        var frames: [Frame] = []
+        var index = 0
+
+        while index < bytes.count {
+            switch bytes[index] {
+            case 0x7B: // {
+                frames.append(Frame(isObject: true, expectsKey: true, keys: []))
+                index += 1
+            case 0x5B: // [
+                frames.append(Frame(isObject: false, expectsKey: false, keys: []))
+                index += 1
+            case 0x7D, 0x5D: // } ]
+                if !frames.isEmpty { frames.removeLast() }
+                index += 1
+            case 0x2C: // ,
+                if let last = frames.indices.last, frames[last].isObject {
+                    frames[last].expectsKey = true
+                }
+                index += 1
+            case 0x22: // "
+                let start = index
+                index += 1
+                var escaped = false
+                while index < bytes.count {
+                    let byte = bytes[index]
+                    if escaped {
+                        escaped = false
+                    } else if byte == 0x5C {
+                        escaped = true
+                    } else if byte == 0x22 {
+                        index += 1
+                        break
+                    }
+                    index += 1
+                }
+                if let last = frames.indices.last,
+                    frames[last].isObject,
+                    frames[last].expectsKey {
+                    guard let key = decodeJSONString(Data(bytes[start ..< index])) else { continue }
+                    if !frames[last].keys.insert(key).inserted { return key }
+                    frames[last].expectsKey = false
+                }
+            default:
+                index += 1
+            }
+        }
+        return nil
+    }
+
+    private static func decodeJSONString(_ data: Data) -> String? {
+        try? JSONDecoder().decode(String.self, from: data)
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
@@ -145,19 +145,28 @@ enum MCPConfigurationImportService {
     }
 
     static func likelySecretKey(_ key: String, isHeader: Bool = false) -> Bool {
-        let normalized = key.uppercased().replacingOccurrences(of: "-", with: "_")
+        let normalized = key.uppercased().map { character in
+            character.isLetter || character.isNumber ? character : "_"
+        }
+        let normalizedKey = String(normalized)
         if isHeader {
-            return normalized == "AUTHORIZATION"
-                || normalized == "COOKIE"
-                || normalized == "PROXY_AUTHORIZATION"
-                || normalized.contains("API_KEY")
-                || normalized.contains("TOKEN")
+            return normalizedKey == "AUTHORIZATION"
+                || normalizedKey == "COOKIE"
+                || normalizedKey == "PROXY_AUTHORIZATION"
+                || normalizedKey.contains("API_KEY")
+                || normalizedKey.contains("TOKEN")
         }
         let markers = ["TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "API_KEY", "AUTH"]
-        return markers.contains { normalized.contains($0) }
-            || normalized.hasSuffix("_KEY")
-            || normalized.hasSuffix("_PAT")
-            || normalized == "GH_PAT"
+        let credentialNames: Set<String> = [
+            "AWS_ACCESS_KEY_ID", "AZURE_CLIENT_ID", "DATABASE_URL", "DB_URL",
+            "MONGODB_URI", "MYSQL_PWD", "REDIS_URL", "SESSION_ID",
+        ]
+        return markers.contains { normalizedKey.contains($0) }
+            || normalizedKey.hasSuffix("_KEY")
+            || normalizedKey.hasSuffix("_PAT")
+            || normalizedKey.hasSuffix("_PRIVATE_KEY")
+            || credentialNames.contains(normalizedKey)
+            || normalizedKey == "GH_PAT"
     }
 
     private static func parseServer(
@@ -428,6 +437,26 @@ enum MCPProviderSetupFingerprint {
 
     private static func append(_ key: String, _ value: String, to data: inout Data) {
         data.append(Data("\n\(key.utf8.count):\(key)\(value.utf8.count):\(value)".utf8))
+    }
+}
+
+enum MCPProviderBearerProbeInput {
+    private static let clearSentinel = "<clear-requested>"
+
+    static func resolved(
+        fieldValue: String,
+        clearRequested: Bool,
+        storedValue: String?
+    ) -> String? {
+        let trimmed = fieldValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return clearRequested ? nil : storedValue
+    }
+
+    static func fingerprint(fieldValue: String, clearRequested: Bool) -> String {
+        let trimmed = fieldValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return clearRequested ? clearSentinel : ""
     }
 }
 

--- a/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPConfigurationImportService.swift
@@ -154,9 +154,17 @@ enum MCPConfigurationImportService {
                 || normalizedKey == "COOKIE"
                 || normalizedKey == "PROXY_AUTHORIZATION"
                 || normalizedKey.contains("API_KEY")
+                || normalizedKey.contains("APIKEY")
                 || normalizedKey.contains("TOKEN")
+                || normalizedKey.contains("SECRET")
+                || normalizedKey.contains("PASSWORD")
+                || normalizedKey.contains("PASSWD")
+                || normalizedKey.contains("CREDENTIAL")
         }
-        let markers = ["TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "API_KEY", "AUTH"]
+        let markers = [
+            "TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL",
+            "API_KEY", "APIKEY", "AUTH", "SERVICE_ROLE",
+        ]
         let credentialNames: Set<String> = [
             "AWS_ACCESS_KEY_ID", "AZURE_CLIENT_ID", "DATABASE_URL", "DB_URL",
             "MONGODB_URI", "MYSQL_PWD", "REDIS_URL", "SESSION_ID",

--- a/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPLocalProviderDiagnostics.swift
@@ -43,11 +43,15 @@ public enum MCPLocalProviderDiagnostics {
         }
 
         let result = snapshot.lastProbe
+        let redactedTransportSummary = MCPProviderProbeRedactor.safeDiagnosticFragment(
+            snapshot.transportSummary,
+            maxLength: 500
+        )
         var detail =
             result.succeeded
             ? (result.toolCount == 1
-                ? L("1 tool discovered via \(snapshot.transportSummary).")
-                : L("\(result.toolCount) tools discovered via \(snapshot.transportSummary)."))
+                ? L("1 tool discovered via \(redactedTransportSummary).")
+                : L("\(result.toolCount) tools discovered via \(redactedTransportSummary)."))
             : result.redactedMessage
         if let state, state.isConnected != result.succeeded {
             detail += " "

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
@@ -1,0 +1,210 @@
+//
+//  MCPProviderCallHistoryStore.swift
+//  osaurus
+//
+//  Bounded, redacted MCP provider call history for the operations hub.
+//
+
+import Foundation
+
+extension Foundation.Notification.Name {
+    static let mcpProviderCallHistoryChanged = Foundation.Notification.Name(
+        "MCPProviderCallHistoryChanged"
+    )
+}
+
+public struct MCPProviderCallRecord: Codable, Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let providerId: UUID
+    public let providerName: String
+    public let toolName: String
+    public let startedAt: Date
+    public let finishedAt: Date
+    public let succeeded: Bool
+    public let argumentSummary: String
+    public let resultSummary: String?
+    public let errorMessage: String?
+
+    public init(
+        id: UUID = UUID(),
+        providerId: UUID,
+        providerName: String,
+        toolName: String,
+        startedAt: Date,
+        finishedAt: Date,
+        succeeded: Bool,
+        argumentSummary: String,
+        resultSummary: String? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.id = id
+        self.providerId = providerId
+        self.providerName = providerName
+        self.toolName = toolName
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.succeeded = succeeded
+        self.argumentSummary = MCPProviderProbeRedactor.safeDiagnosticFragment(argumentSummary, maxLength: 180)
+        self.resultSummary = resultSummary.map {
+            MCPProviderProbeRedactor.safeDiagnosticFragment($0, maxLength: 180)
+        }
+        self.errorMessage = errorMessage.map {
+            MCPProviderProbeRedactor.safeDiagnosticFragment($0, maxLength: 280)
+        }
+    }
+
+    public var durationMilliseconds: Int {
+        max(0, Int(finishedAt.timeIntervalSince(startedAt) * 1_000))
+    }
+
+    public var statusText: String {
+        succeeded ? L("Succeeded") : L("Failed")
+    }
+
+    public var pasteboardText: String {
+        var lines = [
+            "MCP provider call",
+            "Provider: \(providerName)",
+            "Tool: \(toolName)",
+            "Status: \(succeeded ? "succeeded" : "failed")",
+            "Duration: \(durationMilliseconds)ms",
+            "Arguments: \(argumentSummary)",
+        ]
+        if let resultSummary, !resultSummary.isEmpty {
+            lines.append("Result: \(resultSummary)")
+        }
+        if let errorMessage, !errorMessage.isEmpty {
+            lines.append("Error: \(errorMessage)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    public static func summarizeArguments(_ argumentsJSON: String) -> String {
+        let trimmed = argumentsJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return L("No arguments") }
+        guard let data = trimmed.data(using: .utf8) else {
+            return L("Arguments present (not UTF-8)")
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data) else {
+            return L("Arguments present (invalid JSON redacted)")
+        }
+        if let dictionary = object as? [String: Any] {
+            if dictionary.isEmpty { return L("Empty object") }
+            let keys = dictionary.keys.sorted()
+            return L("Object keys: \(keys.joined(separator: ", "))")
+        }
+        if let array = object as? [Any] {
+            return L("Array with \(array.count) item(s)")
+        }
+        return L("JSON \(type(of: object)) argument")
+    }
+
+    public static func summarizeResult(_ result: String) -> String {
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return L("Empty result")
+        }
+        return L("\(result.count) character(s)")
+    }
+}
+
+public enum MCPProviderCallHistoryStore {
+    nonisolated(unsafe) public static var overrideURL: URL?
+    public static let maxRecordsPerProvider = 50
+    private static let lock = NSLock()
+
+    private struct Envelope: Codable, Sendable, Equatable {
+        var records: [MCPProviderCallRecord]
+    }
+
+    public static func load() -> [UUID: [MCPProviderCallRecord]] {
+        withLock {
+            loadUnlocked()
+        }
+    }
+
+    public static func recentCalls(providerId: UUID, limit: Int = maxRecordsPerProvider) -> [MCPProviderCallRecord] {
+        Array((load()[providerId] ?? []).prefix(limit))
+    }
+
+    public static func record(_ record: MCPProviderCallRecord) {
+        withLock {
+            var grouped = loadUnlocked()
+            var records = grouped[record.providerId] ?? []
+            records.insert(record, at: 0)
+            grouped[record.providerId] = Array(sortRecentFirst(records).prefix(maxRecordsPerProvider))
+            saveUnlocked(grouped)
+        }
+        notify(providerId: record.providerId)
+    }
+
+    public static func clear(providerId: UUID) {
+        withLock {
+            var grouped = loadUnlocked()
+            grouped.removeValue(forKey: providerId)
+            saveUnlocked(grouped)
+        }
+        notify(providerId: providerId)
+    }
+
+    public static func clearAll() {
+        withLock {
+            saveUnlocked([:])
+        }
+        notify(providerId: nil)
+    }
+
+    private static func loadUnlocked() -> [UUID: [MCPProviderCallRecord]] {
+        let url = fileURL()
+        guard let data = try? Data(contentsOf: url) else { return [:] }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return [:] }
+        return Dictionary(grouping: envelope.records, by: \.providerId).mapValues(sortRecentFirst)
+    }
+
+    private static func saveUnlocked(_ grouped: [UUID: [MCPProviderCallRecord]]) {
+        let url = fileURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        let records = grouped.values
+            .flatMap { $0 }
+            .sorted {
+                if $0.startedAt == $1.startedAt {
+                    return $0.id.uuidString < $1.id.uuidString
+                }
+                return $0.startedAt > $1.startedAt
+            }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            try encoder.encode(Envelope(records: records)).write(to: url, options: [.atomic])
+        } catch {
+            print("[Osaurus] Failed to save MCP call history: \(error)")
+        }
+    }
+
+    private static func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
+    }
+
+    private static func fileURL() -> URL {
+        if let overrideURL { return overrideURL }
+        return OsaurusPaths.providers().appendingPathComponent("mcp-call-history.json")
+    }
+
+    private static func sortRecentFirst(_ records: [MCPProviderCallRecord]) -> [MCPProviderCallRecord] {
+        records.sorted {
+            if $0.startedAt == $1.startedAt {
+                return $0.id.uuidString < $1.id.uuidString
+            }
+            return $0.startedAt > $1.startedAt
+        }
+    }
+
+    private static func notify(providerId: UUID?) {
+        NotificationCenter.default.post(
+            name: Foundation.Notification.Name.mcpProviderCallHistoryChanged,
+            object: providerId
+        )
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
@@ -96,7 +96,7 @@ public struct MCPProviderCallRecord: Codable, Identifiable, Sendable, Equatable 
         if let array = object as? [Any] {
             return L("Array with \(array.count) item(s)")
         }
-        return L("JSON \(type(of: object)) argument")
+        return L("JSON \(String(describing: type(of: object))) argument")
     }
 
     public static func summarizeResult(_ result: String) -> String {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderCallHistoryStore.swift
@@ -96,7 +96,7 @@ public struct MCPProviderCallRecord: Codable, Identifiable, Sendable, Equatable 
         if let array = object as? [Any] {
             return L("Array with \(array.count) item(s)")
         }
-        return L("JSON \(String(describing: type(of: object))) argument")
+        return L("JSON argument")
     }
 
     public static func summarizeResult(_ result: String) -> String {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
@@ -36,12 +36,29 @@ public struct MCPProviderHealthSnapshot: Codable, Identifiable, Sendable, Equata
     }
 }
 
+struct MCPProviderProbeReservation: Sendable, Equatable {
+    fileprivate let providerId: UUID
+    fileprivate let generation: UInt64
+}
+
+struct MCPProviderHealthProbeAttempt: Sendable, Equatable {
+    fileprivate let providerId: UUID
+    fileprivate let generation: UInt64
+    fileprivate let setupFingerprint: String
+}
+
 public enum MCPProviderHealthSnapshotStore {
     nonisolated(unsafe) public static var overrideURL: URL?
     private static let lock = NSLock()
+    nonisolated(unsafe) private static var probeStates: [UUID: ProbeState] = [:]
 
     private struct Envelope: Codable, Sendable, Equatable {
         var snapshots: [MCPProviderHealthSnapshot]
+    }
+
+    private struct ProbeState {
+        var generation: UInt64
+        var setupFingerprint: String?
     }
 
     public static func load() -> [UUID: MCPProviderHealthSnapshot] {
@@ -55,8 +72,14 @@ public enum MCPProviderHealthSnapshotStore {
         guard let data = try? Data(contentsOf: url) else { return [:] }
         guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return [:] }
         return envelope.snapshots.reduce(into: [:]) { snapshots, snapshot in
-            if let existing = snapshots[snapshot.providerId], existing.updatedAt > snapshot.updatedAt {
-                return
+            if let existing = snapshots[snapshot.providerId] {
+                if existing.lastProbe.finishedAt > snapshot.lastProbe.finishedAt {
+                    return
+                }
+                if existing.lastProbe.finishedAt == snapshot.lastProbe.finishedAt,
+                    existing.updatedAt > snapshot.updatedAt {
+                    return
+                }
             }
             snapshots[snapshot.providerId] = snapshot
         }
@@ -66,22 +89,98 @@ public enum MCPProviderHealthSnapshotStore {
         load()[providerId]
     }
 
-    public static func record(_ result: MCPProviderProbeResult, for provider: MCPProvider) {
-        withLock {
-            var snapshots = loadUnlocked()
-            snapshots[provider.id] = MCPProviderHealthSnapshot(
-                providerId: provider.id,
-                providerName: provider.name,
-                transportSummary: result.transportSummary,
-                lastProbe: result
-            )
-            saveUnlocked(snapshots)
+    /// Direct write path for non-UI callers and tests. UI probes must use a
+    /// shared attempt so a completion from another surface cannot win late.
+    @discardableResult
+    static func record(_ result: MCPProviderProbeResult, for provider: MCPProvider) -> Bool {
+        let recorded = withLock {
+            recordUnlocked(result, for: provider)
         }
-        notify(providerId: provider.id)
+        if recorded {
+            notify(providerId: provider.id)
+        }
+        return recorded
+    }
+
+    /// Reserves the next provider generation before credential capture starts.
+    /// This closes the window where an older surface could finish while the new
+    /// surface is waiting on Keychain.
+    static func reserveProbe(providerId: UUID) -> MCPProviderProbeReservation {
+        withLock {
+            let generation = advanceProbeGenerationUnlocked(providerId: providerId)
+            return MCPProviderProbeReservation(providerId: providerId, generation: generation)
+        }
+    }
+
+    /// Binds an in-memory setup hash to a reservation. Raw credentials never
+    /// enter shared state, persistence, notifications, or logs.
+    static func beginProbe(
+        _ reservation: MCPProviderProbeReservation,
+        setupFingerprint: String
+    ) -> MCPProviderHealthProbeAttempt? {
+        withLock {
+            guard var state = probeStates[reservation.providerId],
+                state.generation == reservation.generation
+            else { return nil }
+            state.setupFingerprint = setupFingerprint
+            probeStates[reservation.providerId] = state
+            return MCPProviderHealthProbeAttempt(
+                providerId: reservation.providerId,
+                generation: reservation.generation,
+                setupFingerprint: setupFingerprint
+            )
+        }
+    }
+
+    /// Cancels only the generation owned by this reservation. A stale editor
+    /// cannot invalidate a newer list, hub, bulk, or editor probe.
+    static func cancelProbe(_ reservation: MCPProviderProbeReservation) {
+        withLock {
+            guard probeStates[reservation.providerId]?.generation == reservation.generation else {
+                return
+            }
+            _ = advanceProbeGenerationUnlocked(providerId: reservation.providerId)
+        }
+    }
+
+    /// Records only the newest cross-surface attempt when the provider and its
+    /// effective credentials still have the setup hash captured at probe start.
+    @discardableResult
+    static func record(
+        _ result: MCPProviderProbeResult,
+        for provider: MCPProvider,
+        attempt: MCPProviderHealthProbeAttempt,
+        currentSetupFingerprint: String?
+    ) -> Bool {
+        let recorded = withLock {
+            guard attempt.providerId == provider.id,
+                result.providerId == provider.id,
+                var state = probeStates[provider.id],
+                state.generation == attempt.generation,
+                state.setupFingerprint == attempt.setupFingerprint
+            else { return false }
+
+            // An attempt is single-use even when its completion is rejected.
+            state.setupFingerprint = nil
+            probeStates[provider.id] = state
+            guard currentSetupFingerprint == attempt.setupFingerprint else { return false }
+            return recordUnlocked(result, for: provider)
+        }
+        if recorded {
+            notify(providerId: provider.id)
+        }
+        return recorded
+    }
+
+    static func invalidateProbeAttempts(providerId: UUID) {
+        withLock {
+            _ = advanceProbeGenerationUnlocked(providerId: providerId)
+        }
     }
 
     public static func clear(providerId: UUID) {
         withLock {
+            _ = advanceProbeGenerationUnlocked(providerId: providerId)
             var snapshots = loadUnlocked()
             snapshots.removeValue(forKey: providerId)
             saveUnlocked(snapshots)
@@ -112,6 +211,35 @@ public enum MCPProviderHealthSnapshotStore {
         } catch {
             print("[Osaurus] Failed to save MCP health snapshots: \(error)")
         }
+    }
+
+    private static func recordUnlocked(
+        _ result: MCPProviderProbeResult,
+        for provider: MCPProvider
+    ) -> Bool {
+        guard result.providerId == provider.id else { return false }
+        var snapshots = loadUnlocked()
+        if let existing = snapshots[provider.id],
+            existing.lastProbe.finishedAt > result.finishedAt {
+            return false
+        }
+        snapshots[provider.id] = MCPProviderHealthSnapshot(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: result.transportSummary,
+            lastProbe: result
+        )
+        saveUnlocked(snapshots)
+        return true
+    }
+
+    private static func advanceProbeGenerationUnlocked(providerId: UUID) -> UInt64 {
+        var generation = (probeStates[providerId]?.generation ?? 0) &+ 1
+        if generation == 0 {
+            generation = 1
+        }
+        probeStates[providerId] = ProbeState(generation: generation, setupFingerprint: nil)
+        return generation
     }
 
     private static func withLock<T>(_ operation: () -> T) -> T {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
@@ -102,6 +102,52 @@ public enum MCPProviderHealthSnapshotStore {
         return recorded
     }
 
+    /// Restores an editor probe after its configuration and credentials have
+    /// been saved. Reserving before credential recapture makes a concurrent
+    /// Keychain mutation invalidate the restore instead of reviving stale
+    /// health for a different credential set.
+    @discardableResult
+    static func restore(
+        _ result: MCPProviderProbeResult,
+        for provider: MCPProvider,
+        verifiedSetupFingerprint: String
+    ) -> Bool {
+        restore(
+            result,
+            for: provider,
+            verifiedSetupFingerprint: verifiedSetupFingerprint,
+            captureCurrentSetupFingerprint: {
+                MCPProviderProbeContext.captureStored(provider: provider).setupFingerprint
+            }
+        )
+    }
+
+    @discardableResult
+    static func restore(
+        _ result: MCPProviderProbeResult,
+        for provider: MCPProvider,
+        verifiedSetupFingerprint: String,
+        captureCurrentSetupFingerprint: () -> String
+    ) -> Bool {
+        let reservation = reserveProbe(providerId: provider.id)
+        let currentSetupFingerprint = captureCurrentSetupFingerprint()
+        guard currentSetupFingerprint == verifiedSetupFingerprint,
+            let attempt = beginProbe(
+                reservation,
+                setupFingerprint: verifiedSetupFingerprint
+            )
+        else {
+            cancelProbe(reservation)
+            return false
+        }
+        return record(
+            result,
+            for: provider,
+            attempt: attempt,
+            currentSetupFingerprint: currentSetupFingerprint
+        )
+    }
+
     /// Reserves the next provider generation before credential capture starts.
     /// This closes the window where an older surface could finish while the new
     /// surface is waiting on Keychain.

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
@@ -54,7 +54,12 @@ public enum MCPProviderHealthSnapshotStore {
         let url = fileURL()
         guard let data = try? Data(contentsOf: url) else { return [:] }
         guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return [:] }
-        return Dictionary(uniqueKeysWithValues: envelope.snapshots.map { ($0.providerId, $0) })
+        return envelope.snapshots.reduce(into: [:]) { snapshots, snapshot in
+            if let existing = snapshots[snapshot.providerId], existing.updatedAt > snapshot.updatedAt {
+                return
+            }
+            snapshots[snapshot.providerId] = snapshot
+        }
     }
 
     public static func snapshot(providerId: UUID) -> MCPProviderHealthSnapshot? {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderHealthSnapshotStore.swift
@@ -38,12 +38,19 @@ public struct MCPProviderHealthSnapshot: Codable, Identifiable, Sendable, Equata
 
 public enum MCPProviderHealthSnapshotStore {
     nonisolated(unsafe) public static var overrideURL: URL?
+    private static let lock = NSLock()
 
     private struct Envelope: Codable, Sendable, Equatable {
         var snapshots: [MCPProviderHealthSnapshot]
     }
 
     public static func load() -> [UUID: MCPProviderHealthSnapshot] {
+        withLock {
+            loadUnlocked()
+        }
+    }
+
+    private static func loadUnlocked() -> [UUID: MCPProviderHealthSnapshot] {
         let url = fileURL()
         guard let data = try? Data(contentsOf: url) else { return [:] }
         guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data) else { return [:] }
@@ -55,25 +62,35 @@ public enum MCPProviderHealthSnapshotStore {
     }
 
     public static func record(_ result: MCPProviderProbeResult, for provider: MCPProvider) {
-        var snapshots = load()
-        snapshots[provider.id] = MCPProviderHealthSnapshot(
-            providerId: provider.id,
-            providerName: provider.name,
-            transportSummary: result.transportSummary,
-            lastProbe: result
-        )
-        save(snapshots)
+        withLock {
+            var snapshots = loadUnlocked()
+            snapshots[provider.id] = MCPProviderHealthSnapshot(
+                providerId: provider.id,
+                providerName: provider.name,
+                transportSummary: result.transportSummary,
+                lastProbe: result
+            )
+            saveUnlocked(snapshots)
+        }
         notify(providerId: provider.id)
     }
 
     public static func clear(providerId: UUID) {
-        var snapshots = load()
-        snapshots.removeValue(forKey: providerId)
-        save(snapshots)
+        withLock {
+            var snapshots = loadUnlocked()
+            snapshots.removeValue(forKey: providerId)
+            saveUnlocked(snapshots)
+        }
         notify(providerId: providerId)
     }
 
     public static func save(_ snapshots: [UUID: MCPProviderHealthSnapshot]) {
+        withLock {
+            saveUnlocked(snapshots)
+        }
+    }
+
+    private static func saveUnlocked(_ snapshots: [UUID: MCPProviderHealthSnapshot]) {
         let url = fileURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         let ordered = snapshots.values.sorted {
@@ -90,6 +107,12 @@ public enum MCPProviderHealthSnapshotStore {
         } catch {
             print("[Osaurus] Failed to save MCP health snapshots: \(error)")
         }
+    }
+
+    private static func withLock<T>(_ operation: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return operation()
     }
 
     private static func fileURL() -> URL {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
@@ -17,6 +17,152 @@
 
 import Foundation
 
+struct MCPProviderSecretWrite: Equatable, Sendable {
+    enum Storage: Hashable, Sendable {
+        case header
+        case environment
+    }
+
+    enum Mutation: Equatable, Sendable {
+        case set(String)
+        case delete
+    }
+
+    let storage: Storage
+    let key: String
+    let mutation: Mutation
+
+    init(storage: Storage, key: String, value: String) {
+        self.init(storage: storage, key: key, mutation: .set(value))
+    }
+
+    init(storage: Storage, key: String, mutation: Mutation) {
+        self.storage = storage
+        self.key = key
+        self.mutation = mutation
+    }
+}
+
+private struct MCPProviderSecretIdentity: Hashable {
+    let storage: MCPProviderSecretWrite.Storage
+    let key: String
+}
+
+private enum MCPProviderPreviousSecret {
+    case missing
+    case value(String)
+}
+
+enum MCPProviderSecretPersistence {
+    static func persist(_ writes: [MCPProviderSecretWrite], for providerId: UUID) -> Bool {
+        persist(
+            writes,
+            for: providerId,
+            readHeader: MCPProviderKeychain.getHeaderSecret,
+            readEnvironment: MCPProviderKeychain.getEnvSecret,
+            writeHeader: MCPProviderKeychain.saveHeaderSecret,
+            writeEnvironment: MCPProviderKeychain.saveEnvSecret,
+            deleteHeader: MCPProviderKeychain.deleteHeaderSecret,
+            deleteEnvironment: MCPProviderKeychain.deleteEnvSecret
+        )
+    }
+
+    static func persist(
+        _ writes: [MCPProviderSecretWrite],
+        for providerId: UUID,
+        readHeader: (String, UUID) -> String?,
+        readEnvironment: (String, UUID) -> String?,
+        writeHeader: (String, String, UUID) -> Bool,
+        writeEnvironment: (String, String, UUID) -> Bool,
+        deleteHeader: (String, UUID) -> Bool,
+        deleteEnvironment: (String, UUID) -> Bool
+    ) -> Bool {
+        var snapshots: [MCPProviderSecretIdentity: MCPProviderPreviousSecret] = [:]
+        var attempted: [MCPProviderSecretIdentity] = []
+        for write in writes {
+            let identity = MCPProviderSecretIdentity(storage: write.storage, key: write.key)
+            if snapshots[identity] == nil {
+                let previous: String?
+                switch write.storage {
+                case .header:
+                    previous = readHeader(write.key, providerId)
+                case .environment:
+                    previous = readEnvironment(write.key, providerId)
+                }
+                snapshots[identity] = previous.map(MCPProviderPreviousSecret.value) ?? .missing
+            }
+            attempted.append(identity)
+
+            let succeeded = mutate(
+                write,
+                providerId: providerId,
+                writeHeader: writeHeader,
+                writeEnvironment: writeEnvironment,
+                deleteHeader: deleteHeader,
+                deleteEnvironment: deleteEnvironment
+            )
+            guard succeeded else {
+                rollback(
+                    attempted: attempted,
+                    snapshots: snapshots,
+                    providerId: providerId,
+                    writeHeader: writeHeader,
+                    writeEnvironment: writeEnvironment,
+                    deleteHeader: deleteHeader,
+                    deleteEnvironment: deleteEnvironment
+                )
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func mutate(
+        _ write: MCPProviderSecretWrite,
+        providerId: UUID,
+        writeHeader: (String, String, UUID) -> Bool,
+        writeEnvironment: (String, String, UUID) -> Bool,
+        deleteHeader: (String, UUID) -> Bool,
+        deleteEnvironment: (String, UUID) -> Bool
+    ) -> Bool {
+        switch (write.storage, write.mutation) {
+        case (.header, .set(let value)):
+            return writeHeader(value, write.key, providerId)
+        case (.environment, .set(let value)):
+            return writeEnvironment(value, write.key, providerId)
+        case (.header, .delete):
+            return deleteHeader(write.key, providerId)
+        case (.environment, .delete):
+            return deleteEnvironment(write.key, providerId)
+        }
+    }
+
+    private static func rollback(
+        attempted: [MCPProviderSecretIdentity],
+        snapshots: [MCPProviderSecretIdentity: MCPProviderPreviousSecret],
+        providerId: UUID,
+        writeHeader: (String, String, UUID) -> Bool,
+        writeEnvironment: (String, String, UUID) -> Bool,
+        deleteHeader: (String, UUID) -> Bool,
+        deleteEnvironment: (String, UUID) -> Bool
+    ) {
+        var restored: Set<MCPProviderSecretIdentity> = []
+        for identity in attempted.reversed() where restored.insert(identity).inserted {
+            guard let previous = snapshots[identity] else { continue }
+            switch (identity.storage, previous) {
+            case (.header, .value(let value)):
+                _ = writeHeader(value, identity.key, providerId)
+            case (.environment, .value(let value)):
+                _ = writeEnvironment(value, identity.key, providerId)
+            case (.header, .missing):
+                _ = deleteHeader(identity.key, providerId)
+            case (.environment, .missing):
+                _ = deleteEnvironment(identity.key, providerId)
+            }
+        }
+    }
+}
+
 /// OAuth 2.1 tokens for a remote MCP provider (per the MCP authorization spec).
 ///
 /// Stored as a single JSON blob in Keychain so access/refresh/scope/expiry stay atomic.

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
@@ -197,7 +197,9 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveToken(_ token: String, for providerId: UUID) -> Bool {
-        setData(Data(token.utf8), account: tokenAccount(for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            setData(Data(token.utf8), account: tokenAccount(for: providerId))
+        }
     }
 
     public static func getToken(for providerId: UUID) -> String? {
@@ -206,7 +208,9 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteToken(for providerId: UUID) -> Bool {
-        deleteItem(account: tokenAccount(for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            deleteItem(account: tokenAccount(for: providerId))
+        }
     }
 
     public static func hasToken(for providerId: UUID) -> Bool {
@@ -218,7 +222,9 @@ public enum MCPProviderKeychain {
     @discardableResult
     public static func saveOAuthTokens(_ tokens: MCPOAuthTokens, for providerId: UUID) -> Bool {
         guard let data = try? JSONEncoder().encode(tokens) else { return false }
-        return setData(data, account: oauthAccount(for: providerId))
+        return invalidatingProbeOnSuccess(providerId: providerId) {
+            setData(data, account: oauthAccount(for: providerId))
+        }
     }
 
     public static func getOAuthTokens(for providerId: UUID) -> MCPOAuthTokens? {
@@ -228,7 +234,9 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteOAuthTokens(for providerId: UUID) -> Bool {
-        deleteItem(account: oauthAccount(for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            deleteItem(account: oauthAccount(for: providerId))
+        }
     }
 
     public static func hasOAuthTokens(for providerId: UUID) -> Bool {
@@ -243,7 +251,9 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveOAuthClientSecret(_ clientSecret: String, for providerId: UUID) -> Bool {
-        setData(Data(clientSecret.utf8), account: oauthClientSecretAccount(for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            setData(Data(clientSecret.utf8), account: oauthClientSecretAccount(for: providerId))
+        }
     }
 
     public static func getOAuthClientSecret(for providerId: UUID) -> String? {
@@ -253,14 +263,18 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteOAuthClientSecret(for providerId: UUID) -> Bool {
-        deleteItem(account: oauthClientSecretAccount(for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            deleteItem(account: oauthClientSecretAccount(for: providerId))
+        }
     }
 
     // MARK: - Header secrets
 
     @discardableResult
     public static func saveHeaderSecret(_ value: String, key: String, for providerId: UUID) -> Bool {
-        setData(Data(value.utf8), account: headerAccount(key: key, for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            setData(Data(value.utf8), account: headerAccount(key: key, for: providerId))
+        }
     }
 
     public static func getHeaderSecret(key: String, for providerId: UUID) -> String? {
@@ -270,14 +284,18 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteHeaderSecret(key: String, for providerId: UUID) -> Bool {
-        deleteItem(account: headerAccount(key: key, for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            deleteItem(account: headerAccount(key: key, for: providerId))
+        }
     }
 
     // MARK: - Env secrets (stdio subprocess)
 
     @discardableResult
     public static func saveEnvSecret(_ value: String, key: String, for providerId: UUID) -> Bool {
-        setData(Data(value.utf8), account: envAccount(key: key, for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            setData(Data(value.utf8), account: envAccount(key: key, for: providerId))
+        }
     }
 
     public static func getEnvSecret(key: String, for providerId: UUID) -> String? {
@@ -287,7 +305,9 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteEnvSecret(key: String, for providerId: UUID) -> Bool {
-        deleteItem(account: envAccount(key: key, for: providerId))
+        invalidatingProbeOnSuccess(providerId: providerId) {
+            deleteItem(account: envAccount(key: key, for: providerId))
+        }
     }
 
     // MARK: - Bulk delete
@@ -297,6 +317,7 @@ public enum MCPProviderKeychain {
     /// or env secrets. Used when removing a provider entirely or resetting
     /// the app.
     public static func deleteAllSecrets(for providerId: UUID) {
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
         if KeychainQueryHelpers.disablesKeychainForProcess { return }
         // Targeted deletes (cheap, idempotent).
         deleteToken(for: providerId)
@@ -351,5 +372,16 @@ public enum MCPProviderKeychain {
     private static func deleteItem(account: String) -> Bool {
         if KeychainQueryHelpers.disablesKeychainForProcess { return true }
         return Keychain.delete(service: service, account: account)
+    }
+
+    private static func invalidatingProbeOnSuccess(
+        providerId: UUID,
+        operation: () -> Bool
+    ) -> Bool {
+        let succeeded = operation()
+        if succeeded {
+            MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
+        }
+        return succeeded
     }
 }

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderKeychain.swift
@@ -197,7 +197,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveToken(_ token: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             setData(Data(token.utf8), account: tokenAccount(for: providerId))
         }
     }
@@ -208,7 +208,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteToken(for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             deleteItem(account: tokenAccount(for: providerId))
         }
     }
@@ -222,7 +222,7 @@ public enum MCPProviderKeychain {
     @discardableResult
     public static func saveOAuthTokens(_ tokens: MCPOAuthTokens, for providerId: UUID) -> Bool {
         guard let data = try? JSONEncoder().encode(tokens) else { return false }
-        return invalidatingProbeOnSuccess(providerId: providerId) {
+        return clearingHealthOnSuccess(providerId: providerId) {
             setData(data, account: oauthAccount(for: providerId))
         }
     }
@@ -234,7 +234,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteOAuthTokens(for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             deleteItem(account: oauthAccount(for: providerId))
         }
     }
@@ -251,7 +251,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveOAuthClientSecret(_ clientSecret: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             setData(Data(clientSecret.utf8), account: oauthClientSecretAccount(for: providerId))
         }
     }
@@ -263,7 +263,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteOAuthClientSecret(for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             deleteItem(account: oauthClientSecretAccount(for: providerId))
         }
     }
@@ -272,7 +272,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveHeaderSecret(_ value: String, key: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             setData(Data(value.utf8), account: headerAccount(key: key, for: providerId))
         }
     }
@@ -284,7 +284,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteHeaderSecret(key: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             deleteItem(account: headerAccount(key: key, for: providerId))
         }
     }
@@ -293,7 +293,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func saveEnvSecret(_ value: String, key: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             setData(Data(value.utf8), account: envAccount(key: key, for: providerId))
         }
     }
@@ -305,7 +305,7 @@ public enum MCPProviderKeychain {
 
     @discardableResult
     public static func deleteEnvSecret(key: String, for providerId: UUID) -> Bool {
-        invalidatingProbeOnSuccess(providerId: providerId) {
+        clearingHealthOnSuccess(providerId: providerId) {
             deleteItem(account: envAccount(key: key, for: providerId))
         }
     }
@@ -317,7 +317,7 @@ public enum MCPProviderKeychain {
     /// or env secrets. Used when removing a provider entirely or resetting
     /// the app.
     public static func deleteAllSecrets(for providerId: UUID) {
-        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
+        MCPProviderHealthSnapshotStore.clear(providerId: providerId)
         if KeychainQueryHelpers.disablesKeychainForProcess { return }
         // Targeted deletes (cheap, idempotent).
         deleteToken(for: providerId)
@@ -374,13 +374,13 @@ public enum MCPProviderKeychain {
         return Keychain.delete(service: service, account: account)
     }
 
-    private static func invalidatingProbeOnSuccess(
+    static func clearingHealthOnSuccess(
         providerId: UUID,
         operation: () -> Bool
     ) -> Bool {
         let succeeded = operation()
         if succeeded {
-            MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: providerId)
+            MCPProviderHealthSnapshotStore.clear(providerId: providerId)
         }
         return succeeded
     }

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -1,0 +1,593 @@
+//
+//  MCPProviderOperationsHub.swift
+//  osaurus
+//
+//  Operations-focused aggregation for MCP provider management.
+//
+
+import Foundation
+
+public enum MCPProviderLaunchPlanStatus: String, Codable, Sendable, Equatable {
+    case ready
+    case warning
+    case blocked
+}
+
+public struct MCPProviderLaunchPlan: Sendable, Equatable {
+    public let providerId: UUID
+    public let transport: MCPProviderTransport
+    public let status: MCPProviderLaunchPlanStatus
+    public let title: String
+    public let detail: String
+    public let redactedCommandLine: String?
+    public let resolvedExecutablePath: String?
+    public let searchPath: String?
+    public let workingDirectory: String?
+    public let configuredEnvironmentKeys: [String]
+    public let secretEnvironmentKeys: [String]
+    public let missingSecretEnvironmentKeys: [String]
+    public let warnings: [String]
+
+    public var pasteboardText: String {
+        var lines = [
+            "Launch plan: \(title)",
+            "Status: \(status.rawValue)",
+            "Detail: \(detail)",
+        ]
+        if let redactedCommandLine {
+            lines.append("Command: \(redactedCommandLine)")
+        }
+        if let resolvedExecutablePath {
+            lines.append("Resolved executable: \(resolvedExecutablePath)")
+        }
+        if let workingDirectory, !workingDirectory.isEmpty {
+            lines.append("Working directory: \(workingDirectory)")
+        }
+        if !configuredEnvironmentKeys.isEmpty {
+            lines.append("Environment keys: \(configuredEnvironmentKeys.joined(separator: ", "))")
+        }
+        if !secretEnvironmentKeys.isEmpty {
+            lines.append("Secret env keys: \(secretEnvironmentKeys.joined(separator: ", "))")
+        }
+        if !missingSecretEnvironmentKeys.isEmpty {
+            lines.append("Missing secret env keys: \(missingSecretEnvironmentKeys.joined(separator: ", "))")
+        }
+        if let searchPath, !searchPath.isEmpty {
+            lines.append("PATH searched: \(searchPath)")
+        }
+        if !warnings.isEmpty {
+            lines.append("Warnings: \(warnings.joined(separator: "; "))")
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+public enum MCPProviderAuthStatusKind: String, Codable, Sendable, Equatable {
+    case none
+    case bearerTokenPresent
+    case bearerTokenMissing
+    case oauthSignedIn
+    case oauthMissing
+    case oauthRequired
+    case headerCredentialPresent
+}
+
+public struct MCPProviderAuthStatus: Sendable, Equatable {
+    public let kind: MCPProviderAuthStatusKind
+    public let severity: ProviderDiagnosticSeverity
+    public let title: String
+    public let detail: String
+    public let action: String?
+}
+
+public struct MCPProviderOperationsReport: Identifiable, Sendable {
+    public var id: UUID { hubReport.id }
+    public let hubReport: MCPServerHubProviderReport
+    public let launchPlan: MCPProviderLaunchPlan
+    public let authStatus: MCPProviderAuthStatus
+    public let callHistory: [MCPProviderCallRecord]
+
+    public var provider: MCPProvider { hubReport.provider }
+    public var status: MCPServerHubStatus { hubReport.status }
+    public var diagnostics: ProviderDiagnosticReport { hubReport.diagnostics }
+    public var lastCall: MCPProviderCallRecord? { callHistory.first }
+
+    public var pasteboardText: String {
+        var lines = [
+            hubReport.diagnostics.pasteboardText,
+            "",
+            launchPlan.pasteboardText,
+            "",
+            "Auth status: \(authStatus.title)",
+            "Auth detail: \(authStatus.detail)",
+        ]
+        if let action = authStatus.action {
+            lines.append("Auth action: \(action)")
+        }
+        if callHistory.isEmpty {
+            lines.append("")
+            lines.append("Recent calls: none")
+        } else {
+            lines.append("")
+            lines.append("Recent calls:")
+            for call in callHistory.prefix(10) {
+                lines.append("- \(call.toolName): \(call.statusText), \(call.durationMilliseconds)ms, \(call.argumentSummary)")
+                if let error = call.errorMessage, !error.isEmpty {
+                    lines.append("  Error: \(error)")
+                }
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+public struct MCPProviderOperationsSnapshot: Sendable {
+    public let generatedAt: Date
+    public let hubSnapshot: MCPServerHubSnapshot
+    public let reports: [MCPProviderOperationsReport]
+
+    public var pasteboardText: String {
+        var lines = [
+            "MCP Operations Hub diagnostics",
+            "\(hubSnapshot.connectedCount)/\(hubSnapshot.totalCount) connected, \(hubSnapshot.attentionCount) attention, \(hubSnapshot.toolCount) tools",
+            "",
+            hubSnapshot.pasteboardText,
+        ]
+        for report in reports {
+            lines.append("")
+            lines.append(report.pasteboardText)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    public func filtered(by filter: MCPServerHubFilter) -> [MCPProviderOperationsReport] {
+        reports.filter { filter.includes($0.hubReport) }
+    }
+}
+
+enum MCPProviderOperationsFieldNormalizer {
+    static func normalize(
+        _ entries: [(key: String, value: String, isSecret: Bool)]
+    ) -> (regular: [String: String], secretKeys: [String]) {
+        var regular: [String: String] = [:]
+        var secretKeys: [String] = []
+
+        for entry in entries {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+
+            regular.removeValue(forKey: key)
+            secretKeys.removeAll { $0 == key }
+            if entry.isSecret {
+                secretKeys.append(key)
+            } else {
+                regular[key] = entry.value
+            }
+        }
+
+        return (regular, secretKeys)
+    }
+}
+
+public enum MCPProviderOperationsHub {
+    static func credentialPresence(
+        for providers: [MCPProvider]
+    ) -> [UUID: MCPProviderCredentialPresence] {
+        var next: [UUID: MCPProviderCredentialPresence] = [:]
+        for provider in providers {
+            let providerId = provider.id
+            next[providerId] = MCPProviderCredentialPresence(
+                bearerTokenPresent: MCPProviderKeychain.hasToken(for: providerId),
+                oauthTokensPresent: MCPProviderKeychain.hasOAuthTokens(for: providerId)
+            )
+        }
+        return next
+    }
+
+    public static func emptySnapshot(
+        generatedAt: Date = Date(),
+        proxy: GlobalProxyDiagnosticState = .disabled
+    ) -> MCPProviderOperationsSnapshot {
+        MCPProviderOperationsSnapshot(
+            generatedAt: generatedAt,
+            hubSnapshot: MCPServerHubSnapshot(reports: [], proxy: proxy),
+            reports: []
+        )
+    }
+
+    public static func snapshot(
+        providers: [MCPProvider],
+        states: [UUID: MCPProviderState],
+        proxy: GlobalProxyDiagnosticState,
+        credentialsByProvider: [UUID: MCPProviderCredentialPresence],
+        healthSnapshots: [UUID: MCPProviderHealthSnapshot],
+        callHistoryByProvider: [UUID: [MCPProviderCallRecord]] = MCPProviderCallHistoryStore.load()
+    ) -> MCPProviderOperationsSnapshot {
+        let hubSnapshot = MCPServerHub.snapshot(
+            providers: providers,
+            states: states,
+            proxy: proxy,
+            credentialsByProvider: credentialsByProvider,
+            healthSnapshots: healthSnapshots
+        )
+        let reports = hubSnapshot.reports.map { report in
+            MCPProviderOperationsReport(
+                hubReport: report,
+                launchPlan: launchPlan(for: report.provider),
+                authStatus: authStatus(
+                    provider: report.provider,
+                    state: report.state,
+                    credentialPresence: credentialsByProvider[report.provider.id] ?? MCPProviderCredentialPresence()
+                ),
+                callHistory: callHistoryByProvider[report.provider.id] ?? []
+            )
+        }
+        return MCPProviderOperationsSnapshot(
+            generatedAt: Date(),
+            hubSnapshot: hubSnapshot,
+            reports: reports
+        )
+    }
+
+    public static func authStatus(
+        provider: MCPProvider,
+        state: MCPProviderState?,
+        credentialPresence: MCPProviderCredentialPresence
+    ) -> MCPProviderAuthStatus {
+        switch provider.authType {
+        case .none:
+            if hasCredentialHeader(provider) {
+                return MCPProviderAuthStatus(
+                    kind: .headerCredentialPresent,
+                    severity: .ok,
+                    title: L("Header credential configured"),
+                    detail: L("A regular or secret Authorization header is configured."),
+                    action: nil
+                )
+            }
+            return MCPProviderAuthStatus(
+                kind: .none,
+                severity: .info,
+                title: L("No auth"),
+                detail: L("Osaurus will not add an Authorization header."),
+                action: nil
+            )
+        case .bearerToken:
+            if credentialPresence.bearerTokenPresent || hasCredentialHeader(provider) {
+                return MCPProviderAuthStatus(
+                    kind: .bearerTokenPresent,
+                    severity: .ok,
+                    title: L("Bearer credential saved"),
+                    detail: L("The token or secret header is stored outside the provider JSON."),
+                    action: nil
+                )
+            }
+            return MCPProviderAuthStatus(
+                kind: .bearerTokenMissing,
+                severity: state?.requiresAuth == true ? .blocked : .warning,
+                title: L("Bearer token missing"),
+                detail: state?.lastError.map(redact) ?? L("No bearer token is present in Keychain."),
+                action: L("Paste a token in the editor or inline auth prompt.")
+            )
+        case .oauth:
+            if state?.requiresAuth == true {
+                return MCPProviderAuthStatus(
+                    kind: .oauthRequired,
+                    severity: .blocked,
+                    title: L("OAuth sign-in required"),
+                    detail: state?.lastError.map(redact) ?? L("The server rejected discovery until sign-in completes."),
+                    action: L("Sign in again and retry discovery.")
+                )
+            }
+            if credentialPresence.oauthTokensPresent {
+                return MCPProviderAuthStatus(
+                    kind: .oauthSignedIn,
+                    severity: .ok,
+                    title: L("OAuth signed in"),
+                    detail: L("OAuth tokens are saved and refreshed before discovery."),
+                    action: nil
+                )
+            }
+            return MCPProviderAuthStatus(
+                kind: .oauthMissing,
+                severity: .warning,
+                title: L("OAuth not signed in"),
+                detail: L("No OAuth token set is saved for this provider."),
+                action: L("Run Sign In before connecting.")
+            )
+        }
+    }
+
+    public static func launchPlan(
+        for provider: MCPProvider,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        secretEnvValues: [String: String]? = nil,
+        isExecutable: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
+        directoryExists: (String) -> Bool = { path in
+            var isDirectory: ObjCBool = false
+            return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+        }
+    ) -> MCPProviderLaunchPlan {
+        switch provider.transport {
+        case .http:
+            return httpLaunchPlan(for: provider)
+        case .stdio:
+            return stdioLaunchPlan(
+                for: provider,
+                processEnvironment: processEnvironment,
+                secretEnvValues: secretEnvValues,
+                isExecutable: isExecutable,
+                directoryExists: directoryExists
+            )
+        }
+    }
+
+    private static func httpLaunchPlan(for provider: MCPProvider) -> MCPProviderLaunchPlan {
+        let trimmedURL = provider.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let endpoint = URL(string: trimmedURL), endpoint.scheme?.isEmpty == false, endpoint.host?.isEmpty == false
+        else {
+            return MCPProviderLaunchPlan(
+                providerId: provider.id,
+                transport: .http,
+                status: .blocked,
+                title: L("HTTP endpoint invalid"),
+                detail: L("The provider URL must include a scheme, host, and MCP path."),
+                redactedCommandLine: nil,
+                resolvedExecutablePath: nil,
+                searchPath: nil,
+                workingDirectory: nil,
+                configuredEnvironmentKeys: [],
+                secretEnvironmentKeys: [],
+                missingSecretEnvironmentKeys: [],
+                warnings: [L("Edit the URL before testing or connecting.")]
+            )
+        }
+
+        let redactedEndpoint = MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(endpoint.absoluteString)
+        return MCPProviderLaunchPlan(
+            providerId: provider.id,
+            transport: .http,
+            status: .ready,
+            title: provider.streamingEnabled ? "HTTP/SSE" : "HTTP",
+            detail: L("Discovery and tool calls target \(redactedEndpoint)."),
+            redactedCommandLine: nil,
+            resolvedExecutablePath: nil,
+            searchPath: nil,
+            workingDirectory: nil,
+            configuredEnvironmentKeys: [],
+            secretEnvironmentKeys: [],
+            missingSecretEnvironmentKeys: [],
+            warnings: []
+        )
+    }
+
+    private static func stdioLaunchPlan(
+        for provider: MCPProvider,
+        processEnvironment: [String: String],
+        secretEnvValues: [String: String]?,
+        isExecutable: (String) -> Bool,
+        directoryExists: (String) -> Bool
+    ) -> MCPProviderLaunchPlan {
+        let command = provider.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secretEnvironmentKeys = uniqueTrimmedKeys(provider.secretEnvKeys).sorted()
+        let configuredEnvironmentKeys = Array(Set(provider.env.keys).union(secretEnvironmentKeys)).sorted()
+        let missingSecretEnvironmentKeys = missingSecretKeys(
+            for: provider,
+            secretEnvKeys: secretEnvironmentKeys,
+            secretEnvValues: secretEnvValues
+        )
+        let redactedCommandLine = redact(commandLine(provider: provider))
+        var warnings: [String] = []
+
+        guard !command.isEmpty else {
+            return MCPProviderLaunchPlan(
+                providerId: provider.id,
+                transport: .stdio,
+                status: .blocked,
+                title: L("Stdio command missing"),
+                detail: L("A local MCP provider needs an executable command before launch."),
+                redactedCommandLine: nil,
+                resolvedExecutablePath: nil,
+                searchPath: nil,
+                workingDirectory: normalizedWorkingDirectory(provider.workingDirectory),
+                configuredEnvironmentKeys: configuredEnvironmentKeys,
+                secretEnvironmentKeys: secretEnvironmentKeys,
+                missingSecretEnvironmentKeys: missingSecretEnvironmentKeys,
+                warnings: [L("Enter a command before testing.")]
+            )
+        }
+
+        if !missingSecretEnvironmentKeys.isEmpty {
+            warnings.append(
+                L("Missing Keychain values for: \(missingSecretEnvironmentKeys.joined(separator: ", ")).")
+            )
+        }
+
+        let cwd = normalizedWorkingDirectory(provider.workingDirectory)
+        if let cwd, provider.executionHost == .host, !directoryExists(cwd) {
+            warnings.append(L("Working directory does not exist: \(cwd)."))
+        }
+
+        switch provider.executionHost {
+        case .sandbox:
+            let status: MCPProviderLaunchPlanStatus =
+                missingSecretEnvironmentKeys.isEmpty && warnings.isEmpty ? .ready : .warning
+            return MCPProviderLaunchPlan(
+                providerId: provider.id,
+                transport: .stdio,
+                status: status,
+                title: L("Sandbox stdio"),
+                detail: L("The command runs inside the Osaurus sandbox via a short-lived stdio process."),
+                redactedCommandLine: redactedCommandLine,
+                resolvedExecutablePath: nil,
+                searchPath: nil,
+                workingDirectory: cwd,
+                configuredEnvironmentKeys: configuredEnvironmentKeys,
+                secretEnvironmentKeys: secretEnvironmentKeys,
+                missingSecretEnvironmentKeys: missingSecretEnvironmentKeys,
+                warnings: warnings
+            )
+        case .host:
+            let fullEnv = resolvedProcessEnvironment(
+                provider: provider,
+                processEnvironment: processEnvironment,
+                secretEnvValues: secretEnvValues
+            )
+            let searchPath = executableSearchPath(env: fullEnv)
+            let expandedCommand = expandUserPath(command)
+            var resolvedExecutablePath: String?
+
+            if expandedCommand.contains("/") {
+                resolvedExecutablePath = expandedCommand
+                if !isExecutable(expandedCommand) {
+                    warnings.append(L("Executable path is not executable: \(expandedCommand)."))
+                }
+            } else if let found = resolveOnPath(expandedCommand, searchPath: searchPath, isExecutable: isExecutable) {
+                resolvedExecutablePath = found
+            } else {
+                return MCPProviderLaunchPlan(
+                    providerId: provider.id,
+                    transport: .stdio,
+                    status: .blocked,
+                    title: L("Host command not found"),
+                    detail: L("`\(command)` was not found on the app PATH or common local bin directories."),
+                    redactedCommandLine: redactedCommandLine,
+                    resolvedExecutablePath: nil,
+                    searchPath: searchPath,
+                    workingDirectory: cwd,
+                    configuredEnvironmentKeys: configuredEnvironmentKeys,
+                    secretEnvironmentKeys: secretEnvironmentKeys,
+                    missingSecretEnvironmentKeys: missingSecretEnvironmentKeys,
+                    warnings: warnings + [L("Use a full executable path such as /opt/homebrew/bin/npx.")]
+                )
+            }
+
+            let status: MCPProviderLaunchPlanStatus = warnings.isEmpty ? .ready : .warning
+            return MCPProviderLaunchPlan(
+                providerId: provider.id,
+                transport: .stdio,
+                status: status,
+                title: L("Host stdio"),
+                detail: L("The command runs directly on macOS and inherits the app environment plus provider env."),
+                redactedCommandLine: redactedCommandLine,
+                resolvedExecutablePath: resolvedExecutablePath,
+                searchPath: searchPath,
+                workingDirectory: cwd,
+                configuredEnvironmentKeys: configuredEnvironmentKeys,
+                secretEnvironmentKeys: secretEnvironmentKeys,
+                missingSecretEnvironmentKeys: missingSecretEnvironmentKeys,
+                warnings: warnings
+            )
+        }
+    }
+
+    private static func hasCredentialHeader(_ provider: MCPProvider) -> Bool {
+        provider.customHeaders.keys.contains { $0.caseInsensitiveCompare("Authorization") == .orderedSame }
+            || provider.secretHeaderKeys.contains { $0.caseInsensitiveCompare("Authorization") == .orderedSame }
+    }
+
+    private static func missingSecretKeys(
+        for provider: MCPProvider,
+        secretEnvKeys: [String],
+        secretEnvValues: [String: String]?
+    ) -> [String] {
+        secretEnvKeys.filter { key in
+            if let secretEnvValues {
+                return secretEnvValues[key]?.isEmpty != false
+            }
+            return MCPProviderKeychain.getEnvSecret(key: key, for: provider.id)?.isEmpty != false
+        }
+        .sorted()
+    }
+
+    private static func resolvedProcessEnvironment(
+        provider: MCPProvider,
+        processEnvironment: [String: String],
+        secretEnvValues: [String: String]?
+    ) -> [String: String] {
+        var merged = processEnvironment
+        for (key, value) in provider.env {
+            merged[key] = value
+        }
+        for key in uniqueTrimmedKeys(provider.secretEnvKeys) {
+            let value = secretEnvValues?[key] ?? MCPProviderKeychain.getEnvSecret(key: key, for: provider.id)
+            if let value, !value.isEmpty {
+                merged[key] = value
+            } else {
+                merged.removeValue(forKey: key)
+            }
+        }
+        return merged
+    }
+
+    private static func commandLine(provider: MCPProvider) -> String {
+        let args = ShellArgs.join(provider.args)
+        return args.isEmpty ? provider.command : "\(provider.command) \(args)"
+    }
+
+    private static func executableSearchPath(env: [String: String]) -> String {
+        var entries =
+            (env["PATH"]?.isEmpty == false ? env["PATH"] : nil)?
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+            ?? []
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        for fallback in [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "\(home)/.local/bin",
+            "\(home)/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ] where !entries.contains(fallback) {
+            entries.append(fallback)
+        }
+        return entries.joined(separator: ":")
+    }
+
+    private static func resolveOnPath(
+        _ command: String,
+        searchPath: String,
+        isExecutable: (String) -> Bool
+    ) -> String? {
+        for directory in searchPath.split(separator: ":", omittingEmptySubsequences: true) {
+            let candidate = "\(directory)/\(command)"
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func normalizedWorkingDirectory(_ raw: String?) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        return expandUserPath(raw)
+    }
+
+    private static func expandUserPath(_ path: String) -> String {
+        guard path == "~" || path.hasPrefix("~/") else { return path }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path == "~" { return home }
+        return home + String(path.dropFirst())
+    }
+
+    private static func redact(_ value: String) -> String {
+        MCPProviderProbeRedactor.safeDiagnosticFragment(value, maxLength: 500)
+    }
+
+    private static func uniqueTrimmedKeys(_ keys: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for key in keys {
+            let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { continue }
+            result.append(trimmed)
+        }
+        return result
+    }
+}

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -413,7 +413,7 @@ public enum MCPProviderOperationsHub {
 
         let cwd = normalizedWorkingDirectory(provider.workingDirectory)
         if let cwd, provider.executionHost == .host, !directoryExists(cwd) {
-            warnings.append(L("Working directory does not exist: \(cwd)."))
+            warnings.append(L("Working directory does not exist."))
         }
 
         switch provider.executionHost {
@@ -448,7 +448,7 @@ public enum MCPProviderOperationsHub {
             if expandedCommand.contains("/") {
                 resolvedExecutablePath = expandedCommand
                 if !isExecutable(expandedCommand) {
-                    warnings.append(L("Executable path is not executable: \(expandedCommand)."))
+                    warnings.append(L("Executable path is not executable."))
                 }
             } else if let found = resolveOnPath(expandedCommand, searchPath: searchPath, isExecutable: isExecutable) {
                 resolvedExecutablePath = found

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -458,7 +458,7 @@ public enum MCPProviderOperationsHub {
                     transport: .stdio,
                     status: .blocked,
                     title: L("Host command not found"),
-                    detail: L("`\(command)` was not found on the app PATH or common local bin directories."),
+                    detail: L("The host command was not found on the app PATH or common local bin directories."),
                     redactedCommandLine: redactedCommandLine,
                     resolvedExecutablePath: nil,
                     searchPath: searchPath,

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -162,7 +162,9 @@ enum MCPProviderOperationsFieldNormalizer {
             if entry.isSecret {
                 secretKeys.append(key)
             } else {
-                regular[key] = entry.value
+                if !entry.value.isEmpty {
+                    regular[key] = entry.value
+                }
             }
         }
 
@@ -179,7 +181,11 @@ public enum MCPProviderOperationsHub {
             let providerId = provider.id
             next[providerId] = MCPProviderCredentialPresence(
                 bearerTokenPresent: MCPProviderKeychain.hasToken(for: providerId),
-                oauthTokensPresent: MCPProviderKeychain.hasOAuthTokens(for: providerId)
+                oauthTokensPresent: MCPProviderKeychain.hasOAuthTokens(for: providerId),
+                authorizationHeaderPresent: provider.secretHeaderKeys.contains { key in
+                    key.caseInsensitiveCompare("Authorization") == .orderedSame
+                        && MCPProviderKeychain.getHeaderSecret(key: key, for: providerId)?.isEmpty == false
+                }
             )
         }
         return next
@@ -237,7 +243,7 @@ public enum MCPProviderOperationsHub {
     ) -> MCPProviderAuthStatus {
         switch provider.authType {
         case .none:
-            if hasCredentialHeader(provider) {
+            if hasCredentialHeader(provider, credentialPresence: credentialPresence) {
                 return MCPProviderAuthStatus(
                     kind: .headerCredentialPresent,
                     severity: .ok,
@@ -254,7 +260,8 @@ public enum MCPProviderOperationsHub {
                 action: nil
             )
         case .bearerToken:
-            if credentialPresence.bearerTokenPresent || hasCredentialHeader(provider) {
+            if credentialPresence.bearerTokenPresent
+                || hasCredentialHeader(provider, credentialPresence: credentialPresence) {
                 return MCPProviderAuthStatus(
                     kind: .bearerTokenPresent,
                     severity: .ok,
@@ -482,9 +489,13 @@ public enum MCPProviderOperationsHub {
         }
     }
 
-    private static func hasCredentialHeader(_ provider: MCPProvider) -> Bool {
-        provider.customHeaders.keys.contains { $0.caseInsensitiveCompare("Authorization") == .orderedSame }
-            || provider.secretHeaderKeys.contains { $0.caseInsensitiveCompare("Authorization") == .orderedSame }
+    private static func hasCredentialHeader(
+        _ provider: MCPProvider,
+        credentialPresence: MCPProviderCredentialPresence
+    ) -> Bool {
+        provider.customHeaders.contains { key, value in
+            key.caseInsensitiveCompare("Authorization") == .orderedSame && !value.isEmpty
+        } || credentialPresence.authorizationHeaderPresent
     }
 
     private static func missingSecretKeys(

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -32,16 +32,16 @@ public struct MCPProviderLaunchPlan: Sendable, Equatable {
         var lines = [
             "Launch plan: \(title)",
             "Status: \(status.rawValue)",
-            "Detail: \(detail)",
+            "Detail: \(transport.rawValue) launch preflight is \(status.rawValue); review on-screen details in Osaurus.",
         ]
-        if let redactedCommandLine {
-            lines.append("Command: \(redactedCommandLine)")
+        if redactedCommandLine != nil {
+            lines.append("Command: configured")
         }
-        if let resolvedExecutablePath {
-            lines.append("Resolved executable: \(resolvedExecutablePath)")
+        if resolvedExecutablePath != nil {
+            lines.append("Resolved executable: present")
         }
         if let workingDirectory, !workingDirectory.isEmpty {
-            lines.append("Working directory: \(workingDirectory)")
+            lines.append("Working directory: configured")
         }
         if !configuredEnvironmentKeys.isEmpty {
             lines.append("Environment keys: \(configuredEnvironmentKeys.joined(separator: ", "))")
@@ -53,10 +53,11 @@ public struct MCPProviderLaunchPlan: Sendable, Equatable {
             lines.append("Missing secret env keys: \(missingSecretEnvironmentKeys.joined(separator: ", "))")
         }
         if let searchPath, !searchPath.isEmpty {
-            lines.append("PATH searched: \(searchPath)")
+            let entryCount = searchPath.split(separator: ":", omittingEmptySubsequences: true).count
+            lines.append("PATH entries searched: \(entryCount)")
         }
         if !warnings.isEmpty {
-            lines.append("Warnings: \(warnings.joined(separator: "; "))")
+            lines.append("Warning count: \(warnings.count)")
         }
         return lines.joined(separator: "\n")
     }

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderOperationsHub.swift
@@ -170,6 +170,31 @@ enum MCPProviderOperationsFieldNormalizer {
 
         return (regular, secretKeys)
     }
+
+    static func secretOverrides(
+        _ entries: [(key: String, value: String, isSecret: Bool)]
+    ) -> [String: String] {
+        var values: [String: String] = [:]
+        for entry in entries {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+
+            values.removeValue(forKey: key)
+            if entry.isSecret, !entry.value.isEmpty {
+                values[key] = entry.value
+            }
+        }
+        return values
+    }
+
+    static func secretWrites(
+        _ entries: [(key: String, value: String, isSecret: Bool)],
+        storage: MCPProviderSecretWrite.Storage
+    ) -> [MCPProviderSecretWrite] {
+        secretOverrides(entries)
+            .sorted { $0.key < $1.key }
+            .map { MCPProviderSecretWrite(storage: storage, key: $0.key, value: $0.value) }
+    }
 }
 
 public enum MCPProviderOperationsHub {

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -256,6 +256,131 @@ enum MCPProviderProbeRedactor {
     }
 }
 
+/// Immutable provider and credential snapshot for one explicit UI probe. Raw
+/// credentials stay private to this short-lived value; shared ordering state
+/// receives only `setupFingerprint`.
+struct MCPProviderProbeContext: Sendable {
+    let provider: MCPProvider
+    let setupFingerprint: String
+
+    private let authorizationToken: String?
+    private let headers: [String: String]
+    private let secretEnvironmentValues: [String: String]
+
+    static func captureStored(provider: MCPProvider) -> MCPProviderProbeContext {
+        capture(
+            provider: provider,
+            bearerTokenField: "",
+            clearBearerToken: false,
+            secretHeaderOverrides: [:],
+            secretEnvironmentOverrides: [:]
+        )
+    }
+
+    static func capture(
+        provider: MCPProvider,
+        bearerTokenField: String,
+        clearBearerToken: Bool,
+        secretHeaderOverrides: [String: String],
+        secretEnvironmentOverrides: [String: String]
+    ) -> MCPProviderProbeContext {
+        let authorizationToken: String? =
+            switch provider.authType {
+            case .bearerToken:
+                MCPProviderBearerProbeInput.resolved(
+                    fieldValue: bearerTokenField,
+                    clearRequested: clearBearerToken,
+                    storedValue: MCPProviderKeychain.getToken(for: provider.id)
+                )
+            case .oauth:
+                MCPProviderKeychain.getOAuthTokens(for: provider.id)?.accessToken
+            case .none:
+                nil
+            }
+        let secretHeaderValues = resolveSecrets(
+            keys: provider.secretHeaderKeys,
+            overrides: secretHeaderOverrides,
+            readStoredValue: { MCPProviderKeychain.getHeaderSecret(key: $0, for: provider.id) }
+        )
+        let secretEnvironmentValues = resolveSecrets(
+            keys: provider.secretEnvKeys,
+            overrides: secretEnvironmentOverrides,
+            readStoredValue: { MCPProviderKeychain.getEnvSecret(key: $0, for: provider.id) }
+        )
+        return make(
+            provider: provider,
+            authorizationToken: authorizationToken,
+            secretHeaderValues: secretHeaderValues,
+            secretEnvironmentValues: secretEnvironmentValues
+        )
+    }
+
+    static func make(
+        provider: MCPProvider,
+        authorizationToken: String?,
+        secretHeaderValues: [String: String],
+        secretEnvironmentValues: [String: String]
+    ) -> MCPProviderProbeContext {
+        var headers = provider.customHeaders
+        for (key, value) in secretHeaderValues where provider.secretHeaderKeys.contains(key) {
+            headers[key] = value
+        }
+        return MCPProviderProbeContext(
+            provider: provider,
+            setupFingerprint: MCPProviderSetupFingerprint.make(
+                provider: provider,
+                bearerToken: authorizationToken,
+                secretHeaderValues: secretHeaderValues,
+                secretEnvironmentValues: secretEnvironmentValues
+            ),
+            authorizationToken: authorizationToken,
+            headers: headers,
+            secretEnvironmentValues: secretEnvironmentValues
+        )
+    }
+
+    func probe() async -> MCPProviderProbeResult {
+        switch provider.transport {
+        case .http:
+            return await MCPProviderProbeService.probeHTTP(
+                providerId: provider.id,
+                name: provider.name,
+                url: provider.url,
+                token: authorizationToken,
+                headers: headers,
+                streamingEnabled: provider.streamingEnabled,
+                discoveryTimeout: provider.discoveryTimeout
+            )
+        case .stdio:
+            // Put the captured values directly on an ephemeral provider so a
+            // later Keychain write cannot change which credentials this probe uses.
+            var frozenProvider = provider
+            for key in frozenProvider.secretEnvKeys {
+                frozenProvider.env.removeValue(forKey: key)
+            }
+            frozenProvider.env.merge(secretEnvironmentValues) { _, captured in captured }
+            frozenProvider.secretEnvKeys = []
+            return await MCPProviderProbeService.probeStdio(provider: frozenProvider)
+        }
+    }
+
+    private static func resolveSecrets(
+        keys: [String],
+        overrides: [String: String],
+        readStoredValue: (String) -> String?
+    ) -> [String: String] {
+        var values: [String: String] = [:]
+        for key in keys {
+            if let override = overrides[key], !override.isEmpty {
+                values[key] = override
+            } else if let stored = readStoredValue(key) {
+                values[key] = stored
+            }
+        }
+        return values
+    }
+}
+
 private struct MCPStdioProbeProcessExitError: LocalizedError, Sendable {
     let status: Int32
 

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -23,6 +23,7 @@ public enum MCPProviderProbeReasonCode: String, Codable, Sendable, Equatable {
     case commandNotFound
     case sandboxUnavailable
     case spawnFailed
+    case processExited
     case timeout
     case authRequired
     case protocolError
@@ -237,6 +238,14 @@ enum MCPProviderProbeRedactor {
     }
 }
 
+private struct MCPStdioProbeProcessExitError: LocalizedError, Sendable {
+    let status: Int32
+
+    var errorDescription: String? {
+        "The stdio MCP process exited before setup completed (status \(status))."
+    }
+}
+
 public enum MCPProviderProbeService {
     public static func probeHTTP(
         providerId: UUID,
@@ -349,7 +358,10 @@ public enum MCPProviderProbeService {
         )
     }
 
-    public static func probeStdio(provider: MCPProvider) async -> MCPProviderProbeResult {
+    public static func probeStdio(
+        provider: MCPProvider,
+        secretEnvOverrides: [String: String] = [:]
+    ) async -> MCPProviderProbeResult {
         let startedAt = Date()
         guard !provider.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return MCPProviderProbeResult.failure(
@@ -363,12 +375,16 @@ public enum MCPProviderProbeService {
         }
 
         do {
-            let (transport, cleanup) = try await makeStdioTransport(for: provider)
+            let (transport, cleanup, processExitSignal) = try await makeStdioTransport(
+                for: provider,
+                secretEnvOverrides: secretEnvOverrides
+            )
             return await runProbe(
                 provider: provider,
                 transport: transport,
                 startedAt: startedAt,
-                cleanup: cleanup
+                cleanup: cleanup,
+                processExitSignal: processExitSignal
             )
         } catch {
             return mapFailure(provider: provider, startedAt: startedAt, stage: .spawn, error: error)
@@ -381,9 +397,12 @@ public enum MCPProviderProbeService {
             let endpoint = MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(provider.url)
             return provider.streamingEnabled ? "HTTP/SSE \(endpoint)" : "HTTP \(endpoint)"
         case .stdio:
-            let args = ShellArgs.join(provider.args)
-            let command = args.isEmpty ? provider.command : "\(provider.command) \(args)"
-            return "stdio \(provider.executionHost.rawValue) \(command)"
+            let pathValues = [provider.command] + provider.args + [provider.workingDirectory ?? ""]
+            let referencesHostPath = pathValues.contains {
+                $0.hasPrefix("/") || $0.hasPrefix("~/")
+            }
+            return "stdio \(provider.executionHost.rawValue) command=configured "
+                + "arguments=\(provider.args.count) host-path-reference=\(referencesHostPath)"
         }
     }
 
@@ -398,14 +417,28 @@ public enum MCPProviderProbeService {
         provider: MCPProvider,
         transport: any MCP.Transport,
         startedAt: Date,
-        cleanup: (@Sendable () async -> Void)? = nil
+        cleanup: (@Sendable () async -> Void)? = nil,
+        processExitSignal: MCPAsyncFailureSignal? = nil
     ) async -> MCPProviderProbeResult {
         let client = MCP.Client(name: "Osaurus", version: "1.0.0")
         do {
-            try await withTimeout(seconds: provider.discoveryTimeout) {
+            try await MCPAsyncTimeout.run(
+                seconds: provider.discoveryTimeout,
+                failureSignal: processExitSignal
+            ) {
                 _ = try await client.connect(transport: transport)
             }
-            let tools = try await withTimeout(seconds: provider.discoveryTimeout) {
+        } catch {
+            await client.disconnect()
+            if let cleanup { await cleanup() }
+            return mapFailure(provider: provider, startedAt: startedAt, stage: .connect, error: error)
+        }
+
+        do {
+            let tools = try await MCPAsyncTimeout.run(
+                seconds: provider.discoveryTimeout,
+                failureSignal: processExitSignal
+            ) {
                 try await client.listAllTools()
             }
             // Probes are short-lived by contract: disconnect the client so
@@ -425,19 +458,27 @@ public enum MCPProviderProbeService {
             if let cleanup {
                 await cleanup()
             }
-            return mapFailure(provider: provider, startedAt: startedAt, stage: .connect, error: error)
+            return mapFailure(provider: provider, startedAt: startedAt, stage: .listTools, error: error)
         }
     }
 
     private static func makeStdioTransport(
-        for provider: MCPProvider
-    ) async throws -> (any MCP.Transport, @Sendable () async -> Void) {
+        for provider: MCPProvider,
+        secretEnvOverrides: [String: String]
+    ) async throws -> (any MCP.Transport, @Sendable () async -> Void, MCPAsyncFailureSignal) {
+        let processExitSignal = MCPAsyncFailureSignal()
         switch provider.executionHost {
         case .host:
             #if canImport(Darwin)
-                let runner = try MCPStdioHostRunner(provider: provider)
+                let runner = try MCPStdioHostRunner(
+                    provider: provider,
+                    secretEnvOverrides: secretEnvOverrides
+                )
+                await runner.setProcessExitHandler { status in
+                    processExitSignal.fail(MCPStdioProbeProcessExitError(status: status))
+                }
                 try await runner.start()
-                return (runner.transport, { await runner.stop() })
+                return (runner.transport, { await runner.stop() }, processExitSignal)
             #else
                 throw MCPStdioTransportError.sandboxUnavailable
             #endif
@@ -464,9 +505,16 @@ public enum MCPProviderProbeService {
                     return (id, SandboxAgentProvisioner.linuxName(for: id.uuidString))
                 }
                 try await SandboxAgentProvisioner.shared.ensureProvisioned(agentId: agentId)
-                let runner = try SandboxStdioRunner(provider: provider, agentName: agentName)
+                let runner = try SandboxStdioRunner(
+                    provider: provider,
+                    agentName: agentName,
+                    secretEnvOverrides: secretEnvOverrides
+                )
+                await runner.setProcessExitHandler { status in
+                    processExitSignal.fail(MCPStdioProbeProcessExitError(status: status))
+                }
                 try await runner.start()
-                return (runner.transport, { await runner.stop() })
+                return (runner.transport, { await runner.stop() }, processExitSignal)
             #else
                 throw MCPStdioTransportError.sandboxUnavailable
             #endif
@@ -480,6 +528,17 @@ public enum MCPProviderProbeService {
         error: Error
     ) -> MCPProviderProbeResult {
         let message = error.localizedDescription
+
+        if error is MCPStdioProbeProcessExitError {
+            return failure(
+                provider: provider,
+                startedAt: startedAt,
+                stage: stage,
+                reasonCode: .processExited,
+                message: message,
+                action: L("Check the provider configuration and process logs, then test again.")
+            )
+        }
 
         if let mcpError = error as? MCPProviderError {
             switch mcpError {
@@ -514,7 +573,7 @@ public enum MCPProviderProbeService {
                     startedAt: startedAt,
                     stage: .configuration,
                     reasonCode: .missingCommand,
-                    message: message,
+                    message: L("No stdio command is configured."),
                     action: L("Enter a command before testing.")
                 )
             case .commandNotFound:
@@ -523,8 +582,8 @@ public enum MCPProviderProbeService {
                     startedAt: startedAt,
                     stage: .spawn,
                     reasonCode: .commandNotFound,
-                    message: message,
-                    action: L("Use a full executable path such as /opt/homebrew/bin/npx.")
+                    message: L("The configured stdio command was not found."),
+                    action: L("Use an absolute executable path or select Sandbox.")
                 )
             case .sandboxUnavailable:
                 return failure(
@@ -532,7 +591,7 @@ public enum MCPProviderProbeService {
                     startedAt: startedAt,
                     stage: .spawn,
                     reasonCode: .sandboxUnavailable,
-                    message: message,
+                    message: L("The sandbox runtime is unavailable."),
                     action: L("Switch to Host for trusted tools or start the sandbox runtime.")
                 )
             case .processSpawnFailed:
@@ -541,7 +600,7 @@ public enum MCPProviderProbeService {
                     startedAt: startedAt,
                     stage: .spawn,
                     reasonCode: .spawnFailed,
-                    message: message,
+                    message: L("The configured stdio process could not be started."),
                     action: L("Check the command, working directory, and environment.")
                 )
             }
@@ -569,7 +628,9 @@ public enum MCPProviderProbeService {
                 startedAt: startedAt,
                 stage: stage,
                 reasonCode: .authRequired,
-                message: message,
+                message: provider.transport == .stdio
+                    ? L("The stdio MCP server rejected authentication.")
+                    : message,
                 action: L("Sign in or save a token, then test again.")
             )
         }
@@ -584,7 +645,9 @@ public enum MCPProviderProbeService {
                 startedAt: startedAt,
                 stage: stage,
                 reasonCode: .protocolError,
-                message: message,
+                message: provider.transport == .stdio
+                    ? L("The stdio MCP server returned an invalid protocol response.")
+                    : message,
                 action: L("Verify the process speaks MCP JSON-RPC on stdin/stdout.")
             )
         }
@@ -594,7 +657,9 @@ public enum MCPProviderProbeService {
             startedAt: startedAt,
             stage: stage,
             reasonCode: .connectionFailed,
-            message: message,
+            message: provider.transport == .stdio
+                ? L("The stdio MCP server connection failed.")
+                : message,
             action: L("Copy the probe result and check the provider logs.")
         )
     }
@@ -617,23 +682,4 @@ public enum MCPProviderProbeService {
         )
     }
 
-    private static func withTimeout<T: Sendable>(
-        seconds: TimeInterval,
-        operation: @escaping @Sendable () async throws -> T
-    ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw MCPProviderError.timeout
-            }
-            guard let result = try await group.next() else {
-                throw MCPProviderError.timeout
-            }
-            group.cancelAll()
-            return result
-        }
-    }
 }

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -200,12 +200,24 @@ enum MCPProviderProbeRedactor {
             (#"(?i)authorization\s*[:=]\s*(?:bearer\s+)?[^\s,;}]+\"?"#, "credential=***"),
             (#"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"#, "credential=***"),
             (
+                #"(?i)\"([A-Za-z0-9_]*(?:access_token|refresh_token|code_verifier|client_secret|api_key|apikey|password|secret|token)[A-Za-z0-9_]*)\"\s*:\s*\"[^\"]*\""#,
+                #""$1":"***""#
+            ),
+            (
+                #"(?i)\b([A-Za-z0-9_]*(?:access_token|refresh_token|code_verifier|client_secret|api_key|apikey|password|secret|token)[A-Za-z0-9_]*)=([^&\s,;}]+)"#,
+                "$1=***"
+            ),
+            (
                 #"(?i)\"(access_token|refresh_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token)\"\s*:\s*\"[^\"]*\""#,
                 #""$1":"***""#
             ),
             (
                 #"(?i)\b(access_token|refresh_token|code_verifier|code|verifier|client_secret|api_key|apikey|password|secret|token)=([^&\s,;}]+)"#,
                 "$1=***"
+            ),
+            (
+                #"(?i)\b(?:sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,}|xox[baprs]-[A-Za-z0-9-]{8,})\b"#,
+                "credential=***"
             ),
             (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
             (#"(?:~|/(?:Users|home|private|var|tmp|opt|Library))/[^\s,;}\]]+"#, "<redacted-path>"),

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -187,6 +187,9 @@ enum MCPProviderProbeRedactor {
         components.password = nil
         components.query = nil
         components.fragment = nil
+        if !components.path.isEmpty && components.path != "/" {
+            components.path = "/redacted-path"
+        }
         return components.string ?? "<redacted-http-url>"
     }
 
@@ -204,6 +207,8 @@ enum MCPProviderProbeRedactor {
                 "$1=***"
             ),
             (#"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"#, "jwt=***"),
+            (#"(?:~|/(?:Users|home|private|var|tmp|opt|Library))/[^\s,;}\]]+"#, "<redacted-path>"),
+            (#"(?i)\b[A-Z]:\\[^\s,;}\]]+"#, "<redacted-path>"),
         ]
         for replacement in replacements {
             value = value.mcpReplacingMatches(of: replacement.pattern, with: replacement.template)

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -21,6 +21,7 @@ public enum MCPProviderProbeReasonCode: String, Codable, Sendable, Equatable {
     case invalidURL
     case missingCommand
     case commandNotFound
+    case unsafeEnvironment
     case sandboxUnavailable
     case spawnFailed
     case processExited
@@ -589,6 +590,15 @@ public enum MCPProviderProbeService {
                     reasonCode: .commandNotFound,
                     message: L("The configured stdio command was not found."),
                     action: L("Use an absolute executable path or select Sandbox.")
+                )
+            case .unsafeEnvironmentKey:
+                return failure(
+                    provider: provider,
+                    startedAt: startedAt,
+                    stage: .configuration,
+                    reasonCode: .unsafeEnvironment,
+                    message: L("Host execution cannot override a protected environment variable."),
+                    action: L("Remove the protected variable or select Sandbox.")
                 )
             case .sandboxUnavailable:
                 return failure(

--- a/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPProviderProbeService.swift
@@ -171,8 +171,26 @@ private extension String {
 }
 
 enum MCPProviderProbeRedactor {
+    static func safeHTTPURLForDiagnostics(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
+            let scheme = components.scheme?.lowercased(),
+            ["http", "https"].contains(scheme),
+            components.host?.isEmpty == false
+        else {
+            return "<redacted-http-url>"
+        }
+
+        components.scheme = scheme
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? "<redacted-http-url>"
+    }
+
     static func safeDiagnosticFragment(_ raw: String, maxLength: Int = 280) -> String {
-        var value = raw
+        var value = redactingHTTPURLs(in: raw)
         let replacements: [(pattern: String, template: String)] = [
             (#"(?i)authorization\s*[:=]\s*(?:bearer\s+)?[^\s,;}]+\"?"#, "credential=***"),
             (#"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"#, "credential=***"),
@@ -198,6 +216,22 @@ enum MCPProviderProbeRedactor {
         }
         if value.count > maxLength {
             return String(value.prefix(maxLength)) + "..."
+        }
+        return value
+    }
+
+    private static func redactingHTTPURLs(in raw: String) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"(?i)\bhttps?://[^\s<>"'`]+"#
+        ) else {
+            return raw
+        }
+
+        var value = raw
+        for match in regex.matches(in: raw, range: NSRange(raw.startIndex..., in: raw)).reversed() {
+            guard let range = Range(match.range, in: value) else { continue }
+            let url = String(value[range])
+            value.replaceSubrange(range, with: safeHTTPURLForDiagnostics(url))
         }
         return value
     }
@@ -344,7 +378,8 @@ public enum MCPProviderProbeService {
     public static func transportSummary(for provider: MCPProvider) -> String {
         switch provider.transport {
         case .http:
-            return provider.streamingEnabled ? "HTTP/SSE \(provider.url)" : "HTTP \(provider.url)"
+            let endpoint = MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(provider.url)
+            return provider.streamingEnabled ? "HTTP/SSE \(endpoint)" : "HTTP \(endpoint)"
         case .stdio:
             let args = ShellArgs.join(provider.args)
             let command = args.isEmpty ? provider.command : "\(provider.command) \(args)"

--- a/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
@@ -10,10 +10,16 @@ import Foundation
 public struct MCPProviderCredentialPresence: Sendable, Equatable {
     public var bearerTokenPresent: Bool
     public var oauthTokensPresent: Bool
+    public var authorizationHeaderPresent: Bool
 
-    public init(bearerTokenPresent: Bool = false, oauthTokensPresent: Bool = false) {
+    public init(
+        bearerTokenPresent: Bool = false,
+        oauthTokensPresent: Bool = false,
+        authorizationHeaderPresent: Bool = false
+    ) {
         self.bearerTokenPresent = bearerTokenPresent
         self.oauthTokensPresent = oauthTokensPresent
+        self.authorizationHeaderPresent = authorizationHeaderPresent
     }
 }
 

--- a/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
@@ -49,7 +49,10 @@
         /// lifetime.
         public let transport: StdioTransport
 
-        public init(provider: MCPProvider) throws {
+        public init(
+            provider: MCPProvider,
+            secretEnvOverrides: [String: String] = [:]
+        ) throws {
             guard !provider.command.isEmpty else {
                 throw MCPStdioTransportError.missingCommand
             }
@@ -57,7 +60,10 @@
             self.command = provider.command
             self.args = provider.args
 
-            let mergedEnv = Self.buildEnv(provider: provider)
+            let mergedEnv = Self.buildEnv(
+                provider: provider,
+                secretEnvOverrides: secretEnvOverrides
+            )
             let executablePath = try Self.resolveExecutablePath(
                 command: Self.expandUserPath(provider.command),
                 env: mergedEnv
@@ -96,9 +102,15 @@
         /// Process env = inherited app env merged with the provider's
         /// own env (plain + Keychain-resolved secrets). Provider entries
         /// win on key conflicts.
-        private static func buildEnv(provider: MCPProvider) -> [String: String] {
+        private static func buildEnv(
+            provider: MCPProvider,
+            secretEnvOverrides: [String: String]
+        ) -> [String: String] {
             var env = ProcessInfo.processInfo.environment
-            for (key, value) in provider.resolvedEnv() {
+            for (key, value) in MCPStdioEnvironmentResolver.providerEnvironment(
+                provider: provider,
+                secretEnvOverrides: secretEnvOverrides
+            ) {
                 env[key] = value
             }
             return env

--- a/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/MCPStdioHostTransport.swift
@@ -60,7 +60,7 @@
             self.command = provider.command
             self.args = provider.args
 
-            let mergedEnv = Self.buildEnv(
+            let mergedEnv = try Self.buildEnv(
                 provider: provider,
                 secretEnvOverrides: secretEnvOverrides
             )
@@ -105,15 +105,37 @@
         private static func buildEnv(
             provider: MCPProvider,
             secretEnvOverrides: [String: String]
-        ) -> [String: String] {
+        ) throws -> [String: String] {
             var env = ProcessInfo.processInfo.environment
-            for (key, value) in MCPStdioEnvironmentResolver.providerEnvironment(
+            let providerEnvironment = MCPStdioEnvironmentResolver.providerEnvironment(
                 provider: provider,
                 secretEnvOverrides: secretEnvOverrides
-            ) {
+            )
+            if let unsafeKey = providerEnvironment.keys.sorted().first(where: isProtectedHostEnvironmentKey) {
+                throw MCPStdioTransportError.unsafeEnvironmentKey(unsafeKey)
+            }
+            for (key, value) in providerEnvironment {
                 env[key] = value
             }
             return env
+        }
+
+        /// Provider configuration must not replace variables that control
+        /// executable lookup, dynamic loading, Objective-C runtime behavior,
+        /// or host process identity. Sandbox execution remains available for
+        /// definitions that genuinely need a custom environment namespace.
+        private static func isProtectedHostEnvironmentKey(_ key: String) -> Bool {
+            let normalized = key.uppercased()
+            if [
+                "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR",
+                "PWD", "OLDPWD", "SHLVL", "_",
+            ].contains(normalized) {
+                return true
+            }
+            return [
+                "DYLD_", "LD_", "OBJC_", "MALLOC_", "NSZOMBIE",
+                "NSDEALLOCATEZOMBIES", "__XPC_", "XPC_",
+            ].contains { normalized.hasPrefix($0) }
         }
 
         /// Resolve `command` to an absolute path the kernel can exec.
@@ -190,6 +212,16 @@
             env: [String: String]
         ) throws -> String {
             try resolveExecutablePath(command: expandUserPath(command), env: env)
+        }
+
+        static func mergedEnvironmentForTesting(
+            inherited: [String: String],
+            provider: [String: String]
+        ) throws -> [String: String] {
+            if let unsafeKey = provider.keys.sorted().first(where: isProtectedHostEnvironmentKey) {
+                throw MCPStdioTransportError.unsafeEnvironmentKey(unsafeKey)
+            }
+            return inherited.merging(provider) { _, configured in configured }
         }
 
         /// Set once a global spawn slot is held so `stop()` releases exactly
@@ -297,6 +329,7 @@
         case missingCommand
         case processSpawnFailed(String)
         case sandboxUnavailable
+        case unsafeEnvironmentKey(String)
         /// Bare-name command (e.g. `npx`) wasn't on `PATH`. `searchedPath`
         /// is the colon-separated string we actually walked — useful for
         /// nvm / asdf users whose Node lives under their home dir but is
@@ -320,6 +353,9 @@
             case .sandboxUnavailable:
                 return
                     "This provider is configured to run in the Osaurus sandbox, but the sandbox runtime is not currently available."
+            case .unsafeEnvironmentKey(let key):
+                return
+                    "Host execution cannot override the protected environment variable '\(key)'. Use Sandbox or remove that variable."
             case .commandNotFound(let command, _):
                 return
                     "`\(command)` was \(Self.commandNotFoundMarker). Use a full path (e.g. /opt/homebrew/bin/npx) or switch to Sandbox."

--- a/Packages/OsaurusCore/Services/MCP/Stdio/SandboxStdioRunner.swift
+++ b/Packages/OsaurusCore/Services/MCP/Stdio/SandboxStdioRunner.swift
@@ -54,7 +54,11 @@
         /// .linuxName`). The subprocess runs as `agent-<agentName>`.
         private let agentName: String
 
-        public init(provider: MCPProvider, agentName: String) throws {
+        public init(
+            provider: MCPProvider,
+            agentName: String,
+            secretEnvOverrides: [String: String] = [:]
+        ) throws {
             guard provider.transport == .stdio else {
                 throw MCPStdioTransportError.missingCommand
             }
@@ -73,7 +77,10 @@
                 command: provider.command,
                 args: provider.args
             )
-            self.env = provider.resolvedEnv()
+            self.env = MCPStdioEnvironmentResolver.providerEnvironment(
+                provider: provider,
+                secretEnvOverrides: secretEnvOverrides
+            )
             self.cwd = provider.workingDirectory
 
             let stdinBridge = SandboxStdioInputStream()

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -722,7 +722,7 @@ public enum ProviderNetworkDiagnostics {
     private static func mcpEndpointSubtitle(for provider: MCPProvider) -> String {
         switch provider.transport {
         case .http:
-            return provider.url
+            return MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(provider.url)
         case .stdio:
             let args = ShellArgs.join(provider.args)
             return args.isEmpty ? provider.command : "\(provider.command) \(args)"

--- a/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderNetworkDiagnostics.swift
@@ -724,12 +724,14 @@ public enum ProviderNetworkDiagnostics {
         case .http:
             return MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(provider.url)
         case .stdio:
-            let args = ShellArgs.join(provider.args)
-            return args.isEmpty ? provider.command : "\(provider.command) \(args)"
+            return "stdio command configured"
         }
     }
 
     private static func safeDiagnostic(_ raw: String) -> String {
-        ProviderDiagnosticRedactor.safe(raw, maxLength: 280)
+        ProviderDiagnosticRedactor.safe(
+            MCPProviderProbeRedactor.safeDiagnosticFragment(raw, maxLength: 280),
+            maxLength: 280
+        )
     }
 }

--- a/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
+++ b/Packages/OsaurusCore/Services/Skill/ClaudePluginInstaller.swift
@@ -569,13 +569,22 @@ public final class ClaudePluginInstaller {
                                     + classifiedEnv.placeholderSecrets,
                                 workingDirectory: expandedCwd
                             )
-                            MCPProviderManager.shared.addProvider(provider, token: nil)
-                            for (key, value) in classifiedEnv.realSecrets {
-                                _ = MCPProviderKeychain.saveEnvSecret(
-                                    value,
-                                    key: key,
-                                    for: provider.id
+                            let secretWrites = classifiedEnv.realSecrets.map {
+                                MCPProviderSecretWrite(
+                                    storage: .environment,
+                                    key: $0.key,
+                                    value: $0.value
                                 )
+                            }
+                            guard MCPProviderManager.shared.addProvider(
+                                provider,
+                                token: nil,
+                                secretWrites: secretWrites
+                            ) else {
+                                summary.errors.append(
+                                    "MCP provider \(server.name): credentials could not be saved"
+                                )
+                                continue
                             }
                             if !classifiedEnv.placeholderSecrets.isEmpty {
                                 summary.stdioProvidersNeedingConfiguration.append(
@@ -621,13 +630,22 @@ public final class ClaudePluginInstaller {
                                 oauth: oauthConfig,
                                 pluginId: pluginId
                             )
-                            MCPProviderManager.shared.addProvider(provider, token: nil)
-                            for (key, value) in classified.realSecrets {
-                                _ = MCPProviderKeychain.saveHeaderSecret(
-                                    value,
-                                    key: key,
-                                    for: provider.id
+                            let secretWrites = classified.realSecrets.map {
+                                MCPProviderSecretWrite(
+                                    storage: .header,
+                                    key: $0.key,
+                                    value: $0.value
                                 )
+                            }
+                            guard MCPProviderManager.shared.addProvider(
+                                provider,
+                                token: nil,
+                                secretWrites: secretWrites
+                            ) else {
+                                summary.errors.append(
+                                    "MCP provider \(server.name): credentials could not be saved"
+                                )
+                                continue
                             }
                             summary.oauthProvidersNeedingSignIn.append(
                                 .init(id: provider.id, name: server.name)
@@ -635,8 +653,7 @@ public final class ClaudePluginInstaller {
                             if !classified.placeholderSecrets.isEmpty
                                 && !summary.placeholderTokensSkipped.contains(
                                     where: { $0.id == provider.id }
-                                )
-                            {
+                                ) {
                                 summary.placeholderTokensSkipped.append(
                                     .init(
                                         id: provider.id,
@@ -671,16 +688,22 @@ public final class ClaudePluginInstaller {
                                 authType: hasAnySecretSlot ? .bearerToken : .none,
                                 pluginId: pluginId
                             )
-                            MCPProviderManager.shared.addProvider(
-                                provider,
-                                token: hasRealToken ? server.token : nil
-                            )
-                            for (key, value) in classified.realSecrets {
-                                _ = MCPProviderKeychain.saveHeaderSecret(
-                                    value,
-                                    key: key,
-                                    for: provider.id
+                            let secretWrites = classified.realSecrets.map {
+                                MCPProviderSecretWrite(
+                                    storage: .header,
+                                    key: $0.key,
+                                    value: $0.value
                                 )
+                            }
+                            guard MCPProviderManager.shared.addProvider(
+                                provider,
+                                token: hasRealToken ? server.token : nil,
+                                secretWrites: secretWrites
+                            ) else {
+                                summary.errors.append(
+                                    "MCP provider \(server.name): credentials could not be saved"
+                                )
+                                continue
                             }
                             if server.tokenIsPlaceholder || !classified.placeholderSecrets.isEmpty {
                                 var missing = classified.placeholderSecrets

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -124,7 +124,11 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             modelId: "scripted",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous)),
-            feed: SubagentFeed(toolCallId: "evidence-ax", kindId: "computer_use", title: "read the title field"),
+            feed: SubagentFeed(
+                toolCallId: "evidence-ax",
+                kindId: SubagentCapabilityRegistry.computerUse.id,
+                title: "read the title field"
+            ),
             interrupt: InterruptToken(),
             confirm: { _ in true },
             limits: RunLimits(maxSteps: 2, wallClockSeconds: 30),

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -111,6 +111,50 @@ struct MCPProviderProbeServiceTests {
         #expect(Set(snapshots.keys) == Set(providers.map(\.id)))
     }
 
+    @Test func healthSnapshotStoreKeepsNewestDuplicateFromCorruptedFile() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let snapshotFile = root.appendingPathComponent("mcp-health.json")
+        MCPProviderHealthSnapshotStore.overrideURL = snapshotFile
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let providerId = UUID()
+        let result = MCPProviderProbeResult(
+            providerId: providerId,
+            providerName: "Duplicate fixture",
+            transportSummary: "HTTP https://example.test/redacted-path",
+            startedAt: Date(timeIntervalSince1970: 1),
+            finishedAt: Date(timeIntervalSince1970: 2),
+            succeeded: true,
+            stage: .listTools,
+            reasonCode: .succeeded,
+            toolCount: 1,
+            toolNames: ["fixture"],
+            message: "Connected",
+            action: nil
+        )
+        let older = MCPProviderHealthSnapshot(
+            providerId: providerId,
+            providerName: "Older",
+            transportSummary: result.transportSummary,
+            lastProbe: result,
+            updatedAt: Date(timeIntervalSince1970: 10)
+        )
+        let newer = MCPProviderHealthSnapshot(
+            providerId: providerId,
+            providerName: "Newer",
+            transportSummary: result.transportSummary,
+            lastProbe: result,
+            updatedAt: Date(timeIntervalSince1970: 20)
+        )
+        let data = try JSONEncoder().encode(HealthSnapshotEnvelope(snapshots: [older, newer]))
+        try data.write(to: snapshotFile, options: .atomic)
+
+        let snapshots = MCPProviderHealthSnapshotStore.load()
+        #expect(snapshots.count == 1)
+        #expect(snapshots[providerId]?.providerName == "Newer")
+    }
+
     #if os(macOS)
     @Test func hostStdioProbeRejectsProcessControlEnvironmentWithoutLeakingValue() async {
         let provider = MCPProvider(
@@ -473,6 +517,10 @@ struct MCPProviderProbeServiceTests {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
     }
+}
+
+private struct HealthSnapshotEnvelope: Codable {
+    let snapshots: [MCPProviderHealthSnapshot]
 }
 
 private actor FakeMCPTransport: MCP.Transport {

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -111,6 +111,99 @@ struct MCPProviderProbeServiceTests {
         #expect(Set(snapshots.keys) == Set(providers.map(\.id)))
     }
 
+    @Test @MainActor func providerConfigurationMutationClearsPersistedSuccess() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        var provider = MCPProvider(
+            id: UUID(),
+            name: "Mutable HTTP MCP",
+            url: "https://example.test/mcp",
+            authType: .none,
+            transport: .http
+        )
+        let success = MCPProviderProbeResult(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "https example.test/redacted-path",
+            startedAt: Date(),
+            finishedAt: Date(),
+            succeeded: true,
+            stage: .listTools,
+            reasonCode: .succeeded,
+            toolCount: 1,
+            toolNames: ["fixture_echo"],
+            message: "Probe passed.",
+            action: nil
+        )
+        #expect(MCPProviderHealthSnapshotStore.record(success, for: provider))
+
+        let manager = MCPProviderManager(
+            configuration: MCPProviderConfiguration(providers: [provider])
+        )
+        provider.url = "https://changed.example.test/mcp"
+
+        #expect(manager.updateProvider(provider))
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
+    }
+
+    @Test func credentialMutationClearsHealthOnlyAfterSuccessfulWrite() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Credential MCP",
+            url: "https://example.test/mcp",
+            authType: .bearerToken,
+            transport: .http
+        )
+        let success = MCPProviderProbeResult(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "https example.test/redacted-path",
+            startedAt: Date(),
+            finishedAt: Date(),
+            succeeded: true,
+            stage: .listTools,
+            reasonCode: .succeeded,
+            toolCount: 0,
+            toolNames: [],
+            message: "Probe passed.",
+            action: nil
+        )
+        #expect(MCPProviderHealthSnapshotStore.record(success, for: provider))
+        #expect(
+            !MCPProviderKeychain.clearingHealthOnSuccess(providerId: provider.id) { false }
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) != nil)
+
+        #expect(
+            MCPProviderKeychain.clearingHealthOnSuccess(providerId: provider.id) { true }
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
+    }
+
+    @Test func runtimeErrorsRedactSecretsURLsAndLocalPathsBeforeUIState() {
+        let raw =
+            "stderr /Users/alice/customer/server.js "
+            + "https://user:password@example.test/private?token=query-secret "
+            + "Authorization: Bearer sk-secret-canary"
+        let safe = MCPProviderRuntimeErrorSanitizer.sanitize(raw)
+
+        #expect(!safe.contains("/Users/alice"))
+        #expect(!safe.contains("customer"))
+        #expect(!safe.contains("password"))
+        #expect(!safe.contains("query-secret"))
+        #expect(!safe.contains("sk-secret-canary"))
+        #expect(safe.contains("<redacted-path>"))
+        #expect(safe.contains("credential=***"))
+    }
+
     @Test func healthSnapshotStoreKeepsNewestDuplicateFromCorruptedFile() throws {
         let root = try makeTemporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -75,6 +75,30 @@ struct MCPProviderProbeServiceTests {
         #expect(result.action?.contains("command") == true)
     }
 
+    #if os(macOS)
+    @Test func hostStdioProbeRejectsProcessControlEnvironmentWithoutLeakingValue() async {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Unsafe environment fixture",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "/bin/sh",
+            env: ["DYLD_INSERT_LIBRARIES": "secret-canary"]
+        )
+
+        let result = await MCPProviderProbeService.probeStdio(provider: provider)
+
+        #expect(!result.succeeded)
+        #expect(result.reasonCode == .unsafeEnvironment)
+        #expect(result.stage == .configuration)
+        #expect(result.action?.contains("Sandbox") == true)
+        #expect(!result.message.contains("secret-canary"))
+        #expect(!result.pasteboardText.contains("secret-canary"))
+    }
+    #endif
+
     @Test func failedStdioProbeDoesNotCopyOrPersistConfiguredPath() async throws {
         let root = try makeTemporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -75,6 +75,42 @@ struct MCPProviderProbeServiceTests {
         #expect(result.action?.contains("command") == true)
     }
 
+    @Test func healthSnapshotStoreSerializesConcurrentProviderWrites() async throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let providers = (0..<24).map { index in
+            MCPProvider(id: UUID(), name: "Provider \(index)", url: "https://example.com/mcp")
+        }
+        await withTaskGroup(of: Void.self) { group in
+            for provider in providers {
+                group.addTask {
+                    let result = MCPProviderProbeResult(
+                        providerId: provider.id,
+                        providerName: provider.name,
+                        transportSummary: "HTTP https://example.com/redacted-path",
+                        startedAt: Date(timeIntervalSince1970: 1),
+                        finishedAt: Date(timeIntervalSince1970: 2),
+                        succeeded: true,
+                        stage: .listTools,
+                        reasonCode: .succeeded,
+                        toolCount: 1,
+                        toolNames: ["fixture"],
+                        message: "Connected",
+                        action: nil
+                    )
+                    MCPProviderHealthSnapshotStore.record(result, for: provider)
+                }
+            }
+        }
+
+        let snapshots = MCPProviderHealthSnapshotStore.load()
+        #expect(snapshots.count == providers.count)
+        #expect(Set(snapshots.keys) == Set(providers.map(\.id)))
+    }
+
     #if os(macOS)
     @Test func hostStdioProbeRejectsProcessControlEnvironmentWithoutLeakingValue() async {
         let provider = MCPProvider(

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -155,6 +155,191 @@ struct MCPProviderProbeServiceTests {
         #expect(snapshots[providerId]?.providerName == "Newer")
     }
 
+    @Test func sharedProbeGateRejectsOlderSurfaceAndAcceptsLatestAttempt() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let snapshotFile = root.appendingPathComponent("mcp-health.json")
+        MCPProviderHealthSnapshotStore.overrideURL = snapshotFile
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Cross-surface fixture",
+            url: "https://example.test/mcp",
+            authType: .bearerToken
+        )
+        let olderContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "older-secret-canary",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let olderReservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        let olderAttempt = try #require(
+            MCPProviderHealthSnapshotStore.beginProbe(
+                olderReservation,
+                setupFingerprint: olderContext.setupFingerprint
+            )
+        )
+
+        let latestContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "latest-secret-canary",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let latestReservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        let latestAttempt = try #require(
+            MCPProviderHealthSnapshotStore.beginProbe(
+                latestReservation,
+                setupFingerprint: latestContext.setupFingerprint
+            )
+        )
+        MCPProviderHealthSnapshotStore.cancelProbe(olderReservation)
+
+        let latestResult = probeResult(provider: provider, finishedAt: 20, toolName: "latest")
+        #expect(
+            MCPProviderHealthSnapshotStore.record(
+                latestResult,
+                for: provider,
+                attempt: latestAttempt,
+                currentSetupFingerprint: latestContext.setupFingerprint
+            )
+        )
+
+        // The older surface finishes last, but its superseded generation must
+        // not replace the accepted result even with a later wall-clock date.
+        let olderResult = probeResult(provider: provider, finishedAt: 30, toolName: "older")
+        #expect(
+            !MCPProviderHealthSnapshotStore.record(
+                olderResult,
+                for: provider,
+                attempt: olderAttempt,
+                currentSetupFingerprint: olderContext.setupFingerprint
+            )
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id)?.lastProbe.toolNames == ["latest"])
+
+        let persisted = try String(contentsOf: snapshotFile, encoding: .utf8)
+        #expect(!persisted.contains("older-secret-canary"))
+        #expect(!persisted.contains("latest-secret-canary"))
+    }
+
+    @Test func sharedProbeGateRejectsProviderAndCredentialFingerprintChanges() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Fingerprint fixture",
+            url: "https://example.test/mcp",
+            authType: .bearerToken
+        )
+        let originalContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "credential-one",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+
+        let editedReservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        let editedAttempt = try #require(
+            MCPProviderHealthSnapshotStore.beginProbe(
+                editedReservation,
+                setupFingerprint: originalContext.setupFingerprint
+            )
+        )
+        var editedProvider = provider
+        editedProvider.url = "https://edited.example.test/mcp"
+        let editedContext = MCPProviderProbeContext.make(
+            provider: editedProvider,
+            authorizationToken: "credential-one",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        #expect(
+            !MCPProviderHealthSnapshotStore.record(
+                probeResult(provider: provider, finishedAt: 10, toolName: "edited"),
+                for: provider,
+                attempt: editedAttempt,
+                currentSetupFingerprint: editedContext.setupFingerprint
+            )
+        )
+
+        let credentialReservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        let credentialAttempt = try #require(
+            MCPProviderHealthSnapshotStore.beginProbe(
+                credentialReservation,
+                setupFingerprint: originalContext.setupFingerprint
+            )
+        )
+        let rotatedCredentialContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "credential-two",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        #expect(
+            !MCPProviderHealthSnapshotStore.record(
+                probeResult(provider: provider, finishedAt: 11, toolName: "rotated"),
+                for: provider,
+                attempt: credentialAttempt,
+                currentSetupFingerprint: rotatedCredentialContext.setupFingerprint
+            )
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
+    }
+
+    @Test func credentialMutationInvalidatesMatchingInFlightAttempt() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(id: UUID(), name: "Mutation fixture", url: "https://example.test/mcp")
+        let context = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "same-current-value",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let reservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        let attempt = try #require(
+            MCPProviderHealthSnapshotStore.beginProbe(
+                reservation,
+                setupFingerprint: context.setupFingerprint
+            )
+        )
+
+        MCPProviderHealthSnapshotStore.invalidateProbeAttempts(providerId: provider.id)
+
+        #expect(
+            !MCPProviderHealthSnapshotStore.record(
+                probeResult(provider: provider, finishedAt: 10, toolName: "invalidated"),
+                for: provider,
+                attempt: attempt,
+                currentSetupFingerprint: context.setupFingerprint
+            )
+        )
+    }
+
+    @Test func directRecordCannotDemoteSnapshotByFinishedAt() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(id: UUID(), name: "Timestamp fixture", url: "https://example.test/mcp")
+        let newest = probeResult(provider: provider, finishedAt: 20, toolName: "newest")
+        let older = probeResult(provider: provider, finishedAt: 10, toolName: "older")
+
+        #expect(MCPProviderHealthSnapshotStore.record(newest, for: provider))
+        #expect(!MCPProviderHealthSnapshotStore.record(older, for: provider))
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id)?.lastProbe.toolNames == ["newest"])
+    }
+
     #if os(macOS)
     @Test func hostStdioProbeRejectsProcessControlEnvironmentWithoutLeakingValue() async {
         let provider = MCPProvider(
@@ -487,6 +672,27 @@ struct MCPProviderProbeServiceTests {
             return ProviderDiagnosticRow(id: id, title: "missing", value: "missing", severity: .blocked)
         }
         return found
+    }
+
+    private func probeResult(
+        provider: MCPProvider,
+        finishedAt: TimeInterval,
+        toolName: String
+    ) -> MCPProviderProbeResult {
+        MCPProviderProbeResult(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "HTTP https://example.test/redacted-path",
+            startedAt: Date(timeIntervalSince1970: finishedAt - 1),
+            finishedAt: Date(timeIntervalSince1970: finishedAt),
+            succeeded: true,
+            stage: .listTools,
+            reasonCode: .succeeded,
+            toolCount: 1,
+            toolNames: [toolName],
+            message: "Connected",
+            action: nil
+        )
     }
 
     private static let hostFixtureScript = #"""

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -385,6 +385,87 @@ struct MCPProviderProbeServiceTests {
         #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
     }
 
+    @Test func postSaveRestoreRequiresExactCurrentCredentialFingerprint() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Restore fixture",
+            url: "https://example.test/mcp",
+            authType: .oauth
+        )
+        let verifiedContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "oauth-token-a",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let rotatedContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "oauth-token-b",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let result = probeResult(provider: provider, finishedAt: 20, toolName: "fixture")
+
+        #expect(
+            !MCPProviderHealthSnapshotStore.restore(
+                result,
+                for: provider,
+                verifiedSetupFingerprint: verifiedContext.setupFingerprint,
+                captureCurrentSetupFingerprint: { rotatedContext.setupFingerprint }
+            )
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
+
+        #expect(
+            MCPProviderHealthSnapshotStore.restore(
+                result,
+                for: provider,
+                verifiedSetupFingerprint: verifiedContext.setupFingerprint,
+                captureCurrentSetupFingerprint: { verifiedContext.setupFingerprint }
+            )
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id)?.lastProbe == result)
+    }
+
+    @Test func credentialMutationDuringPostSaveRecaptureInvalidatesRestore() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        MCPProviderHealthSnapshotStore.overrideURL = root.appendingPathComponent("mcp-health.json")
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Restore race fixture",
+            url: "https://example.test/mcp",
+            authType: .bearerToken
+        )
+        let context = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "credential",
+            secretHeaderValues: [:],
+            secretEnvironmentValues: [:]
+        )
+        let result = probeResult(provider: provider, finishedAt: 20, toolName: "fixture")
+
+        #expect(
+            !MCPProviderHealthSnapshotStore.restore(
+                result,
+                for: provider,
+                verifiedSetupFingerprint: context.setupFingerprint,
+                captureCurrentSetupFingerprint: {
+                    MCPProviderHealthSnapshotStore.clear(providerId: provider.id)
+                    return context.setupFingerprint
+                }
+            )
+        )
+        #expect(MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id) == nil)
+    }
+
     @Test func credentialMutationInvalidatesMatchingInFlightAttempt() throws {
         let root = try makeTemporaryRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPProviderProbeServiceTests.swift
@@ -30,7 +30,8 @@ struct MCPProviderProbeServiceTests {
             authType: .none,
             transport: .stdio,
             executionHost: .host,
-            command: "fake-mcp"
+            command: "/Users/alice/private/fake-mcp",
+            args: ["--workspace", "/Users/alice/customer-data"]
         )
 
         let result = await MCPProviderProbeService.probeForTesting(
@@ -48,6 +49,10 @@ struct MCPProviderProbeServiceTests {
         let snapshot = MCPProviderHealthSnapshotStore.snapshot(providerId: provider.id)
         #expect(snapshot?.lastProbe.reasonCode == .succeeded)
         #expect(snapshot?.lastProbe.toolNames == ["fake_echo"])
+        #expect(!result.transportSummary.contains("/Users/alice"))
+        let persisted = try String(contentsOf: snapshotFile, encoding: .utf8)
+        #expect(!persisted.contains("/Users/alice"))
+        #expect(!persisted.contains("customer-data"))
         #expect(FileManager.default.fileExists(atPath: snapshotFile.path))
     }
 
@@ -68,6 +73,181 @@ struct MCPProviderProbeServiceTests {
         #expect(result.reasonCode == .missingCommand)
         #expect(result.stage == .configuration)
         #expect(result.action?.contains("command") == true)
+    }
+
+    @Test func failedStdioProbeDoesNotCopyOrPersistConfiguredPath() async throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let snapshotFile = root.appendingPathComponent("mcp-health.json")
+        MCPProviderHealthSnapshotStore.overrideURL = snapshotFile
+        defer { MCPProviderHealthSnapshotStore.overrideURL = nil }
+        let privatePath = "/Users/alice/customer-work/missing-mcp"
+        let provider = MCPProvider(
+            name: "Missing fixture",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: privatePath
+        )
+
+        let result = await MCPProviderProbeService.probeStdio(provider: provider)
+        MCPProviderHealthSnapshotStore.record(result, for: provider)
+        let persisted = try String(contentsOf: snapshotFile, encoding: .utf8)
+
+        #expect(result.reasonCode == .spawnFailed)
+        #expect(!result.pasteboardText.contains(privatePath))
+        #expect(!result.message.contains(privatePath))
+        #expect(!persisted.contains(privatePath))
+        #expect(!persisted.contains("customer-work"))
+    }
+
+    #if os(macOS)
+    @Test func hostStdioProbeReportsEarlyProcessExitWithoutWaitingForTimeout() async {
+        let provider = MCPProvider(
+            name: "Early exit fixture",
+            url: "",
+            discoveryTimeout: 5,
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "/bin/sh",
+            args: ["-c", "exit 42"]
+        )
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let result = await MCPProviderProbeService.probeStdio(provider: provider)
+
+        #expect(!result.succeeded)
+        #expect(result.reasonCode == .processExited)
+        #expect(result.stage == .connect)
+        #expect(result.message.contains("42"))
+        #expect(!result.pasteboardText.contains("exit 42"))
+        #expect(started.duration(to: clock.now) < .seconds(1))
+    }
+
+    @Test func hostStdioProbeUsesDraftSecretAndDiscoversFixtureTool() async {
+        let provider = MCPProvider(
+            name: "Host fixture",
+            url: "",
+            discoveryTimeout: 5,
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "/bin/sh",
+            args: ["-c", Self.hostFixtureScript],
+            secretEnvKeys: ["MCP_TEST_TOKEN"]
+        )
+
+        let result = await MCPProviderProbeService.probeStdio(
+            provider: provider,
+            secretEnvOverrides: ["MCP_TEST_TOKEN": "draft-secret"]
+        )
+
+        #expect(result.succeeded)
+        #expect(result.reasonCode == .succeeded)
+        #expect(result.toolNames == ["fixture_echo"])
+        #expect(!result.transportSummary.contains("/bin/sh"))
+        #expect(!result.transportSummary.contains(Self.hostFixtureScript))
+        #expect(!result.pasteboardText.contains("draft-secret"))
+    }
+
+    @Test func hostStdioFixtureExecutesToolAndTerminatesCleanly() async throws {
+        let provider = MCPProvider(
+            name: "Host fixture",
+            url: "",
+            discoveryTimeout: 5,
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "/bin/sh",
+            args: ["-c", Self.hostFixtureScript],
+            secretEnvKeys: ["MCP_TEST_TOKEN"]
+        )
+        let runner = try MCPStdioHostRunner(
+            provider: provider,
+            secretEnvOverrides: ["MCP_TEST_TOKEN": "draft-secret"]
+        )
+        try await runner.start()
+        let client = MCP.Client(name: "Osaurus fixture test", version: "1.0")
+
+        do {
+            _ = try await MCPAsyncTimeout.run(seconds: 5) {
+                try await client.connect(transport: runner.transport)
+            }
+            let result = try await MCPAsyncTimeout.run(seconds: 5) {
+                try await client.callTool(name: "fixture_echo", arguments: [:])
+            }
+            #expect(result.isError != true)
+            #expect(result.content == [.text(text: "fixture-ok", annotations: nil, _meta: nil)])
+            await client.disconnect()
+            await runner.stop()
+        } catch {
+            await client.disconnect()
+            await runner.stop()
+            throw error
+        }
+    }
+    #endif
+
+    @Test func timeoutReturnsWithoutWaitingForCancellationIgnoringOperation() async {
+        let clock = ContinuousClock()
+        let started = clock.now
+        do {
+            _ = try await MCPAsyncTimeout.run(seconds: 0.05) {
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+                        continuation.resume(returning: "late")
+                    }
+                }
+            }
+            Issue.record("Expected timeout")
+        } catch MCPProviderError.timeout {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(started.duration(to: clock.now) < .milliseconds(500))
+    }
+
+    @Test func externalFailureSignalEndsOperationBeforeTimeout() async {
+        let signal = MCPAsyncFailureSignal()
+        let clock = ContinuousClock()
+        let started = clock.now
+        Task {
+            try? await Task.sleep(for: .milliseconds(25))
+            signal.fail(MCPProviderError.providerDisabled)
+        }
+
+        do {
+            _ = try await MCPAsyncTimeout.run(seconds: 5, failureSignal: signal) {
+                try await Task.sleep(for: .seconds(5))
+                return "late"
+            }
+            Issue.record("Expected process failure")
+        } catch MCPProviderError.providerDisabled {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(started.duration(to: clock.now) < .milliseconds(500))
+    }
+
+    @Test func failureSignalLatchedBeforeObservationIsNotLost() async {
+        let signal = MCPAsyncFailureSignal()
+        signal.fail(MCPProviderError.providerDisabled)
+
+        do {
+            _ = try await MCPAsyncTimeout.run(seconds: 5, failureSignal: signal) {
+                "unexpected"
+            }
+            Issue.record("Expected the latched failure")
+        } catch MCPProviderError.providerDisabled {
+            // Expected.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     @Test func capturePolicyRequiresExplicitOptInAndPermission() {
@@ -204,6 +384,26 @@ struct MCPProviderProbeServiceTests {
         }
         return found
     }
+
+    private static let hostFixtureScript = #"""
+    [ "$MCP_TEST_TOKEN" = "draft-secret" ] || exit 42
+    while IFS= read -r line; do
+      id=$(printf '%s' "$line" | sed -E 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+      case "$line" in
+        *notifications/initialized*)
+          ;;
+        *initialize*)
+          printf '{"jsonrpc":"2.0","id":"%s","result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":"1.0"}}}\n' "$id"
+          ;;
+        *tools*list*)
+          printf '{"jsonrpc":"2.0","id":"%s","result":{"tools":[{"name":"fixture_echo","description":"Fixture echo","inputSchema":{"type":"object","properties":{}}}]}}\n' "$id"
+          ;;
+        *tools*call*)
+          printf '{"jsonrpc":"2.0","id":"%s","result":{"content":[{"type":"text","text":"fixture-ok"}],"isError":false}}\n' "$id"
+          ;;
+      esac
+    done
+    """#
 
     private func makeTemporaryRoot() throws -> URL {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Packages/OsaurusCore/Tests/MCPOAuth/ShellArgsTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/ShellArgsTests.swift
@@ -183,5 +183,30 @@ final class MCPStdioTransportErrorTests: XCTestCase {
                 "/usr/local/bin/mcp-server"
             )
         }
+
+        func testHostEnvironmentAcceptsOrdinaryProviderValues() throws {
+            let merged = try MCPStdioHostRunner.mergedEnvironmentForTesting(
+                inherited: ["PATH": "/usr/bin", "LANG": "en_US.UTF-8"],
+                provider: ["MCP_LOG_LEVEL": "debug", "MCP_TOKEN": "canary"]
+            )
+
+            XCTAssertEqual(merged["PATH"], "/usr/bin")
+            XCTAssertEqual(merged["MCP_LOG_LEVEL"], "debug")
+            XCTAssertEqual(merged["MCP_TOKEN"], "canary")
+        }
+
+        func testHostEnvironmentRejectsProcessControlOverrides() throws {
+            for key in ["PATH", "DYLD_INSERT_LIBRARIES", "LD_PRELOAD", "OBJC_PRINT_LOAD_METHODS"] {
+                XCTAssertThrowsError(
+                    try MCPStdioHostRunner.mergedEnvironmentForTesting(
+                        inherited: ["PATH": "/usr/bin"],
+                        provider: [key: "canary"]
+                    )
+                ) { error in
+                    XCTAssertEqual(error as? MCPStdioTransportError, .unsafeEnvironmentKey(key))
+                    XCTAssertFalse(error.localizedDescription.contains("canary"))
+                }
+            }
+        }
     }
 #endif

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -131,12 +131,16 @@ struct MCPConfigurationImportServiceTests {
 
     @Test func classifiesCommonSecretNamesConservatively() {
         for key in [
-            "API_KEY", "OPENAI_KEY", "GH_PAT", "client-secret", "AUTH_TOKEN", "PASSWORD",
-            "AWS_ACCESS_KEY_ID", "AZURE_CLIENT_ID", "DATABASE_URL", "MYSQL_PWD", "SESSION_ID",
+            "API_KEY", "APIKEY", "OPENAI_APIKEY", "OPENAI_KEY", "GH_PAT",
+            "client-secret", "AUTH_TOKEN", "PASSWORD", "SUPABASE_SERVICE_ROLE",
+            "AWS_ACCESS_KEY_ID", "AZURE_CLIENT_ID", "DATABASE_URL", "MYSQL_PWD",
+            "SESSION_ID",
         ] {
             #expect(MCPConfigurationImportService.likelySecretKey(key))
         }
-        #expect(MCPConfigurationImportService.likelySecretKey("Authorization", isHeader: true))
+        for header in ["Authorization", "X-ApiKey", "X-Secret", "X-Password"] {
+            #expect(MCPConfigurationImportService.likelySecretKey(header, isHeader: true))
+        }
         #expect(!MCPConfigurationImportService.likelySecretKey("LOG_LEVEL"))
         #expect(!MCPConfigurationImportService.likelySecretKey("Accept", isHeader: true))
     }

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -130,7 +130,10 @@ struct MCPConfigurationImportServiceTests {
     }
 
     @Test func classifiesCommonSecretNamesConservatively() {
-        for key in ["API_KEY", "OPENAI_KEY", "GH_PAT", "client-secret", "AUTH_TOKEN", "PASSWORD"] {
+        for key in [
+            "API_KEY", "OPENAI_KEY", "GH_PAT", "client-secret", "AUTH_TOKEN", "PASSWORD",
+            "AWS_ACCESS_KEY_ID", "AZURE_CLIENT_ID", "DATABASE_URL", "MYSQL_PWD", "SESSION_ID",
+        ] {
             #expect(MCPConfigurationImportService.likelySecretKey(key))
         }
         #expect(MCPConfigurationImportService.likelySecretKey("Authorization", isHeader: true))

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -229,6 +229,8 @@ struct MCPConfigurationImportServiceTests {
         var gate = MCPProviderProbeGate()
         let first = gate.start(fingerprint: "first")
         let second = gate.start(fingerprint: "second")
+        #expect(!gate.isCurrent(first))
+        #expect(gate.isCurrent(second))
 
         let acceptedFirst = gate.accept(first, currentFingerprint: "second", succeeded: true)
         #expect(!acceptedFirst)
@@ -251,6 +253,7 @@ struct MCPConfigurationImportServiceTests {
 
         let invalidated = gate.start(fingerprint: "second")
         gate.invalidate()
+        #expect(!gate.isCurrent(invalidated))
         let acceptedInvalidated = gate.accept(
             invalidated,
             currentFingerprint: "second",

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -225,6 +225,46 @@ struct MCPConfigurationImportServiceTests {
         #expect(provider.env["TOKEN"] == nil)
     }
 
+    @Test func storedAndEditorProbeContextsShareCanonicalCredentialFingerprint() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Canonical fixture",
+            url: "https://example.test/mcp",
+            enabled: false,
+            customHeaders: ["Accept": "application/json"],
+            streamingEnabled: true,
+            discoveryTimeout: 37,
+            toolCallTimeout: 61,
+            autoConnect: false,
+            secretHeaderKeys: ["X-API-Key"],
+            authType: .bearerToken,
+            pluginId: "fixture-plugin"
+        )
+        let storedContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "bearer-secret-canary",
+            secretHeaderValues: ["X-API-Key": "header-secret-canary"],
+            secretEnvironmentValues: [:]
+        )
+        let editorContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "bearer-secret-canary",
+            secretHeaderValues: ["X-API-Key": "header-secret-canary"],
+            secretEnvironmentValues: [:]
+        )
+        let rotatedContext = MCPProviderProbeContext.make(
+            provider: provider,
+            authorizationToken: "rotated-secret-canary",
+            secretHeaderValues: ["X-API-Key": "header-secret-canary"],
+            secretEnvironmentValues: [:]
+        )
+
+        #expect(storedContext.setupFingerprint == editorContext.setupFingerprint)
+        #expect(storedContext.setupFingerprint != rotatedContext.setupFingerprint)
+        #expect(!storedContext.setupFingerprint.contains("bearer-secret-canary"))
+        #expect(!storedContext.setupFingerprint.contains("header-secret-canary"))
+    }
+
     @Test func probeGateRejectsStaleCompletionAndBindsSuccessToCurrentInputs() {
         var gate = MCPProviderProbeGate()
         let first = gate.start(fingerprint: "first")

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -1,0 +1,252 @@
+//
+//  MCPConfigurationImportServiceTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct MCPConfigurationImportServiceTests {
+    @Test func importsStdioAndHTTPServersWithoutPersistingSecretsInPreview() throws {
+        let servers = try parse(
+            """
+            {
+              "mcpServers": {
+                "files": {
+                  "type": "stdio",
+                  "command": "/opt/homebrew/bin/uvx",
+                  "args": ["server", "/Users/alice/private"],
+                  "cwd": "/Users/alice/work",
+                  "env": {
+                    "GITHUB_TOKEN": "secret-token-value",
+                    "LOG_LEVEL": "info"
+                  }
+                },
+                "remote": {
+                  "type": "sse",
+                  "url": "https://mcp.example.test/events?tenant=private",
+                  "headers": {
+                    "Authorization": "Bearer secret-header-value",
+                    "X-Mode": "test"
+                  }
+                }
+              }
+            }
+            """
+        )
+
+        #expect(servers.count == 2)
+        let files = try #require(servers.first { $0.name == "files" })
+        #expect(files.transport == .stdio)
+        #expect(files.referencesHostPaths)
+        #expect(files.environment.first { $0.key == "GITHUB_TOKEN" }?.isSecret == true)
+        #expect(files.environment.first { $0.key == "LOG_LEVEL" }?.isSecret == false)
+        #expect(!files.reporterSafeSummary.contains("secret-token-value"))
+        #expect(!files.reporterSafeSummary.contains("/Users/alice"))
+
+        let remote = try #require(servers.first { $0.name == "remote" })
+        #expect(remote.transport == .http)
+        #expect(remote.streamingEnabled)
+        #expect(remote.headers.first { $0.key == "Authorization" }?.isSecret == true)
+        #expect(!remote.reporterSafeSummary.contains("secret-header-value"))
+        #expect(!remote.reporterSafeSummary.contains("mcp.example.test"))
+    }
+
+    @Test func importsSingleNamedServerAndStreamableHTTP() throws {
+        let server = try #require(
+            parse(
+                """
+                {
+                  "name": "company-search",
+                  "type": "streamable-http",
+                  "url": "https://mcp.example.test/mcp"
+                }
+                """
+            ).first
+        )
+
+        #expect(server.name == "company-search")
+        #expect(server.transport == .http)
+        #expect(!server.streamingEnabled)
+    }
+
+    @Test func rejectsDuplicateKeysIncludingEscapedAliases() {
+        expectFailure(.duplicateKey, json: #"{"mcpServers":{"a":{"command":"one","\u0063ommand":"two"}}}"#)
+    }
+
+    @Test func rejectsMixedAndConflictingTransportShapes() {
+        expectFailure(
+            .mixedTransport,
+            json: #"{"name":"mixed","command":"npx","url":"https://example.test"}"#
+        )
+        expectFailure(
+            .mixedTransport,
+            json: #"{"name":"wrong","type":"stdio","url":"https://example.test"}"#
+        )
+        expectFailure(
+            .unsupportedTransport,
+            json: #"{"name":"wrong","type":"websocket","url":"https://example.test"}"#
+        )
+    }
+
+    @Test func rejectsUnsafeHeadersAndEmbeddedURLCredentials() {
+        expectFailure(
+            .unsafeValue,
+            json: "{\"name\":\"bad\",\"url\":\"https://example.test\",\"headers\":{\"X-Test\":\"ok\\r\\nInjected: yes\"}}"
+        )
+        expectFailure(
+            .invalidURL,
+            json: #"{"name":"bad","url":"https://user:password@example.test/mcp"}"#
+        )
+    }
+
+    @Test func rejectsNonStringValuesAndOversizedCollections() throws {
+        expectFailure(
+            .invalidField,
+            json: #"{"name":"bad","command":"npx","args":[1]}"#
+        )
+        expectFailure(
+            .invalidField,
+            json: #"{"name":"bad","command":"npx","args":"--version"}"#
+        )
+        expectFailure(
+            .invalidField,
+            json: #"{"name":"bad","command":"npx","env":[]}"#
+        )
+        let args = Array(repeating: "x", count: MCPConfigurationImportService.maximumArguments + 1)
+        let object: [String: Any] = ["name": "large", "command": "npx", "args": args]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        do {
+            _ = try MCPConfigurationImportService.parse(data)
+            Issue.record("Expected oversized argument list to fail")
+        } catch let error as MCPConfigurationImportFailure {
+            #expect(error.reason == .tooManyValues)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func classifiesCommonSecretNamesConservatively() {
+        for key in ["API_KEY", "OPENAI_KEY", "GH_PAT", "client-secret", "AUTH_TOKEN", "PASSWORD"] {
+            #expect(MCPConfigurationImportService.likelySecretKey(key))
+        }
+        #expect(MCPConfigurationImportService.likelySecretKey("Authorization", isHeader: true))
+        #expect(!MCPConfigurationImportService.likelySecretKey("LOG_LEVEL"))
+        #expect(!MCPConfigurationImportService.likelySecretKey("Accept", isHeader: true))
+    }
+
+    @Test func setupFingerprintChangesForEverySecretAndProviderInput() {
+        let provider = MCPProvider(
+            name: "fixture",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            command: "/usr/bin/env",
+            args: ["node", "server.js"],
+            env: ["LOG_LEVEL": "info"],
+            secretEnvKeys: ["TOKEN"]
+        )
+        let original = MCPProviderSetupFingerprint.make(
+            provider: provider,
+            bearerToken: nil,
+            secretHeaderValues: [:],
+            secretEnvironmentValues: ["TOKEN": "one"]
+        )
+        let changedSecret = MCPProviderSetupFingerprint.make(
+            provider: provider,
+            bearerToken: nil,
+            secretHeaderValues: [:],
+            secretEnvironmentValues: ["TOKEN": "two"]
+        )
+        var changedProvider = provider
+        changedProvider.args.append("--verbose")
+        let changedArgument = MCPProviderSetupFingerprint.make(
+            provider: changedProvider,
+            bearerToken: nil,
+            secretHeaderValues: [:],
+            secretEnvironmentValues: ["TOKEN": "one"]
+        )
+
+        #expect(original != changedSecret)
+        #expect(original != changedArgument)
+        #expect(!original.contains("one"))
+    }
+
+    @Test func draftSecretOverridesReachOnlyDeclaredSecretEnvironmentKeys() {
+        let provider = MCPProvider(
+            name: "fixture",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            command: "/usr/bin/env",
+            env: ["LOG_LEVEL": "info"],
+            secretEnvKeys: ["TOKEN"]
+        )
+
+        let environment = MCPStdioEnvironmentResolver.providerEnvironment(
+            provider: provider,
+            secretEnvOverrides: [
+                "TOKEN": "in-memory-only",
+                "UNDECLARED": "must-not-pass",
+            ]
+        )
+
+        #expect(environment["LOG_LEVEL"] == "info")
+        #expect(environment["TOKEN"] == "in-memory-only")
+        #expect(environment["UNDECLARED"] == nil)
+        #expect(provider.env["TOKEN"] == nil)
+    }
+
+    @Test func probeGateRejectsStaleCompletionAndBindsSuccessToCurrentInputs() {
+        var gate = MCPProviderProbeGate()
+        let first = gate.start(fingerprint: "first")
+        let second = gate.start(fingerprint: "second")
+
+        let acceptedFirst = gate.accept(first, currentFingerprint: "second", succeeded: true)
+        #expect(!acceptedFirst)
+        #expect(!gate.hasCurrentSuccess(fingerprint: "first"))
+        let acceptedEdited = gate.accept(second, currentFingerprint: "edited", succeeded: true)
+        #expect(!acceptedEdited)
+        let acceptedSecond = gate.accept(second, currentFingerprint: "second", succeeded: true)
+        #expect(acceptedSecond)
+        #expect(gate.hasCurrentSuccess(fingerprint: "second"))
+        #expect(!gate.hasCurrentSuccess(fingerprint: "edited"))
+
+        let failedRetry = gate.start(fingerprint: "second")
+        let acceptedFailure = gate.accept(
+            failedRetry,
+            currentFingerprint: "second",
+            succeeded: false
+        )
+        #expect(acceptedFailure)
+        #expect(!gate.hasCurrentSuccess(fingerprint: "second"))
+
+        let invalidated = gate.start(fingerprint: "second")
+        gate.invalidate()
+        let acceptedInvalidated = gate.accept(
+            invalidated,
+            currentFingerprint: "second",
+            succeeded: true
+        )
+        #expect(!acceptedInvalidated)
+    }
+
+    private func parse(_ json: String) throws -> [MCPImportedServerConfiguration] {
+        try MCPConfigurationImportService.parse(Data(json.utf8))
+    }
+
+    private func expectFailure(_ reason: MCPConfigurationImportReason, json: String) {
+        do {
+            _ = try? JSONSerialization.jsonObject(with: Data(json.utf8))
+            _ = try MCPConfigurationImportService.parse(Data(json.utf8))
+            Issue.record("Expected import to fail with \(reason.rawValue)")
+        } catch let error as MCPConfigurationImportFailure {
+            #expect(error.reason == reason)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPConfigurationImportServiceTests.swift
@@ -176,9 +176,27 @@ struct MCPConfigurationImportServiceTests {
             secretHeaderValues: [:],
             secretEnvironmentValues: ["TOKEN": "one"]
         )
+        changedProvider = provider
+        changedProvider.discoveryTimeout = 60
+        let changedDiscoveryTimeout = MCPProviderSetupFingerprint.make(
+            provider: changedProvider,
+            bearerToken: nil,
+            secretHeaderValues: [:],
+            secretEnvironmentValues: ["TOKEN": "one"]
+        )
+        changedProvider = provider
+        changedProvider.toolCallTimeout = 90
+        let changedToolCallTimeout = MCPProviderSetupFingerprint.make(
+            provider: changedProvider,
+            bearerToken: nil,
+            secretHeaderValues: [:],
+            secretEnvironmentValues: ["TOKEN": "one"]
+        )
 
         #expect(original != changedSecret)
         #expect(original != changedArgument)
+        #expect(original != changedDiscoveryTimeout)
+        #expect(original != changedToolCallTimeout)
         #expect(!original.contains("one"))
     }
 

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -1,0 +1,547 @@
+//
+//  MCPOperationsHubTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Logging
+import MCP
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MCP Operations Hub", .serialized)
+struct MCPOperationsHubTests {
+    @Test func hostLaunchPlanResolvesExecutableAndRedactsCommandSecrets() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Filesystem",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "npx",
+            args: ["--token=secret-token", "@modelcontextprotocol/server-filesystem"],
+            env: ["VISIBLE": "value"],
+            secretEnvKeys: ["API_TOKEN", "MISSING_TOKEN"],
+            workingDirectory: "~/Projects"
+        )
+
+        let plan = MCPProviderOperationsHub.launchPlan(
+            for: provider,
+            processEnvironment: ["PATH": "/custom/bin"],
+            secretEnvValues: ["API_TOKEN": "secret-value"],
+            isExecutable: { $0 == "/custom/bin/npx" },
+            directoryExists: { $0.hasSuffix("/Projects") }
+        )
+
+        #expect(plan.status == .warning)
+        #expect(plan.resolvedExecutablePath == "/custom/bin/npx")
+        #expect(plan.searchPath?.contains("/custom/bin") == true)
+        #expect(plan.workingDirectory?.hasSuffix("/Projects") == true)
+        #expect(plan.configuredEnvironmentKeys == ["API_TOKEN", "MISSING_TOKEN", "VISIBLE"])
+        #expect(plan.secretEnvironmentKeys == ["API_TOKEN", "MISSING_TOKEN"])
+        #expect(plan.missingSecretEnvironmentKeys == ["MISSING_TOKEN"])
+        #expect(plan.redactedCommandLine?.contains("secret-token") == false)
+        #expect(plan.pasteboardText.contains("secret-value") == false)
+    }
+
+    @Test func duplicateHeaderAndEnvRowsNormalizeWithoutTrap() {
+        let normalized = MCPProviderOperationsFieldNormalizer.normalize([
+            (key: "Authorization", value: "plain-old", isSecret: false),
+            (key: "API_TOKEN", value: "first", isSecret: true),
+            (key: " Authorization ", value: "secret-new", isSecret: true),
+            (key: "API_TOKEN", value: "plain-new", isSecret: false),
+            (key: "EMPTY", value: "ignored", isSecret: false),
+            (key: "EMPTY", value: "", isSecret: true),
+        ])
+
+        #expect(normalized.regular == ["API_TOKEN": "plain-new"])
+        #expect(normalized.secretKeys == ["Authorization", "EMPTY"])
+    }
+
+    @Test func launchPlanDeduplicatesSecretEnvironmentKeysBeforeKeychainChecks() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Duplicate Env",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "npx",
+            env: ["VISIBLE": "value"],
+            secretEnvKeys: ["API_TOKEN", " API_TOKEN ", "MISSING_TOKEN", "MISSING_TOKEN"]
+        )
+
+        let plan = MCPProviderOperationsHub.launchPlan(
+            for: provider,
+            processEnvironment: ["PATH": "/custom/bin"],
+            secretEnvValues: ["API_TOKEN": "secret-value"],
+            isExecutable: { $0 == "/custom/bin/npx" },
+            directoryExists: { _ in true }
+        )
+
+        #expect(plan.status == .warning)
+        #expect(plan.configuredEnvironmentKeys == ["API_TOKEN", "MISSING_TOKEN", "VISIBLE"])
+        #expect(plan.secretEnvironmentKeys == ["API_TOKEN", "MISSING_TOKEN"])
+        #expect(plan.missingSecretEnvironmentKeys == ["MISSING_TOKEN"])
+    }
+
+    @Test func hostLaunchPlanBlocksWhenCommandIsNotOnPath() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Missing",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "not-installed"
+        )
+
+        let plan = MCPProviderOperationsHub.launchPlan(
+            for: provider,
+            processEnvironment: ["PATH": "/empty/bin"],
+            secretEnvValues: [:],
+            isExecutable: { _ in false },
+            directoryExists: { _ in true }
+        )
+
+        #expect(plan.status == .blocked)
+        #expect(plan.title.contains("not found"))
+        #expect(plan.resolvedExecutablePath == nil)
+        #expect(plan.searchPath?.contains("/empty/bin") == true)
+    }
+
+    @Test func callHistoryStoreBoundsAndRedactsRecords() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyFile = root.appendingPathComponent("mcp-call-history.json")
+        MCPProviderCallHistoryStore.overrideURL = historyFile
+        defer { MCPProviderCallHistoryStore.overrideURL = nil }
+
+        let providerId = UUID()
+        for index in 0..<55 {
+            let record = MCPProviderCallRecord(
+                providerId: providerId,
+                providerName: "Secret MCP",
+                toolName: "lookup_\(index)",
+                startedAt: Date(timeIntervalSince1970: Double(index)),
+                finishedAt: Date(timeIntervalSince1970: Double(index) + 0.25),
+                succeeded: index.isMultiple(of: 2),
+                argumentSummary: MCPProviderCallRecord.summarizeArguments(
+                    #"{"password":"hunter2","query":"status"}"#
+                ),
+                resultSummary: MCPProviderCallRecord.summarizeResult(
+                    #"{"access_token":"secret-token","customer":"bare-private-value"}"#
+                ),
+                errorMessage: "Authorization: Bearer raw-token"
+            )
+            MCPProviderCallHistoryStore.record(record)
+        }
+
+        let records = MCPProviderCallHistoryStore.recentCalls(providerId: providerId, limit: 100)
+        #expect(records.count == MCPProviderCallHistoryStore.maxRecordsPerProvider)
+        #expect(records.first?.toolName == "lookup_54")
+        #expect(records.last?.toolName == "lookup_5")
+        #expect(FileManager.default.fileExists(atPath: historyFile.path))
+
+        let pasteboard = records.first?.pasteboardText ?? ""
+        #expect(pasteboard.contains("password"))
+        #expect(!pasteboard.contains("hunter2"))
+        #expect(!pasteboard.contains("secret-token"))
+        #expect(!pasteboard.contains("bare-private-value"))
+        #expect(!pasteboard.contains("raw-token"))
+    }
+
+    @Test func callHistoryStoreSerializesConcurrentRecordWrites() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyFile = root.appendingPathComponent("mcp-call-history.json")
+        MCPProviderCallHistoryStore.overrideURL = historyFile
+        defer { MCPProviderCallHistoryStore.overrideURL = nil }
+
+        let providerId = UUID()
+        DispatchQueue.concurrentPerform(iterations: 20) { index in
+            MCPProviderCallHistoryStore.record(
+                MCPProviderCallRecord(
+                    providerId: providerId,
+                    providerName: "Concurrent MCP",
+                    toolName: "lookup_\(index)",
+                    startedAt: Date(timeIntervalSince1970: Double(index)),
+                    finishedAt: Date(timeIntervalSince1970: Double(index) + 0.1),
+                    succeeded: true,
+                    argumentSummary: #"{"index":\#(index)}"#
+                )
+            )
+        }
+
+        let records = MCPProviderCallHistoryStore.recentCalls(providerId: providerId, limit: 100)
+        #expect(records.count == 20)
+        #expect(Set(records.map(\.toolName)).count == 20)
+    }
+
+    @Test @MainActor func managerExecuteToolRecordsCallHistoryFromProductionPath() async throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyFile = root.appendingPathComponent("mcp-call-history.json")
+        MCPProviderCallHistoryStore.overrideURL = historyFile
+        defer { MCPProviderCallHistoryStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "History MCP",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "fake-mcp",
+            args: []
+        )
+        let client = MCP.Client(name: "OsaurusTests", version: "1.0.0")
+        _ = try await client.connect(transport: ToolCallHistoryMCPTransport())
+
+        let manager = MCPProviderManager(configuration: MCPProviderConfiguration(providers: [provider]))
+        manager.installConnectedClientForTesting(client, provider: provider)
+
+        let result = try await manager.executeTool(
+            providerId: provider.id,
+            toolName: "fake_echo",
+            argumentsJSON: #"{"password":"hunter2","query":"status"}"#
+        )
+
+        #expect(result.contains("Echo: status"))
+
+        let records = MCPProviderCallHistoryStore.recentCalls(providerId: provider.id)
+        let record = try #require(records.first)
+        #expect(records.count == 1)
+        #expect(record.providerName == "History MCP")
+        #expect(record.toolName == "fake_echo")
+        #expect(record.succeeded)
+        #expect(record.argumentSummary.contains("password"))
+        #expect(record.argumentSummary.contains("query"))
+        #expect(record.resultSummary?.contains("character") == true)
+
+        let pasteboard = record.pasteboardText
+        #expect(!pasteboard.contains("hunter2"))
+        #expect(!pasteboard.contains("server-secret"))
+    }
+
+    @Test @MainActor func managerExecuteToolRecordsErrorCallHistoryOnce() async throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let historyFile = root.appendingPathComponent("mcp-call-history.json")
+        MCPProviderCallHistoryStore.overrideURL = historyFile
+        defer { MCPProviderCallHistoryStore.overrideURL = nil }
+
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Error MCP",
+            url: "",
+            authType: .none,
+            transport: .stdio,
+            executionHost: .host,
+            command: "fake-mcp",
+            args: []
+        )
+        let client = MCP.Client(name: "OsaurusTests", version: "1.0.0")
+        _ = try await client.connect(transport: ToolCallHistoryMCPTransport())
+
+        let manager = MCPProviderManager(configuration: MCPProviderConfiguration(providers: [provider]))
+        manager.installConnectedClientForTesting(client, provider: provider)
+
+        do {
+            _ = try await manager.executeTool(
+                providerId: provider.id,
+                toolName: "fake_error",
+                argumentsJSON: #"{"password":"hunter2","query":"status"}"#
+            )
+            Issue.record("Expected fake_error to throw")
+        } catch MCPProviderError.toolExecutionFailed(let message) {
+            #expect(message.contains("Denied"))
+        }
+
+        let records = MCPProviderCallHistoryStore.recentCalls(providerId: provider.id)
+        let record = try #require(records.first)
+        #expect(records.count == 1)
+        #expect(record.providerName == "Error MCP")
+        #expect(record.toolName == "fake_error")
+        #expect(!record.succeeded)
+        #expect(record.errorMessage?.contains("Denied") == true)
+
+        let pasteboard = record.pasteboardText
+        #expect(!pasteboard.contains("hunter2"))
+        #expect(!pasteboard.contains("server-secret"))
+    }
+
+    @Test func operationsSnapshotCombinesAuthLaunchHealthAndHistory() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Linear",
+            url: "https://mcp.linear.app/mcp",
+            authType: .oauth,
+            transport: .http
+        )
+        var state = MCPProviderState(providerId: provider.id)
+        state.requiresAuth = true
+        state.lastError = #"401 {"access_token":"leaked-token"}"#
+
+        let history = MCPProviderCallRecord(
+            providerId: provider.id,
+            providerName: provider.name,
+            toolName: "linear_search",
+            startedAt: Date(timeIntervalSince1970: 1),
+            finishedAt: Date(timeIntervalSince1970: 2),
+            succeeded: false,
+            argumentSummary: MCPProviderCallRecord.summarizeArguments(#"{"query":"issue"}"#),
+            errorMessage: "client_secret=secret-code"
+        )
+
+        let snapshot = MCPProviderOperationsHub.snapshot(
+            providers: [provider],
+            states: [provider.id: state],
+            proxy: .disabled,
+            credentialsByProvider: [:],
+            healthSnapshots: [:],
+            callHistoryByProvider: [provider.id: [history]]
+        )
+
+        let report = snapshot.reports[0]
+        #expect(report.status == .needsAttention)
+        #expect(report.authStatus.kind == .oauthRequired)
+        #expect(report.launchPlan.status == .ready)
+        #expect(report.callHistory.map(\.toolName) == ["linear_search"])
+        #expect(snapshot.pasteboardText.contains("linear_search"))
+        #expect(!snapshot.pasteboardText.contains("leaked-token"))
+        #expect(!snapshot.pasteboardText.contains("secret-code"))
+    }
+
+    @Test func operationsDiagnosticsRedactHTTPURLUserinfoQueryAndFragment() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Sensitive HTTP",
+            url: "https://user:pass@mcp.example.com/mcp?workspace=secret&token=raw#fragment",
+            authType: .bearerToken,
+            transport: .http
+        )
+        let probe = MCPProviderProbeResult(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "HTTP https://user:pass@mcp.example.com/mcp?workspace=secret&token=raw#fragment",
+            startedAt: Date(timeIntervalSince1970: 1),
+            finishedAt: Date(timeIntervalSince1970: 2),
+            succeeded: true,
+            stage: .listTools,
+            reasonCode: .succeeded,
+            toolCount: 1,
+            toolNames: ["lookup"],
+            message: "Reached https://user:pass@mcp.example.com/mcp?workspace=secret&token=raw#fragment",
+            action: nil
+        )
+        let health = MCPProviderHealthSnapshot(
+            providerId: provider.id,
+            providerName: provider.name,
+            transportSummary: "HTTP https://user:pass@mcp.example.com/mcp?workspace=secret&token=raw#fragment",
+            lastProbe: probe
+        )
+
+        let snapshot = MCPProviderOperationsHub.snapshot(
+            providers: [provider],
+            states: [:],
+            proxy: .disabled,
+            credentialsByProvider: [:],
+            healthSnapshots: [provider.id: health],
+            callHistoryByProvider: [:]
+        )
+
+        let pasteboard = snapshot.pasteboardText
+        #expect(pasteboard.contains("https://mcp.example.com/mcp"))
+        #expect(!pasteboard.contains("user:pass"))
+        #expect(!pasteboard.contains("workspace=secret"))
+        #expect(!pasteboard.contains("token=raw"))
+        #expect(!pasteboard.contains("#fragment"))
+    }
+
+    @Test func blankBearerTokenFieldPreservesExistingSecret() {
+        var saved: [String] = []
+        var deleteCount = 0
+
+        let edit = MCPProviderBearerTokenEdit.fromBearerField("   ", authType: .bearerToken)
+        edit.apply(
+            save: {
+                saved.append($0)
+                return true
+            },
+            delete: {
+                deleteCount += 1
+                return true
+            }
+        )
+
+        #expect(edit == .preserve)
+        #expect(saved.isEmpty)
+        #expect(deleteCount == 0)
+    }
+
+    @Test func bearerTokenEditReplacesOrClearsOnlyByExplicitIntent() {
+        var saved: [String] = []
+        var deleteCount = 0
+
+        let explicitClear = MCPProviderBearerTokenEdit.fromBearerField(
+            "",
+            authType: .bearerToken,
+            clearRequested: true
+        )
+        MCPProviderBearerTokenEdit.replace("new-token").apply(
+            save: {
+                saved.append($0)
+                return true
+            },
+            delete: {
+                deleteCount += 1
+                return true
+            }
+        )
+        MCPProviderBearerTokenEdit.replace("").apply(
+            save: {
+                saved.append($0)
+                return true
+            },
+            delete: {
+                deleteCount += 1
+                return true
+            }
+        )
+        explicitClear.apply(
+            save: {
+                saved.append($0)
+                return true
+            },
+            delete: {
+                deleteCount += 1
+                return true
+            }
+        )
+
+        #expect(explicitClear == .clear)
+        #expect(saved == ["new-token"])
+        #expect(deleteCount == 1)
+    }
+
+    private func makeTemporaryRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-mcp-ops-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+
+private actor ToolCallHistoryMCPTransport: MCP.Transport {
+    nonisolated let logger = Logger(
+        label: "osaurus.tests.mcp-call-history-transport",
+        factory: { _ in SwiftLogNoOpLogHandler() }
+    )
+
+    private let stream: AsyncThrowingStream<Data, Error>
+    private let continuation: AsyncThrowingStream<Data, Error>.Continuation
+
+    init() {
+        var continuation: AsyncThrowingStream<Data, Error>.Continuation!
+        self.stream = AsyncThrowingStream { continuation = $0 }
+        self.continuation = continuation
+    }
+
+    func connect() async throws {}
+
+    func disconnect() async {
+        continuation.finish()
+    }
+
+    func send(_ data: Data) async throws {
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let object else { return }
+        guard let method = object["method"] as? String else { return }
+        let id = object["id"] ?? 0
+
+        switch method {
+        case "initialize":
+            continuation.yield(
+                responseData(
+                    id: id,
+                    result: [
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": ["tools": [:]],
+                        "serverInfo": ["name": "fake", "version": "1.0.0"],
+                    ]
+                )
+            )
+        case "tools/list":
+            continuation.yield(
+                responseData(
+                    id: id,
+                    result: [
+                        "tools": [
+                            [
+                                "name": "fake_echo",
+                                "description": "Echo fixture",
+                                "inputSchema": ["type": "object", "properties": [:]],
+                            ]
+                        ]
+                    ]
+                )
+            )
+        case "tools/call":
+            let params = object["params"] as? [String: Any]
+            let name = params?["name"] as? String ?? "unknown"
+            let args = params?["arguments"] as? [String: Any]
+            let query = args?["query"] as? String ?? "missing"
+            if name == "fake_error" {
+                continuation.yield(
+                    responseData(
+                        id: id,
+                        result: [
+                            "content": [
+                                [
+                                    "type": "text",
+                                    "text": "Denied access_token=server-secret",
+                                ]
+                            ],
+                            "isError": true,
+                        ]
+                    )
+                )
+                return
+            }
+            continuation.yield(
+                responseData(
+                    id: id,
+                    result: [
+                        "content": [
+                            [
+                                "type": "text",
+                                "text": "Echo: \(query) access_token=server-secret",
+                            ]
+                        ],
+                        "isError": false,
+                    ]
+                )
+            )
+        default:
+            break
+        }
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Error> {
+        stream
+    }
+
+    private func responseData(id: Any, result: [String: Any]) -> Data {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ]
+        return try! JSONSerialization.data(withJSONObject: response)
+    }
+}

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -12,6 +12,33 @@ import Testing
 
 @Suite("MCP Operations Hub", .serialized)
 struct MCPOperationsHubTests {
+    @Test func declaredSecretAuthorizationHeaderRequiresStoredValueForHealthyAuth() {
+        let provider = MCPProvider(
+            id: UUID(),
+            name: "Remote",
+            url: "https://example.test/mcp",
+            secretHeaderKeys: ["Authorization"],
+            authType: .none,
+            transport: .http
+        )
+
+        let missing = MCPProviderOperationsHub.authStatus(
+            provider: provider,
+            state: nil,
+            credentialPresence: MCPProviderCredentialPresence()
+        )
+        let present = MCPProviderOperationsHub.authStatus(
+            provider: provider,
+            state: nil,
+            credentialPresence: MCPProviderCredentialPresence(authorizationHeaderPresent: true)
+        )
+
+        #expect(missing.kind == .none)
+        #expect(missing.severity == .info)
+        #expect(present.kind == .headerCredentialPresent)
+        #expect(present.severity == .ok)
+    }
+
     @Test func hostLaunchPlanResolvesExecutableAndRedactsCommandSecrets() {
         let provider = MCPProvider(
             id: UUID(),
@@ -48,7 +75,7 @@ struct MCPOperationsHubTests {
         #expect(!plan.pasteboardText.contains("/Projects"))
         #expect(!plan.pasteboardText.contains("server-filesystem"))
         #expect(!plan.pasteboardText.contains("npx"))
-        #expect(plan.pasteboardText.contains("PATH entries searched: 1"))
+        #expect(plan.pasteboardText.contains("PATH entries searched: 10"))
     }
 
     @Test func duplicateHeaderAndEnvRowsNormalizeWithoutTrap() {
@@ -59,6 +86,7 @@ struct MCPOperationsHubTests {
             (key: "API_TOKEN", value: "plain-new", isSecret: false),
             (key: "EMPTY", value: "ignored", isSecret: false),
             (key: "EMPTY", value: "", isSecret: true),
+            (key: "BLANK", value: "", isSecret: false),
         ])
 
         #expect(normalized.regular == ["API_TOKEN": "plain-new"])
@@ -359,7 +387,8 @@ struct MCPOperationsHubTests {
         )
 
         let pasteboard = snapshot.pasteboardText
-        #expect(pasteboard.contains("https://mcp.example.com/mcp"))
+        #expect(pasteboard.contains("https://mcp.example.com/redacted-path"))
+        #expect(!pasteboard.contains("/mcp/private"))
         #expect(!pasteboard.contains("user:pass"))
         #expect(!pasteboard.contains("workspace=secret"))
         #expect(!pasteboard.contains("token=raw"))
@@ -387,6 +416,44 @@ struct MCPOperationsHubTests {
         #expect(deleteCount == 0)
     }
 
+    @Test func transportScopingDropsInactiveConfigurationAndSecretReferences() {
+        let id = UUID()
+        let mixed = MCPProvider(
+            id: id,
+            name: "Mixed",
+            url: "https://private.example/mcp",
+            customHeaders: ["X-Visible": "value"],
+            streamingEnabled: true,
+            secretHeaderKeys: ["Authorization"],
+            authType: .bearerToken,
+            transport: .stdio,
+            command: "/private/bin/server",
+            args: ["--serve"],
+            env: ["VISIBLE": "value"],
+            secretEnvKeys: ["API_TOKEN"],
+            workingDirectory: "/private/work"
+        )
+
+        let stdio = mixed.scopedToActiveTransport()
+        #expect(stdio.url.isEmpty)
+        #expect(stdio.customHeaders.isEmpty)
+        #expect(stdio.secretHeaderKeys.isEmpty)
+        #expect(stdio.authType == .none)
+        #expect(!stdio.streamingEnabled)
+        #expect(stdio.command == "/private/bin/server")
+        #expect(stdio.secretEnvKeys == ["API_TOKEN"])
+
+        var httpInput = mixed
+        httpInput.transport = .http
+        let http = httpInput.scopedToActiveTransport()
+        #expect(http.command.isEmpty)
+        #expect(http.args.isEmpty)
+        #expect(http.env.isEmpty)
+        #expect(http.secretEnvKeys.isEmpty)
+        #expect(http.workingDirectory == nil)
+        #expect(http.secretHeaderKeys == ["Authorization"])
+    }
+
     @Test func bearerTokenEditReplacesOrClearsOnlyByExplicitIntent() {
         var saved: [String] = []
         var deleteCount = 0
@@ -394,6 +461,11 @@ struct MCPOperationsHubTests {
         let explicitClear = MCPProviderBearerTokenEdit.fromBearerField(
             "",
             authType: .bearerToken,
+            clearRequested: true
+        )
+        let clearAfterAuthSwitch = MCPProviderBearerTokenEdit.fromBearerField(
+            "",
+            authType: .none,
             clearRequested: true
         )
         MCPProviderBearerTokenEdit.replace("new-token").apply(
@@ -426,10 +498,18 @@ struct MCPOperationsHubTests {
                 return true
             }
         )
+        clearAfterAuthSwitch.apply(
+            save: { _ in false },
+            delete: {
+                deleteCount += 1
+                return true
+            }
+        )
 
         #expect(explicitClear == .clear)
+        #expect(clearAfterAuthSwitch == .clear)
         #expect(saved == ["new-token"])
-        #expect(deleteCount == 1)
+        #expect(deleteCount == 2)
     }
 
     private func makeTemporaryRoot() throws -> URL {
@@ -439,6 +519,128 @@ struct MCPOperationsHubTests {
         )
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
+    }
+}
+
+@Suite("MCP provider secret persistence")
+struct MCPProviderSecretPersistenceTests {
+    @Test func failedWriteRollsBackEarlierMutationsWithoutExposingValues() {
+        let providerId = UUID()
+        let writes = [
+            MCPProviderSecretWrite(storage: .header, key: "Authorization", value: "header-secret"),
+            MCPProviderSecretWrite(storage: .environment, key: "API_TOKEN", value: "env-secret"),
+        ]
+        var headerValues = ["Authorization": "old-header"]
+        var environmentValues: [String: String] = [:]
+        var events: [String] = []
+
+        let succeeded = MCPProviderSecretPersistence.persist(
+            writes,
+            for: providerId,
+            readHeader: { key, _ in headerValues[key] },
+            readEnvironment: { key, _ in environmentValues[key] },
+            writeHeader: { value, key, id in
+                events.append("set-header:\(key):\(id)")
+                headerValues[key] = value
+                return true
+            },
+            writeEnvironment: { _, key, id in
+                events.append("set-environment:\(key):\(id)")
+                return false
+            },
+            deleteHeader: { key, id in
+                events.append("delete-header:\(key):\(id)")
+                headerValues.removeValue(forKey: key)
+                return true
+            },
+            deleteEnvironment: { key, id in
+                events.append("delete-environment:\(key):\(id)")
+                environmentValues.removeValue(forKey: key)
+                return true
+            }
+        )
+
+        #expect(!succeeded)
+        #expect(headerValues == ["Authorization": "old-header"])
+        #expect(environmentValues.isEmpty)
+        #expect(events == [
+            "set-header:Authorization:\(providerId)",
+            "set-environment:API_TOKEN:\(providerId)",
+            "delete-environment:API_TOKEN:\(providerId)",
+            "set-header:Authorization:\(providerId)",
+        ])
+        #expect(!events.joined().contains("header-secret"))
+        #expect(!events.joined().contains("env-secret"))
+    }
+
+    @Test func emptyWriteSetSucceedsWithoutCallingStorage() {
+        let succeeded = MCPProviderSecretPersistence.persist(
+            [],
+            for: UUID(),
+            readHeader: { _, _ in Issue.record("unexpected header read"); return nil },
+            readEnvironment: { _, _ in Issue.record("unexpected environment read"); return nil },
+            writeHeader: { _, _, _ in Issue.record("unexpected header write"); return false },
+            writeEnvironment: { _, _, _ in Issue.record("unexpected environment write"); return false },
+            deleteHeader: { _, _ in Issue.record("unexpected header delete"); return false },
+            deleteEnvironment: { _, _ in Issue.record("unexpected environment delete"); return false }
+        )
+
+        #expect(succeeded)
+    }
+
+    @Test func credentialTransactionRestoresBearerTokenWhenSecretPersistenceFails() {
+        let providerId = UUID()
+        var storedToken: String? = "old-token"
+        var events: [String] = []
+
+        let succeeded = MCPProviderCredentialPersistence.persist(
+            providerId: providerId,
+            tokenEdit: .replace("new-token"),
+            secretWrites: [MCPProviderSecretWrite(storage: .header, key: "Authorization", value: "secret")],
+            readToken: { _ in storedToken },
+            saveToken: { token, _ in
+                events.append(token == "new-token" ? "replace" : "restore")
+                storedToken = token
+                return true
+            },
+            deleteToken: { _ in
+                events.append("delete")
+                storedToken = nil
+                return true
+            },
+            persistSecrets: { _, _ in false }
+        )
+
+        #expect(!succeeded)
+        #expect(storedToken == "old-token")
+        #expect(events == ["replace", "restore"])
+    }
+
+    @Test func bearerClearIntentChangesProbeAndFingerprintWithoutUsingStoredSecret() {
+        let stored = "stored-secret"
+        let preserved = MCPProviderBearerProbeInput.resolved(
+            fieldValue: "",
+            clearRequested: false,
+            storedValue: stored
+        )
+        let cleared = MCPProviderBearerProbeInput.resolved(
+            fieldValue: "",
+            clearRequested: true,
+            storedValue: stored
+        )
+        let preservedFingerprint = MCPProviderBearerProbeInput.fingerprint(
+            fieldValue: "",
+            clearRequested: false
+        )
+        let clearedFingerprint = MCPProviderBearerProbeInput.fingerprint(
+            fieldValue: "",
+            clearRequested: true
+        )
+
+        #expect(preserved == stored)
+        #expect(cleared == nil)
+        #expect(preservedFingerprint != clearedFingerprint)
+        #expect(!clearedFingerprint.contains(stored))
     }
 }
 

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -116,6 +116,26 @@ struct MCPOperationsHubTests {
         #expect(normalized.secretKeys == ["Authorization", "EMPTY"])
     }
 
+    @Test func secretOverridesUseLastRowAndIgnoreEmptyDraftValues() {
+        let entries = [
+            (key: " API_TOKEN ", value: "first", isSecret: true),
+            (key: "API_TOKEN", value: "", isSecret: true),
+            (key: "AUTH", value: "old", isSecret: true),
+            (key: "AUTH", value: "visible", isSecret: false),
+            (key: "PASSWORD", value: "new-secret", isSecret: true),
+            (key: " ", value: "ignored", isSecret: true),
+        ]
+        let values = MCPProviderOperationsFieldNormalizer.secretOverrides(entries)
+        let writes = MCPProviderOperationsFieldNormalizer.secretWrites(entries, storage: .header)
+
+        #expect(values == ["PASSWORD": "new-secret"])
+        #expect(
+            writes == [
+                MCPProviderSecretWrite(storage: .header, key: "PASSWORD", value: "new-secret")
+            ]
+        )
+    }
+
     @Test func launchPlanDeduplicatesSecretEnvironmentKeysBeforeKeychainChecks() {
         let provider = MCPProvider(
             id: UUID(),

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -164,8 +164,39 @@ struct MCPOperationsHubTests {
 
         #expect(plan.status == .blocked)
         #expect(plan.title.contains("not found"))
+        #expect(!plan.detail.contains("not-installed"))
         #expect(plan.resolvedExecutablePath == nil)
         #expect(plan.searchPath?.contains("/empty/bin") == true)
+    }
+
+    @Test func hostLaunchPlanDetailDoesNotExposeCommandPathCanaries() {
+        for command in [
+            "raw-command-canary",
+            "/private/customer-work/absolute-command-canary",
+            "~/customer-work/tilde-command-canary",
+        ] {
+            let provider = MCPProvider(
+                id: UUID(),
+                name: "Missing",
+                url: "",
+                authType: .none,
+                transport: .stdio,
+                executionHost: .host,
+                command: command
+            )
+
+            let plan = MCPProviderOperationsHub.launchPlan(
+                for: provider,
+                processEnvironment: ["PATH": "/empty/bin"],
+                secretEnvValues: [:],
+                isExecutable: { _ in false },
+                directoryExists: { _ in true }
+            )
+
+            #expect(!plan.detail.contains(command))
+            #expect(!plan.detail.contains("customer-work"))
+            #expect(!plan.detail.contains("command-canary"))
+        }
     }
 
     @Test func callHistoryStoreBoundsAndRedactsRecords() throws {

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -395,6 +395,18 @@ struct MCPOperationsHubTests {
         #expect(!pasteboard.contains("#fragment"))
     }
 
+    @Test func diagnosticRedactorHidesPrefixedKeysAndOpaqueTokenFormats() {
+        let diagnostic = MCPProviderProbeRedactor.safeDiagnosticFragment(
+            "OPENAI_API_KEY=sk-1234567890 GH_TOKEN=ghp_1234567890 slack=xoxb-1234567890"
+        )
+
+        #expect(!diagnostic.contains("sk-1234567890"))
+        #expect(!diagnostic.contains("ghp_1234567890"))
+        #expect(!diagnostic.contains("xoxb-1234567890"))
+        #expect(diagnostic.contains("OPENAI_API_KEY=***"))
+        #expect(diagnostic.contains("GH_TOKEN=***"))
+    }
+
     @Test func blankBearerTokenFieldPreservesExistingSecret() {
         var saved: [String] = []
         var deleteCount = 0

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -12,6 +12,29 @@ import Testing
 
 @Suite("MCP Operations Hub", .serialized)
 struct MCPOperationsHubTests {
+    @Test func operationsDisplayNeverExposesEndpointOrLocalPaths() {
+        let endpoint = MCPOperationsDisplaySanitizer.endpoint(
+            "https://user:password@example.test/private/mcp?token=secret-canary#fragment"
+        )
+        #expect(endpoint == "https://example.test/redacted-path")
+        #expect(!endpoint.contains("secret-canary"))
+        #expect(!endpoint.contains("password"))
+
+        let executable = MCPOperationsDisplaySanitizer.resolvedExecutable(
+            "/Users/alice/private/bin/customer-mcp"
+        )
+        let workingDirectory = MCPOperationsDisplaySanitizer.workingDirectory(
+            "/Users/alice/customer-data"
+        )
+        let warning = MCPOperationsDisplaySanitizer.warning(
+            "Working directory does not exist: /Users/alice/customer-data"
+        )
+        #expect(executable == "Resolved")
+        #expect(workingDirectory == "Configured")
+        #expect(!warning.contains("/Users/alice"))
+        #expect(!warning.contains("customer-data"))
+    }
+
     @Test func declaredSecretAuthorizationHeaderRequiresStoredValueForHealthyAuth() {
         let provider = MCPProvider(
             id: UUID(),

--- a/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOperationsHub/MCPOperationsHubTests.swift
@@ -44,6 +44,11 @@ struct MCPOperationsHubTests {
         #expect(plan.missingSecretEnvironmentKeys == ["MISSING_TOKEN"])
         #expect(plan.redactedCommandLine?.contains("secret-token") == false)
         #expect(plan.pasteboardText.contains("secret-value") == false)
+        #expect(!plan.pasteboardText.contains("/custom/bin"))
+        #expect(!plan.pasteboardText.contains("/Projects"))
+        #expect(!plan.pasteboardText.contains("server-filesystem"))
+        #expect(!plan.pasteboardText.contains("npx"))
+        #expect(plan.pasteboardText.contains("PATH entries searched: 1"))
     }
 
     @Test func duplicateHeaderAndEnvRowsNormalizeWithoutTrap() {

--- a/Packages/OsaurusCore/Views/MCP/MCPConfigurationImportSheet.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPConfigurationImportSheet.swift
@@ -1,0 +1,340 @@
+//
+//  MCPConfigurationImportSheet.swift
+//  OsaurusCore
+//
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct MCPConfigurationImportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let onApply: (MCPImportedServerConfiguration) -> Void
+
+    @State private var jsonText = ""
+    @State private var servers: [MCPImportedServerConfiguration] = []
+    @State private var selectedServerID: String?
+    @State private var errorMessage: String?
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    sourceSection
+                    if let errorMessage {
+                        errorBanner(errorMessage)
+                    }
+                    if !servers.isEmpty {
+                        previewSection
+                    }
+                }
+                .padding(20)
+            }
+            footer
+        }
+        .frame(width: 560, height: 620)
+        .background(theme.primaryBackground)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "square.and.arrow.down")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(theme.accentColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Import MCP Configuration", bundle: .module)
+                    .font(.system(size: 16, weight: .semibold))
+                Text("Review a server before adding it", bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+            }
+            Spacer()
+            Button { dismiss() } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.plain)
+            .localizedHelp("Close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(theme.secondaryBackground)
+    }
+
+    private var sourceSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("MCP JSON", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                Spacer()
+                Button(action: chooseFile) {
+                    Label {
+                        Text("Choose JSON", bundle: .module)
+                    } icon: {
+                        Image(systemName: "folder")
+                    }
+                }
+                .buttonStyle(.borderless)
+            }
+
+            TextEditor(text: $jsonText)
+                .font(.system(size: 11, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .frame(minHeight: 118, maxHeight: 150)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(theme.tertiaryBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(theme.primaryBorder, lineWidth: 1)
+                        )
+                )
+
+            HStack {
+                Spacer()
+                Button("Preview", action: parseText)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(jsonText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var previewSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if servers.count > 1 {
+                Picker("Server", selection: selectedServerBinding) {
+                    ForEach(servers) { server in
+                        Text(server.name).tag(server.id)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
+            ForEach($servers) { $server in
+                if server.id == selectedServerID {
+                    serverPreview($server)
+                }
+            }
+        }
+    }
+
+    private func serverPreview(
+        _ server: Binding<MCPImportedServerConfiguration>
+    ) -> some View {
+        let value = server.wrappedValue
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(value.name)
+                        .font(.system(size: 14, weight: .semibold))
+                    Text(value.transport == .stdio ? "Stdio" : (value.streamingEnabled ? "HTTP / SSE" : "HTTP"))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                }
+                Spacer()
+                Button {
+                    copyReporterSummary(value.reporterSafeSummary)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .buttonStyle(.plain)
+                .localizedHelp("Copy import summary")
+                if value.referencesHostPaths {
+                    Label {
+                        Text("Host paths", bundle: .module)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                    }
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.orange)
+                }
+            }
+
+            if value.transport == .stdio {
+                previewValue("Command", value: value.command)
+                if !value.args.isEmpty {
+                    previewValue("Arguments", value: ShellArgs.join(value.args))
+                }
+                if let workingDirectory = value.workingDirectory {
+                    previewValue("Working Directory", value: workingDirectory)
+                }
+                fieldClassification(title: "Environment", fields: server.environment)
+            } else {
+                previewValue(
+                    "URL",
+                    value: MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(value.url)
+                )
+                fieldClassification(title: "Headers", fields: server.headers)
+            }
+
+            ForEach(value.warnings, id: \.self) { warning in
+                HStack(alignment: .top, spacing: 7) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text(warning)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.primaryBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func previewValue(_ title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+            Text(value)
+                .font(.system(size: 11, design: .monospaced))
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func fieldClassification(
+        title: String,
+        fields: Binding<[MCPImportedConfigurationField]>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if !fields.wrappedValue.isEmpty {
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                ForEach(fields) { $field in
+                    HStack {
+                        Text(field.key)
+                            .font(.system(size: 11, design: .monospaced))
+                        Spacer()
+                        Toggle("Secret", isOn: $field.isSecret)
+                            .toggleStyle(.checkbox)
+                            .font(.system(size: 10))
+                    }
+                }
+            }
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "xmark.octagon.fill")
+                .foregroundColor(theme.errorColor)
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.errorColor.opacity(0.08))
+    }
+
+    private var footer: some View {
+        HStack {
+            Button(
+                action: { dismiss() },
+                label: { Text("Cancel", bundle: .module) }
+            )
+                .buttonStyle(.borderless)
+            Spacer()
+            Button {
+                guard let server = selectedServer else { return }
+                onApply(server)
+                dismiss()
+            } label: {
+                Text("Use Configuration", bundle: .module)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(selectedServer == nil)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .background(theme.secondaryBackground)
+    }
+
+    private var selectedServer: MCPImportedServerConfiguration? {
+        servers.first { $0.id == selectedServerID }
+    }
+
+    private var selectedServerBinding: Binding<String> {
+        Binding(
+            get: { selectedServerID ?? servers.first?.id ?? "" },
+            set: { selectedServerID = $0 }
+        )
+    }
+
+    private func parseText() {
+        parse(Data(jsonText.utf8))
+    }
+
+    private func chooseFile() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        do {
+            let values = try url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            guard values.isRegularFile == true else {
+                throw MCPConfigurationImportFailure(
+                    reason: .invalidField,
+                    message: "Choose a regular JSON file."
+                )
+            }
+            guard let fileSize = values.fileSize,
+                fileSize <= MCPConfigurationImportService.maximumBytes
+            else {
+                throw MCPConfigurationImportFailure(
+                    reason: .oversized,
+                    message: "The MCP configuration is larger than 256 KB."
+                )
+            }
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            let data = try handle.read(
+                upToCount: MCPConfigurationImportService.maximumBytes + 1
+            ) ?? Data()
+            jsonText = String(data: data, encoding: .utf8) ?? ""
+            parse(data)
+        } catch {
+            servers = []
+            selectedServerID = nil
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "The file could not be read."
+        }
+    }
+
+    private func parse(_ data: Data) {
+        do {
+            let parsed = try MCPConfigurationImportService.parse(data)
+            servers = parsed
+            selectedServerID = parsed.first?.id
+            errorMessage = nil
+        } catch {
+            servers = []
+            selectedServerID = nil
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? "The MCP configuration could not be imported."
+        }
+    }
+
+    private func copyReporterSummary(_ summary: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(summary, forType: .string)
+    }
+}

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -1,0 +1,1306 @@
+//
+//  MCPOperationsHubView.swift
+//  osaurus
+//
+//  Self-contained operations surface for local stdio and HTTP MCP providers.
+//
+
+import AppKit
+import SwiftUI
+
+struct MCPOperationsHubView: View {
+    @Environment(\.theme) private var theme
+    @ObservedObject private var manager = MCPProviderManager.shared
+
+    @State private var filter: MCPServerHubFilter = .all
+    @State private var operationsSnapshot: MCPProviderOperationsSnapshot = MCPProviderOperationsHub.emptySnapshot()
+    @State private var snapshotRefreshTask: Task<Void, Never>?
+    @State private var selectedProviderId: UUID?
+    @State private var editingProvider: MCPProvider?
+    @State private var showingAddSheet = false
+    @State private var probingProviderIds: Set<UUID> = []
+    @State private var reconnectingProviderIds: Set<UUID> = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            if operationsSnapshot.reports.isEmpty {
+                emptyState
+            } else {
+                HStack(spacing: 0) {
+                    providerList
+                        .frame(minWidth: 340, idealWidth: 380, maxWidth: 460)
+                    Divider()
+                    detailPane
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+        .background(theme.primaryBackground)
+        .onAppear {
+            refreshAll(selectFirstIfNeeded: true)
+        }
+        .onDisappear {
+            snapshotRefreshTask?.cancel()
+            snapshotRefreshTask = nil
+        }
+        .onReceive(manager.$configuration) { _ in
+            refreshAll(reconcileSelection: true)
+        }
+        .onReceive(manager.$providerStates) { _ in
+            refreshAll(reconcileSelection: true)
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: Foundation.Notification.Name.mcpProviderHealthSnapshotChanged)
+        ) { _ in
+            Task { @MainActor in
+                refreshAll(reconcileSelection: true)
+            }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: Foundation.Notification.Name.mcpProviderCallHistoryChanged)
+        ) { _ in
+            Task { @MainActor in
+                refreshAll(reconcileSelection: true)
+            }
+        }
+        .sheet(isPresented: $showingAddSheet) {
+            MCPOperationsProviderEditor(provider: nil) { provider, tokenEdit in
+                manager.addProvider(provider, token: tokenEdit.tokenForNewProvider)
+                refreshAll()
+            }
+            .environment(\.theme, theme)
+        }
+        .sheet(item: $editingProvider) { provider in
+            MCPOperationsProviderEditor(provider: provider) { updatedProvider, tokenEdit in
+                manager.updateProvider(updatedProvider, tokenEdit: tokenEdit)
+                refreshAll()
+            }
+            .environment(\.theme, theme)
+        }
+    }
+
+    private var visibleReports: [MCPProviderOperationsReport] {
+        operationsSnapshot.filtered(by: filter)
+    }
+
+    private var selectedReport: MCPProviderOperationsReport? {
+        let reports = visibleReports
+        if let selectedProviderId, let match = reports.first(where: { $0.id == selectedProviderId }) {
+            return match
+        }
+        return reports.first
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "server.rack")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(theme.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(theme.accentColor.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("MCP Operations", bundle: .module)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(headerSubtitle)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Picker("", selection: $filter) {
+                ForEach(MCPServerHubFilter.allCases, id: \.self) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 420)
+
+            iconButton("doc.on.doc", help: "Copy diagnostics") {
+                copyToPasteboard(operationsSnapshot.pasteboardText)
+            }
+
+            Button {
+                showingAddSheet = true
+            } label: {
+                Label {
+                    Text("Add", bundle: .module)
+                } icon: {
+                    Image(systemName: "plus")
+                }
+                .font(.system(size: 13, weight: .semibold))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.white)
+            .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 14)
+        .background(theme.secondaryBackground)
+        .overlay(Rectangle().fill(theme.primaryBorder).frame(height: 1), alignment: .bottom)
+    }
+
+    private var headerSubtitle: String {
+        let hub = operationsSnapshot.hubSnapshot
+        if hub.totalCount == 0 {
+            return L("Add HTTP/SSE or stdio MCP providers")
+        }
+        return L("\(hub.connectedCount)/\(hub.totalCount) connected - \(hub.attentionCount) attention - \(hub.toolCount) tools")
+    }
+
+    private var providerList: some View {
+        VStack(spacing: 0) {
+            metrics
+                .padding(14)
+            Divider()
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(visibleReports) { report in
+                        providerRow(report)
+                    }
+                }
+                .padding(12)
+            }
+        }
+        .background(theme.primaryBackground)
+    }
+
+    private var metrics: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 92), spacing: 8)], spacing: 8) {
+            metric("Connected", "\(operationsSnapshot.hubSnapshot.connectedCount)", theme.successColor)
+            metric("Attention", "\(operationsSnapshot.hubSnapshot.attentionCount)", theme.warningColor)
+            metric("Tools", "\(operationsSnapshot.hubSnapshot.toolCount)", theme.accentColor)
+            metric("Stdio", "\(operationsSnapshot.hubSnapshot.stdioCount)", theme.infoColor)
+        }
+    }
+
+    private func metric(_ title: String, _ value: String, _ color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .foregroundColor(color)
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(RoundedRectangle(cornerRadius: 8).fill(color.opacity(0.10)))
+    }
+
+    private func providerRow(_ report: MCPProviderOperationsReport) -> some View {
+        let isSelected = selectedReport?.id == report.id
+        return Button {
+            selectedProviderId = report.id
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: iconName(for: report))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(statusColor(for: report))
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(statusColor(for: report).opacity(0.12)))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(report.provider.name)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                            .lineLimit(1)
+                        transportBadge(report.provider)
+                    }
+                    Text(rowSubtitle(report))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if report.hubReport.hasAttention {
+                        Text(report.hubReport.summary)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.secondaryText)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? theme.accentColor.opacity(0.10) : theme.cardBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(isSelected ? theme.accentColor.opacity(0.35) : theme.cardBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if let report = selectedReport {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    detailHeader(report)
+                    launchPlanCard(report.launchPlan)
+                    authCard(report.authStatus)
+                    healthCard(report)
+                    diagnosticsCard(report)
+                    callHistoryCard(report)
+                }
+                .padding(22)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            emptyState
+        }
+    }
+
+    private func detailHeader(_ report: MCPProviderOperationsReport) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: iconName(for: report))
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(statusColor(for: report))
+                    .frame(width: 42, height: 42)
+                    .background(Circle().fill(statusColor(for: report).opacity(0.12)))
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Text(report.provider.name)
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                        statusBadge(report.status)
+                        transportBadge(report.provider)
+                    }
+                    Text(rowSubtitle(report))
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+
+                Spacer(minLength: 12)
+
+                iconButton("doc.on.doc", help: "Copy provider diagnostics") {
+                    copyToPasteboard(report.pasteboardText)
+                }
+            }
+
+            HStack(spacing: 8) {
+                actionButton("antenna.radiowaves.left.and.right", title: "Test", busy: probingProviderIds.contains(report.id)) {
+                    probe(report.provider)
+                }
+                actionButton("arrow.clockwise", title: "Reconnect", busy: reconnectingProviderIds.contains(report.id)) {
+                    reconnect(report.provider)
+                }
+                actionButton("pencil", title: "Edit", busy: false) {
+                    editingProvider = report.provider
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 8).fill(theme.cardBackground))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.cardBorder, lineWidth: 1))
+    }
+
+    private func launchPlanCard(_ plan: MCPProviderLaunchPlan) -> some View {
+        operationsCard(title: "Launch Resolution", icon: "terminal") {
+            VStack(alignment: .leading, spacing: 10) {
+                keyValueRow("Status", plan.status.rawValue)
+                keyValueRow("Plan", plan.title)
+                keyValueRow("Detail", plan.detail)
+                if let command = plan.redactedCommandLine {
+                    keyValueRow("Command", command, monospaced: true)
+                }
+                if let resolved = plan.resolvedExecutablePath {
+                    keyValueRow("Executable", resolved, monospaced: true)
+                }
+                if let cwd = plan.workingDirectory {
+                    keyValueRow("Working directory", cwd, monospaced: true)
+                }
+                if !plan.configuredEnvironmentKeys.isEmpty {
+                    keyValueRow("Environment", plan.configuredEnvironmentKeys.joined(separator: ", "))
+                }
+                if !plan.missingSecretEnvironmentKeys.isEmpty {
+                    keyValueRow("Missing secrets", plan.missingSecretEnvironmentKeys.joined(separator: ", "))
+                }
+                ForEach(plan.warnings, id: \.self) { warning in
+                    warningRow(warning)
+                }
+            }
+        }
+    }
+
+    private func authCard(_ status: MCPProviderAuthStatus) -> some View {
+        operationsCard(title: "Authentication", icon: "person.badge.key") {
+            VStack(alignment: .leading, spacing: 10) {
+                keyValueRow("State", status.title)
+                keyValueRow("Detail", status.detail)
+                if let action = status.action {
+                    warningRow(action)
+                }
+            }
+        }
+    }
+
+    private func healthCard(_ report: MCPProviderOperationsReport) -> some View {
+        operationsCard(title: "Health Snapshot", icon: "waveform.path.ecg") {
+            if let snapshot = report.hubReport.healthSnapshot {
+                VStack(alignment: .leading, spacing: 10) {
+                    keyValueRow("Reason", snapshot.lastProbe.reasonCode.rawValue)
+                    keyValueRow("Stage", snapshot.lastProbe.stage.rawValue)
+                    keyValueRow("Tools", "\(snapshot.lastProbe.toolCount)")
+                    keyValueRow("Message", snapshot.lastProbe.redactedMessage)
+                    if let action = snapshot.lastProbe.redactedAction {
+                        warningRow(action)
+                    }
+                }
+            } else {
+                Text("No probe has been recorded for this provider.", bundle: .module)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+            }
+        }
+    }
+
+    private func diagnosticsCard(_ report: MCPProviderOperationsReport) -> some View {
+        operationsCard(title: "Redacted Diagnostics", icon: "stethoscope") {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(report.diagnostics.rows) { row in
+                    HStack(alignment: .top, spacing: 8) {
+                        Circle()
+                            .fill(color(for: row.severity))
+                            .frame(width: 7, height: 7)
+                            .padding(.top, 5)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("\(row.title): \(row.value)")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(theme.primaryText)
+                            if let detail = row.detail, !detail.isEmpty {
+                                Text(detail)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(theme.secondaryText)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            if let action = row.action, !action.isEmpty {
+                                Text(action)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(theme.accentColor)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func callHistoryCard(_ report: MCPProviderOperationsReport) -> some View {
+        operationsCard(title: "Call History", icon: "clock.arrow.circlepath") {
+            if report.callHistory.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No MCP tool calls have been recorded for this provider.", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(report.callHistory.prefix(20)) { call in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 8) {
+                                Text(call.toolName)
+                                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                    .foregroundColor(theme.primaryText)
+                                statusBadge(call.succeeded ? .connected : .needsAttention)
+                                Text("\(call.durationMilliseconds)ms")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(theme.tertiaryText)
+                                Spacer()
+                                Text(call.startedAt.formatted(date: .omitted, time: .shortened))
+                                    .font(.system(size: 11))
+                                    .foregroundColor(theme.tertiaryText)
+                            }
+                            Text(call.argumentSummary)
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.secondaryText)
+                            if let error = call.errorMessage, !error.isEmpty {
+                                Text(error)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(theme.errorColor)
+                            }
+                        }
+                        .padding(10)
+                        .background(RoundedRectangle(cornerRadius: 7).fill(theme.tertiaryBackground))
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "server.rack")
+                .font(.system(size: 38, weight: .light))
+                .foregroundColor(theme.tertiaryText)
+            Text("No MCP providers", bundle: .module)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+            Text("Add an HTTP/SSE endpoint or a local stdio command to start managing MCP operations.", bundle: .module)
+                .font(.system(size: 13))
+                .foregroundColor(theme.secondaryText)
+                .multilineTextAlignment(.center)
+            Button {
+                showingAddSheet = true
+            } label: {
+                Label {
+                    Text("Add Provider", bundle: .module)
+                } icon: {
+                    Image(systemName: "plus")
+                }
+                .font(.system(size: 13, weight: .semibold))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.white)
+            .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(40)
+    }
+
+    private func operationsCard<Content: View>(
+        title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+            }
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(theme.cardBackground))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.cardBorder, lineWidth: 1))
+    }
+
+    private func keyValueRow(_ key: String, _ value: String, monospaced: Bool = false) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(LocalizedStringKey(key), bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: 120, alignment: .leading)
+            Text(value)
+                .font(.system(size: 11, design: monospaced ? .monospaced : .default))
+                .foregroundColor(theme.secondaryText)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func warningRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundColor(theme.warningColor)
+                .padding(.top, 2)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 7).fill(theme.warningColor.opacity(0.10)))
+    }
+
+    private func actionButton(
+        _ systemName: String,
+        title: String,
+        busy: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if busy {
+                    ProgressView().scaleEffect(0.6).frame(width: 13, height: 13)
+                } else {
+                    Image(systemName: systemName)
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(theme.secondaryText)
+        .background(RoundedRectangle(cornerRadius: 7).fill(theme.tertiaryBackground))
+        .disabled(busy)
+        .localizedHelp(LocalizedStringKey(title))
+    }
+
+    private func iconButton(_ systemName: String, help: LocalizedStringKey, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 13, weight: .semibold))
+                .frame(width: 30, height: 30)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(theme.secondaryText)
+        .background(Circle().fill(theme.tertiaryBackground))
+        .localizedHelp(help)
+    }
+
+    private func statusBadge(_ status: MCPServerHubStatus) -> some View {
+        Text(status.displayName)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(statusColor(for: status))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(statusColor(for: status).opacity(0.12)))
+    }
+
+    private func transportBadge(_ provider: MCPProvider) -> some View {
+        Text(provider.transport == .stdio ? provider.executionHost.rawValue : "http")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(provider.transport == .stdio ? theme.infoColor : theme.accentColor)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(
+                Capsule().fill((provider.transport == .stdio ? theme.infoColor : theme.accentColor).opacity(0.12))
+            )
+    }
+
+    private func rowSubtitle(_ report: MCPProviderOperationsReport) -> String {
+        switch report.provider.transport {
+        case .http:
+            return report.provider.url
+        case .stdio:
+            return report.launchPlan.redactedCommandLine ?? L("stdio command not set")
+        }
+    }
+
+    private func iconName(for report: MCPProviderOperationsReport) -> String {
+        switch report.status {
+        case .connected:
+            return "checkmark.seal.fill"
+        case .connecting:
+            return "arrow.triangle.2.circlepath"
+        case .needsAttention:
+            return "exclamationmark.triangle.fill"
+        case .disabled:
+            return "pause.circle.fill"
+        case .idle:
+            return "server.rack"
+        }
+    }
+
+    private func statusColor(for report: MCPProviderOperationsReport) -> Color {
+        statusColor(for: report.status)
+    }
+
+    private func statusColor(for status: MCPServerHubStatus) -> Color {
+        switch status {
+        case .connected:
+            return theme.successColor
+        case .connecting:
+            return theme.accentColor
+        case .needsAttention:
+            return theme.warningColor
+        case .disabled:
+            return theme.tertiaryText
+        case .idle:
+            return theme.infoColor
+        }
+    }
+
+    private func color(for severity: ProviderDiagnosticSeverity) -> Color {
+        switch severity {
+        case .ok:
+            return theme.successColor
+        case .info:
+            return theme.infoColor
+        case .warning:
+            return theme.warningColor
+        case .blocked:
+            return theme.errorColor
+        }
+    }
+
+    private func refreshAll(
+        selectFirstIfNeeded: Bool = false,
+        reconcileSelection: Bool = false
+    ) {
+        let providers = manager.configuration.providers
+        let states = manager.providerStates
+
+        snapshotRefreshTask?.cancel()
+        snapshotRefreshTask = Task {
+            let snapshot = await Task.detached(priority: .utility) {
+                let proxy = GlobalProxySettings.currentDiagnostic()
+                let healthSnapshots = MCPProviderHealthSnapshotStore.load()
+                let callHistory = MCPProviderCallHistoryStore.load()
+                let credentials = MCPProviderOperationsHub.credentialPresence(for: providers)
+                return MCPProviderOperationsHub.snapshot(
+                    providers: providers,
+                    states: states,
+                    proxy: proxy,
+                    credentialsByProvider: credentials,
+                    healthSnapshots: healthSnapshots,
+                    callHistoryByProvider: callHistory
+                )
+            }.value
+
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                operationsSnapshot = snapshot
+                if selectFirstIfNeeded || reconcileSelection, selectedProviderId == nil {
+                    selectedProviderId = snapshot.reports.first?.id
+                }
+                if reconcileSelection,
+                    let selectedProviderId,
+                    !snapshot.reports.contains(where: { $0.id == selectedProviderId }) {
+                    self.selectedProviderId = snapshot.reports.first?.id
+                }
+            }
+        }
+    }
+
+    private func probe(_ provider: MCPProvider) {
+        guard !probingProviderIds.contains(provider.id) else { return }
+        probingProviderIds.insert(provider.id)
+        Task {
+            let result: MCPProviderProbeResult
+            switch provider.transport {
+            case .http:
+                let credentials = await Task.detached(priority: .utility) {
+                    let token: String? =
+                        switch provider.authType {
+                        case .bearerToken:
+                            MCPProviderKeychain.getToken(for: provider.id)
+                        case .oauth:
+                            MCPProviderKeychain.getOAuthTokens(for: provider.id)?.accessToken
+                        case .none:
+                            nil
+                        }
+                    return (token, provider.resolvedHeaders())
+                }.value
+                result = await MCPProviderProbeService.probeHTTP(
+                    providerId: provider.id,
+                    name: provider.name,
+                    url: provider.url,
+                    token: credentials.0,
+                    headers: credentials.1,
+                    streamingEnabled: provider.streamingEnabled,
+                    discoveryTimeout: provider.discoveryTimeout
+                )
+            case .stdio:
+                result = await MCPProviderProbeService.probeStdio(provider: provider)
+            }
+            MCPProviderHealthSnapshotStore.record(result, for: provider)
+            await MainActor.run {
+                probingProviderIds.remove(provider.id)
+                refreshAll(reconcileSelection: true)
+            }
+        }
+    }
+
+    private func reconnect(_ provider: MCPProvider) {
+        guard provider.enabled, !reconnectingProviderIds.contains(provider.id) else { return }
+        reconnectingProviderIds.insert(provider.id)
+        Task {
+            do {
+                try await manager.reconnect(providerId: provider.id)
+            } catch {
+                // The provider state carries the row error.
+            }
+            await MainActor.run {
+                reconnectingProviderIds.remove(provider.id)
+                refreshAll()
+            }
+        }
+    }
+
+    private func copyToPasteboard(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+}
+
+private struct MCPOperationsProviderEditor: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    let provider: MCPProvider?
+    let onSave: (MCPProvider, MCPProviderBearerTokenEdit) -> Void
+
+    @State private var draftId = UUID()
+    @State private var name = ""
+    @State private var transport: MCPProviderTransport = .http
+    @State private var url = ""
+    @State private var authType: MCPProviderAuthType = .bearerToken
+    @State private var token = ""
+    @State private var clearBearerToken = false
+    @State private var enabled = true
+    @State private var autoConnect = true
+    @State private var streamingEnabled = false
+    @State private var discoveryTimeout = 20.0
+    @State private var toolCallTimeout = 45.0
+    @State private var executionHost: MCPProviderExecutionHost = .sandbox
+    @State private var command = ""
+    @State private var argsString = ""
+    @State private var workingDirectory = ""
+    @State private var headerEntries: [KeyValueEntry] = []
+    @State private var envEntries: [KeyValueEntry] = []
+    @State private var isTesting = false
+    @State private var probeResult: MCPProviderProbeResult?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: provider == nil ? "plus.circle.fill" : "pencil.circle.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(provider == nil ? "Add MCP Provider" : "Edit MCP Provider", bundle: .module)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text("Configure HTTP/SSE or local stdio MCP operations", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                }
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.secondaryText)
+                .background(Circle().fill(theme.tertiaryBackground))
+            }
+            .padding(18)
+            .background(theme.secondaryBackground)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    editorCard("Connection", icon: "link") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            labeledTextField("Name", text: $name, placeholder: "Filesystem MCP")
+
+                            Picker("", selection: $transport) {
+                                Text("HTTP/SSE", bundle: .module).tag(MCPProviderTransport.http)
+                                Text("Stdio", bundle: .module).tag(MCPProviderTransport.stdio)
+                            }
+                            .pickerStyle(.segmented)
+
+                            Toggle("Enabled", isOn: $enabled)
+                                .toggleStyle(.switch)
+                            Toggle("Auto-connect", isOn: $autoConnect)
+                                .toggleStyle(.switch)
+                        }
+                    }
+
+                    if transport == .http {
+                        httpFields
+                    } else {
+                        stdioFields
+                    }
+
+                    advancedFields
+
+                    if let probeResult {
+                        probeCard(probeResult)
+                    }
+                }
+                .padding(18)
+            }
+
+            HStack(spacing: 10) {
+                Button { testProvider() } label: {
+                    HStack(spacing: 6) {
+                        if isTesting {
+                            ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
+                        } else {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        Text("Test", bundle: .module)
+                    }
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.secondaryText)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(theme.tertiaryBackground))
+                .disabled(isTesting || !canTest)
+
+                Spacer()
+
+                Button("Cancel", role: .cancel) { dismiss() }
+                    .buttonStyle(.plain)
+                    .foregroundColor(theme.secondaryText)
+                Button {
+                    save()
+                } label: {
+                    Text(provider == nil ? "Add Provider" : "Save", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSave)
+            }
+            .padding(18)
+            .background(theme.secondaryBackground)
+        }
+        .frame(width: 560, height: 680)
+        .background(theme.primaryBackground)
+        .onAppear(perform: load)
+    }
+
+    private var httpFields: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            editorCard("HTTP", icon: "network") {
+                VStack(alignment: .leading, spacing: 12) {
+                    labeledTextField("URL", text: $url, placeholder: "https://mcp.example.com/mcp", monospaced: true)
+                    Picker("", selection: $authType) {
+                        Text("None", bundle: .module).tag(MCPProviderAuthType.none)
+                        Text("Bearer", bundle: .module).tag(MCPProviderAuthType.bearerToken)
+                        Text("OAuth", bundle: .module).tag(MCPProviderAuthType.oauth)
+                    }
+                    .pickerStyle(.segmented)
+                    if authType == .bearerToken {
+                        secureTextField("Bearer Token", text: $token, placeholder: "Stored in Keychain")
+                        if provider != nil {
+                            Toggle("Clear saved token", isOn: $clearBearerToken)
+                                .font(.system(size: 11))
+                                .toggleStyle(.checkbox)
+                                .foregroundColor(theme.secondaryText)
+                                .disabled(!token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
+                    }
+                    Toggle("Streaming/SSE", isOn: $streamingEnabled)
+                        .toggleStyle(.switch)
+                }
+            }
+            keyValueEditor(
+                title: "Custom Headers",
+                icon: "list.bullet.rectangle",
+                addLabel: "Add Header",
+                entries: $headerEntries
+            )
+        }
+    }
+
+    private var stdioFields: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            editorCard("Stdio", icon: "terminal") {
+                VStack(alignment: .leading, spacing: 12) {
+                    Picker("", selection: $executionHost) {
+                        Text("Sandbox", bundle: .module).tag(MCPProviderExecutionHost.sandbox)
+                        Text("Host", bundle: .module).tag(MCPProviderExecutionHost.host)
+                    }
+                    .pickerStyle(.segmented)
+                    labeledTextField("Command", text: $command, placeholder: "npx", monospaced: true)
+                    labeledTextField("Arguments", text: $argsString, placeholder: "-y @modelcontextprotocol/server-filesystem", monospaced: true)
+                    labeledTextField("Working directory", text: $workingDirectory, placeholder: "Optional", monospaced: true)
+                }
+            }
+            keyValueEditor(
+                title: "Environment",
+                icon: "wand.and.stars",
+                addLabel: "Add Variable",
+                entries: $envEntries
+            )
+        }
+    }
+
+    private var advancedFields: some View {
+        editorCard("Timeouts", icon: "clock") {
+            VStack(alignment: .leading, spacing: 12) {
+                timeoutSlider("Discovery", value: $discoveryTimeout, range: 5...120)
+                timeoutSlider("Tool call", value: $toolCallTimeout, range: 5...300)
+            }
+        }
+    }
+
+    private func timeoutSlider(_ label: String, value: Binding<Double>, range: ClosedRange<Double>) -> some View {
+        HStack(spacing: 12) {
+            Text(LocalizedStringKey(label), bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+                .frame(width: 90, alignment: .leading)
+            Slider(value: value, in: range, step: 1)
+            Text("\(Int(value.wrappedValue))s")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: 44, alignment: .trailing)
+        }
+    }
+
+    private func editorCard<Content: View>(
+        _ title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+            }
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(theme.cardBackground))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.cardBorder, lineWidth: 1))
+    }
+
+    private func labeledTextField(
+        _ label: String,
+        text: Binding<String>,
+        placeholder: String,
+        monospaced: Bool = false
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(LocalizedStringKey(label), bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: monospaced ? .monospaced : .default))
+                .foregroundColor(theme.primaryText)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .background(
+                    RoundedRectangle(cornerRadius: 7)
+                        .fill(theme.inputBackground)
+                        .overlay(RoundedRectangle(cornerRadius: 7).stroke(theme.inputBorder, lineWidth: 1))
+                )
+        }
+    }
+
+    private func secureTextField(_ label: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(LocalizedStringKey(label), bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+            SecureField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(theme.primaryText)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .background(
+                    RoundedRectangle(cornerRadius: 7)
+                        .fill(theme.inputBackground)
+                        .overlay(RoundedRectangle(cornerRadius: 7).stroke(theme.inputBorder, lineWidth: 1))
+                )
+        }
+    }
+
+    private func keyValueEditor(
+        title: String,
+        icon: String,
+        addLabel: String,
+        entries: Binding<[KeyValueEntry]>
+    ) -> some View {
+        editorCard(title, icon: icon) {
+            VStack(spacing: 10) {
+                ForEach(entries.wrappedValue) { entry in
+                    if let index = entries.wrappedValue.firstIndex(where: { $0.id == entry.id }) {
+                        HStack(spacing: 8) {
+                            TextField("KEY", text: entries[index].key)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(size: 11, design: .monospaced))
+                            if entries[index].isSecret.wrappedValue {
+                                SecureField("Value", text: entries[index].value)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 11, design: .monospaced))
+                            } else {
+                                TextField("Value", text: entries[index].value)
+                                    .textFieldStyle(.roundedBorder)
+                                    .font(.system(size: 11, design: .monospaced))
+                            }
+                            Toggle("Secret", isOn: entries[index].isSecret)
+                                .font(.system(size: 11))
+                                .toggleStyle(.checkbox)
+                            Button {
+                                entries.wrappedValue.removeAll { $0.id == entry.id }
+                            } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundColor(theme.errorColor)
+                        }
+                    }
+                }
+                Button {
+                    entries.wrappedValue.append(KeyValueEntry(key: "", value: "", isSecret: false))
+                } label: {
+                    Label(LocalizedStringKey(addLabel), systemImage: "plus.circle")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func probeCard(_ result: MCPProviderProbeResult) -> some View {
+        editorCard(result.succeeded ? "Probe Passed" : "Probe Failed", icon: result.succeeded ? "checkmark.seal" : "exclamationmark.triangle") {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("\(result.reasonCode.rawValue) / \(result.stage.rawValue)")
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundColor(result.succeeded ? theme.successColor : theme.errorColor)
+                Text(result.redactedMessage)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+                if let action = result.redactedAction {
+                    Text(action)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                }
+            }
+        }
+    }
+
+    private var canTest: Bool {
+        switch transport {
+        case .http:
+            return !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .stdio:
+            return !command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && canTest
+    }
+
+    private func load() {
+        guard let provider else { return }
+        draftId = provider.id
+        name = provider.name
+        transport = provider.transport
+        url = provider.url
+        authType = provider.authType
+        clearBearerToken = false
+        enabled = provider.enabled
+        autoConnect = provider.autoConnect
+        streamingEnabled = provider.streamingEnabled
+        discoveryTimeout = provider.discoveryTimeout
+        toolCallTimeout = provider.toolCallTimeout
+        executionHost = provider.executionHost
+        command = provider.command
+        argsString = ShellArgs.join(provider.args)
+        workingDirectory = provider.workingDirectory ?? ""
+        headerEntries = provider.customHeaders.map { KeyValueEntry(key: $0.key, value: $0.value, isSecret: false) }
+            + provider.secretHeaderKeys.map { KeyValueEntry(key: $0, value: "", isSecret: true) }
+        envEntries = provider.env.map { KeyValueEntry(key: $0.key, value: $0.value, isSecret: false) }
+            + provider.secretEnvKeys.map { KeyValueEntry(key: $0, value: "", isSecret: true) }
+    }
+
+    private func save() {
+        let provider = makeProvider()
+        saveSecrets(for: provider)
+        onSave(
+            provider,
+            MCPProviderBearerTokenEdit.fromBearerField(
+                token,
+                authType: provider.authType,
+                clearRequested: clearBearerToken
+            )
+        )
+        dismiss()
+    }
+
+    private func testProvider() {
+        guard canTest else { return }
+        isTesting = true
+        let provider = makeProvider()
+        Task {
+            let result: MCPProviderProbeResult
+            switch provider.transport {
+            case .http:
+                result = await MCPProviderProbeService.probeHTTP(
+                    providerId: provider.id,
+                    name: provider.name,
+                    url: provider.url,
+                    token: bearerTokenForProbe(provider: provider),
+                    headers: headersForProbe(provider: provider),
+                    streamingEnabled: provider.streamingEnabled,
+                    discoveryTimeout: provider.discoveryTimeout
+                )
+            case .stdio:
+                result = await MCPProviderProbeService.probeStdio(provider: providerForStdioProbe(provider))
+            }
+            await MainActor.run {
+                probeResult = result
+                isTesting = false
+            }
+        }
+    }
+
+    private func makeProvider() -> MCPProvider {
+        let headers = normalizedEntries(headerEntries)
+        let envFields = normalizedEntries(envEntries)
+        return MCPProvider(
+            id: draftId,
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            url: transport == .http ? url.trimmingCharacters(in: .whitespacesAndNewlines) : "",
+            enabled: enabled,
+            customHeaders: headers.regular,
+            streamingEnabled: transport == .http && streamingEnabled,
+            discoveryTimeout: discoveryTimeout,
+            toolCallTimeout: toolCallTimeout,
+            autoConnect: autoConnect,
+            secretHeaderKeys: headers.secretKeys,
+            authType: transport == .http ? authType : .none,
+            oauth: provider?.oauth,
+            pluginId: provider?.pluginId,
+            transport: transport,
+            executionHost: executionHost,
+            command: transport == .stdio ? command.trimmingCharacters(in: .whitespacesAndNewlines) : "",
+            args: transport == .stdio ? ShellArgs.split(argsString) : [],
+            env: transport == .stdio ? envFields.regular : [:],
+            secretEnvKeys: transport == .stdio ? envFields.secretKeys : [],
+            workingDirectory: workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private func normalizedEntries(_ entries: [KeyValueEntry]) -> (regular: [String: String], secretKeys: [String]) {
+        MCPProviderOperationsFieldNormalizer.normalize(
+            entries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) }
+        )
+    }
+
+    private func saveSecrets(for provider: MCPProvider) {
+        for entry in headerEntries where entry.isSecret {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty, !entry.value.isEmpty else { continue }
+            MCPProviderKeychain.saveHeaderSecret(entry.value, key: key, for: provider.id)
+        }
+        saveEnvSecrets(for: provider)
+    }
+
+    private func saveEnvSecrets(for provider: MCPProvider) {
+        for entry in envEntries where entry.isSecret {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty, !entry.value.isEmpty else { continue }
+            MCPProviderKeychain.saveEnvSecret(entry.value, key: key, for: provider.id)
+        }
+    }
+
+    private func bearerTokenForProbe(provider: MCPProvider) -> String? {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        if clearBearerToken { return nil }
+
+        switch provider.authType {
+        case .bearerToken:
+            return self.provider?.getToken()
+        case .oauth:
+            return self.provider?.getOAuthTokens()?.accessToken
+        case .none:
+            return nil
+        }
+    }
+
+    private func headersForProbe(provider: MCPProvider) -> [String: String] {
+        var headers = provider.customHeaders
+        for entry in headerEntries where entry.isSecret {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+            if !entry.value.isEmpty {
+                headers[key] = entry.value
+            } else if let value = MCPProviderKeychain.getHeaderSecret(key: key, for: provider.id),
+                !value.isEmpty {
+                headers[key] = value
+            }
+        }
+        return headers
+    }
+
+    private func providerForStdioProbe(_ provider: MCPProvider) -> MCPProvider {
+        MCPProvider(
+            id: provider.id,
+            name: provider.name,
+            url: provider.url,
+            enabled: provider.enabled,
+            customHeaders: provider.customHeaders,
+            streamingEnabled: provider.streamingEnabled,
+            discoveryTimeout: provider.discoveryTimeout,
+            toolCallTimeout: provider.toolCallTimeout,
+            autoConnect: provider.autoConnect,
+            secretHeaderKeys: provider.secretHeaderKeys,
+            authType: provider.authType,
+            oauth: provider.oauth,
+            pluginId: provider.pluginId,
+            transport: provider.transport,
+            executionHost: provider.executionHost,
+            command: provider.command,
+            args: provider.args,
+            env: envForProbe(provider: provider),
+            secretEnvKeys: [],
+            workingDirectory: provider.workingDirectory
+        )
+    }
+
+    private func envForProbe(provider: MCPProvider) -> [String: String] {
+        var env = provider.env
+        for entry in envEntries where entry.isSecret {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+            if !entry.value.isEmpty {
+                env[key] = entry.value
+            } else if let value = MCPProviderKeychain.getEnvSecret(key: key, for: provider.id),
+                !value.isEmpty {
+                env[key] = value
+            }
+        }
+        return env
+    }
+}
+
+private struct KeyValueEntry: Identifiable, Equatable {
+    let id = UUID()
+    var key: String
+    var value: String
+    var isSecret: Bool
+}

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -720,36 +720,37 @@ struct MCPOperationsHubView: View {
 
     private func probe(_ provider: MCPProvider) {
         guard !probingProviderIds.contains(provider.id) else { return }
+        let reservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
         probingProviderIds.insert(provider.id)
         Task {
-            let result: MCPProviderProbeResult
-            switch provider.transport {
-            case .http:
-                let credentials = await Task.detached(priority: .utility) {
-                    let token: String? =
-                        switch provider.authType {
-                        case .bearerToken:
-                            MCPProviderKeychain.getToken(for: provider.id)
-                        case .oauth:
-                            MCPProviderKeychain.getOAuthTokens(for: provider.id)?.accessToken
-                        case .none:
-                            nil
+            let context = await Task.detached(priority: .utility) {
+                MCPProviderProbeContext.captureStored(provider: provider)
+            }.value
+            if !Task.isCancelled,
+                let attempt = MCPProviderHealthSnapshotStore.beginProbe(
+                    reservation,
+                    setupFingerprint: context.setupFingerprint
+                ) {
+                let result = await context.probe()
+                if !Task.isCancelled {
+                    let currentProvider = await MainActor.run {
+                        manager.configuration.provider(id: provider.id)
+                    }
+                    let currentFingerprint = await Task.detached(priority: .utility) {
+                        currentProvider.map {
+                            MCPProviderProbeContext.captureStored(provider: $0).setupFingerprint
                         }
-                    return (token, provider.resolvedHeaders())
-                }.value
-                result = await MCPProviderProbeService.probeHTTP(
-                    providerId: provider.id,
-                    name: provider.name,
-                    url: provider.url,
-                    token: credentials.0,
-                    headers: credentials.1,
-                    streamingEnabled: provider.streamingEnabled,
-                    discoveryTimeout: provider.discoveryTimeout
-                )
-            case .stdio:
-                result = await MCPProviderProbeService.probeStdio(provider: provider)
+                    }.value
+                    _ = await Task.detached(priority: .utility) {
+                        MCPProviderHealthSnapshotStore.record(
+                            result,
+                            for: context.provider,
+                            attempt: attempt,
+                            currentSetupFingerprint: currentFingerprint
+                        )
+                    }.value
+                }
             }
-            MCPProviderHealthSnapshotStore.record(result, for: provider)
             await MainActor.run {
                 probingProviderIds.remove(provider.id)
                 refreshAll(reconcileSelection: true)
@@ -809,6 +810,7 @@ private struct MCPOperationsProviderEditor: View {
     @State private var probeResult: MCPProviderProbeResult?
     @State private var probeGate = MCPProviderProbeGate()
     @State private var probeTask: Task<Void, Never>?
+    @State private var activeProbeReservation: MCPProviderProbeReservation?
     @State private var credentialSaveError: String?
 
     var body: some View {
@@ -925,6 +927,7 @@ private struct MCPOperationsProviderEditor: View {
         .onChange(of: currentProbeFingerprint) { _, _ in
             probeTask?.cancel()
             probeTask = nil
+            cancelActiveProbeReservation()
             probeGate.invalidate()
             probeResult = nil
             isTesting = false
@@ -932,6 +935,7 @@ private struct MCPOperationsProviderEditor: View {
         .onDisappear {
             probeTask?.cancel()
             probeTask = nil
+            cancelActiveProbeReservation()
             probeGate.invalidate()
             isTesting = false
         }
@@ -1211,39 +1215,82 @@ private struct MCPOperationsProviderEditor: View {
         isTesting = true
         let provider = makeProvider()
         let fingerprint = currentProbeFingerprint
-        let attempt = probeGate.start(fingerprint: fingerprint)
+        let localAttempt = probeGate.start(fingerprint: fingerprint)
+        let reservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        activeProbeReservation = reservation
+        let bearerTokenField = token
+        let clearBearerTokenRequested = clearBearerToken
+        let secretHeaderOverrides = secretValues(headerEntries)
+        let secretEnvironmentOverrides = secretValues(envEntries)
         probeTask?.cancel()
         probeTask = Task {
-            let result: MCPProviderProbeResult
-            switch provider.transport {
-            case .http:
-                result = await MCPProviderProbeService.probeHTTP(
-                    providerId: provider.id,
-                    name: provider.name,
-                    url: provider.url,
-                    token: bearerTokenForProbe(provider: provider),
-                    headers: headersForProbe(provider: provider),
-                    streamingEnabled: provider.streamingEnabled,
-                    discoveryTimeout: provider.discoveryTimeout
-                )
-            case .stdio:
-                result = await MCPProviderProbeService.probeStdio(
+            let context = await Task.detached(priority: .utility) {
+                MCPProviderProbeContext.capture(
                     provider: provider,
-                    secretEnvOverrides: secretEnvironmentValues(provider: provider)
+                    bearerTokenField: bearerTokenField,
+                    clearBearerToken: clearBearerTokenRequested,
+                    secretHeaderOverrides: secretHeaderOverrides,
+                    secretEnvironmentOverrides: secretEnvironmentOverrides
                 )
+            }.value
+            guard !Task.isCancelled,
+                let sharedAttempt = MCPProviderHealthSnapshotStore.beginProbe(
+                    reservation,
+                    setupFingerprint: context.setupFingerprint
+                )
+            else {
+                await MainActor.run {
+                    guard probeGate.isCurrent(localAttempt) else { return }
+                    if activeProbeReservation == reservation {
+                        activeProbeReservation = nil
+                    }
+                    isTesting = false
+                    probeTask = nil
+                }
+                return
             }
+
+            let result = await context.probe()
+            let localStillCurrent = await MainActor.run {
+                probeGate.isCurrent(localAttempt) && currentProbeFingerprint == fingerprint
+            }
+            guard !Task.isCancelled, localStillCurrent else { return }
+
+            let storedProvider = await MainActor.run {
+                MCPProviderManager.shared.configuration.provider(id: provider.id)
+            }
+            let storedFingerprint = await Task.detached(priority: .utility) {
+                storedProvider.map {
+                    MCPProviderProbeContext.captureStored(provider: $0).setupFingerprint
+                }
+            }.value
+            let stillCurrentAfterRecapture = await MainActor.run {
+                probeGate.isCurrent(localAttempt) && currentProbeFingerprint == fingerprint
+            }
+            guard !Task.isCancelled, stillCurrentAfterRecapture else { return }
+            _ = await Task.detached(priority: .utility) {
+                MCPProviderHealthSnapshotStore.record(
+                    result,
+                    for: context.provider,
+                    attempt: sharedAttempt,
+                    currentSetupFingerprint: storedFingerprint
+                )
+            }.value
+
             await MainActor.run {
-                let isCurrentAttempt = probeGate.isCurrent(attempt)
+                let isCurrentAttempt = probeGate.isCurrent(localAttempt)
                 let accepted = probeGate.accept(
-                    attempt,
+                    localAttempt,
                     currentFingerprint: currentProbeFingerprint,
                     succeeded: result.succeeded
                 )
                 guard isCurrentAttempt else { return }
                 isTesting = false
                 probeTask = nil
+                if activeProbeReservation == reservation {
+                    activeProbeReservation = nil
+                }
                 guard accepted else { return }
-                MCPProviderHealthSnapshotStore.record(result, for: provider)
                 probeResult = result
             }
         }
@@ -1291,7 +1338,7 @@ private struct MCPOperationsProviderEditor: View {
                 || workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil
                 : workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
+        ).scopedToActiveTransport()
     }
 
     private func normalizedEntries(_ entries: [KeyValueEntry]) -> (regular: [String: String], secretKeys: [String]) {
@@ -1314,51 +1361,6 @@ private struct MCPOperationsProviderEditor: View {
         return headerWrites + environmentWrites
     }
 
-    private func bearerTokenForProbe(provider: MCPProvider) -> String? {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty { return trimmed }
-        if clearBearerToken { return nil }
-
-        switch provider.authType {
-        case .bearerToken:
-            return self.provider?.getToken()
-        case .oauth:
-            return self.provider?.getOAuthTokens()?.accessToken
-        case .none:
-            return nil
-        }
-    }
-
-    private func headersForProbe(provider: MCPProvider) -> [String: String] {
-        var headers = provider.customHeaders
-        for entry in headerEntries where entry.isSecret {
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else { continue }
-            if !entry.value.isEmpty {
-                headers[key] = entry.value
-            } else if let value = MCPProviderKeychain.getHeaderSecret(key: key, for: provider.id),
-                !value.isEmpty {
-                headers[key] = value
-            }
-        }
-        return headers
-    }
-
-    private func secretEnvironmentValues(provider: MCPProvider) -> [String: String] {
-        var values: [String: String] = [:]
-        for entry in envEntries where entry.isSecret {
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else { continue }
-            if !entry.value.isEmpty {
-                values[key] = entry.value
-            } else if let value = MCPProviderKeychain.getEnvSecret(key: key, for: provider.id),
-                !value.isEmpty {
-                values[key] = value
-            }
-        }
-        return values
-    }
-
     private func secretValues(_ entries: [KeyValueEntry]) -> [String: String] {
         var values: [String: String] = [:]
         for entry in entries where entry.isSecret {
@@ -1367,6 +1369,12 @@ private struct MCPOperationsProviderEditor: View {
             values[key] = entry.value
         }
         return values
+    }
+
+    private func cancelActiveProbeReservation() {
+        guard let activeProbeReservation else { return }
+        MCPProviderHealthSnapshotStore.cancelProbe(activeProbeReservation)
+        self.activeProbeReservation = nil
     }
 }
 

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -809,6 +809,7 @@ private struct MCPOperationsProviderEditor: View {
     @State private var isTesting = false
     @State private var probeResult: MCPProviderProbeResult?
     @State private var probeResultFingerprint: String?
+    @State private var probeResultSetupFingerprint: String?
     @State private var probeGate = MCPProviderProbeGate()
     @State private var probeTask: Task<Void, Never>?
     @State private var activeProbeReservation: MCPProviderProbeReservation?
@@ -932,6 +933,7 @@ private struct MCPOperationsProviderEditor: View {
             probeGate.invalidate()
             probeResult = nil
             probeResultFingerprint = nil
+            probeResultSetupFingerprint = nil
             isTesting = false
         }
         .onDisappear {
@@ -1195,6 +1197,7 @@ private struct MCPOperationsProviderEditor: View {
         credentialSaveError = nil
         let provider = makeProvider()
         let verifiedProbeResult = currentProbeResult
+        let verifiedSetupFingerprint = probeResultSetupFingerprint
         guard onSave(
             provider,
             MCPProviderBearerTokenEdit.fromBearerField(
@@ -1210,8 +1213,12 @@ private struct MCPOperationsProviderEditor: View {
             )
             return
         }
-        if let verifiedProbeResult {
-            MCPProviderHealthSnapshotStore.record(verifiedProbeResult, for: provider)
+        if let verifiedProbeResult, let verifiedSetupFingerprint {
+            MCPProviderHealthSnapshotStore.restore(
+                verifiedProbeResult,
+                for: provider,
+                verifiedSetupFingerprint: verifiedSetupFingerprint
+            )
         }
         dismiss()
     }
@@ -1221,6 +1228,7 @@ private struct MCPOperationsProviderEditor: View {
         isTesting = true
         probeResult = nil
         probeResultFingerprint = nil
+        probeResultSetupFingerprint = nil
         let provider = makeProvider()
         let fingerprint = currentProbeFingerprint
         let localAttempt = probeGate.start(fingerprint: fingerprint)
@@ -1301,6 +1309,7 @@ private struct MCPOperationsProviderEditor: View {
                 guard accepted else { return }
                 probeResult = result
                 probeResultFingerprint = fingerprint
+                probeResultSetupFingerprint = context.setupFingerprint
             }
         }
     }

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -808,6 +808,7 @@ private struct MCPOperationsProviderEditor: View {
     @State private var envEntries: [KeyValueEntry] = []
     @State private var isTesting = false
     @State private var probeResult: MCPProviderProbeResult?
+    @State private var probeResultFingerprint: String?
     @State private var probeGate = MCPProviderProbeGate()
     @State private var probeTask: Task<Void, Never>?
     @State private var activeProbeReservation: MCPProviderProbeReservation?
@@ -930,6 +931,7 @@ private struct MCPOperationsProviderEditor: View {
             cancelActiveProbeReservation()
             probeGate.invalidate()
             probeResult = nil
+            probeResultFingerprint = nil
             isTesting = false
         }
         .onDisappear {
@@ -1192,6 +1194,7 @@ private struct MCPOperationsProviderEditor: View {
     private func save() {
         credentialSaveError = nil
         let provider = makeProvider()
+        let verifiedProbeResult = currentProbeResult
         guard onSave(
             provider,
             MCPProviderBearerTokenEdit.fromBearerField(
@@ -1207,12 +1210,17 @@ private struct MCPOperationsProviderEditor: View {
             )
             return
         }
+        if let verifiedProbeResult {
+            MCPProviderHealthSnapshotStore.record(verifiedProbeResult, for: provider)
+        }
         dismiss()
     }
 
     private func testProvider() {
         guard canTest else { return }
         isTesting = true
+        probeResult = nil
+        probeResultFingerprint = nil
         let provider = makeProvider()
         let fingerprint = currentProbeFingerprint
         let localAttempt = probeGate.start(fingerprint: fingerprint)
@@ -1292,6 +1300,7 @@ private struct MCPOperationsProviderEditor: View {
                 }
                 guard accepted else { return }
                 probeResult = result
+                probeResultFingerprint = fingerprint
             }
         }
     }
@@ -1309,6 +1318,11 @@ private struct MCPOperationsProviderEditor: View {
             secretHeaderValues: secretValues(headerEntries),
             secretEnvironmentValues: secretValues(envEntries)
         )
+    }
+
+    private var currentProbeResult: MCPProviderProbeResult? {
+        guard probeResultFingerprint == currentProbeFingerprint else { return nil }
+        return probeResult
     }
 
     private func makeProvider() -> MCPProvider {
@@ -1348,27 +1362,24 @@ private struct MCPOperationsProviderEditor: View {
     }
 
     private func secretWrites(for provider: MCPProvider) -> [MCPProviderSecretWrite] {
-        let headerWrites = headerEntries.compactMap { entry -> MCPProviderSecretWrite? in
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard provider.transport == .http, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
-            return MCPProviderSecretWrite(storage: .header, key: key, value: entry.value)
+        switch provider.transport {
+        case .http:
+            return MCPProviderOperationsFieldNormalizer.secretWrites(
+                headerEntries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) },
+                storage: .header
+            )
+        case .stdio:
+            return MCPProviderOperationsFieldNormalizer.secretWrites(
+                envEntries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) },
+                storage: .environment
+            )
         }
-        let environmentWrites = envEntries.compactMap { entry -> MCPProviderSecretWrite? in
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard provider.transport == .stdio, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
-            return MCPProviderSecretWrite(storage: .environment, key: key, value: entry.value)
-        }
-        return headerWrites + environmentWrites
     }
 
     private func secretValues(_ entries: [KeyValueEntry]) -> [String: String] {
-        var values: [String: String] = [:]
-        for entry in entries where entry.isSecret {
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else { continue }
-            values[key] = entry.value
-        }
-        return values
+        MCPProviderOperationsFieldNormalizer.secretOverrides(
+            entries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) }
+        )
     }
 
     private func cancelActiveProbeReservation() {

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -8,6 +8,24 @@
 import AppKit
 import SwiftUI
 
+enum MCPOperationsDisplaySanitizer {
+    static func endpoint(_ raw: String) -> String {
+        MCPProviderProbeRedactor.safeHTTPURLForDiagnostics(raw)
+    }
+
+    static func resolvedExecutable(_ path: String?) -> String? {
+        path == nil ? nil : L("Resolved")
+    }
+
+    static func workingDirectory(_ path: String?) -> String? {
+        path == nil ? nil : L("Configured")
+    }
+
+    static func warning(_ raw: String) -> String {
+        MCPProviderProbeRedactor.safeDiagnosticFragment(raw)
+    }
+}
+
 struct MCPOperationsHubView: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var manager = MCPProviderManager.shared
@@ -336,10 +354,10 @@ struct MCPOperationsHubView: View {
                 if let command = plan.redactedCommandLine {
                     keyValueRow("Command", command, monospaced: true)
                 }
-                if let resolved = plan.resolvedExecutablePath {
+                if let resolved = MCPOperationsDisplaySanitizer.resolvedExecutable(plan.resolvedExecutablePath) {
                     keyValueRow("Executable", resolved, monospaced: true)
                 }
-                if let cwd = plan.workingDirectory {
+                if let cwd = MCPOperationsDisplaySanitizer.workingDirectory(plan.workingDirectory) {
                     keyValueRow("Working directory", cwd, monospaced: true)
                 }
                 if !plan.configuredEnvironmentKeys.isEmpty {
@@ -348,8 +366,8 @@ struct MCPOperationsHubView: View {
                 if !plan.missingSecretEnvironmentKeys.isEmpty {
                     keyValueRow("Missing secrets", plan.missingSecretEnvironmentKeys.joined(separator: ", "))
                 }
-                ForEach(plan.warnings, id: \.self) { warning in
-                    warningRow(warning)
+                ForEach(Array(plan.warnings.enumerated()), id: \.offset) { _, warning in
+                    warningRow(MCPOperationsDisplaySanitizer.warning(warning))
                 }
             }
         }
@@ -608,7 +626,7 @@ struct MCPOperationsHubView: View {
     private func rowSubtitle(_ report: MCPProviderOperationsReport) -> String {
         switch report.provider.transport {
         case .http:
-            return report.provider.url
+            return MCPOperationsDisplaySanitizer.endpoint(report.provider.url)
         case .stdio:
             return report.launchPlan.redactedCommandLine ?? L("stdio command not set")
         }
@@ -1215,15 +1233,18 @@ private struct MCPOperationsProviderEditor: View {
                 )
             }
             await MainActor.run {
-                guard probeGate.accept(
+                let isCurrentAttempt = probeGate.isCurrent(attempt)
+                let accepted = probeGate.accept(
                     attempt,
                     currentFingerprint: currentProbeFingerprint,
                     succeeded: result.succeeded
-                ) else { return }
-                MCPProviderHealthSnapshotStore.record(result, for: provider)
-                probeResult = result
+                )
+                guard isCurrentAttempt else { return }
                 isTesting = false
                 probeTask = nil
+                guard accepted else { return }
+                MCPProviderHealthSnapshotStore.record(result, for: provider)
+                probeResult = result
             }
         }
     }

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -789,6 +789,8 @@ private struct MCPOperationsProviderEditor: View {
     @State private var envEntries: [KeyValueEntry] = []
     @State private var isTesting = false
     @State private var probeResult: MCPProviderProbeResult?
+    @State private var probeGate = MCPProviderProbeGate()
+    @State private var probeTask: Task<Void, Never>?
     @State private var credentialSaveError: String?
 
     var body: some View {
@@ -902,6 +904,19 @@ private struct MCPOperationsProviderEditor: View {
         .frame(width: 560, height: 680)
         .background(theme.primaryBackground)
         .onAppear(perform: load)
+        .onChange(of: currentProbeFingerprint) { _, _ in
+            probeTask?.cancel()
+            probeTask = nil
+            probeGate.invalidate()
+            probeResult = nil
+            isTesting = false
+        }
+        .onDisappear {
+            probeTask?.cancel()
+            probeTask = nil
+            probeGate.invalidate()
+            isTesting = false
+        }
     }
 
     private var httpFields: some View {
@@ -1177,7 +1192,10 @@ private struct MCPOperationsProviderEditor: View {
         guard canTest else { return }
         isTesting = true
         let provider = makeProvider()
-        Task {
+        let fingerprint = currentProbeFingerprint
+        let attempt = probeGate.start(fingerprint: fingerprint)
+        probeTask?.cancel()
+        probeTask = Task {
             let result: MCPProviderProbeResult
             switch provider.transport {
             case .http:
@@ -1197,10 +1215,32 @@ private struct MCPOperationsProviderEditor: View {
                 )
             }
             await MainActor.run {
+                guard probeGate.accept(
+                    attempt,
+                    currentFingerprint: currentProbeFingerprint,
+                    succeeded: result.succeeded
+                ) else { return }
+                MCPProviderHealthSnapshotStore.record(result, for: provider)
                 probeResult = result
                 isTesting = false
+                probeTask = nil
             }
         }
+    }
+
+    private var currentProbeFingerprint: String {
+        let provider = makeProvider()
+        return MCPProviderSetupFingerprint.make(
+            provider: provider,
+            bearerToken: provider.authType == .bearerToken
+                ? MCPProviderBearerProbeInput.fingerprint(
+                    fieldValue: token,
+                    clearRequested: clearBearerToken
+                )
+                : nil,
+            secretHeaderValues: secretValues(headerEntries),
+            secretEnvironmentValues: secretValues(envEntries)
+        )
     }
 
     private func makeProvider() -> MCPProvider {
@@ -1294,6 +1334,16 @@ private struct MCPOperationsProviderEditor: View {
                 !value.isEmpty {
                 values[key] = value
             }
+        }
+        return values
+    }
+
+    private func secretValues(_ entries: [KeyValueEntry]) -> [String: String] {
+        var values: [String: String] = [:]
+        for entry in entries where entry.isSecret {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+            values[key] = entry.value
         }
         return values
     }

--- a/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
+++ b/Packages/OsaurusCore/Views/MCP/MCPOperationsHubView.swift
@@ -66,16 +66,26 @@ struct MCPOperationsHubView: View {
             }
         }
         .sheet(isPresented: $showingAddSheet) {
-            MCPOperationsProviderEditor(provider: nil) { provider, tokenEdit in
-                manager.addProvider(provider, token: tokenEdit.tokenForNewProvider)
-                refreshAll()
+            MCPOperationsProviderEditor(provider: nil) { provider, tokenEdit, secretWrites in
+                let saved = manager.addProvider(
+                    provider,
+                    token: tokenEdit.tokenForNewProvider,
+                    secretWrites: secretWrites
+                )
+                if saved { refreshAll() }
+                return saved
             }
             .environment(\.theme, theme)
         }
         .sheet(item: $editingProvider) { provider in
-            MCPOperationsProviderEditor(provider: provider) { updatedProvider, tokenEdit in
-                manager.updateProvider(updatedProvider, tokenEdit: tokenEdit)
-                refreshAll()
+            MCPOperationsProviderEditor(provider: provider) { updatedProvider, tokenEdit, secretWrites in
+                let saved = manager.updateProvider(
+                    updatedProvider,
+                    tokenEdit: tokenEdit,
+                    secretWrites: secretWrites
+                )
+                if saved { refreshAll() }
+                return saved
             }
             .environment(\.theme, theme)
         }
@@ -757,7 +767,7 @@ private struct MCPOperationsProviderEditor: View {
     @Environment(\.dismiss) private var dismiss
 
     let provider: MCPProvider?
-    let onSave: (MCPProvider, MCPProviderBearerTokenEdit) -> Void
+    let onSave: (MCPProvider, MCPProviderBearerTokenEdit, [MCPProviderSecretWrite]) -> Bool
 
     @State private var draftId = UUID()
     @State private var name = ""
@@ -779,6 +789,7 @@ private struct MCPOperationsProviderEditor: View {
     @State private var envEntries: [KeyValueEntry] = []
     @State private var isTesting = false
     @State private var probeResult: MCPProviderProbeResult?
+    @State private var credentialSaveError: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -841,7 +852,13 @@ private struct MCPOperationsProviderEditor: View {
                 .padding(18)
             }
 
-            HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 8) {
+                if let credentialSaveError {
+                    Label(credentialSaveError, systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.errorColor)
+                }
+                HStack(spacing: 10) {
                 Button { testProvider() } label: {
                     HStack(spacing: 6) {
                         if isTesting {
@@ -877,6 +894,7 @@ private struct MCPOperationsProviderEditor: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSave)
+                }
             }
             .padding(18)
             .background(theme.secondaryBackground)
@@ -1135,16 +1153,23 @@ private struct MCPOperationsProviderEditor: View {
     }
 
     private func save() {
+        credentialSaveError = nil
         let provider = makeProvider()
-        saveSecrets(for: provider)
-        onSave(
+        guard onSave(
             provider,
             MCPProviderBearerTokenEdit.fromBearerField(
                 token,
                 authType: provider.authType,
                 clearRequested: clearBearerToken
+            ),
+            secretWrites(for: provider)
+        ) else {
+            credentialSaveError = String(
+                localized: "Credentials could not be saved to Keychain. Check Keychain access and try again.",
+                bundle: .module
             )
-        )
+            return
+        }
         dismiss()
     }
 
@@ -1166,7 +1191,10 @@ private struct MCPOperationsProviderEditor: View {
                     discoveryTimeout: provider.discoveryTimeout
                 )
             case .stdio:
-                result = await MCPProviderProbeService.probeStdio(provider: providerForStdioProbe(provider))
+                result = await MCPProviderProbeService.probeStdio(
+                    provider: provider,
+                    secretEnvOverrides: secretEnvironmentValues(provider: provider)
+                )
             }
             await MainActor.run {
                 probeResult = result
@@ -1188,9 +1216,9 @@ private struct MCPOperationsProviderEditor: View {
             discoveryTimeout: discoveryTimeout,
             toolCallTimeout: toolCallTimeout,
             autoConnect: autoConnect,
-            secretHeaderKeys: headers.secretKeys,
+            secretHeaderKeys: transport == .http ? headers.secretKeys : [],
             authType: transport == .http ? authType : .none,
-            oauth: provider?.oauth,
+            oauth: transport == .http ? provider?.oauth : nil,
             pluginId: provider?.pluginId,
             transport: transport,
             executionHost: executionHost,
@@ -1198,7 +1226,8 @@ private struct MCPOperationsProviderEditor: View {
             args: transport == .stdio ? ShellArgs.split(argsString) : [],
             env: transport == .stdio ? envFields.regular : [:],
             secretEnvKeys: transport == .stdio ? envFields.secretKeys : [],
-            workingDirectory: workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            workingDirectory: transport == .http
+                || workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil
                 : workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         )
@@ -1210,21 +1239,18 @@ private struct MCPOperationsProviderEditor: View {
         )
     }
 
-    private func saveSecrets(for provider: MCPProvider) {
-        for entry in headerEntries where entry.isSecret {
+    private func secretWrites(for provider: MCPProvider) -> [MCPProviderSecretWrite] {
+        let headerWrites = headerEntries.compactMap { entry -> MCPProviderSecretWrite? in
             let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty, !entry.value.isEmpty else { continue }
-            MCPProviderKeychain.saveHeaderSecret(entry.value, key: key, for: provider.id)
+            guard provider.transport == .http, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
+            return MCPProviderSecretWrite(storage: .header, key: key, value: entry.value)
         }
-        saveEnvSecrets(for: provider)
-    }
-
-    private func saveEnvSecrets(for provider: MCPProvider) {
-        for entry in envEntries where entry.isSecret {
+        let environmentWrites = envEntries.compactMap { entry -> MCPProviderSecretWrite? in
             let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty, !entry.value.isEmpty else { continue }
-            MCPProviderKeychain.saveEnvSecret(entry.value, key: key, for: provider.id)
+            guard provider.transport == .stdio, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
+            return MCPProviderSecretWrite(storage: .environment, key: key, value: entry.value)
         }
+        return headerWrites + environmentWrites
     }
 
     private func bearerTokenForProbe(provider: MCPProvider) -> String? {
@@ -1257,44 +1283,19 @@ private struct MCPOperationsProviderEditor: View {
         return headers
     }
 
-    private func providerForStdioProbe(_ provider: MCPProvider) -> MCPProvider {
-        MCPProvider(
-            id: provider.id,
-            name: provider.name,
-            url: provider.url,
-            enabled: provider.enabled,
-            customHeaders: provider.customHeaders,
-            streamingEnabled: provider.streamingEnabled,
-            discoveryTimeout: provider.discoveryTimeout,
-            toolCallTimeout: provider.toolCallTimeout,
-            autoConnect: provider.autoConnect,
-            secretHeaderKeys: provider.secretHeaderKeys,
-            authType: provider.authType,
-            oauth: provider.oauth,
-            pluginId: provider.pluginId,
-            transport: provider.transport,
-            executionHost: provider.executionHost,
-            command: provider.command,
-            args: provider.args,
-            env: envForProbe(provider: provider),
-            secretEnvKeys: [],
-            workingDirectory: provider.workingDirectory
-        )
-    }
-
-    private func envForProbe(provider: MCPProvider) -> [String: String] {
-        var env = provider.env
+    private func secretEnvironmentValues(provider: MCPProvider) -> [String: String] {
+        var values: [String: String] = [:]
         for entry in envEntries where entry.isSecret {
             let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !key.isEmpty else { continue }
             if !entry.value.isEmpty {
-                env[key] = entry.value
+                values[key] = entry.value
             } else if let value = MCPProviderKeychain.getEnvSecret(key: key, for: provider.id),
                 !value.isEmpty {
-                env[key] = value
+                values[key] = value
             }
         }
-        return env
+        return values
     }
 }
 

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -1665,18 +1665,35 @@ private struct ProviderEditSheet: View {
         transition(to: .chooseProvider)
     }
 
-    /// Reset the draft to a blank slate. Used when transitioning between phases
-    /// so a previous selection's name / url / OAuth state doesn't leak through.
-    /// Token state is dropped from Keychain via `resetDraftOAuthState`. Manual
-    /// OAuth override fields are also wiped so a half-typed Client ID /
-    /// Client Secret from one template doesn't bleed into the next.
+    /// Reset every connection-specific draft field before moving between
+    /// catalog choices. Imported configurations can contain credentials and
+    /// host-execution settings, so a partial reset would let a discarded
+    /// import bleed into the next provider.
     private func clearDraft(authType: MCPProviderAuthType, name: String = "", url: String = "") {
+        probeGate.invalidate()
         self.name = name
         self.url = url
         self.authType = authType
+        transport = .http
+        executionHost = .sandbox
+        command = ""
+        argsString = ""
+        workingDirectory = ""
+        envEntries.removeAll()
+        streamingEnabled = false
+        discoveryTimeout = 20
+        toolCallTimeout = 45
+        autoConnect = true
         clearBearerToken = false
         customHeaders.removeAll()
+        isTesting = false
         testResult = nil
+        testResultFingerprint = nil
+        importedSetupRequiresProbe = false
+        credentialSaveError = nil
+        showAdvanced = false
+        showImportConfiguration = false
+        isSigningIn = false
         manualAuthEndpoint = ""
         manualTokenEndpoint = ""
         manualClientId = ""

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -1281,6 +1281,7 @@ private struct ProviderEditSheet: View {
     @State private var testResult: TestResult?
     @State private var testResultFingerprint: String?
     @State private var probeGate = MCPProviderProbeGate()
+    @State private var probeTask: Task<Void, Never>?
     @State private var importedSetupRequiresProbe = false
     @State private var showImportConfiguration = false
     @State private var showAdvanced: Bool = false
@@ -1380,6 +1381,12 @@ private struct ProviderEditSheet: View {
                 .stroke(themeManager.currentTheme.primaryBorder, lineWidth: 1)
         )
         .onAppear { loadProvider() }
+        .onDisappear {
+            probeTask?.cancel()
+            probeTask = nil
+            probeGate.invalidate()
+            isTesting = false
+        }
         .sheet(isPresented: $showImportConfiguration) {
             MCPConfigurationImportSheet { imported in
                 applyImportedConfiguration(imported)
@@ -1387,6 +1394,10 @@ private struct ProviderEditSheet: View {
         }
         .onChange(of: currentProbeFingerprint) { _, fingerprint in
             guard testResultFingerprint != fingerprint else { return }
+            probeTask?.cancel()
+            probeTask = nil
+            probeGate.invalidate()
+            isTesting = false
             testResult = nil
             testResultFingerprint = nil
         }
@@ -1670,6 +1681,8 @@ private struct ProviderEditSheet: View {
     /// host-execution settings, so a partial reset would let a discarded
     /// import bleed into the next provider.
     private func clearDraft(authType: MCPProviderAuthType, name: String = "", url: String = "") {
+        probeTask?.cancel()
+        probeTask = nil
         probeGate.invalidate()
         self.name = name
         self.url = url
@@ -3051,6 +3064,8 @@ private struct ProviderEditSheet: View {
     }
 
     private func applyImportedConfiguration(_ imported: MCPImportedServerConfiguration) {
+        probeTask?.cancel()
+        probeTask = nil
         name = imported.name
         transport = imported.transport
         url = imported.url
@@ -3084,7 +3099,8 @@ private struct ProviderEditSheet: View {
         testResult = nil
         testResultFingerprint = nil
 
-        Task {
+        probeTask?.cancel()
+        probeTask = Task {
             let result: MCPProviderProbeResult
             switch context.provider.transport {
             case .http:
@@ -3118,6 +3134,7 @@ private struct ProviderEditSheet: View {
                 testResult = result.succeeded ? .success(result) : .failure(result)
                 testResultFingerprint = context.fingerprint
                 isTesting = false
+                probeTask = nil
             }
         }
     }
@@ -3188,6 +3205,8 @@ private struct ProviderEditSheet: View {
             id: effectiveProviderId,
             name: name.isEmpty ? "Stdio test" : name,
             url: "",
+            discoveryTimeout: discoveryTimeout,
+            toolCallTimeout: toolCallTimeout,
             authType: .none,
             transport: .stdio,
             executionHost: executionHost,

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -21,6 +21,7 @@ struct ProvidersView: View {
     @State private var reconnectingAll = false
     @State private var probingAll = false
     @State private var probingProviderIds: Set<UUID> = []
+    @State private var showOperationsHub = false
 
     var body: some View {
         ScrollView {
@@ -114,20 +115,27 @@ struct ProvidersView: View {
                 for: Foundation.Notification.Name.mcpProviderHealthSnapshotChanged
             )
         ) { _ in
-            refreshHealthSnapshots()
+            Task { @MainActor in
+                refreshHealthSnapshots()
+            }
         }
         .sheet(isPresented: $showAddSheet) {
-            ProviderEditSheet(provider: nil) { provider, token in
-                manager.addProvider(provider, token: token)
+            ProviderEditSheet(provider: nil) { provider, tokenEdit in
+                manager.addProvider(provider, token: tokenEdit.tokenForNewProvider)
                 refreshCredentialPresence()
             }
         }
         .sheet(item: $editingProvider) { provider in
-            ProviderEditSheet(provider: provider) { updatedProvider, token in
-                manager.updateProvider(updatedProvider, token: token)
+            ProviderEditSheet(provider: provider) { updatedProvider, tokenEdit in
+                manager.updateProvider(updatedProvider, tokenEdit: tokenEdit)
                 refreshCredentialPresence()
                 refreshHealthSnapshots()
             }
+        }
+        .sheet(isPresented: $showOperationsHub) {
+            MCPOperationsHubView()
+                .environment(\.theme, theme)
+                .frame(width: 980, height: 720)
         }
     }
 
@@ -292,22 +300,46 @@ struct ProvidersView: View {
             title: "Connections",
             description: "Connect services that give your agents more tools, using MCP (Model Context Protocol)"
         ) {
-            Button(action: { showAddSheet = true }) {
-                HStack(spacing: 6) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .semibold))
-                    Text("Add Connection", bundle: .module)
-                        .font(.system(size: 13, weight: .semibold))
-                }
-                .foregroundColor(.white)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(theme.accentColor)
-                )
+            HStack(spacing: 8) {
+                Button(action: { showOperationsHub = true }, label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "slider.horizontal.3")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text("Operations", bundle: .module)
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .foregroundColor(theme.primaryText)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.tertiaryBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+                })
+                .buttonStyle(PlainButtonStyle())
+                .localizedHelp("Open MCP operations hub")
+
+                Button(action: { showAddSheet = true }, label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text("Add Connection", bundle: .module)
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(theme.accentColor)
+                    )
+                })
+                .buttonStyle(PlainButtonStyle())
             }
-            .buttonStyle(PlainButtonStyle())
         }
     }
 
@@ -1209,7 +1241,7 @@ private struct ProviderEditSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let provider: MCPProvider?
-    let onSave: (MCPProvider, String?) -> Void
+    let onSave: (MCPProvider, MCPProviderBearerTokenEdit) -> Void
 
     /// Stable identity for "draft" providers (sheet not yet saved). Reused so OAuth
     /// tokens persisted to Keychain mid-flow stay tied to the provider once saved.
@@ -1218,6 +1250,7 @@ private struct ProviderEditSheet: View {
     @State private var name: String = ""
     @State private var url: String = ""
     @State private var token: String = ""
+    @State private var clearBearerToken: Bool = false
     @State private var customHeaders: [HeaderEntry] = []
     @State private var streamingEnabled: Bool = false
     @State private var discoveryTimeout: Double = 20
@@ -1601,6 +1634,7 @@ private struct ProviderEditSheet: View {
         self.name = name
         self.url = url
         self.authType = authType
+        clearBearerToken = false
         customHeaders.removeAll()
         testResult = nil
         manualAuthEndpoint = ""
@@ -2203,6 +2237,14 @@ private struct ProviderEditSheet: View {
                                 placeholder: "Optional - stored securely in Keychain",
                                 text: $token
                             )
+                            if isEditing {
+                                MCPToggleRow(
+                                    title: "Clear saved token",
+                                    description: "Remove the Keychain token on save",
+                                    isOn: $clearBearerToken
+                                )
+                                .disabled(!token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                            }
                         case .oauth:
                             oauthSection
                         }
@@ -2854,6 +2896,7 @@ private struct ProviderEditSheet: View {
         draftId = provider.id
         name = provider.name
         url = provider.url
+        clearBearerToken = false
         streamingEnabled = provider.streamingEnabled
         discoveryTimeout = provider.discoveryTimeout
         toolCallTimeout = provider.toolCallTimeout
@@ -3093,11 +3136,12 @@ private struct ProviderEditSheet: View {
             MCPProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: updatedProvider.id)
         }
 
-        // Pass token (empty string means no change, nil means keep existing).
-        // For OAuth this is unused (tokens went through MCPOAuthService directly).
-        let tokenToSave: String? = (authType == .bearerToken && !token.isEmpty) ? token : nil
-
-        onSave(updatedProvider, tokenToSave)
+        let tokenEdit = MCPProviderBearerTokenEdit.fromBearerField(
+            token,
+            authType: authType,
+            clearRequested: clearBearerToken
+        )
+        onSave(updatedProvider, tokenEdit)
         dismiss()
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -3283,26 +3283,14 @@ private struct ProviderEditSheet: View {
     }
 
     private func secretHeaderValues() -> [String: String] {
-        Dictionary(
-            customHeaders
-                .compactMap { entry -> (String, String)? in
-                    let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
-                    return (key, entry.value)
-                },
-            uniquingKeysWith: { _, latest in latest }
+        MCPProviderOperationsFieldNormalizer.secretOverrides(
+            customHeaders.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) }
         )
     }
 
     private func secretEnvironmentValues() -> [String: String] {
-        Dictionary(
-            envEntries
-                .compactMap { entry -> (String, String)? in
-                    let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
-                    return (key, entry.value)
-                },
-            uniquingKeysWith: { _, latest in latest }
+        MCPProviderOperationsFieldNormalizer.secretOverrides(
+            envEntries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) }
         )
     }
 
@@ -3319,17 +3307,28 @@ private struct ProviderEditSheet: View {
             return
         }
         let updatedProvider = makeProvider()
+        let verifiedProbeResult: MCPProviderProbeResult?
+        switch currentTestResult {
+        case .success(let result), .failure(let result):
+            verifiedProbeResult = result
+        case nil:
+            verifiedProbeResult = nil
+        }
 
         // Blank values preserve existing Keychain entries. Explicit values
         // are committed atomically with bearer-token intent by the manager.
-        let secretWrites = envEntries.compactMap { entry -> MCPProviderSecretWrite? in
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard transport == .stdio, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
-            return MCPProviderSecretWrite(storage: .environment, key: key, value: entry.value)
-        } + customHeaders.compactMap { header -> MCPProviderSecretWrite? in
-            let key = header.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard transport == .http, header.isSecret, !key.isEmpty, !header.value.isEmpty else { return nil }
-            return MCPProviderSecretWrite(storage: .header, key: key, value: header.value)
+        let secretWrites: [MCPProviderSecretWrite]
+        switch transport {
+        case .http:
+            secretWrites = MCPProviderOperationsFieldNormalizer.secretWrites(
+                customHeaders.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) },
+                storage: .header
+            )
+        case .stdio:
+            secretWrites = MCPProviderOperationsFieldNormalizer.secretWrites(
+                envEntries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) },
+                storage: .environment
+            )
         }
         let tokenEdit = MCPProviderBearerTokenEdit.fromBearerField(
             token,
@@ -3342,6 +3341,9 @@ private struct ProviderEditSheet: View {
                 bundle: .module
             )
             return
+        }
+        if let verifiedProbeResult {
+            MCPProviderHealthSnapshotStore.record(verifiedProbeResult, for: updatedProvider)
         }
         dismiss()
     }

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -1286,6 +1286,7 @@ private struct ProviderEditSheet: View {
     @State private var isTesting: Bool = false
     @State private var testResult: TestResult?
     @State private var testResultFingerprint: String?
+    @State private var testResultSetupFingerprint: String?
     @State private var probeGate = MCPProviderProbeGate()
     @State private var probeTask: Task<Void, Never>?
     @State private var activeProbeReservation: MCPProviderProbeReservation?
@@ -1409,6 +1410,7 @@ private struct ProviderEditSheet: View {
             isTesting = false
             testResult = nil
             testResultFingerprint = nil
+            testResultSetupFingerprint = nil
         }
     }
 
@@ -1712,6 +1714,7 @@ private struct ProviderEditSheet: View {
         isTesting = false
         testResult = nil
         testResultFingerprint = nil
+        testResultSetupFingerprint = nil
         importedSetupRequiresProbe = false
         credentialSaveError = nil
         showAdvanced = false
@@ -3097,6 +3100,7 @@ private struct ProviderEditSheet: View {
         }
         testResult = nil
         testResultFingerprint = nil
+        testResultSetupFingerprint = nil
         probeGate.invalidate()
         isTesting = false
         importedSetupRequiresProbe = true
@@ -3116,6 +3120,7 @@ private struct ProviderEditSheet: View {
         isTesting = true
         testResult = nil
         testResultFingerprint = nil
+        testResultSetupFingerprint = nil
 
         probeTask?.cancel()
         probeTask = Task {
@@ -3188,6 +3193,7 @@ private struct ProviderEditSheet: View {
                 guard accepted else { return }
                 testResult = result.succeeded ? .success(result) : .failure(result)
                 testResultFingerprint = fingerprint
+                testResultSetupFingerprint = context.setupFingerprint
             }
         }
     }
@@ -3206,27 +3212,17 @@ private struct ProviderEditSheet: View {
     }
 
     private func parseStdioFields() -> ParsedStdioFields {
-        var regularEnv: [String: String] = [:]
-        var secretEnvKeys: [String] = []
-        for entry in envEntries {
-            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else { continue }
-            if entry.isSecret {
-                secretEnvKeys.append(key)
-            } else if !entry.value.isEmpty {
-                // Skip empty regular env vars — persisting `KEY=""`
-                // would silently shadow whatever the subprocess
-                // inherits from its environment, which is almost
-                // never what the user intended.
-                regularEnv[key] = entry.value
-            }
-        }
+        // Use the same last-row-wins contract as probing and credential
+        // persistence so a duplicate key cannot remain both plain and secret.
+        let normalizedEnvironment = MCPProviderOperationsFieldNormalizer.normalize(
+            envEntries.map { (key: $0.key, value: $0.value, isSecret: $0.isSecret) }
+        )
         let trimmedCwd = workingDirectory.trimmingCharacters(in: .whitespaces)
         return ParsedStdioFields(
             command: command.trimmingCharacters(in: .whitespaces),
             args: ShellArgs.split(argsString),
-            env: regularEnv,
-            secretEnvKeys: secretEnvKeys,
+            env: normalizedEnvironment.regular,
+            secretEnvKeys: normalizedEnvironment.secretKeys,
             workingDirectory: trimmedCwd.isEmpty ? nil : trimmedCwd
         )
     }
@@ -3314,6 +3310,7 @@ private struct ProviderEditSheet: View {
         case nil:
             verifiedProbeResult = nil
         }
+        let verifiedSetupFingerprint = testResultSetupFingerprint
 
         // Blank values preserve existing Keychain entries. Explicit values
         // are committed atomically with bearer-token intent by the manager.
@@ -3342,8 +3339,12 @@ private struct ProviderEditSheet: View {
             )
             return
         }
-        if let verifiedProbeResult {
-            MCPProviderHealthSnapshotStore.record(verifiedProbeResult, for: updatedProvider)
+        if let verifiedProbeResult, let verifiedSetupFingerprint {
+            MCPProviderHealthSnapshotStore.restore(
+                verifiedProbeResult,
+                for: updatedProvider,
+                verifiedSetupFingerprint: verifiedSetupFingerprint
+            )
         }
         dismiss()
     }

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -239,12 +239,17 @@ struct ProvidersView: View {
     private func probeEnabledProviders() {
         let targets = manager.configuration.providers.filter(\.enabled)
         guard !targets.isEmpty else { return }
+        let requests = targets.map {
+            (
+                provider: $0,
+                reservation: MCPProviderHealthSnapshotStore.reserveProbe(providerId: $0.id)
+            )
+        }
         probingAll = true
         probingProviderIds.formUnion(targets.map(\.id))
         Task {
-            for provider in targets {
-                let result = await probeResult(for: provider)
-                MCPProviderHealthSnapshotStore.record(result, for: provider)
+            for request in requests {
+                await runProbe(provider: request.provider, reservation: request.reservation)
             }
             await MainActor.run {
                 refreshHealthSnapshots()
@@ -256,10 +261,10 @@ struct ProvidersView: View {
 
     private func probeProvider(_ provider: MCPProvider) {
         guard !probingProviderIds.contains(provider.id) else { return }
+        let reservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
         probingProviderIds.insert(provider.id)
         Task {
-            let result = await probeResult(for: provider)
-            MCPProviderHealthSnapshotStore.record(result, for: provider)
+            await runProbe(provider: provider, reservation: reservation)
             await MainActor.run {
                 refreshHealthSnapshots()
                 _ = probingProviderIds.remove(provider.id)
@@ -267,36 +272,37 @@ struct ProvidersView: View {
         }
     }
 
-    private func probeResult(for provider: MCPProvider) async -> MCPProviderProbeResult {
-        switch provider.transport {
-        case .http:
-            let credentials = await Task.detached(priority: .utility) {
-                let token: String? =
-                    switch provider.authType {
-                    case .bearerToken:
-                        MCPProviderKeychain.getToken(for: provider.id)
-                    case .oauth:
-                        MCPProviderKeychain.getOAuthTokens(for: provider.id)?.accessToken
-                    case .none:
-                        nil
-                    }
-                return (
-                    token,
-                    provider.resolvedHeaders()
-                )
-            }.value
-            return await MCPProviderProbeService.probeHTTP(
-                providerId: provider.id,
-                name: provider.name,
-                url: provider.url,
-                token: credentials.0,
-                headers: credentials.1,
-                streamingEnabled: provider.streamingEnabled,
-                discoveryTimeout: provider.discoveryTimeout
+    @MainActor
+    private func runProbe(
+        provider: MCPProvider,
+        reservation: MCPProviderProbeReservation
+    ) async {
+        let context = await Task.detached(priority: .utility) {
+            MCPProviderProbeContext.captureStored(provider: provider)
+        }.value
+        guard !Task.isCancelled,
+            let attempt = MCPProviderHealthSnapshotStore.beginProbe(
+                reservation,
+                setupFingerprint: context.setupFingerprint
             )
-        case .stdio:
-            return await MCPProviderProbeService.probeStdio(provider: provider)
-        }
+        else { return }
+
+        let result = await context.probe()
+        guard !Task.isCancelled else { return }
+        let currentProvider = manager.configuration.provider(id: provider.id)
+        let currentFingerprint = await Task.detached(priority: .utility) {
+            currentProvider.map {
+                MCPProviderProbeContext.captureStored(provider: $0).setupFingerprint
+            }
+        }.value
+        _ = await Task.detached(priority: .utility) {
+            MCPProviderHealthSnapshotStore.record(
+                result,
+                for: context.provider,
+                attempt: attempt,
+                currentSetupFingerprint: currentFingerprint
+            )
+        }.value
     }
 
     private func copyHubReport() {
@@ -1282,6 +1288,7 @@ private struct ProviderEditSheet: View {
     @State private var testResultFingerprint: String?
     @State private var probeGate = MCPProviderProbeGate()
     @State private var probeTask: Task<Void, Never>?
+    @State private var activeProbeReservation: MCPProviderProbeReservation?
     @State private var importedSetupRequiresProbe = false
     @State private var showImportConfiguration = false
     @State private var showAdvanced: Bool = false
@@ -1384,6 +1391,7 @@ private struct ProviderEditSheet: View {
         .onDisappear {
             probeTask?.cancel()
             probeTask = nil
+            cancelActiveProbeReservation()
             probeGate.invalidate()
             isTesting = false
         }
@@ -1396,6 +1404,7 @@ private struct ProviderEditSheet: View {
             guard testResultFingerprint != fingerprint else { return }
             probeTask?.cancel()
             probeTask = nil
+            cancelActiveProbeReservation()
             probeGate.invalidate()
             isTesting = false
             testResult = nil
@@ -1683,6 +1692,7 @@ private struct ProviderEditSheet: View {
     private func clearDraft(authType: MCPProviderAuthType, name: String = "", url: String = "") {
         probeTask?.cancel()
         probeTask = nil
+        cancelActiveProbeReservation()
         probeGate.invalidate()
         self.name = name
         self.url = url
@@ -3066,6 +3076,7 @@ private struct ProviderEditSheet: View {
     private func applyImportedConfiguration(_ imported: MCPImportedServerConfiguration) {
         probeTask?.cancel()
         probeTask = nil
+        cancelActiveProbeReservation()
         name = imported.name
         transport = imported.transport
         url = imported.url
@@ -3093,67 +3104,91 @@ private struct ProviderEditSheet: View {
     }
 
     private func testConnection() {
-        let context = makeProbeContext()
-        let attempt = probeGate.start(fingerprint: context.fingerprint)
+        let provider = makeProvider()
+        let fingerprint = currentProbeFingerprint
+        let localAttempt = probeGate.start(fingerprint: fingerprint)
+        let reservation = MCPProviderHealthSnapshotStore.reserveProbe(providerId: provider.id)
+        activeProbeReservation = reservation
+        let bearerTokenField = token
+        let clearBearerTokenRequested = clearBearerToken
+        let secretHeaderOverrides = secretHeaderValues()
+        let secretEnvironmentOverrides = secretEnvironmentValues()
         isTesting = true
         testResult = nil
         testResultFingerprint = nil
 
         probeTask?.cancel()
         probeTask = Task {
-            let result: MCPProviderProbeResult
-            switch context.provider.transport {
-            case .http:
-                result = await MCPProviderProbeService.probeHTTP(
-                    providerId: context.provider.id,
-                    name: context.provider.name,
-                    url: context.provider.url,
-                    token: context.httpToken,
-                    headers: context.httpHeaders,
-                    streamingEnabled: context.provider.streamingEnabled,
-                    discoveryTimeout: context.provider.discoveryTimeout
+            let context = await Task.detached(priority: .utility) {
+                MCPProviderProbeContext.capture(
+                    provider: provider,
+                    bearerTokenField: bearerTokenField,
+                    clearBearerToken: clearBearerTokenRequested,
+                    secretHeaderOverrides: secretHeaderOverrides,
+                    secretEnvironmentOverrides: secretEnvironmentOverrides
                 )
-            case .stdio:
-                result = await MCPProviderProbeService.probeStdio(
-                    provider: context.provider,
-                    secretEnvOverrides: context.secretEnvironmentValues
+            }.value
+            guard !Task.isCancelled,
+                let sharedAttempt = MCPProviderHealthSnapshotStore.beginProbe(
+                    reservation,
+                    setupFingerprint: context.setupFingerprint
                 )
+            else {
+                await MainActor.run {
+                    guard probeGate.isCurrent(localAttempt) else { return }
+                    if activeProbeReservation == reservation {
+                        activeProbeReservation = nil
+                    }
+                    isTesting = false
+                    probeTask = nil
+                }
+                return
             }
+
+            let result = await context.probe()
+            let localStillCurrent = await MainActor.run {
+                probeGate.isCurrent(localAttempt) && currentProbeFingerprint == fingerprint
+            }
+            guard !Task.isCancelled, localStillCurrent else { return }
+
+            let storedProvider = await MainActor.run {
+                MCPProviderManager.shared.configuration.provider(id: provider.id)
+            }
+            let storedFingerprint = await Task.detached(priority: .utility) {
+                storedProvider.map {
+                    MCPProviderProbeContext.captureStored(provider: $0).setupFingerprint
+                }
+            }.value
+            let stillCurrentAfterRecapture = await MainActor.run {
+                probeGate.isCurrent(localAttempt) && currentProbeFingerprint == fingerprint
+            }
+            guard !Task.isCancelled, stillCurrentAfterRecapture else { return }
+            _ = await Task.detached(priority: .utility) {
+                MCPProviderHealthSnapshotStore.record(
+                    result,
+                    for: context.provider,
+                    attempt: sharedAttempt,
+                    currentSetupFingerprint: storedFingerprint
+                )
+            }.value
 
             await MainActor.run {
-                guard attempt.generation == probeGate.generation else { return }
-                guard probeGate.accept(
-                    attempt,
+                let isCurrentAttempt = probeGate.isCurrent(localAttempt)
+                let accepted = probeGate.accept(
+                    localAttempt,
                     currentFingerprint: currentProbeFingerprint,
                     succeeded: result.succeeded
-                ) else {
-                    isTesting = false
-                    return
-                }
-                MCPProviderHealthSnapshotStore.record(result, for: context.provider)
-                testResult = result.succeeded ? .success(result) : .failure(result)
-                testResultFingerprint = context.fingerprint
+                )
+                guard isCurrentAttempt else { return }
                 isTesting = false
                 probeTask = nil
+                if activeProbeReservation == reservation {
+                    activeProbeReservation = nil
+                }
+                guard accepted else { return }
+                testResult = result.succeeded ? .success(result) : .failure(result)
+                testResultFingerprint = fingerprint
             }
-        }
-    }
-
-    /// Token to use for the HTTP test request. OAuth providers reuse the
-    /// access token already in Keychain so the user can probe the server
-    /// before clicking Save.
-    private func httpTestToken() -> String? {
-        switch authType {
-        case .bearerToken:
-            return MCPProviderBearerProbeInput.resolved(
-                fieldValue: token,
-                clearRequested: clearBearerToken,
-                storedValue: provider?.getToken()
-            )
-        case .oauth:
-            return MCPProviderKeychain.getOAuthTokens(for: effectiveProviderId)?.accessToken
-        case .none:
-            return nil
         }
     }
 
@@ -3196,61 +3231,39 @@ private struct ProviderEditSheet: View {
         )
     }
 
-    /// Synthesize an in-memory `MCPProvider` from the current editor
-    /// state so we can hand it to `testStdioConnection`. This is **not**
-    /// persisted; it lives just long enough to spawn + handshake.
-    private func makeStdioProbeProvider() -> MCPProvider {
+    /// Builds the exact provider shape shared by probing, fingerprinting, and
+    /// save so an untouched editor hashes identically to the stored provider.
+    private func makeProvider() -> MCPProvider {
         let fields = parseStdioFields()
+        let normalizedHeaders = MCPProviderOperationsFieldNormalizer.normalize(
+            customHeaders.map { ($0.key, $0.value, $0.isSecret) }
+        )
         return MCPProvider(
             id: effectiveProviderId,
-            name: name.isEmpty ? "Stdio test" : name,
-            url: "",
+            name: name.trimmingCharacters(in: .whitespaces),
+            url: transport == .http ? url.trimmingCharacters(in: .whitespaces) : "",
+            enabled: provider?.enabled ?? true,
+            customHeaders: transport == .http ? normalizedHeaders.regular : [:],
+            streamingEnabled: transport == .http && streamingEnabled,
             discoveryTimeout: discoveryTimeout,
             toolCallTimeout: toolCallTimeout,
-            authType: .none,
-            transport: .stdio,
+            autoConnect: autoConnect,
+            secretHeaderKeys: transport == .http ? normalizedHeaders.secretKeys : [],
+            authType: transport == .http ? authType : .none,
+            oauth: transport == .http && authType == .oauth ? mergedManualOAuthConfig() : nil,
+            pluginId: provider?.pluginId,
+            transport: transport,
             executionHost: executionHost,
-            command: fields.command,
-            args: fields.args,
-            env: fields.env,
-            secretEnvKeys: fields.secretEnvKeys,
-            workingDirectory: fields.workingDirectory
+            command: transport == .stdio ? fields.command : "",
+            args: transport == .stdio ? fields.args : [],
+            env: transport == .stdio ? fields.env : [:],
+            secretEnvKeys: transport == .stdio ? fields.secretEnvKeys : [],
+            workingDirectory: transport == .stdio ? fields.workingDirectory : nil
         )
     }
 
-    private func makeProbeProvider() -> MCPProvider {
-        switch transport {
-        case .http:
-            let normalized = MCPProviderOperationsFieldNormalizer.normalize(
-                customHeaders.map { ($0.key, $0.value, $0.isSecret) }
-            )
-            return MCPProvider(
-                id: effectiveProviderId,
-                name: name.isEmpty ? "HTTP MCP probe" : name,
-                url: url.trimmingCharacters(in: .whitespaces),
-                customHeaders: normalized.regular,
-                streamingEnabled: streamingEnabled,
-                discoveryTimeout: discoveryTimeout,
-                toolCallTimeout: toolCallTimeout,
-                secretHeaderKeys: normalized.secretKeys,
-                authType: authType,
-                transport: .http
-            )
-        case .stdio:
-            return makeStdioProbeProvider()
-        }
-    }
-
-    private struct ProbeContext {
-        let provider: MCPProvider
-        let fingerprint: String
-        let httpToken: String?
-        let httpHeaders: [String: String]
-        let secretEnvironmentValues: [String: String]
-    }
-
     private var currentProbeFingerprint: String {
-        let provider = makeProbeProvider()
+        let provider = makeProvider()
         return MCPProviderSetupFingerprint.make(
             provider: provider,
             bearerToken: authType == .bearerToken
@@ -3267,29 +3280,6 @@ private struct ProviderEditSheet: View {
     private var currentTestResult: TestResult? {
         guard testResultFingerprint == currentProbeFingerprint else { return nil }
         return testResult
-    }
-
-    private func makeProbeContext() -> ProbeContext {
-        let provider = makeProbeProvider()
-        let secretHeaders = secretHeaderValues()
-        let secretEnvironment = secretEnvironmentValues()
-        return ProbeContext(
-            provider: provider,
-            fingerprint: MCPProviderSetupFingerprint.make(
-                provider: provider,
-                bearerToken: authType == .bearerToken
-                    ? MCPProviderBearerProbeInput.fingerprint(
-                        fieldValue: token,
-                        clearRequested: clearBearerToken
-                    )
-                    : nil,
-                secretHeaderValues: secretHeaders,
-                secretEnvironmentValues: secretEnvironment
-            ),
-            httpToken: httpTestToken(),
-            httpHeaders: buildHeaders(),
-            secretEnvironmentValues: secretEnvironment
-        )
     }
 
     private func secretHeaderValues() -> [String: String] {
@@ -3316,57 +3306,19 @@ private struct ProviderEditSheet: View {
         )
     }
 
+    private func cancelActiveProbeReservation() {
+        guard let activeProbeReservation else { return }
+        MCPProviderHealthSnapshotStore.cancelProbe(activeProbeReservation)
+        self.activeProbeReservation = nil
+    }
+
     private func save() {
         credentialSaveError = nil
         if importedSetupRequiresProbe
             && !probeGate.hasCurrentSuccess(fingerprint: currentProbeFingerprint) {
             return
         }
-        let trimmedName = name.trimmingCharacters(in: .whitespaces)
-        let trimmedURL = url.trimmingCharacters(in: .whitespaces)
-
-        // Use the same normalization contract as probes and the operations
-        // hub. A blank secret value means "preserve the Keychain value", so
-        // its key must remain in the provider configuration.
-        let normalizedHeaders = MCPProviderOperationsFieldNormalizer.normalize(
-            customHeaders.map { ($0.key, $0.value, $0.isSecret) }
-        )
-
-        // Merge any manual OAuth overrides into the saved config so they
-        // survive past sheet dismissal, even if the user hasn't clicked
-        // Sign In yet.
-        let oauthForSave: MCPOAuthConfig? =
-            authType == .oauth ? mergedManualOAuthConfig() : nil
-
-        // Stdio fields (command + args + env). Shared with the
-        // test-connection probe so the two paths can't drift.
-        let stdio = parseStdioFields()
-
-        let updatedProvider = MCPProvider(
-            id: effectiveProviderId,
-            name: trimmedName,
-            url: transport == .http ? trimmedURL : "",
-            enabled: provider?.enabled ?? true,
-            customHeaders: transport == .http ? normalizedHeaders.regular : [:],
-            streamingEnabled: transport == .http && streamingEnabled,
-            discoveryTimeout: discoveryTimeout,
-            toolCallTimeout: toolCallTimeout,
-            autoConnect: autoConnect,
-            secretHeaderKeys: transport == .http ? normalizedHeaders.secretKeys : [],
-            authType: transport == .http ? authType : .none,
-            oauth: transport == .http ? oauthForSave : nil,
-            // Preserve the plugin grouping so an edit-then-save on a
-            // Claude-plugin-imported provider doesn't strip its uninstall
-            // tag.
-            pluginId: provider?.pluginId,
-            transport: transport,
-            executionHost: executionHost,
-            command: transport == .stdio ? stdio.command : "",
-            args: transport == .stdio ? stdio.args : [],
-            env: transport == .stdio ? stdio.env : [:],
-            secretEnvKeys: transport == .stdio ? stdio.secretEnvKeys : [],
-            workingDirectory: transport == .stdio ? stdio.workingDirectory : nil
-        )
+        let updatedProvider = makeProvider()
 
         // Blank values preserve existing Keychain entries. Explicit values
         // are committed atomically with bearer-token intent by the manager.
@@ -3392,22 +3344,6 @@ private struct ProviderEditSheet: View {
             return
         }
         dismiss()
-    }
-
-    private func buildHeaders() -> [String: String] {
-        var headers: [String: String] = [:]
-        for header in customHeaders where !header.key.isEmpty {
-            let key = header.key.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !key.isEmpty else { continue }
-            if !header.value.isEmpty {
-                headers[key] = header.value
-            } else if header.isSecret,
-                let provider,
-                let value = MCPProviderKeychain.getHeaderSecret(key: key, for: provider.id) {
-                headers[key] = value
-            }
-        }
-        return headers
     }
 }
 

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -1261,6 +1261,10 @@ private struct ProviderEditSheet: View {
 
     @State private var isTesting: Bool = false
     @State private var testResult: TestResult?
+    @State private var testResultFingerprint: String?
+    @State private var probeGate = MCPProviderProbeGate()
+    @State private var importedSetupRequiresProbe = false
+    @State private var showImportConfiguration = false
     @State private var showAdvanced: Bool = false
 
     @State private var isSigningIn: Bool = false
@@ -1357,6 +1361,16 @@ private struct ProviderEditSheet: View {
                 .stroke(themeManager.currentTheme.primaryBorder, lineWidth: 1)
         )
         .onAppear { loadProvider() }
+        .sheet(isPresented: $showImportConfiguration) {
+            MCPConfigurationImportSheet { imported in
+                applyImportedConfiguration(imported)
+            }
+        }
+        .onChange(of: currentProbeFingerprint) { _, fingerprint in
+            guard testResultFingerprint != fingerprint else { return }
+            testResult = nil
+            testResultFingerprint = nil
+        }
     }
 
     @ViewBuilder
@@ -1563,7 +1577,7 @@ private struct ProviderEditSheet: View {
                 Group {
                     if isTesting {
                         ProgressView().scaleEffect(0.6)
-                    } else if let result = testResult {
+                    } else if let result = currentTestResult {
                         switch result {
                         case .success:
                             Image(systemName: "checkmark.circle.fill")
@@ -1579,7 +1593,7 @@ private struct ProviderEditSheet: View {
                 }
                 .frame(width: 16, height: 16)
 
-                if let result = testResult {
+                if let result = currentTestResult {
                     switch result {
                     case .success(let probe):
                         Text(
@@ -2207,6 +2221,21 @@ private struct ProviderEditSheet: View {
 
     private var configureCustomBody: some View {
         VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Spacer()
+                Button {
+                    showImportConfiguration = true
+                } label: {
+                    Label {
+                        Text("Import Configuration", bundle: .module)
+                    } icon: {
+                        Image(systemName: "square.and.arrow.down")
+                    }
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.borderless)
+            }
+
             EditorCard(title: "Connection", icon: "link") {
                 VStack(alignment: .leading, spacing: 14) {
                     MCPStyledTextField(
@@ -2260,9 +2289,25 @@ private struct ProviderEditSheet: View {
                 stdioEnvCard
             }
 
+            if importedSetupNeedsProbe {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "checkmark.shield.fill")
+                        .foregroundColor(themeManager.currentTheme.accentColor)
+                    Text(
+                        "Test this imported configuration before saving it.",
+                        bundle: .module
+                    )
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(themeManager.currentTheme.secondaryText)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(themeManager.currentTheme.accentColor.opacity(0.08))
+            }
+
             advancedCard
 
-            if let result = testResult {
+            if let result = currentTestResult {
                 probeResultCard(result.probeResult)
             }
         }
@@ -2858,7 +2903,7 @@ private struct ProviderEditSheet: View {
     }
 
     private var testResultColor: Color {
-        guard let result = testResult else { return themeManager.currentTheme.secondaryText }
+        guard let result = currentTestResult else { return themeManager.currentTheme.secondaryText }
         switch result {
         case .success: return themeManager.currentTheme.successColor
         case .failure: return themeManager.currentTheme.errorColor
@@ -2866,7 +2911,7 @@ private struct ProviderEditSheet: View {
     }
 
     private var testResultBackground: Color {
-        guard let result = testResult else { return themeManager.currentTheme.tertiaryBackground }
+        guard let result = currentTestResult else { return themeManager.currentTheme.tertiaryBackground }
         switch result {
         case .success: return themeManager.currentTheme.successColor.opacity(0.12)
         case .failure: return themeManager.currentTheme.errorColor.opacity(0.12)
@@ -2875,12 +2920,21 @@ private struct ProviderEditSheet: View {
 
     private var canSave: Bool {
         guard !name.trimmingCharacters(in: .whitespaces).isEmpty else { return false }
+        let hasRequiredFields: Bool
         switch transport {
         case .http:
-            return !url.trimmingCharacters(in: .whitespaces).isEmpty
+            hasRequiredFields = !url.trimmingCharacters(in: .whitespaces).isEmpty
         case .stdio:
-            return !command.trimmingCharacters(in: .whitespaces).isEmpty
+            hasRequiredFields = !command.trimmingCharacters(in: .whitespaces).isEmpty
         }
+        guard hasRequiredFields else { return false }
+        return !importedSetupRequiresProbe
+            || probeGate.hasCurrentSuccess(fingerprint: currentProbeFingerprint)
+    }
+
+    private var importedSetupNeedsProbe: Bool {
+        importedSetupRequiresProbe
+            && !probeGate.hasCurrentSuccess(fingerprint: currentProbeFingerprint)
     }
 
     private func loadProvider() {
@@ -2947,31 +3001,73 @@ private struct ProviderEditSheet: View {
         phase = .configureCustom
     }
 
+    private func applyImportedConfiguration(_ imported: MCPImportedServerConfiguration) {
+        name = imported.name
+        transport = imported.transport
+        url = imported.url
+        streamingEnabled = imported.streamingEnabled
+        command = imported.command
+        argsString = ShellArgs.join(imported.args)
+        workingDirectory = imported.workingDirectory ?? ""
+        executionHost = .sandbox
+        authType = .none
+        token = ""
+        clearBearerToken = false
+        oauthConfig = nil
+        customHeaders = imported.headers.map {
+            HeaderEntry(key: $0.key, value: $0.value, isSecret: $0.isSecret)
+        }
+        envEntries = imported.environment.map {
+            HeaderEntry(key: $0.key, value: $0.value, isSecret: $0.isSecret)
+        }
+        testResult = nil
+        testResultFingerprint = nil
+        probeGate.invalidate()
+        isTesting = false
+        importedSetupRequiresProbe = true
+        phase = .configureCustom
+    }
+
     private func testConnection() {
+        let context = makeProbeContext()
+        let attempt = probeGate.start(fingerprint: context.fingerprint)
         isTesting = true
         testResult = nil
+        testResultFingerprint = nil
 
         Task {
-            let provider = makeProbeProvider()
             let result: MCPProviderProbeResult
-            switch transport {
+            switch context.provider.transport {
             case .http:
                 result = await MCPProviderProbeService.probeHTTP(
-                    providerId: provider.id,
-                    name: provider.name,
-                    url: provider.url,
-                    token: httpTestToken(),
-                    headers: buildHeaders(),
-                    streamingEnabled: provider.streamingEnabled,
-                    discoveryTimeout: provider.discoveryTimeout
+                    providerId: context.provider.id,
+                    name: context.provider.name,
+                    url: context.provider.url,
+                    token: context.httpToken,
+                    headers: context.httpHeaders,
+                    streamingEnabled: context.provider.streamingEnabled,
+                    discoveryTimeout: context.provider.discoveryTimeout
                 )
             case .stdio:
-                result = await MCPProviderProbeService.probeStdio(provider: provider)
+                result = await MCPProviderProbeService.probeStdio(
+                    provider: context.provider,
+                    secretEnvOverrides: context.secretEnvironmentValues
+                )
             }
-            MCPProviderHealthSnapshotStore.record(result, for: provider)
 
             await MainActor.run {
+                guard attempt.generation == probeGate.generation else { return }
+                guard probeGate.accept(
+                    attempt,
+                    currentFingerprint: currentProbeFingerprint,
+                    succeeded: result.succeeded
+                ) else {
+                    isTesting = false
+                    return
+                }
+                MCPProviderHealthSnapshotStore.record(result, for: context.provider)
                 testResult = result.succeeded ? .success(result) : .failure(result)
+                testResultFingerprint = context.fingerprint
                 isTesting = false
             }
         }
@@ -3051,14 +3147,18 @@ private struct ProviderEditSheet: View {
     private func makeProbeProvider() -> MCPProvider {
         switch transport {
         case .http:
+            let normalized = MCPProviderOperationsFieldNormalizer.normalize(
+                customHeaders.map { ($0.key, $0.value, $0.isSecret) }
+            )
             return MCPProvider(
                 id: effectiveProviderId,
                 name: name.isEmpty ? "HTTP MCP probe" : name,
                 url: url.trimmingCharacters(in: .whitespaces),
-                customHeaders: buildHeaders(),
+                customHeaders: normalized.regular,
                 streamingEnabled: streamingEnabled,
                 discoveryTimeout: discoveryTimeout,
                 toolCallTimeout: toolCallTimeout,
+                secretHeaderKeys: normalized.secretKeys,
                 authType: authType,
                 transport: .http
             )
@@ -3067,7 +3167,70 @@ private struct ProviderEditSheet: View {
         }
     }
 
+    private struct ProbeContext {
+        let provider: MCPProvider
+        let fingerprint: String
+        let httpToken: String?
+        let httpHeaders: [String: String]
+        let secretEnvironmentValues: [String: String]
+    }
+
+    private var currentProbeFingerprint: String {
+        let provider = makeProbeProvider()
+        return MCPProviderSetupFingerprint.make(
+            provider: provider,
+            bearerToken: authType == .bearerToken ? token : nil,
+            secretHeaderValues: secretHeaderValues(),
+            secretEnvironmentValues: secretEnvironmentValues()
+        )
+    }
+
+    private var currentTestResult: TestResult? {
+        guard testResultFingerprint == currentProbeFingerprint else { return nil }
+        return testResult
+    }
+
+    private func makeProbeContext() -> ProbeContext {
+        let provider = makeProbeProvider()
+        let secretHeaders = secretHeaderValues()
+        let secretEnvironment = secretEnvironmentValues()
+        return ProbeContext(
+            provider: provider,
+            fingerprint: MCPProviderSetupFingerprint.make(
+                provider: provider,
+                bearerToken: authType == .bearerToken ? token : nil,
+                secretHeaderValues: secretHeaders,
+                secretEnvironmentValues: secretEnvironment
+            ),
+            httpToken: httpTestToken(),
+            httpHeaders: buildHeaders(),
+            secretEnvironmentValues: secretEnvironment
+        )
+    }
+
+    private func secretHeaderValues() -> [String: String] {
+        Dictionary(
+            customHeaders
+                .filter { $0.isSecret && !$0.key.isEmpty && !$0.value.isEmpty }
+                .map { ($0.key, $0.value) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+    }
+
+    private func secretEnvironmentValues() -> [String: String] {
+        Dictionary(
+            envEntries
+                .filter { $0.isSecret && !$0.key.isEmpty && !$0.value.isEmpty }
+                .map { ($0.key, $0.value) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+    }
+
     private func save() {
+        if importedSetupRequiresProbe
+            && !probeGate.hasCurrentSuccess(fingerprint: currentProbeFingerprint) {
+            return
+        }
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         let trimmedURL = url.trimmingCharacters(in: .whitespaces)
 

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -73,7 +73,13 @@ struct ProvidersView: View {
                             onSaveBearerToken: { token in
                                 // Persist directly to Keychain (the provider record
                                 // itself doesn't change) and immediately retry.
-                                _ = MCPProviderKeychain.saveToken(token, for: report.id)
+                                guard MCPProviderKeychain.saveToken(token, for: report.id) else {
+                                    _ = ToastManager.shared.error(
+                                        L("Credentials could not be saved"),
+                                        message: L("Check Keychain access and try again.")
+                                    )
+                                    return
+                                }
                                 refreshCredentialPresence()
                                 // Enable the provider so the retry connect doesn't no-op.
                                 if !report.provider.enabled {
@@ -120,16 +126,28 @@ struct ProvidersView: View {
             }
         }
         .sheet(isPresented: $showAddSheet) {
-            ProviderEditSheet(provider: nil) { provider, tokenEdit in
-                manager.addProvider(provider, token: tokenEdit.tokenForNewProvider)
-                refreshCredentialPresence()
+            ProviderEditSheet(provider: nil) { provider, tokenEdit, secretWrites in
+                let saved = manager.addProvider(
+                    provider,
+                    token: tokenEdit.tokenForNewProvider,
+                    secretWrites: secretWrites
+                )
+                if saved { refreshCredentialPresence() }
+                return saved
             }
         }
         .sheet(item: $editingProvider) { provider in
-            ProviderEditSheet(provider: provider) { updatedProvider, tokenEdit in
-                manager.updateProvider(updatedProvider, tokenEdit: tokenEdit)
-                refreshCredentialPresence()
-                refreshHealthSnapshots()
+            ProviderEditSheet(provider: provider) { updatedProvider, tokenEdit, secretWrites in
+                let saved = manager.updateProvider(
+                    updatedProvider,
+                    tokenEdit: tokenEdit,
+                    secretWrites: secretWrites
+                )
+                if saved {
+                    refreshCredentialPresence()
+                    refreshHealthSnapshots()
+                }
+                return saved
             }
         }
         .sheet(isPresented: $showOperationsHub) {
@@ -1241,7 +1259,7 @@ private struct ProviderEditSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let provider: MCPProvider?
-    let onSave: (MCPProvider, MCPProviderBearerTokenEdit) -> Void
+    let onSave: (MCPProvider, MCPProviderBearerTokenEdit, [MCPProviderSecretWrite]) -> Bool
 
     /// Stable identity for "draft" providers (sheet not yet saved). Reused so OAuth
     /// tokens persisted to Keychain mid-flow stay tied to the provider once saved.
@@ -1266,6 +1284,7 @@ private struct ProviderEditSheet: View {
     @State private var importedSetupRequiresProbe = false
     @State private var showImportConfiguration = false
     @State private var showAdvanced: Bool = false
+    @State private var credentialSaveError: String?
 
     @State private var isSigningIn: Bool = false
     @State private var oauthError: String?
@@ -1497,10 +1516,17 @@ private struct ProviderEditSheet: View {
 
     @ViewBuilder
     private var sheetFooter: some View {
-        HStack(spacing: 12) {
-            footerLeading
-            Spacer()
-            footerTrailing
+        VStack(alignment: .leading, spacing: 8) {
+            if let credentialSaveError {
+                Label(credentialSaveError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(themeManager.currentTheme.errorColor)
+            }
+            HStack(spacing: 12) {
+                footerLeading
+                Spacer()
+                footerTrailing
+            }
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 16)
@@ -2827,10 +2853,16 @@ private struct ProviderEditSheet: View {
             let trimmedClientId = manualClientId.trimmingCharacters(in: .whitespaces)
             let trimmedClientSecret = manualClientSecret.trimmingCharacters(in: .whitespaces)
             guard !trimmedClientId.isEmpty, !trimmedClientSecret.isEmpty else { return }
-            MCPProviderKeychain.saveOAuthClientSecret(
+            guard MCPProviderKeychain.saveOAuthClientSecret(
                 trimmedClientSecret,
                 for: effectiveProviderId
-            )
+            ) else {
+                oauthError = String(
+                    localized: "Credentials could not be saved to Keychain. Check Keychain access and try again.",
+                    bundle: .module
+                )
+                return
+            }
         }
 
         isSigningIn = true
@@ -3079,7 +3111,11 @@ private struct ProviderEditSheet: View {
     private func httpTestToken() -> String? {
         switch authType {
         case .bearerToken:
-            return token.isEmpty ? nil : token
+            return MCPProviderBearerProbeInput.resolved(
+                fieldValue: token,
+                clearRequested: clearBearerToken,
+                storedValue: provider?.getToken()
+            )
         case .oauth:
             return MCPProviderKeychain.getOAuthTokens(for: effectiveProviderId)?.accessToken
         case .none:
@@ -3103,15 +3139,17 @@ private struct ProviderEditSheet: View {
     private func parseStdioFields() -> ParsedStdioFields {
         var regularEnv: [String: String] = [:]
         var secretEnvKeys: [String] = []
-        for entry in envEntries where !entry.key.isEmpty {
+        for entry in envEntries {
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
             if entry.isSecret {
-                secretEnvKeys.append(entry.key)
+                secretEnvKeys.append(key)
             } else if !entry.value.isEmpty {
                 // Skip empty regular env vars — persisting `KEY=""`
                 // would silently shadow whatever the subprocess
                 // inherits from its environment, which is almost
                 // never what the user intended.
-                regularEnv[entry.key] = entry.value
+                regularEnv[key] = entry.value
             }
         }
         let trimmedCwd = workingDirectory.trimmingCharacters(in: .whitespaces)
@@ -3179,7 +3217,12 @@ private struct ProviderEditSheet: View {
         let provider = makeProbeProvider()
         return MCPProviderSetupFingerprint.make(
             provider: provider,
-            bearerToken: authType == .bearerToken ? token : nil,
+            bearerToken: authType == .bearerToken
+                ? MCPProviderBearerProbeInput.fingerprint(
+                    fieldValue: token,
+                    clearRequested: clearBearerToken
+                )
+                : nil,
             secretHeaderValues: secretHeaderValues(),
             secretEnvironmentValues: secretEnvironmentValues()
         )
@@ -3198,7 +3241,12 @@ private struct ProviderEditSheet: View {
             provider: provider,
             fingerprint: MCPProviderSetupFingerprint.make(
                 provider: provider,
-                bearerToken: authType == .bearerToken ? token : nil,
+                bearerToken: authType == .bearerToken
+                    ? MCPProviderBearerProbeInput.fingerprint(
+                        fieldValue: token,
+                        clearRequested: clearBearerToken
+                    )
+                    : nil,
                 secretHeaderValues: secretHeaders,
                 secretEnvironmentValues: secretEnvironment
             ),
@@ -3211,8 +3259,11 @@ private struct ProviderEditSheet: View {
     private func secretHeaderValues() -> [String: String] {
         Dictionary(
             customHeaders
-                .filter { $0.isSecret && !$0.key.isEmpty && !$0.value.isEmpty }
-                .map { ($0.key, $0.value) },
+                .compactMap { entry -> (String, String)? in
+                    let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
+                    return (key, entry.value)
+                },
             uniquingKeysWith: { _, latest in latest }
         )
     }
@@ -3220,13 +3271,17 @@ private struct ProviderEditSheet: View {
     private func secretEnvironmentValues() -> [String: String] {
         Dictionary(
             envEntries
-                .filter { $0.isSecret && !$0.key.isEmpty && !$0.value.isEmpty }
-                .map { ($0.key, $0.value) },
+                .compactMap { entry -> (String, String)? in
+                    let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
+                    return (key, entry.value)
+                },
             uniquingKeysWith: { _, latest in latest }
         )
     }
 
     private func save() {
+        credentialSaveError = nil
         if importedSetupRequiresProbe
             && !probeGate.hasCurrentSuccess(fingerprint: currentProbeFingerprint) {
             return
@@ -3234,17 +3289,12 @@ private struct ProviderEditSheet: View {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         let trimmedURL = url.trimmingCharacters(in: .whitespaces)
 
-        // Separate regular headers from secret headers
-        var regularHeaders: [String: String] = [:]
-        var secretKeys: [String] = []
-
-        for header in customHeaders where !header.key.isEmpty {
-            if header.isSecret {
-                secretKeys.append(header.key)
-            } else {
-                regularHeaders[header.key] = header.value
-            }
-        }
+        // Use the same normalization contract as probes and the operations
+        // hub. A blank secret value means "preserve the Keychain value", so
+        // its key must remain in the provider configuration.
+        let normalizedHeaders = MCPProviderOperationsFieldNormalizer.normalize(
+            customHeaders.map { ($0.key, $0.value, $0.isSecret) }
+        )
 
         // Merge any manual OAuth overrides into the saved config so they
         // survive past sheet dismissal, even if the user hasn't clicked
@@ -3259,59 +3309,67 @@ private struct ProviderEditSheet: View {
         let updatedProvider = MCPProvider(
             id: effectiveProviderId,
             name: trimmedName,
-            url: trimmedURL,
+            url: transport == .http ? trimmedURL : "",
             enabled: provider?.enabled ?? true,
-            customHeaders: regularHeaders,
-            streamingEnabled: streamingEnabled,
+            customHeaders: transport == .http ? normalizedHeaders.regular : [:],
+            streamingEnabled: transport == .http && streamingEnabled,
             discoveryTimeout: discoveryTimeout,
             toolCallTimeout: toolCallTimeout,
             autoConnect: autoConnect,
-            secretHeaderKeys: secretKeys,
-            authType: authType,
-            oauth: oauthForSave,
+            secretHeaderKeys: transport == .http ? normalizedHeaders.secretKeys : [],
+            authType: transport == .http ? authType : .none,
+            oauth: transport == .http ? oauthForSave : nil,
             // Preserve the plugin grouping so an edit-then-save on a
             // Claude-plugin-imported provider doesn't strip its uninstall
             // tag.
             pluginId: provider?.pluginId,
             transport: transport,
             executionHost: executionHost,
-            command: stdio.command,
-            args: stdio.args,
-            env: stdio.env,
-            secretEnvKeys: stdio.secretEnvKeys,
-            workingDirectory: stdio.workingDirectory
+            command: transport == .stdio ? stdio.command : "",
+            args: transport == .stdio ? stdio.args : [],
+            env: transport == .stdio ? stdio.env : [:],
+            secretEnvKeys: transport == .stdio ? stdio.secretEnvKeys : [],
+            workingDirectory: transport == .stdio ? stdio.workingDirectory : nil
         )
 
-        // Save secret env values to Keychain. Like the bearer/secret-header
-        // path, blank values mean "don't overwrite" so the user can leave
-        // sensitive fields alone after the first save.
-        for entry in envEntries
-        where entry.isSecret && !entry.key.isEmpty && !entry.value.isEmpty {
-            _ = MCPProviderKeychain.saveEnvSecret(
-                entry.value,
-                key: entry.key,
-                for: updatedProvider.id
-            )
+        // Blank values preserve existing Keychain entries. Explicit values
+        // are committed atomically with bearer-token intent by the manager.
+        let secretWrites = envEntries.compactMap { entry -> MCPProviderSecretWrite? in
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard transport == .stdio, entry.isSecret, !key.isEmpty, !entry.value.isEmpty else { return nil }
+            return MCPProviderSecretWrite(storage: .environment, key: key, value: entry.value)
+        } + customHeaders.compactMap { header -> MCPProviderSecretWrite? in
+            let key = header.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard transport == .http, header.isSecret, !key.isEmpty, !header.value.isEmpty else { return nil }
+            return MCPProviderSecretWrite(storage: .header, key: key, value: header.value)
         }
-
-        // Save secret header values to Keychain
-        for header in customHeaders where header.isSecret && !header.key.isEmpty && !header.value.isEmpty {
-            MCPProviderKeychain.saveHeaderSecret(header.value, key: header.key, for: updatedProvider.id)
-        }
-
         let tokenEdit = MCPProviderBearerTokenEdit.fromBearerField(
             token,
-            authType: authType,
+            authType: updatedProvider.authType,
             clearRequested: clearBearerToken
         )
-        onSave(updatedProvider, tokenEdit)
+        guard onSave(updatedProvider, tokenEdit, secretWrites) else {
+            credentialSaveError = String(
+                localized: "Credentials could not be saved to Keychain. Check Keychain access and try again.",
+                bundle: .module
+            )
+            return
+        }
         dismiss()
     }
 
     private func buildHeaders() -> [String: String] {
         var headers: [String: String] = [:]
-        for header in customHeaders where !header.key.isEmpty && !header.value.isEmpty {
-            headers[header.key] = header.value
+        for header in customHeaders where !header.key.isEmpty {
+            let key = header.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+            if !header.value.isEmpty {
+                headers[key] = header.value
+            } else if header.isSecret,
+                let provider,
+                let value = MCPProviderKeychain.getHeaderSecret(key: key, for: provider.id) {
+                headers[key] = value
+            }
         }
         return headers
     }

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -176,6 +176,31 @@ attention, connected, stdio, HTTP, or disabled providers. The hub actions can
 probe every enabled provider, reconnect every enabled provider, or copy a single
 redacted support report for the whole provider set.
 
+The reusable **MCP Operations Hub** surface builds on the same provider data and
+adds an operator-focused detail view for each local stdio or HTTP/SSE provider:
+
+- Add or edit HTTP/SSE providers and local stdio providers from one compact
+  editor.
+- Test providers with the same explicit initialize/listTools probe used by the
+  provider rows. Successful and failed tests update the persisted health
+  snapshot.
+- Resolve stdio launch details before the process starts: host commands show the
+  executable path found on the app `PATH` plus common local-bin fallbacks, while
+  sandbox commands show the quoted command that will run inside the sandbox.
+- Show working-directory and environment-key state without printing environment
+  values. Secret env keys are listed by key name only, and missing Keychain
+  values are called out before launch.
+- Show authentication status separately from transport health: no-auth, bearer
+  token present/missing, OAuth signed in/missing, or OAuth sign-in required.
+- Copy a single redacted diagnostic bundle for a provider or for the whole hub.
+  Command arguments, probe messages, auth errors, and call-history errors are
+  passed through the same redaction path used by MCP probe diagnostics.
+- Read persisted MCP call-history records when present. The history format keeps
+  provider/tool names, timestamps, durations, success state, JSON argument keys,
+  result sizes, and redacted errors; it does not store raw argument values or raw
+  tool output. Live execution still needs the MCP manager hook to populate this
+  history automatically because that manager is outside the operations-hub lane.
+
 For stdio providers, diagnostics distinguish sandbox vs host execution and point
 command-not-found failures at the executable path/PATH fix. For HTTP/SSE
 providers, diagnostics show whether the global proxy is active, disabled, or

--- a/docs/REMOTE_MCP_PROVIDERS.md
+++ b/docs/REMOTE_MCP_PROVIDERS.md
@@ -103,9 +103,52 @@ subprocess and therefore do not send traffic through URLSession's proxy path.
 The Test button now records a provider health snapshot after the explicit
 initialize/listTools probe. The copied probe result includes the stable reason
 code (`succeeded`, `invalidURL`, `missingCommand`, `commandNotFound`,
-`sandboxUnavailable`, `spawnFailed`, `timeout`, `authRequired`,
+`sandboxUnavailable`, `spawnFailed`, `processExited`, `timeout`, `authRequired`,
 `protocolError`, or `connectionFailed`) plus the stage that failed, but never
 includes credentials, env values, headers, request bodies, or tokens.
+
+### Importing an existing MCP configuration
+
+The Custom Server editor can import JSON from clients that use an `mcpServers`
+object. Choose **Import Configuration**, paste JSON or choose a `.json` file,
+select one server, review its command or URL, and confirm which environment or
+header fields are secrets. Imported fields marked **Secret** stay in the editor
+until Save and are then stored in Keychain rather than `mcp.json`.
+
+```json
+{
+  "mcpServers": {
+    "company-search": {
+      "command": "/opt/homebrew/bin/uvx",
+      "args": ["company-search-mcp"],
+      "env": {
+        "COMPANY_API_TOKEN": "paste-token-here"
+      }
+    }
+  }
+}
+```
+
+The importer accepts stdio `command`, `args`, `env`, and `cwd` fields, plus
+HTTP `url` and `headers` fields. Explicit types `stdio`, `http`,
+`streamable-http`, and `sse` are supported. It rejects mixed URL/command
+records, embedded URL credentials, duplicate JSON keys, unsafe header values,
+and configurations that exceed the import limits. Importing only fills the
+editor; it does not run a command. Review the command and arguments before
+running Test because a configured package runner or shell command can download
+or execute code inside the selected execution host.
+
+Imported definitions must pass the current editor Test before Save. The test
+uses in-memory secret values without writing them first. A successful test is
+invalidated if any command, URL, argument, execution-host, auth, header, env, or
+secret input changes.
+
+Stdio imports default to **Sandbox**. A host path in the command, arguments, or
+working directory is shown as a warning but never switches the execution host
+automatically. Choose **Host** only for a trusted server that genuinely needs a
+host virtual environment or host files. A macOS GUI app may not inherit the
+same `PATH` as Terminal; use an absolute executable path when the probe reports
+`commandNotFound`.
 
 ---
 
@@ -198,8 +241,8 @@ adds an operator-focused detail view for each local stdio or HTTP/SSE provider:
 - Read persisted MCP call-history records when present. The history format keeps
   provider/tool names, timestamps, durations, success state, JSON argument keys,
   result sizes, and redacted errors; it does not store raw argument values or raw
-  tool output. Live execution still needs the MCP manager hook to populate this
-  history automatically because that manager is outside the operations-hub lane.
+  tool output. Production MCP tool executions populate this history through the
+  provider manager.
 
 For stdio providers, diagnostics distinguish sandbox vs host execution and point
 command-not-found failures at the executable path/PATH fix. For HTTP/SSE


### PR DESCRIPTION
## Summary

Adds one MCP setup and operations workflow for local stdio and remote HTTP providers:

- imports bounded `mcpServers` JSON from paste or file and previews the resolved transport before applying it
- validates stdio, HTTP, streamable HTTP, and SSE configurations with typed failures
- classifies secret headers and environment values, keeps draft values in memory, and stores saved credentials in Keychain
- rejects host process-control environment overrides such as `PATH`, `HOME`, `DYLD_*`, and `LD_*`
- requires a successful test of the exact imported configuration before import save
- allows an offline, disabled, or OAuth configuration to be saved from the generic editors, but clears prior health whenever configuration or credentials change
- restores a tested result after save only when the provider and resolved credentials still match the tested fingerprint; generation checks reject concurrent credential rotation and stale cross-surface completions
- runs MCP `initialize` and `listTools` preflight with bounded timeout, child-exit detection, typed stage failures, and deterministic subprocess cleanup
- exposes health, authentication state, launch preflight, discovered tools, redacted call history, and copyable diagnostics
- serializes health and call-history persistence and redacts runtime errors before they reach stored or visible state

## Validation

- 58 focused configuration-import, operations, credential, probe, redaction, race, and host-stdio tests passed on the final head
- live host stdio fixtures proved draft-secret injection, `initialize`, `listTools`, a real tool call, result decoding, disconnect, and process teardown
- security coverage includes input limits, duplicate keys, mixed transports, invalid types, CRLF headers, embedded URL credentials, undeclared secrets, process-control environment injection, credential rollback, stale-test rejection, concurrent mutation during health restore, concurrent snapshot writes, and diagnostic canaries
- localization validation and `git diff --check` passed
- scoped lint adds no violations relative to the pre-repair head
- unsigned Release CLI and app build passed locally

## Draft gates

- capture the native import, provider editor, and operations hub workflow with screenshots from this exact head
- prove a sandbox stdio provider on this exact head
- prove live HTTP/SSE behavior and a credentialed OAuth flow

Importing configuration never executes it. Running Test launches the reviewed stdio command only in the execution host selected by the user.
