### PR TITLE
Add memory management console

### DIFF
--- a/Packages/OsaurusCore/Models/Memory/MemoryManagementConsoleModels.swift
+++ b/Packages/OsaurusCore/Models/Memory/MemoryManagementConsoleModels.swift
@@ -1,0 +1,336 @@
+//
+//  MemoryManagementConsoleModels.swift
+//  osaurus
+//
+//  Data contracts for the Memory management console. The console is an
+//  administrative view over SQL-backed memory rows, so it uses privacy-safe
+//  display models rather than exposing raw row payloads directly to SwiftUI.
+//
+
+import Foundation
+
+public enum MemoryConsoleScope: String, CaseIterable, Identifiable, Sendable {
+    case all
+    case pinned
+    case episodes
+    case transcript
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .all: return "All"
+        case .pinned: return "Pinned"
+        case .episodes: return "Episodes"
+        case .transcript: return "Transcript"
+        }
+    }
+}
+
+public enum MemoryConsoleItemKind: String, Sendable {
+    case pinnedFact
+    case episode
+    case transcriptTurn
+
+    public var displayName: String {
+        switch self {
+        case .pinnedFact: return "Pinned fact"
+        case .episode: return "Episode"
+        case .transcriptTurn: return "Transcript turn"
+        }
+    }
+}
+
+public struct MemoryConsoleQuery: Equatable, Sendable {
+    public var text: String
+    public var scope: MemoryConsoleScope
+    public var agentId: String?
+    public var includeDisabled: Bool
+    public var limit: Int
+
+    public init(
+        text: String = "",
+        scope: MemoryConsoleScope = .all,
+        agentId: String? = nil,
+        includeDisabled: Bool = false,
+        limit: Int = 60
+    ) {
+        self.text = text
+        self.scope = scope
+        self.agentId = agentId
+        self.includeDisabled = includeDisabled
+        self.limit = max(1, min(limit, 250))
+    }
+
+    public var trimmedText: String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+public struct MemoryRedactionResult: Equatable, Sendable {
+    public var text: String
+    public var redactionCounts: [String: Int]
+    public var originalCharacterCount: Int
+    public var displayedCharacterCount: Int
+    public var wasTruncated: Bool
+
+    public init(
+        text: String,
+        redactionCounts: [String: Int] = [:],
+        originalCharacterCount: Int,
+        displayedCharacterCount: Int,
+        wasTruncated: Bool
+    ) {
+        self.text = text
+        self.redactionCounts = redactionCounts
+        self.originalCharacterCount = originalCharacterCount
+        self.displayedCharacterCount = displayedCharacterCount
+        self.wasTruncated = wasTruncated
+    }
+
+    public var redactionCount: Int {
+        redactionCounts.values.reduce(0, +)
+    }
+}
+
+public struct MemoryConsoleMetadata: Equatable, Sendable {
+    public var salience: Double?
+    public var sourceCount: Int?
+    public var sourceEpisodeId: Int?
+    public var lastUsed: String?
+    public var useCount: Int?
+    public var status: String?
+    public var createdAt: String?
+    public var tokenCount: Int?
+    public var conversationAt: String?
+    public var conversationId: String?
+    public var conversationTitle: String?
+    public var chunkIndex: Int?
+    public var role: String?
+    public var model: String?
+    public var tags: [String]
+    public var topics: [String]
+    public var entities: [String]
+
+    public init(
+        salience: Double? = nil,
+        sourceCount: Int? = nil,
+        sourceEpisodeId: Int? = nil,
+        lastUsed: String? = nil,
+        useCount: Int? = nil,
+        status: String? = nil,
+        createdAt: String? = nil,
+        tokenCount: Int? = nil,
+        conversationAt: String? = nil,
+        conversationId: String? = nil,
+        conversationTitle: String? = nil,
+        chunkIndex: Int? = nil,
+        role: String? = nil,
+        model: String? = nil,
+        tags: [String] = [],
+        topics: [String] = [],
+        entities: [String] = []
+    ) {
+        self.salience = salience
+        self.sourceCount = sourceCount
+        self.sourceEpisodeId = sourceEpisodeId
+        self.lastUsed = lastUsed
+        self.useCount = useCount
+        self.status = status
+        self.createdAt = createdAt
+        self.tokenCount = tokenCount
+        self.conversationAt = conversationAt
+        self.conversationId = conversationId
+        self.conversationTitle = conversationTitle
+        self.chunkIndex = chunkIndex
+        self.role = role
+        self.model = model
+        self.tags = tags
+        self.topics = topics
+        self.entities = entities
+    }
+}
+
+public struct MemoryConsoleItem: Identifiable, Equatable, Sendable {
+    public var id: String
+    public var kind: MemoryConsoleItemKind
+    public var storageId: String
+    public var agentId: String
+    public var title: String
+    public var preview: MemoryRedactionResult
+    public var detail: MemoryRedactionResult
+    public var relevanceExplanation: String
+    public var metadata: MemoryConsoleMetadata
+    public var canDisable: Bool
+    public var canForget: Bool
+
+    public init(
+        id: String,
+        kind: MemoryConsoleItemKind,
+        storageId: String,
+        agentId: String,
+        title: String,
+        preview: MemoryRedactionResult,
+        detail: MemoryRedactionResult,
+        relevanceExplanation: String,
+        metadata: MemoryConsoleMetadata,
+        canDisable: Bool,
+        canForget: Bool = true
+    ) {
+        self.id = id
+        self.kind = kind
+        self.storageId = storageId
+        self.agentId = agentId
+        self.title = title
+        self.preview = preview
+        self.detail = detail
+        self.relevanceExplanation = relevanceExplanation
+        self.metadata = metadata
+        self.canDisable = canDisable
+        self.canForget = canForget
+    }
+
+    public var isDisabled: Bool {
+        metadata.status == "disabled" || metadata.status == "evicted"
+    }
+}
+
+public struct MemoryConsoleSnapshot: Sendable {
+    public var query: MemoryConsoleQuery
+    public var items: [MemoryConsoleItem]
+    public var health: MemoryStorageHealth
+    public var generatedAt: Date
+
+    public init(
+        query: MemoryConsoleQuery,
+        items: [MemoryConsoleItem],
+        health: MemoryStorageHealth,
+        generatedAt: Date = Date()
+    ) {
+        self.query = query
+        self.items = items
+        self.health = health
+        self.generatedAt = generatedAt
+    }
+}
+
+public enum MemoryConsoleMutation: String, Sendable {
+    case disable
+    case forget
+}
+
+public struct MemoryConsoleMutationResult: Equatable, Sendable {
+    public var itemId: String
+    public var mutation: MemoryConsoleMutation
+    public var changed: Bool
+    public var message: String
+
+    public init(
+        itemId: String,
+        mutation: MemoryConsoleMutation,
+        changed: Bool,
+        message: String
+    ) {
+        self.itemId = itemId
+        self.mutation = mutation
+        self.changed = changed
+        self.message = message
+    }
+}
+
+public struct MemoryStorageHealth: Sendable {
+    public enum Level: String, Sendable {
+        case healthy
+        case degraded
+        case unavailable
+
+        public var displayName: String {
+            switch self {
+            case .healthy: return "Healthy"
+            case .degraded: return "Needs attention"
+            case .unavailable: return "Unavailable"
+            }
+        }
+    }
+
+    public var level: Level
+    public var databaseOpen: Bool
+    public var schemaVersion: Int?
+    public var expectedSchemaVersion: Int
+    public var databaseSizeBytes: Int64
+    public var activePinnedCount: Int
+    public var disabledPinnedCount: Int
+    public var activeEpisodeCount: Int
+    public var disabledEpisodeCount: Int
+    public var transcriptCount: Int
+    public var pendingSignals: PendingSignalsSummary
+    public var processingStats: ProcessingStats
+    public var ftsTablesReady: Bool
+    public var vectorSearchAvailable: Bool
+    public var vectorIndexFailures: Int
+    public var lastOpenError: String?
+    public var diagnostics: [String]
+
+    public init(
+        level: Level,
+        databaseOpen: Bool,
+        schemaVersion: Int?,
+        expectedSchemaVersion: Int,
+        databaseSizeBytes: Int64,
+        activePinnedCount: Int,
+        disabledPinnedCount: Int,
+        activeEpisodeCount: Int,
+        disabledEpisodeCount: Int,
+        transcriptCount: Int,
+        pendingSignals: PendingSignalsSummary,
+        processingStats: ProcessingStats,
+        ftsTablesReady: Bool,
+        vectorSearchAvailable: Bool,
+        vectorIndexFailures: Int,
+        lastOpenError: String?,
+        diagnostics: [String]
+    ) {
+        self.level = level
+        self.databaseOpen = databaseOpen
+        self.schemaVersion = schemaVersion
+        self.expectedSchemaVersion = expectedSchemaVersion
+        self.databaseSizeBytes = databaseSizeBytes
+        self.activePinnedCount = activePinnedCount
+        self.disabledPinnedCount = disabledPinnedCount
+        self.activeEpisodeCount = activeEpisodeCount
+        self.disabledEpisodeCount = disabledEpisodeCount
+        self.transcriptCount = transcriptCount
+        self.pendingSignals = pendingSignals
+        self.processingStats = processingStats
+        self.ftsTablesReady = ftsTablesReady
+        self.vectorSearchAvailable = vectorSearchAvailable
+        self.vectorIndexFailures = vectorIndexFailures
+        self.lastOpenError = lastOpenError
+        self.diagnostics = diagnostics
+    }
+}
+
+public struct MemoryContextPreview: Equatable, Sendable {
+    public var agentId: String
+    public var query: String
+    public var maxTokens: Int
+    public var estimatedTokens: Int
+    public var redactedContext: MemoryRedactionResult
+    public var wasEmpty: Bool
+
+    public init(
+        agentId: String,
+        query: String,
+        maxTokens: Int,
+        estimatedTokens: Int,
+        redactedContext: MemoryRedactionResult,
+        wasEmpty: Bool
+    ) {
+        self.agentId = agentId
+        self.query = query
+        self.maxTokens = maxTokens
+        self.estimatedTokens = estimatedTokens
+        self.redactedContext = redactedContext
+        self.wasEmpty = wasEmpty
+    }
+}

--- a/Packages/OsaurusCore/Services/Memory/MemoryManagementConsoleService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryManagementConsoleService.swift
@@ -1,0 +1,900 @@
+//
+//  MemoryManagementConsoleService.swift
+//  osaurus
+//
+//  SQL-backed inspection, mutation, and diagnostics for the Memory console.
+//  This deliberately bypasses the runtime search APIs because the console
+//  must be able to show disabled rows while runtime recall must not.
+//
+
+import Foundation
+import OsaurusSQLCipher
+
+public enum MemoryPrivacyRedactor {
+    private struct Pattern {
+        let name: String
+        let replacement: String
+        let regex: NSRegularExpression
+    }
+
+    private static func compile(
+        _ pattern: String,
+        options: NSRegularExpression.Options = []
+    ) -> NSRegularExpression {
+        do {
+            return try NSRegularExpression(pattern: pattern, options: options)
+        } catch {
+            preconditionFailure("Invalid memory redaction regex: \(pattern)")
+        }
+    }
+
+    private static let patterns: [Pattern] = [
+        Pattern(
+            name: "email",
+            replacement: "[redacted email]",
+            regex: compile(
+                #"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b"#,
+                options: [.caseInsensitive]
+            )
+        ),
+        Pattern(
+            name: "url",
+            replacement: "[redacted url]",
+            regex: compile(
+                #"\bhttps?://[^\s<>()]+"#,
+                options: [.caseInsensitive]
+            )
+        ),
+        Pattern(
+            name: "secret",
+            replacement: "[redacted secret]",
+            regex: compile(
+                #"\b(?:sk|pk|rk|ghp|gho|ghu|ghs|github_pat|hf|xoxb|xoxp)[A-Za-z0-9_\-]{16,}\b|\b[A-Fa-f0-9]{32,}\b"#,
+                options: []
+            )
+        ),
+        Pattern(
+            name: "ssn",
+            replacement: "[redacted ssn]",
+            regex: compile(#"\b\d{3}-\d{2}-\d{4}\b"#)
+        ),
+        Pattern(
+            name: "account",
+            replacement: "[redacted account]",
+            regex: compile(#"\b(?:\d[ -]?){13,19}\b"#)
+        ),
+        Pattern(
+            name: "phone",
+            replacement: "[redacted phone]",
+            regex: compile(#"\b(?:\+?1[\s.\-]?)?(?:\(?\d{3}\)?[\s.\-]?)\d{3}[\s.\-]?\d{4}\b"#)
+        ),
+    ]
+
+    public static func redact(_ text: String, maxCharacters: Int = 600) -> MemoryRedactionResult {
+        let originalCount = text.count
+        var redacted = text
+        var counts: [String: Int] = [:]
+
+        for pattern in patterns {
+            let nsRange = NSRange(redacted.startIndex..., in: redacted)
+            let matches = pattern.regex.matches(in: redacted, range: nsRange)
+            guard !matches.isEmpty else { continue }
+            counts[pattern.name, default: 0] += matches.count
+            redacted = pattern.regex.stringByReplacingMatches(
+                in: redacted,
+                range: nsRange,
+                withTemplate: pattern.replacement
+            )
+        }
+
+        let boundedLimit = max(0, maxCharacters)
+        let wasTruncated = redacted.count > boundedLimit
+        if wasTruncated {
+            let suffix = "..."
+            if boundedLimit <= suffix.count {
+                redacted = String(suffix.prefix(boundedLimit))
+            } else {
+                redacted = String(redacted.prefix(boundedLimit - suffix.count)) + suffix
+            }
+        }
+
+        return MemoryRedactionResult(
+            text: redacted,
+            redactionCounts: counts,
+            originalCharacterCount: originalCount,
+            displayedCharacterCount: redacted.count,
+            wasTruncated: wasTruncated
+        )
+    }
+}
+
+public struct MemoryManagementConsoleService: Sendable {
+    public init() {}
+
+    public func snapshot(
+        query: MemoryConsoleQuery,
+        db: MemoryDatabase = .shared,
+        includeVectorState: Bool = true
+    ) async throws -> MemoryConsoleSnapshot {
+        let items = try search(query: query, db: db)
+        let health = await diagnoseStorage(db: db, includeVectorState: includeVectorState)
+        return MemoryConsoleSnapshot(query: query, items: items, health: health)
+    }
+
+    public func search(
+        query: MemoryConsoleQuery,
+        db: MemoryDatabase = .shared
+    ) throws -> [MemoryConsoleItem] {
+        let normalized = MemoryConsoleQuery(
+            text: query.text,
+            scope: query.scope,
+            agentId: query.agentId,
+            includeDisabled: query.includeDisabled,
+            limit: query.limit
+        )
+        let terms = Self.searchTerms(normalized.trimmedText)
+        var items: [MemoryConsoleItem] = []
+
+        if normalized.scope == .all || normalized.scope == .pinned {
+            items.append(contentsOf: try loadPinnedItems(query: normalized, terms: terms, db: db))
+        }
+        if normalized.scope == .all || normalized.scope == .episodes {
+            items.append(contentsOf: try loadEpisodeItems(query: normalized, terms: terms, db: db))
+        }
+        if normalized.scope == .all || normalized.scope == .transcript {
+            items.append(contentsOf: try loadTranscriptItems(query: normalized, terms: terms, db: db))
+        }
+
+        return Array(
+            items.sorted(by: Self.sortConsoleItems).prefix(normalized.limit)
+        )
+    }
+
+    public func disable(
+        itemId: String,
+        db: MemoryDatabase = .shared
+    ) async throws -> MemoryConsoleMutationResult {
+        let parsed = try Self.parseItemId(itemId)
+        switch parsed.kind {
+        case .pinnedFact:
+            let agentId = try agentIdForPinnedFact(id: parsed.storageId, db: db)
+            let changed = try updateStatus(
+                table: "pinned_facts",
+                idColumn: "id",
+                id: parsed.storageId,
+                status: "disabled",
+                db: db
+            )
+            if changed {
+                await MemorySearchService.shared.removeDocument(id: parsed.storageId, agentId: agentId)
+                await MemoryContextAssembler.shared.invalidateCache(agentId: agentId)
+            }
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .disable,
+                changed: changed,
+                message: changed ? "Pinned fact disabled." : "Pinned fact was not found."
+            )
+
+        case .episode:
+            guard let episodeId = Int(parsed.storageId) else {
+                throw MemoryDatabaseError.failedToExecute("Invalid episode id: \(parsed.storageId)")
+            }
+            let agentId = try agentIdForEpisode(id: episodeId, db: db)
+            let changed = try updateStatus(
+                table: "episodes",
+                idColumn: "id",
+                id: parsed.storageId,
+                status: "disabled",
+                db: db
+            )
+            if changed {
+                let vectorId = TextSimilarity.deterministicUUID(from: "episode:\(episodeId)").uuidString
+                await MemorySearchService.shared.removeDocument(id: vectorId, agentId: agentId)
+                await MemoryContextAssembler.shared.invalidateCache(agentId: agentId)
+            }
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .disable,
+                changed: changed,
+                message: changed ? "Episode disabled." : "Episode was not found."
+            )
+
+        case .transcriptTurn:
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .disable,
+                changed: false,
+                message: "Transcript turns do not have a disabled state. Use Forget to remove the row."
+            )
+        }
+    }
+
+    public func forget(
+        itemId: String,
+        db: MemoryDatabase = .shared
+    ) async throws -> MemoryConsoleMutationResult {
+        let parsed = try Self.parseItemId(itemId)
+        switch parsed.kind {
+        case .pinnedFact:
+            let agentId = try agentIdForPinnedFact(id: parsed.storageId, db: db)
+            guard agentId != nil else {
+                return MemoryConsoleMutationResult(
+                    itemId: itemId,
+                    mutation: .forget,
+                    changed: false,
+                    message: "Pinned fact was not found."
+                )
+            }
+            try db.deletePinnedFact(id: parsed.storageId)
+            await MemorySearchService.shared.removeDocument(id: parsed.storageId, agentId: agentId)
+            await MemoryContextAssembler.shared.invalidateCache(agentId: agentId)
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .forget,
+                changed: true,
+                message: "Pinned fact forgotten."
+            )
+
+        case .episode:
+            guard let episodeId = Int(parsed.storageId) else {
+                throw MemoryDatabaseError.failedToExecute("Invalid episode id: \(parsed.storageId)")
+            }
+            let agentId = try agentIdForEpisode(id: episodeId, db: db)
+            guard agentId != nil else {
+                return MemoryConsoleMutationResult(
+                    itemId: itemId,
+                    mutation: .forget,
+                    changed: false,
+                    message: "Episode was not found."
+                )
+            }
+            try db.deleteEpisode(id: episodeId)
+            let vectorId = TextSimilarity.deterministicUUID(from: "episode:\(episodeId)").uuidString
+            await MemorySearchService.shared.removeDocument(id: vectorId, agentId: agentId)
+            await MemoryContextAssembler.shared.invalidateCache(agentId: agentId)
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .forget,
+                changed: true,
+                message: "Episode forgotten."
+            )
+
+        case .transcriptTurn:
+            guard let transcriptId = Int(parsed.storageId) else {
+                throw MemoryDatabaseError.failedToExecute("Invalid transcript id: \(parsed.storageId)")
+            }
+            let row = try transcriptVectorKey(id: transcriptId, db: db)
+            let changed = try deleteTranscriptTurn(id: transcriptId, db: db)
+            if let row, changed {
+                let vectorId = TextSimilarity
+                    .deterministicUUID(from: "transcript:\(row.conversationId):\(row.chunkIndex)")
+                    .uuidString
+                await MemorySearchService.shared.removeDocument(id: vectorId, agentId: row.agentId)
+                await MemoryContextAssembler.shared.invalidateCache(agentId: row.agentId)
+            }
+            return MemoryConsoleMutationResult(
+                itemId: itemId,
+                mutation: .forget,
+                changed: changed,
+                message: changed ? "Transcript turn forgotten." : "Transcript turn was not found."
+            )
+        }
+    }
+
+    public func contextPreview(
+        agentId: String,
+        query: String,
+        maxTokens: Int,
+        config: MemoryConfiguration = MemoryConfigurationStore.load()
+    ) async -> MemoryContextPreview {
+        var previewConfig = config.validated()
+        previewConfig.memoryBudgetTokens = max(100, min(maxTokens, 4000))
+        let assembled = await MemoryContextAssembler.assembleContext(
+            agentId: agentId,
+            config: previewConfig,
+            query: query
+        )
+        let trimmed = assembled.trimmingCharacters(in: .whitespacesAndNewlines)
+        let maxChars = max(1, maxTokens) * MemoryConfiguration.charsPerToken
+        let redacted = MemoryPrivacyRedactor.redact(
+            trimmed.isEmpty ? "(No memory context assembled.)" : trimmed,
+            maxCharacters: maxChars
+        )
+        return MemoryContextPreview(
+            agentId: agentId,
+            query: query,
+            maxTokens: maxTokens,
+            estimatedTokens: max(1, redacted.text.count / MemoryConfiguration.charsPerToken),
+            redactedContext: redacted,
+            wasEmpty: trimmed.isEmpty
+        )
+    }
+
+    public func diagnoseStorage(
+        db: MemoryDatabase = .shared,
+        includeVectorState: Bool = true
+    ) async -> MemoryStorageHealth {
+        let databaseOpen = db.isOpen
+        let schemaVersion = db.schemaUserVersion()
+        let expectedSchemaVersion = MemoryDatabase.expectedSchemaVersion
+        let activePinned = (try? statusCount(table: "pinned_facts", status: "active", db: db)) ?? 0
+        let disabledPinned = (try? statusCount(table: "pinned_facts", status: "disabled", db: db)) ?? 0
+        let activeEpisodes = (try? statusCount(table: "episodes", status: "active", db: db)) ?? 0
+        let disabledEpisodes = (try? statusCount(table: "episodes", status: "disabled", db: db)) ?? 0
+        let transcriptCount = (try? countRows(table: "transcript", db: db)) ?? 0
+        let pendingSignals = (try? db.pendingSignalsSummary()) ?? PendingSignalsSummary()
+        let processingStats = (try? db.processingStats()) ?? ProcessingStats()
+        let ftsReady = (try? ftsTablesReady(db: db)) ?? false
+        let vectorAvailable = includeVectorState ? await MemorySearchService.shared.isVecturaAvailable : false
+        let vectorFailures = includeVectorState ? await MemorySearchService.shared.indexFailures() : 0
+
+        var diagnostics: [String] = []
+        if !databaseOpen {
+            diagnostics.append("Memory database is not open.")
+        }
+        if schemaVersion != expectedSchemaVersion {
+            let actual = schemaVersion.map(String.init) ?? "unknown"
+            diagnostics.append("Schema version is \(actual), expected \(expectedSchemaVersion).")
+        }
+        if !ftsReady {
+            diagnostics.append("FTS mirrors are missing or unavailable; text search may fall back to LIKE scans.")
+        }
+        if vectorFailures > 0 {
+            diagnostics.append("Vector index recorded \(vectorFailures) write failure(s); rebuild may be needed.")
+        }
+        if let lastOpenError = db.lastOpenErrorDescription, !lastOpenError.isEmpty {
+            diagnostics.append("Last open error: \(lastOpenError)")
+        }
+        if pendingSignals.totalSignals > 0 && processingStats.totalCalls == 0 {
+            diagnostics.append("Pending signals exist but no processing log rows were written.")
+        }
+
+        let level: MemoryStorageHealth.Level
+        if !databaseOpen {
+            level = .unavailable
+        } else if diagnostics.isEmpty {
+            level = .healthy
+        } else {
+            level = .degraded
+        }
+
+        return MemoryStorageHealth(
+            level: level,
+            databaseOpen: databaseOpen,
+            schemaVersion: schemaVersion,
+            expectedSchemaVersion: expectedSchemaVersion,
+            databaseSizeBytes: db.databaseSizeBytes(),
+            activePinnedCount: activePinned,
+            disabledPinnedCount: disabledPinned,
+            activeEpisodeCount: activeEpisodes,
+            disabledEpisodeCount: disabledEpisodes,
+            transcriptCount: transcriptCount,
+            pendingSignals: pendingSignals,
+            processingStats: processingStats,
+            ftsTablesReady: ftsReady,
+            vectorSearchAvailable: vectorAvailable,
+            vectorIndexFailures: vectorFailures,
+            lastOpenError: db.lastOpenErrorDescription,
+            diagnostics: diagnostics
+        )
+    }
+
+    // MARK: - Loading
+
+    private func loadPinnedItems(
+        query: MemoryConsoleQuery,
+        terms: [String],
+        db: MemoryDatabase
+    ) throws -> [MemoryConsoleItem] {
+        var sql = """
+            SELECT id, agent_id, content, salience, source_count, source_episode_id,
+                   last_used, use_count, status, created_at, tags_csv
+            FROM pinned_facts
+            WHERE 1 = 1
+            """
+        let (agentClause, agentBindIndex) = Self.agentClause(query.agentId, nextIndex: 1)
+        sql += agentClause
+        var nextIndex = agentBindIndex
+        let statusIndex = nextIndex
+        nextIndex += 1
+        sql += " AND (?\(statusIndex) = 1 OR status = 'active')"
+        let search = Self.searchClause(
+            columns: ["content", "tags_csv"],
+            terms: terms,
+            startingAt: nextIndex
+        )
+        sql += search.sql
+        nextIndex = search.nextIndex
+        let limitIndex = nextIndex
+        sql += " ORDER BY salience DESC, created_at DESC LIMIT ?\(limitIndex)"
+
+        var items: [MemoryConsoleItem] = []
+        try db.prepareAndExecute(
+            sql,
+            bind: { stmt in
+                if let agentId = query.agentId {
+                    MemoryDatabase.bindText(stmt, index: 1, value: agentId)
+                }
+                sqlite3_bind_int(stmt, Int32(statusIndex), query.includeDisabled ? 1 : 0)
+                Self.bindTerms(stmt, terms: terms, bindings: search.bindings)
+                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(query.limit))
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    items.append(Self.pinnedItem(stmt: stmt, terms: terms))
+                }
+            }
+        )
+        return items
+    }
+
+    private func loadEpisodeItems(
+        query: MemoryConsoleQuery,
+        terms: [String],
+        db: MemoryDatabase
+    ) throws -> [MemoryConsoleItem] {
+        var sql = """
+            SELECT id, agent_id, conversation_id, summary, topics_csv, entities_csv,
+                   decisions, action_items, salience, token_count, model,
+                   conversation_at, status, created_at
+            FROM episodes
+            WHERE 1 = 1
+            """
+        let (agentClause, agentBindIndex) = Self.agentClause(query.agentId, nextIndex: 1)
+        sql += agentClause
+        var nextIndex = agentBindIndex
+        let statusIndex = nextIndex
+        nextIndex += 1
+        sql += " AND (?\(statusIndex) = 1 OR status = 'active')"
+        let search = Self.searchClause(
+            columns: ["summary", "topics_csv", "entities_csv", "decisions", "action_items"],
+            terms: terms,
+            startingAt: nextIndex
+        )
+        sql += search.sql
+        nextIndex = search.nextIndex
+        let limitIndex = nextIndex
+        sql += " ORDER BY conversation_at DESC, salience DESC LIMIT ?\(limitIndex)"
+
+        var items: [MemoryConsoleItem] = []
+        try db.prepareAndExecute(
+            sql,
+            bind: { stmt in
+                if let agentId = query.agentId {
+                    MemoryDatabase.bindText(stmt, index: 1, value: agentId)
+                }
+                sqlite3_bind_int(stmt, Int32(statusIndex), query.includeDisabled ? 1 : 0)
+                Self.bindTerms(stmt, terms: terms, bindings: search.bindings)
+                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(query.limit))
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    items.append(Self.episodeItem(stmt: stmt, terms: terms))
+                }
+            }
+        )
+        return items
+    }
+
+    private func loadTranscriptItems(
+        query: MemoryConsoleQuery,
+        terms: [String],
+        db: MemoryDatabase
+    ) throws -> [MemoryConsoleItem] {
+        var sql = """
+            SELECT id, agent_id, conversation_id, chunk_index, role, content,
+                   token_count, title, created_at
+            FROM transcript
+            WHERE 1 = 1
+            """
+        let (agentClause, agentBindIndex) = Self.agentClause(query.agentId, nextIndex: 1)
+        sql += agentClause
+        var nextIndex = agentBindIndex
+        let search = Self.searchClause(columns: ["content", "title"], terms: terms, startingAt: nextIndex)
+        sql += search.sql
+        nextIndex = search.nextIndex
+        let limitIndex = nextIndex
+        sql += " ORDER BY created_at DESC, chunk_index DESC LIMIT ?\(limitIndex)"
+
+        var items: [MemoryConsoleItem] = []
+        try db.prepareAndExecute(
+            sql,
+            bind: { stmt in
+                if let agentId = query.agentId {
+                    MemoryDatabase.bindText(stmt, index: 1, value: agentId)
+                }
+                Self.bindTerms(stmt, terms: terms, bindings: search.bindings)
+                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(query.limit))
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    items.append(Self.transcriptItem(stmt: stmt, terms: terms))
+                }
+            }
+        )
+        return items
+    }
+
+    // MARK: - Row Mapping
+
+    private static func pinnedItem(stmt: OpaquePointer, terms: [String]) -> MemoryConsoleItem {
+        let id = columnText(stmt, 0)
+        let agentId = columnText(stmt, 1)
+        let content = columnText(stmt, 2)
+        let tags = splitCSV(columnText(stmt, 10))
+        let detail = MemoryPrivacyRedactor.redact(content, maxCharacters: 2_000)
+        let preview = MemoryPrivacyRedactor.redact(content, maxCharacters: 260)
+        let matched = matchedTerms(terms, in: [content] + tags)
+        let salience = sqlite3_column_double(stmt, 3)
+        return MemoryConsoleItem(
+            id: "pinned:\(id)",
+            kind: .pinnedFact,
+            storageId: id,
+            agentId: agentId,
+            title: "Pinned fact",
+            preview: preview,
+            detail: detail,
+            relevanceExplanation: explanation(
+                kind: "pinned fact",
+                matchedTerms: matched,
+                fallback: "Sorted by salience \(Int(salience * 100))% and last use."
+            ),
+            metadata: MemoryConsoleMetadata(
+                salience: salience,
+                sourceCount: Int(sqlite3_column_int(stmt, 4)),
+                sourceEpisodeId: sqlite3_column_type(stmt, 5) == SQLITE_NULL ? nil : Int(sqlite3_column_int(stmt, 5)),
+                lastUsed: columnText(stmt, 6),
+                useCount: Int(sqlite3_column_int(stmt, 7)),
+                status: columnText(stmt, 8),
+                createdAt: columnText(stmt, 9),
+                tags: tags
+            ),
+            canDisable: columnText(stmt, 8) == "active"
+        )
+    }
+
+    private static func episodeItem(stmt: OpaquePointer, terms: [String]) -> MemoryConsoleItem {
+        let id = Int(sqlite3_column_int(stmt, 0))
+        let agentId = columnText(stmt, 1)
+        let summary = columnText(stmt, 3)
+        let topics = splitCSV(columnText(stmt, 4))
+        let entities = splitCSV(columnText(stmt, 5))
+        let decisions = columnText(stmt, 6)
+        let actionItems = columnText(stmt, 7)
+        let status = columnText(stmt, 12)
+        let searchable = [summary, decisions, actionItems] + topics + entities
+        let matched = matchedTerms(terms, in: searchable)
+        let fullText = [summary, decisions, actionItems].filter { !$0.isEmpty }.joined(separator: "\n")
+        let detail = MemoryPrivacyRedactor.redact(fullText, maxCharacters: 2_000)
+        let preview = MemoryPrivacyRedactor.redact(summary, maxCharacters: 300)
+        return MemoryConsoleItem(
+            id: "episode:\(id)",
+            kind: .episode,
+            storageId: "\(id)",
+            agentId: agentId,
+            title: episodeTitle(date: columnText(stmt, 11), topics: topics),
+            preview: preview,
+            detail: detail,
+            relevanceExplanation: explanation(
+                kind: "episode",
+                matchedTerms: matched,
+                fallback: "Sorted by conversation date and salience."
+            ),
+            metadata: MemoryConsoleMetadata(
+                salience: sqlite3_column_double(stmt, 8),
+                status: status,
+                createdAt: columnText(stmt, 13),
+                tokenCount: Int(sqlite3_column_int(stmt, 9)),
+                conversationAt: columnText(stmt, 11),
+                conversationId: columnText(stmt, 2),
+                model: columnText(stmt, 10),
+                topics: topics,
+                entities: entities
+            ),
+            canDisable: status == "active"
+        )
+    }
+
+    private static func transcriptItem(stmt: OpaquePointer, terms: [String]) -> MemoryConsoleItem {
+        let id = Int(sqlite3_column_int(stmt, 0))
+        let agentId = columnText(stmt, 1)
+        let conversationId = columnText(stmt, 2)
+        let chunkIndex = Int(sqlite3_column_int(stmt, 3))
+        let role = columnText(stmt, 4)
+        let content = columnText(stmt, 5)
+        let title = columnText(stmt, 7)
+        let createdAt = columnText(stmt, 8)
+        let matched = matchedTerms(terms, in: [content, title])
+        let detail = MemoryPrivacyRedactor.redact(content, maxCharacters: 2_000)
+        let preview = MemoryPrivacyRedactor.redact(content, maxCharacters: 300)
+        return MemoryConsoleItem(
+            id: "transcript:\(id)",
+            kind: .transcriptTurn,
+            storageId: "\(id)",
+            agentId: agentId,
+            title: title.isEmpty ? "\(role.capitalized) turn" : title,
+            preview: preview,
+            detail: detail,
+            relevanceExplanation: explanation(
+                kind: "transcript turn",
+                matchedTerms: matched,
+                fallback: "Sorted by latest transcript activity."
+            ),
+            metadata: MemoryConsoleMetadata(
+                createdAt: createdAt,
+                tokenCount: Int(sqlite3_column_int(stmt, 6)),
+                conversationId: conversationId,
+                conversationTitle: title.isEmpty ? nil : title,
+                chunkIndex: chunkIndex,
+                role: role
+            ),
+            canDisable: false
+        )
+    }
+
+    // MARK: - Mutations
+
+    private func updateStatus(
+        table: String,
+        idColumn: String,
+        id: String,
+        status: String,
+        db: MemoryDatabase
+    ) throws -> Bool {
+        var changed = false
+        try db.prepareAndExecute(
+            "UPDATE \(table) SET status = ?1 WHERE \(idColumn) = ?2 AND status != ?1",
+            bind: { stmt in
+                MemoryDatabase.bindText(stmt, index: 1, value: status)
+                if let intId = Int(id) {
+                    sqlite3_bind_int(stmt, 2, Int32(intId))
+                } else {
+                    MemoryDatabase.bindText(stmt, index: 2, value: id)
+                }
+            },
+            process: { stmt in
+                let step = sqlite3_step(stmt)
+                guard step == SQLITE_DONE else {
+                    throw MemoryDatabaseError.failedToExecute("UPDATE \(table) failed with code \(step)")
+                }
+                changed = sqlite3_changes(sqlite3_db_handle(stmt)) > 0
+            }
+        )
+        return changed
+    }
+
+    private func deleteTranscriptTurn(id: Int, db: MemoryDatabase) throws -> Bool {
+        var changed = false
+        try db.prepareAndExecute(
+            "DELETE FROM transcript WHERE id = ?1",
+            bind: { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) },
+            process: { stmt in
+                let step = sqlite3_step(stmt)
+                guard step == SQLITE_DONE else {
+                    throw MemoryDatabaseError.failedToExecute("DELETE transcript failed with code \(step)")
+                }
+                changed = sqlite3_changes(sqlite3_db_handle(stmt)) > 0
+            }
+        )
+        return changed
+    }
+
+    private func agentIdForPinnedFact(id: String, db: MemoryDatabase) throws -> String? {
+        try singleText(
+            "SELECT agent_id FROM pinned_facts WHERE id = ?1",
+            db: db,
+            bind: { stmt in MemoryDatabase.bindText(stmt, index: 1, value: id) }
+        )
+    }
+
+    private func agentIdForEpisode(id: Int, db: MemoryDatabase) throws -> String? {
+        try singleText(
+            "SELECT agent_id FROM episodes WHERE id = ?1",
+            db: db,
+            bind: { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) }
+        )
+    }
+
+    private func transcriptVectorKey(
+        id: Int,
+        db: MemoryDatabase
+    ) throws -> (agentId: String, conversationId: String, chunkIndex: Int)? {
+        var row: (agentId: String, conversationId: String, chunkIndex: Int)?
+        try db.prepareAndExecute(
+            "SELECT agent_id, conversation_id, chunk_index FROM transcript WHERE id = ?1",
+            bind: { stmt in sqlite3_bind_int(stmt, 1, Int32(id)) },
+            process: { stmt in
+                if sqlite3_step(stmt) == SQLITE_ROW {
+                    row = (
+                        agentId: Self.columnText(stmt, 0),
+                        conversationId: Self.columnText(stmt, 1),
+                        chunkIndex: Int(sqlite3_column_int(stmt, 2))
+                    )
+                }
+            }
+        )
+        return row
+    }
+
+    // MARK: - Diagnostics
+
+    private func statusCount(table: String, status: String, db: MemoryDatabase) throws -> Int {
+        try singleInt(
+            "SELECT COUNT(*) FROM \(table) WHERE status = ?1",
+            db: db,
+            bind: { stmt in MemoryDatabase.bindText(stmt, index: 1, value: status) }
+        )
+    }
+
+    private func countRows(table: String, db: MemoryDatabase) throws -> Int {
+        try singleInt("SELECT COUNT(*) FROM \(table)", db: db, bind: { _ in })
+    }
+
+    private func ftsTablesReady(db: MemoryDatabase) throws -> Bool {
+        let found = try singleInt(
+            """
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type = 'table' AND name IN ('fts_pinned', 'fts_episodes', 'fts_transcript')
+            """,
+            db: db,
+            bind: { _ in }
+        )
+        return found == 3
+    }
+
+    private func singleInt(
+        _ sql: String,
+        db: MemoryDatabase,
+        bind: (OpaquePointer) -> Void
+    ) throws -> Int {
+        var value = 0
+        try db.prepareAndExecute(
+            sql,
+            bind: bind,
+            process: { stmt in
+                if sqlite3_step(stmt) == SQLITE_ROW {
+                    value = Int(sqlite3_column_int(stmt, 0))
+                }
+            }
+        )
+        return value
+    }
+
+    private func singleText(
+        _ sql: String,
+        db: MemoryDatabase,
+        bind: (OpaquePointer) -> Void
+    ) throws -> String? {
+        var value: String?
+        try db.prepareAndExecute(
+            sql,
+            bind: bind,
+            process: { stmt in
+                if sqlite3_step(stmt) == SQLITE_ROW {
+                    value = Self.columnText(stmt, 0)
+                }
+            }
+        )
+        return value
+    }
+
+    // MARK: - Query Helpers
+
+    private static func searchTerms(_ query: String) -> [String] {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let normalized = String(
+            query.lowercased().unicodeScalars.map { allowed.contains($0) ? Character($0) : " " }
+        )
+        let terms = normalized
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+            .filter { $0.count >= 2 && !stopWords.contains($0) }
+        return Array(NSOrderedSet(array: terms).compactMap { $0 as? String })
+    }
+
+    private static let stopWords: Set<String> = [
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+        "i", "in", "is", "it", "me", "my", "of", "on", "or", "the", "to",
+        "we", "you", "your",
+    ]
+
+    private static func agentClause(_ agentId: String?, nextIndex: Int) -> (String, Int) {
+        guard agentId != nil else { return ("", nextIndex) }
+        return (" AND agent_id = ?\(nextIndex)", nextIndex + 1)
+    }
+
+    private static func searchClause(
+        columns: [String],
+        terms: [String],
+        startingAt: Int
+    ) -> (sql: String, bindings: [(index: Int, term: String)], nextIndex: Int) {
+        guard !terms.isEmpty else { return ("", [], startingAt) }
+        var next = startingAt
+        var bindings: [(Int, String)] = []
+        let clauses = terms.map { term -> String in
+            let termClauses = columns.map { column -> String in
+                let index = next
+                next += 1
+                bindings.append((index, term))
+                return "COALESCE(\(column), '') LIKE '%' || ?\(index) || '%'"
+            }
+            return "(" + termClauses.joined(separator: " OR ") + ")"
+        }
+        return (" AND " + clauses.joined(separator: " AND "), bindings, next)
+    }
+
+    private static func bindTerms(
+        _ stmt: OpaquePointer,
+        terms: [String],
+        bindings: [(index: Int, term: String)]
+    ) {
+        guard !terms.isEmpty else { return }
+        for binding in bindings {
+            MemoryDatabase.bindText(stmt, index: Int32(binding.index), value: binding.term)
+        }
+    }
+
+    private static func matchedTerms(_ terms: [String], in fields: [String]) -> [String] {
+        guard !terms.isEmpty else { return [] }
+        let searchable = fields.joined(separator: " ").lowercased()
+        return terms.filter { searchable.contains($0) }
+    }
+
+    private static func explanation(
+        kind: String,
+        matchedTerms: [String],
+        fallback: String
+    ) -> String {
+        if matchedTerms.isEmpty {
+            return "Shown as a recent \(kind). \(fallback)"
+        }
+        let terms = matchedTerms.prefix(5).joined(separator: ", ")
+        return "Matched \(kind) text for: \(terms)."
+    }
+
+    private static func sortConsoleItems(_ lhs: MemoryConsoleItem, _ rhs: MemoryConsoleItem) -> Bool {
+        let lhsDate = lhs.metadata.conversationAt ?? lhs.metadata.createdAt ?? lhs.metadata.lastUsed ?? ""
+        let rhsDate = rhs.metadata.conversationAt ?? rhs.metadata.createdAt ?? rhs.metadata.lastUsed ?? ""
+        if lhsDate != rhsDate {
+            return lhsDate > rhsDate
+        }
+        let lhsSalience = lhs.metadata.salience ?? 0
+        let rhsSalience = rhs.metadata.salience ?? 0
+        if lhsSalience != rhsSalience {
+            return lhsSalience > rhsSalience
+        }
+        return lhs.id < rhs.id
+    }
+
+    private static func splitCSV(_ csv: String) -> [String] {
+        csv.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func episodeTitle(date: String, topics: [String]) -> String {
+        let day = date.isEmpty ? "Episode" : String(date.prefix(10))
+        guard let topic = topics.first, !topic.isEmpty else { return day }
+        return "\(day) - \(topic)"
+    }
+
+    private static func columnText(_ stmt: OpaquePointer, _ index: Int32) -> String {
+        guard let pointer = sqlite3_column_text(stmt, index) else { return "" }
+        return String(cString: pointer)
+    }
+
+    private static func parseItemId(_ itemId: String) throws -> (kind: MemoryConsoleItemKind, storageId: String) {
+        let parts = itemId.split(separator: ":", maxSplits: 1).map(String.init)
+        guard parts.count == 2, !parts[1].isEmpty else {
+            throw MemoryDatabaseError.failedToExecute("Invalid memory console item id: \(itemId)")
+        }
+        switch parts[0] {
+        case "pinned": return (.pinnedFact, parts[1])
+        case "episode": return (.episode, parts[1])
+        case "transcript": return (.transcriptTurn, parts[1])
+        default:
+            throw MemoryDatabaseError.failedToExecute("Unknown memory console item kind: \(parts[0])")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Memory/MemoryManagementConsoleTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/MemoryManagementConsoleTests.swift
@@ -1,0 +1,204 @@
+//
+//  MemoryManagementConsoleTests.swift
+//  osaurus
+//
+//  Focused coverage for the Memory management console service.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Memory Management Console")
+struct MemoryManagementConsoleTests {
+    private let agentId = Agent.defaultId.uuidString
+
+    private func makeDB() throws -> MemoryDatabase {
+        let db = MemoryDatabase()
+        try db.openInMemory()
+        return db
+    }
+
+    @Test func searchReturnsPrivacySafeRowsWithRelevanceExplanation() throws {
+        let db = try makeDB()
+        let service = MemoryManagementConsoleService()
+        try db.insertPinnedFact(
+            PinnedFact(
+                agentId: agentId,
+                content: "Project OSIRIS contact is alex@example.com",
+                salience: 0.92,
+                tagsCSV: "osiris, planning"
+            )
+        )
+        _ = try db.insertEpisode(
+            Episode(
+                agentId: agentId,
+                conversationId: "conversation-1",
+                summary: "We picked the OSIRIS release checklist.",
+                topicsCSV: "OSIRIS, release",
+                entitiesCSV: "OSIRIS",
+                decisions: "Ship after privacy review",
+                salience: 0.8,
+                tokenCount: 42,
+                model: "test",
+                conversationAt: "2026-06-18T10:00:00Z"
+            )
+        )
+
+        let results = try service.search(
+            query: MemoryConsoleQuery(text: "osiris", scope: .all, agentId: agentId),
+            db: db
+        )
+
+        #expect(results.count == 2)
+        #expect(results.allSatisfy { $0.relevanceExplanation.lowercased().contains("osiris") })
+        #expect(results.contains { $0.kind == .pinnedFact && $0.preview.text.contains("[redacted email]") })
+        #expect(!results.contains { $0.preview.text.contains("alex@example.com") })
+    }
+
+    @Test func disablePinnedFactHidesItUnlessDisabledRowsAreIncluded() async throws {
+        let db = try makeDB()
+        let service = MemoryManagementConsoleService()
+        let fact = PinnedFact(
+            id: UUID().uuidString,
+            agentId: agentId,
+            content: "Remember Project Clover budget",
+            salience: 0.7
+        )
+        try db.insertPinnedFact(fact)
+
+        let disableResult = try await service.disable(itemId: "pinned:\(fact.id)", db: db)
+        #expect(disableResult.changed)
+
+        let activeOnly = try service.search(
+            query: MemoryConsoleQuery(text: "clover", scope: .pinned, agentId: agentId),
+            db: db
+        )
+        #expect(activeOnly.isEmpty)
+
+        let includingDisabled = try service.search(
+            query: MemoryConsoleQuery(
+                text: "clover",
+                scope: .pinned,
+                agentId: agentId,
+                includeDisabled: true
+            ),
+            db: db
+        )
+        #expect(includingDisabled.count == 1)
+        #expect(includingDisabled[0].isDisabled)
+        #expect(includingDisabled[0].canDisable == false)
+    }
+
+    @Test func forgetRemovesEpisodeAndTranscriptRows() async throws {
+        let db = try makeDB()
+        let service = MemoryManagementConsoleService()
+        let episodeId = try db.insertEpisode(
+            Episode(
+                agentId: agentId,
+                conversationId: "conversation-forget",
+                summary: "We discussed the Atlas launch timeline.",
+                topicsCSV: "Atlas",
+                entitiesCSV: "Atlas",
+                conversationAt: "2026-06-18T11:00:00Z"
+            )
+        )
+        try db.insertTranscriptTurn(
+            agentId: agentId,
+            conversationId: "conversation-forget",
+            chunkIndex: 0,
+            role: "user",
+            content: "Literal Atlas launch note",
+            tokenCount: 5,
+            title: "Atlas",
+            createdAt: "2026-06-18T11:01:00Z"
+        )
+
+        let episodeForget = try await service.forget(itemId: "episode:\(episodeId)", db: db)
+        #expect(episodeForget.changed)
+
+        let transcript = try service.search(
+            query: MemoryConsoleQuery(text: "literal atlas", scope: .transcript, agentId: agentId),
+            db: db
+        )
+        #expect(transcript.count == 1)
+
+        let transcriptForget = try await service.forget(itemId: transcript[0].id, db: db)
+        #expect(transcriptForget.changed)
+
+        let remaining = try service.search(
+            query: MemoryConsoleQuery(text: "atlas", scope: .all, agentId: agentId),
+            db: db
+        )
+        #expect(remaining.isEmpty)
+    }
+
+    @Test func diagnosticsReportStorageCountsAndSchemaHealth() async throws {
+        let db = try makeDB()
+        let service = MemoryManagementConsoleService()
+        try db.insertPinnedFact(PinnedFact(agentId: agentId, content: "Active preference"))
+        try db.insertPinnedFact(PinnedFact(agentId: agentId, content: "Disabled preference", status: "disabled"))
+        _ = try db.insertEpisode(
+            Episode(
+                agentId: agentId,
+                conversationId: "health-1",
+                summary: "Active episode",
+                conversationAt: "2026-06-18T12:00:00Z"
+            )
+        )
+        _ = try db.insertEpisode(
+            Episode(
+                agentId: agentId,
+                conversationId: "health-2",
+                summary: "Disabled episode",
+                conversationAt: "2026-06-18T12:10:00Z",
+                status: "disabled"
+            )
+        )
+        try db.insertTranscriptTurn(
+            agentId: agentId,
+            conversationId: "health-3",
+            chunkIndex: 0,
+            role: "user",
+            content: "Health transcript",
+            tokenCount: 3,
+            createdAt: "2026-06-18T12:20:00Z"
+        )
+
+        let health = await service.diagnoseStorage(db: db, includeVectorState: false)
+
+        #expect(health.databaseOpen)
+        #expect(health.schemaVersion == health.expectedSchemaVersion)
+        #expect(health.activePinnedCount == 1)
+        #expect(health.disabledPinnedCount == 1)
+        #expect(health.activeEpisodeCount == 1)
+        #expect(health.disabledEpisodeCount == 1)
+        #expect(health.transcriptCount == 1)
+        #expect(health.ftsTablesReady)
+    }
+
+    @Test func privacyRedactorMasksSensitiveValuesAndBoundsPreview() {
+        let sensitive = """
+        Email alex@example.com, phone 415-555-1212, SSN 123-45-6789,
+        account 4242 4242 4242 4242, token sk-test_abcdefghijklmnopqrstuvwxyz1234567890,
+        url https://example.com/private/path
+        """
+
+        let redacted = MemoryPrivacyRedactor.redact(sensitive, maxCharacters: 120)
+
+        #expect(redacted.wasTruncated)
+        #expect(redacted.text.count <= 120)
+        #expect(!redacted.text.contains("alex@example.com"))
+        #expect(!redacted.text.contains("415-555-1212"))
+        #expect(!redacted.text.contains("123-45-6789"))
+        #expect(!redacted.text.contains("4242 4242 4242 4242"))
+        #expect(!redacted.text.contains("sk-test_abcdefghijklmnopqrstuvwxyz1234567890"))
+        #expect(redacted.redactionCounts["email"] == 1)
+        #expect(redacted.redactionCounts["phone"] == 1)
+        #expect(redacted.redactionCounts["ssn"] == 1)
+        #expect(redacted.redactionCounts["account"] == 1)
+        #expect(redacted.redactionCounts["secret"] == 1)
+        #expect((redacted.redactionCounts["url"] ?? 0) >= 1)
+    }
+}

--- a/Packages/OsaurusCore/Views/Memory/MemoryManagementConsoleView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryManagementConsoleView.swift
@@ -1,0 +1,758 @@
+//
+//  MemoryManagementConsoleView.swift
+//  osaurus
+//
+//  User-visible console for inspecting, searching, disabling, forgetting,
+//  and diagnosing stored memory.
+//
+
+import SwiftUI
+
+struct MemoryManagementConsoleView: View {
+    @Environment(\.theme) private var theme
+
+    let agents: [Agent]
+    let onMemoryChanged: () -> Void
+    let showToast: (String, Bool) -> Void
+
+    private let service = MemoryManagementConsoleService()
+
+    @State private var searchText = ""
+    @State private var scope: MemoryConsoleScope = .all
+    @State private var agentFilter = MemoryAgentFilter.all
+    @State private var includeDisabled = false
+    @State private var isLoading = false
+    @State private var showDiagnostics = false
+    @State private var snapshot: MemoryConsoleSnapshot?
+    @State private var selectedItem: MemoryConsoleItem?
+    @State private var pendingAction: PendingMemoryConsoleAction?
+    @State private var previewQuery = ""
+    @State private var previewAgentId = Agent.defaultId.uuidString
+    @State private var previewTokenLimit = 800
+    @State private var contextPreview: MemoryContextPreview?
+    @State private var isPreviewLoading = false
+
+    var body: some View {
+        MemorySectionCard(
+            title: "Memory Console",
+            icon: "rectangle.and.text.magnifyingglass",
+            count: snapshot?.items.count,
+            trailing: {
+                HStack(spacing: 6) {
+                    MemorySectionActionButton(
+                        showDiagnostics ? "Hide Diagnostics" : "Diagnose",
+                        icon: "stethoscope"
+                    ) {
+                        showDiagnostics.toggle()
+                        if showDiagnostics { refresh() }
+                    }
+
+                    MemorySectionActionButton("Search", icon: "magnifyingglass") {
+                        refresh()
+                    }
+                }
+            },
+            content: {
+                VStack(alignment: .leading, spacing: 14) {
+                    controls
+
+                    if showDiagnostics, let health = snapshot?.health {
+                        diagnosticsPanel(health)
+                    }
+
+                    contextPreviewPanel
+
+                    Divider().opacity(0.5)
+
+                    resultsPanel
+                }
+            }
+        )
+        .onAppear {
+            if snapshot == nil { refresh() }
+        }
+        .sheet(item: $selectedItem) { item in
+            MemoryConsoleInspectSheet(item: item)
+                .frame(minWidth: 560, minHeight: 520)
+        }
+        .themedAlert(
+            pendingAction?.title ?? "Memory Action",
+            isPresented: Binding(
+                get: { pendingAction != nil },
+                set: { if !$0 { pendingAction = nil } }
+            ),
+            message: pendingAction?.message,
+            primaryButton: .destructive(pendingAction?.buttonTitle ?? "Confirm") {
+                performPendingAction()
+            },
+            secondaryButton: .cancel("Cancel") {
+                pendingAction = nil
+            },
+            presentationStyle: .contained
+        )
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.tertiaryText)
+                    TextField("Search memories", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 13))
+                        .onSubmit { refresh() }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            HStack(spacing: 12) {
+                Picker("Scope", selection: $scope) {
+                    ForEach(MemoryConsoleScope.allCases) { value in
+                        Text(value.displayName).tag(value)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 360)
+                .onChange(of: scope) { _, _ in refresh() }
+
+                Picker("Agent", selection: $agentFilter) {
+                    Text("All agents", bundle: .module).tag(MemoryAgentFilter.all)
+                    Text(Agent.default.displayName).tag(MemoryAgentFilter.defaultAgent)
+                    ForEach(agents) { agent in
+                        Text(agent.displayName).tag(MemoryAgentFilter.agent(agent.id.uuidString))
+                    }
+                }
+                .frame(width: 220)
+                .onChange(of: agentFilter) { _, _ in refresh() }
+
+                Toggle(isOn: $includeDisabled) {
+                    Text("Include disabled", bundle: .module)
+                        .font(.system(size: 12))
+                }
+                .toggleStyle(.checkbox)
+                .onChange(of: includeDisabled) { _, _ in refresh() }
+            }
+        }
+    }
+
+    private var contextPreviewPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text("BOUNDED CONTEXT PREVIEW", bundle: .module)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                    .tracking(0.3)
+                Spacer()
+                Text("~\(previewTokenLimit) tokens", bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            }
+
+            HStack(spacing: 10) {
+                TextField("Preview query", text: $previewQuery)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(theme.inputBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+
+                Picker("Preview Agent", selection: $previewAgentId) {
+                    Text(Agent.default.displayName).tag(Agent.defaultId.uuidString)
+                    ForEach(agents) { agent in
+                        Text(agent.displayName).tag(agent.id.uuidString)
+                    }
+                }
+                .frame(width: 190)
+
+                Stepper(value: $previewTokenLimit, in: 100 ... 2000, step: 100) {
+                    EmptyView()
+                }
+                .labelsHidden()
+
+                Button {
+                    loadContextPreview()
+                } label: {
+                    Image(systemName: "eye")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .disabled(isPreviewLoading)
+                .help(Text("Preview bounded memory context", bundle: .module))
+            }
+
+            if isPreviewLoading {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Assembling preview...", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            } else if let contextPreview {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(
+                            contextPreview.wasEmpty
+                                ? "No context assembled"
+                                : "Preview context",
+                            bundle: .module
+                        )
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.secondaryText)
+
+                        Spacer()
+
+                        if contextPreview.redactedContext.redactionCount > 0 {
+                            Text(
+                                "\(contextPreview.redactedContext.redactionCount) redaction(s)",
+                                bundle: .module
+                            )
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(theme.warningColor)
+                        }
+                    }
+
+                    Text(contextPreview.redactedContext.text)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.primaryText)
+                        .textSelection(.enabled)
+                        .lineLimit(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(theme.inputBackground.opacity(0.55))
+                        )
+                }
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.tertiaryBackground.opacity(0.45))
+        )
+    }
+
+    @ViewBuilder
+    private func diagnosticsPanel(_ health: MemoryStorageHealth) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(healthColor(health.level))
+                    .frame(width: 8, height: 8)
+                Text(health.level.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+                Text(formatBytes(health.databaseSizeBytes))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 126), spacing: 8)], spacing: 8) {
+                healthTile("Pinned", "\(health.activePinnedCount)", footnote: "\(health.disabledPinnedCount) disabled")
+                healthTile("Episodes", "\(health.activeEpisodeCount)", footnote: "\(health.disabledEpisodeCount) disabled")
+                healthTile("Transcript", "\(health.transcriptCount)", footnote: "stored turns")
+                healthTile("Pending", "\(health.pendingSignals.totalSignals)", footnote: "signals")
+                healthTile("Schema", health.schemaVersion.map(String.init) ?? "-", footnote: "expected \(health.expectedSchemaVersion)")
+                healthTile("FTS", health.ftsTablesReady ? "Ready" : "Missing", footnote: "text mirrors")
+                healthTile("Vector", health.vectorSearchAvailable ? "Ready" : "Fallback", footnote: "\(health.vectorIndexFailures) failures")
+                healthTile("Logs", "\(health.processingStats.totalCalls)", footnote: "\(health.processingStats.errorCount) errors")
+            }
+
+            if !health.diagnostics.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(health.diagnostics, id: \.self) { diagnostic in
+                        HStack(alignment: .top, spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(theme.warningColor)
+                            Text(diagnostic)
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.secondaryText)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.inputBackground.opacity(0.6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.inputBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private var resultsPanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("RESULTS", bundle: .module)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                    .tracking(0.3)
+                Spacer()
+                if let generatedAt = snapshot?.generatedAt {
+                    Text(generatedAt, style: .time)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+
+            if isLoading && snapshot == nil {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading memories...", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 24)
+            } else if let items = snapshot?.items, !items.isEmpty {
+                VStack(spacing: 0) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        if index > 0 {
+                            Divider().opacity(0.5)
+                        }
+                        MemoryConsoleResultRow(
+                            item: item,
+                            onInspect: { selectedItem = item },
+                            onDisable: {
+                                pendingAction = PendingMemoryConsoleAction(
+                                    mutation: .disable,
+                                    item: item
+                                )
+                            },
+                            onForget: {
+                                pendingAction = PendingMemoryConsoleAction(
+                                    mutation: .forget,
+                                    item: item
+                                )
+                            }
+                        )
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.inputBackground.opacity(0.5))
+                )
+            } else {
+                Text("No memories match this search.", bundle: .module)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.tertiaryText)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+            }
+        }
+    }
+
+    private func healthTile(_ label: String, _ value: String, footnote: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+            Text(value)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(1)
+            Text(footnote)
+                .font(.system(size: 10))
+                .foregroundColor(theme.tertiaryText)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(theme.cardBackground)
+        )
+    }
+
+    private func refresh() {
+        guard !isLoading else { return }
+        isLoading = true
+        let query = MemoryConsoleQuery(
+            text: searchText,
+            scope: scope,
+            agentId: agentFilter.agentId,
+            includeDisabled: includeDisabled,
+            limit: 80
+        )
+        Task {
+            do {
+                let next = try await service.snapshot(query: query)
+                await MainActor.run {
+                    snapshot = next
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading = false
+                    let message = "Failed to load memory console: \(error.localizedDescription)"
+                    showToast(message, true)
+                }
+            }
+        }
+    }
+
+    private func loadContextPreview() {
+        guard !isPreviewLoading else { return }
+        isPreviewLoading = true
+        Task {
+            let preview = await service.contextPreview(
+                agentId: previewAgentId,
+                query: previewQuery.isEmpty ? searchText : previewQuery,
+                maxTokens: previewTokenLimit
+            )
+            await MainActor.run {
+                contextPreview = preview
+                isPreviewLoading = false
+            }
+        }
+    }
+
+    private func performPendingAction() {
+        guard let action = pendingAction else { return }
+        pendingAction = nil
+        Task {
+            do {
+                let result: MemoryConsoleMutationResult
+                switch action.mutation {
+                case .disable:
+                    result = try await service.disable(itemId: action.item.id)
+                case .forget:
+                    result = try await service.forget(itemId: action.item.id)
+                }
+                await MainActor.run {
+                    showToast(result.message, !result.changed && action.mutation == .forget)
+                    refresh()
+                    onMemoryChanged()
+                }
+            } catch {
+                await MainActor.run {
+                    let message = "Memory action failed: \(error.localizedDescription)"
+                    showToast(message, true)
+                }
+            }
+        }
+    }
+
+    private func healthColor(_ level: MemoryStorageHealth.Level) -> Color {
+        switch level {
+        case .healthy: return theme.successColor
+        case .degraded: return theme.warningColor
+        case .unavailable: return theme.errorColor
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+}
+
+private enum MemoryAgentFilter: Hashable {
+    case all
+    case defaultAgent
+    case agent(String)
+
+    var agentId: String? {
+        switch self {
+        case .all:
+            return nil
+        case .defaultAgent:
+            return Agent.defaultId.uuidString
+        case .agent(let id):
+            return id
+        }
+    }
+}
+
+private struct PendingMemoryConsoleAction {
+    let mutation: MemoryConsoleMutation
+    let item: MemoryConsoleItem
+
+    var title: String {
+        switch mutation {
+        case .disable: return "Disable Memory?"
+        case .forget: return "Forget Memory?"
+        }
+    }
+
+    var buttonTitle: String {
+        switch mutation {
+        case .disable: return "Disable"
+        case .forget: return "Forget"
+        }
+    }
+
+    var message: String {
+        switch mutation {
+        case .disable:
+            return "This removes the memory from future recall while keeping the row available for diagnostics."
+        case .forget:
+            return "This permanently deletes the selected memory row and removes its vector document when present."
+        }
+    }
+}
+
+private struct MemoryConsoleResultRow: View {
+    @Environment(\.theme) private var theme
+
+    let item: MemoryConsoleItem
+    let onInspect: () -> Void
+    let onDisable: () -> Void
+    let onForget: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(item.isDisabled ? theme.tertiaryText : theme.accentColor)
+                .frame(width: 22, height: 22)
+                .background(
+                    Circle()
+                        .fill(theme.tertiaryBackground)
+                )
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 7) {
+                    Text(item.kind.displayName)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    if item.isDisabled {
+                        Text("Disabled", bundle: .module)
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(theme.warningColor)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(theme.warningColor.opacity(0.12)))
+                    }
+                    if item.preview.redactionCount > 0 {
+                        Text("Redacted", bundle: .module)
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(theme.secondaryText)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Capsule().fill(theme.tertiaryBackground))
+                    }
+                    Spacer()
+                }
+
+                Text(item.preview.text)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(item.relevanceExplanation)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: 4) {
+                iconButton("info.circle", help: "Inspect memory", action: onInspect)
+                iconButton("pause.circle", help: "Disable memory", action: onDisable)
+                    .disabled(!item.canDisable)
+                    .opacity(item.canDisable ? 1 : 0.35)
+                iconButton("trash", help: "Forget memory", action: onForget)
+            }
+        }
+        .padding(12)
+    }
+
+    private var icon: String {
+        switch item.kind {
+        case .pinnedFact: return "pin.fill"
+        case .episode: return "doc.text"
+        case .transcriptTurn: return "text.bubble"
+        }
+    }
+
+    private func iconButton(_ systemName: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+                .frame(width: 26, height: 26)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(theme.tertiaryBackground)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}
+
+private struct MemoryConsoleInspectSheet: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+    @Environment(\.dismiss) private var dismiss
+
+    let item: MemoryConsoleItem
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.kind.displayName)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(item.relevanceExplanation)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                Spacer()
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.secondaryText)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6).fill(theme.tertiaryBackground)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help(Text("Close", bundle: .module))
+            }
+            .padding(20)
+
+            Divider().opacity(0.5)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    inspectBlock("Privacy-safe detail", item.detail.text, monospaced: false)
+
+                    if item.detail.redactionCount > 0 {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("REDACTIONS", bundle: .module)
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundColor(theme.tertiaryText)
+                                .tracking(0.3)
+                            ForEach(item.detail.redactionCounts.keys.sorted(), id: \.self) { key in
+                                Text("\(key): \(item.detail.redactionCounts[key] ?? 0)", bundle: .module)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(theme.secondaryText)
+                            }
+                        }
+                    }
+
+                    metadataGrid
+                }
+                .padding(20)
+            }
+        }
+        .background(theme.primaryBackground)
+        .environment(\.theme, themeManager.currentTheme)
+    }
+
+    private var metadataGrid: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("METADATA", bundle: .module)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .tracking(0.3)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
+                metadataTile("Storage ID", item.storageId)
+                metadataTile("Agent", item.agentId)
+                if let status = item.metadata.status { metadataTile("Status", status) }
+                if let salience = item.metadata.salience { metadataTile("Salience", "\(Int(salience * 100))%") }
+                if let useCount = item.metadata.useCount { metadataTile("Use count", "\(useCount)") }
+                if let sourceCount = item.metadata.sourceCount { metadataTile("Sources", "\(sourceCount)") }
+                if let sourceEpisodeId = item.metadata.sourceEpisodeId {
+                    metadataTile("Source episode", "\(sourceEpisodeId)")
+                }
+                if let tokenCount = item.metadata.tokenCount { metadataTile("Tokens", "\(tokenCount)") }
+                if let conversationId = item.metadata.conversationId {
+                    metadataTile("Conversation", conversationId)
+                }
+                if let chunkIndex = item.metadata.chunkIndex { metadataTile("Chunk", "\(chunkIndex)") }
+                if let role = item.metadata.role { metadataTile("Role", role) }
+                if let model = item.metadata.model, !model.isEmpty { metadataTile("Model", model) }
+                if let createdAt = item.metadata.createdAt { metadataTile("Created", createdAt) }
+                if let conversationAt = item.metadata.conversationAt {
+                    metadataTile("Conversation at", conversationAt)
+                }
+                if !item.metadata.tags.isEmpty { metadataTile("Tags", item.metadata.tags.joined(separator: ", ")) }
+                if !item.metadata.topics.isEmpty { metadataTile("Topics", item.metadata.topics.joined(separator: ", ")) }
+                if !item.metadata.entities.isEmpty {
+                    metadataTile("Entities", item.metadata.entities.joined(separator: ", "))
+                }
+            }
+        }
+    }
+
+    private func inspectBlock(_ title: String, _ text: String, monospaced: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title.uppercased())
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .tracking(0.3)
+
+            Text(text)
+                .font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 13))
+                .foregroundColor(theme.primaryText)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.inputBackground.opacity(0.7))
+                )
+        }
+    }
+
+    private func metadataTile(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+            Text(value)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .lineLimit(3)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(theme.inputBackground.opacity(0.6))
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Memory/MemoryView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryView.swift
@@ -160,6 +160,7 @@ struct MemoryView: View {
 
                                 identitySection
                                 overridesSection
+                                memoryConsoleSection
                                 agentsSection
                                 statsSection
                                 configurationSection
@@ -585,6 +586,16 @@ struct MemoryView: View {
     }
 
     // MARK: - Agents Section
+
+    private var memoryConsoleSection: some View {
+        MemoryManagementConsoleView(
+            agents: agentManager.agents,
+            onMemoryChanged: { loadData() },
+            showToast: { message, isError in
+                showToast(message, isError: isError)
+            }
+        )
+    }
 
     private var agentsSection: some View {
         MemorySectionCard(title: L("Agents"), icon: "person.2") {

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -288,6 +288,7 @@ Open the Management window (`⌘ Shift M`) → **Memory** to see:
 - Your **identity** (auto-derived content + manual overrides)
 - **Pinned facts** with salience bars and use counts
 - **Episodes** for the default agent
+- **Memory Console** search, inspection, disable/forget actions, diagnostics, and bounded context previews
 - **Per-agent counts**
 - **Processing statistics** (total calls, success rate, average duration)
 - **Database size**
@@ -304,6 +305,17 @@ Identity overrides are explicit facts that always appear in context.
 ### Clearing Memory
 
 The Memory view includes a danger zone for clearing all memory data. This removes identity, pinned facts, episodes, and transcript. The action is irreversible.
+
+### Memory Console
+
+The Memory Console is an administrative view over the encrypted memory database:
+
+- **Inspect** shows a privacy-safe preview and metadata for pinned facts, episodes, and transcript turns. Emails, phone numbers, account-like values, URLs, and credential-shaped tokens are redacted before display.
+- **Search** can be scoped to all memory, pinned facts, episodes, transcript, or one agent. Disabled rows are hidden by default and can be included explicitly.
+- **Disable** removes pinned facts and episodes from future recall without deleting the row. Transcript turns do not have a disabled state in the current schema, so the console explains that limitation and keeps **Forget** available.
+- **Forget** permanently deletes the selected row and removes its vector document when a matching vector id exists.
+- **Diagnose** reports storage health: schema version, row counts, pending signals, processing logs, FTS mirror availability, vector index state, and recent storage errors.
+- **Bounded context preview** assembles the memory block for a selected agent/query under an explicit token cap, then redacts the preview before showing it.
 
 ### Sync / Run Consolidation
 


### PR DESCRIPTION
## Summary
- Adds a memory management console for reviewing memory records, transcript links, and cleanup actions.
- Adds service/model support for memory inspection and forget operations.
- Wires the console into the existing Memory view with tests and documentation.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter MemoryManagementConsoleTests`

## Notes
- Transcript rows can be forgotten through the console; soft-disable support is not added because the current schema has no status column.
