### PR TITLE
Add schedule automation history

### DIFF
--- a/Packages/OsaurusCore/Models/Schedule/Schedule.swift
+++ b/Packages/OsaurusCore/Models/Schedule/Schedule.swift
@@ -345,6 +345,8 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     public var lastTriggeredAt: Date?
     /// The chat session ID from the last run (for viewing results)
     public var lastChatSessionId: UUID?
+    /// Bounded local execution history inferred from schedule persistence transitions
+    public var runHistory: [ScheduleRunHistoryEntry]
     /// When the schedule was created
     public let createdAt: Date
     /// When the schedule was last modified
@@ -363,6 +365,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         lastRunAt: Date? = nil,
         lastTriggeredAt: Date? = nil,
         lastChatSessionId: UUID? = nil,
+        runHistory: [ScheduleRunHistoryEntry] = [],
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -378,6 +381,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         self.lastRunAt = lastRunAt
         self.lastTriggeredAt = lastTriggeredAt
         self.lastChatSessionId = lastChatSessionId
+        self.runHistory = runHistory
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -390,6 +394,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         case mode  // legacy key (chat / work) — ignored on decode
         case folderPath, folderBookmark
         case frequency, isEnabled, lastRunAt, lastTriggeredAt, lastChatSessionId
+        case runHistory
         case createdAt, updatedAt
     }
 
@@ -412,6 +417,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         lastRunAt = try container.decodeIfPresent(Date.self, forKey: .lastRunAt)
         lastTriggeredAt = try container.decodeIfPresent(Date.self, forKey: .lastTriggeredAt)
         lastChatSessionId = try container.decodeIfPresent(UUID.self, forKey: .lastChatSessionId)
+        runHistory = try container.decodeIfPresent([ScheduleRunHistoryEntry].self, forKey: .runHistory) ?? []
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
@@ -430,6 +436,9 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         try container.encodeIfPresent(lastRunAt, forKey: .lastRunAt)
         try container.encodeIfPresent(lastTriggeredAt, forKey: .lastTriggeredAt)
         try container.encodeIfPresent(lastChatSessionId, forKey: .lastChatSessionId)
+        if !runHistory.isEmpty {
+            try container.encode(runHistory, forKey: .runHistory)
+        }
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
     }

--- a/Packages/OsaurusCore/Models/Schedule/ScheduleRunHistory.swift
+++ b/Packages/OsaurusCore/Models/Schedule/ScheduleRunHistory.swift
@@ -1,0 +1,335 @@
+//
+//  ScheduleRunHistory.swift
+//  osaurus
+//
+//  Durable run-history models for user-authored schedules.
+//
+
+import Foundation
+
+public enum ScheduleRunStatus: String, Codable, CaseIterable, Sendable, Equatable {
+    case running
+    case succeeded
+    case failed
+    case cancelled
+    case skipped
+
+    public var isTerminal: Bool {
+        switch self {
+        case .running:
+            return false
+        case .succeeded, .failed, .cancelled, .skipped:
+            return true
+        }
+    }
+
+    public var isError: Bool {
+        switch self {
+        case .failed:
+            return true
+        case .running, .succeeded, .cancelled, .skipped:
+            return false
+        }
+    }
+}
+
+public enum ScheduleRunHistorySource: String, Codable, Sendable, Equatable {
+    case scheduleStore = "schedule_store"
+    case agentRun = "agent_run"
+}
+
+public struct ScheduleRunHistoryEntry: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var scheduleId: UUID
+    public var agentId: UUID?
+    public var status: ScheduleRunStatus
+    public var source: ScheduleRunHistorySource
+    public var startedAt: Date
+    public var endedAt: Date?
+    public var chatSessionId: UUID?
+    public var agentRunId: UUID?
+    public var errorMessage: String?
+    public var instructionsPreview: String?
+    public var tokensIn: Int?
+    public var tokensOut: Int?
+    public var costUSD: Double?
+
+    public init(
+        id: UUID = UUID(),
+        scheduleId: UUID,
+        agentId: UUID?,
+        status: ScheduleRunStatus,
+        source: ScheduleRunHistorySource = .scheduleStore,
+        startedAt: Date,
+        endedAt: Date? = nil,
+        chatSessionId: UUID? = nil,
+        agentRunId: UUID? = nil,
+        errorMessage: String? = nil,
+        instructionsPreview: String? = nil,
+        tokensIn: Int? = nil,
+        tokensOut: Int? = nil,
+        costUSD: Double? = nil
+    ) {
+        self.id = id
+        self.scheduleId = scheduleId
+        self.agentId = agentId
+        self.status = status
+        self.source = source
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.chatSessionId = chatSessionId
+        self.agentRunId = agentRunId
+        self.errorMessage = errorMessage
+        self.instructionsPreview = instructionsPreview
+        self.tokensIn = tokensIn
+        self.tokensOut = tokensOut
+        self.costUSD = costUSD
+    }
+
+    public var durationSeconds: TimeInterval? {
+        guard let endedAt else { return nil }
+        return max(0, endedAt.timeIntervalSince(startedAt))
+    }
+}
+
+public enum ScheduleNextRunPreviewState: String, Codable, Sendable, Equatable {
+    case scheduled
+    case due
+    case paused
+    case exhausted
+}
+
+public struct ScheduleNextRunPreview: Codable, Sendable, Equatable {
+    public var state: ScheduleNextRunPreviewState
+    public var nextRunAt: Date?
+    public var generatedAt: Date
+    public var description: String
+
+    public init(
+        state: ScheduleNextRunPreviewState,
+        nextRunAt: Date?,
+        generatedAt: Date,
+        description: String
+    ) {
+        self.state = state
+        self.nextRunAt = nextRunAt
+        self.generatedAt = generatedAt
+        self.description = description
+    }
+}
+
+public struct ScheduleLastErrorDiagnostic: Codable, Sendable, Equatable {
+    public var runId: UUID
+    public var occurredAt: Date
+    public var message: String
+    public var status: ScheduleRunStatus
+
+    public init(runId: UUID, occurredAt: Date, message: String, status: ScheduleRunStatus) {
+        self.runId = runId
+        self.occurredAt = occurredAt
+        self.message = message
+        self.status = status
+    }
+}
+
+extension Schedule {
+    public static let maxRunHistoryEntries = 50
+
+    public func nextRunPreview(asOf now: Date = Date()) -> ScheduleNextRunPreview {
+        guard isEnabled else {
+            return ScheduleNextRunPreview(
+                state: .paused,
+                nextRunAt: nil,
+                generatedAt: now,
+                description: "Paused"
+            )
+        }
+
+        guard let nextRun = nextRunDateAfterExecutionAnchor(asOf: now) else {
+            return ScheduleNextRunPreview(
+                state: .exhausted,
+                nextRunAt: nil,
+                generatedAt: now,
+                description: "No upcoming run"
+            )
+        }
+
+        if nextRun <= now {
+            return ScheduleNextRunPreview(
+                state: .due,
+                nextRunAt: nextRun,
+                generatedAt: now,
+                description: "Due now"
+            )
+        }
+
+        return ScheduleNextRunPreview(
+            state: .scheduled,
+            nextRunAt: nextRun,
+            generatedAt: now,
+            description: Self.formatNextRun(nextRun, relativeTo: now)
+        )
+    }
+
+    public mutating func recordRunStarted(at startedAt: Date) {
+        if runHistory.contains(where: { entry in
+            entry.status == .running
+                && abs(entry.startedAt.timeIntervalSince(startedAt)) < 0.001
+        }) {
+            return
+        }
+
+        runHistory.append(
+            ScheduleRunHistoryEntry(
+                scheduleId: id,
+                agentId: agentId,
+                status: .running,
+                startedAt: startedAt,
+                instructionsPreview: Self.instructionsPreview(instructions)
+            )
+        )
+        trimRunHistory()
+    }
+
+    public mutating func recordRunSucceeded(endedAt: Date, chatSessionId: UUID?) {
+        let startedAt = lastTriggeredAt ?? endedAt
+        let index = latestRunningHistoryIndex(startedAt: startedAt)
+        if let index {
+            runHistory[index].status = .succeeded
+            runHistory[index].endedAt = endedAt
+            runHistory[index].chatSessionId = chatSessionId ?? runHistory[index].chatSessionId
+            runHistory[index].errorMessage = nil
+        } else {
+            runHistory.append(
+                ScheduleRunHistoryEntry(
+                    scheduleId: id,
+                    agentId: agentId,
+                    status: .succeeded,
+                    startedAt: startedAt,
+                    endedAt: endedAt,
+                    chatSessionId: chatSessionId,
+                    instructionsPreview: Self.instructionsPreview(instructions)
+                )
+            )
+        }
+        trimRunHistory()
+    }
+
+    public mutating func recordRunFailed(
+        startedAt: Date,
+        endedAt: Date,
+        status: ScheduleRunStatus = .failed,
+        errorMessage: String
+    ) {
+        let terminalStatus: ScheduleRunStatus = status.isTerminal ? status : .failed
+        let index = latestRunningHistoryIndex(startedAt: startedAt)
+        if let index {
+            runHistory[index].status = terminalStatus
+            runHistory[index].endedAt = endedAt
+            runHistory[index].errorMessage = errorMessage
+        } else {
+            runHistory.append(
+                ScheduleRunHistoryEntry(
+                    scheduleId: id,
+                    agentId: agentId,
+                    status: terminalStatus,
+                    startedAt: startedAt,
+                    endedAt: endedAt,
+                    errorMessage: errorMessage,
+                    instructionsPreview: Self.instructionsPreview(instructions)
+                )
+            )
+        }
+        trimRunHistory()
+    }
+
+    public mutating func mergeRunHistory(_ other: [ScheduleRunHistoryEntry]) {
+        guard !other.isEmpty else {
+            trimRunHistory()
+            return
+        }
+
+        var mergedById: [UUID: ScheduleRunHistoryEntry] = [:]
+        for entry in runHistory + other {
+            if let existing = mergedById[entry.id] {
+                mergedById[entry.id] = Self.preferredHistoryEntry(existing, entry)
+            } else {
+                mergedById[entry.id] = entry
+            }
+        }
+        runHistory = Array(mergedById.values)
+        trimRunHistory()
+    }
+
+    public mutating func trimRunHistory(limit: Int = Self.maxRunHistoryEntries) {
+        runHistory = runHistory
+            .sorted { lhs, rhs in
+                if lhs.startedAt == rhs.startedAt {
+                    return lhs.id.uuidString < rhs.id.uuidString
+                }
+                return lhs.startedAt > rhs.startedAt
+            }
+        if runHistory.count > limit {
+            runHistory.removeSubrange(limit...)
+        }
+    }
+
+    private func latestRunningHistoryIndex(startedAt: Date) -> Int? {
+        let running = runHistory.indices
+            .filter { runHistory[$0].status == .running }
+            .sorted { runHistory[$0].startedAt > runHistory[$1].startedAt }
+
+        if let exact = running.first(where: { abs(runHistory[$0].startedAt.timeIntervalSince(startedAt)) < 2 }) {
+            return exact
+        }
+        return running.first
+    }
+
+    private static func preferredHistoryEntry(
+        _ lhs: ScheduleRunHistoryEntry,
+        _ rhs: ScheduleRunHistoryEntry
+    ) -> ScheduleRunHistoryEntry {
+        if lhs.status == .running, rhs.status.isTerminal { return rhs }
+        if rhs.status == .running, lhs.status.isTerminal { return lhs }
+        if lhs.source == .scheduleStore, rhs.source == .agentRun { return rhs }
+        if (rhs.endedAt ?? rhs.startedAt) > (lhs.endedAt ?? lhs.startedAt) { return rhs }
+        return lhs
+    }
+
+    private static func instructionsPreview(_ instructions: String) -> String? {
+        let trimmed = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.count <= 240 { return trimmed }
+        return String(trimmed.prefix(237)) + "..."
+    }
+
+    private static func formatNextRun(_ date: Date, relativeTo now: Date) -> String {
+        let calendar = Calendar.current
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .short
+
+        if calendar.isDate(date, inSameDayAs: now) {
+            return "Today at \(timeFormatter.string(from: date))"
+        }
+
+        if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now),
+            calendar.isDate(date, inSameDayAs: tomorrow)
+        {
+            return "Tomorrow at \(timeFormatter.string(from: date))"
+        }
+
+        let daysDiff = calendar.dateComponents([.day], from: now, to: date).day ?? 0
+        if daysDiff < 7 {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "EEEE 'at' h:mm a"
+            return formatter.string(from: date)
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}

--- a/Packages/OsaurusCore/Models/Schedule/ScheduleStore.swift
+++ b/Packages/OsaurusCore/Models/Schedule/ScheduleStore.swift
@@ -70,12 +70,18 @@ public enum ScheduleStore {
     /// Save a schedule to disk
     public static func save(_ schedule: Schedule) {
         let url = fileURL(for: schedule.id)
+        let previous = load(id: schedule.id)
+        var scheduleToSave = schedule
+        if let previous {
+            scheduleToSave.mergeRunHistory(previous.runHistory)
+        }
+        applyHistoryTransitions(to: &scheduleToSave, previous: previous)
 
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .iso8601
-            let data = try encoder.encode(schedule)
+            let data = try encoder.encode(scheduleToSave)
             try data.write(to: url, options: [.atomic])
         } catch {
             print("[Osaurus] Failed to save schedule \(schedule.id): \(error)")
@@ -118,5 +124,17 @@ public enum ScheduleStore {
         for schedule in schedules {
             save(schedule)
         }
+    }
+
+    private static func applyHistoryTransitions(to schedule: inout Schedule, previous: Schedule?) {
+        if previous?.lastTriggeredAt != schedule.lastTriggeredAt, let triggeredAt = schedule.lastTriggeredAt {
+            schedule.recordRunStarted(at: triggeredAt)
+        }
+
+        if previous?.lastRunAt != schedule.lastRunAt, let lastRunAt = schedule.lastRunAt {
+            schedule.recordRunSucceeded(endedAt: lastRunAt, chatSessionId: schedule.lastChatSessionId)
+        }
+
+        schedule.trimRunHistory()
     }
 }

--- a/Packages/OsaurusCore/Services/Schedule/ScheduleHistoryService.swift
+++ b/Packages/OsaurusCore/Services/Schedule/ScheduleHistoryService.swift
@@ -72,6 +72,16 @@ public struct ScheduleHistoryService: Sendable {
         })
     }
 
+    public func summariesOffMain(
+        for schedules: [Schedule],
+        runLimit: Int = 8,
+        asOf now: Date = Date()
+    ) async -> [UUID: ScheduleAutomationSummary] {
+        await Task.detached(priority: .utility) {
+            self.summaries(for: schedules, runLimit: runLimit, asOf: now)
+        }.value
+    }
+
     public func summary(
         for schedule: Schedule,
         runLimit: Int = 10,
@@ -87,6 +97,16 @@ public struct ScheduleHistoryService: Sendable {
             runs: runs,
             lastError: lastError
         )
+    }
+
+    public func summaryOffMain(
+        for schedule: Schedule,
+        runLimit: Int = 10,
+        asOf now: Date = Date()
+    ) async -> ScheduleAutomationSummary {
+        await Task.detached(priority: .utility) {
+            self.summary(for: schedule, runLimit: runLimit, asOf: now)
+        }.value
     }
 
     public func markdownSummary(for schedule: Schedule, summary: ScheduleAutomationSummary) -> String {

--- a/Packages/OsaurusCore/Services/Schedule/ScheduleHistoryService.swift
+++ b/Packages/OsaurusCore/Services/Schedule/ScheduleHistoryService.swift
@@ -1,0 +1,319 @@
+//
+//  ScheduleHistoryService.swift
+//  osaurus
+//
+//  Summaries and export formatting for schedule automation history.
+//
+
+import Foundation
+
+public protocol ScheduleAgentRunProviding: Sendable {
+    func runs(agentId: UUID, limit: Int) throws -> [AgentRunRecord]
+}
+
+public struct LiveScheduleAgentRunProvider: ScheduleAgentRunProviding {
+    public init() {}
+
+    public func runs(agentId: UUID, limit: Int) throws -> [AgentRunRecord] {
+        if !SchedulerDatabase.shared.isOpen {
+            try SchedulerDatabase.shared.open()
+        }
+        return try SchedulerDatabase.shared.runs(agentId: agentId, limit: limit)
+    }
+}
+
+public struct ScheduleAutomationSummary: Codable, Sendable, Equatable {
+    public var scheduleId: UUID
+    public var generatedAt: Date
+    public var nextRun: ScheduleNextRunPreview
+    public var runs: [ScheduleRunHistoryEntry]
+    public var lastError: ScheduleLastErrorDiagnostic?
+
+    public init(
+        scheduleId: UUID,
+        generatedAt: Date,
+        nextRun: ScheduleNextRunPreview,
+        runs: [ScheduleRunHistoryEntry],
+        lastError: ScheduleLastErrorDiagnostic?
+    ) {
+        self.scheduleId = scheduleId
+        self.generatedAt = generatedAt
+        self.nextRun = nextRun
+        self.runs = runs
+        self.lastError = lastError
+    }
+
+    public var latestRun: ScheduleRunHistoryEntry? {
+        runs.first
+    }
+}
+
+public struct ScheduleHistoryService: Sendable {
+    public static let shared = ScheduleHistoryService()
+
+    private let agentRunProvider: any ScheduleAgentRunProviding
+    private let calendar: Calendar
+
+    public init(
+        agentRunProvider: any ScheduleAgentRunProviding = LiveScheduleAgentRunProvider(),
+        calendar: Calendar = .current
+    ) {
+        self.agentRunProvider = agentRunProvider
+        self.calendar = calendar
+    }
+
+    public func summaries(
+        for schedules: [Schedule],
+        runLimit: Int = 8,
+        asOf now: Date = Date()
+    ) -> [UUID: ScheduleAutomationSummary] {
+        Dictionary(uniqueKeysWithValues: schedules.map { schedule in
+            (schedule.id, summary(for: schedule, runLimit: runLimit, asOf: now))
+        })
+    }
+
+    public func summary(
+        for schedule: Schedule,
+        runLimit: Int = 10,
+        asOf now: Date = Date()
+    ) -> ScheduleAutomationSummary {
+        let agentRunEntries = loadAgentRunEntries(for: schedule, limit: max(runLimit, Schedule.maxRunHistoryEntries))
+        let runs = merge(local: schedule.runHistory, agentRuns: agentRunEntries, limit: runLimit)
+        let lastError = latestError(in: runs)
+        return ScheduleAutomationSummary(
+            scheduleId: schedule.id,
+            generatedAt: now,
+            nextRun: schedule.nextRunPreview(asOf: now),
+            runs: runs,
+            lastError: lastError
+        )
+    }
+
+    public func markdownSummary(for schedule: Schedule, summary: ScheduleAutomationSummary) -> String {
+        var lines: [String] = []
+        lines.append("# Schedule Run Summary: \(schedule.name)")
+        lines.append("")
+        lines.append("- Schedule ID: `\(schedule.id.uuidString)`")
+        if let agentId = schedule.agentId {
+            lines.append("- Agent ID: `\(agentId.uuidString)`")
+        }
+        lines.append("- Frequency: \(schedule.frequency.displayDescription)")
+        lines.append("- State: \(schedule.isEnabled ? "Enabled" : "Paused")")
+        lines.append("- Generated: \(formatDate(summary.generatedAt))")
+        lines.append("- Next run: \(summary.nextRun.description)")
+        if let nextRunAt = summary.nextRun.nextRunAt {
+            lines.append("- Next run timestamp: \(isoString(nextRunAt))")
+        }
+
+        if let lastError = summary.lastError {
+            lines.append("")
+            lines.append("## Last Error")
+            lines.append("")
+            lines.append("- Run ID: `\(lastError.runId.uuidString)`")
+            lines.append("- Occurred: \(formatDate(lastError.occurredAt))")
+            lines.append("- Status: \(lastError.status.rawValue)")
+            lines.append("- Message: \(lastError.message)")
+        }
+
+        lines.append("")
+        lines.append("## Recent Runs")
+        lines.append("")
+        if summary.runs.isEmpty {
+            lines.append("No runs yet.")
+        } else {
+            lines.append("| Started | Status | Duration | Session | Error |")
+            lines.append("| --- | --- | --- | --- | --- |")
+            for run in summary.runs {
+                let started = formatDate(run.startedAt)
+                let duration = run.durationSeconds.map(formatDuration) ?? "-"
+                let session = run.chatSessionId?.uuidString ?? "-"
+                let error = run.errorMessage.map(escapeMarkdownTableCell) ?? "-"
+                lines.append(
+                    "| \(escapeMarkdownTableCell(started)) | \(run.status.rawValue) | \(duration) | \(session) | \(error) |"
+                )
+            }
+        }
+
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+
+    public func jsonData(for summary: ScheduleAutomationSummary) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(summary)
+    }
+
+    public func suggestedExportFilename(for schedule: Schedule, generatedAt: Date = Date()) -> String {
+        let safeName = schedule.name
+            .lowercased()
+            .map { character -> Character in
+                character.isLetter || character.isNumber ? character : "-"
+            }
+            .reduce(into: "") { result, character in
+                if character == "-", result.last == "-" { return }
+                result.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let stamp = formatter.string(from: generatedAt)
+        return "\(safeName.isEmpty ? "schedule" : safeName)-runs-\(stamp).md"
+    }
+
+    private func loadAgentRunEntries(for schedule: Schedule, limit: Int) -> [ScheduleRunHistoryEntry] {
+        guard let agentId = schedule.agentId else { return [] }
+        do {
+            return try agentRunProvider.runs(agentId: agentId, limit: limit)
+                .filter { record in
+                    record.triggerKind == .recurringSchedule
+                        && Self.scheduleId(fromTriggerPayload: record.triggerPayload) == schedule.id
+                }
+                .map { Self.entry(from: $0, schedule: schedule) }
+        } catch {
+            return []
+        }
+    }
+
+    private func merge(
+        local: [ScheduleRunHistoryEntry],
+        agentRuns: [ScheduleRunHistoryEntry],
+        limit: Int
+    ) -> [ScheduleRunHistoryEntry] {
+        var merged = agentRuns
+        for localEntry in local {
+            if let index = merged.firstIndex(where: { Self.isSameRun($0, localEntry) }) {
+                merged[index] = Self.combine(preferred: merged[index], fallback: localEntry)
+            } else {
+                merged.append(localEntry)
+            }
+        }
+
+        merged = merged.sorted { lhs, rhs in
+            if lhs.startedAt == rhs.startedAt {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.startedAt > rhs.startedAt
+        }
+        if merged.count > limit {
+            merged.removeSubrange(limit...)
+        }
+        return merged
+    }
+
+    private func latestError(in runs: [ScheduleRunHistoryEntry]) -> ScheduleLastErrorDiagnostic? {
+        for run in runs {
+            guard run.status == .failed || (run.status != .succeeded && run.errorMessage != nil),
+                let message = run.errorMessage,
+                !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { continue }
+
+            return ScheduleLastErrorDiagnostic(
+                runId: run.id,
+                occurredAt: run.endedAt ?? run.startedAt,
+                message: message,
+                status: run.status
+            )
+        }
+        return nil
+    }
+
+    private static func entry(from record: AgentRunRecord, schedule: Schedule) -> ScheduleRunHistoryEntry {
+        ScheduleRunHistoryEntry(
+            id: record.id,
+            scheduleId: schedule.id,
+            agentId: record.agentId,
+            status: ScheduleRunStatus(record.status),
+            source: .agentRun,
+            startedAt: record.startedAt,
+            endedAt: record.endedAt,
+            agentRunId: record.id,
+            errorMessage: record.error,
+            instructionsPreview: preview(record.instructions),
+            tokensIn: record.tokensIn,
+            tokensOut: record.tokensOut,
+            costUSD: record.costUSD
+        )
+    }
+
+    private static func combine(
+        preferred: ScheduleRunHistoryEntry,
+        fallback: ScheduleRunHistoryEntry
+    ) -> ScheduleRunHistoryEntry {
+        var combined = preferred
+        combined.chatSessionId = preferred.chatSessionId ?? fallback.chatSessionId
+        combined.errorMessage = preferred.errorMessage ?? fallback.errorMessage
+        combined.instructionsPreview = preferred.instructionsPreview ?? fallback.instructionsPreview
+        return combined
+    }
+
+    private static func isSameRun(_ lhs: ScheduleRunHistoryEntry, _ rhs: ScheduleRunHistoryEntry) -> Bool {
+        lhs.scheduleId == rhs.scheduleId
+            && abs(lhs.startedAt.timeIntervalSince(rhs.startedAt)) < 2
+    }
+
+    private static func scheduleId(fromTriggerPayload payload: String?) -> UUID? {
+        guard let payload,
+            let data = payload.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let key = json["external_session_key"] as? String
+        else { return nil }
+        return UUID(uuidString: key)
+    }
+
+    private static func preview(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.count <= 240 { return trimmed }
+        return String(trimmed.prefix(237)) + "..."
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private func isoString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        if duration < 1 { return "<1s" }
+        if duration < 60 { return "\(Int(duration.rounded()))s" }
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return "\(minutes)m \(seconds)s"
+    }
+
+    private func escapeMarkdownTableCell(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "|", with: "\\|")
+    }
+
+}
+
+extension ScheduleRunStatus {
+    init(_ status: AgentRunStatus) {
+        switch status {
+        case .running:
+            self = .running
+        case .success:
+            self = .succeeded
+        case .error:
+            self = .failed
+        case .cancelled:
+            self = .cancelled
+        case .clamped:
+            self = .skipped
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Schedule/ScheduleHistoryServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Schedule/ScheduleHistoryServiceTests.swift
@@ -11,6 +11,42 @@ import Testing
 @testable import OsaurusCore
 
 struct ScheduleHistoryServiceTests {
+    @MainActor
+    @Test func summaryOffMainLoadsProviderAwayFromMainThread() async {
+        let schedule = Schedule(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            name: "Daily summary",
+            instructions: "Summarize",
+            agentId: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            frequency: .daily(hour: 9, minute: 0)
+        )
+        let provider = ThreadCheckingAgentRunProvider()
+        let service = ScheduleHistoryService(agentRunProvider: provider)
+
+        let summary = await service.summaryOffMain(for: schedule, runLimit: 8)
+
+        #expect(summary.scheduleId == schedule.id)
+        #expect(provider.didRunOnMainThread == false)
+    }
+
+    @MainActor
+    @Test func summariesOffMainLoadsProviderAwayFromMainThread() async {
+        let schedule = Schedule(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Weekly report",
+            instructions: "Report",
+            agentId: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+            frequency: .weekly(dayOfWeek: 2, hour: 9, minute: 0)
+        )
+        let provider = ThreadCheckingAgentRunProvider()
+        let service = ScheduleHistoryService(agentRunProvider: provider)
+
+        let summaries = await service.summariesOffMain(for: [schedule], runLimit: 8)
+
+        #expect(summaries[schedule.id]?.scheduleId == schedule.id)
+        #expect(provider.didRunOnMainThread == false)
+    }
+
     @Test func summaryMergesAgentRunErrorsWithLocalHistory() {
         let scheduleId = UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!
         let agentId = UUID(uuidString: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")!
@@ -123,6 +159,24 @@ struct ScheduleHistoryServiceTests {
 
         func runs(agentId: UUID, limit: Int) throws -> [AgentRunRecord] {
             Array(records.filter { $0.agentId == agentId }.prefix(limit))
+        }
+    }
+
+    private final class ThreadCheckingAgentRunProvider: ScheduleAgentRunProviding, @unchecked Sendable {
+        private let lock = NSLock()
+        private var observedMainThread: Bool?
+
+        var didRunOnMainThread: Bool? {
+            lock.lock()
+            defer { lock.unlock() }
+            return observedMainThread
+        }
+
+        func runs(agentId: UUID, limit: Int) throws -> [AgentRunRecord] {
+            lock.lock()
+            observedMainThread = Thread.isMainThread
+            lock.unlock()
+            return []
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Schedule/ScheduleHistoryServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Schedule/ScheduleHistoryServiceTests.swift
@@ -1,0 +1,128 @@
+//
+//  ScheduleHistoryServiceTests.swift
+//  osaurusTests
+//
+//  Verifies schedule history summaries and exports.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ScheduleHistoryServiceTests {
+    @Test func summaryMergesAgentRunErrorsWithLocalHistory() {
+        let scheduleId = UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!
+        let agentId = UUID(uuidString: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")!
+        let sessionId = UUID(uuidString: "cccccccc-cccc-cccc-cccc-cccccccccccc")!
+        let startedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let endedAt = startedAt.addingTimeInterval(12)
+
+        let localRun = ScheduleRunHistoryEntry(
+            scheduleId: scheduleId,
+            agentId: agentId,
+            status: .running,
+            startedAt: startedAt,
+            chatSessionId: sessionId,
+            instructionsPreview: "Summarize"
+        )
+        let schedule = Schedule(
+            id: scheduleId,
+            name: "Daily summary",
+            instructions: "Summarize",
+            agentId: agentId,
+            frequency: .daily(hour: 9, minute: 0),
+            runHistory: [localRun]
+        )
+
+        let run = AgentRunRecord(
+            id: UUID(uuidString: "dddddddd-dddd-dddd-dddd-dddddddddddd")!,
+            agentId: agentId,
+            triggerKind: .recurringSchedule,
+            triggerPayload: #"{"source":"schedule","external_session_key":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}"#,
+            instructions: "Summarize",
+            startedAt: startedAt.addingTimeInterval(0.5),
+            endedAt: endedAt,
+            status: .error,
+            tokensIn: 10,
+            tokensOut: 0,
+            costUSD: nil,
+            error: "Model unavailable"
+        )
+        let unrelated = AgentRunRecord(
+            id: UUID(),
+            agentId: agentId,
+            triggerKind: .recurringSchedule,
+            triggerPayload: #"{"source":"schedule","external_session_key":"eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"}"#,
+            instructions: "Other",
+            startedAt: startedAt,
+            status: .success
+        )
+
+        let service = ScheduleHistoryService(agentRunProvider: FakeAgentRunProvider(records: [run, unrelated]))
+        let summary = service.summary(for: schedule, runLimit: 10, asOf: endedAt)
+
+        #expect(summary.runs.count == 1)
+        #expect(summary.runs[0].status == .failed)
+        #expect(summary.runs[0].chatSessionId == sessionId)
+        #expect(summary.runs[0].tokensIn == 10)
+        #expect(summary.lastError?.message == "Model unavailable")
+        #expect(summary.lastError?.runId == run.id)
+    }
+
+    @Test func markdownExportIncludesNextRunAndRecentRuns() {
+        let scheduleId = UUID(uuidString: "99999999-9999-9999-9999-999999999999")!
+        let runId = UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
+        let generatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let schedule = Schedule(
+            id: scheduleId,
+            name: "Weekly | Report",
+            instructions: "Write report",
+            frequency: .weekly(dayOfWeek: 2, hour: 9, minute: 0)
+        )
+        let summary = ScheduleAutomationSummary(
+            scheduleId: scheduleId,
+            generatedAt: generatedAt,
+            nextRun: ScheduleNextRunPreview(
+                state: .scheduled,
+                nextRunAt: generatedAt.addingTimeInterval(3600),
+                generatedAt: generatedAt,
+                description: "Today at 10:00 AM"
+            ),
+            runs: [
+                ScheduleRunHistoryEntry(
+                    id: runId,
+                    scheduleId: scheduleId,
+                    agentId: nil,
+                    status: .failed,
+                    startedAt: generatedAt,
+                    endedAt: generatedAt.addingTimeInterval(2),
+                    errorMessage: "Tool | failed"
+                )
+            ],
+            lastError: ScheduleLastErrorDiagnostic(
+                runId: runId,
+                occurredAt: generatedAt.addingTimeInterval(2),
+                message: "Tool | failed",
+                status: .failed
+            )
+        )
+
+        let service = ScheduleHistoryService(agentRunProvider: FakeAgentRunProvider(records: []))
+        let markdown = service.markdownSummary(for: schedule, summary: summary)
+
+        #expect(markdown.contains("# Schedule Run Summary: Weekly | Report"))
+        #expect(markdown.contains("- Next run: Today at 10:00 AM"))
+        #expect(markdown.contains("## Last Error"))
+        #expect(markdown.contains("Tool \\| failed"))
+        #expect(markdown.contains("| Started | Status | Duration | Session | Error |"))
+    }
+
+    private struct FakeAgentRunProvider: ScheduleAgentRunProviding {
+        let records: [AgentRunRecord]
+
+        func runs(agentId: UUID, limit: Int) throws -> [AgentRunRecord] {
+            Array(records.filter { $0.agentId == agentId }.prefix(limit))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Schedule/ScheduleNextRunPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Schedule/ScheduleNextRunPreviewTests.swift
@@ -1,0 +1,83 @@
+//
+//  ScheduleNextRunPreviewTests.swift
+//  osaurusTests
+//
+//  Verifies schedule next-run preview semantics.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ScheduleNextRunPreviewTests {
+    @Test func recurringPreviewUsesExecutionAnchor() {
+        let now = localDate(year: 2026, month: 6, day: 18, hour: 10, minute: 0)
+        let triggeredToday = localDate(year: 2026, month: 6, day: 18, hour: 9, minute: 0)
+        let expectedTomorrow = localDate(year: 2026, month: 6, day: 19, hour: 9, minute: 0)
+
+        let schedule = Schedule(
+            name: "Daily check",
+            instructions: "Run check",
+            frequency: .daily(hour: 9, minute: 0),
+            lastTriggeredAt: triggeredToday
+        )
+
+        let preview = schedule.nextRunPreview(asOf: now)
+        #expect(preview.state == .scheduled)
+        #expect(preview.nextRunAt == expectedTomorrow)
+    }
+
+    @Test func missedRecurringPreviewShowsDueNow() {
+        let now = localDate(year: 2026, month: 6, day: 18, hour: 10, minute: 0)
+        let triggeredYesterday = localDate(year: 2026, month: 6, day: 17, hour: 9, minute: 0)
+        let missedRun = localDate(year: 2026, month: 6, day: 18, hour: 9, minute: 0)
+
+        let schedule = Schedule(
+            name: "Daily check",
+            instructions: "Run check",
+            frequency: .daily(hour: 9, minute: 0),
+            lastTriggeredAt: triggeredYesterday
+        )
+
+        let preview = schedule.nextRunPreview(asOf: now)
+        #expect(preview.state == .due)
+        #expect(preview.nextRunAt == missedRun)
+        #expect(preview.description == "Due now")
+    }
+
+    @Test func pausedAndCompletedOneShotHaveExplicitPreviewStates() {
+        let now = localDate(year: 2026, month: 6, day: 18, hour: 10, minute: 0)
+        let fireDate = localDate(year: 2026, month: 6, day: 18, hour: 9, minute: 0)
+
+        let paused = Schedule(
+            name: "Paused daily",
+            instructions: "Run check",
+            frequency: .daily(hour: 9, minute: 0),
+            isEnabled: false
+        )
+        let oneShot = Schedule(
+            name: "One shot",
+            instructions: "Run once",
+            frequency: .once(date: fireDate),
+            lastTriggeredAt: fireDate
+        )
+
+        #expect(paused.nextRunPreview(asOf: now).state == .paused)
+        #expect(paused.nextRunPreview(asOf: now).nextRunAt == nil)
+        #expect(oneShot.nextRunPreview(asOf: now).state == .exhausted)
+        #expect(oneShot.nextRunPreview(asOf: now).nextRunAt == nil)
+    }
+
+    private func localDate(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar.current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return components.date!
+    }
+}

--- a/Packages/OsaurusCore/Tests/Schedule/ScheduleRunHistoryStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Schedule/ScheduleRunHistoryStoreTests.swift
@@ -1,0 +1,120 @@
+//
+//  ScheduleRunHistoryStoreTests.swift
+//  osaurusTests
+//
+//  Verifies schedule persistence records run-history transitions.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ScheduleRunHistoryStoreTests {
+    @Test func storeRecordsStartAndCompletionTransitions() async throws {
+        try await Self.withIsolatedRoot(label: "store-transitions") {
+            let scheduleId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+            let agentId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+            let sessionId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+            let start = Self.localDate(year: 2026, month: 6, day: 18, hour: 9, minute: 0)
+            let end = start.addingTimeInterval(45)
+
+            let base = Schedule(
+                id: scheduleId,
+                name: "Daily summary",
+                instructions: "Summarize the workspace",
+                agentId: agentId,
+                frequency: .daily(hour: 9, minute: 0),
+                createdAt: Self.localDate(year: 2026, month: 6, day: 1, hour: 8, minute: 0),
+                updatedAt: Self.localDate(year: 2026, month: 6, day: 1, hour: 8, minute: 0)
+            )
+            ScheduleStore.save(base)
+            #expect(ScheduleStore.load(id: scheduleId)?.runHistory.isEmpty == true)
+
+            var triggered = base
+            triggered.lastTriggeredAt = start
+            ScheduleStore.save(triggered)
+
+            let afterStart = try #require(ScheduleStore.load(id: scheduleId))
+            #expect(afterStart.runHistory.count == 1)
+            #expect(afterStart.runHistory[0].status == .running)
+            #expect(afterStart.runHistory[0].startedAt == start)
+
+            var completed = triggered
+            completed.lastRunAt = end
+            completed.lastChatSessionId = sessionId
+            ScheduleStore.save(completed)
+
+            let afterCompletion = try #require(ScheduleStore.load(id: scheduleId))
+            #expect(afterCompletion.runHistory.count == 1)
+            #expect(afterCompletion.runHistory[0].status == .succeeded)
+            #expect(afterCompletion.runHistory[0].startedAt == start)
+            #expect(afterCompletion.runHistory[0].endedAt == end)
+            #expect(afterCompletion.runHistory[0].chatSessionId == sessionId)
+            #expect(afterCompletion.runHistory[0].durationSeconds == 45)
+
+            var edited = afterCompletion
+            edited.name = "Daily summary edited"
+            ScheduleStore.save(edited)
+
+            let afterEdit = try #require(ScheduleStore.load(id: scheduleId))
+            #expect(afterEdit.runHistory.count == 1)
+            #expect(afterEdit.name == "Daily summary edited")
+        }
+    }
+
+    @Test func runHistoryIsBoundedNewestFirst() async throws {
+        try await Self.withIsolatedRoot(label: "store-bounds") {
+            var schedule = Schedule(
+                id: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+                name: "Frequent check",
+                instructions: "Check state",
+                frequency: .everyNMinutes(minutes: 5)
+            )
+
+            for offset in 0 ..< 60 {
+                let start = Date(timeIntervalSince1970: TimeInterval(1_800_000_000 + offset * 60))
+                schedule.lastTriggeredAt = start
+                schedule.lastRunAt = start.addingTimeInterval(5)
+                ScheduleStore.save(schedule)
+                schedule = try #require(ScheduleStore.load(id: schedule.id))
+            }
+
+            let loaded = try #require(ScheduleStore.load(id: schedule.id))
+            #expect(loaded.runHistory.count == Schedule.maxRunHistoryEntries)
+            #expect(loaded.runHistory.first?.startedAt == Date(timeIntervalSince1970: 1_800_000_000 + 59 * 60))
+            #expect(loaded.runHistory.last?.startedAt == Date(timeIntervalSince1970: 1_800_000_000 + 10 * 60))
+        }
+    }
+
+    private static func withIsolatedRoot<T: Sendable>(
+        label: String,
+        _ body: @Sendable () throws -> T
+    ) async throws -> T {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-schedule-history-\(label)-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+            return try body()
+        }
+    }
+
+    private static func localDate(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar.current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return components.date!
+    }
+}

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -22,6 +22,7 @@ struct SchedulesView: View {
     @State private var editingSchedule: Schedule?
     @State private var historySchedule: Schedule?
     @State private var scheduleSummaries: [UUID: ScheduleAutomationSummary] = [:]
+    @State private var summaryLoadTask: Task<Void, Never>?
     @State private var hasAppeared = false
     @State private var successMessage: String?
 
@@ -74,7 +75,7 @@ struct SchedulesView: View {
                                 schedule in
                                 ScheduleCard(
                                     schedule: schedule,
-                                    summary: scheduleSummaries[schedule.id] ?? fallbackSummary(for: schedule),
+                                    summary: displaySummary(for: schedule),
                                     isRunning: scheduleManager.isRunning(schedule.id),
                                     animationDelay: Double(index) * 0.05,
                                     hasAppeared: hasAppeared,
@@ -166,7 +167,7 @@ struct SchedulesView: View {
         .sheet(item: $historySchedule) { schedule in
             ScheduleHistorySheet(
                 schedule: schedule,
-                summary: scheduleSummaries[schedule.id] ?? fallbackSummary(for: schedule),
+                summary: displaySummary(for: schedule),
                 onExport: {
                     exportSummary(for: schedule)
                 }
@@ -186,6 +187,10 @@ struct SchedulesView: View {
         .onReceive(NotificationCenter.default.publisher(for: .scheduleExecutionCompleted)) { _ in
             scheduleManager.refresh()
             reloadHistorySummaries()
+        }
+        .onDisappear {
+            summaryLoadTask?.cancel()
+            summaryLoadTask = nil
         }
     }
 
@@ -235,37 +240,79 @@ struct SchedulesView: View {
     }
 
     private func reloadHistorySummaries() {
-        scheduleSummaries = ScheduleHistoryService.shared.summaries(for: scheduleManager.schedules)
+        let schedules = scheduleManager.schedules
+        let scheduleIds = Set(schedules.map(\.id))
+        let now = Date()
+        var summaries = scheduleSummaries.filter { scheduleIds.contains($0.key) }
+        for schedule in schedules where summaries[schedule.id] == nil {
+            summaries[schedule.id] = placeholderSummary(for: schedule, asOf: now)
+        }
+        scheduleSummaries = summaries
+
+        summaryLoadTask?.cancel()
+        summaryLoadTask = Task { @MainActor in
+            let loadedSummaries = await ScheduleHistoryService.shared.summariesOffMain(
+                for: schedules,
+                runLimit: 8,
+                asOf: now
+            )
+            guard !Task.isCancelled else { return }
+            scheduleSummaries = loadedSummaries
+        }
     }
 
-    private func fallbackSummary(for schedule: Schedule) -> ScheduleAutomationSummary {
-        let now = Date()
+    private func displaySummary(for schedule: Schedule) -> ScheduleAutomationSummary {
+        scheduleSummaries[schedule.id] ?? placeholderSummary(for: schedule)
+    }
+
+    private func placeholderSummary(for schedule: Schedule, asOf now: Date = Date()) -> ScheduleAutomationSummary {
         let runs = Array(schedule.runHistory.prefix(8))
         return ScheduleAutomationSummary(
             scheduleId: schedule.id,
             generatedAt: now,
             nextRun: schedule.nextRunPreview(asOf: now),
             runs: runs,
-            lastError: ScheduleHistoryService.shared.summary(for: schedule, runLimit: 8, asOf: now).lastError
+            lastError: latestLocalError(in: runs)
         )
+    }
+
+    private func latestLocalError(in runs: [ScheduleRunHistoryEntry]) -> ScheduleLastErrorDiagnostic? {
+        for run in runs {
+            guard run.status == .failed || (run.status != .succeeded && run.errorMessage != nil),
+                let message = run.errorMessage,
+                !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { continue }
+
+            return ScheduleLastErrorDiagnostic(
+                runId: run.id,
+                occurredAt: run.endedAt ?? run.startedAt,
+                message: message,
+                status: run.status
+            )
+        }
+        return nil
     }
 
     private func exportSummary(for schedule: Schedule) {
         let service = ScheduleHistoryService.shared
-        let summary = service.summary(for: schedule, runLimit: Schedule.maxRunHistoryEntries)
-        let markdown = service.markdownSummary(for: schedule, summary: summary)
+        let filenameSummary = displaySummary(for: schedule)
 
         let panel = NSSavePanel()
         panel.title = L("Export")
         panel.prompt = L("Export")
-        panel.nameFieldStringValue = service.suggestedExportFilename(for: schedule, generatedAt: summary.generatedAt)
+        panel.nameFieldStringValue = service.suggestedExportFilename(for: schedule, generatedAt: filenameSummary.generatedAt)
         panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
         panel.canCreateDirectories = true
 
         Task { @MainActor in
             guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            let summary = await service.summaryOffMain(for: schedule, runLimit: Schedule.maxRunHistoryEntries)
+            let markdown = service.markdownSummary(for: schedule, summary: summary)
             do {
-                try markdown.write(to: url, atomically: true, encoding: .utf8)
+                try await Task.detached(priority: .utility) {
+                    try markdown.write(to: url, atomically: true, encoding: .utf8)
+                }.value
+                scheduleSummaries[schedule.id] = summary
                 showSuccess("Exported \"\(schedule.name)\"")
             } catch {
                 showSuccess("Export failed: \(error.localizedDescription)")

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - Schedules View
 
@@ -19,6 +20,8 @@ struct SchedulesView: View {
 
     @State private var isCreating = false
     @State private var editingSchedule: Schedule?
+    @State private var historySchedule: Schedule?
+    @State private var scheduleSummaries: [UUID: ScheduleAutomationSummary] = [:]
     @State private var hasAppeared = false
     @State private var successMessage: String?
 
@@ -71,21 +74,34 @@ struct SchedulesView: View {
                                 schedule in
                                 ScheduleCard(
                                     schedule: schedule,
+                                    summary: scheduleSummaries[schedule.id] ?? fallbackSummary(for: schedule),
                                     isRunning: scheduleManager.isRunning(schedule.id),
                                     animationDelay: Double(index) * 0.05,
                                     hasAppeared: hasAppeared,
                                     onToggle: { enabled in
                                         scheduleManager.setEnabled(schedule.id, enabled: enabled)
+                                        scheduleManager.refresh()
+                                        reloadHistorySummaries()
+                                        showSuccess(enabled ? "Resumed \"\(schedule.name)\"" : "Paused \"\(schedule.name)\"")
                                     },
                                     onRunNow: {
                                         scheduleManager.runNow(schedule.id)
+                                        scheduleManager.refresh()
+                                        reloadHistorySummaries()
                                         showSuccess("Started \"\(schedule.name)\"")
+                                    },
+                                    onShowHistory: {
+                                        historySchedule = schedule
+                                    },
+                                    onExportSummary: {
+                                        exportSummary(for: schedule)
                                     },
                                     onEdit: {
                                         editingSchedule = schedule
                                     },
                                     onDelete: {
                                         scheduleManager.delete(id: schedule.id)
+                                        reloadHistorySummaries()
                                         showSuccess("Deleted \"\(schedule.name)\"")
                                     }
                                 )
@@ -125,6 +141,7 @@ struct SchedulesView: View {
                         isEnabled: schedule.isEnabled
                     )
                     isCreating = false
+                    reloadHistorySummaries()
                     showSuccess("Created \"\(schedule.name)\"")
                 },
                 onCancel: {
@@ -138,6 +155,7 @@ struct SchedulesView: View {
                 onSave: { updated in
                     scheduleManager.update(updated)
                     editingSchedule = nil
+                    reloadHistorySummaries()
                     showSuccess("Updated \"\(updated.name)\"")
                 },
                 onCancel: {
@@ -145,8 +163,18 @@ struct SchedulesView: View {
                 }
             )
         }
+        .sheet(item: $historySchedule) { schedule in
+            ScheduleHistorySheet(
+                schedule: schedule,
+                summary: scheduleSummaries[schedule.id] ?? fallbackSummary(for: schedule),
+                onExport: {
+                    exportSummary(for: schedule)
+                }
+            )
+        }
         .onAppear {
             scheduleManager.refresh()
+            reloadHistorySummaries()
             withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
                 hasAppeared = true
             }
@@ -154,6 +182,10 @@ struct SchedulesView: View {
         }
         .onChange(of: managementState.pendingScheduleEditId) { _, _ in
             consumePendingScheduleEditRequest()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .scheduleExecutionCompleted)) { _ in
+            scheduleManager.refresh()
+            reloadHistorySummaries()
         }
     }
 
@@ -164,6 +196,7 @@ struct SchedulesView: View {
     private func consumePendingScheduleEditRequest() {
         guard let pending = managementState.pendingScheduleEditId else { return }
         scheduleManager.refresh()
+        reloadHistorySummaries()
         if let match = scheduleManager.schedules.first(where: { $0.id == pending }) {
             editingSchedule = match
         }
@@ -180,6 +213,7 @@ struct SchedulesView: View {
         ) {
             HeaderIconButton("arrow.clockwise", help: "Refresh schedules") {
                 scheduleManager.refresh()
+                reloadHistorySummaries()
             }
             HeaderPrimaryButton("Create Schedule", icon: "plus") {
                 isCreating = true
@@ -199,6 +233,45 @@ struct SchedulesView: View {
             }
         }
     }
+
+    private func reloadHistorySummaries() {
+        scheduleSummaries = ScheduleHistoryService.shared.summaries(for: scheduleManager.schedules)
+    }
+
+    private func fallbackSummary(for schedule: Schedule) -> ScheduleAutomationSummary {
+        let now = Date()
+        let runs = Array(schedule.runHistory.prefix(8))
+        return ScheduleAutomationSummary(
+            scheduleId: schedule.id,
+            generatedAt: now,
+            nextRun: schedule.nextRunPreview(asOf: now),
+            runs: runs,
+            lastError: ScheduleHistoryService.shared.summary(for: schedule, runLimit: 8, asOf: now).lastError
+        )
+    }
+
+    private func exportSummary(for schedule: Schedule) {
+        let service = ScheduleHistoryService.shared
+        let summary = service.summary(for: schedule, runLimit: Schedule.maxRunHistoryEntries)
+        let markdown = service.markdownSummary(for: schedule, summary: summary)
+
+        let panel = NSSavePanel()
+        panel.title = L("Export")
+        panel.prompt = L("Export")
+        panel.nameFieldStringValue = service.suggestedExportFilename(for: schedule, generatedAt: summary.generatedAt)
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        panel.canCreateDirectories = true
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            do {
+                try markdown.write(to: url, atomically: true, encoding: .utf8)
+                showSuccess("Exported \"\(schedule.name)\"")
+            } catch {
+                showSuccess("Export failed: \(error.localizedDescription)")
+            }
+        }
+    }
 }
 
 // MARK: - Schedule Card
@@ -208,11 +281,14 @@ private struct ScheduleCard: View {
     @ObservedObject private var agentManager = AgentManager.shared
 
     let schedule: Schedule
+    let summary: ScheduleAutomationSummary
     let isRunning: Bool
     let animationDelay: Double
     let hasAppeared: Bool
     let onToggle: (Bool) -> Void
     let onRunNow: () -> Void
+    let onShowHistory: () -> Void
+    let onExportSummary: () -> Void
     let onEdit: () -> Void
     let onDelete: () -> Void
 
@@ -295,6 +371,20 @@ private struct ScheduleCard: View {
                             }
                         }
                         .disabled(isRunning)
+                        Button(action: onShowHistory) {
+                            Label {
+                                Text("History", bundle: .module)
+                            } icon: {
+                                Image(systemName: "clock.arrow.circlepath")
+                            }
+                        }
+                        Button(action: onExportSummary) {
+                            Label {
+                                Text("Export…", bundle: .module)
+                            } icon: {
+                                Image(systemName: "square.and.arrow.up")
+                            }
+                        }
                         Divider()
                         Button {
                             onToggle(!schedule.isEnabled)
@@ -337,6 +427,12 @@ private struct ScheduleCard: View {
                         .lineLimit(2)
                         .lineSpacing(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                nextRunPreview
+
+                if let lastError = summary.lastError {
+                    lastErrorPreview(lastError)
                 }
 
                 Spacer(minLength: 0)
@@ -432,14 +528,95 @@ private struct ScheduleCard: View {
 
     // MARK: - Compact Stats
 
+    private var nextRunPreview: some View {
+        HStack(spacing: 8) {
+            Image(systemName: nextRunIcon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(nextRunColor)
+                .frame(width: 14)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Next run", bundle: .module)
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                Text(summary.nextRun.description)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(nextRunColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(nextRunColor.opacity(0.18), lineWidth: 1)
+                )
+        )
+    }
+
+    private var nextRunIcon: String {
+        switch summary.nextRun.state {
+        case .scheduled:
+            return "clock"
+        case .due:
+            return "bell.badge.fill"
+        case .paused:
+            return "pause.circle"
+        case .exhausted:
+            return "checkmark.circle"
+        }
+    }
+
+    private var nextRunColor: Color {
+        switch summary.nextRun.state {
+        case .scheduled:
+            return theme.accentColor
+        case .due:
+            return .orange
+        case .paused:
+            return .orange
+        case .exhausted:
+            return theme.tertiaryText
+        }
+    }
+
+    private func lastErrorPreview(_ diagnostic: ScheduleLastErrorDiagnostic) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.errorColor)
+                .frame(width: 14)
+            Text(diagnostic.message)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.errorColor)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.errorColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.errorColor.opacity(0.18), lineWidth: 1)
+                )
+        )
+    }
+
     @ViewBuilder
     private var compactStats: some View {
         HStack(spacing: 0) {
             statItem(icon: schedule.frequency.frequencyType.icon, text: schedule.frequency.shortDescription)
 
-            if let nextRun = schedule.nextRunDescription {
+            if let latest = summary.latestRun {
                 statDot
-                statItem(icon: "clock", text: nextRun)
+                statItem(icon: latest.status.iconName, text: latest.status.displayName)
             }
 
             if let agentName = agent?.name, agent?.isBuiltIn == false {
@@ -467,6 +644,396 @@ private struct ScheduleCard: View {
             .fill(theme.tertiaryText.opacity(0.4))
             .frame(width: 3, height: 3)
             .padding(.horizontal, 8)
+    }
+}
+
+// MARK: - Schedule History Sheet
+
+private struct ScheduleHistorySheet: View {
+    @Environment(\.theme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    let schedule: Schedule
+    let summary: ScheduleAutomationSummary
+    let onExport: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    overview
+
+                    if let diagnostic = summary.lastError {
+                        diagnosticPanel(diagnostic)
+                    }
+
+                    runsSection
+                }
+                .padding(24)
+            }
+
+            footer
+        }
+        .frame(width: 640, height: 560)
+        .background(theme.primaryBackground)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(theme.accentColor)
+                .frame(width: 36, height: 36)
+                .background(Circle().fill(theme.accentColor.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("History", bundle: .module)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(schedule.name)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(theme.tertiaryBackground))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.escape, modifiers: [])
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(theme.secondaryBackground)
+    }
+
+    private var overview: some View {
+        HStack(spacing: 12) {
+            ScheduleHistoryMetric(
+                icon: schedule.isEnabled ? "checkmark.circle.fill" : "pause.circle.fill",
+                title: "State",
+                value: schedule.isEnabled ? "Enabled" : "Paused",
+                color: schedule.isEnabled ? theme.successColor : .orange
+            )
+            ScheduleHistoryMetric(
+                icon: summary.nextRun.state.iconName,
+                title: "Next run",
+                value: summary.nextRun.description,
+                color: summary.nextRun.state.color(theme: theme)
+            )
+            ScheduleHistoryMetric(
+                icon: "list.bullet.rectangle",
+                title: "Runs",
+                value: "\(summary.runs.count)",
+                color: theme.accentColor
+            )
+        }
+    }
+
+    private func diagnosticPanel(_ diagnostic: ScheduleLastErrorDiagnostic) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(theme.errorColor)
+                Text("Diagnostics", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+                Text(formatDate(diagnostic.occurredAt))
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+            }
+
+            Text(diagnostic.message)
+                .font(.system(size: 12))
+                .foregroundColor(theme.errorColor)
+                .textSelection(.enabled)
+
+            Text("Run ID: \(diagnostic.runId.uuidString)", bundle: .module)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(theme.tertiaryText)
+                .textSelection(.enabled)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.errorColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.errorColor.opacity(0.18), lineWidth: 1)
+                )
+        )
+    }
+
+    private var runsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Recent Runs", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+            }
+
+            if summary.runs.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "clock.badge.questionmark")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundColor(theme.tertiaryText)
+                    Text("No runs yet.", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(theme.secondaryBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(theme.cardBorder, lineWidth: 1)
+                        )
+                )
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(summary.runs) { run in
+                        ScheduleRunHistoryRow(run: run)
+                    }
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Spacer()
+            Button(action: { dismiss() }) {
+                Text("Close", bundle: .module)
+            }
+            .buttonStyle(ScheduleSecondaryButtonStyle())
+
+            Button {
+                onExport()
+            } label: {
+                Label {
+                    Text("Export…", bundle: .module)
+                } icon: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+            .buttonStyle(SchedulePrimaryButtonStyle())
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+        .background(
+            theme.secondaryBackground
+                .overlay(Rectangle().fill(theme.primaryBorder).frame(height: 1), alignment: .top)
+        )
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+private struct ScheduleHistoryMetric: View {
+    @Environment(\.theme) private var theme
+
+    let icon: String
+    let title: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(color.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: title)
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+                Text(value)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct ScheduleRunHistoryRow: View {
+    @Environment(\.theme) private var theme
+
+    let run: ScheduleRunHistoryEntry
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: run.status.iconName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(run.status.color(theme: theme))
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(run.status.color(theme: theme).opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(run.status.displayName)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(formatDate(run.startedAt))
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                    Spacer()
+                    if let duration = run.durationSeconds {
+                        Text(formatDuration(duration))
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(theme.secondaryText)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    if let sessionId = run.chatSessionId {
+                        Label(String(sessionId.uuidString.prefix(8)), systemImage: "bubble.left.and.bubble.right")
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.tertiaryText)
+                    }
+                    if let error = run.errorMessage, !error.isEmpty {
+                        Text(error)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.errorColor)
+                            .lineLimit(1)
+                    } else if let preview = run.instructionsPreview {
+                        Text(preview)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.tertiaryText)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        if duration < 1 { return "<1s" }
+        if duration < 60 { return "\(Int(duration.rounded()))s" }
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return "\(minutes)m \(seconds)s"
+    }
+}
+
+private extension ScheduleRunStatus {
+    var displayName: String {
+        switch self {
+        case .running:
+            return L("Running")
+        case .succeeded:
+            return L("Completed")
+        case .failed:
+            return L("Failed")
+        case .cancelled:
+            return L("Cancelled")
+        case .skipped:
+            return "Skipped"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .running:
+            return "play.circle.fill"
+        case .succeeded:
+            return "checkmark.circle.fill"
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        case .cancelled:
+            return "xmark.circle.fill"
+        case .skipped:
+            return "forward.end.circle.fill"
+        }
+    }
+
+    func color(theme: ThemeProtocol) -> Color {
+        switch self {
+        case .running:
+            return theme.accentColor
+        case .succeeded:
+            return theme.successColor
+        case .failed:
+            return theme.errorColor
+        case .cancelled, .skipped:
+            return .orange
+        }
+    }
+}
+
+private extension ScheduleNextRunPreviewState {
+    var iconName: String {
+        switch self {
+        case .scheduled:
+            return "clock"
+        case .due:
+            return "bell.badge.fill"
+        case .paused:
+            return "pause.circle.fill"
+        case .exhausted:
+            return "checkmark.circle.fill"
+        }
+    }
+
+    func color(theme: ThemeProtocol) -> Color {
+        switch self {
+        case .scheduled:
+            return theme.accentColor
+        case .due, .paused:
+            return .orange
+        case .exhausted:
+            return theme.tertiaryText
+        }
     }
 }
 
@@ -1654,6 +2221,11 @@ struct ScheduleEditorSheet: View {
             || buildFrequency() != original.frequency
     }
 
+    private var existingRunHistory: [ScheduleRunHistoryEntry] {
+        if case .edit(let schedule) = mode { return schedule.runHistory }
+        return []
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             headerView
@@ -2555,6 +3127,7 @@ struct ScheduleEditorSheet: View {
             lastRunAt: existingLastRunAt,
             lastTriggeredAt: existingLastTriggeredAt,
             lastChatSessionId: existingLastChatSessionId,
+            runHistory: existingRunHistory,
             createdAt: existingCreatedAt ?? Date(),
             updatedAt: Date()
         )

--- a/docs/SCHEDULES.md
+++ b/docs/SCHEDULES.md
@@ -1,0 +1,36 @@
+# Schedules
+
+Schedules run saved agent instructions on a calendar or cron cadence. Each
+schedule stores a bounded local run history alongside its JSON configuration.
+
+## Run History
+
+The schedule store records a history entry when a schedule is selected for
+execution and marks that entry complete when the run finishes successfully.
+The Schedules tab also enriches that local history with matching `agent_runs`
+audit records when the target agent has database run logging enabled. Those
+audit records add terminal failures, cancellations, token counts, and error
+messages when available.
+
+History entries are matched to schedules through the schedule UUID carried as
+the scheduled dispatch external session key.
+
+## Next Run Preview
+
+The preview uses the schedule's execution anchor (`lastTriggeredAt`, falling
+back to `lastRunAt`) so missed or in-flight runs do not make the UI preview the
+same slot as an upcoming run. Paused schedules show no next run. Completed
+one-shot schedules show no upcoming run.
+
+## Pause and Resume
+
+Schedules can be paused and resumed from the Schedules tab action menu. Pausing
+preserves existing history and switches the next-run preview to the paused
+state; resuming recalculates the next run from the schedule's execution anchor.
+
+## Export
+
+Use the Schedules tab history menu to export a Markdown run summary. The export
+includes schedule identity, frequency, enabled state, generated time, next-run
+preview, the latest error diagnostic, and recent run rows with status, duration,
+session ID, and error text when present.


### PR DESCRIPTION
## Summary
- Adds schedule run history models, persistence, and history services.
- Extends the schedules UI so users can review recent automation outcomes.
- Adds tests for history persistence, next-run previews, and service behavior.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter Schedule`

## Notes
- The localization check still reports the existing stale-key warning set from main.
