### PR TITLE
Add router account usage center

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -59944,6 +59944,144 @@
           }
         }
       }
+    },
+    "Account Status" : {
+      "shouldTranslate" : false
+    },
+    "Account details" : {
+      "shouldTranslate" : false
+    },
+    "Account status, usage activity, signed request diagnostics, and support export." : {
+      "shouldTranslate" : false
+    },
+    "Balance" : {
+      "shouldTranslate" : false
+    },
+    "Billing" : {
+      "shouldTranslate" : false
+    },
+    "Billing Ledger" : {
+      "shouldTranslate" : false
+    },
+    "Body SHA-256" : {
+      "shouldTranslate" : false
+    },
+    "Bytes" : {
+      "shouldTranslate" : false
+    },
+    "Credits Activity" : {
+      "shouldTranslate" : false
+    },
+    "Export Router Support Bundle" : {
+      "shouldTranslate" : false
+    },
+    "Flagged" : {
+      "shouldTranslate" : false
+    },
+    "Identity required" : {
+      "shouldTranslate" : false
+    },
+    "Input tokens" : {
+      "shouldTranslate" : false
+    },
+    "Ledger cost" : {
+      "shouldTranslate" : false
+    },
+    "Ledger rows" : {
+      "shouldTranslate" : false
+    },
+    "Loading activity" : {
+      "shouldTranslate" : false
+    },
+    "Local rows" : {
+      "shouldTranslate" : false
+    },
+    "Metadata only" : {
+      "shouldTranslate" : false
+    },
+    "Metadata only - no prompts, replies, tool payloads, private keys, or signatures." : {
+      "shouldTranslate" : false
+    },
+    "Missing" : {
+      "shouldTranslate" : false
+    },
+    "Net credits" : {
+      "shouldTranslate" : false
+    },
+    "No local ledger rows" : {
+      "shouldTranslate" : false
+    },
+    "No signed checks yet" : {
+      "shouldTranslate" : false
+    },
+    "No usage activity" : {
+      "shouldTranslate" : false
+    },
+    "Osaurus Router is off." : {
+      "shouldTranslate" : false
+    },
+    "Output tokens" : {
+      "shouldTranslate" : false
+    },
+    "Rendered" : {
+      "shouldTranslate" : false
+    },
+    "Requests" : {
+      "shouldTranslate" : false
+    },
+    "Router" : {
+      "shouldTranslate" : false
+    },
+    "Router Account" : {
+      "shouldTranslate" : false
+    },
+    "Router off" : {
+      "shouldTranslate" : false
+    },
+    "Router usage appears here after a hosted model request is billed." : {
+      "shouldTranslate" : false
+    },
+    "Run" : {
+      "shouldTranslate" : false
+    },
+    "Run a local signing check to inspect the redacted request shape." : {
+      "shouldTranslate" : false
+    },
+    "Signature" : {
+      "shouldTranslate" : false
+    },
+    "Signed Request Diagnostics" : {
+      "shouldTranslate" : false
+    },
+    "Signed request diagnostics refreshed." : {
+      "shouldTranslate" : false
+    },
+    "Support Export" : {
+      "shouldTranslate" : false
+    },
+    "The encrypted local billing ledger has no rows available." : {
+      "shouldTranslate" : false
+    },
+    "Top-ups" : {
+      "shouldTranslate" : false
+    },
+    "Transaction rows" : {
+      "shouldTranslate" : false
+    },
+    "Usage cost" : {
+      "shouldTranslate" : false
+    },
+    "Usage rows" : {
+      "shouldTranslate" : false
+    },
+    "Wallet" : {
+      "shouldTranslate" : false
+    },
+    "\\(snapshot.ledger.pendingCount) pending / \\(snapshot.ledger.issueCount) flagged" : {
+      "shouldTranslate" : false
+    },
+    "\\(snapshot.transactions.transactionCount) transaction(s)" : {
+      "shouldTranslate" : false
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/Router/OsaurusRouterAccountService.swift
+++ b/Packages/OsaurusCore/Services/Router/OsaurusRouterAccountService.swift
@@ -8,8 +8,11 @@ final class OsaurusRouterAccountService: ObservableObject {
     @Published private(set) var balance: OsaurusRouterBalanceResponse?
     @Published private(set) var usage: [OsaurusRouterUsageItem] = []
     @Published private(set) var nextUsageCursor: String?
+    @Published private(set) var transactions: [OsaurusRouterTransactionItem] = []
+    @Published private(set) var nextTransactionsCursor: String?
     @Published private(set) var isLoadingBalance = false
     @Published private(set) var isLoadingUsage = false
+    @Published private(set) var isLoadingTransactions = false
     @Published private(set) var isCreatingCheckout = false
     @Published var lastError: String?
 
@@ -62,6 +65,8 @@ final class OsaurusRouterAccountService: ObservableObject {
         balance = nil
         usage = []
         nextUsageCursor = nil
+        transactions = []
+        nextTransactionsCursor = nil
         lastError = nil
     }
 
@@ -128,6 +133,35 @@ final class OsaurusRouterAccountService: ObservableObject {
     func loadMoreUsage() async {
         guard nextUsageCursor != nil, !isLoadingUsage else { return }
         await refreshUsage(reset: false)
+    }
+
+    func refreshTransactions(reset: Bool = true) async {
+        guard OsaurusRouter.isEnabled else { return }
+        guard OsaurusIdentity.exists() else {
+            transactions = []
+            nextTransactionsCursor = nil
+            lastError = OsaurusRouterAPIError.noIdentity.localizedDescription
+            return
+        }
+
+        if reset {
+            nextTransactionsCursor = nil
+        }
+        isLoadingTransactions = true
+        defer { isLoadingTransactions = false }
+        do {
+            let response = try await client.transactions(limit: 50, cursor: reset ? nil : nextTransactionsCursor)
+            transactions = reset ? response.data : transactions + response.data
+            nextTransactionsCursor = response.nextCursor
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func loadMoreTransactions() async {
+        guard nextTransactionsCursor != nil, !isLoadingTransactions else { return }
+        await refreshTransactions(reset: false)
     }
 
     func createCheckout(amountMicro: Int = OsaurusRouter.minimumTopUpMicro) async -> URL? {

--- a/Packages/OsaurusCore/Services/Router/RouterAccountUsageCenter.swift
+++ b/Packages/OsaurusCore/Services/Router/RouterAccountUsageCenter.swift
@@ -1,0 +1,480 @@
+import Foundation
+
+struct RouterAccountStatusSnapshot: Codable, Equatable, Sendable {
+    enum State: String, Codable, Equatable, Sendable {
+        case active
+        case disabled
+        case missingIdentity
+        case frozen
+        case unavailable
+    }
+
+    let routerEnabled: Bool
+    let identityAvailable: Bool
+    let balanceMicro: String?
+    let formattedBalance: String
+    let frozen: Bool
+    let lastError: String?
+    let state: State
+    let generatedAt: Date
+
+    init(
+        routerEnabled: Bool,
+        identityAvailable: Bool,
+        balance: OsaurusRouterBalanceResponse?,
+        lastError: String?,
+        generatedAt: Date = Date()
+    ) {
+        self.routerEnabled = routerEnabled
+        self.identityAvailable = identityAvailable
+        self.balanceMicro = balance?.balanceMicro
+        self.formattedBalance = OsaurusRouter.formatMicroUSD(balance?.balanceMicro ?? "0")
+        self.frozen = balance?.frozen == true
+        self.lastError = lastError?.isEmpty == false ? lastError : nil
+        self.generatedAt = generatedAt
+
+        if !routerEnabled {
+            self.state = .disabled
+        } else if !identityAvailable {
+            self.state = .missingIdentity
+        } else if balance?.frozen == true {
+            self.state = .frozen
+        } else if balance != nil {
+            self.state = .active
+        } else {
+            self.state = .unavailable
+        }
+    }
+}
+
+struct RouterUsageBreakdown: Codable, Equatable, Sendable, Identifiable {
+    let name: String
+    let requestCount: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    let costMicro: String
+
+    var id: String { name }
+}
+
+struct RouterCreditsSummary: Codable, Equatable, Sendable {
+    let requestCount: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    let costMicro: String
+    let latestUsageAt: Date?
+    let providerBreakdown: [RouterUsageBreakdown]
+    let statusBreakdown: [RouterUsageBreakdown]
+    let modelBreakdown: [RouterUsageBreakdown]
+}
+
+struct RouterLedgerOutcomeBreakdown: Codable, Equatable, Sendable, Identifiable {
+    let outcome: RouterBillingOutcome
+    let entryCount: Int
+    let costMicro: String
+
+    var id: String { outcome.rawValue }
+}
+
+struct RouterLedgerSummary: Codable, Equatable, Sendable {
+    let entryCount: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    let costMicro: String
+    let latestEntryAt: Date?
+    let pendingCount: Int
+    let issueCount: Int
+    let outcomeBreakdown: [RouterLedgerOutcomeBreakdown]
+    let modelBreakdown: [RouterUsageBreakdown]
+}
+
+struct RouterTransactionBreakdown: Codable, Equatable, Sendable, Identifiable {
+    let entryType: String
+    let transactionCount: Int
+    let netAmountMicro: String
+
+    var id: String { entryType }
+}
+
+struct RouterTransactionSummary: Codable, Equatable, Sendable {
+    let transactionCount: Int
+    let creditMicro: String
+    let debitMicro: String
+    let netMicro: String
+    let latestTransactionAt: Date?
+    let entryTypeBreakdown: [RouterTransactionBreakdown]
+}
+
+struct RouterAccountUsageSnapshot: Codable, Equatable, Sendable {
+    let generatedAt: Date
+    let accountStatus: RouterAccountStatusSnapshot
+    let credits: RouterCreditsSummary
+    let transactions: RouterTransactionSummary
+    let ledger: RouterLedgerSummary
+}
+
+struct RouterSignedRequestDiagnostic: Codable, Equatable, Sendable, Identifiable {
+    let id: String
+    let generatedAt: Date
+    let method: String
+    let pathAndQuery: String
+    let bodySHA256: String
+    let bodyBytes: Int
+    let walletAddress: String?
+    let walletTimestamp: String?
+    let walletNonce: String?
+    let signatureFingerprint: String?
+    let signedHeaderNames: [String]
+    let redactedHeaders: [String: String]
+    let warnings: [String]
+
+    init(
+        request: URLRequest,
+        body: Data? = nil,
+        generatedAt: Date = Date()
+    ) {
+        let bodyData = body ?? request.httpBody ?? Data()
+        let headers = request.allHTTPHeaderFields ?? [:]
+        let method = (request.httpMethod ?? "GET").uppercased()
+        let pathAndQuery = request.url.map(OsaurusRouterAuthSigner.pathAndQuery(for:)) ?? ""
+        let address = Self.headerValue(headers, named: "x-wallet-address")?.lowercased()
+        let timestamp = Self.headerValue(headers, named: "x-wallet-timestamp")
+        let nonce = Self.headerValue(headers, named: "x-wallet-nonce")
+        let signature = Self.headerValue(headers, named: "x-wallet-signature")
+
+        self.id = "\(method):\(pathAndQuery):\(timestamp ?? "missing"):\(generatedAt.timeIntervalSince1970)"
+        self.generatedAt = generatedAt
+        self.method = method
+        self.pathAndQuery = pathAndQuery
+        self.bodySHA256 = OsaurusRouterAuthSigner.sha256Hex(bodyData)
+        self.bodyBytes = bodyData.count
+        self.walletAddress = address
+        self.walletTimestamp = timestamp
+        self.walletNonce = nonce?.isEmpty == false ? nonce : nil
+        self.signatureFingerprint = signature.map(Self.fingerprint)
+        self.signedHeaderNames = headers.keys.map { $0.lowercased() }.sorted()
+        self.redactedHeaders = Dictionary(
+            uniqueKeysWithValues: headers.map {
+                ($0.key.lowercased(), RouterAccountUsageCenter.redactedHeaderValue(headerName: $0.key, value: $0.value))
+            }
+        )
+
+        var warnings: [String] = []
+        if request.url == nil {
+            warnings.append("Missing URL")
+        }
+        for name in ["x-wallet-address", "x-wallet-timestamp", "x-wallet-signature"] {
+            if Self.headerValue(headers, named: name)?.isEmpty != false {
+                warnings.append("Missing \(name)")
+            }
+        }
+        self.warnings = warnings
+    }
+
+    private static func headerValue(_ headers: [String: String], named name: String) -> String? {
+        headers.first { $0.key.caseInsensitiveCompare(name) == .orderedSame }?.value
+    }
+
+    private static func fingerprint(_ value: String) -> String {
+        let digest = OsaurusRouterAuthSigner.sha256Hex(Data(value.utf8))
+        return "sha256:\(String(digest.prefix(16)))"
+    }
+}
+
+struct RouterSupportUsageItem: Codable, Equatable, Sendable {
+    let id: String
+    let requestId: String?
+    let model: String
+    let provider: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let costMicro: String
+    let status: String
+    let tokenSource: String
+    let createdAt: String
+
+    init(_ item: OsaurusRouterUsageItem) {
+        self.id = item.id
+        self.requestId = item.requestId
+        self.model = item.model
+        self.provider = item.provider
+        self.inputTokens = item.inputTokens
+        self.outputTokens = item.outputTokens
+        self.costMicro = item.costMicro
+        self.status = item.status
+        self.tokenSource = item.tokenSource
+        self.createdAt = item.createdAt
+    }
+}
+
+struct RouterSupportTransactionItem: Codable, Equatable, Sendable {
+    let id: String
+    let amountMicro: String
+    let entryType: String
+    let refType: String?
+    let refId: String?
+    let createdAt: String
+
+    init(_ item: OsaurusRouterTransactionItem) {
+        self.id = item.id
+        self.amountMicro = item.amountMicro
+        self.entryType = item.entryType
+        self.refType = item.refType
+        self.refId = item.refId
+        self.createdAt = item.createdAt
+    }
+}
+
+struct RouterSupportLedgerEntry: Codable, Equatable, Sendable {
+    let id: String
+    let requestId: String?
+    let createdAt: Date
+    let sessionId: String?
+    let turnId: String?
+    let model: String?
+    let tokenSource: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let costMicro: String
+    let status: String
+    let outcome: RouterBillingOutcome
+    let appVersion: String?
+
+    init(_ entry: RouterBillingEntry) {
+        self.id = entry.id
+        self.requestId = entry.requestId
+        self.createdAt = entry.createdAt
+        self.sessionId = entry.sessionId
+        self.turnId = entry.turnId
+        self.model = entry.model
+        self.tokenSource = entry.tokenSource
+        self.inputTokens = entry.inputTokens
+        self.outputTokens = entry.outputTokens
+        self.costMicro = entry.costMicro
+        self.status = entry.status
+        self.outcome = entry.outcome
+        self.appVersion = entry.appVersion
+    }
+}
+
+struct RouterSupportExport: Codable, Equatable, Sendable {
+    static let schemaVersion = 1
+
+    let schemaVersion: Int
+    let generatedAt: Date
+    let walletAddress: String?
+    let account: RouterAccountUsageSnapshot
+    let signedRequestDiagnostics: [RouterSignedRequestDiagnostic]
+    let usage: [RouterSupportUsageItem]
+    let transactions: [RouterSupportTransactionItem]
+    let ledgerEntries: [RouterSupportLedgerEntry]
+    let redaction: [String]
+}
+
+enum RouterAccountUsageCenter {
+    static let redactedValue = "<redacted>"
+
+    static func snapshot(
+        routerEnabled: Bool,
+        identityAvailable: Bool,
+        balance: OsaurusRouterBalanceResponse?,
+        lastError: String?,
+        usageItems: [OsaurusRouterUsageItem],
+        transactions: [OsaurusRouterTransactionItem],
+        ledgerEntries: [RouterBillingEntry],
+        generatedAt: Date = Date()
+    ) -> RouterAccountUsageSnapshot {
+        RouterAccountUsageSnapshot(
+            generatedAt: generatedAt,
+            accountStatus: RouterAccountStatusSnapshot(
+                routerEnabled: routerEnabled,
+                identityAvailable: identityAvailable,
+                balance: balance,
+                lastError: lastError,
+                generatedAt: generatedAt
+            ),
+            credits: creditsSummary(usageItems),
+            transactions: transactionSummary(transactions),
+            ledger: ledgerSummary(ledgerEntries)
+        )
+    }
+
+    static func creditsSummary(_ usageItems: [OsaurusRouterUsageItem]) -> RouterCreditsSummary {
+        RouterCreditsSummary(
+            requestCount: usageItems.count,
+            inputTokens: usageItems.reduce(0) { $0 + $1.inputTokens },
+            outputTokens: usageItems.reduce(0) { $0 + $1.outputTokens },
+            costMicro: String(sumMicro(usageItems.map(\.costMicro))),
+            latestUsageAt: usageItems.compactMap { CreditsActivityProjector.date(fromRouterTimestamp: $0.createdAt) }.max(),
+            providerBreakdown: usageBreakdown(usageItems, key: \.provider),
+            statusBreakdown: usageBreakdown(usageItems, key: \.status),
+            modelBreakdown: usageBreakdown(usageItems, key: \.model)
+        )
+    }
+
+    static func ledgerSummary(_ entries: [RouterBillingEntry]) -> RouterLedgerSummary {
+        let outcomeBreakdown = Dictionary(grouping: entries, by: \.outcome)
+            .map { outcome, rows in
+                RouterLedgerOutcomeBreakdown(
+                    outcome: outcome,
+                    entryCount: rows.count,
+                    costMicro: String(sumMicro(rows.map(\.costMicro)))
+                )
+            }
+            .sorted {
+                if $0.entryCount != $1.entryCount { return $0.entryCount > $1.entryCount }
+                return $0.outcome.rawValue < $1.outcome.rawValue
+            }
+
+        let issueOutcomes: Set<RouterBillingOutcome> = [.empty, .error, .cancelled]
+
+        return RouterLedgerSummary(
+            entryCount: entries.count,
+            inputTokens: entries.reduce(0) { $0 + $1.inputTokens },
+            outputTokens: entries.reduce(0) { $0 + $1.outputTokens },
+            costMicro: String(sumMicro(entries.map(\.costMicro))),
+            latestEntryAt: entries.map(\.createdAt).max(),
+            pendingCount: entries.filter { $0.outcome == .pending }.count,
+            issueCount: entries.filter { issueOutcomes.contains($0.outcome) }.count,
+            outcomeBreakdown: outcomeBreakdown,
+            modelBreakdown: ledgerModelBreakdown(entries)
+        )
+    }
+
+    static func transactionSummary(_ transactions: [OsaurusRouterTransactionItem]) -> RouterTransactionSummary {
+        let amounts = transactions.map { microValue($0.amountMicro) }
+        let credits = amounts.filter { $0 > 0 }.reduce(0, +)
+        let debits = amounts.filter { $0 < 0 }.reduce(0, +)
+        let entryTypeBreakdown = Dictionary(grouping: transactions, by: { normalizedName($0.entryType) })
+            .map { entryType, rows in
+                RouterTransactionBreakdown(
+                    entryType: entryType,
+                    transactionCount: rows.count,
+                    netAmountMicro: String(sumMicro(rows.map(\.amountMicro)))
+                )
+            }
+            .sorted {
+                if $0.transactionCount != $1.transactionCount { return $0.transactionCount > $1.transactionCount }
+                return $0.entryType < $1.entryType
+            }
+
+        return RouterTransactionSummary(
+            transactionCount: transactions.count,
+            creditMicro: String(credits),
+            debitMicro: String(abs(debits)),
+            netMicro: String(credits + debits),
+            latestTransactionAt: transactions.compactMap { CreditsActivityProjector.date(fromRouterTimestamp: $0.createdAt) }.max(),
+            entryTypeBreakdown: entryTypeBreakdown
+        )
+    }
+
+    static func supportExport(
+        walletAddress: String?,
+        snapshot: RouterAccountUsageSnapshot,
+        signedDiagnostics: [RouterSignedRequestDiagnostic],
+        usageItems: [OsaurusRouterUsageItem],
+        transactions: [OsaurusRouterTransactionItem],
+        ledgerEntries: [RouterBillingEntry],
+        generatedAt: Date = Date()
+    ) -> RouterSupportExport {
+        RouterSupportExport(
+            schemaVersion: RouterSupportExport.schemaVersion,
+            generatedAt: generatedAt,
+            walletAddress: walletAddress?.lowercased(),
+            account: snapshot,
+            signedRequestDiagnostics: signedDiagnostics,
+            usage: usageItems.map(RouterSupportUsageItem.init),
+            transactions: transactions.map(RouterSupportTransactionItem.init),
+            ledgerEntries: ledgerEntries.map(RouterSupportLedgerEntry.init),
+            redaction: [
+                "Prompt text, response text, tool arguments, tool results, private keys, bearer tokens, cookies, and wallet signatures are not exported.",
+                "Signed request diagnostics include request shape, body hash, signed header names, and a signature fingerprint only.",
+            ]
+        )
+    }
+
+    static func redactedHeaderValue(headerName: String, value: String) -> String {
+        let lowered = headerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if lowered == "x-wallet-signature" {
+            return redactedValue
+        }
+        if isSensitiveHeader(lowered) {
+            return redactedValue
+        }
+        if lowered == "x-wallet-address" {
+            return value.lowercased()
+        }
+        return value
+    }
+
+    private static func isSensitiveHeader(_ loweredName: String) -> Bool {
+        loweredName == "authorization"
+            || loweredName == "cookie"
+            || loweredName == "set-cookie"
+            || loweredName.contains("api-key")
+            || loweredName.contains("apikey")
+            || loweredName.contains("token")
+            || loweredName.contains("secret")
+            || loweredName.contains("private")
+            || loweredName.contains("signature")
+    }
+
+    private static func usageBreakdown(
+        _ usageItems: [OsaurusRouterUsageItem],
+        key: (OsaurusRouterUsageItem) -> String
+    ) -> [RouterUsageBreakdown] {
+        Dictionary(grouping: usageItems, by: { normalizedName(key($0)) })
+            .map { name, rows in
+                RouterUsageBreakdown(
+                    name: name,
+                    requestCount: rows.count,
+                    inputTokens: rows.reduce(0) { $0 + $1.inputTokens },
+                    outputTokens: rows.reduce(0) { $0 + $1.outputTokens },
+                    costMicro: String(sumMicro(rows.map(\.costMicro)))
+                )
+            }
+            .sorted(by: breakdownSort)
+    }
+
+    private static func ledgerModelBreakdown(_ entries: [RouterBillingEntry]) -> [RouterUsageBreakdown] {
+        Dictionary(grouping: entries, by: { normalizedName($0.model ?? "") })
+            .map { name, rows in
+                RouterUsageBreakdown(
+                    name: name,
+                    requestCount: rows.count,
+                    inputTokens: rows.reduce(0) { $0 + $1.inputTokens },
+                    outputTokens: rows.reduce(0) { $0 + $1.outputTokens },
+                    costMicro: String(sumMicro(rows.map(\.costMicro)))
+                )
+            }
+            .sorted(by: breakdownSort)
+    }
+
+    private static func breakdownSort(_ lhs: RouterUsageBreakdown, _ rhs: RouterUsageBreakdown) -> Bool {
+        let lhsCost = microValue(lhs.costMicro)
+        let rhsCost = microValue(rhs.costMicro)
+        if lhsCost != rhsCost { return lhsCost > rhsCost }
+        if lhs.requestCount != rhs.requestCount { return lhs.requestCount > rhs.requestCount }
+        return lhs.name < rhs.name
+    }
+
+    private static func normalizedName(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    private static func sumMicro(_ values: [String]) -> Int64 {
+        values.reduce(Int64(0)) { partial, raw in
+            let value = microValue(raw)
+            let (sum, overflow) = partial.addingReportingOverflow(value)
+            if overflow {
+                return value >= 0 ? Int64.max : Int64.min
+            }
+            return sum
+        }
+    }
+
+    static func microValue(_ raw: String) -> Int64 {
+        Int64(raw.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+}

--- a/Packages/OsaurusCore/Services/Router/RouterAccountUsageCenter.swift
+++ b/Packages/OsaurusCore/Services/Router/RouterAccountUsageCenter.swift
@@ -257,12 +257,19 @@ struct RouterSupportLedgerEntry: Codable, Equatable, Sendable {
     }
 }
 
+public enum RouterSupportWalletAddressStatus: String, Codable, Equatable, Sendable {
+    case available
+    case identityMissing = "identity_missing"
+    case unavailableWithoutPrompt = "unavailable_without_prompt"
+}
+
 struct RouterSupportExport: Codable, Equatable, Sendable {
-    static let schemaVersion = 1
+    static let schemaVersion = 2
 
     let schemaVersion: Int
     let generatedAt: Date
     let walletAddress: String?
+    let walletAddressStatus: RouterSupportWalletAddressStatus
     let account: RouterAccountUsageSnapshot
     let signedRequestDiagnostics: [RouterSignedRequestDiagnostic]
     let usage: [RouterSupportUsageItem]
@@ -377,10 +384,19 @@ enum RouterAccountUsageCenter {
         ledgerEntries: [RouterBillingEntry],
         generatedAt: Date = Date()
     ) -> RouterSupportExport {
-        RouterSupportExport(
+        let resolvedWalletAddress = nonPromptingWalletAddress(
+            explicitWalletAddress: walletAddress,
+            signedDiagnostics: signedDiagnostics
+        )
+
+        return RouterSupportExport(
             schemaVersion: RouterSupportExport.schemaVersion,
             generatedAt: generatedAt,
-            walletAddress: walletAddress?.lowercased(),
+            walletAddress: resolvedWalletAddress,
+            walletAddressStatus: walletAddressStatus(
+                walletAddress: resolvedWalletAddress,
+                snapshot: snapshot
+            ),
             account: snapshot,
             signedRequestDiagnostics: signedDiagnostics,
             usage: usageItems.map(RouterSupportUsageItem.init),
@@ -389,8 +405,35 @@ enum RouterAccountUsageCenter {
             redaction: [
                 "Prompt text, response text, tool arguments, tool results, private keys, bearer tokens, cookies, and wallet signatures are not exported.",
                 "Signed request diagnostics include request shape, body hash, signed header names, and a signature fingerprint only.",
+                "Support export does not prompt for biometric authentication; walletAddress is populated only from non-prompting sources.",
             ]
         )
+    }
+
+    static func nonPromptingWalletAddress(
+        explicitWalletAddress: String?,
+        signedDiagnostics: [RouterSignedRequestDiagnostic]
+    ) -> String? {
+        if let explicit = normalizedWalletAddress(explicitWalletAddress) {
+            return explicit
+        }
+
+        return signedDiagnostics.lazy
+            .compactMap { normalizedWalletAddress($0.walletAddress) }
+            .first
+    }
+
+    static func walletAddressStatus(
+        walletAddress: String?,
+        snapshot: RouterAccountUsageSnapshot
+    ) -> RouterSupportWalletAddressStatus {
+        if normalizedWalletAddress(walletAddress) != nil {
+            return .available
+        }
+        if !snapshot.accountStatus.identityAvailable {
+            return .identityMissing
+        }
+        return .unavailableWithoutPrompt
     }
 
     static func redactedHeaderValue(headerName: String, value: String) -> String {
@@ -405,6 +448,13 @@ enum RouterAccountUsageCenter {
             return value.lowercased()
         }
         return value
+    }
+
+    private static func normalizedWalletAddress(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.lowercased()
     }
 
     private static func isSensitiveHeader(_ loweredName: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Router/RouterBillingLedger.swift
+++ b/Packages/OsaurusCore/Services/Router/RouterBillingLedger.swift
@@ -123,34 +123,41 @@ public final class RouterBillingLedger: @unchecked Sendable {
 
     /// Current export schema. Bump when the diagnostics shape changes so support
     /// tooling can branch on it.
-    public static let diagnosticsSchemaVersion = 1
+    public static let diagnosticsSchemaVersion = 2
 
     /// Metadata-only diagnostics bundle for support. Composed solely of
     /// `RouterBillingEntry` rows (no prompt/response text by construction) plus
-    /// environment tags and the public wallet address for server correlation.
+    /// environment tags and optional public wallet-address correlation status.
     public struct Diagnostics: Codable, Sendable {
         public let schemaVersion: Int
         public let generatedAt: Date
         public let appVersion: String?
         public let osVersion: String
         /// Public Osaurus ID (wallet address) the router bills, for server-side
-        /// correlation. Best-effort: nil when the identity couldn't be read.
+        /// correlation. Nil when no non-prompting source is available.
         public let walletAddress: String?
+        /// Explains why `walletAddress` is present or absent. Support exports
+        /// should not trigger biometric auth only to fill the address.
+        public let walletAddressStatus: RouterSupportWalletAddressStatus
         public let entries: [RouterBillingEntry]
     }
 
-    /// Build a metadata-only diagnostics bundle. `walletAddress` is supplied by
-    /// the caller (read from identity) so this layer never touches the Keychain.
+    /// Build a metadata-only diagnostics bundle. `walletAddress`, when present,
+    /// is supplied by the caller from a non-prompting source so this layer never
+    /// touches the Keychain.
     public func buildDiagnostics(
         walletAddress: String?,
+        walletAddressStatus: RouterSupportWalletAddressStatus? = nil,
         limit: Int = RouterBillingDatabase.maxRows
     ) -> Diagnostics {
-        Diagnostics(
+        let hasWalletAddress = walletAddress?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        return Diagnostics(
             schemaVersion: Self.diagnosticsSchemaVersion,
             generatedAt: Date(),
             appVersion: Self.appVersion,
             osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
             walletAddress: walletAddress,
+            walletAddressStatus: walletAddressStatus ?? (hasWalletAddress ? .available : .unavailableWithoutPrompt),
             entries: recent(limit: limit)
         )
     }

--- a/Packages/OsaurusCore/Tests/Router/OsaurusRouterAPIClientTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/OsaurusRouterAPIClientTests.swift
@@ -93,6 +93,26 @@ struct OsaurusRouterAPIClientTests {
         #expect(response.nextCursor == nil)
     }
 
+    @Test func transactions_includesCursorAndDecodesLedgerItems() async throws {
+        let client = try makeClient { request in
+            #expect(request.url?.path == "/credits/transactions")
+            #expect(request.url?.query?.contains("limit=3") == true)
+            #expect(request.url?.query?.contains("cursor=cursor-2") == true)
+            return json(
+                """
+                {"data":[{"id":"tx_1","amount_micro":"5000000","entry_type":"topup","ref_type":"stripe_checkout","ref_id":"cs_test","created_at":"2026-06-13T18:00:00Z"}],"next_cursor":"cursor-3"}
+                """
+            )
+        }
+
+        let response = try await client.transactions(limit: 3, cursor: "cursor-2")
+        #expect(response.data.count == 1)
+        #expect(response.data[0].amountMicro == "5000000")
+        #expect(response.data[0].entryType == "topup")
+        #expect(response.data[0].refType == "stripe_checkout")
+        #expect(response.nextCursor == "cursor-3")
+    }
+
     @Test func errorEnvelope_mapsInsufficientFunds() async throws {
         let client = try makeClient { _ in
             json(#"{"error":{"code":"INSUFFICIENT_FUNDS","message":"top up required"}}"#, status: 402)

--- a/Packages/OsaurusCore/Tests/Router/RouterAccountUsageCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/RouterAccountUsageCenterTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Router account usage center")
+struct RouterAccountUsageCenterTests {
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private static let timestamp = ISO8601DateFormatter().string(from: now)
+
+    @Test func snapshot_summarizesAccountUsageTransactionsAndLedger() throws {
+        let usageItems = [
+            usage(id: "u1", model: "venice/minimax-m3", provider: "venice", cost: "1250"),
+            usage(id: "u2", model: "openai/gpt-4.1", provider: "openai", cost: "2000", status: "error"),
+        ]
+        let transactions = [
+            transaction(id: "tx-topup", amount: "5000000", entryType: "topup"),
+            transaction(id: "tx-charge", amount: "-3250", entryType: "usage_charge"),
+        ]
+        let ledgerEntries = [
+            ledger(id: "l1", cost: "1250", outcome: .rendered),
+            ledger(id: "l2", cost: "2000", outcome: .empty),
+            ledger(id: "l3", cost: "0", outcome: .pending),
+        ]
+
+        let snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "7000000", frozen: false),
+            lastError: nil,
+            usageItems: usageItems,
+            transactions: transactions,
+            ledgerEntries: ledgerEntries,
+            generatedAt: Self.now
+        )
+
+        #expect(snapshot.accountStatus.state == .active)
+        #expect(snapshot.accountStatus.formattedBalance == "$7.00")
+        #expect(snapshot.credits.requestCount == 2)
+        #expect(snapshot.credits.costMicro == "3250")
+        #expect(snapshot.credits.inputTokens == 22)
+        #expect(snapshot.transactions.creditMicro == "5000000")
+        #expect(snapshot.transactions.debitMicro == "3250")
+        #expect(snapshot.transactions.netMicro == "4996750")
+        #expect(snapshot.ledger.entryCount == 3)
+        #expect(snapshot.ledger.costMicro == "3250")
+        #expect(snapshot.ledger.pendingCount == 1)
+        #expect(snapshot.ledger.issueCount == 1)
+        #expect(snapshot.ledger.outcomeBreakdown.map(\.outcome).contains(.empty))
+    }
+
+    @Test func accountStatus_distinguishesDisabledMissingIdentityAndFrozen() {
+        let disabled = RouterAccountUsageCenter.snapshot(
+            routerEnabled: false,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "1", frozen: false),
+            lastError: nil,
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+        #expect(disabled.accountStatus.state == .disabled)
+
+        let missingIdentity = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: false,
+            balance: nil,
+            lastError: nil,
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+        #expect(missingIdentity.accountStatus.state == .missingIdentity)
+
+        let frozen = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "1", frozen: true),
+            lastError: nil,
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+        #expect(frozen.accountStatus.state == .frozen)
+    }
+
+    @Test func signedRequestDiagnostic_redactsSensitiveHeadersAndFingerprintsSignature() throws {
+        let url = try #require(URL(string: "https://router.osaurus.ai/credits/balance"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("0xABCDEF", forHTTPHeaderField: "x-wallet-address")
+        request.setValue("1717171717", forHTTPHeaderField: "x-wallet-timestamp")
+        request.setValue("0x" + String(repeating: "a", count: 130), forHTTPHeaderField: "x-wallet-signature")
+        request.setValue("Bearer secret-token", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let diagnostic = RouterSignedRequestDiagnostic(request: request, body: Data())
+
+        #expect(diagnostic.walletAddress == "0xabcdef")
+        #expect(diagnostic.signatureFingerprint?.hasPrefix("sha256:") == true)
+        #expect(diagnostic.signatureFingerprint != "0x" + String(repeating: "a", count: 130))
+        #expect(diagnostic.redactedHeaders["x-wallet-signature"] == RouterAccountUsageCenter.redactedValue)
+        #expect(diagnostic.redactedHeaders["authorization"] == RouterAccountUsageCenter.redactedValue)
+        #expect(diagnostic.redactedHeaders["accept"] == "application/json")
+        #expect(diagnostic.warnings.isEmpty)
+    }
+
+    @Test func supportExport_isMetadataOnlyAndDoesNotLeakSecrets() throws {
+        let secretSignature = "0x" + String(repeating: "b", count: 130)
+        let bearer = "Bearer live-secret-token"
+        let url = try #require(URL(string: "https://router.osaurus.ai/credits/estimate"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = Data(#"{"prompt":"do not export"}"#.utf8)
+        request.setValue("0xABCDEF", forHTTPHeaderField: "x-wallet-address")
+        request.setValue("1717171717", forHTTPHeaderField: "x-wallet-timestamp")
+        request.setValue(secretSignature, forHTTPHeaderField: "x-wallet-signature")
+        request.setValue(bearer, forHTTPHeaderField: "Authorization")
+        let diagnostic = RouterSignedRequestDiagnostic(request: request, body: request.httpBody)
+        let snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "7000000", frozen: false),
+            lastError: nil,
+            usageItems: [usage()],
+            transactions: [transaction()],
+            ledgerEntries: [ledger()]
+        )
+
+        let export = RouterAccountUsageCenter.supportExport(
+            walletAddress: "0xABCDEF",
+            snapshot: snapshot,
+            signedDiagnostics: [diagnostic],
+            usageItems: [usage()],
+            transactions: [transaction()],
+            ledgerEntries: [ledger()]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let payload = String(decoding: try encoder.encode(export), as: UTF8.self)
+
+        #expect(!payload.contains(secretSignature))
+        #expect(!payload.contains(bearer))
+        #expect(!payload.contains("live-secret-token"))
+        #expect(!payload.contains("do not export"))
+        #expect(!payload.contains(#""prompt""#))
+        #expect(payload.contains(RouterAccountUsageCenter.redactedValue))
+        #expect(export.walletAddress == "0xabcdef")
+        #expect(export.usage.count == 1)
+        #expect(export.ledgerEntries.count == 1)
+    }
+
+    private func usage(
+        id: String = "usage-1",
+        requestId: String? = "run-1",
+        model: String = "venice/minimax-m3",
+        provider: String = "venice",
+        inputTokens: Int = 11,
+        outputTokens: Int = 7,
+        cost: String = "1250",
+        status: String = "completed",
+        tokenSource: String = "provider",
+        createdAt: String = RouterAccountUsageCenterTests.timestamp
+    ) -> OsaurusRouterUsageItem {
+        OsaurusRouterUsageItem(
+            id: id,
+            requestId: requestId,
+            model: model,
+            provider: provider,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            costMicro: cost,
+            status: status,
+            tokenSource: tokenSource,
+            createdAt: createdAt
+        )
+    }
+
+    private func transaction(
+        id: String = "tx-1",
+        amount: String = "5000000",
+        entryType: String = "topup",
+        refType: String? = "stripe_checkout",
+        refId: String? = "cs_test",
+        createdAt: String = RouterAccountUsageCenterTests.timestamp
+    ) -> OsaurusRouterTransactionItem {
+        OsaurusRouterTransactionItem(
+            id: id,
+            amountMicro: amount,
+            entryType: entryType,
+            refType: refType,
+            refId: refId,
+            createdAt: createdAt
+        )
+    }
+
+    private func ledger(
+        id: String = "ledger-1",
+        requestId: String? = "run-1",
+        createdAt: Date = RouterAccountUsageCenterTests.now,
+        cost: String = "1250",
+        outcome: RouterBillingOutcome = .rendered
+    ) -> RouterBillingEntry {
+        RouterBillingEntry(
+            id: id,
+            requestId: requestId,
+            createdAt: createdAt,
+            sessionId: UUID().uuidString,
+            turnId: UUID().uuidString,
+            model: "venice/minimax-m3",
+            tokenSource: "provider",
+            inputTokens: 11,
+            outputTokens: 7,
+            costMicro: cost,
+            status: "completed",
+            outcome: outcome,
+            appVersion: "1.2.3"
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Router/RouterAccountUsageCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/RouterAccountUsageCenterTests.swift
@@ -148,8 +148,71 @@ struct RouterAccountUsageCenterTests {
         #expect(!payload.contains(#""prompt""#))
         #expect(payload.contains(RouterAccountUsageCenter.redactedValue))
         #expect(export.walletAddress == "0xabcdef")
+        #expect(export.walletAddressStatus == .available)
         #expect(export.usage.count == 1)
         #expect(export.ledgerEntries.count == 1)
+    }
+
+    @Test func supportExport_usesSignedDiagnosticWalletAddressWithoutPrompting() throws {
+        let url = try #require(URL(string: "https://router.osaurus.ai/credits/balance"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(" 0xABCDEF ", forHTTPHeaderField: "x-wallet-address")
+        request.setValue("1717171717", forHTTPHeaderField: "x-wallet-timestamp")
+        request.setValue("0x" + String(repeating: "c", count: 130), forHTTPHeaderField: "x-wallet-signature")
+        let diagnostic = RouterSignedRequestDiagnostic(request: request, body: Data())
+        let snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "7000000", frozen: false),
+            lastError: nil,
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+
+        let export = RouterAccountUsageCenter.supportExport(
+            walletAddress: nil,
+            snapshot: snapshot,
+            signedDiagnostics: [diagnostic],
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+
+        #expect(export.walletAddress == "0xabcdef")
+        #expect(export.walletAddressStatus == .available)
+    }
+
+    @Test func supportExport_recordsWalletAddressStatusWhenAddressUnavailableWithoutPrompt() throws {
+        let snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: true,
+            identityAvailable: true,
+            balance: OsaurusRouterBalanceResponse(balanceMicro: "7000000", frozen: false),
+            lastError: nil,
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+
+        let export = RouterAccountUsageCenter.supportExport(
+            walletAddress: nil,
+            snapshot: snapshot,
+            signedDiagnostics: [],
+            usageItems: [],
+            transactions: [],
+            ledgerEntries: []
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let payload = String(decoding: try encoder.encode(export), as: UTF8.self)
+
+        #expect(export.walletAddress == nil)
+        #expect(export.walletAddressStatus == .unavailableWithoutPrompt)
+        #expect(payload.contains(#""walletAddressStatus":"unavailable_without_prompt""#))
+        #expect(export.redaction.contains { $0.contains("does not prompt for biometric authentication") })
     }
 
     private func usage(

--- a/Packages/OsaurusCore/Tests/Service/RouterBillingLedgerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RouterBillingLedgerTests.swift
@@ -182,6 +182,7 @@ struct RouterBillingLedgerTests {
 
         let diagnostics = ledger.buildDiagnostics(walletAddress: "0xABCDEF")
         #expect(diagnostics.walletAddress == "0xABCDEF")
+        #expect(diagnostics.walletAddressStatus == .available)
         #expect(diagnostics.schemaVersion == RouterBillingLedger.diagnosticsSchemaVersion)
         #expect(diagnostics.entries.count == 1)
 
@@ -204,5 +205,14 @@ struct RouterBillingLedgerTests {
         for forbidden in Self.forbiddenContentKeys {
             #expect(!raw.contains("\"\(forbidden)\""), "export payload contains forbidden key \(forbidden)")
         }
+    }
+
+    @Test func buildDiagnostics_recordsWalletStatusWhenAddressUnavailableWithoutPrompt() throws {
+        let (ledger, _) = try makeLedger()
+
+        let diagnostics = ledger.buildDiagnostics(walletAddress: nil)
+
+        #expect(diagnostics.walletAddress == nil)
+        #expect(diagnostics.walletAddressStatus == .unavailableWithoutPrompt)
     }
 }

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -727,9 +727,8 @@ struct CreditsView: View {
         ledgerTotalCount = result.total
     }
 
-    /// Write a metadata-only diagnostics file via a save panel. Reads the public
-    /// wallet address best-effort (may trigger one biometric prompt); a failed
-    /// or declined read just omits the address, and the export still succeeds.
+    /// Write a metadata-only diagnostics file via a save panel. It does not
+    /// trigger biometric authentication only to derive wallet-address metadata.
     private func exportDiagnostics() {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.json]
@@ -747,10 +746,10 @@ struct CreditsView: View {
         isExportingDiagnostics = true
         defer { isExportingDiagnostics = false }
 
-        let address = await Task.detached(priority: .userInitiated) {
-            Self.bestEffortWalletAddress()
-        }.value
-        let diagnostics = RouterBillingLedger.shared.buildDiagnostics(walletAddress: address)
+        let diagnostics = RouterBillingLedger.shared.buildDiagnostics(
+            walletAddress: nil,
+            walletAddressStatus: OsaurusIdentity.existsCached() ? .unavailableWithoutPrompt : .identityMissing
+        )
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -765,20 +764,6 @@ struct CreditsView: View {
         } catch {
             diagnosticsMessage = error.localizedDescription
         }
-    }
-
-    /// Read the public Osaurus ID without forcing the flow to fail when it
-    /// isn't available (declined biometric, keychain-disabled test mode). The
-    /// address is the server's billing account id, so support can line up the
-    /// local ledger with server-side usage. Best-effort by design.
-    nonisolated private static func bestEffortWalletAddress() -> String? {
-        guard OsaurusIdentity.exists() else { return nil }
-        let context = OsaurusIdentityContext.biometric()
-        guard var masterKeyData = try? MasterKey.getPrivateKey(context: context) else {
-            return nil
-        }
-        defer { masterKeyData.zeroOut() }
-        return try? deriveOsaurusId(from: masterKeyData)
     }
 
 }

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -22,6 +22,7 @@ struct CreditsView: View {
     @State private var diagnosticsMessage: String?
     @State private var showTopUpSheet = false
     @State private var showDisableRouterConfirm = false
+    @State private var showRouterUsageCenter = false
 
     /// User master switch state. When off, the Credits screen hides the
     /// balance/activity cards (the router is no longer polled) and shows the
@@ -82,6 +83,11 @@ struct CreditsView: View {
             CreditsTopUpSheet()
                 .environment(\.theme, themeManager.currentTheme)
         }
+        .sheet(isPresented: $showRouterUsageCenter) {
+            RouterAccountUsageCenterView()
+                .environment(\.theme, themeManager.currentTheme)
+                .frame(width: 980, height: 760)
+        }
         .confirmationDialog(
             Text("Turn off Osaurus Router?", bundle: .module),
             isPresented: $showDisableRouterConfirm,
@@ -115,6 +121,14 @@ struct CreditsView: View {
                 help: "Refresh"
             ) {
                 Task { await refreshCredits(resetPages: true) }
+            }
+            .disabled(!routerEnabled)
+            .opacity(routerEnabled ? 1 : 0.55)
+            HeaderIconButton(
+                "chart.bar.xaxis",
+                help: "Account details"
+            ) {
+                showRouterUsageCenter = true
             }
             .disabled(!routerEnabled)
             .opacity(routerEnabled ? 1 : 0.55)

--- a/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterView.swift
+++ b/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterView.swift
@@ -1,0 +1,684 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct RouterAccountUsageCenterView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+    @StateObject private var model = RouterAccountUsageCenterViewModel()
+    @State private var hasAppeared = false
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ManagerHeaderWithActions(
+                title: L("Router Account"),
+                subtitle: L("Account status, usage activity, signed request diagnostics, and support export.")
+            ) {
+                HeaderIconButton(
+                    "arrow.clockwise",
+                    isLoading: model.isRefreshing,
+                    help: "Refresh"
+                ) {
+                    Task { await model.refresh() }
+                }
+
+                HeaderIconButton(
+                    "signature",
+                    isLoading: model.isSigningDiagnostics,
+                    help: "Signed request diagnostics"
+                ) {
+                    Task { await model.runSignedRequestDiagnostics() }
+                }
+
+                HeaderPrimaryButton("Export support", icon: "square.and.arrow.up") {
+                    chooseSupportExportURL()
+                }
+                .disabled(model.isExportingSupport)
+                .opacity(model.isExportingSupport ? 0.6 : 1)
+            }
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    statusMetrics
+
+                    if let message = model.message, !message.isEmpty {
+                        messageBanner(message)
+                    }
+
+                    accountStatusSection
+                    creditsActivitySection
+                    ledgerSection
+                    signedDiagnosticsSection
+                    supportExportSection
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 24)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+            .opacity(hasAppeared ? 1 : 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.primaryBackground)
+        .environment(\.theme, themeManager.currentTheme)
+        .task {
+            await model.refresh()
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.22).delay(0.04)) {
+                hasAppeared = true
+            }
+        }
+    }
+
+    private var statusMetrics: some View {
+        let snapshot = model.snapshot
+        return LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 180, maximum: 280), spacing: 12)],
+            alignment: .leading,
+            spacing: 12
+        ) {
+            metricTile(
+                title: L("Balance"),
+                value: snapshot.accountStatus.formattedBalance,
+                detail: statusTitle(snapshot.accountStatus.state),
+                icon: "creditcard.fill",
+                color: statusColor(snapshot.accountStatus.state)
+            )
+            metricTile(
+                title: L("Requests"),
+                value: snapshot.credits.requestCount.formatted(),
+                detail: OsaurusRouter.formatMicroUSDPrecise(snapshot.credits.costMicro),
+                icon: "arrow.left.arrow.right",
+                color: theme.accentColor
+            )
+            metricTile(
+                title: L("Ledger rows"),
+                value: snapshot.ledger.entryCount.formatted(),
+                detail: L("\(snapshot.ledger.pendingCount) pending / \(snapshot.ledger.issueCount) flagged"),
+                icon: "list.bullet.rectangle.portrait",
+                color: snapshot.ledger.issueCount > 0 ? theme.warningColor : theme.successColor
+            )
+            metricTile(
+                title: L("Net credits"),
+                value: OsaurusRouter.formatMicroUSDPrecise(snapshot.transactions.netMicro),
+                detail: L("\(snapshot.transactions.transactionCount) transaction(s)"),
+                icon: "plus.forwardslash.minus",
+                color: RouterAccountUsageCenter.microValue(snapshot.transactions.netMicro) >= 0
+                    ? theme.successColor : theme.warningColor
+            )
+        }
+    }
+
+    private var accountStatusSection: some View {
+        sectionCard(title: L("Account Status"), icon: "person.badge.key.fill") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .center, spacing: 12) {
+                    statusPill(
+                        statusTitle(model.snapshot.accountStatus.state),
+                        icon: statusIcon(model.snapshot.accountStatus.state),
+                        color: statusColor(model.snapshot.accountStatus.state)
+                    )
+                    Spacer()
+                    Text(verbatim: model.snapshot.generatedAt.formatted(date: .abbreviated, time: .standard))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.tertiaryText)
+                }
+
+                keyValueGrid([
+                    (L("Router"), model.snapshot.accountStatus.routerEnabled ? L("On") : L("Off")),
+                    (L("Identity"), model.snapshot.accountStatus.identityAvailable ? L("Available") : L("Missing")),
+                    (L("Billing"), model.snapshot.accountStatus.frozen ? L("On hold") : L("Ready")),
+                ])
+
+                if let error = model.snapshot.accountStatus.lastError {
+                    Text(error)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.errorColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private var creditsActivitySection: some View {
+        sectionCard(title: L("Credits Activity"), icon: "clock.arrow.circlepath") {
+            VStack(alignment: .leading, spacing: 14) {
+                keyValueGrid([
+                    (L("Input tokens"), model.snapshot.credits.inputTokens.formatted()),
+                    (L("Output tokens"), model.snapshot.credits.outputTokens.formatted()),
+                    (L("Usage cost"), OsaurusRouter.formatMicroUSDPrecise(model.snapshot.credits.costMicro)),
+                    (L("Top-ups"), OsaurusRouter.formatMicroUSDPrecise(model.snapshot.transactions.creditMicro)),
+                ])
+
+                Divider()
+
+                let rows = Array(model.activityRows.prefix(8))
+                if rows.isEmpty {
+                    emptyState(
+                        icon: model.isBusy ? "hourglass" : "tray",
+                        title: model.isBusy ? L("Loading activity") : L("No usage activity"),
+                        detail: L("Router usage appears here after a hosted model request is billed.")
+                    )
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            activityRow(row)
+                            if row.id != rows.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(theme.cardBorder, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+
+                if !model.transactions.isEmpty {
+                    Divider()
+                    transactionSummaryRows
+                }
+            }
+        }
+    }
+
+    private var transactionSummaryRows: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Transaction ledger", bundle: .module)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+            ForEach(model.snapshot.transactions.entryTypeBreakdown) { row in
+                HStack(spacing: 12) {
+                    Text(verbatim: row.entryType)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                    Spacer()
+                    Text(verbatim: "\(row.transactionCount.formatted())")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                    Text(verbatim: OsaurusRouter.formatMicroUSDPrecise(row.netAmountMicro))
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    private var ledgerSection: some View {
+        sectionCard(title: L("Billing Ledger"), icon: "list.bullet.rectangle") {
+            VStack(alignment: .leading, spacing: 14) {
+                keyValueGrid([
+                    (L("Local rows"), model.snapshot.ledger.entryCount.formatted()),
+                    (L("Ledger cost"), OsaurusRouter.formatMicroUSDPrecise(model.snapshot.ledger.costMicro)),
+                    (L("Pending"), model.snapshot.ledger.pendingCount.formatted()),
+                    (L("Flagged"), model.snapshot.ledger.issueCount.formatted()),
+                ])
+
+                Divider()
+
+                if model.snapshot.ledger.outcomeBreakdown.isEmpty {
+                    emptyState(
+                        icon: "doc.text.magnifyingglass",
+                        title: L("No local ledger rows"),
+                        detail: L("The encrypted local billing ledger has no rows available.")
+                    )
+                } else {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(model.snapshot.ledger.outcomeBreakdown) { row in
+                            HStack(spacing: 12) {
+                                Circle()
+                                    .fill(outcomeColor(row.outcome))
+                                    .frame(width: 8, height: 8)
+                                Text(LocalizedStringKey(outcomeLabel(row.outcome)), bundle: .module)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundColor(theme.primaryText)
+                                Spacer()
+                                Text(verbatim: "\(row.entryCount.formatted())")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(theme.secondaryText)
+                                Text(verbatim: OsaurusRouter.formatMicroUSDPrecise(row.costMicro))
+                                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                                    .foregroundColor(theme.primaryText)
+                                    .monospacedDigit()
+                            }
+                        }
+                    }
+                }
+
+                if !model.snapshot.ledger.modelBreakdown.isEmpty {
+                    Divider()
+                    modelBreakdownRows(model.snapshot.ledger.modelBreakdown)
+                }
+            }
+        }
+    }
+
+    private var signedDiagnosticsSection: some View {
+        sectionCard(title: L("Signed Request Diagnostics"), icon: "signature") {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .center, spacing: 12) {
+                    Text("Last signed checks", bundle: .module)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.secondaryText)
+                    Spacer()
+                    Button {
+                        Task { await model.runSignedRequestDiagnostics() }
+                    } label: {
+                        if model.isSigningDiagnostics {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                        } else {
+                            Label(localized: "Run", systemImage: "checkmark.seal")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(model.isSigningDiagnostics)
+                }
+
+                if model.signedDiagnostics.isEmpty {
+                    emptyState(
+                        icon: "signature",
+                        title: L("No signed checks yet"),
+                        detail: L("Run a local signing check to inspect the redacted request shape.")
+                    )
+                } else {
+                    let diagnostics = model.signedDiagnostics
+                    ForEach(diagnostics) { diagnostic in
+                        signedDiagnosticRow(diagnostic)
+                        if diagnostic.id != diagnostics.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var supportExportSection: some View {
+        sectionCard(title: L("Support Export"), icon: "square.and.arrow.up") {
+            VStack(alignment: .leading, spacing: 12) {
+                keyValueGrid([
+                    (L("Schema"), "\(RouterSupportExport.schemaVersion)"),
+                    (L("Usage rows"), model.usageItems.count.formatted()),
+                    (L("Transaction rows"), model.transactions.count.formatted()),
+                    (L("Ledger rows"), model.ledgerEntries.count.formatted()),
+                ])
+
+                Divider()
+
+                HStack(alignment: .center, spacing: 12) {
+                    Label(localized: "Metadata only", systemImage: "lock.shield")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                    Spacer()
+                    Button {
+                        chooseSupportExportURL()
+                    } label: {
+                        if model.isExportingSupport {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                        } else {
+                            Label(localized: "Export", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(model.isExportingSupport)
+                }
+            }
+        }
+    }
+
+    private func signedDiagnosticRow(_ diagnostic: RouterSignedRequestDiagnostic) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(verbatim: diagnostic.method)
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundColor(theme.accentColor)
+                Text(verbatim: diagnostic.pathAndQuery)
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Text(verbatim: diagnostic.generatedAt.formatted(date: .omitted, time: .standard))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.tertiaryText)
+            }
+
+            keyValueGrid([
+                (L("Body SHA-256"), diagnostic.bodySHA256),
+                (L("Bytes"), diagnostic.bodyBytes.formatted()),
+                (L("Wallet"), diagnostic.walletAddress ?? L("Missing")),
+                (L("Signature"), diagnostic.signatureFingerprint ?? L("Missing")),
+            ])
+
+            if !diagnostic.warnings.isEmpty {
+                Text(verbatim: diagnostic.warnings.joined(separator: " · "))
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.warningColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(diagnostic.redactedHeaders.keys.sorted(), id: \.self) { header in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(verbatim: header)
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundColor(theme.secondaryText)
+                            .frame(minWidth: 150, alignment: .leading)
+                        Text(verbatim: diagnostic.redactedHeaders[header] ?? "")
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.primaryText)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+            .padding(.top, 2)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func activityRow(_ row: CreditsActivityRow) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Circle()
+                .fill(stateColor(row.stateKind))
+                .frame(width: 8, height: 8)
+                .padding(.top, 5)
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 8) {
+                    Text(verbatim: row.modelDisplay ?? L("Unknown model"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    outcomeBadge(for: row)
+                }
+
+                Text(verbatim: row.metadataLine)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+
+                Text(verbatim: row.tokensLine)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.tertiaryText)
+            }
+
+            Spacer(minLength: 12)
+
+            Text(verbatim: OsaurusRouter.formatMicroUSDPrecise(row.costMicro))
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                .foregroundColor(theme.primaryText)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 11)
+        .background(theme.cardBackground)
+    }
+
+    private func outcomeBadge(for row: CreditsActivityRow) -> some View {
+        HStack(spacing: 4) {
+            Text(LocalizedStringKey(row.stateLabel), bundle: .module)
+            if let detail = row.stateDetail, !detail.isEmpty {
+                Text(verbatim: "·")
+                Text(LocalizedStringKey(detail), bundle: .module)
+            }
+        }
+        .font(.system(size: 10, weight: .medium))
+        .foregroundColor(stateColor(row.stateKind))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(Capsule().fill(stateColor(row.stateKind).opacity(0.12)))
+        .fixedSize()
+    }
+
+    private func modelBreakdownRows(_ rows: [RouterUsageBreakdown]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Model totals", bundle: .module)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+            ForEach(rows.prefix(5)) { row in
+                HStack(spacing: 12) {
+                    Text(verbatim: row.name)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Text(verbatim: "\(row.requestCount.formatted())")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                    Text(verbatim: OsaurusRouter.formatMicroUSDPrecise(row.costMicro))
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    private func keyValueGrid(_ items: [(String, String)]) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 150, maximum: 260), spacing: 12)],
+            alignment: .leading,
+            spacing: 10
+        ) {
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(LocalizedStringKey(item.0), bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                    Text(verbatim: item.1)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func metricTile(title: String, value: String, detail: String, icon: String, color: Color) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(color.opacity(0.13)))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+                Text(verbatim: value)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .monospacedDigit()
+                Text(LocalizedStringKey(detail), bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(minHeight: 112, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func sectionCard<Content: View>(
+        title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                    .frame(width: 20, height: 20)
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+            }
+
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func emptyState(icon: String, title: String, detail: String) -> some View {
+        VStack(spacing: 9) {
+            if model.isBusy {
+                ProgressView()
+                    .scaleEffect(0.75)
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundColor(theme.tertiaryText)
+            }
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+            Text(LocalizedStringKey(detail), bundle: .module)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    private func statusPill(_ title: String, icon: String, color: Color) -> some View {
+        Label(title, systemImage: icon)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(Capsule().fill(color.opacity(0.12)))
+    }
+
+    private func messageBanner(_ message: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "info.circle.fill")
+                .foregroundColor(theme.infoColor)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.infoColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.infoColor.opacity(0.25), lineWidth: 1)
+                )
+        )
+    }
+
+    private func stateColor(_ kind: CreditsActivityStateKind) -> Color {
+        switch kind {
+        case .success: return theme.successColor
+        case .warning: return theme.warningColor
+        case .error: return theme.errorColor
+        case .secondary: return theme.secondaryText
+        }
+    }
+
+    private func outcomeColor(_ outcome: RouterBillingOutcome) -> Color {
+        switch outcome {
+        case .rendered, .toolOnly, .reasoningOnly: return theme.successColor
+        case .pending: return theme.secondaryText
+        case .cancelled: return theme.warningColor
+        case .empty, .error: return theme.errorColor
+        }
+    }
+
+    private func outcomeLabel(_ outcome: RouterBillingOutcome) -> String {
+        switch outcome {
+        case .pending: return L("Pending")
+        case .rendered: return L("Rendered")
+        case .reasoningOnly: return L("Reasoning only")
+        case .toolOnly: return L("Tools only")
+        case .empty: return L("No reply")
+        case .error: return L("Error")
+        case .cancelled: return L("Stopped")
+        }
+    }
+
+    private func statusTitle(_ state: RouterAccountStatusSnapshot.State) -> String {
+        switch state {
+        case .active: return L("Active")
+        case .disabled: return L("Router off")
+        case .missingIdentity: return L("Identity required")
+        case .frozen: return L("On hold")
+        case .unavailable: return L("Unavailable")
+        }
+    }
+
+    private func statusIcon(_ state: RouterAccountStatusSnapshot.State) -> String {
+        switch state {
+        case .active: return "checkmark.circle.fill"
+        case .disabled: return "bolt.slash.fill"
+        case .missingIdentity: return "person.badge.key.fill"
+        case .frozen: return "pause.circle.fill"
+        case .unavailable: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func statusColor(_ state: RouterAccountStatusSnapshot.State) -> Color {
+        switch state {
+        case .active: return theme.successColor
+        case .disabled: return theme.secondaryText
+        case .missingIdentity, .frozen: return theme.warningColor
+        case .unavailable: return theme.errorColor
+        }
+    }
+
+    private func chooseSupportExportURL() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "osaurus-router-support-export.json"
+        panel.canCreateDirectories = true
+        panel.title = L("Export Router Support Bundle")
+        panel.message = L("Metadata only - no prompts, replies, tool payloads, private keys, or signatures.")
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            await model.exportSupport(to: url)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterViewModel.swift
+++ b/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterViewModel.swift
@@ -1,0 +1,186 @@
+import Combine
+import Foundation
+
+@MainActor
+final class RouterAccountUsageCenterViewModel: ObservableObject {
+    @Published private(set) var snapshot: RouterAccountUsageSnapshot
+    @Published private(set) var ledgerEntries: [RouterBillingEntry] = []
+    @Published private(set) var signedDiagnostics: [RouterSignedRequestDiagnostic] = []
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var isLoadingLedger = false
+    @Published private(set) var isSigningDiagnostics = false
+    @Published private(set) var isExportingSupport = false
+    @Published var message: String?
+
+    private let accountService: OsaurusRouterAccountService
+    private let providerManager: RemoteProviderManager
+    private let client: OsaurusRouterAPIClient
+    private let ledger: RouterBillingLedger
+    private let ledgerLimit = 500
+
+    init(
+        accountService: OsaurusRouterAccountService = .shared,
+        providerManager: RemoteProviderManager = .shared,
+        client: OsaurusRouterAPIClient = .shared,
+        ledger: RouterBillingLedger = .shared
+    ) {
+        self.accountService = accountService
+        self.providerManager = providerManager
+        self.client = client
+        self.ledger = ledger
+        self.snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: providerManager.isOsaurusRouterEnabled,
+            identityAvailable: OsaurusIdentity.existsCached(),
+            balance: accountService.balance,
+            lastError: accountService.lastError,
+            usageItems: accountService.usage,
+            transactions: accountService.transactions,
+            ledgerEntries: []
+        )
+    }
+
+    var usageItems: [OsaurusRouterUsageItem] {
+        accountService.usage
+    }
+
+    var transactions: [OsaurusRouterTransactionItem] {
+        accountService.transactions
+    }
+
+    var isBusy: Bool {
+        isRefreshing
+            || isLoadingLedger
+            || isSigningDiagnostics
+            || isExportingSupport
+            || accountService.isLoadingBalance
+            || accountService.isLoadingUsage
+            || accountService.isLoadingTransactions
+    }
+
+    var activityRows: [CreditsActivityRow] {
+        CreditsActivityProjector().rows(
+            usageItems: accountService.usage,
+            ledgerEntries: ledgerEntries
+        )
+    }
+
+    func refresh() async {
+        isRefreshing = true
+        defer {
+            isRefreshing = false
+            rebuildSnapshot()
+        }
+
+        if providerManager.isOsaurusRouterEnabled {
+            await accountService.refreshAll()
+            await accountService.refreshTransactions(reset: true)
+        }
+        await reloadLedger()
+    }
+
+    func loadMoreTransactions() async {
+        guard providerManager.isOsaurusRouterEnabled else { return }
+        await accountService.loadMoreTransactions()
+        rebuildSnapshot()
+    }
+
+    func runSignedRequestDiagnostics() async {
+        guard providerManager.isOsaurusRouterEnabled else {
+            message = L("Osaurus Router is off.")
+            return
+        }
+        guard OsaurusIdentity.exists() else {
+            message = OsaurusRouterAPIError.noIdentity.localizedDescription
+            return
+        }
+
+        isSigningDiagnostics = true
+        defer { isSigningDiagnostics = false }
+        do {
+            let balanceRequest = try await client.signedJSONRequest(
+                method: "GET",
+                path: "/credits/balance",
+                body: Data()
+            )
+            let estimateBody = Data(#"{"input_tokens":1,"max_tokens":1,"model":"diagnostic"}"#.utf8)
+            let estimateRequest = try await client.signedJSONRequest(
+                method: "POST",
+                path: "/credits/estimate",
+                body: estimateBody
+            )
+            signedDiagnostics = [
+                RouterSignedRequestDiagnostic(request: balanceRequest, body: Data()),
+                RouterSignedRequestDiagnostic(request: estimateRequest, body: estimateBody),
+            ]
+            message = L("Signed request diagnostics refreshed.")
+        } catch {
+            message = error.localizedDescription
+        }
+    }
+
+    func exportSupport(to url: URL) async {
+        isExportingSupport = true
+        defer { isExportingSupport = false }
+
+        rebuildSnapshot()
+        let walletAddress = await Task.detached(priority: .userInitiated) {
+            Self.bestEffortWalletAddress()
+        }.value
+        let export = RouterAccountUsageCenter.supportExport(
+            walletAddress: walletAddress,
+            snapshot: snapshot,
+            signedDiagnostics: signedDiagnostics,
+            usageItems: accountService.usage,
+            transactions: accountService.transactions,
+            ledgerEntries: ledgerEntries
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        do {
+            let data = try encoder.encode(export)
+            try data.write(to: url, options: .atomic)
+            message = String(
+                localized: "Exported router support bundle to \(url.lastPathComponent).",
+                bundle: .module
+            )
+        } catch {
+            message = error.localizedDescription
+        }
+    }
+
+    private func reloadLedger() async {
+        isLoadingLedger = true
+        defer { isLoadingLedger = false }
+
+        let limit = ledgerLimit
+        let ledger = ledger
+        let entries = await Task.detached(priority: .utility) {
+            ledger.recent(limit: limit)
+        }.value
+        ledgerEntries = entries
+    }
+
+    private func rebuildSnapshot() {
+        snapshot = RouterAccountUsageCenter.snapshot(
+            routerEnabled: providerManager.isOsaurusRouterEnabled,
+            identityAvailable: OsaurusIdentity.existsCached(),
+            balance: accountService.balance,
+            lastError: accountService.lastError,
+            usageItems: accountService.usage,
+            transactions: accountService.transactions,
+            ledgerEntries: ledgerEntries
+        )
+    }
+
+    nonisolated private static func bestEffortWalletAddress() -> String? {
+        guard OsaurusIdentity.exists() else { return nil }
+        let context = OsaurusIdentityContext.biometric()
+        guard var masterKeyData = try? MasterKey.getPrivateKey(context: context) else {
+            return nil
+        }
+        defer { masterKeyData.zeroOut() }
+        return try? deriveOsaurusId(from: masterKeyData)
+    }
+}

--- a/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterViewModel.swift
+++ b/Packages/OsaurusCore/Views/Router/RouterAccountUsageCenterViewModel.swift
@@ -123,11 +123,8 @@ final class RouterAccountUsageCenterViewModel: ObservableObject {
         defer { isExportingSupport = false }
 
         rebuildSnapshot()
-        let walletAddress = await Task.detached(priority: .userInitiated) {
-            Self.bestEffortWalletAddress()
-        }.value
         let export = RouterAccountUsageCenter.supportExport(
-            walletAddress: walletAddress,
+            walletAddress: nil,
             snapshot: snapshot,
             signedDiagnostics: signedDiagnostics,
             usageItems: accountService.usage,
@@ -172,15 +169,5 @@ final class RouterAccountUsageCenterViewModel: ObservableObject {
             transactions: accountService.transactions,
             ledgerEntries: ledgerEntries
         )
-    }
-
-    nonisolated private static func bestEffortWalletAddress() -> String? {
-        guard OsaurusIdentity.exists() else { return nil }
-        let context = OsaurusIdentityContext.biometric()
-        guard var masterKeyData = try? MasterKey.getPrivateKey(context: context) else {
-            return nil
-        }
-        defer { masterKeyData.zeroOut() }
-        return try? deriveOsaurusId(from: masterKeyData)
     }
 }

--- a/docs/OSAURUS_ROUTER.md
+++ b/docs/OSAURUS_ROUTER.md
@@ -135,10 +135,14 @@ local billing ledger:
 
 Support export is metadata-only. It may include public wallet address,
 redacted signed-request diagnostics, usage rows, transaction rows, and local
-ledger metadata. It must not include prompts, assistant replies, tool arguments,
-tool results, private keys, bearer tokens, cookies, or raw wallet signatures.
-Wallet signatures are replaced with `<redacted>` and only a SHA-256 fingerprint
-of the signature is retained for local/server correlation.
+ledger metadata. Export never reads the Master Key or triggers biometric
+authentication just to derive the wallet address; it uses an existing
+non-prompting source such as signed-request diagnostics when available. When no
+such source exists, `walletAddressStatus` records that the address was
+unavailable without prompting. It must not include prompts, assistant replies,
+tool arguments, tool results, private keys, bearer tokens, cookies, or raw
+wallet signatures. Wallet signatures are replaced with `<redacted>` and only a
+SHA-256 fingerprint of the signature is retained for local/server correlation.
 
 ## Empty Stream Diagnostics
 

--- a/docs/OSAURUS_ROUTER.md
+++ b/docs/OSAURUS_ROUTER.md
@@ -115,6 +115,31 @@ Outcomes are classified as `rendered`, `toolOnly`, `reasoningOnly`, `empty`,
 distinguish a truly empty billed response from a tool-only or reasoning-only
 turn.
 
+## Account Usage Center
+
+The Router account usage center composes the hosted account endpoints with the
+local billing ledger:
+
+- Account status comes from the Router master switch, local identity presence,
+  `/credits/balance`, and the account hold flag.
+- Credits activity is based on `/credits/usage`, with local ledger rows matched
+  by Router request id when available.
+- Transaction summaries come from `/credits/transactions` and separate credits,
+  debits, and net movement in micro-USD.
+- Ledger summaries are local-only aggregates over recent encrypted
+  `RouterBillingEntry` rows, including outcome counts and model totals.
+- Signed request diagnostics are generated locally by signing representative
+  Router requests without sending them. The UI shows method, path, body hash,
+  signed header names, timestamp, public wallet address, and a signature
+  fingerprint.
+
+Support export is metadata-only. It may include public wallet address,
+redacted signed-request diagnostics, usage rows, transaction rows, and local
+ledger metadata. It must not include prompts, assistant replies, tool arguments,
+tool results, private keys, bearer tokens, cookies, or raw wallet signatures.
+Wallet signatures are replaced with `<redacted>` and only a SHA-256 fingerprint
+of the signature is retained for local/server correlation.
+
 ## Empty Stream Diagnostics
 
 Router has a low-volume diagnostic path for terminal streams that produce no
@@ -152,6 +177,9 @@ Keep tests close to the contract:
 - `OpenAICompatibleStreamParserTests` covers shared SSE framing, raw JSON
   fallback, split-data repair, streaming tool-call accumulation, and
   `finish_reason=length` handling.
+- `RouterAccountUsageCenterTests` covers account status summaries, credits and
+  transaction totals, ledger aggregates, signed-request redaction, and support
+  export safety.
 - `OsaurusRouterProviderTests` covers Router adapter behavior such as billing
   summary frames and empty-stream diagnostics.
 - `RouterBillingDatabaseTests`, `RouterBillingLedgerTests`, and


### PR DESCRIPTION
## Summary
- Adds a router account usage center for balances, usage, billing ledger rows, and account diagnostics.
- Wires account details into the Credits view through a dedicated sheet.
- Adds router service/view-model coverage and updates router documentation.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter 'OsaurusRouterAuthSignerTests|OsaurusRouterAPIClientTests|RouterAccountUsageCenterTests|RouterBillingLedgerTests|RemoteProviderHeaderRedactorTests'`

## Notes
- The localization check still reports the existing stale-key warning set from main.
