### PR TITLE
Add runtime resilience dashboard

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofMatrixReporter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeProofMatrixReporter.swift
@@ -53,6 +53,85 @@ public struct RuntimeProofClassificationReport: Codable, Sendable, Equatable {
     }
 }
 
+public enum RuntimeProofResilienceSignal: String, Codable, Sendable, Equatable, Hashable, CaseIterable {
+    case tokensPerSecond = "tokens_per_second"
+    case cache
+    case markerLeak = "marker_leak"
+    case cancellation
+    case crashProof = "crash_proof"
+
+    public var displayName: String {
+        switch self {
+        case .tokensPerSecond:
+            return "Token/s"
+        case .cache:
+            return "Cache"
+        case .markerLeak:
+            return "Marker leak"
+        case .cancellation:
+            return "Cancellation"
+        case .crashProof:
+            return "Crash proof"
+        }
+    }
+}
+
+public struct RuntimeProofTokenRateEvidence: Codable, Sendable, Equatable {
+    public var completionTokens: Int?
+    public var elapsedSeconds: Double?
+    public var tokensPerSecond: Double?
+
+    public init(
+        completionTokens: Int? = nil,
+        elapsedSeconds: Double? = nil,
+        tokensPerSecond: Double? = nil
+    ) {
+        self.completionTokens = completionTokens
+        self.elapsedSeconds = elapsedSeconds
+        self.tokensPerSecond = tokensPerSecond
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case completionTokens = "completion_tokens"
+        case elapsedSeconds = "elapsed_seconds"
+        case tokensPerSecond = "tokens_per_second"
+    }
+}
+
+public struct RuntimeProofSignalEvidence: Codable, Sendable, Equatable {
+    public var verdict: RuntimeProofVerdict
+    public var summary: String
+    public var evidencePaths: [String]
+    public var metrics: [String: Double]
+
+    public init(
+        verdict: RuntimeProofVerdict = .unproven,
+        summary: String = "",
+        evidencePaths: [String] = [],
+        metrics: [String: Double] = [:]
+    ) {
+        self.verdict = verdict
+        self.summary = summary
+        self.evidencePaths = evidencePaths
+        self.metrics = metrics
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case verdict
+        case summary
+        case evidencePaths = "evidence_paths"
+        case metrics
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.verdict = try container.decodeIfPresent(RuntimeProofVerdict.self, forKey: .verdict) ?? .unproven
+        self.summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+        self.evidencePaths = try container.decodeIfPresent([String].self, forKey: .evidencePaths) ?? []
+        self.metrics = try container.decodeIfPresent([String: Double].self, forKey: .metrics) ?? [:]
+    }
+}
+
 public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
     public var id: String
     public var model: String?
@@ -66,6 +145,9 @@ public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
     public var blockers: [RuntimeProofMatrixMessage]
     public var warnings: [RuntimeProofMatrixMessage]
     public var failedChecks: [String]
+    public var cacheDelta: [String: Double]
+    public var tokenRates: [String: RuntimeProofTokenRateEvidence]
+    public var resilienceEvidence: [String: RuntimeProofSignalEvidence]
 
     public init(
         id: String,
@@ -79,7 +161,10 @@ public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
         acceptableForProvenClaim: Bool = false,
         blockers: [RuntimeProofMatrixMessage] = [],
         warnings: [RuntimeProofMatrixMessage] = [],
-        failedChecks: [String] = []
+        failedChecks: [String] = [],
+        cacheDelta: [String: Double] = [:],
+        tokenRates: [String: RuntimeProofTokenRateEvidence] = [:],
+        resilienceEvidence: [String: RuntimeProofSignalEvidence] = [:]
     ) {
         self.id = id
         self.model = model
@@ -93,6 +178,9 @@ public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
         self.blockers = blockers
         self.warnings = warnings
         self.failedChecks = failedChecks
+        self.cacheDelta = cacheDelta
+        self.tokenRates = tokenRates
+        self.resilienceEvidence = resilienceEvidence
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -108,6 +196,34 @@ public struct RuntimeProofClassificationRow: Codable, Sendable, Equatable {
         case blockers
         case warnings
         case failedChecks = "failed_checks"
+        case cacheDelta = "cache_delta"
+        case tokenRates = "token_rates"
+        case resilienceEvidence = "resilience_evidence"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.model = try container.decodeIfPresent(String.self, forKey: .model)
+        self.family = try container.decodeIfPresent(String.self, forKey: .family)
+        self.priority = try container.decodeIfPresent(String.self, forKey: .priority)
+        self.requirements = try container.decodeIfPresent([String].self, forKey: .requirements) ?? []
+        self.artifactPaths = try container.decodeIfPresent([String].self, forKey: .artifactPaths) ?? []
+        self.summaryPath = try container.decodeIfPresent(String.self, forKey: .summaryPath)
+        self.verdict = try container.decodeIfPresent(RuntimeProofVerdict.self, forKey: .verdict) ?? .unproven
+        self.acceptableForProvenClaim =
+            try container.decodeIfPresent(Bool.self, forKey: .acceptableForProvenClaim) ?? false
+        self.blockers = try container.decodeIfPresent([RuntimeProofMatrixMessage].self, forKey: .blockers) ?? []
+        self.warnings = try container.decodeIfPresent([RuntimeProofMatrixMessage].self, forKey: .warnings) ?? []
+        self.failedChecks = try container.decodeIfPresent([String].self, forKey: .failedChecks) ?? []
+        self.cacheDelta = try container.decodeIfPresent([String: Double].self, forKey: .cacheDelta) ?? [:]
+        self.tokenRates =
+            try container.decodeIfPresent([String: RuntimeProofTokenRateEvidence].self, forKey: .tokenRates) ?? [:]
+        self.resilienceEvidence =
+            try container.decodeIfPresent(
+                [String: RuntimeProofSignalEvidence].self,
+                forKey: .resilienceEvidence
+            ) ?? [:]
     }
 }
 
@@ -215,9 +331,76 @@ public struct RuntimeProofMatrixSurface: Codable, Sendable, Equatable {
     }
 }
 
+public struct RuntimeResilienceDashboardRow: Codable, Sendable, Equatable {
+    public var id: String
+    public var model: String
+    public var family: String
+    public var priority: String
+    public var verdict: RuntimeProofVerdict
+    public var signalEvidence: [String: RuntimeProofSignalEvidence]
+    public var evidencePointers: [String]
+    public var blockers: [String]
+    public var failedChecks: [String]
+    public var isSchemaOnly: Bool
+
+    public init(
+        id: String,
+        model: String,
+        family: String,
+        priority: String,
+        verdict: RuntimeProofVerdict,
+        signalEvidence: [String: RuntimeProofSignalEvidence],
+        evidencePointers: [String],
+        blockers: [String],
+        failedChecks: [String] = [],
+        isSchemaOnly: Bool = false
+    ) {
+        self.id = id
+        self.model = model
+        self.family = family
+        self.priority = priority
+        self.verdict = verdict
+        self.signalEvidence = signalEvidence
+        self.evidencePointers = evidencePointers
+        self.blockers = blockers
+        self.failedChecks = failedChecks
+        self.isSchemaOnly = isSchemaOnly
+    }
+}
+
+public struct RuntimeResilienceDashboardSurface: Codable, Sendable, Equatable {
+    public var generatedAt: String
+    public var sourceClassificationPath: String?
+    public var artifactRoot: String?
+    public var verdictCounts: [String: Int]
+    public var signalCounts: [String: [String: Int]]
+    public var rows: [RuntimeResilienceDashboardRow]
+    public var issueCoverage: [String: RuntimeProofIssueCoverage]
+
+    public init(
+        generatedAt: String,
+        sourceClassificationPath: String?,
+        artifactRoot: String?,
+        verdictCounts: [String: Int],
+        signalCounts: [String: [String: Int]],
+        rows: [RuntimeResilienceDashboardRow],
+        issueCoverage: [String: RuntimeProofIssueCoverage]
+    ) {
+        self.generatedAt = generatedAt
+        self.sourceClassificationPath = sourceClassificationPath
+        self.artifactRoot = artifactRoot
+        self.verdictCounts = verdictCounts
+        self.signalCounts = signalCounts
+        self.rows = rows
+        self.issueCoverage = issueCoverage
+    }
+}
+
 public enum RuntimeProofMatrixReporter {
     public static let markdownBeginMarker = "<!-- BEGIN RUNTIME PROOF MATRIX -->"
     public static let markdownEndMarker = "<!-- END RUNTIME PROOF MATRIX -->"
+    public static let dashboardMarkdownBeginMarker = "<!-- BEGIN RUNTIME RESILIENCE DASHBOARD -->"
+    public static let dashboardMarkdownEndMarker = "<!-- END RUNTIME RESILIENCE DASHBOARD -->"
 
     public static func decodeClassification(data: Data) throws -> RuntimeProofClassificationReport {
         let decoder = JSONDecoder()
@@ -245,6 +428,96 @@ public enum RuntimeProofMatrixReporter {
         let existing = Set(liveRows.map(\.id))
         let schemaRows = requiredSchemaRows.filter { !existing.contains($0.id) }
         return (liveRows + schemaRows).sorted(by: rowSort)
+    }
+
+    public static func dashboardSurface(
+        from report: RuntimeProofClassificationReport,
+        sourceClassificationPath: String? = nil,
+        generatedAt: String? = nil
+    ) -> RuntimeResilienceDashboardSurface {
+        let rows = dashboardRows(from: report)
+        return RuntimeResilienceDashboardSurface(
+            generatedAt: generatedAt ?? report.generatedAt ?? "unknown",
+            sourceClassificationPath: sourceClassificationPath,
+            artifactRoot: report.artifactRoot,
+            verdictCounts: verdictCounts(for: rows),
+            signalCounts: signalCounts(for: rows),
+            rows: rows,
+            issueCoverage: report.issueCoverage
+        )
+    }
+
+    public static func dashboardRows(from report: RuntimeProofClassificationReport)
+        -> [RuntimeResilienceDashboardRow]
+    {
+        let liveRows = report.rows.map(dashboardRow(from:))
+        let existing = Set(liveRows.map(\.id))
+        let schemaRows = requiredSchemaRows
+            .filter { !existing.contains($0.id) }
+            .map(dashboardRow(fromSchemaRow:))
+        return (liveRows + schemaRows).sorted(by: dashboardRowSort)
+    }
+
+    public static func dashboardMarkdown(
+        from report: RuntimeProofClassificationReport,
+        sourceClassificationPath: String? = nil,
+        generatedAt: String? = nil
+    ) -> String {
+        let surface = dashboardSurface(
+            from: report,
+            sourceClassificationPath: sourceClassificationPath,
+            generatedAt: generatedAt
+        )
+        let source = surface.sourceClassificationPath ?? report.summaryPath ?? "PROOF_CLASSIFICATION.json"
+        let verdictSummary = RuntimeProofVerdict.allCases
+            .map { "\($0.rawValue)=\(surface.verdictCounts[$0.rawValue, default: 0])" }
+            .joined(separator: ", ")
+        let signalSummary = RuntimeProofResilienceSignal.allCases
+            .map { signal -> String in
+                let counts = surface.signalCounts[signal.rawValue, default: [:]]
+                let values = RuntimeProofVerdict.allCases
+                    .map { "\($0.rawValue)=\(counts[$0.rawValue, default: 0])" }
+                    .joined(separator: ", ")
+                return "\(signal.displayName) \(values)"
+            }
+            .joined(separator: "; ")
+        let crashCoverage = surface.issueCoverage["#1228"]
+
+        var lines: [String] = [
+            dashboardMarkdownBeginMarker,
+            "",
+            "Generated from \(escapeMarkdown(source)) at \(escapeMarkdown(surface.generatedAt)).",
+            "",
+            "Verdicts: \(escapeMarkdown(verdictSummary))",
+            "",
+            "Signals: \(escapeMarkdown(signalSummary))",
+            "",
+            "Crash/cancellation issue coverage: \(escapeMarkdown(crashCoverage?.verdict.rawValue ?? "unproven")) - \(escapeMarkdown(crashCoverage?.note ?? "not recorded"))",
+            "",
+            "| Row | Model | Verdict | Token/s | Cache | Marker leak | Cancellation | Crash proof | Blockers |",
+            "|---|---|---|---|---|---|---|---|---|",
+        ]
+        for row in surface.rows {
+            lines.append(
+                [
+                    row.id,
+                    row.model,
+                    row.verdict.rawValue,
+                    signalCell(row, .tokensPerSecond),
+                    signalCell(row, .cache),
+                    signalCell(row, .markerLeak),
+                    signalCell(row, .cancellation),
+                    signalCell(row, .crashProof),
+                    row.blockers.isEmpty ? "none" : row.blockers.joined(separator: "<br>"),
+                ]
+                .map(escapeMarkdown)
+                .joined(separator: " | ")
+                .withMarkdownTablePipes()
+            )
+        }
+        lines.append("")
+        lines.append(dashboardMarkdownEndMarker)
+        return lines.joined(separator: "\n") + "\n"
     }
 
     public static func markdownMatrix(
@@ -318,6 +591,221 @@ public enum RuntimeProofMatrixReporter {
         )
     }
 
+    private static func dashboardRow(from row: RuntimeProofClassificationRow) -> RuntimeResilienceDashboardRow {
+        let evidence = uniqueNonEmpty([row.summaryPath].compactMap { $0 } + row.artifactPaths)
+        let blockers = blockerStrings(from: row.blockers)
+        let signalEvidence = Dictionary(
+            uniqueKeysWithValues: RuntimeProofResilienceSignal.allCases.map { signal in
+                (
+                    signal.rawValue,
+                    normalizedSignalEvidence(
+                        signal,
+                        row: row,
+                        fallbackEvidence: evidence
+                    )
+                )
+            }
+        )
+        return RuntimeResilienceDashboardRow(
+            id: row.id,
+            model: row.model ?? row.id,
+            family: row.family ?? "unknown",
+            priority: row.priority ?? "unspecified",
+            verdict: row.verdict,
+            signalEvidence: signalEvidence,
+            evidencePointers: evidence,
+            blockers: blockers,
+            failedChecks: row.failedChecks,
+            isSchemaOnly: false
+        )
+    }
+
+    private static func dashboardRow(fromSchemaRow row: RuntimeProofMatrixRow) -> RuntimeResilienceDashboardRow {
+        let signalEvidence = Dictionary(
+            uniqueKeysWithValues: RuntimeProofResilienceSignal.allCases.map { signal in
+                (
+                    signal.rawValue,
+                    RuntimeProofSignalEvidence(
+                        verdict: .unproven,
+                        summary: schemaSignalSummary(signal, requirements: row.requirements),
+                        evidencePaths: []
+                    )
+                )
+            }
+        )
+        return RuntimeResilienceDashboardRow(
+            id: row.id,
+            model: row.model,
+            family: row.family,
+            priority: row.priority,
+            verdict: row.verdict,
+            signalEvidence: signalEvidence,
+            evidencePointers: row.evidencePointers,
+            blockers: row.blockers,
+            isSchemaOnly: true
+        )
+    }
+
+    private static func normalizedSignalEvidence(
+        _ signal: RuntimeProofResilienceSignal,
+        row: RuntimeProofClassificationRow,
+        fallbackEvidence: [String]
+    ) -> RuntimeProofSignalEvidence {
+        if let evidence = row.resilienceEvidence[signal.rawValue] {
+            var normalized = evidence
+            if normalized.evidencePaths.isEmpty {
+                normalized.evidencePaths = fallbackEvidence
+            }
+            return normalized
+        }
+        return fallbackSignalEvidence(signal, row: row, fallbackEvidence: fallbackEvidence)
+    }
+
+    private static func fallbackSignalEvidence(
+        _ signal: RuntimeProofResilienceSignal,
+        row: RuntimeProofClassificationRow,
+        fallbackEvidence: [String]
+    ) -> RuntimeProofSignalEvidence {
+        let requirements = Set(row.requirements)
+        let blockers = blockerStrings(from: row.blockers)
+        let rowFailed = row.verdict == .failed
+
+        switch signal {
+        case .tokensPerSecond:
+            if let best = bestTokenRate(row.tokenRates) {
+                return RuntimeProofSignalEvidence(
+                    verdict: .proven,
+                    summary: "\(best.turn): \(String(format: "%.2f", best.rate)) token/s",
+                    evidencePaths: fallbackEvidence
+                )
+            }
+            return RuntimeProofSignalEvidence(
+                verdict: rowFailed ? .failed : .partial,
+                summary: blockers.first { $0.hasPrefix("tokens_per_second:") } ?? "no positive token/s was recorded",
+                evidencePaths: fallbackEvidence
+        )
+        case .cache:
+            if requirements.contains("cache_hit") {
+                let hasCacheBlocker = blockers.contains { $0.hasPrefix("cache_hit:") }
+                let verdict: RuntimeProofVerdict = hasCacheBlocker ? (rowFailed ? .failed : .partial) : .proven
+                return RuntimeProofSignalEvidence(
+                    verdict: verdict,
+                    summary: verdict == .proven
+                        ? "topology-specific cache evidence passed"
+                        : "required topology-specific cache evidence is incomplete",
+                    evidencePaths: fallbackEvidence,
+                    metrics: row.cacheDelta
+                )
+            }
+            if !row.cacheDelta.isEmpty {
+                return RuntimeProofSignalEvidence(
+                    verdict: .partial,
+                    summary: "cache counters were recorded, but this row does not require cache-hit proof",
+                    evidencePaths: fallbackEvidence,
+                    metrics: row.cacheDelta
+                )
+            }
+            return RuntimeProofSignalEvidence(
+                verdict: .unproven,
+                summary: "no cache evidence was recorded for this row",
+                evidencePaths: fallbackEvidence
+            )
+        case .markerLeak:
+            if blockers.contains(where: { $0.hasPrefix("no_parser_marker_leak:") }) {
+                return RuntimeProofSignalEvidence(
+                    verdict: rowFailed ? .failed : .partial,
+                    summary: "parser/runtime marker leak checks failed",
+                    evidencePaths: fallbackEvidence
+                )
+            }
+            let verdict: RuntimeProofVerdict = requirements.contains("no_parser_marker_leak") ? .proven : .unproven
+            return RuntimeProofSignalEvidence(
+                verdict: verdict,
+                summary: verdict == .proven
+                    ? "no parser/runtime marker leak detected in recorded output"
+                    : "marker-leak evidence was not recorded",
+                evidencePaths: fallbackEvidence
+            )
+        case .cancellation:
+            return RuntimeProofSignalEvidence(
+                verdict: .unproven,
+                summary: "no cancellation cleanup proof was recorded for this row",
+                evidencePaths: fallbackEvidence
+            )
+        case .crashProof:
+            return RuntimeProofSignalEvidence(
+                verdict: rowFailed ? .failed : .unproven,
+                summary: rowFailed
+                    ? "row failed or server health did not survive the proof run"
+                    : "no crash/health evidence was recorded for this row",
+                evidencePaths: fallbackEvidence
+            )
+        }
+    }
+
+    private static func schemaSignalSummary(
+        _ signal: RuntimeProofResilienceSignal,
+        requirements: [String]
+    ) -> String {
+        switch signal {
+        case .tokensPerSecond:
+            return requirements.contains("tokens_per_second")
+                ? "requires a live artifact with token/s"
+                : "token/s evidence is not part of this schema row"
+        case .cache:
+            return requirements.contains("cache_hit")
+                ? "requires topology-specific cache evidence"
+                : "cache evidence is not part of this schema row"
+        case .markerLeak:
+            return requirements.contains("no_parser_marker_leak")
+                ? "requires live output without parser/runtime marker leakage"
+                : "marker-leak evidence is not part of this schema row"
+        case .cancellation:
+            return "requires live cancellation cleanup evidence before it can be proven"
+        case .crashProof:
+            return "requires crash/health artifacts before it can be proven"
+        }
+    }
+
+    private static func bestTokenRate(_ rates: [String: RuntimeProofTokenRateEvidence]) -> (turn: String, rate: Double)? {
+        rates.compactMap { key, value -> (String, Double)? in
+            guard let tokens = value.completionTokens, tokens > 0, let rate = value.tokensPerSecond, rate > 0 else {
+                return nil
+            }
+            return (key, rate)
+        }
+        .max { lhs, rhs in lhs.1 < rhs.1 }
+    }
+
+    private static func signalCell(
+        _ row: RuntimeResilienceDashboardRow,
+        _ signal: RuntimeProofResilienceSignal
+    ) -> String {
+        let evidence = row.signalEvidence[signal.rawValue] ?? RuntimeProofSignalEvidence()
+        return "\(evidence.verdict.rawValue): \(evidence.summary)<br>\(markdownLinks(evidence.evidencePaths))"
+    }
+
+    private static func markdownLinks(_ paths: [String], limit: Int = 3) -> String {
+        let unique = uniqueNonEmpty(paths)
+        guard !unique.isEmpty else { return "no links" }
+        var links = unique.prefix(limit).enumerated().map { index, path in
+            "[\(index + 1)](\(path))"
+        }
+        if unique.count > limit {
+            links.append("+\(unique.count - limit) more")
+        }
+        return links.joined(separator: ", ")
+    }
+
+    private static func blockerStrings(from messages: [RuntimeProofMatrixMessage]) -> [String] {
+        messages.map { message in
+            if let requirement = message.requirement, !requirement.isEmpty {
+                return "\(requirement): \(message.message)"
+            }
+            return message.message
+        }
+    }
+
     private static let requiredSchemaRows: [RuntimeProofMatrixRow] = [
         RuntimeProofMatrixRow(
             id: "issue-903-system-prompt-injection-schema",
@@ -384,7 +872,42 @@ public enum RuntimeProofMatrixReporter {
             )
     }
 
+    private static func verdictCounts(for rows: [RuntimeResilienceDashboardRow]) -> [String: Int] {
+        Dictionary(grouping: rows, by: { $0.verdict.rawValue })
+            .mapValues(\.count)
+            .merging(
+                Dictionary(uniqueKeysWithValues: RuntimeProofVerdict.allCases.map { ($0.rawValue, 0) }),
+                uniquingKeysWith: { lhs, _ in lhs }
+            )
+    }
+
+    private static func signalCounts(for rows: [RuntimeResilienceDashboardRow]) -> [String: [String: Int]] {
+        Dictionary(
+            uniqueKeysWithValues: RuntimeProofResilienceSignal.allCases.map { signal in
+                let verdicts = rows.map {
+                    $0.signalEvidence[signal.rawValue]?.verdict.rawValue ?? RuntimeProofVerdict.unproven.rawValue
+                }
+                let counts = Dictionary(grouping: verdicts, by: { $0 })
+                    .mapValues(\.count)
+                    .merging(
+                        Dictionary(uniqueKeysWithValues: RuntimeProofVerdict.allCases.map { ($0.rawValue, 0) }),
+                        uniquingKeysWith: { lhs, _ in lhs }
+                    )
+                return (signal.rawValue, counts)
+            }
+        )
+    }
+
     private static func rowSort(_ lhs: RuntimeProofMatrixRow, _ rhs: RuntimeProofMatrixRow) -> Bool {
+        let left = [lhs.family, lhs.model, lhs.id]
+        let right = [rhs.family, rhs.model, rhs.id]
+        return left.lexicographicallyPrecedes(right)
+    }
+
+    private static func dashboardRowSort(
+        _ lhs: RuntimeResilienceDashboardRow,
+        _ rhs: RuntimeResilienceDashboardRow
+    ) -> Bool {
         let left = [lhs.family, lhs.model, lhs.id]
         let right = [rhs.family, rhs.model, rhs.id]
         return left.lexicographicallyPrecedes(right)

--- a/Packages/OsaurusCore/Tests/Model/RuntimeResilienceDashboardTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/RuntimeResilienceDashboardTests.swift
@@ -1,0 +1,150 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Runtime resilience dashboard")
+struct RuntimeResilienceDashboardTests {
+    @Test("dashboard surface preserves per-signal evidence without promoting schema rows")
+    func dashboardSurfacePreservesSignalEvidence() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+
+        let surface = RuntimeProofMatrixReporter.dashboardSurface(
+            from: report,
+            sourceClassificationPath: "/tmp/runtime/PROOF_CLASSIFICATION.json",
+            generatedAt: "2026-06-18T00:00:00Z"
+        )
+
+        #expect(surface.generatedAt == "2026-06-18T00:00:00Z")
+        #expect(surface.verdictCounts["proven"] == 1)
+        #expect(surface.verdictCounts["unproven"] == 2)
+        #expect(surface.signalCounts["tokens_per_second"]?["proven"] == 1)
+        #expect(surface.signalCounts["cancellation"]?["proven"] == 1)
+        #expect(surface.signalCounts["cancellation"]?["unproven"] == 2)
+
+        let liveRow = try #require(surface.rows.first { $0.id == "gemma4-text-required" })
+        #expect(liveRow.signalEvidence["tokens_per_second"]?.summary.contains("18.40 token/s") == true)
+        #expect(liveRow.signalEvidence["cache"]?.evidencePaths.contains("/tmp/runtime/gemma/cache-after.json") == true)
+        #expect(liveRow.signalEvidence["marker_leak"]?.verdict == .proven)
+        #expect(liveRow.signalEvidence["crash_proof"]?.verdict == .proven)
+
+        let promptInjection = try #require(
+            surface.rows.first { $0.id == "issue-903-system-prompt-injection-schema" }
+        )
+        #expect(promptInjection.isSchemaOnly)
+        #expect(promptInjection.verdict == .unproven)
+        #expect(promptInjection.signalEvidence["tokens_per_second"]?.verdict == .unproven)
+    }
+
+    @Test("dashboard markdown renders links and issue coverage")
+    func dashboardMarkdownRendersLinksAndCoverage() throws {
+        let report = try RuntimeProofMatrixReporter.decodeClassification(data: Self.fixtureData)
+
+        let markdown = RuntimeProofMatrixReporter.dashboardMarkdown(
+            from: report,
+            sourceClassificationPath: "/tmp/runtime/PROOF_CLASSIFICATION.json",
+            generatedAt: "2026-06-18T00:00:00Z"
+        )
+
+        #expect(markdown.contains(RuntimeProofMatrixReporter.dashboardMarkdownBeginMarker))
+        #expect(markdown.contains("| Row | Model | Verdict | Token/s | Cache | Marker leak | Cancellation | Crash proof |"))
+        #expect(markdown.contains("Crash/cancellation issue coverage: partial"))
+        #expect(markdown.contains("[1](/tmp/runtime/gemma/SUMMARY.json)"))
+        #expect(markdown.contains("issue-1163-hy3-harmony-retro-validation-schema"))
+    }
+
+    private static let fixtureData = Data(
+        """
+        {
+          "generated_at": "2026-06-18T00:00:00Z",
+          "summary_path": "/tmp/runtime/SUMMARY.json",
+          "manifest_path": "scripts/live-proof/family-runtime-chat-matrix.json",
+          "artifact_root": "/tmp/runtime",
+          "verdict_counts": {
+            "proven": 1,
+            "partial": 0,
+            "failed": 0,
+            "unproven": 0
+          },
+          "required_rows_not_proven": [],
+          "passed": true,
+          "rows": [
+            {
+              "id": "gemma4-text-required",
+              "model": "Gemma4 text",
+              "family": "gemma4",
+              "priority": "required",
+              "requirements": [
+                "visible_output",
+                "tokens_per_second",
+                "no_parser_marker_leak",
+                "multi_turn_coherency",
+                "cache_hit",
+                "cancellation"
+              ],
+              "artifact_paths": [
+                "/tmp/runtime/gemma/SUMMARY.json"
+              ],
+              "summary_path": "/tmp/runtime/gemma/SUMMARY.json",
+              "verdict": "proven",
+              "acceptable_for_proven_claim": true,
+              "blockers": [],
+              "warnings": [],
+              "failed_checks": [],
+              "cache_delta": {
+                "block_disk_hits": 2
+              },
+              "token_rates": {
+                "turn2": {
+                  "completion_tokens": 42,
+                  "elapsed_seconds": 2.28,
+                  "tokens_per_second": 18.4
+                }
+              },
+              "resilience_evidence": {
+                "tokens_per_second": {
+                  "verdict": "proven",
+                  "summary": "turn2: 18.40 token/s over 42 completion tokens",
+                  "evidence_paths": ["/tmp/runtime/gemma/SUMMARY.json"],
+                  "metrics": {"token_rates_turn2_tokens_per_second": 18.4}
+                },
+                "cache": {
+                  "verdict": "proven",
+                  "summary": "topology-specific cache evidence passed",
+                  "evidence_paths": ["/tmp/runtime/gemma/SUMMARY.json", "/tmp/runtime/gemma/cache-after.json"],
+                  "metrics": {"cache_delta_block_disk_hits": 2}
+                },
+                "marker_leak": {
+                  "verdict": "proven",
+                  "summary": "no parser/runtime marker leak detected in recorded output",
+                  "evidence_paths": ["/tmp/runtime/gemma/SUMMARY.json", "/tmp/runtime/gemma/response.json"],
+                  "metrics": {}
+                },
+                "cancellation": {
+                  "verdict": "proven",
+                  "summary": "cancellation cleanup checks passed: cancellation_cleaned_up",
+                  "evidence_paths": ["/tmp/runtime/gemma/SUMMARY.json", "/tmp/runtime/gemma/health-after.json"],
+                  "metrics": {}
+                },
+                "crash_proof": {
+                  "verdict": "proven",
+                  "summary": "server stayed healthy with no in-flight work after the row",
+                  "evidence_paths": ["/tmp/runtime/gemma/SUMMARY.json", "/tmp/runtime/gemma/health-after.json"],
+                  "metrics": {}
+                }
+              }
+            }
+          ],
+          "issue_coverage": {
+            "#1228": {
+              "verdict": "partial",
+              "note": "crash closure needs reporter-aligned crash and cancellation artifacts; dashboard rows only surface existing evidence",
+              "rows": ["gemma4-text-required"]
+            }
+          }
+        }
+        """.utf8
+    )
+}

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -137,6 +137,9 @@ records:
 - the claimed proof requirements for that row
 - blocker messages for missing token/s, visible output, parser-leak checks,
   multi-turn coherency, topology-specific cache evidence, or media-path proof
+- dashboard evidence for token/s, cache, marker-leak, cancellation, and
+  crash/health signals, with artifact paths copied from live summaries instead
+  of inferred from source
 - issue-coverage notes for #1228, #1161, #1162, #1163, #903, and #1183
 
 This report is intentionally stricter than the harness pass/fail bit. A row can
@@ -145,12 +148,43 @@ VL model was tested through a text/tool path without a real media payload and
 media cache salt. Those rows stay useful as evidence, but they must not close a
 runtime/media issue as proven.
 
+The same classification report feeds the runtime resilience dashboard. Live
+matrix runs and `--dry-run` now write these files under the artifact root:
+
+- `runtime-resilience-dashboard.md` -- a maintainer-readable table with one
+  cell each for token/s, cache, marker-leak, cancellation, and crash proof.
+- `runtime-resilience-dashboard.json` -- the same rows plus `signal_counts`,
+  intended for inspection tools and release checklists.
+- `runtime-proof-matrix.md` and `runtime-proof-surface.json` -- the existing
+  verdict matrix and read-only row surface.
+
+Dashboard cells are per-signal, not row promotion. A partial row can show
+`proven` token/s and `partial` cache evidence, while the row verdict remains
+`partial`. Cancellation stays `unproven` unless a live artifact records explicit
+cleanup checks such as cancelled-load unload or no-zombie-load evidence. Crash
+proof is tied to recorded post-run health/error artifacts; a failed row links
+the error artifact instead of hiding the failure. The #903 system-prompt and
+#1163 Hy3/harmony schema rows are still injected as `unproven` until matching
+live artifacts exist.
+
 Use `scripts/live-proof/render-runtime-proof-matrix.py` to render the latest
 `PROOF_CLASSIFICATION.json` into the matrix appendix in
 [`RUNTIME_VALIDATION_STANDARD.md`](RUNTIME_VALIDATION_STANDARD.md). The renderer
 also writes a read-only JSON surface for inspection workflows, and it keeps the
 #903 system-prompt-injection and #1163 Hy3/harmony schema rows `unproven` until
 real live artifacts exist.
+
+For a no-model smoke of the reporting path:
+
+```bash
+ARTIFACT_ROOT=/tmp/osaurus-runtime-dashboard-dry-run \
+scripts/live-proof/run-family-runtime-chat-matrix.sh \
+  --dry-run MODEL_FILTER=minimax-m27-small-jangtq
+```
+
+The dry run writes selected rows and dashboard files with every live-only signal
+left unproven. It is useful for validating report generation, not for promoting
+runtime health.
 
 osaurus deliberately does not pass `GenerateParameters.maxKVSize` -- a
 global rotating cache window forced from the app layer conflicted with
@@ -296,6 +330,7 @@ sentinels.
 | `RuntimeConfig.swift` | Server-side default `topP`. |
 | `InferenceFeatureFlags.swift` | Single user-tunable: `mlxBatchEngineMaxBatchSize`. |
 | `RuntimeProofValidation.swift` | Source-level validation for runtime proof rows and issue-closure evidence. |
+| `RuntimeProofMatrixReporter.swift` | Read-only proof matrix and runtime resilience dashboard surfaces backed by classifier output. |
 | `MetalGate.swift` | Embedding-only counter (kept as the canonical hook for any future MLX-vs-CoreML interlock). |
 | `ModelLease.swift` | Per-model refcount; `unload(name)` waits for `count == 0` before freeing buffers. |
 | `ModelResidencyManager.swift` | Per-model idle timers and health snapshots for the Settings residency policy. |
@@ -310,6 +345,7 @@ sentinels.
 | `TaskCoalescerTests` | Single-flight engine-creation discipline and teardown-during-creation races. |
 | `RuntimePolicySourceTests` | Source-level guardrails for DSV4 cache ownership, vmlx pin, SSM re-derive opt-out, idle residency wiring, and max-batch docs. |
 | `RuntimeProofValidationTests` | Proven/partial/failed/unproven proof-row validation; token/s, parser leak, cache, media, and artifact checks. |
+| `RuntimeResilienceDashboardTests` | Swift dashboard surface and Markdown rendering for token/s, cache, marker-leak, cancellation, crash-proof, and schema-only rows. |
 | `GenerationEventMapperTests` | `chunk` -> `tokens`; `toolCall` -> `toolInvocation` JSON serialization (happy path + failure envelope); `info` -> `completionInfo`; cross-chunk stop-sequence cut. |
 | `StreamingReasoningHintTests` | Sentinel encode/decode round-trip; co-existence with the tool sentinel filter. |
 | `MetalGateTests` | Embedding gate happy paths. |

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -161,9 +161,10 @@ matrix runs and `--dry-run` now write these files under the artifact root:
 Dashboard cells are per-signal, not row promotion. A partial row can show
 `proven` token/s and `partial` cache evidence, while the row verdict remains
 `partial`. Cancellation stays `unproven` unless a live artifact records explicit
-cleanup checks such as cancelled-load unload or no-zombie-load evidence. Crash
-proof is tied to recorded post-run health/error artifacts; a failed row links
-the error artifact instead of hiding the failure. The #903 system-prompt and
+cleanup checks such as cancelled-load unload or no-zombie-load evidence; a
+`stop_status_cancelled` marker alone only proves cancellation was observed, not
+that cleanup completed. Crash proof is tied to recorded post-run health/error
+artifacts; a failed row links the error artifact instead of hiding the failure. The #903 system-prompt and
 #1163 Hy3/harmony schema rows are still injected as `unproven` until matching
 live artifacts exist.
 

--- a/scripts/live-proof/classify-runtime-proof-summary.py
+++ b/scripts/live-proof/classify-runtime-proof-summary.py
@@ -265,6 +265,32 @@ def media_payload_proven(payload: dict[str, Any]) -> bool:
     return False
 
 
+def cancellation_cleanup_failures(payload: dict[str, Any]) -> list[str]:
+    row_checks = checks(payload)
+    return [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is False]
+
+
+def cancellation_cleanup_passes(payload: dict[str, Any]) -> list[str]:
+    row_checks = checks(payload)
+    return [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is True]
+
+
+def cancellation_requirement_blocker(payload: dict[str, Any]) -> str | None:
+    failures = cancellation_cleanup_failures(payload)
+    if failures:
+        return "row cancellation cleanup checks failed: " + ", ".join(failures)
+    if cancellation_cleanup_passes(payload):
+        return None
+    row_checks = checks(payload)
+    observed = [name for name in CANCELLATION_OBSERVATION_CHECKS if row_checks.get(name) is True]
+    if observed:
+        return "cancellation was observed but cleanup proof is missing: " + ", ".join(observed)
+    explicit = payload.get("cancellation_evidence") or payload.get("cancellation")
+    if explicit or any(name in row_checks for name in CANCELLATION_CHECKS):
+        return "row cancellation cleanup evidence is incomplete"
+    return "row lacks required cancellation cleanup evidence"
+
+
 def token_rate_signal(
     payload: dict[str, Any],
     payload_path: str | None,
@@ -372,14 +398,14 @@ def cancellation_signal(
     present = required or bool(explicit) or any(name in row_checks for name in CANCELLATION_CHECKS)
     if not present:
         return signal_record("unproven", "no cancellation cleanup proof was recorded for this row", paths)
-    failures = [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is False]
+    failures = cancellation_cleanup_failures(payload)
     if failures:
         return signal_record(
             "failed" if row_failed else "partial",
             "cancellation cleanup checks failed: " + ", ".join(failures),
             paths,
         )
-    passed = [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is True]
+    passed = cancellation_cleanup_passes(payload)
     if passed:
         return signal_record(
             "proven",
@@ -504,6 +530,15 @@ def requirement_blockers(payload: dict[str, Any], manifest_row: dict[str, Any]) 
                 "message": "VL/media row lacks real media payload, media routing, or media cache-hit proof",
             }
         )
+    if "cancellation" in requirements:
+        message = cancellation_requirement_blocker(payload)
+        if message:
+            blockers.append(
+                {
+                    "requirement": "cancellation",
+                    "message": message,
+                }
+            )
     return blockers
 
 

--- a/scripts/live-proof/classify-runtime-proof-summary.py
+++ b/scripts/live-proof/classify-runtime-proof-summary.py
@@ -51,6 +51,17 @@ CANCELLATION_CHECKS = (
     "stop_status_cancelled",
 )
 
+CANCELLATION_CLEANUP_CHECKS = (
+    "cancellation_cleaned_up",
+    "cancelled_load_unloaded",
+    "cancelled_generation_finished",
+    "no_zombie_load",
+)
+
+CANCELLATION_OBSERVATION_CHECKS = (
+    "stop_status_cancelled",
+)
+
 
 def load_json(path: pathlib.Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -361,18 +372,25 @@ def cancellation_signal(
     present = required or bool(explicit) or any(name in row_checks for name in CANCELLATION_CHECKS)
     if not present:
         return signal_record("unproven", "no cancellation cleanup proof was recorded for this row", paths)
-    failures = [name for name in CANCELLATION_CHECKS if row_checks.get(name) is False]
+    failures = [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is False]
     if failures:
         return signal_record(
             "failed" if row_failed else "partial",
             "cancellation cleanup checks failed: " + ", ".join(failures),
             paths,
         )
-    passed = [name for name in CANCELLATION_CHECKS if row_checks.get(name) is True]
+    passed = [name for name in CANCELLATION_CLEANUP_CHECKS if row_checks.get(name) is True]
     if passed:
         return signal_record(
             "proven",
             "cancellation cleanup checks passed: " + ", ".join(passed),
+            paths,
+        )
+    observed = [name for name in CANCELLATION_OBSERVATION_CHECKS if row_checks.get(name) is True]
+    if observed:
+        return signal_record(
+            "failed" if row_failed else "partial",
+            "cancellation was observed but cleanup proof is missing: " + ", ".join(observed),
             paths,
         )
     messages = blockers_for_requirement(blockers, "cancellation")

--- a/scripts/live-proof/classify-runtime-proof-summary.py
+++ b/scripts/live-proof/classify-runtime-proof-summary.py
@@ -35,6 +35,22 @@ PROTOCOL_MARKERS = (
 
 REQUIRED_PRIORITIES = {"required", "required-local"}
 
+RESILIENCE_SIGNALS = (
+    "tokens_per_second",
+    "cache",
+    "marker_leak",
+    "cancellation",
+    "crash_proof",
+)
+
+CANCELLATION_CHECKS = (
+    "cancellation_cleaned_up",
+    "cancelled_load_unloaded",
+    "cancelled_generation_finished",
+    "no_zombie_load",
+    "stop_status_cancelled",
+)
+
 
 def load_json(path: pathlib.Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
@@ -69,6 +85,29 @@ def first_summary_payload(row: dict[str, Any]) -> tuple[dict[str, Any] | None, s
     return None, None
 
 
+def existing_artifacts(payload_path: str | None, patterns: tuple[str, ...]) -> list[str]:
+    if not payload_path:
+        return []
+    root = pathlib.Path(payload_path).parent
+    paths: list[str] = []
+    for pattern in patterns:
+        paths.extend(str(path) for path in sorted(root.glob(pattern)) if path.exists())
+    return list(dict.fromkeys(paths))
+
+
+def explicit_artifact_paths(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key in ("artifact_path", "artifact_paths", "path", "paths", "summary_path"):
+            out.extend(explicit_artifact_paths(value.get(key)))
+        return out
+    return []
+
+
 def row_requirements(manifest_row: dict[str, Any]) -> list[str]:
     requirements = [
         "visible_output",
@@ -83,21 +122,60 @@ def row_requirements(manifest_row: dict[str, Any]) -> list[str]:
     row_id = str(manifest_row.get("id", "")).lower()
     if "vl" in topology or "-vl" in model or "-vl" in row_id or row_id.endswith("-vl"):
         requirements.append("media_payload")
+    if manifest_row.get("required_cancellation_evidence"):
+        requirements.append("cancellation")
     return requirements
 
 
-def has_token_rate(payload: dict[str, Any]) -> bool:
+def positive_token_rates(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     token_rates = payload.get("token_rates")
     if not isinstance(token_rates, dict):
-        return False
-    for value in token_rates.values():
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for turn, value in token_rates.items():
         if not isinstance(value, dict):
             continue
         tokens = value.get("completion_tokens")
         rate = value.get("tokens_per_second")
         if isinstance(tokens, int) and tokens > 0 and isinstance(rate, (int, float)) and rate > 0:
-            return True
-    return False
+            out[str(turn)] = value
+    return out
+
+
+def has_token_rate(payload: dict[str, Any]) -> bool:
+    return bool(positive_token_rates(payload))
+
+
+def numeric_metrics(prefix: str, value: Any) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            metrics.update(numeric_metrics(f"{prefix}_{key}" if prefix else str(key), nested))
+    elif isinstance(value, (int, float)) and not isinstance(value, bool):
+        metrics[prefix] = float(value)
+    return metrics
+
+
+def blockers_for_requirement(blockers: list[dict[str, str]], requirement: str) -> list[str]:
+    return [
+        str(blocker.get("message", ""))
+        for blocker in blockers
+        if blocker.get("requirement") == requirement and blocker.get("message")
+    ]
+
+
+def signal_record(
+    verdict: str,
+    summary: str,
+    evidence_paths: list[str],
+    metrics: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    return {
+        "verdict": verdict,
+        "summary": summary,
+        "evidence_paths": list(dict.fromkeys(path for path in evidence_paths if path)),
+        "metrics": metrics or {},
+    }
 
 
 def parser_leaks(payload: dict[str, Any]) -> list[str]:
@@ -174,6 +252,190 @@ def media_payload_proven(payload: dict[str, Any]) -> bool:
     if has_real_payload and all(row_checks.get(name) is True for name in media_checks):
         return True
     return False
+
+
+def token_rate_signal(
+    payload: dict[str, Any],
+    payload_path: str | None,
+    blockers: list[dict[str, str]],
+    row_failed: bool,
+) -> dict[str, Any]:
+    rates = positive_token_rates(payload)
+    if rates:
+        best_turn, best = max(
+            rates.items(),
+            key=lambda item: float(item[1].get("tokens_per_second", 0)),
+        )
+        rate = float(best.get("tokens_per_second", 0))
+        tokens = int(best.get("completion_tokens", 0))
+        return signal_record(
+            "proven",
+            f"{best_turn}: {rate:.2f} token/s over {tokens} completion tokens",
+            [payload_path] if payload_path else [],
+            numeric_metrics("token_rates", rates),
+        )
+    messages = blockers_for_requirement(blockers, "tokens_per_second")
+    return signal_record(
+        "failed" if row_failed else "partial",
+        messages[0] if messages else "no positive token/s was recorded",
+        [payload_path] if payload_path else [],
+    )
+
+
+def cache_signal(
+    payload: dict[str, Any],
+    manifest_row: dict[str, Any],
+    payload_path: str | None,
+    blockers: list[dict[str, str]],
+    row_failed: bool,
+) -> dict[str, Any]:
+    required = bool(manifest_row.get("required_cache_evidence"))
+    cache_delta = payload.get("cache_delta")
+    cache_paths = existing_artifacts(payload_path, ("*cache_before.json", "*cache_after.json"))
+    if payload_path:
+        cache_paths.insert(0, payload_path)
+    if required and cache_hit_proven(payload, manifest_row):
+        return signal_record(
+            "proven",
+            "topology-specific cache evidence passed",
+            cache_paths,
+            numeric_metrics("cache_delta", cache_delta),
+        )
+    if required:
+        messages = blockers_for_requirement(blockers, "cache_hit")
+        return signal_record(
+            "failed" if row_failed else "partial",
+            messages[0] if messages else "required topology-specific cache evidence is incomplete",
+            cache_paths,
+            numeric_metrics("cache_delta", cache_delta),
+        )
+    if isinstance(cache_delta, dict) and cache_delta:
+        return signal_record(
+            "partial",
+            "cache counters were recorded, but this row does not require cache-hit proof",
+            cache_paths,
+            numeric_metrics("cache_delta", cache_delta),
+        )
+    return signal_record("unproven", "no cache evidence was recorded for this row", cache_paths)
+
+
+def marker_leak_signal(
+    payload: dict[str, Any],
+    payload_path: str | None,
+    blockers: list[dict[str, str]],
+    row_failed: bool,
+) -> dict[str, Any]:
+    leak_paths = existing_artifacts(payload_path, ("*.response.json",))
+    if payload_path:
+        leak_paths.insert(0, payload_path)
+    leaks = parser_leaks(payload)
+    if leaks:
+        return signal_record(
+            "failed",
+            "parser/runtime markers present: " + ", ".join(leaks),
+            leak_paths,
+        )
+    messages = blockers_for_requirement(blockers, "no_parser_marker_leak")
+    if messages:
+        return signal_record("failed" if row_failed else "partial", messages[0], leak_paths)
+    return signal_record("proven", "no parser/runtime marker leak detected in recorded output", leak_paths)
+
+
+def cancellation_signal(
+    payload: dict[str, Any],
+    manifest_row: dict[str, Any],
+    payload_path: str | None,
+    blockers: list[dict[str, str]],
+    row_failed: bool,
+) -> dict[str, Any]:
+    row_checks = checks(payload)
+    required = bool(manifest_row.get("required_cancellation_evidence"))
+    explicit = payload.get("cancellation_evidence") or payload.get("cancellation")
+    paths = existing_artifacts(
+        payload_path,
+        ("*health_before.json", "*health_after.json", "process-*.txt", "vm-*.txt"),
+    )
+    paths.extend(explicit_artifact_paths(explicit))
+    if payload_path:
+        paths.insert(0, payload_path)
+    present = required or bool(explicit) or any(name in row_checks for name in CANCELLATION_CHECKS)
+    if not present:
+        return signal_record("unproven", "no cancellation cleanup proof was recorded for this row", paths)
+    failures = [name for name in CANCELLATION_CHECKS if row_checks.get(name) is False]
+    if failures:
+        return signal_record(
+            "failed" if row_failed else "partial",
+            "cancellation cleanup checks failed: " + ", ".join(failures),
+            paths,
+        )
+    passed = [name for name in CANCELLATION_CHECKS if row_checks.get(name) is True]
+    if passed:
+        return signal_record(
+            "proven",
+            "cancellation cleanup checks passed: " + ", ".join(passed),
+            paths,
+        )
+    messages = blockers_for_requirement(blockers, "cancellation")
+    return signal_record(
+        "failed" if row_failed else "partial",
+        messages[0] if messages else "cancellation evidence is present but incomplete",
+        paths,
+    )
+
+
+def crash_proof_signal(
+    payload: dict[str, Any],
+    payload_path: str | None,
+    row_failed: bool,
+) -> dict[str, Any]:
+    row_checks = checks(payload)
+    paths = existing_artifacts(
+        payload_path,
+        (
+            "*health_after.json",
+            "*health_before.json",
+            "process-*.txt",
+            "vm-*.txt",
+            "*error.json",
+            "*crash*.json",
+            "*crash*.log",
+            "*crash*.txt",
+        ),
+    )
+    paths.extend(explicit_artifact_paths(payload.get("crash_evidence") or payload.get("crash_proof")))
+    if payload_path:
+        paths.insert(0, payload_path)
+    error = payload.get("error")
+    if isinstance(error, dict):
+        message = str(error.get("message") or error.get("type") or "runtime error recorded")
+        return signal_record("failed", "runtime error artifact recorded: " + message, paths)
+    if row_checks.get("server_healthy_after") is True and row_checks.get("no_inflight_after") is True:
+        return signal_record(
+            "proven",
+            "server stayed healthy with no in-flight work after the row",
+            paths,
+        )
+    if row_checks.get("server_healthy_after") is False or row_failed:
+        return signal_record("failed", "row failed or server health did not survive the proof run", paths)
+    if paths:
+        return signal_record("partial", "crash/health artifacts exist but do not prove post-run health", paths)
+    return signal_record("unproven", "no crash/health evidence was recorded for this row", paths)
+
+
+def resilience_evidence(
+    payload: dict[str, Any],
+    manifest_row: dict[str, Any],
+    payload_path: str | None,
+    blockers: list[dict[str, str]],
+    row_failed: bool,
+) -> dict[str, Any]:
+    return {
+        "tokens_per_second": token_rate_signal(payload, payload_path, blockers, row_failed),
+        "cache": cache_signal(payload, manifest_row, payload_path, blockers, row_failed),
+        "marker_leak": marker_leak_signal(payload, payload_path, blockers, row_failed),
+        "cancellation": cancellation_signal(payload, manifest_row, payload_path, blockers, row_failed),
+        "crash_proof": crash_proof_signal(payload, payload_path, row_failed),
+    }
 
 
 def requirement_blockers(payload: dict[str, Any], manifest_row: dict[str, Any]) -> list[dict[str, str]]:
@@ -255,6 +517,14 @@ def classify_row(row: dict[str, Any], manifest_rows: dict[str, dict[str, Any]]) 
                     }
                 ],
                 "warnings": [],
+                "resilience_evidence": {
+                    signal: signal_record(
+                        "unproven",
+                        "row has no readable summary payload",
+                        artifact_paths,
+                    )
+                    for signal in RESILIENCE_SIGNALS
+                },
             }
         )
         return result
@@ -289,6 +559,13 @@ def classify_row(row: dict[str, Any], manifest_rows: dict[str, dict[str, Any]]) 
             "failed_checks": failed,
             "cache_delta": payload.get("cache_delta", {}),
             "token_rates": payload.get("token_rates", {}),
+            "resilience_evidence": resilience_evidence(
+                payload,
+                manifest_row,
+                payload_path,
+                blockers,
+                row_failed=verdict == "failed",
+            ),
         }
     )
     return result
@@ -311,6 +588,22 @@ def issue_coverage(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     hy3_rows = [row for row in rows if str(row.get("family")) == "hy3"]
     media_rows = [
         row for row in rows if "media_payload" in row.get("requirements", [])
+    ]
+    crash_rows = [
+        row["id"]
+        for row in rows
+        if row.get("resilience_evidence", {})
+        .get("crash_proof", {})
+        .get("verdict")
+        in {"proven", "partial", "failed"}
+    ]
+    cancellation_rows = [
+        row["id"]
+        for row in rows
+        if row.get("resilience_evidence", {})
+        .get("cancellation", {})
+        .get("verdict")
+        in {"proven", "partial", "failed"}
     ]
 
     runtime_matrix_verdict = "proven" if not required_not_proven and required else "partial"
@@ -340,8 +633,9 @@ def issue_coverage(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
             "note": "this tool/cache matrix does not claim system-prompt injection proof",
         },
         "#1228": {
-            "verdict": "partial" if any(row.get("verdict") == "failed" for row in rows) else "unproven",
-            "note": "crash closure needs a reporter-aligned crash/cancellation artifact",
+            "verdict": "partial" if crash_rows or cancellation_rows else "unproven",
+            "note": "crash closure needs reporter-aligned crash and cancellation artifacts; dashboard rows only surface existing evidence",
+            "rows": sorted(set(crash_rows + cancellation_rows)),
         },
         "#1183": {
             "verdict": "proven"

--- a/scripts/live-proof/render-runtime-proof-matrix.py
+++ b/scripts/live-proof/render-runtime-proof-matrix.py
@@ -17,6 +17,24 @@ from typing import Any
 
 BEGIN = "<!-- BEGIN RUNTIME PROOF MATRIX -->"
 END = "<!-- END RUNTIME PROOF MATRIX -->"
+DASHBOARD_BEGIN = "<!-- BEGIN RUNTIME RESILIENCE DASHBOARD -->"
+DASHBOARD_END = "<!-- END RUNTIME RESILIENCE DASHBOARD -->"
+
+RESILIENCE_SIGNALS = (
+    "tokens_per_second",
+    "cache",
+    "marker_leak",
+    "cancellation",
+    "crash_proof",
+)
+
+SIGNAL_LABELS = {
+    "tokens_per_second": "Token/s",
+    "cache": "Cache",
+    "marker_leak": "Marker leak",
+    "cancellation": "Cancellation",
+    "crash_proof": "Crash proof",
+}
 
 SCHEMA_ROWS = [
     {
@@ -111,6 +129,8 @@ def normalized_row(row: dict[str, Any]) -> dict[str, Any]:
         "evidence": evidence,
         "blockers": blocker_messages(row),
         "schema_only": bool(row.get("schema_only")),
+        "failed_checks": [str(value) for value in row.get("failed_checks") or []],
+        "resilience_evidence": normalized_resilience_evidence(row),
     }
 
 
@@ -126,6 +146,119 @@ def matrix_rows(report: dict[str, Any]) -> list[dict[str, Any]]:
 def verdict_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
     counts = Counter(row["verdict"] for row in rows)
     return {key: counts.get(key, 0) for key in ("proven", "partial", "failed", "unproven")}
+
+
+def normalized_resilience_signal(raw: Any, fallback_summary: str, fallback_paths: list[str]) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return {
+            "verdict": str(raw.get("verdict") or "unproven"),
+            "summary": str(raw.get("summary") or fallback_summary),
+            "evidence_paths": [
+                str(path)
+                for path in raw.get("evidence_paths") or fallback_paths
+                if path
+            ],
+            "metrics": raw.get("metrics") if isinstance(raw.get("metrics"), dict) else {},
+        }
+    return {
+        "verdict": "unproven",
+        "summary": fallback_summary,
+        "evidence_paths": fallback_paths,
+        "metrics": {},
+    }
+
+
+def normalized_resilience_evidence(row: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = row.get("resilience_evidence") if isinstance(row.get("resilience_evidence"), dict) else {}
+    fallback_paths = []
+    if row.get("summary_path"):
+        fallback_paths.append(str(row["summary_path"]))
+    fallback_paths.extend(str(path) for path in row.get("artifact_paths") or [] if path)
+    evidence: dict[str, dict[str, Any]] = {}
+    for signal in RESILIENCE_SIGNALS:
+        evidence[signal] = normalized_resilience_signal(
+            raw.get(signal),
+            f"{SIGNAL_LABELS[signal].lower()} evidence was not recorded",
+            fallback_paths,
+        )
+    return evidence
+
+
+def signal_counts(rows: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {}
+    for signal in RESILIENCE_SIGNALS:
+        verdicts = Counter(
+            row["resilience_evidence"].get(signal, {}).get("verdict", "unproven")
+            for row in rows
+        )
+        counts[signal] = {
+            key: verdicts.get(key, 0)
+            for key in ("proven", "partial", "failed", "unproven")
+        }
+    return counts
+
+
+def evidence_links(paths: list[str], limit: int = 3) -> str:
+    unique = list(dict.fromkeys(path for path in paths if path))
+    if not unique:
+        return "no links"
+    links = [f"[{index}]({path})" for index, path in enumerate(unique[:limit], start=1)]
+    if len(unique) > limit:
+        links.append(f"+{len(unique) - limit} more")
+    return ", ".join(links)
+
+
+def signal_cell(row: dict[str, Any], signal: str) -> str:
+    evidence = row["resilience_evidence"].get(signal, {})
+    verdict = evidence.get("verdict", "unproven")
+    summary = evidence.get("summary", "")
+    paths = evidence.get("evidence_paths") or []
+    return f"{verdict}: {summary}<br>{evidence_links(paths)}"
+
+
+def render_dashboard_markdown(report: dict[str, Any], source: pathlib.Path, generated_at: str | None = None) -> str:
+    rows = matrix_rows(report)
+    counts = verdict_counts(rows)
+    per_signal = signal_counts(rows)
+    issue_1228 = (report.get("issue_coverage") or {}).get("#1228") or {}
+    lines = [
+        DASHBOARD_BEGIN,
+        "",
+        f"Generated from {escape_markdown(source)} at {escape_markdown(generated_at or report.get('generated_at') or 'unknown')}.",
+        "",
+        "Verdicts: "
+        + ", ".join(f"{name}={counts[name]}" for name in ("proven", "partial", "failed", "unproven")),
+        "",
+        "Signals: "
+        + "; ".join(
+            f"{SIGNAL_LABELS[signal]} "
+            + ", ".join(f"{name}={per_signal[signal][name]}" for name in ("proven", "partial", "failed", "unproven"))
+            for signal in RESILIENCE_SIGNALS
+        ),
+        "",
+        "Crash/cancellation issue coverage: "
+        + escape_markdown(issue_1228.get("verdict", "unproven"))
+        + " - "
+        + escape_markdown(issue_1228.get("note", "not recorded")),
+        "",
+        "| Row | Model | Verdict | Token/s | Cache | Marker leak | Cancellation | Crash proof | Blockers |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        values = [
+            row["id"],
+            row["model"],
+            row["verdict"],
+            signal_cell(row, "tokens_per_second"),
+            signal_cell(row, "cache"),
+            signal_cell(row, "marker_leak"),
+            signal_cell(row, "cancellation"),
+            signal_cell(row, "crash_proof"),
+            "<br>".join(row["blockers"]) if row["blockers"] else "none",
+        ]
+        lines.append("| " + " | ".join(escape_markdown(value) for value in values) + " |")
+    lines.extend(["", DASHBOARD_END, ""])
+    return "\n".join(lines)
 
 
 def render_markdown(report: dict[str, Any], source: pathlib.Path, generated_at: str | None = None) -> str:
@@ -168,16 +301,18 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("classification", type=pathlib.Path, help="PROOF_CLASSIFICATION.json")
     parser.add_argument("--output", type=pathlib.Path, help="write matrix markdown to this file")
+    parser.add_argument("--dashboard-output", type=pathlib.Path, help="write resilience dashboard markdown to this file")
     parser.add_argument("--update-doc", type=pathlib.Path, help="replace or append the marked matrix in this doc")
     parser.add_argument("--generated-at", help="override generated timestamp for deterministic tests")
     parser.add_argument("--json-surface", type=pathlib.Path, help="write the read-only row surface as JSON")
+    parser.add_argument("--dashboard-json-surface", type=pathlib.Path, help="write the resilience dashboard as JSON")
     args = parser.parse_args()
 
     report = load_json(args.classification)
     matrix = render_markdown(report, args.classification, generated_at=args.generated_at)
+    rows = matrix_rows(report)
 
     if args.json_surface:
-        rows = matrix_rows(report)
         args.json_surface.write_text(
             json.dumps(
                 {
@@ -192,6 +327,31 @@ def main() -> int:
                 sort_keys=True,
             )
             + "\n",
+            encoding="utf-8",
+        )
+
+    if args.dashboard_json_surface:
+        args.dashboard_json_surface.write_text(
+            json.dumps(
+                {
+                    "generated_at": args.generated_at or report.get("generated_at") or "unknown",
+                    "source_classification_path": str(args.classification),
+                    "artifact_root": report.get("artifact_root"),
+                    "verdict_counts": verdict_counts(rows),
+                    "signal_counts": signal_counts(rows),
+                    "rows": rows,
+                    "issue_coverage": report.get("issue_coverage") or {},
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if args.dashboard_output:
+        args.dashboard_output.write_text(
+            render_dashboard_markdown(report, args.classification, generated_at=args.generated_at),
             encoding="utf-8",
         )
 

--- a/scripts/live-proof/run-family-runtime-chat-matrix.sh
+++ b/scripts/live-proof/run-family-runtime-chat-matrix.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MANIFEST="$ROOT/scripts/live-proof/family-runtime-chat-matrix.json"
 HARNESS="$ROOT/scripts/live-proof/run-local-family-multiturn-tool-cache-proof.py"
 CLASSIFIER="$ROOT/scripts/live-proof/classify-runtime-proof-summary.py"
+RENDERER="$ROOT/scripts/live-proof/render-runtime-proof-matrix.py"
 
 BASE_URL="${OSAURUS_BASE_URL:-http://127.0.0.1:1337}"
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-/tmp/osaurus-family-runtime-chat-matrix-$(date +%Y%m%d-%H%M%S)}"
@@ -78,6 +79,16 @@ if [[ ! -x "$HARNESS" ]]; then
   exit 66
 fi
 
+if [[ ! -x "$CLASSIFIER" ]]; then
+  echo "missing executable classifier: $CLASSIFIER" >&2
+  exit 66
+fi
+
+if [[ ! -x "$RENDERER" ]]; then
+  echo "missing executable renderer: $RENDERER" >&2
+  exit 66
+fi
+
 mkdir -p "$ARTIFACT_ROOT"
 
 python3 - "$MANIFEST" "$FAMILY_FILTER" "$MODEL_FILTER" >"$ARTIFACT_ROOT/selected.tsv" <<'PY'
@@ -112,6 +123,38 @@ echo "selected_rows:"
 cat "$ARTIFACT_ROOT/selected.tsv"
 
 if [[ "$DRY_RUN" == "1" ]]; then
+  python3 - "$ARTIFACT_ROOT" "$ARTIFACT_ROOT/selected.tsv" >"$ARTIFACT_ROOT/SUMMARY.json" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+selected = pathlib.Path(sys.argv[2])
+rows = []
+for line in selected.read_text(encoding="utf-8").splitlines():
+    row_id, *_ = line.rstrip("\n").split("\t")
+    rows.append(
+        {
+            "id": row_id,
+            "status": "DRY_RUN",
+            "passed": None,
+            "summary_files": [],
+        }
+    )
+print(json.dumps({"artifact_root": str(root), "passed": False, "rows": rows}, indent=2, sort_keys=True))
+PY
+  "$CLASSIFIER" "$ARTIFACT_ROOT/SUMMARY.json" \
+    --manifest "$MANIFEST" \
+    --output "$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json" >/dev/null
+  "$RENDERER" "$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json" \
+    --output "$ARTIFACT_ROOT/runtime-proof-matrix.md" \
+    --json-surface "$ARTIFACT_ROOT/runtime-proof-surface.json" \
+    --dashboard-output "$ARTIFACT_ROOT/runtime-resilience-dashboard.md" \
+    --dashboard-json-surface "$ARTIFACT_ROOT/runtime-resilience-dashboard.json"
+  echo "summary=$ARTIFACT_ROOT/SUMMARY.json"
+  echo "proof_classification=$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json"
+  echo "runtime_resilience_dashboard=$ARTIFACT_ROOT/runtime-resilience-dashboard.md"
+  echo "runtime_resilience_dashboard_json=$ARTIFACT_ROOT/runtime-resilience-dashboard.json"
   exit 0
 fi
 
@@ -185,5 +228,12 @@ cat "$ARTIFACT_ROOT/SUMMARY.json"
 "$CLASSIFIER" "$ARTIFACT_ROOT/SUMMARY.json" \
   --manifest "$MANIFEST" \
   --output "$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json"
+"$RENDERER" "$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json" \
+  --output "$ARTIFACT_ROOT/runtime-proof-matrix.md" \
+  --json-surface "$ARTIFACT_ROOT/runtime-proof-surface.json" \
+  --dashboard-output "$ARTIFACT_ROOT/runtime-resilience-dashboard.md" \
+  --dashboard-json-surface "$ARTIFACT_ROOT/runtime-resilience-dashboard.json"
 echo "proof_classification=$ARTIFACT_ROOT/PROOF_CLASSIFICATION.json"
+echo "runtime_resilience_dashboard=$ARTIFACT_ROOT/runtime-resilience-dashboard.md"
+echo "runtime_resilience_dashboard_json=$ARTIFACT_ROOT/runtime-resilience-dashboard.json"
 exit "$fail"

--- a/scripts/live-proof/test-classify-runtime-proof-summary.py
+++ b/scripts/live-proof/test-classify-runtime-proof-summary.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -10,6 +11,8 @@ import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 CLASSIFIER = ROOT / "scripts/live-proof/classify-runtime-proof-summary.py"
+RENDERER = ROOT / "scripts/live-proof/render-runtime-proof-matrix.py"
+RUNNER = ROOT / "scripts/live-proof/run-family-runtime-chat-matrix.sh"
 
 
 def write(path: pathlib.Path, value: object) -> None:
@@ -70,6 +73,9 @@ def base_payload() -> dict[str, object]:
         "turn1_no_protocol_leak": True,
         "turn2_no_protocol_leak": True,
         "turn3_no_protocol_leak": True,
+        "no_inflight_before": True,
+        "server_healthy_after": True,
+        "no_inflight_after": True,
         "cache_evidence_cache_topology": True,
         "cache_evidence_disk_l2_hits": True,
     }
@@ -163,11 +169,125 @@ def test_unreadable_row_is_unproven() -> None:
         assert report["passed"] is False
 
 
+def test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_links() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        payload = base_payload()
+        payload["checks"]["cancellation_cleaned_up"] = True
+        summary = matrix_summary(root, "full-kv", payload)
+        row_dir = root / "full-kv"
+        (row_dir / "model_cache_after.json").write_text("{}", encoding="utf-8")
+        (row_dir / "model_health_after.json").write_text("{}", encoding="utf-8")
+        (row_dir / "model_02_none_followup.response.json").write_text("{}", encoding="utf-8")
+        manifest = [
+            {
+                "id": "full-kv",
+                "model": "model",
+                "family": "minimax",
+                "priority": "required",
+                "topology": "full-kv",
+                "required_cache_evidence": ["cache_topology", "disk_l2_hits"],
+                "required_cancellation_evidence": ["cold_load_cleanup"],
+            }
+        ]
+
+        report = run_classifier(root, manifest, summary)
+        row = report["rows"][0]
+        evidence = row["resilience_evidence"]
+
+        assert evidence["tokens_per_second"]["verdict"] == "proven", evidence
+        assert "16.00 token/s" in evidence["tokens_per_second"]["summary"]
+        assert evidence["cache"]["verdict"] == "proven", evidence
+        assert any(path.endswith("model_cache_after.json") for path in evidence["cache"]["evidence_paths"])
+        assert evidence["marker_leak"]["verdict"] == "proven", evidence
+        assert any(path.endswith(".response.json") for path in evidence["marker_leak"]["evidence_paths"])
+        assert evidence["cancellation"]["verdict"] == "proven", evidence
+        assert evidence["crash_proof"]["verdict"] == "proven", evidence
+        assert report["issue_coverage"]["#1228"]["verdict"] == "partial"
+        assert "full-kv" in report["issue_coverage"]["#1228"]["rows"]
+
+
+def test_renderer_writes_runtime_resilience_dashboard() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        report = run_classifier(
+            root,
+            [
+                {
+                    "id": "full-kv",
+                    "model": "model",
+                    "family": "minimax",
+                    "priority": "required",
+                    "topology": "full-kv",
+                    "required_cache_evidence": ["cache_topology", "disk_l2_hits"],
+                }
+            ],
+            matrix_summary(root, "full-kv", base_payload()),
+        )
+        classification_path = root / "PROOF_CLASSIFICATION.json"
+        dashboard_path = root / "runtime-resilience-dashboard.md"
+        dashboard_json_path = root / "runtime-resilience-dashboard.json"
+        matrix_path = root / "runtime-proof-matrix.md"
+        write(classification_path, report)
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(RENDERER),
+                str(classification_path),
+                "--output",
+                str(matrix_path),
+                "--dashboard-output",
+                str(dashboard_path),
+                "--dashboard-json-surface",
+                str(dashboard_json_path),
+                "--generated-at",
+                "2026-06-18T00:00:00Z",
+            ],
+            check=True,
+            cwd=ROOT,
+        )
+
+        dashboard = dashboard_path.read_text(encoding="utf-8")
+        dashboard_json = json.loads(dashboard_json_path.read_text(encoding="utf-8"))
+        assert "BEGIN RUNTIME RESILIENCE DASHBOARD" in dashboard
+        assert "| Row | Model | Verdict | Token/s | Cache | Marker leak | Cancellation | Crash proof |" in dashboard
+        assert "16.00 token/s" in dashboard
+        assert dashboard_json["signal_counts"]["tokens_per_second"]["proven"] >= 1
+
+
+def test_family_runner_dry_run_writes_dashboard_artifacts() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp) / "dry-run"
+        env = os.environ.copy()
+        env["ARTIFACT_ROOT"] = str(root)
+        subprocess.run(
+            [
+                str(RUNNER),
+                "--dry-run",
+                "MODEL_FILTER=minimax-m27-small-jangtq",
+            ],
+            check=True,
+            cwd=ROOT,
+            env=env,
+            stdout=subprocess.DEVNULL,
+        )
+
+        classification = json.loads((root / "PROOF_CLASSIFICATION.json").read_text(encoding="utf-8"))
+        dashboard = json.loads((root / "runtime-resilience-dashboard.json").read_text(encoding="utf-8"))
+        assert classification["rows"][0]["verdict"] == "unproven"
+        assert (root / "runtime-resilience-dashboard.md").exists()
+        assert dashboard["signal_counts"]["tokens_per_second"]["unproven"] >= 1
+
+
 def main() -> int:
     test_proven_row()
     test_missing_token_rate_is_partial()
     test_vl_row_without_media_payload_is_not_proven()
     test_unreadable_row_is_unproven()
+    test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_links()
+    test_renderer_writes_runtime_resilience_dashboard()
+    test_family_runner_dry_run_writes_dashboard_artifacts()
     print("runtime proof classifier tests passed")
     return 0
 

--- a/scripts/live-proof/test-classify-runtime-proof-summary.py
+++ b/scripts/live-proof/test-classify-runtime-proof-summary.py
@@ -207,6 +207,29 @@ def test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_l
         assert "full-kv" in report["issue_coverage"]["#1228"]["rows"]
 
 
+def test_cancellation_stop_status_alone_is_not_cleanup_proof() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        payload = base_payload()
+        payload["checks"]["stop_status_cancelled"] = True
+        summary = matrix_summary(root, "cancel-observed", payload)
+        manifest = [
+            {
+                "id": "cancel-observed",
+                "model": "model",
+                "family": "gemma4",
+                "priority": "required",
+                "required_cancellation_evidence": ["cold_load_cleanup"],
+            }
+        ]
+
+        report = run_classifier(root, manifest, summary)
+        evidence = report["rows"][0]["resilience_evidence"]["cancellation"]
+
+        assert evidence["verdict"] == "partial", evidence
+        assert "cleanup proof is missing" in evidence["summary"]
+
+
 def test_renderer_writes_runtime_resilience_dashboard() -> None:
     with tempfile.TemporaryDirectory() as temp:
         root = pathlib.Path(temp)
@@ -286,6 +309,7 @@ def main() -> int:
     test_vl_row_without_media_payload_is_not_proven()
     test_unreadable_row_is_unproven()
     test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_links()
+    test_cancellation_stop_status_alone_is_not_cleanup_proof()
     test_renderer_writes_runtime_resilience_dashboard()
     test_family_runner_dry_run_writes_dashboard_artifacts()
     print("runtime proof classifier tests passed")

--- a/scripts/live-proof/test-classify-runtime-proof-summary.py
+++ b/scripts/live-proof/test-classify-runtime-proof-summary.py
@@ -195,6 +195,8 @@ def test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_l
         row = report["rows"][0]
         evidence = row["resilience_evidence"]
 
+        assert row["verdict"] == "proven", row
+        assert not any(issue["requirement"] == "cancellation" for issue in row["blockers"])
         assert evidence["tokens_per_second"]["verdict"] == "proven", evidence
         assert "16.00 token/s" in evidence["tokens_per_second"]["summary"]
         assert evidence["cache"]["verdict"] == "proven", evidence
@@ -205,6 +207,31 @@ def test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_l
         assert evidence["crash_proof"]["verdict"] == "proven", evidence
         assert report["issue_coverage"]["#1228"]["verdict"] == "partial"
         assert "full-kv" in report["issue_coverage"]["#1228"]["rows"]
+
+
+def test_required_cancellation_without_evidence_blocks_proven_row() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        summary = matrix_summary(root, "cancel-required", base_payload())
+        manifest = [
+            {
+                "id": "cancel-required",
+                "model": "model",
+                "family": "gemma4",
+                "priority": "required",
+                "required_cancellation_evidence": ["cold_load_cleanup"],
+            }
+        ]
+
+        report = run_classifier(root, manifest, summary)
+        row = report["rows"][0]
+        evidence = row["resilience_evidence"]["cancellation"]
+
+        assert row["verdict"] == "partial", row
+        assert any(issue["requirement"] == "cancellation" for issue in row["blockers"])
+        assert "lacks required cancellation cleanup evidence" in row["blockers"][0]["message"]
+        assert evidence["verdict"] == "partial", evidence
+        assert report["passed"] is False
 
 
 def test_cancellation_stop_status_alone_is_not_cleanup_proof() -> None:
@@ -224,10 +251,43 @@ def test_cancellation_stop_status_alone_is_not_cleanup_proof() -> None:
         ]
 
         report = run_classifier(root, manifest, summary)
-        evidence = report["rows"][0]["resilience_evidence"]["cancellation"]
+        row = report["rows"][0]
+        evidence = row["resilience_evidence"]["cancellation"]
 
+        assert row["verdict"] == "partial", row
+        assert any(issue["requirement"] == "cancellation" for issue in row["blockers"])
+        assert "cleanup proof is missing" in row["blockers"][0]["message"]
         assert evidence["verdict"] == "partial", evidence
         assert "cleanup proof is missing" in evidence["summary"]
+        assert report["passed"] is False
+
+
+def test_failed_cancellation_cleanup_blocks_proven_row() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        root = pathlib.Path(temp)
+        payload = base_payload()
+        payload["checks"]["cancelled_load_unloaded"] = False
+        summary = matrix_summary(root, "cancel-failed", payload)
+        manifest = [
+            {
+                "id": "cancel-failed",
+                "model": "model",
+                "family": "gemma4",
+                "priority": "required",
+                "required_cancellation_evidence": ["cold_load_cleanup"],
+            }
+        ]
+
+        report = run_classifier(root, manifest, summary)
+        row = report["rows"][0]
+        evidence = row["resilience_evidence"]["cancellation"]
+
+        assert row["verdict"] == "partial", row
+        assert any(issue["requirement"] == "cancellation" for issue in row["blockers"])
+        assert "cancelled_load_unloaded" in row["blockers"][0]["message"]
+        assert evidence["verdict"] == "partial", evidence
+        assert "cancelled_load_unloaded" in evidence["summary"]
+        assert report["passed"] is False
 
 
 def test_renderer_writes_runtime_resilience_dashboard() -> None:
@@ -309,7 +369,9 @@ def main() -> int:
     test_vl_row_without_media_payload_is_not_proven()
     test_unreadable_row_is_unproven()
     test_resilience_evidence_records_token_cache_marker_cancellation_and_crash_links()
+    test_required_cancellation_without_evidence_blocks_proven_row()
     test_cancellation_stop_status_alone_is_not_cleanup_proof()
+    test_failed_cancellation_cleanup_blocks_proven_row()
     test_renderer_writes_runtime_resilience_dashboard()
     test_family_runner_dry_run_writes_dashboard_artifacts()
     print("runtime proof classifier tests passed")


### PR DESCRIPTION
## Summary
- Adds runtime proof summary classification and matrix rendering for live-proof artifacts.
- Extends live-proof scripts so runtime rows can be reported as proven, partial, failed, or unproven.
- Adds Swift and Python tests plus inference-runtime documentation.

## Validation
- `git diff --check`
- `python3 scripts/live-proof/test-classify-runtime-proof-summary.py`
- `ARTIFACT_ROOT=/tmp/osaurus-runtime-dashboard-dry-run-validation scripts/live-proof/run-family-runtime-chat-matrix.sh --dry-run MODEL_FILTER=minimax-m27-small-jangtq`
- `scripts/live-proof/assert-osaurus-no-forced-behavior-pr.sh`
- `swift test --package-path Packages/OsaurusCore --filter RuntimeResilienceDashboardTests`
- `swift test --package-path Packages/OsaurusCore --filter RuntimeProofValidationTests`
- `swift test --package-path Packages/OsaurusCore --filter RuntimeProofMatrixTests`

## Notes
- This PR adds reporting and dry-run proof plumbing; it does not claim new live model runtime proof.
