### PR TITLE
Add tool exposure control center

### DIFF
--- a/Packages/OsaurusCore/Models/Tool/ToolExposureDiagnostic.swift
+++ b/Packages/OsaurusCore/Models/Tool/ToolExposureDiagnostic.swift
@@ -8,6 +8,61 @@
 
 import Foundation
 
+enum ToolExposureSource: String, Codable, CaseIterable, Sendable {
+    case builtIn = "built_in"
+    case runtime
+    case plugin
+    case mcpProvider = "mcp_provider"
+    case sandboxPlugin = "sandbox_plugin"
+    case native
+    case unknown
+
+    var displayLabel: String {
+        switch self {
+        case .builtIn:
+            return "Built-in"
+        case .runtime:
+            return "Runtime"
+        case .plugin:
+            return "Plugin"
+        case .mcpProvider:
+            return "MCP"
+        case .sandboxPlugin:
+            return "Sandbox"
+        case .native:
+            return "Native"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}
+
+enum ToolExposureState: String, Codable, CaseIterable, Sendable {
+    case exposed
+    case loadable
+    case hidden
+    case disabled
+    case blocked
+    case unavailable
+
+    var displayLabel: String {
+        switch self {
+        case .exposed:
+            return "Exposed"
+        case .loadable:
+            return "Loadable"
+        case .hidden:
+            return "Hidden"
+        case .disabled:
+            return "Disabled"
+        case .blocked:
+            return "Blocked"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+}
+
 enum ToolExposureSearchReasonCode: String, Codable, CaseIterable, Sendable {
     case searchable
     case indexed
@@ -22,25 +77,66 @@ enum ToolExposureSearchReasonCode: String, Codable, CaseIterable, Sendable {
 }
 
 struct ToolExposureDiagnostic: Equatable, Sendable {
-    struct Row: Equatable, Sendable {
+    struct Row: Equatable, Identifiable, Sendable {
+        var id: String { toolName }
+
         let toolName: String
+        let description: String
+        let source: ToolExposureSource
+        let state: ToolExposureState
         let availability: ToolAvailability
         let registered: Bool
         let globallyEnabled: Bool
         let indexedForSearch: Bool
         let searchableByCapabilitiesDiscover: Bool
         let searchReasonCodes: [ToolExposureSearchReasonCode]
+        let tokenEstimate: Int
+
+        var allowsGlobalEnablementChange: Bool {
+            registered && source != .builtIn && source != .runtime
+        }
 
         var compactSummary: String {
             let searchCodes = searchReasonCodes.map(\.rawValue).joined(separator: ",")
             return
-                "availability=\(availability.compactSummary); indexed=\(indexedForSearch); searchable=\(searchableByCapabilitiesDiscover); search=\(searchCodes)"
+                "source=\(source.rawValue); state=\(state.rawValue); availability=\(availability.compactSummary); indexed=\(indexedForSearch); searchable=\(searchableByCapabilitiesDiscover); search=\(searchCodes)"
         }
     }
 
     let registeredToolCount: Int
     let indexedToolCount: Int
     let rows: [Row]
+
+    var sourceCounts: [ToolExposureSource: Int] {
+        Dictionary(grouping: rows, by: \.source).mapValues(\.count)
+    }
+
+    var stateCounts: [ToolExposureState: Int] {
+        Dictionary(grouping: rows, by: \.state).mapValues(\.count)
+    }
+
+    func filteredRows(
+        query rawQuery: String = "",
+        source: ToolExposureSource? = nil,
+        state: ToolExposureState? = nil
+    ) -> [Row] {
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return rows.filter { row in
+            if let source, row.source != source { return false }
+            if let state, row.state != state { return false }
+            guard !query.isEmpty else { return true }
+            let haystack = [
+                row.toolName,
+                row.description,
+                row.source.displayLabel,
+                row.state.displayLabel,
+                row.availability.displayDetail,
+                row.availability.reasonCodes.map(\.rawValue).joined(separator: " "),
+                row.searchReasonCodes.map(\.rawValue).joined(separator: " "),
+            ].joined(separator: " ").lowercased()
+            return haystack.contains(query)
+        }
+    }
 
     var textBlock: String {
         guard !rows.isEmpty else { return "" }
@@ -52,5 +148,77 @@ struct ToolExposureDiagnostic: Equatable, Sendable {
             lines.append("- tool/\(row.toolName): \(row.compactSummary)")
         }
         return lines.joined(separator: "\n")
+    }
+
+    func reporterSafeMarkdown(generatedAt: Date = Date(), rows selectedRows: [Row]? = nil) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+
+        let reportRows = (selectedRows ?? rows)
+            .sorted { lhs, rhs in
+                if lhs.source.rawValue == rhs.source.rawValue {
+                    return lhs.toolName.localizedCaseInsensitiveCompare(rhs.toolName) == .orderedAscending
+                }
+                return lhs.source.rawValue < rhs.source.rawValue
+            }
+        let reportStateCounts = Dictionary(grouping: reportRows, by: \.state).mapValues(\.count)
+        let reportSourceCounts = Dictionary(grouping: reportRows, by: \.source).mapValues(\.count)
+
+        var lines: [String] = [
+            "# Tool Exposure Report",
+            "",
+            "- Generated: \(formatter.string(from: generatedAt))",
+            "- Registered tools: \(registeredToolCount)",
+            "- Indexed tools: \(indexedToolCount)",
+            "- Rows in report: \(reportRows.count)",
+            "- Reporter-safe fields only: no schemas, arguments, secrets, provider URLs, manifest paths, or runtime paths.",
+            "",
+            "## State Counts",
+        ]
+
+        for state in ToolExposureState.allCases {
+            lines.append("- \(state.displayLabel): \(reportStateCounts[state, default: 0])")
+        }
+
+        lines.append(contentsOf: [
+            "",
+            "## Source Counts",
+        ])
+
+        for source in ToolExposureSource.allCases {
+            let count = reportSourceCounts[source, default: 0]
+            if count > 0 {
+                lines.append("- \(source.displayLabel): \(count)")
+            }
+        }
+
+        lines.append(contentsOf: [
+            "",
+            "## Rows",
+            "",
+            "| Tool | Source | State | Availability reasons | Capability search reasons | Enabled | Indexed | Searchable | Tokens |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | ---: |",
+        ])
+
+        for row in reportRows {
+            lines.append(
+                "| \(Self.escapeMarkdown(row.toolName)) | \(row.source.rawValue) | \(row.state.rawValue) | \(Self.joinCodes(row.availability.reasonCodes.map(\.rawValue))) | \(Self.joinCodes(row.searchReasonCodes.map(\.rawValue))) | \(row.globallyEnabled) | \(row.indexedForSearch) | \(row.searchableByCapabilitiesDiscover) | \(row.tokenEstimate) |"
+            )
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func joinCodes(_ codes: [String]) -> String {
+        guard !codes.isEmpty else { return "-" }
+        return escapeMarkdown(codes.joined(separator: ", "))
+    }
+
+    private static func escapeMarkdown(_ raw: String) -> String {
+        raw
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
     }
 }

--- a/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
@@ -127,6 +127,24 @@ public actor ToolIndexService {
         await ToolSearchService.shared.search(query: query, topK: topK)
     }
 
+    /// Snapshot every registered session tool with the same availability and
+    /// capability-search reasons used by named diagnostics.
+    func exposureSnapshot(
+        agentAllowedNames: Set<String>? = nil,
+        executionMode: ExecutionMode? = nil,
+        selectedPreflightNames: Set<String>? = nil
+    ) async -> ToolExposureDiagnostic {
+        let toolNames = await MainActor.run {
+            ToolRegistry.shared.listTools().map(\.name)
+        }
+        return await exposureDiagnostic(
+            forToolNames: toolNames,
+            agentAllowedNames: agentAllowedNames,
+            executionMode: executionMode,
+            selectedPreflightNames: selectedPreflightNames
+        )
+    }
+
     /// Explain how named tools move through the registry → search index →
     /// capability-discovery path. This is intentionally read-only: callers
     /// still enforce loading and execution through `ToolRegistry` and
@@ -158,22 +176,35 @@ public actor ToolIndexService {
             let enabledNames: Set<String>
             let runtimeManagedNames: Set<String>
             let capabilityToolNames: Set<String>
+            let entriesByName: [String: ToolRegistry.ToolEntry]
+            let sourcesByName: [String: ToolExposureSource]
             let availabilityByName: [String: ToolAvailability]
         }
 
         let snapshot = await MainActor.run {
             let tools = ToolRegistry.shared.listTools()
+            let registry = ToolRegistry.shared
+            let entriesByName = Dictionary(
+                uniqueKeysWithValues: tools.map { ($0.name, $0) }
+            )
+            let sourcesByName = Dictionary(
+                uniqueKeysWithValues: tools.map { tool in
+                    (tool.name, Self.exposureSource(for: tool.name, registry: registry))
+                }
+            )
             return RegistrySnapshot(
                 registeredToolCount: tools.count,
                 registeredNames: Set(tools.map(\.name)),
                 enabledNames: Set(tools.filter(\.enabled).map(\.name)),
-                runtimeManagedNames: ToolRegistry.shared.runtimeManagedToolNames,
+                runtimeManagedNames: registry.runtimeManagedToolNames,
                 capabilityToolNames: ToolRegistry.capabilityToolNames,
+                entriesByName: entriesByName,
+                sourcesByName: sourcesByName,
                 availabilityByName: Dictionary(
                     uniqueKeysWithValues: names.map {
                         (
                             $0,
-                            ToolRegistry.shared.availability(
+                            registry.availability(
                                 forTool: $0,
                                 agentAllowedNames: agentAllowedNames,
                                 executionMode: executionMode,
@@ -189,6 +220,7 @@ public actor ToolIndexService {
             let registered = snapshot.registeredNames.contains(name)
             let globallyEnabled = snapshot.enabledNames.contains(name)
             let indexedForSearch = indexedNames.contains(name)
+            let entry = snapshot.entriesByName[name]
             let availability =
                 snapshot.availabilityByName[name]
                 ?? ToolAvailability(
@@ -250,12 +282,16 @@ public actor ToolIndexService {
 
             return ToolExposureDiagnostic.Row(
                 toolName: name,
+                description: entry?.description ?? "",
+                source: snapshot.sourcesByName[name] ?? .unknown,
+                state: Self.exposureState(for: availability),
                 availability: availability,
                 registered: registered,
                 globallyEnabled: globallyEnabled,
                 indexedForSearch: indexedForSearch,
                 searchableByCapabilitiesDiscover: searchable,
-                searchReasonCodes: reasons
+                searchReasonCodes: reasons,
+                tokenEstimate: entry?.estimatedTokens ?? 0
             )
         }
 
@@ -264,6 +300,52 @@ public actor ToolIndexService {
             indexedToolCount: indexedToolCount,
             rows: rows
         )
+    }
+
+    @MainActor
+    private static func exposureSource(
+        for toolName: String,
+        registry: ToolRegistry
+    ) -> ToolExposureSource {
+        if registry.runtimeManagedToolNames.contains(toolName) {
+            return .runtime
+        }
+        if registry.builtInToolNames.contains(toolName) {
+            return .builtIn
+        }
+        if registry.isMCPTool(toolName) {
+            return .mcpProvider
+        }
+        if registry.isSandboxTool(toolName) {
+            return .sandboxPlugin
+        }
+        if registry.isPluginTool(toolName) {
+            return .plugin
+        }
+        return .native
+    }
+
+    private static func exposureState(for availability: ToolAvailability) -> ToolExposureState {
+        let reasons = Set(availability.reasonCodes)
+        if reasons.contains(.permissionBlocked) || reasons.contains(.missingPermission) {
+            return .blocked
+        }
+        if reasons.contains(.disabled) {
+            return .disabled
+        }
+        if reasons.contains(.hiddenByAgentScope)
+            || reasons.contains(.hiddenByExecutionMode)
+            || reasons.contains(.notSelectedByPreflight)
+        {
+            return .hidden
+        }
+        if availability.isCallableNow {
+            return .exposed
+        }
+        if availability.isLoadableViaCapabilitiesLoad {
+            return .loadable
+        }
+        return .unavailable
     }
 
     /// Build a compact text index for injection into system prompt.

--- a/Packages/OsaurusCore/Tests/Tool/ToolExposureControlCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolExposureControlCenterTests.swift
@@ -1,0 +1,243 @@
+//
+//  ToolExposureControlCenterTests.swift
+//  osaurus
+//
+//  Tests for the tool exposure control-center snapshot and report contract.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ToolExposureControlCenterTests {
+
+    @Test @MainActor
+    func exposureSnapshotClassifiesSourcesStatesAndReasons() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tool-exposure-control-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let dbWasOpen = ToolDatabase.shared.isOpen
+            if !dbWasOpen {
+                try ToolDatabase.shared.openInMemory()
+            }
+
+            let enabled = ExposureControlFixtureTool(
+                name: Self.uniqueName("enabled"),
+                description: "Search current exposure control rows"
+            )
+            let disabled = ExposureControlFixtureTool(
+                name: Self.uniqueName("disabled"),
+                description: "Search disabled exposure control rows"
+            )
+
+            ToolRegistry.shared.registerPluginTool(enabled)
+            ToolRegistry.shared.registerPluginTool(disabled)
+            ToolRegistry.shared.setEnabled(true, for: enabled.name)
+            ToolRegistry.shared.setEnabled(false, for: disabled.name)
+
+            defer {
+                ToolRegistry.shared.unregister(names: [enabled.name, disabled.name])
+                try? ToolDatabase.shared.deleteEntry(id: enabled.name)
+                try? ToolDatabase.shared.deleteEntry(id: disabled.name)
+                if !dbWasOpen {
+                    ToolDatabase.shared.close()
+                }
+            }
+
+            await ToolIndexService.shared.onToolRegistered(
+                name: enabled.name,
+                description: enabled.description,
+                runtime: .native,
+                tokenCount: 12,
+                parameters: enabled.parameters
+            )
+            await ToolIndexService.shared.onToolRegistered(
+                name: disabled.name,
+                description: disabled.description,
+                runtime: .native,
+                tokenCount: 12,
+                parameters: disabled.parameters
+            )
+
+            let allToolsCount = ToolRegistry.shared.toolCount
+            let snapshot = await ToolIndexService.shared.exposureSnapshot(
+                agentAllowedNames: [enabled.name]
+            )
+            #expect(snapshot.registeredToolCount == allToolsCount)
+            #expect(snapshot.rows.count == allToolsCount)
+
+            let rowsByName = Dictionary(uniqueKeysWithValues: snapshot.rows.map { ($0.toolName, $0) })
+            let enabledRow = try #require(rowsByName[enabled.name])
+            #expect(enabledRow.source == .plugin)
+            #expect(enabledRow.state == .loadable)
+            #expect(enabledRow.availability.reasonCodes == [.loadableViaCapabilitiesLoad])
+            #expect(enabledRow.searchReasonCodes.contains(.searchable))
+            #expect(enabledRow.searchableByCapabilitiesDiscover)
+
+            let disabledRow = try #require(rowsByName[disabled.name])
+            #expect(disabledRow.source == .plugin)
+            #expect(disabledRow.state == .disabled)
+            #expect(disabledRow.availability.reasonCodes.contains(.disabled))
+            #expect(disabledRow.searchReasonCodes.contains(.globallyDisabled))
+            #expect(!disabledRow.searchableByCapabilitiesDiscover)
+
+            let hidden = await ToolIndexService.shared.exposureDiagnostic(
+                forToolNames: [enabled.name],
+                agentAllowedNames: []
+            )
+            let hiddenRow = try #require(hidden.rows.first)
+            #expect(hiddenRow.state == .hidden)
+            #expect(hiddenRow.availability.reasonCodes.contains(.hiddenByAgentScope))
+            #expect(hiddenRow.searchReasonCodes.contains(.hiddenByAgentScope))
+
+            let pluginRows = snapshot.filteredRows(source: .plugin)
+            #expect(pluginRows.contains { $0.toolName == enabled.name })
+            #expect(pluginRows.contains { $0.toolName == disabled.name })
+            #expect(snapshot.filteredRows(state: .disabled).contains { $0.toolName == disabled.name })
+        }
+    }
+
+    @Test @MainActor
+    func reporterSafeMarkdownOmitsSchemasArgumentsAndRuntimeDetails() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tool = ExposureControlFixtureTool(
+                name: Self.uniqueName("secret_report"),
+                description: "Tool with a schema field that must not leak into reports"
+            )
+            let excluded = ExposureControlFixtureTool(
+                name: Self.uniqueName("excluded_report"),
+                description: "Tool filtered out of the report"
+            )
+            ToolRegistry.shared.registerPluginTool(tool)
+            ToolRegistry.shared.registerPluginTool(excluded)
+            ToolRegistry.shared.setEnabled(true, for: tool.name)
+            ToolRegistry.shared.setEnabled(true, for: excluded.name)
+            defer { ToolRegistry.shared.unregister(names: [tool.name, excluded.name]) }
+
+            let diagnostic = await ToolIndexService.shared.exposureDiagnostic(
+                forToolNames: [tool.name, excluded.name]
+            )
+            let row = try #require(diagnostic.rows.first { $0.toolName == tool.name })
+            let report = diagnostic.reporterSafeMarkdown(
+                generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+                rows: [row]
+            )
+
+            #expect(report.contains("# Tool Exposure Report"))
+            #expect(report.contains(tool.name))
+            #expect(!report.contains(excluded.name))
+            #expect(report.contains("- Rows in report: 1"))
+            #expect(report.contains("Reporter-safe fields only"))
+            #expect(!report.contains("api_key"))
+            #expect(!report.contains("Secret credential"))
+            #expect(!report.contains("Search query"))
+            #expect(!report.contains(tool.description))
+        }
+    }
+
+    @Test @MainActor
+    func capabilitySearchDoesNotReturnGloballyDisabledIndexedTool() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-tool-exposure-search-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            let previousOverride = ToolConfigurationStore.overrideDirectory
+            ToolConfigurationStore.overrideDirectory = tempDir
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                ToolConfigurationStore.overrideDirectory = previousOverride
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let dbWasOpen = ToolDatabase.shared.isOpen
+            if !dbWasOpen {
+                try ToolDatabase.shared.openInMemory()
+            }
+
+            let disabled = ExposureControlFixtureTool(
+                name: Self.uniqueName("search_disabled"),
+                description: "Find exposurecontrolkeyword online search results"
+            )
+            ToolRegistry.shared.registerPluginTool(disabled)
+            ToolRegistry.shared.setEnabled(false, for: disabled.name)
+            defer {
+                ToolRegistry.shared.unregister(names: [disabled.name])
+                try? ToolDatabase.shared.deleteEntry(id: disabled.name)
+                if !dbWasOpen {
+                    ToolDatabase.shared.close()
+                }
+            }
+
+            await ToolIndexService.shared.onToolRegistered(
+                name: disabled.name,
+                description: disabled.description,
+                runtime: .native,
+                tokenCount: 12,
+                parameters: disabled.parameters
+            )
+
+            let bm25 = try ToolDatabase.shared.searchBM25(query: "exposurecontrolkeyword", topK: 5)
+            #expect(bm25.contains { $0.id == disabled.name })
+
+            let (hybrid, diagnostic) = await ToolSearchService.shared.searchHybridWithDiagnostic(
+                query: "exposurecontrolkeyword",
+                topK: 5,
+                minFusedScore: CapabilitySearch.minimumFusedScore
+            )
+            #expect(diagnostic.allHits.contains { $0.name == disabled.name })
+            #expect(!hybrid.contains { $0.entry.name == disabled.name })
+
+            let capabilityResults = await CapabilitySearch.search(
+                query: "exposurecontrolkeyword",
+                topK: (methods: 0, tools: 5, skills: 0)
+            )
+            #expect(!capabilityResults.tools.contains { $0.entry.name == disabled.name })
+
+            let exposure = await ToolIndexService.shared.exposureDiagnostic(forToolNames: [disabled.name])
+            let row = try #require(exposure.rows.first)
+            #expect(row.state == .disabled)
+            #expect(row.searchReasonCodes.contains(.globallyDisabled))
+            #expect(!row.searchableByCapabilitiesDiscover)
+        }
+    }
+
+    private static func uniqueName(_ suffix: String) -> String {
+        "tool_exposure_\(suffix)_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))"
+    }
+}
+
+private struct ExposureControlFixtureTool: OsaurusTool {
+    let name: String
+    let description: String
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "query": .object([
+                "type": .string("string"),
+                "description": .string("Search query"),
+            ]),
+            "api_key": .object([
+                "type": .string("string"),
+                "description": .string("Secret credential used only by tests"),
+            ]),
+        ]),
+        "required": .array([.string("query")]),
+    ])
+
+    func execute(argumentsJSON: String) async throws -> String {
+        argumentsJSON
+    }
+}

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -36,6 +36,10 @@ struct ToolsManagerView: View {
     /// Precomputed once per refresh so tool rows never call
     /// `ToolRegistry.availability(forTool:)` during SwiftUI layout.
     @State private var availabilityCache: [String: ToolAvailability] = [:]
+    @State private var exposureDiagnostic: ToolExposureDiagnostic?
+    @State private var exposureSourceFilter: ToolExposureSourceFilter = .all
+    @State private var exposureStateFilter: ToolExposureStateFilter = .all
+    @State private var exposureExportError: String?
 
     // Cached filtered results
     @State private var installedPluginsWithTools: [(plugin: PluginState, tools: [ToolRegistry.ToolEntry])] = []
@@ -105,6 +109,23 @@ struct ToolsManagerView: View {
             remoteProviderCount = providerManager.configuration.providers.count
             reload()
         }
+        .alert(
+            Text("Export Failed", bundle: .module),
+            isPresented: Binding(
+                get: { exposureExportError != nil },
+                set: { if !$0 { exposureExportError = nil } }
+            )
+        ) {
+            Button(role: .cancel) {
+                exposureExportError = nil
+            } label: {
+                Text("OK", bundle: .module)
+            }
+        } message: {
+            if let error = exposureExportError {
+                Text(error)
+            }
+        }
     }
 
     // MARK: - Header Bar
@@ -161,6 +182,22 @@ struct ToolsManagerView: View {
                 let plugins = installedPluginsWithTools
                 let remoteTools = remoteProviderTools
                 let runtimeTools = runtimeManagedToolEntries
+                let exposureRows = filteredExposureRows
+
+                if let exposureDiagnostic {
+                    ToolExposureControlCenter(
+                        diagnostic: exposureDiagnostic,
+                        rows: exposureRows,
+                        sourceFilter: $exposureSourceFilter,
+                        stateFilter: $exposureStateFilter,
+                        toolEntriesByName: Dictionary(
+                            uniqueKeysWithValues: toolEntries.map { ($0.name, $0) }
+                        ),
+                        policyInfoCache: policyInfoCache,
+                        onExport: exportExposureReport,
+                        onChange: { reload() }
+                    )
+                }
 
                 if runtimeTools.isEmpty && plugins.isEmpty && remoteTools.isEmpty {
                     emptyState(
@@ -395,6 +432,17 @@ struct ToolsManagerView: View {
             }
         }
         pluginsWithMissingPermissionsCount = permissionCount
+
+        exposureDiagnostic = await ToolIndexService.shared.exposureSnapshot()
+    }
+
+    private var filteredExposureRows: [ToolExposureDiagnostic.Row] {
+        guard let exposureDiagnostic else { return [] }
+        return exposureDiagnostic.filteredRows(
+            query: searchText,
+            source: exposureSourceFilter.source,
+            state: exposureStateFilter.state
+        )
     }
 
     private func runtimeBadge(for entry: ToolRegistry.ToolEntry) -> String {
@@ -420,6 +468,22 @@ struct ToolsManagerView: View {
         Task { await updateFilteredLists() }
     }
 
+    private func exportExposureReport() {
+        guard let exposureDiagnostic else { return }
+        let report = exposureDiagnostic.reporterSafeMarkdown(rows: filteredExposureRows)
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = "osaurus-tool-exposure-report.md"
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            do {
+                try report.write(to: url, atomically: true, encoding: .utf8)
+            } catch {
+                exposureExportError = error.localizedDescription
+            }
+        }
+    }
+
     /// Honour one-shot navigation requests routed through
     /// `ManagementStateManager.pendingToolsSubTab` (e.g. the Claude plugin
     /// install summary deep-linking to the Remote MCP tab after OAuth or
@@ -441,6 +505,409 @@ private func cachedAvailability(
     for entry: ToolRegistry.ToolEntry
 ) -> ToolAvailability {
     cache[entry.name] ?? ToolRegistry.shared.availability(forTool: entry.name)
+}
+
+// MARK: - Tool Exposure Control Center
+
+private enum ToolExposureSourceFilter: String, CaseIterable, Identifiable {
+    case all
+    case builtIn
+    case runtime
+    case plugin
+    case mcpProvider
+    case sandboxPlugin
+    case native
+    case unknown
+
+    var id: String { rawValue }
+
+    var source: ToolExposureSource? {
+        switch self {
+        case .all:
+            return nil
+        case .builtIn:
+            return .builtIn
+        case .runtime:
+            return .runtime
+        case .plugin:
+            return .plugin
+        case .mcpProvider:
+            return .mcpProvider
+        case .sandboxPlugin:
+            return .sandboxPlugin
+        case .native:
+            return .native
+        case .unknown:
+            return .unknown
+        }
+    }
+
+    var title: String {
+        source?.displayLabel ?? "All Sources"
+    }
+}
+
+private enum ToolExposureStateFilter: String, CaseIterable, Identifiable {
+    case all
+    case exposed
+    case loadable
+    case hidden
+    case disabled
+    case blocked
+    case unavailable
+
+    var id: String { rawValue }
+
+    var state: ToolExposureState? {
+        switch self {
+        case .all:
+            return nil
+        case .exposed:
+            return .exposed
+        case .loadable:
+            return .loadable
+        case .hidden:
+            return .hidden
+        case .disabled:
+            return .disabled
+        case .blocked:
+            return .blocked
+        case .unavailable:
+            return .unavailable
+        }
+    }
+
+    var title: String {
+        state?.displayLabel ?? "All States"
+    }
+}
+
+private struct ToolExposureControlCenter: View {
+    @Environment(\.theme) private var theme
+
+    let diagnostic: ToolExposureDiagnostic
+    let rows: [ToolExposureDiagnostic.Row]
+    @Binding var sourceFilter: ToolExposureSourceFilter
+    @Binding var stateFilter: ToolExposureStateFilter
+    let toolEntriesByName: [String: ToolRegistry.ToolEntry]
+    let policyInfoCache: [String: ToolRegistry.ToolPolicyInfo]
+    let onExport: () -> Void
+    let onChange: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.accentColor.opacity(0.12))
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(theme.accentColor)
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("Tool Exposure Control Center", bundle: .module)
+                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                            .foregroundColor(theme.primaryText)
+
+                        Text("\(rows.count)/\(diagnostic.rows.count)", bundle: .module)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(theme.secondaryText)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(theme.tertiaryBackground))
+                    }
+
+                    HStack(spacing: 6) {
+                        exposureCountBadge(.exposed, icon: "eye")
+                        exposureCountBadge(.loadable, icon: "arrow.down.circle")
+                        exposureCountBadge(.hidden, icon: "eye.slash")
+                        exposureCountBadge(.disabled, icon: "power")
+                        exposureCountBadge(.blocked, icon: "lock")
+                    }
+                }
+
+                Spacer()
+
+                HStack(spacing: 8) {
+                    ExposureFilterMenu(
+                        icon: "square.grid.2x2",
+                        title: sourceFilter.title,
+                        options: ToolExposureSourceFilter.allCases,
+                        selection: $sourceFilter
+                    )
+
+                    ExposureFilterMenu(
+                        icon: "line.3.horizontal.decrease.circle",
+                        title: stateFilter.title,
+                        options: ToolExposureStateFilter.allCases,
+                        selection: $stateFilter
+                    )
+
+                    Button(action: onExport) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.primaryText)
+                            .frame(width: 30, height: 28)
+                            .background(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .fill(theme.tertiaryBackground)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 7)
+                                            .stroke(theme.inputBorder, lineWidth: 1)
+                                    )
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help(Text("Export reporter-safe exposure report", bundle: .module))
+                }
+            }
+
+            if rows.isEmpty {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(theme.tertiaryText)
+                    Text("No exposure rows match the current filters", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                    Spacer()
+                }
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 8).fill(theme.tertiaryBackground.opacity(0.5)))
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(rows) { row in
+                        ToolExposureRowView(
+                            row: row,
+                            entry: toolEntriesByName[row.toolName],
+                            policyInfo: policyInfoCache[row.toolName],
+                            onChange: onChange
+                        )
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity)
+        .background(HoverableCardBackground())
+    }
+
+    private func exposureCountBadge(_ state: ToolExposureState, icon: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .semibold))
+            Text("\(diagnostic.stateCounts[state, default: 0]) \(state.displayLabel)", bundle: .module)
+                .font(.system(size: 10, weight: .medium))
+        }
+        .foregroundColor(color(for: state))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(color(for: state).opacity(0.12)))
+    }
+
+    private func color(for state: ToolExposureState) -> Color {
+        switch state {
+        case .exposed:
+            return theme.successColor
+        case .loadable:
+            return theme.accentColor
+        case .hidden:
+            return theme.warningColor
+        case .disabled:
+            return theme.secondaryText
+        case .blocked, .unavailable:
+            return theme.errorColor
+        }
+    }
+}
+
+private protocol ToolExposureFilterOption: Identifiable, Hashable {
+    var title: String { get }
+}
+
+extension ToolExposureSourceFilter: ToolExposureFilterOption {}
+extension ToolExposureStateFilter: ToolExposureFilterOption {}
+
+private struct ExposureFilterMenu<Option: ToolExposureFilterOption>: View {
+    @Environment(\.theme) private var theme
+
+    let icon: String
+    let title: String
+    let options: [Option]
+    @Binding var selection: Option
+
+    var body: some View {
+        Menu {
+            ForEach(options, id: \.self) { option in
+                Button {
+                    selection = option
+                } label: {
+                    HStack {
+                        if option == selection {
+                            Image(systemName: "checkmark")
+                        }
+                        Text(LocalizedStringKey(option.title), bundle: .module)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .semibold))
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+            }
+            .foregroundColor(theme.primaryText)
+            .padding(.horizontal, 9)
+            .frame(height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(theme.tertiaryBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+}
+
+private struct ToolExposureRowView: View {
+    @Environment(\.theme) private var theme
+
+    let row: ToolExposureDiagnostic.Row
+    let entry: ToolRegistry.ToolEntry?
+    let policyInfo: ToolRegistry.ToolPolicyInfo?
+    let onChange: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(stateColor.opacity(0.1))
+                Image(systemName: iconName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(stateColor)
+            }
+            .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 5) {
+                    Text(verbatim: row.toolName)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+
+                    ExposurePill(label: row.source.displayLabel, color: theme.accentColor)
+                    ExposurePill(label: row.state.displayLabel, color: stateColor)
+                }
+
+                if !row.description.isEmpty {
+                    Text(verbatim: row.description)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: 6) {
+                    ToolAvailabilityBadge(availability: row.availability)
+                    Text(row.availability.displayDetail)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                }
+
+                HStack(spacing: 6) {
+                    exposureReasonText
+                    Text("tokens \(row.tokenEstimate)", bundle: .module)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+
+            Spacer()
+
+            if let policyInfo {
+                ToolPolicyMenu(
+                    toolName: row.toolName,
+                    info: policyInfo,
+                    onChange: onChange
+                )
+            }
+
+            if row.allowsGlobalEnablementChange, let entry {
+                ToolEnableToggle(entry: entry, onChange: onChange)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.tertiaryBackground.opacity(0.5))
+        )
+    }
+
+    private var exposureReasonText: some View {
+        let indexStatus = row.indexedForSearch ? "indexed" : "not indexed"
+        let searchStatus = row.searchableByCapabilitiesDiscover ? "discoverable" : "not discoverable"
+        let reasons = row.searchReasonCodes.map(\.rawValue).joined(separator: ", ")
+        return Text("\(indexStatus) / \(searchStatus) / \(reasons)", bundle: .module)
+            .font(.system(size: 10))
+            .foregroundColor(theme.tertiaryText)
+            .lineLimit(1)
+    }
+
+    private var iconName: String {
+        switch row.state {
+        case .exposed:
+            return "eye"
+        case .loadable:
+            return "arrow.down.circle"
+        case .hidden:
+            return "eye.slash"
+        case .disabled:
+            return "power"
+        case .blocked:
+            return "lock"
+        case .unavailable:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    private var stateColor: Color {
+        switch row.state {
+        case .exposed:
+            return theme.successColor
+        case .loadable:
+            return theme.accentColor
+        case .hidden:
+            return theme.warningColor
+        case .disabled:
+            return theme.secondaryText
+        case .blocked, .unavailable:
+            return theme.errorColor
+        }
+    }
+}
+
+private struct ExposurePill: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        Text(LocalizedStringKey(label), bundle: .module)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(color.opacity(0.12)))
+    }
 }
 
 // MARK: - Sandbox Plugins Tab

--- a/docs/TOOL_EXPOSURE_CONTROL_CENTER.md
+++ b/docs/TOOL_EXPOSURE_CONTROL_CENTER.md
@@ -1,0 +1,35 @@
+# Tool Exposure Control Center
+
+The Tools settings view includes a Tool Exposure Control Center panel for
+inspecting the tools registered in the current session.
+
+The panel shows each session tool's source, exposure state, availability
+reason, capability-search indexing state, global enablement, and estimated
+schema token cost. Source and state filters use the same typed diagnostic data
+that backs `capabilities_discover` miss explanations.
+
+## Sources
+
+- Built-in: baseline tools registered by Osaurus.
+- Runtime: folder and built-in sandbox tools managed by the active session.
+- Plugin: native plugin tools.
+- MCP: tools registered by connected remote MCP providers.
+- Sandbox: JSON sandbox plugin tools.
+- Native: registered tools that do not belong to the other buckets.
+- Unknown: named diagnostics for tools that are not registered.
+
+## States
+
+- Exposed: callable in the active baseline.
+- Loadable: registered and available through `capabilities_load`.
+- Hidden: filtered by agent scope, execution mode, or preflight selection.
+- Disabled: globally disabled by tool configuration.
+- Blocked: permission policy or missing system permission blocks use.
+- Unavailable: not registered, not installed, or otherwise unavailable.
+
+## Reporter-Safe Export
+
+The export button writes a Markdown report designed for issue reports. It
+includes tool names, source/state, reason codes, indexing booleans, and token
+estimates. It deliberately omits raw schemas, arguments, secrets, provider
+URLs, manifest paths, and runtime paths.


### PR DESCRIPTION
## Summary
- Adds a tool exposure control center to inspect advertised tools, hidden tools, exposure status, and gating reasons.
- Extends the tool index service with diagnostics that explain why tools are available or suppressed.
- Adds focused tests and operator documentation for reviewing tool exposure.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter ToolExposureControlCenterTests`
- `swift test --package-path Packages/OsaurusCore --filter 'ToolSearchServiceTests|ConfigureToolExposureTests|ToolIndexServiceTests'`
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"`

## Notes
- The localization check still reports the existing stale-key warning set from main.
