### PR TITLE
Add agent loop eval regression lab

### DIFF
--- a/Packages/OsaurusEvals/Package.swift
+++ b/Packages/OsaurusEvals/Package.swift
@@ -44,7 +44,10 @@ let package = Package(
             dependencies: [
                 "OsaurusEvalsKit"
             ],
-            path: "Tests/OsaurusEvalsKitTests"
+            path: "Tests/OsaurusEvalsKitTests",
+            resources: [
+                .copy("Fixtures")
+            ]
         ),
     ]
 )

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -55,6 +55,36 @@ swift run osaurus-evals run --suite Suites/CapabilitySearch --filter browser --o
 swift run osaurus-evals run --suite Suites/CapabilitySearch --bootstrap-plugins
 ```
 
+For maintainer proof on agent-loop changes, use the regression lab. It runs
+selected `agent_loop` suites, writes per-suite JSON artifacts, compares the
+current run against a saved baseline report or report directory, and emits a
+concise JSON + Markdown summary:
+
+```bash
+scripts/evals/agent-loop-regression-lab.sh \
+  --baseline reports/main-agentloop-baseline \
+  --model foundation
+
+# Compare saved reports without running a model (useful for smoke/fixtures):
+swift run --package-path Packages/OsaurusEvals osaurus-evals agent-loop-lab \
+  --baseline baseline.json \
+  --current current.json \
+  --out-dir build/evals/lab-smoke
+```
+
+The default run selection is `Suites/AgentLoop` plus `Suites/AgentLoopFrontier`.
+Pass `--suite <dir>` repeatedly to narrow or expand it. Artifacts land under
+`build/evals/agent-loop-regression-lab/<timestamp>/` unless `--out-dir` is set:
+
+- `reports/<Suite>.json` — raw `EvalReport` output for each suite run.
+- `regression-summary.json` — machine-readable case deltas.
+- `regression-summary.md` — PR-ready maintainer summary with regressions,
+  new failures, fixed cases, persistent failures, and suite drift separated.
+
+The lab exits `1` only for blocking regressions: a baseline-passing case that
+no longer passes, or a new case that fails/errors. Existing failures that stay
+red are reported as persistent failures without blocking the comparison.
+
 Startup bootstrap is domain-aware. Suites that require installed native plugins
 load them and rebuild search indices so they mirror the host app. `capability_search`
 suites initialize only the selected tool / method / skill index lanes without
@@ -220,6 +250,17 @@ The suite covers seventeen scenarios under `Suites/AgentLoop/`: `edit-file-then-
 make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop MODEL=foundation
 make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop MODEL=mlx-community/Qwen3-4B-MLX-4bit
 make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop MODEL=openai/gpt-4o-mini JUDGE_MODEL=openai/gpt-4o
+```
+
+For release or PR proof against a known-good row, prefer the regression lab so
+the raw reports and summary stay together:
+
+```bash
+scripts/evals/agent-loop-regression-lab.sh \
+  --baseline build/eval-baselines/<model>/agent-loop \
+  --suite Packages/OsaurusEvals/Suites/AgentLoop \
+  --suite Packages/OsaurusEvals/Suites/AgentLoopFrontier \
+  --model <prefix>/<model-id>
 ```
 
 ### Other domains

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/AgentLoopRegressionLabCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/AgentLoopRegressionLabCLI.swift
@@ -1,0 +1,364 @@
+//
+//  AgentLoopRegressionLabCLI.swift
+//  osaurus-evals
+//
+//  CLI surface for running and comparing agent_loop eval regression reports.
+//
+
+import Darwin
+import Foundation
+import OsaurusEvalsKit
+
+extension OsaurusEvalsCLI {
+    static func runAgentLoopLab(_ args: [String]) async -> Int32 {
+        let opts: AgentLoopLabOptions
+        do {
+            opts = try AgentLoopLabOptions.parse(args)
+        } catch {
+            FileHandle.standardError.write(
+                Data(("argument error: \(error.localizedDescription)\n").utf8)
+            )
+            printAgentLoopLabUsage()
+            return 2
+        }
+
+        do {
+            if let current = opts.current {
+                return try compareExistingAgentLoopReports(options: opts, current: current)
+            }
+            return try await runAgentLoopLabSuites(options: opts)
+        } catch {
+            FileHandle.standardError.write(
+                Data(("agent-loop lab failed: \(error.localizedDescription)\n").utf8)
+            )
+            return 2
+        }
+    }
+
+    private static func compareExistingAgentLoopReports(
+        options opts: AgentLoopLabOptions,
+        current: URL
+    ) throws -> Int32 {
+        let baseline = try AgentLoopRegressionReportSet.load(
+            from: opts.baseline,
+            label: opts.baselineLabel
+        ).filteringCaseIDs(containing: opts.filter)
+        let currentSet = try AgentLoopRegressionReportSet.load(
+            from: current,
+            label: opts.currentLabel ?? current.deletingPathExtension().lastPathComponent
+        ).filteringCaseIDs(containing: opts.filter)
+        let summary = try AgentLoopRegressionLab.compare(
+            baseline: baseline,
+            current: currentSet,
+            artifacts: [
+                .init(kind: "baseline reports", path: opts.baseline.path),
+                .init(kind: "current reports", path: current.path),
+            ]
+        )
+        let written = try writeAgentLoopLabSummary(summary, outDir: opts.outDir)
+        print(summary.formatMarkdown())
+        print("wrote summary JSON to \(written.json.path)")
+        print("wrote summary Markdown to \(written.markdown.path)")
+        return summary.hasBlockingRegressions ? 1 : 0
+    }
+
+    @MainActor
+    private static func runAgentLoopLabSuites(options opts: AgentLoopLabOptions) async throws -> Int32 {
+        let suiteURLs = opts.suites.isEmpty ? defaultAgentLoopLabSuites() : opts.suites
+        var loaded: [(url: URL, suite: EvalSuite)] = []
+        for suiteURL in suiteURLs {
+            let suite = try EvalSuite.load(from: suiteURL)
+            try AgentLoopRegressionLab.validateAgentLoopSuite(suite, filter: opts.filter)
+            loaded.append((suiteURL, suite))
+        }
+
+        let combinedSuite = EvalSuite(
+            directory: URL(fileURLWithPath: "agent-loop-lab", isDirectory: true),
+            cases: loaded.flatMap(\.suite.cases),
+            decodeFailures: loaded.flatMap(\.suite.decodeFailures)
+        )
+        let bootstrapPlan = EvalBootstrapPlan.make(
+            suite: combinedSuite,
+            filter: opts.filter,
+            preference: opts.pluginBootstrapPreference
+        )
+        _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
+        let startupWatchdog =
+            bootstrapPlan.requiresWork
+            ? makeAgentLoopLabStartupWatchdog(options: opts, suite: combinedSuite)
+            : nil
+        await EvalBootstrap.run(bootstrapPlan)
+        startupWatchdog?.cancel()
+
+        let ephemeralProviderIds = await EvalRemoteProviderBootstrap.connectIfNeeded(
+            modelIds: EvalRemoteProviderBootstrap.candidateModelIds(runModel: opts.model)
+        )
+        defer { EvalRemoteProviderBootstrap.teardown(ephemeralProviderIds) }
+
+        let reportsDir = opts.outDir.appendingPathComponent("reports", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: reportsDir,
+            withIntermediateDirectories: true
+        )
+
+        var namedReports: [AgentLoopRegressionReportSet.NamedReport] = []
+        var reportArtifacts: [AgentLoopRegressionArtifact] = []
+        var usedNames: [String: Int] = [:]
+
+        for item in loaded {
+            let suiteName = uniqueSuiteName(suiteURL: item.url, usedNames: &usedNames)
+            print("running \(suiteName)...")
+            let report = await EvalRunner.run(
+                suite: item.suite,
+                model: opts.model,
+                filter: opts.filter,
+                bootstrapMode: .alreadyLoaded
+            )
+            let outURL = reportsDir.appendingPathComponent("\(suiteName).json")
+            try report.toJSON(prettyPrinted: true).write(to: outURL)
+            namedReports.append(.init(name: suiteName, url: outURL, report: report))
+            reportArtifacts.append(.init(kind: "\(suiteName) report", path: outURL.path))
+
+            let counts = report.counts
+            print(
+                "finished \(suiteName): \(counts.passed) passed, "
+                    + "\(counts.failed) failed, \(counts.errored) errored, "
+                    + "\(counts.skipped) skipped"
+            )
+            if opts.verbose {
+                print("")
+                print(report.formatHumanReadable(verbose: true))
+                print("")
+            }
+        }
+
+        let baseline = try AgentLoopRegressionReportSet.load(
+            from: opts.baseline,
+            label: opts.baselineLabel
+        ).filteringCaseIDs(containing: opts.filter)
+        let current = AgentLoopRegressionReportSet(
+            label: opts.currentLabel ?? "current run",
+            reports: namedReports
+        ).filteringCaseIDs(containing: opts.filter)
+        let summary = try AgentLoopRegressionLab.compare(
+            baseline: baseline,
+            current: current,
+            artifacts: [.init(kind: "baseline reports", path: opts.baseline.path)] + reportArtifacts
+        )
+        let written = try writeAgentLoopLabSummary(summary, outDir: opts.outDir)
+        print("")
+        print(summary.formatMarkdown())
+        print("wrote summary JSON to \(written.json.path)")
+        print("wrote summary Markdown to \(written.markdown.path)")
+        return summary.hasBlockingRegressions ? 1 : 0
+    }
+
+    private static func writeAgentLoopLabSummary(
+        _ summary: AgentLoopRegressionLabSummary,
+        outDir: URL
+    ) throws -> (json: URL, markdown: URL) {
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        let jsonURL = outDir.appendingPathComponent("regression-summary.json")
+        let markdownURL = outDir.appendingPathComponent("regression-summary.md")
+        try summary.toJSON(prettyPrinted: true).write(to: jsonURL)
+        try summary.formatMarkdown().write(to: markdownURL, atomically: true, encoding: .utf8)
+        return (jsonURL, markdownURL)
+    }
+
+    @MainActor
+    private static func makeAgentLoopLabStartupWatchdog(
+        options opts: AgentLoopLabOptions,
+        suite: EvalSuite
+    ) -> EvalStartupWatchdog? {
+        guard let timeoutSeconds = opts.startupTimeoutSeconds else { return nil }
+        let reportData = try? EvalTimeoutReport.makeReport(
+            suite: suite,
+            modelId: ModelOverride.describe(opts.model),
+            filter: opts.filter,
+            timeoutSeconds: timeoutSeconds,
+            phase: "startup bootstrap"
+        ).toJSON(prettyPrinted: true)
+
+        return EvalStartupWatchdog(
+            timeoutSeconds: timeoutSeconds,
+            payload: EvalStartupWatchdog.Payload(
+                phase: "startup bootstrap",
+                timeoutLabel: EvalTimeoutReport.formatSeconds(timeoutSeconds),
+                reportData: reportData,
+                outPath: opts.outDir.appendingPathComponent("startup-timeout.json").path
+            )
+        )
+    }
+
+    private static func defaultAgentLoopLabSuites() -> [URL] {
+        let repoRootAgentLoop = URL(fileURLWithPath: "Packages/OsaurusEvals/Suites/AgentLoop", isDirectory: true)
+        let repoRootFrontier = URL(fileURLWithPath: "Packages/OsaurusEvals/Suites/AgentLoopFrontier", isDirectory: true)
+        if FileManager.default.fileExists(atPath: repoRootAgentLoop.path) {
+            return [repoRootAgentLoop, repoRootFrontier]
+        }
+        return [
+            URL(fileURLWithPath: "Suites/AgentLoop", isDirectory: true),
+            URL(fileURLWithPath: "Suites/AgentLoopFrontier", isDirectory: true),
+        ]
+    }
+
+    private static func uniqueSuiteName(
+        suiteURL: URL,
+        usedNames: inout [String: Int]
+    ) -> String {
+        let base = suiteURL.lastPathComponent.isEmpty
+            ? suiteURL.deletingLastPathComponent().lastPathComponent
+            : suiteURL.lastPathComponent
+        let count = usedNames[base, default: 0]
+        usedNames[base] = count + 1
+        return count == 0 ? base : "\(base)-\(count + 1)"
+    }
+
+    static func printAgentLoopLabUsage() {
+        let usage = """
+            osaurus-evals agent-loop-lab - compare agent_loop reports against a baseline
+
+            USAGE:
+                osaurus-evals agent-loop-lab --baseline <path> [--suite <dir> ...] [--model <id>]
+                                                [--filter <substr>] [--out-dir <dir>]
+                osaurus-evals agent-loop-lab --baseline <path> --current <path> [--out-dir <dir>]
+
+            FLAGS:
+                --baseline <path>       Required. Baseline EvalReport JSON file or directory
+                                        of per-suite JSON reports.
+                --current <path>        Compare-only mode. Reads current EvalReport JSON
+                                        file or directory instead of running model evals.
+                --suite <dir>           Agent-loop suite to run. May be repeated. Defaults
+                                        to AgentLoop and AgentLoopFrontier.
+                --model <id>            Same model grammar as `run`; default is auto.
+                --filter <substr>       Only run/compare cases whose id contains <substr>.
+                --out-dir <dir>         Artifact directory. Defaults to
+                                        build/evals/agent-loop-regression-lab/<timestamp>.
+                --baseline-label <text> Label used in JSON/Markdown summary.
+                --current-label <text>  Label used in JSON/Markdown summary.
+                --verbose, -v           Print full per-suite reports after each run.
+                --startup-timeout <s>   Startup bootstrap watchdog. Use 0 to disable.
+                --bootstrap-plugins     Force installed native plugin loading.
+                --no-plugin-bootstrap   Disable installed native plugin loading.
+
+            ARTIFACTS:
+                reports/<Suite>.json
+                regression-summary.json
+                regression-summary.md
+
+            EXAMPLES:
+                osaurus-evals agent-loop-lab --baseline reports/main-agentloop
+                osaurus-evals agent-loop-lab --baseline baseline.json --current current.json --out-dir build/evals/lab-smoke
+            """
+        print(usage)
+    }
+
+    struct AgentLoopLabOptions {
+        let baseline: URL
+        let current: URL?
+        let suites: [URL]
+        let model: ModelSelection
+        let filter: String?
+        let outDir: URL
+        let baselineLabel: String?
+        let currentLabel: String?
+        let verbose: Bool
+        let startupTimeoutSeconds: Double?
+        let pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference
+
+        static func parse(_ args: [String]) throws -> AgentLoopLabOptions {
+            var baseline: URL?
+            var current: URL?
+            var suites: [URL] = []
+            var modelRaw: String?
+            var filter: String?
+            var outDir: URL?
+            var baselineLabel: String?
+            var currentLabel: String?
+            var verbose = false
+            var startupTimeoutSeconds = EvalTimeoutReport.configuredStartupTimeoutSeconds()
+            var pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference = .automatic
+
+            var i = 0
+            while i < args.count {
+                let arg = args[i]
+                switch arg {
+                case "--baseline":
+                    baseline = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--current":
+                    current = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--suite":
+                    suites.append(try urlForArg(args, after: i, flag: arg))
+                    i += 2
+                case "--model":
+                    modelRaw = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--filter":
+                    filter = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--out-dir":
+                    outDir = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--baseline-label":
+                    baselineLabel = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--current-label":
+                    currentLabel = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--verbose", "-v":
+                    verbose = true
+                    i += 1
+                case "--startup-timeout":
+                    let raw = try valueForArg(args, after: i, flag: arg)
+                    guard let value = EvalTimeoutReport.parseTimeoutSeconds(raw) else {
+                        throw CLIError.invalidValue(arg, raw)
+                    }
+                    startupTimeoutSeconds = value > 0 ? value : nil
+                    i += 2
+                case "--bootstrap-plugins":
+                    pluginBootstrapPreference = .force
+                    i += 1
+                case "--no-plugin-bootstrap":
+                    pluginBootstrapPreference = .disabled
+                    i += 1
+                case "--help", "-h":
+                    printAgentLoopLabUsage()
+                    Darwin.exit(0)
+                default:
+                    throw CLIError.unknownArg(arg)
+                }
+            }
+
+            guard let baseline else { throw CLIError.missingFlag("--baseline") }
+            return AgentLoopLabOptions(
+                baseline: baseline,
+                current: current,
+                suites: suites,
+                model: ModelSelection.parse(modelRaw),
+                filter: filter,
+                outDir: outDir ?? defaultAgentLoopLabOutDir(),
+                baselineLabel: baselineLabel,
+                currentLabel: currentLabel,
+                verbose: verbose,
+                startupTimeoutSeconds: startupTimeoutSeconds,
+                pluginBootstrapPreference: pluginBootstrapPreference
+            )
+        }
+
+        private static func defaultAgentLoopLabOutDir() -> URL {
+            URL(fileURLWithPath: "build/evals/agent-loop-regression-lab", isDirectory: true)
+                .appendingPathComponent(timestampForPath(), isDirectory: true)
+        }
+
+        private static func timestampForPath() -> String {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .gregorian)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+            return formatter.string(from: Date())
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -28,14 +28,30 @@ struct OsaurusEvalsCLI {
 
     static func main() async {
         let args = Array(CommandLine.arguments.dropFirst())
-        guard let first = args.first, first == "run" else {
+        guard let command = args.first else {
             printUsage()
-            exit(args.isEmpty ? 0 : 2)
+            exit(0)
         }
 
+        switch command {
+        case "run":
+            await runCommand(Array(args.dropFirst()))
+        case "agent-loop-lab":
+            exit(await runAgentLoopLab(Array(args.dropFirst())))
+        case "--help", "-h":
+            printUsage()
+            exit(0)
+        default:
+            printUsage()
+            exit(2)
+        }
+    }
+
+    @MainActor
+    static func runCommand(_ args: [String]) async {
         let opts: Options
         do {
-            opts = try Options.parse(Array(args.dropFirst()))
+            opts = try Options.parse(args)
         } catch {
             FileHandle.standardError.write(
                 Data(("argument error: \(error.localizedDescription)\n").utf8)
@@ -547,6 +563,7 @@ struct OsaurusEvalsCLI {
                 osaurus-evals run --suite <dir> [--model <id>] [--filter <substr>] [--out <path>]
                                               [--threshold <float>] [--report-forensics]
                                               [--startup-timeout <seconds>]
+                osaurus-evals agent-loop-lab --baseline <path> [--suite <dir> ...] [--model <id>]
 
             FLAGS:
                 --suite <dir>         Required. Directory of *.json eval cases
@@ -617,6 +634,7 @@ struct OsaurusEvalsCLI {
                 osaurus-evals run --suite Suites/CapabilitySearch --filter browser --out report.json
                 osaurus-evals run --suite Suites/CapabilitySearch --threshold 0.25 --report-forensics
                 osaurus-evals run --suite Suites/CapabilitySearch --fail-on-floor
+                osaurus-evals agent-loop-lab --baseline reports/main-agentloop
             """
         print(usage)
     }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/AgentLoopRegressionLab.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/AgentLoopRegressionLab.swift
@@ -1,0 +1,580 @@
+//
+//  AgentLoopRegressionLab.swift
+//  OsaurusEvalsKit
+//
+//  Baseline comparison and artifact rendering for the agent_loop eval lane.
+//
+
+import Foundation
+
+public struct AgentLoopRegressionArtifact: Sendable, Codable, Equatable {
+    public let kind: String
+    public let path: String
+
+    public init(kind: String, path: String) {
+        self.kind = kind
+        self.path = path
+    }
+}
+
+public struct AgentLoopRegressionReportSet: Sendable {
+    public struct NamedReport: Sendable {
+        public let name: String
+        public let url: URL?
+        public let report: EvalReport
+
+        public init(name: String, url: URL?, report: EvalReport) {
+            self.name = name
+            self.url = url
+            self.report = report
+        }
+    }
+
+    public let label: String
+    public let reports: [NamedReport]
+
+    public init(label: String, reports: [NamedReport]) {
+        self.label = label
+        self.reports = reports
+    }
+
+    public func filteringCaseIDs(containing filter: String?) -> AgentLoopRegressionReportSet {
+        guard let filter, !filter.isEmpty else { return self }
+        return AgentLoopRegressionReportSet(
+            label: label,
+            reports: reports.map { named in
+                NamedReport(
+                    name: named.name,
+                    url: named.url,
+                    report: EvalReport(
+                        modelId: named.report.modelId,
+                        startedAt: named.report.startedAt,
+                        cases: named.report.cases.filter { $0.id.contains(filter) }
+                    )
+                )
+            }
+        )
+    }
+
+    public static func load(from url: URL, label: String? = nil) throws -> AgentLoopRegressionReportSet {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            throw AgentLoopRegressionLabError.pathNotFound(url.path)
+        }
+
+        let reportURLs: [URL]
+        if isDirectory.boolValue {
+            reportURLs = try fm.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+                .filter { $0.pathExtension.lowercased() == "json" }
+                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            if reportURLs.isEmpty {
+                throw AgentLoopRegressionLabError.noReports(url.path)
+            }
+        } else {
+            reportURLs = [url]
+        }
+
+        let decoder = JSONDecoder()
+        let reports = try reportURLs.map { reportURL -> NamedReport in
+            let data = try Data(contentsOf: reportURL)
+            let report = try decoder.decode(EvalReport.self, from: data)
+            return NamedReport(
+                name: reportURL.deletingPathExtension().lastPathComponent,
+                url: reportURL,
+                report: report
+            )
+        }
+
+        return AgentLoopRegressionReportSet(
+            label: label ?? url.deletingPathExtension().lastPathComponent,
+            reports: reports
+        )
+    }
+}
+
+public struct AgentLoopRegressionOutcomeCounts: Sendable, Codable, Equatable {
+    public let total: Int
+    public let passed: Int
+    public let failed: Int
+    public let skipped: Int
+    public let errored: Int
+
+    public init(cases: [AgentLoopRegressionCaseSnapshot]) {
+        total = cases.count
+        passed = cases.filter { $0.outcome == .passed }.count
+        failed = cases.filter { $0.outcome == .failed }.count
+        skipped = cases.filter { $0.outcome == .skipped }.count
+        errored = cases.filter { $0.outcome == .errored }.count
+    }
+}
+
+public struct AgentLoopRegressionCaseSnapshot: Sendable, Codable, Equatable {
+    public let suite: String
+    public let id: String
+    public let label: String
+    public let outcome: EvalCaseOutcome
+    public let modelId: String
+    public let latencyMs: Double?
+    public let notes: [String]
+    public let toolCalls: Int?
+    public let toolErrors: Int?
+    public let toolDeduped: Int?
+
+    public init(suite: String, row: EvalCaseReport) {
+        let usage = row.toolUsage ?? []
+        let calls = usage.map(\.calls).reduce(0, +)
+        let errors = usage.map(\.errors).reduce(0, +)
+        let deduped = usage.map(\.deduped).reduce(0, +)
+
+        self.suite = suite
+        self.id = row.id
+        self.label = row.label
+        self.outcome = row.outcome
+        self.modelId = row.modelId
+        self.latencyMs = row.latencyMs
+        self.notes = row.notes
+        self.toolCalls = usage.isEmpty ? nil : calls
+        self.toolErrors = usage.isEmpty ? nil : errors
+        self.toolDeduped = usage.isEmpty ? nil : deduped
+    }
+}
+
+public struct AgentLoopRegressionCaseDelta: Sendable, Codable, Equatable {
+    public let id: String
+    public let suite: String
+    public let baselineOutcome: EvalCaseOutcome?
+    public let currentOutcome: EvalCaseOutcome?
+    public let baselineLatencyMs: Double?
+    public let currentLatencyMs: Double?
+    public let latencyDeltaMs: Double?
+    public let baselineToolCalls: Int?
+    public let currentToolCalls: Int?
+    public let toolCallDelta: Int?
+    public let baselineToolErrors: Int?
+    public let currentToolErrors: Int?
+    public let toolErrorDelta: Int?
+    public let baselineNotes: [String]
+    public let currentNotes: [String]
+
+    public init(
+        baseline: AgentLoopRegressionCaseSnapshot?,
+        current: AgentLoopRegressionCaseSnapshot?
+    ) {
+        let lhs = baseline
+        let rhs = current
+        id = rhs?.id ?? lhs?.id ?? "(unknown)"
+        suite = rhs?.suite ?? lhs?.suite ?? "(unknown)"
+        baselineOutcome = lhs?.outcome
+        currentOutcome = rhs?.outcome
+        baselineLatencyMs = lhs?.latencyMs
+        currentLatencyMs = rhs?.latencyMs
+        if let base = lhs?.latencyMs, let now = rhs?.latencyMs {
+            latencyDeltaMs = now - base
+        } else {
+            latencyDeltaMs = nil
+        }
+        baselineToolCalls = lhs?.toolCalls
+        currentToolCalls = rhs?.toolCalls
+        if let base = lhs?.toolCalls, let now = rhs?.toolCalls {
+            toolCallDelta = now - base
+        } else {
+            toolCallDelta = nil
+        }
+        baselineToolErrors = lhs?.toolErrors
+        currentToolErrors = rhs?.toolErrors
+        if let base = lhs?.toolErrors, let now = rhs?.toolErrors {
+            toolErrorDelta = now - base
+        } else {
+            toolErrorDelta = nil
+        }
+        baselineNotes = lhs?.notes ?? []
+        currentNotes = rhs?.notes ?? []
+    }
+}
+
+public struct AgentLoopRegressionLabSummary: Sendable, Codable, Equatable {
+    public let generatedAt: String
+    public let baselineLabel: String
+    public let currentLabel: String
+    public let baselineModelId: String?
+    public let currentModelId: String?
+    public let baselineStartedAt: String?
+    public let currentStartedAt: String?
+    public let baselineCounts: AgentLoopRegressionOutcomeCounts
+    public let currentCounts: AgentLoopRegressionOutcomeCounts
+    public let regressions: [AgentLoopRegressionCaseDelta]
+    public let newFailures: [AgentLoopRegressionCaseDelta]
+    public let fixed: [AgentLoopRegressionCaseDelta]
+    public let persistentFailures: [AgentLoopRegressionCaseDelta]
+    public let newCases: [AgentLoopRegressionCaseDelta]
+    public let removedCases: [AgentLoopRegressionCaseDelta]
+    public let warnings: [String]
+    public let artifacts: [AgentLoopRegressionArtifact]
+
+    public var hasBlockingRegressions: Bool {
+        !regressions.isEmpty || !newFailures.isEmpty
+    }
+
+    public func toJSON(prettyPrinted: Bool = true) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting =
+            prettyPrinted
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    public func formatMarkdown() -> String {
+        var lines: [String] = []
+        let verdict =
+            hasBlockingRegressions
+            ? "REGRESSED: \(regressions.count) regression(s), \(newFailures.count) new failing case(s)"
+            : "PASS: no blocking agent_loop regressions"
+
+        lines.append("# Agent Loop Regression Lab")
+        lines.append("")
+        lines.append("- Verdict: \(verdict)")
+        lines.append("- Generated: \(generatedAt)")
+        lines.append("- Baseline: \(baselineLabel)\(modelSuffix(baselineModelId, baselineStartedAt))")
+        lines.append("- Current: \(currentLabel)\(modelSuffix(currentModelId, currentStartedAt))")
+        lines.append("")
+        lines.append("## Totals")
+        lines.append("")
+        lines.append("| Bucket | Baseline | Current |")
+        lines.append("| --- | ---: | ---: |")
+        lines.append("| total | \(baselineCounts.total) | \(currentCounts.total) |")
+        lines.append("| passed | \(baselineCounts.passed) | \(currentCounts.passed) |")
+        lines.append("| failed | \(baselineCounts.failed) | \(currentCounts.failed) |")
+        lines.append("| errored | \(baselineCounts.errored) | \(currentCounts.errored) |")
+        lines.append("| skipped | \(baselineCounts.skipped) | \(currentCounts.skipped) |")
+
+        appendDeltaSection(
+            title: "Blocking Regressions",
+            rows: regressions,
+            into: &lines
+        )
+        appendDeltaSection(
+            title: "New Failing Cases",
+            rows: newFailures,
+            into: &lines
+        )
+        appendDeltaSection(
+            title: "Fixed Cases",
+            rows: fixed,
+            into: &lines
+        )
+        appendDeltaSection(
+            title: "Persistent Failures",
+            rows: persistentFailures,
+            into: &lines
+        )
+        appendDeltaSection(
+            title: "Suite Drift",
+            rows: newCases + removedCases,
+            into: &lines
+        )
+
+        if !artifacts.isEmpty {
+            lines.append("")
+            lines.append("## Artifacts")
+            lines.append("")
+            for artifact in artifacts {
+                lines.append("- \(markdownCell(artifact.kind)): `\(artifact.path)`")
+            }
+        }
+
+        if !warnings.isEmpty {
+            lines.append("")
+            lines.append("## Warnings")
+            lines.append("")
+            for warning in warnings {
+                lines.append("- \(markdownCell(warning))")
+            }
+        }
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func appendDeltaSection(
+        title: String,
+        rows: [AgentLoopRegressionCaseDelta],
+        into lines: inout [String]
+    ) {
+        guard !rows.isEmpty else { return }
+        lines.append("")
+        lines.append("## \(title)")
+        lines.append("")
+        lines.append("| Case | Baseline | Current | Latency | Tools | Notes |")
+        lines.append("| --- | --- | --- | ---: | ---: | --- |")
+        for row in rows {
+            lines.append(
+                "| \(markdownCell(row.id)) | \(outcomeLabel(row.baselineOutcome)) | "
+                    + "\(outcomeLabel(row.currentOutcome)) | \(latencyLabel(row)) | "
+                    + "\(toolLabel(row)) | \(notesLabel(row)) |"
+            )
+        }
+    }
+
+    private func modelSuffix(_ modelId: String?, _ startedAt: String?) -> String {
+        let model = modelId ?? "unknown model"
+        if let startedAt {
+            return " (\(model), \(startedAt))"
+        }
+        return " (\(model))"
+    }
+
+    private func outcomeLabel(_ outcome: EvalCaseOutcome?) -> String {
+        outcome?.rawValue ?? "missing"
+    }
+
+    private func latencyLabel(_ row: AgentLoopRegressionCaseDelta) -> String {
+        guard let delta = row.latencyDeltaMs else { return "-" }
+        return signedMs(delta)
+    }
+
+    private func toolLabel(_ row: AgentLoopRegressionCaseDelta) -> String {
+        var parts: [String] = []
+        if let calls = row.toolCallDelta {
+            parts.append("calls \(signedInt(calls))")
+        }
+        if let errors = row.toolErrorDelta {
+            parts.append("errors \(signedInt(errors))")
+        }
+        return parts.isEmpty ? "-" : markdownCell(parts.joined(separator: ", "))
+    }
+
+    private func notesLabel(_ row: AgentLoopRegressionCaseDelta) -> String {
+        let notes = row.currentNotes.isEmpty ? row.baselineNotes : row.currentNotes
+        if notes.isEmpty { return "-" }
+        return markdownCell(notes.prefix(2).joined(separator: " / "))
+    }
+
+    private func signedMs(_ value: Double) -> String {
+        let rounded = Int(value.rounded())
+        return "\(signedInt(rounded))ms"
+    }
+
+    private func signedInt(_ value: Int) -> String {
+        value >= 0 ? "+\(value)" : "\(value)"
+    }
+
+    private func markdownCell(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "|", with: "\\|")
+    }
+}
+
+public enum AgentLoopRegressionLab {
+    public static func compare(
+        baseline: AgentLoopRegressionReportSet,
+        current: AgentLoopRegressionReportSet,
+        generatedAt: String? = nil,
+        artifacts: [AgentLoopRegressionArtifact] = []
+    ) throws -> AgentLoopRegressionLabSummary {
+        let baselineIndex = indexAgentLoopCases(in: baseline)
+        let currentIndex = indexAgentLoopCases(in: current)
+
+        guard !baselineIndex.cases.isEmpty else {
+            throw AgentLoopRegressionLabError.noAgentLoopCases("baseline")
+        }
+        guard !currentIndex.cases.isEmpty else {
+            throw AgentLoopRegressionLabError.noAgentLoopCases("current")
+        }
+
+        let baselineIds = Set(baselineIndex.byId.keys)
+        let currentIds = Set(currentIndex.byId.keys)
+        let commonIds = baselineIds.intersection(currentIds).sorted()
+        let currentOnlyIds = currentIds.subtracting(baselineIds).sorted()
+        let baselineOnlyIds = baselineIds.subtracting(currentIds).sorted()
+
+        var regressions: [AgentLoopRegressionCaseDelta] = []
+        var fixed: [AgentLoopRegressionCaseDelta] = []
+        var persistentFailures: [AgentLoopRegressionCaseDelta] = []
+        var newFailures: [AgentLoopRegressionCaseDelta] = []
+        var newCases: [AgentLoopRegressionCaseDelta] = []
+        var removedCases: [AgentLoopRegressionCaseDelta] = []
+
+        for id in commonIds {
+            let baselineCase = baselineIndex.byId[id]
+            let currentCase = currentIndex.byId[id]
+            let delta = AgentLoopRegressionCaseDelta(
+                baseline: baselineCase,
+                current: currentCase
+            )
+            if isBlockingRegression(baseline: baselineCase?.outcome, current: currentCase?.outcome) {
+                regressions.append(delta)
+            } else if isFixed(baseline: baselineCase?.outcome, current: currentCase?.outcome) {
+                fixed.append(delta)
+            } else if isPersistentFailure(baseline: baselineCase?.outcome, current: currentCase?.outcome) {
+                persistentFailures.append(delta)
+            }
+        }
+
+        for id in currentOnlyIds {
+            let currentCase = currentIndex.byId[id]
+            let delta = AgentLoopRegressionCaseDelta(baseline: nil, current: currentCase)
+            if isFailing(currentCase?.outcome) {
+                newFailures.append(delta)
+            } else {
+                newCases.append(delta)
+            }
+        }
+
+        for id in baselineOnlyIds {
+            removedCases.append(
+                AgentLoopRegressionCaseDelta(
+                    baseline: baselineIndex.byId[id],
+                    current: nil
+                )
+            )
+        }
+
+        return AgentLoopRegressionLabSummary(
+            generatedAt: generatedAt ?? isoNowForAgentLoopRegressionLab(),
+            baselineLabel: baseline.label,
+            currentLabel: current.label,
+            baselineModelId: commonModelId(in: baseline),
+            currentModelId: commonModelId(in: current),
+            baselineStartedAt: commonStartedAt(in: baseline),
+            currentStartedAt: commonStartedAt(in: current),
+            baselineCounts: AgentLoopRegressionOutcomeCounts(cases: baselineIndex.cases),
+            currentCounts: AgentLoopRegressionOutcomeCounts(cases: currentIndex.cases),
+            regressions: regressions,
+            newFailures: newFailures,
+            fixed: fixed,
+            persistentFailures: persistentFailures,
+            newCases: newCases,
+            removedCases: removedCases,
+            warnings: (baselineIndex.warnings + currentIndex.warnings).sorted(),
+            artifacts: artifacts
+        )
+    }
+
+    public static func validateAgentLoopSuite(
+        _ suite: EvalSuite,
+        filter: String?
+    ) throws {
+        let selected = suite.cases.filter { testCase in
+            filter.map { testCase.id.contains($0) } ?? true
+        }
+        guard !selected.isEmpty else {
+            throw AgentLoopRegressionLabError.noSelectedCases(suite.directory.path)
+        }
+        let nonAgentLoop = selected.filter { $0.domain != "agent_loop" }.map(\.id)
+        guard nonAgentLoop.isEmpty else {
+            throw AgentLoopRegressionLabError.nonAgentLoopCases(nonAgentLoop.sorted())
+        }
+    }
+
+    private static func indexAgentLoopCases(
+        in set: AgentLoopRegressionReportSet
+    ) -> (
+        cases: [AgentLoopRegressionCaseSnapshot],
+        byId: [String: AgentLoopRegressionCaseSnapshot],
+        warnings: [String]
+    ) {
+        var cases: [AgentLoopRegressionCaseSnapshot] = []
+        var byId: [String: AgentLoopRegressionCaseSnapshot] = [:]
+        var warnings: [String] = []
+
+        for named in set.reports.sorted(by: { $0.name < $1.name }) {
+            for row in named.report.cases where row.domain == "agent_loop" {
+                let snapshot = AgentLoopRegressionCaseSnapshot(suite: named.name, row: row)
+                cases.append(snapshot)
+                if let existing = byId[snapshot.id] {
+                    warnings.append(
+                        "duplicate agent_loop case id '\(snapshot.id)' in \(existing.suite) and \(snapshot.suite); keeping \(existing.suite)"
+                    )
+                } else {
+                    byId[snapshot.id] = snapshot
+                }
+            }
+        }
+
+        cases.sort { lhs, rhs in
+            if lhs.suite == rhs.suite { return lhs.id < rhs.id }
+            return lhs.suite < rhs.suite
+        }
+        return (cases, byId, warnings)
+    }
+
+    private static func isBlockingRegression(
+        baseline: EvalCaseOutcome?,
+        current: EvalCaseOutcome?
+    ) -> Bool {
+        guard let baseline, let current else { return false }
+        if baseline == .passed && current != .passed { return true }
+        if baseline == .failed && current == .errored { return true }
+        if baseline == .skipped && current == .errored { return true }
+        return false
+    }
+
+    private static func isFixed(
+        baseline: EvalCaseOutcome?,
+        current: EvalCaseOutcome?
+    ) -> Bool {
+        guard let baseline, let current else { return false }
+        return (baseline == .failed || baseline == .errored) && current == .passed
+    }
+
+    private static func isPersistentFailure(
+        baseline: EvalCaseOutcome?,
+        current: EvalCaseOutcome?
+    ) -> Bool {
+        guard let baseline, let current else { return false }
+        return isFailing(baseline) && isFailing(current) && !isBlockingRegression(
+            baseline: baseline,
+            current: current
+        )
+    }
+
+    private static func isFailing(_ outcome: EvalCaseOutcome?) -> Bool {
+        outcome == .failed || outcome == .errored
+    }
+
+    private static func commonModelId(in set: AgentLoopRegressionReportSet) -> String? {
+        commonValue(set.reports.map(\.report.modelId))
+    }
+
+    private static func commonStartedAt(in set: AgentLoopRegressionReportSet) -> String? {
+        commonValue(set.reports.map(\.report.startedAt))
+    }
+
+    private static func commonValue(_ values: [String]) -> String? {
+        let unique = Set(values)
+        if unique.count == 1 { return unique.first }
+        if values.isEmpty { return nil }
+        return "mixed"
+    }
+}
+
+public enum AgentLoopRegressionLabError: Error, LocalizedError, Equatable {
+    case pathNotFound(String)
+    case noReports(String)
+    case noAgentLoopCases(String)
+    case noSelectedCases(String)
+    case nonAgentLoopCases([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .pathNotFound(let path):
+            return "path does not exist: \(path)"
+        case .noReports(let path):
+            return "no JSON eval reports found at: \(path)"
+        case .noAgentLoopCases(let label):
+            return "\(label) report set has no agent_loop cases"
+        case .noSelectedCases(let path):
+            return "suite selection has no cases: \(path)"
+        case .nonAgentLoopCases(let ids):
+            return "agent-loop lab only accepts agent_loop cases; non-agent cases: \(ids.joined(separator: ", "))"
+        }
+    }
+}
+
+private func isoNowForAgentLoopRegressionLab() -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: Date())
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopRegressionLabTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopRegressionLabTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct AgentLoopRegressionLabTests {
+    @Test func fixtureReportsProduceExpectedMarkdownAndJSON() throws {
+        let fixtures = try fixturesURL()
+        let baseline = try AgentLoopRegressionReportSet.load(
+            from: fixtures.appendingPathComponent("baseline.json"),
+            label: "fixture baseline"
+        )
+        let current = try AgentLoopRegressionReportSet.load(
+            from: fixtures.appendingPathComponent("current.json"),
+            label: "fixture current"
+        )
+
+        let summary = try AgentLoopRegressionLab.compare(
+            baseline: baseline,
+            current: current,
+            generatedAt: "2026-06-18T12:00:00Z"
+        )
+
+        #expect(summary.hasBlockingRegressions)
+        #expect(summary.baselineCounts.total == 5)
+        #expect(summary.currentCounts.errored == 1)
+        #expect(summary.regressions.map(\.id) == ["agent_loop.search-then-multi-file-edit"])
+        #expect(summary.newFailures.map(\.id) == ["agent_loop.write-new-file"])
+        #expect(summary.fixed.map(\.id) == ["agent_loop.compaction-stress"])
+        #expect(summary.persistentFailures.map(\.id) == ["agent_loop.legacy-case"])
+
+        let expectedMarkdown = try String(
+            contentsOf: fixtures.appendingPathComponent("expected-summary.md"),
+            encoding: .utf8
+        )
+        #expect(summary.formatMarkdown() == expectedMarkdown)
+
+        let encoded = try summary.toJSON(prettyPrinted: true)
+        let decoded = try JSONDecoder().decode(
+            AgentLoopRegressionLabSummary.self,
+            from: encoded
+        )
+        #expect(decoded.regressions.first?.toolErrorDelta == 1)
+        #expect(decoded.newCases.map(\.id) == ["agent_loop.new-stable"])
+        #expect(decoded.removedCases.map(\.id) == ["agent_loop.removed-case"])
+    }
+
+    @Test func suiteValidationRejectsNonAgentLoopSelections() {
+        let suite = EvalSuite(
+            directory: URL(fileURLWithPath: "/tmp/MixedSuite", isDirectory: true),
+            cases: [
+                makeCase(id: "agent_loop.ok", domain: "agent_loop"),
+                makeCase(id: "schema.minimum-bound", domain: "schema"),
+            ]
+        )
+
+        #expect(throws: AgentLoopRegressionLabError.self) {
+            try AgentLoopRegressionLab.validateAgentLoopSuite(suite, filter: nil)
+        }
+    }
+
+    @Test func suiteValidationHonorsFilterBeforeRejecting() throws {
+        let suite = EvalSuite(
+            directory: URL(fileURLWithPath: "/tmp/MixedSuite", isDirectory: true),
+            cases: [
+                makeCase(id: "agent_loop.ok", domain: "agent_loop"),
+                makeCase(id: "schema.minimum-bound", domain: "schema"),
+            ]
+        )
+
+        try AgentLoopRegressionLab.validateAgentLoopSuite(suite, filter: "agent_loop.ok")
+    }
+
+    @Test func reportSetFilteringKeepsBaselineAndCurrentAligned() throws {
+        let fixtures = try fixturesURL()
+        let baseline = try AgentLoopRegressionReportSet.load(
+            from: fixtures.appendingPathComponent("baseline.json"),
+            label: "fixture baseline"
+        ).filteringCaseIDs(containing: "search-then")
+        let current = try AgentLoopRegressionReportSet.load(
+            from: fixtures.appendingPathComponent("current.json"),
+            label: "fixture current"
+        ).filteringCaseIDs(containing: "search-then")
+
+        let summary = try AgentLoopRegressionLab.compare(
+            baseline: baseline,
+            current: current,
+            generatedAt: "2026-06-18T12:00:00Z"
+        )
+
+        #expect(summary.baselineCounts.total == 1)
+        #expect(summary.currentCounts.total == 1)
+        #expect(summary.regressions.map(\.id) == ["agent_loop.search-then-multi-file-edit"])
+        #expect(summary.removedCases.isEmpty)
+    }
+
+    private func fixturesURL() throws -> URL {
+        try #require(Bundle.module.resourceURL)
+            .appendingPathComponent("Fixtures/AgentLoopRegressionLab", isDirectory: true)
+    }
+
+    private func makeCase(id: String, domain: String) -> EvalCase {
+        EvalCase(
+            id: id,
+            domain: domain,
+            query: "query",
+            fixtures: .init(),
+            expect: .init(agentLoop: domain == "agent_loop" ? .init() : nil)
+        )
+    }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/baseline.json
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/baseline.json
@@ -1,0 +1,88 @@
+{
+  "cases": [
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.edit-file-then-verify",
+      "label": "agent loop edit file",
+      "latencyMs": 1000,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "fix a typo",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_read" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_write" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "complete" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.search-then-multi-file-edit",
+      "label": "agent loop search then edit",
+      "latencyMs": 2200,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "rename API calls",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_search" },
+        { "calls": 2, "deduped": 0, "errors": 0, "tool": "file_edit" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "shell_run" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "complete" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.compaction-stress",
+      "label": "agent loop compaction",
+      "latencyMs": 5000,
+      "modelId": "foundation",
+      "notes": [
+        "finalText missing 'log4'"
+      ],
+      "outcome": "failed",
+      "query": "summarize logs",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "todo" },
+        { "calls": 3, "deduped": 0, "errors": 0, "tool": "file_read" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.legacy-case",
+      "label": "agent loop legacy failure",
+      "latencyMs": 1200,
+      "modelId": "foundation",
+      "notes": [
+        "old known failure"
+      ],
+      "outcome": "failed",
+      "query": "legacy failing task",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 1, "tool": "file_read" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.removed-case",
+      "label": "agent loop removed",
+      "latencyMs": 800,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "removed task"
+    },
+    {
+      "domain": "capability_search",
+      "id": "capability_search.browser-prefix",
+      "label": "ignored non-agent row",
+      "latencyMs": 3,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "browser"
+    }
+  ],
+  "modelId": "foundation",
+  "startedAt": "2026-06-17T00:00:00Z"
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/current.json
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/current.json
@@ -1,0 +1,90 @@
+{
+  "cases": [
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.edit-file-then-verify",
+      "label": "agent loop edit file",
+      "latencyMs": 900,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "fix a typo",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_read" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_write" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "complete" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.search-then-multi-file-edit",
+      "label": "agent loop search then edit",
+      "latencyMs": 2400,
+      "modelId": "foundation",
+      "notes": [
+        "command exit mismatch: grep fetchDataV1 exited 0",
+        "finalText missing 'updated imports'"
+      ],
+      "outcome": "failed",
+      "query": "rename API calls",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_search" },
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "file_edit" },
+        { "calls": 1, "deduped": 0, "errors": 1, "tool": "shell_run" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.compaction-stress",
+      "label": "agent loop compaction",
+      "latencyMs": 4500,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "summarize logs",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 0, "tool": "todo" },
+        { "calls": 3, "deduped": 0, "errors": 0, "tool": "file_read" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.legacy-case",
+      "label": "agent loop legacy failure",
+      "latencyMs": 1500,
+      "modelId": "foundation",
+      "notes": [
+        "still fails: stale summary"
+      ],
+      "outcome": "failed",
+      "query": "legacy failing task",
+      "toolUsage": [
+        { "calls": 1, "deduped": 0, "errors": 1, "tool": "file_read" }
+      ]
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.write-new-file",
+      "label": "agent loop write new file",
+      "latencyMs": 700,
+      "modelId": "foundation",
+      "notes": [
+        "agent loop error: tool schema unavailable"
+      ],
+      "outcome": "errored",
+      "query": "write TODO"
+    },
+    {
+      "domain": "agent_loop",
+      "id": "agent_loop.new-stable",
+      "label": "agent loop new stable",
+      "latencyMs": 600,
+      "modelId": "foundation",
+      "notes": [],
+      "outcome": "passed",
+      "query": "new passing task"
+    }
+  ],
+  "modelId": "foundation",
+  "startedAt": "2026-06-18T00:00:00Z"
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/expected-summary.md
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/expected-summary.md
@@ -1,0 +1,47 @@
+# Agent Loop Regression Lab
+
+- Verdict: REGRESSED: 1 regression(s), 1 new failing case(s)
+- Generated: 2026-06-18T12:00:00Z
+- Baseline: fixture baseline (foundation, 2026-06-17T00:00:00Z)
+- Current: fixture current (foundation, 2026-06-18T00:00:00Z)
+
+## Totals
+
+| Bucket | Baseline | Current |
+| --- | ---: | ---: |
+| total | 5 | 6 |
+| passed | 3 | 3 |
+| failed | 2 | 2 |
+| errored | 0 | 1 |
+| skipped | 0 | 0 |
+
+## Blocking Regressions
+
+| Case | Baseline | Current | Latency | Tools | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| agent_loop.search-then-multi-file-edit | passed | failed | +200ms | calls -2, errors +1 | command exit mismatch: grep fetchDataV1 exited 0 / finalText missing 'updated imports' |
+
+## New Failing Cases
+
+| Case | Baseline | Current | Latency | Tools | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| agent_loop.write-new-file | missing | errored | - | - | agent loop error: tool schema unavailable |
+
+## Fixed Cases
+
+| Case | Baseline | Current | Latency | Tools | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| agent_loop.compaction-stress | failed | passed | -500ms | calls +0, errors +0 | finalText missing 'log4' |
+
+## Persistent Failures
+
+| Case | Baseline | Current | Latency | Tools | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| agent_loop.legacy-case | failed | failed | +300ms | calls +0, errors +0 | still fails: stale summary |
+
+## Suite Drift
+
+| Case | Baseline | Current | Latency | Tools | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| agent_loop.new-stable | missing | passed | - | - | - |
+| agent_loop.removed-case | passed | missing | - | - | - |

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -583,14 +583,19 @@ export OPENROUTER_API_KEY=. # openrouter/<model>
 # 2. Optional: fixed judge for cross-model comparability
 export JUDGE_MODEL=xai/grok-4.3   # needs XAI_API_KEY
 
-# 3. Run both suites
-swift run --package-path Packages/OsaurusEvals osaurus-evals run \
-  --suite Packages/OsaurusEvals/Suites/AgentLoopFrontier \
-  --model <prefix>/<model-id> --out build/eval-reports/<model>-frontier.json
-swift run --package-path Packages/OsaurusEvals osaurus-evals run \
-  --suite Packages/OsaurusEvals/Suites/AgentLoop \
-  --model <prefix>/<model-id> --out build/eval-reports/<model>-agentloop.json
+# 3. Run the regression lab against a saved baseline
+scripts/evals/agent-loop-regression-lab.sh \
+  --baseline build/eval-baselines/<model>/agent-loop \
+  --model <prefix>/<model-id> \
+  --out-dir build/eval-reports/<model>-agent-loop-lab
 ```
+
+The lab runs `AgentLoop` and `AgentLoopFrontier` by default, captures raw
+per-suite JSON under `reports/`, and writes `regression-summary.json` plus
+`regression-summary.md`. Use the Markdown summary as the short proof block for
+new rows; keep the JSON paths for failure attribution and later comparisons. To
+compare already-captured reports without rerunning a model, pass `--current
+<path>` alongside `--baseline <path>`.
 
 Keys ride in ephemeral in-memory providers — never written to disk or
 Keychain. New providers need a preset in

--- a/scripts/evals/agent-loop-regression-lab.sh
+++ b/scripts/evals/agent-loop-regression-lab.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Run the Osaurus agent-loop eval regression lab.
+
+Usage:
+  scripts/evals/agent-loop-regression-lab.sh --baseline <path> [--suite <dir> ...] [--model <id>]
+  scripts/evals/agent-loop-regression-lab.sh --baseline <path> --current <path> [--out-dir <dir>]
+
+By default the CLI runs Packages/OsaurusEvals/Suites/AgentLoop and
+Packages/OsaurusEvals/Suites/AgentLoopFrontier, writes per-suite JSON reports,
+and emits regression-summary.json plus regression-summary.md under
+build/evals/agent-loop-regression-lab/<timestamp>.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+cd "${REPO_ROOT}"
+exec swift run --package-path Packages/OsaurusEvals osaurus-evals agent-loop-lab "$@"


### PR DESCRIPTION
## Summary
- Adds an agent-loop regression lab to compare baseline and current eval artifacts.
- Adds CLI support, fixtures, tests, and a helper script for producing regression reports.
- Documents how to use the lab for harness compatibility review.

## Validation
- `git diff --check`
- `swift test --package-path Packages/OsaurusEvals`
- `swift run --package-path Packages/OsaurusEvals osaurus-evals agent-loop-lab --baseline Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/baseline.json --current Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/current.json --out-dir build/evals/lab-smoke`

## Notes
- The lab consumes eval artifacts; it does not alter runtime prompting or parser behavior.
