### PR TITLE
Add theme library management center

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
+++ b/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
@@ -47,6 +47,43 @@ public struct ThemeMetadata: Codable, Equatable, Sendable {
     }
 }
 
+// MARK: - Theme Library Metadata
+
+/// Where a theme entered the local library. This is intentionally persisted
+/// with custom themes so the library can distinguish hand-authored themes
+/// from file imports and share-link installs after relaunch.
+public enum ThemeLibrarySource: String, Codable, CaseIterable, Sendable {
+    case builtIn
+    case local
+    case imported
+    case shared
+}
+
+public struct ThemeLibraryInfo: Codable, Equatable, Sendable {
+    public var source: ThemeLibrarySource
+    public var importedAt: Date?
+    public var sharedAt: Date?
+    public var remoteHash: String?
+    public var remoteURL: String?
+    public var sourceDetail: String?
+
+    public init(
+        source: ThemeLibrarySource = .local,
+        importedAt: Date? = nil,
+        sharedAt: Date? = nil,
+        remoteHash: String? = nil,
+        remoteURL: String? = nil,
+        sourceDetail: String? = nil
+    ) {
+        self.source = source
+        self.importedAt = importedAt
+        self.sharedAt = sharedAt
+        self.remoteHash = remoteHash
+        self.remoteURL = remoteURL
+        self.sourceDetail = sourceDetail
+    }
+}
+
 // MARK: - Theme Colors
 
 /// All customizable colors in a theme
@@ -613,6 +650,10 @@ public struct CustomTheme: Codable, Equatable, Sendable {
     /// Syntax highlighting theme name (Highlightr). nil = auto (dark/light).
     public var codeHighlightTheme: String?
 
+    /// Optional library provenance. Missing values are treated as local
+    /// custom themes, while built-in presets are always classified as built-in.
+    public var library: ThemeLibraryInfo?
+
     /// Whether this is a built-in theme (cannot be deleted)
     public var isBuiltIn: Bool
     public var isDark: Bool
@@ -628,6 +669,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         messages: ThemeMessages = ThemeMessages(),
         borders: ThemeBorders = ThemeBorders(),
         codeHighlightTheme: String? = nil,
+        library: ThemeLibraryInfo? = nil,
         isBuiltIn: Bool = false,
         isDark: Bool = true
     ) {
@@ -641,6 +683,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         self.messages = messages
         self.borders = borders
         self.codeHighlightTheme = codeHighlightTheme
+        self.library = library
         self.isBuiltIn = isBuiltIn
         self.isDark = isDark
     }
@@ -658,6 +701,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         messages = try container.decodeIfPresent(ThemeMessages.self, forKey: .messages) ?? ThemeMessages()
         borders = try container.decodeIfPresent(ThemeBorders.self, forKey: .borders) ?? ThemeBorders()
         codeHighlightTheme = try container.decodeIfPresent(String.self, forKey: .codeHighlightTheme)
+        library = try container.decodeIfPresent(ThemeLibraryInfo.self, forKey: .library)
         isBuiltIn = try container.decode(Bool.self, forKey: .isBuiltIn)
         isDark = try container.decode(Bool.self, forKey: .isDark)
     }

--- a/Packages/OsaurusCore/Models/Theme/ThemeConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/Theme/ThemeConfigurationStore.swift
@@ -72,8 +72,9 @@ public enum ThemeConfigurationStore {
     static func saveTheme(_ theme: CustomTheme) {
         do {
             try OsaurusPaths.ensureExists(themesDirectoryURL())
-            let data = try encodeTheme(theme)
-            try data.write(to: themeFileURL(for: theme.metadata.id), options: .atomic)
+            let normalizedTheme = normalizedForSave(theme)
+            let data = try encodeTheme(normalizedTheme)
+            try data.write(to: themeFileURL(for: normalizedTheme.metadata.id), options: .atomic)
         } catch {
             print("[Osaurus] Failed to save theme '\(theme.metadata.name)': \(error)")
         }
@@ -101,25 +102,66 @@ public enum ThemeConfigurationStore {
         try data.write(to: url, options: .atomic)
     }
 
-    static func importTheme(from url: URL) throws -> CustomTheme {
+    static func importTheme(from url: URL, libraryInfo: ThemeLibraryInfo? = nil) throws -> CustomTheme {
+        let now = Date()
         var theme = try decodeTheme(from: url)
         theme.metadata.id = UUID()
-        theme.metadata.createdAt = Date()
-        theme.metadata.updatedAt = Date()
+        theme.metadata.createdAt = now
+        theme.metadata.updatedAt = now
         theme.isBuiltIn = false
+        theme.library =
+            libraryInfo
+            ?? ThemeLibraryInfo(
+                source: .imported,
+                importedAt: now,
+                sourceDetail: url.lastPathComponent
+            )
         saveTheme(theme)
         return theme
     }
 
     static func duplicateTheme(_ theme: CustomTheme, newName: String) -> CustomTheme {
+        let now = Date()
         var newTheme = theme
         newTheme.metadata.id = UUID()
         newTheme.metadata.name = newName
-        newTheme.metadata.createdAt = Date()
-        newTheme.metadata.updatedAt = Date()
+        newTheme.metadata.createdAt = now
+        newTheme.metadata.updatedAt = now
         newTheme.isBuiltIn = false
+        newTheme.library = ThemeLibraryInfo(
+            source: .local,
+            importedAt: nil,
+            sharedAt: nil,
+            remoteHash: nil,
+            remoteURL: nil,
+            sourceDetail: "Duplicated from \(theme.metadata.name)"
+        )
         saveTheme(newTheme)
         return newTheme
+    }
+
+    @discardableResult
+    static func markThemeShared(id: UUID, hash: String, serverURL: URL, sharedAt: Date = Date()) -> CustomTheme? {
+        guard var theme = loadTheme(id: id), !theme.isBuiltIn else { return nil }
+
+        var library = theme.library ?? ThemeLibraryInfo(source: .local)
+        library.source = .shared
+        library.sharedAt = sharedAt
+        library.remoteHash = hash.lowercased()
+        library.remoteURL = serverURL.absoluteString
+        theme.library = library
+        theme.metadata.updatedAt = sharedAt
+
+        saveTheme(theme)
+        return theme
+    }
+
+    @discardableResult
+    static func rollbackActiveThemeToDefault() -> UUID? {
+        let previous = loadActiveThemeId()
+        saveActiveThemeId(nil)
+        installBuiltInThemesIfNeeded()
+        return previous
     }
 
     // MARK: - Built-in Themes
@@ -197,5 +239,15 @@ public enum ThemeConfigurationStore {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         return try encoder.encode(theme)
+    }
+
+    private static func normalizedForSave(_ theme: CustomTheme) -> CustomTheme {
+        var normalized = theme
+        if normalized.isBuiltIn {
+            normalized.library = nil
+        } else if normalized.library == nil {
+            normalized.library = ThemeLibraryInfo(source: .local)
+        }
+        return normalized
     }
 }

--- a/Packages/OsaurusCore/Services/Themes/ThemeLibraryManagementService.swift
+++ b/Packages/OsaurusCore/Services/Themes/ThemeLibraryManagementService.swift
@@ -1,0 +1,486 @@
+//
+//  ThemeLibraryManagementService.swift
+//  osaurus
+//
+//  Pure helpers for the Themes management center: provenance summaries,
+//  validation, duplicate detection, and Import-by-ID diagnostics.
+//
+
+import AppKit
+import CryptoKit
+import Foundation
+
+public enum ThemeValidationSeverity: String, Codable, Hashable, Sendable {
+    case warning
+    case error
+}
+
+public struct ThemeValidationIssue: Codable, Equatable, Hashable, Sendable {
+    public let severity: ThemeValidationSeverity
+    public let field: String
+    public let message: String
+
+    public init(severity: ThemeValidationSeverity, field: String, message: String) {
+        self.severity = severity
+        self.field = field
+        self.message = message
+    }
+}
+
+public struct ThemeValidationReport: Codable, Equatable, Sendable {
+    public let themeID: UUID
+    public let themeName: String
+    public let source: ThemeLibrarySource
+    public let issues: [ThemeValidationIssue]
+
+    public var errorCount: Int { issues.filter { $0.severity == .error }.count }
+    public var warningCount: Int { issues.filter { $0.severity == .warning }.count }
+    public var isValid: Bool { errorCount == 0 }
+    public var needsReview: Bool { !issues.isEmpty }
+}
+
+public struct ThemeDuplicateMember: Codable, Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let source: ThemeLibrarySource
+}
+
+public struct ThemeDuplicateGroup: Identifiable, Codable, Equatable, Sendable {
+    public let id: String
+    public let members: [ThemeDuplicateMember]
+
+    public var count: Int { members.count }
+}
+
+public struct ThemeLibrarySummary: Codable, Equatable, Sendable {
+    public let builtInCount: Int
+    public let localCount: Int
+    public let importedCount: Int
+    public let sharedCount: Int
+    public let validationErrorCount: Int
+    public let validationWarningCount: Int
+    public let duplicateGroupCount: Int
+
+    public static let empty = ThemeLibrarySummary(
+        builtInCount: 0,
+        localCount: 0,
+        importedCount: 0,
+        sharedCount: 0,
+        validationErrorCount: 0,
+        validationWarningCount: 0,
+        duplicateGroupCount: 0
+    )
+}
+
+public enum ThemeImportInputKind: String, Codable, Sendable {
+    case empty
+    case rawHash
+    case deepLink
+    case webURL
+    case invalid
+}
+
+public struct ThemeImportInstalledMatch: Codable, Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let source: ThemeLibrarySource
+}
+
+public struct ThemeImportDiagnostics: Codable, Equatable, Sendable {
+    public let kind: ThemeImportInputKind
+    public let normalizedHash: String?
+    public let deepLinkURL: URL?
+    public let serverURL: URL?
+    public let installedMatches: [ThemeImportInstalledMatch]
+
+    public var canImport: Bool { normalizedHash != nil }
+}
+
+public enum ThemeLibraryManagementService {
+    public static func source(for theme: CustomTheme) -> ThemeLibrarySource {
+        if theme.isBuiltIn { return .builtIn }
+        return theme.library?.source ?? .local
+    }
+
+    public static func validationReports(for themes: [CustomTheme]) -> [ThemeValidationReport] {
+        themes.map(validate(_:))
+    }
+
+    public static func validate(_ theme: CustomTheme) -> ThemeValidationReport {
+        var issues: [ThemeValidationIssue] = []
+
+        if theme.metadata.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.init(severity: .error, field: "metadata.name", message: "Theme name is required."))
+        } else if theme.metadata.name.count > 80 {
+            issues.append(.init(severity: .warning, field: "metadata.name", message: "Theme name is very long."))
+        }
+
+        if theme.metadata.author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.init(severity: .warning, field: "metadata.author", message: "Author is empty."))
+        }
+
+        validateColors(theme.colors, issues: &issues)
+        validateBackground(theme.background, fallbackBackground: theme.colors.primaryBackground, issues: &issues)
+        validateGlass(theme.glass, issues: &issues)
+        validateTypography(theme.typography, issues: &issues)
+        validateAnimation(theme.animationConfig, issues: &issues)
+        validateShadows(theme.shadows, issues: &issues)
+        validateMessages(theme.messages, issues: &issues)
+        validateBorders(theme.borders, issues: &issues)
+        validateLibrary(theme, issues: &issues)
+
+        return ThemeValidationReport(
+            themeID: theme.metadata.id,
+            themeName: theme.metadata.name,
+            source: source(for: theme),
+            issues: issues
+        )
+    }
+
+    public static func duplicateGroups(in themes: [CustomTheme]) -> [ThemeDuplicateGroup] {
+        let grouped = Dictionary(grouping: themes) { theme in
+            visualFingerprint(for: theme)
+        }
+
+        return grouped.compactMap { fingerprint, members -> ThemeDuplicateGroup? in
+            guard members.count > 1 else { return nil }
+            let sorted = members.sorted { $0.metadata.name.localizedCaseInsensitiveCompare($1.metadata.name) == .orderedAscending }
+            return ThemeDuplicateGroup(
+                id: fingerprint,
+                members: sorted.map {
+                    ThemeDuplicateMember(
+                        id: $0.metadata.id,
+                        name: $0.metadata.name,
+                        source: source(for: $0)
+                    )
+                }
+            )
+        }
+        .sorted { lhs, rhs in
+            (lhs.members.first?.name ?? "").localizedCaseInsensitiveCompare(rhs.members.first?.name ?? "") == .orderedAscending
+        }
+    }
+
+    public static func summary(
+        for themes: [CustomTheme],
+        reports: [ThemeValidationReport],
+        duplicateGroups: [ThemeDuplicateGroup]
+    ) -> ThemeLibrarySummary {
+        let sources = themes.map(source(for:))
+        return ThemeLibrarySummary(
+            builtInCount: sources.filter { $0 == .builtIn }.count,
+            localCount: sources.filter { $0 == .local }.count,
+            importedCount: sources.filter { $0 == .imported }.count,
+            sharedCount: sources.filter { $0 == .shared }.count,
+            validationErrorCount: reports.reduce(0) { $0 + $1.errorCount },
+            validationWarningCount: reports.reduce(0) { $0 + $1.warningCount },
+            duplicateGroupCount: duplicateGroups.count
+        )
+    }
+
+    public static func diagnoseImportInput(
+        _ rawInput: String,
+        installedThemes: [CustomTheme]
+    ) -> ThemeImportDiagnostics {
+        let parsed = parseImportInput(rawInput)
+        guard let hash = parsed.hash else {
+            return ThemeImportDiagnostics(
+                kind: parsed.kind,
+                normalizedHash: nil,
+                deepLinkURL: nil,
+                serverURL: nil,
+                installedMatches: []
+            )
+        }
+
+        let matches =
+            installedThemes
+            .filter { $0.library?.remoteHash?.lowercased() == hash }
+            .sorted { $0.metadata.name.localizedCaseInsensitiveCompare($1.metadata.name) == .orderedAscending }
+            .map {
+                ThemeImportInstalledMatch(
+                    id: $0.metadata.id,
+                    name: $0.metadata.name,
+                    source: source(for: $0)
+                )
+            }
+
+        return ThemeImportDiagnostics(
+            kind: parsed.kind,
+            normalizedHash: hash,
+            deepLinkURL: ThemeShareService.deepLink(for: hash),
+            serverURL: ThemesAPIClient.defaultBaseURL.appendingPathComponent("themes/\(hash)"),
+            installedMatches: matches
+        )
+    }
+
+    public static func visualFingerprint(for theme: CustomTheme) -> String {
+        let payload = VisualFingerprintPayload(theme: theme)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = (try? encoder.encode(payload)) ?? Data()
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Validation helpers
+
+    private static func validateColors(_ colors: ThemeColors, issues: inout [ThemeValidationIssue]) {
+        let required: [(String, String)] = [
+            ("colors.primaryText", colors.primaryText),
+            ("colors.secondaryText", colors.secondaryText),
+            ("colors.tertiaryText", colors.tertiaryText),
+            ("colors.primaryBackground", colors.primaryBackground),
+            ("colors.secondaryBackground", colors.secondaryBackground),
+            ("colors.tertiaryBackground", colors.tertiaryBackground),
+            ("colors.sidebarBackground", colors.sidebarBackground),
+            ("colors.sidebarSelectedBackground", colors.sidebarSelectedBackground),
+            ("colors.accentColor", colors.accentColor),
+            ("colors.accentColorLight", colors.accentColorLight),
+            ("colors.primaryBorder", colors.primaryBorder),
+            ("colors.secondaryBorder", colors.secondaryBorder),
+            ("colors.focusBorder", colors.focusBorder),
+            ("colors.successColor", colors.successColor),
+            ("colors.warningColor", colors.warningColor),
+            ("colors.errorColor", colors.errorColor),
+            ("colors.infoColor", colors.infoColor),
+            ("colors.cardBackground", colors.cardBackground),
+            ("colors.cardBorder", colors.cardBorder),
+            ("colors.buttonBackground", colors.buttonBackground),
+            ("colors.buttonBorder", colors.buttonBorder),
+            ("colors.inputBackground", colors.inputBackground),
+            ("colors.inputBorder", colors.inputBorder),
+            ("colors.glassTintOverlay", colors.glassTintOverlay),
+            ("colors.codeBlockBackground", colors.codeBlockBackground),
+            ("colors.shadowColor", colors.shadowColor),
+            ("colors.selectionColor", colors.selectionColor),
+            ("colors.cursorColor", colors.cursorColor)
+        ]
+
+        required.forEach { validateHex($0.1, field: $0.0, issues: &issues) }
+        if let placeholder = colors.placeholderText {
+            validateHex(placeholder, field: "colors.placeholderText", issues: &issues)
+        }
+    }
+
+    private static func validateBackground(
+        _ background: ThemeBackground,
+        fallbackBackground: String,
+        issues: inout [ThemeValidationIssue]
+    ) {
+        switch background.type {
+        case .solid:
+            validateHex(background.solidColor ?? fallbackBackground, field: "background.solidColor", issues: &issues)
+        case .gradient:
+            let colors = background.gradientColors ?? []
+            if colors.count < 2 {
+                issues.append(.init(severity: .error, field: "background.gradientColors", message: "Gradient backgrounds need at least two colors."))
+            }
+            for (index, color) in colors.enumerated() {
+                validateHex(color, field: "background.gradientColors[\(index)]", issues: &issues)
+            }
+        case .image:
+            guard let imageData = background.imageData, !imageData.isEmpty else {
+                issues.append(.init(severity: .error, field: "background.imageData", message: "Image backgrounds need image data."))
+                break
+            }
+            guard let data = Data(base64Encoded: imageData) else {
+                issues.append(.init(severity: .error, field: "background.imageData", message: "Image data is not valid base64."))
+                break
+            }
+            if data.count > ThemesAPIClient.maxBodyBytes {
+                issues.append(.init(severity: .warning, field: "background.imageData", message: "Image data may exceed the share upload limit."))
+            }
+            if NSImage(data: data) == nil {
+                issues.append(.init(severity: .error, field: "background.imageData", message: "Image data could not be decoded."))
+            }
+        }
+
+        if let overlay = background.overlayColor {
+            validateHex(overlay, field: "background.overlayColor", issues: &issues)
+        }
+        validateUnit(background.imageOpacity, field: "background.imageOpacity", issues: &issues)
+        validateUnit(background.overlayOpacity, field: "background.overlayOpacity", issues: &issues)
+    }
+
+    private static func validateGlass(_ glass: ThemeGlass, issues: inout [ThemeValidationIssue]) {
+        validateRange(glass.blurRadius, 0 ... 120, field: "glass.blurRadius", issues: &issues)
+        validateUnit(glass.opacityPrimary, field: "glass.opacityPrimary", issues: &issues)
+        validateUnit(glass.opacitySecondary, field: "glass.opacitySecondary", issues: &issues)
+        validateUnit(glass.opacityTertiary, field: "glass.opacityTertiary", issues: &issues)
+        validateUnit(glass.tintOpacity, field: "glass.tintOpacity", issues: &issues)
+        validateUnit(glass.windowBackingOpacity, field: "glass.windowBackingOpacity", issues: &issues)
+        validateHex(glass.edgeLight, field: "glass.edgeLight", issues: &issues)
+        if let tint = glass.tintColor {
+            validateHex(tint, field: "glass.tintColor", issues: &issues)
+        }
+        if let width = glass.edgeLightWidth {
+            validateRange(width, 0 ... 12, field: "glass.edgeLightWidth", issues: &issues)
+        }
+    }
+
+    private static func validateTypography(_ typography: ThemeTypography, issues: inout [ThemeValidationIssue]) {
+        if typography.primaryFont.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.init(severity: .warning, field: "typography.primaryFont", message: "Primary font is empty."))
+        }
+        if typography.monoFont.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(.init(severity: .warning, field: "typography.monoFont", message: "Monospace font is empty."))
+        }
+
+        validateRange(typography.titleSize, 8 ... 72, field: "typography.titleSize", issues: &issues)
+        validateRange(typography.headingSize, 8 ... 64, field: "typography.headingSize", issues: &issues)
+        validateRange(typography.bodySize, 8 ... 36, field: "typography.bodySize", issues: &issues)
+        validateRange(typography.captionSize, 8 ... 28, field: "typography.captionSize", issues: &issues)
+        validateRange(typography.codeSize, 8 ... 36, field: "typography.codeSize", issues: &issues)
+    }
+
+    private static func validateAnimation(_ animation: ThemeAnimation, issues: inout [ThemeValidationIssue]) {
+        validateRange(animation.durationQuick, 0 ... 5, field: "animationConfig.durationQuick", issues: &issues)
+        validateRange(animation.durationMedium, 0 ... 5, field: "animationConfig.durationMedium", issues: &issues)
+        validateRange(animation.durationSlow, 0 ... 5, field: "animationConfig.durationSlow", issues: &issues)
+        validateRange(animation.springResponse, 0.01 ... 5, field: "animationConfig.springResponse", issues: &issues)
+        validateRange(animation.springDamping, 0 ... 1.5, field: "animationConfig.springDamping", issues: &issues)
+    }
+
+    private static func validateShadows(_ shadows: ThemeShadows, issues: inout [ThemeValidationIssue]) {
+        validateUnit(shadows.shadowOpacity, field: "shadows.shadowOpacity", issues: &issues)
+        validateRange(shadows.cardShadowRadius, 0 ... 80, field: "shadows.cardShadowRadius", issues: &issues)
+        validateRange(shadows.cardShadowRadiusHover, 0 ... 100, field: "shadows.cardShadowRadiusHover", issues: &issues)
+        validateRange(shadows.cardShadowY, -40 ... 80, field: "shadows.cardShadowY", issues: &issues)
+        validateRange(shadows.cardShadowYHover, -40 ... 100, field: "shadows.cardShadowYHover", issues: &issues)
+    }
+
+    private static func validateMessages(_ messages: ThemeMessages, issues: inout [ThemeValidationIssue]) {
+        validateRange(messages.bubbleCornerRadius, 0 ... 80, field: "messages.bubbleCornerRadius", issues: &issues)
+        validateUnit(messages.userBubbleOpacity, field: "messages.userBubbleOpacity", issues: &issues)
+        validateUnit(messages.assistantBubbleOpacity, field: "messages.assistantBubbleOpacity", issues: &issues)
+        validateRange(messages.borderWidth, 0 ... 12, field: "messages.borderWidth", issues: &issues)
+        validateRange(messages.inlineAvatarSize, 10 ... 80, field: "messages.inlineAvatarSize", issues: &issues)
+        validateRange(messages.agentNameSize, 8 ... 32, field: "messages.agentNameSize", issues: &issues)
+        if let color = messages.userBubbleColor {
+            validateHex(color, field: "messages.userBubbleColor", issues: &issues)
+        }
+        if let color = messages.assistantBubbleColor {
+            validateHex(color, field: "messages.assistantBubbleColor", issues: &issues)
+        }
+    }
+
+    private static func validateBorders(_ borders: ThemeBorders, issues: inout [ThemeValidationIssue]) {
+        validateRange(borders.defaultWidth, 0 ... 12, field: "borders.defaultWidth", issues: &issues)
+        validateRange(borders.cardCornerRadius, 0 ... 80, field: "borders.cardCornerRadius", issues: &issues)
+        validateRange(borders.inputCornerRadius, 0 ... 80, field: "borders.inputCornerRadius", issues: &issues)
+        validateUnit(borders.borderOpacity, field: "borders.borderOpacity", issues: &issues)
+    }
+
+    private static func validateLibrary(_ theme: CustomTheme, issues: inout [ThemeValidationIssue]) {
+        if theme.isBuiltIn, theme.library != nil {
+            issues.append(.init(severity: .warning, field: "library", message: "Built-in themes ignore library provenance."))
+        }
+
+        guard let library = theme.library else { return }
+        if library.source == .shared {
+            guard let hash = library.remoteHash, ThemeShareService.isValidHash(hash) else {
+                issues.append(.init(severity: .warning, field: "library.remoteHash", message: "Shared theme is missing a valid remote ID."))
+                return
+            }
+            if let remoteURL = library.remoteURL, URL(string: remoteURL) == nil {
+                issues.append(.init(severity: .warning, field: "library.remoteURL", message: "Shared theme URL is invalid."))
+            }
+        }
+    }
+
+    private static func validateHex(_ value: String, field: String, issues: inout [ThemeValidationIssue]) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard [3, 6, 8].contains(body.count), body.allSatisfy(\.isHexDigit) else {
+            issues.append(.init(severity: .error, field: field, message: "Expected #RGB, #RRGGBB, or #AARRGGBB."))
+            return
+        }
+        if !trimmed.hasPrefix("#") {
+            issues.append(.init(severity: .warning, field: field, message: "Hex colors should include a leading #."))
+        }
+    }
+
+    private static func validateUnit(_ value: Double?, field: String, issues: inout [ThemeValidationIssue]) {
+        guard let value else { return }
+        validateUnit(value, field: field, issues: &issues)
+    }
+
+    private static func validateUnit(_ value: Double, field: String, issues: inout [ThemeValidationIssue]) {
+        validateRange(value, 0 ... 1, field: field, issues: &issues)
+    }
+
+    private static func validateRange(
+        _ value: Double,
+        _ range: ClosedRange<Double>,
+        field: String,
+        issues: inout [ThemeValidationIssue]
+    ) {
+        guard range.contains(value), value.isFinite else {
+            issues.append(.init(severity: .error, field: field, message: "Value must be between \(range.lowerBound) and \(range.upperBound)."))
+            return
+        }
+    }
+
+    private static func parseImportInput(_ rawInput: String) -> (kind: ThemeImportInputKind, hash: String?) {
+        let trimmed = rawInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return (.empty, nil) }
+
+        if ThemeShareService.isValidHash(trimmed) {
+            return (.rawHash, trimmed.lowercased())
+        }
+
+        guard let url = URL(string: trimmed),
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else {
+            return (.invalid, nil)
+        }
+
+        let scheme = url.scheme?.lowercased()
+        if scheme == ThemeShareService.deepLinkScheme,
+            url.host?.lowercased() == ThemeShareService.deepLinkHost
+        {
+            let value = components.queryItems?
+                .first(where: { $0.name.lowercased() == ThemeShareService.deepLinkHashParam })?
+                .value
+            guard let value, ThemeShareService.isValidHash(value) else { return (.invalid, nil) }
+            return (.deepLink, value.lowercased())
+        }
+
+        if scheme == "https" || scheme == "http" {
+            let candidate = url.lastPathComponent
+            if ThemeShareService.isValidHash(candidate) {
+                return (.webURL, candidate.lowercased())
+            }
+        }
+
+        return (.invalid, nil)
+    }
+}
+
+private struct VisualFingerprintPayload: Encodable {
+    let colors: ThemeColors
+    let background: ThemeBackground
+    let glass: ThemeGlass
+    let typography: ThemeTypography
+    let animationConfig: ThemeAnimation
+    let shadows: ThemeShadows
+    let messages: ThemeMessages
+    let borders: ThemeBorders
+    let codeHighlightTheme: String?
+    let isDark: Bool
+
+    init(theme: CustomTheme) {
+        colors = theme.colors
+        background = theme.background
+        glass = theme.glass
+        typography = theme.typography
+        animationConfig = theme.animationConfig
+        shadows = theme.shadows
+        messages = theme.messages
+        borders = theme.borders
+        codeHighlightTheme = theme.codeHighlightTheme
+        isDark = theme.isDark
+    }
+}

--- a/Packages/OsaurusCore/Services/Themes/ThemeShareService.swift
+++ b/Packages/OsaurusCore/Services/Themes/ThemeShareService.swift
@@ -75,9 +75,9 @@ public final class ThemeShareService {
     public static let shared = ThemeShareService()
 
     /// Deep link constants. Mirrors `osaurus://plugins-install?tool=…`.
-    public static let deepLinkScheme = "osaurus"
-    public static let deepLinkHost = "themes-install"
-    public static let deepLinkHashParam = "hash"
+    public nonisolated static let deepLinkScheme = "osaurus"
+    public nonisolated static let deepLinkHost = "themes-install"
+    public nonisolated static let deepLinkHashParam = "hash"
 
     private let api: ThemesAPIClient
 
@@ -200,7 +200,17 @@ public final class ThemeShareService {
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
         do {
-            let imported = try ThemeConfigurationStore.importTheme(from: tempURL)
+            let serverURL = await api.themeURL(hash: hash)
+            let imported = try ThemeConfigurationStore.importTheme(
+                from: tempURL,
+                libraryInfo: ThemeLibraryInfo(
+                    source: .shared,
+                    importedAt: Date(),
+                    remoteHash: hash,
+                    remoteURL: serverURL.absoluteString,
+                    sourceDetail: "Import by ID"
+                )
+            )
             ThemeManager.shared.refreshInstalledThemes()
             return imported
         } catch {
@@ -211,7 +221,7 @@ public final class ThemeShareService {
     // MARK: - Helpers
 
     /// Build the Osaurus deep link for a content hash.
-    public static func deepLink(for hash: String) -> URL {
+    public nonisolated static func deepLink(for hash: String) -> URL {
         var components = URLComponents()
         components.scheme = deepLinkScheme
         components.host = deepLinkHost
@@ -222,7 +232,7 @@ public final class ThemeShareService {
 
     /// Accepts a 64-char hex hash, an `osaurus://themes-install?hash=…` deep
     /// link, or the public web URL `https://themes.osaurus.ai/themes/<hash>`.
-    public static func parseHash(from input: String) -> String? {
+    public nonisolated static func parseHash(from input: String) -> String? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
@@ -257,7 +267,7 @@ public final class ThemeShareService {
         return nil
     }
 
-    public static func isValidHash(_ candidate: String) -> Bool {
+    public nonisolated static func isValidHash(_ candidate: String) -> Bool {
         guard candidate.count == 64 else { return false }
         return candidate.allSatisfy { $0.isHexDigit }
     }
@@ -265,7 +275,7 @@ public final class ThemeShareService {
     /// Stable JSON encoding for hashing/deduplication. Strips per-import
     /// fields so the same look from different installations produces the
     /// same SHA-256.
-    public static func canonicalEncode(_ theme: CustomTheme) throws -> Data {
+    public nonisolated static func canonicalEncode(_ theme: CustomTheme) throws -> Data {
         var canonical = theme
         canonical.metadata.id = UUID(
             uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -273,6 +283,7 @@ public final class ThemeShareService {
         canonical.metadata.createdAt = Date(timeIntervalSince1970: 0)
         canonical.metadata.updatedAt = Date(timeIntervalSince1970: 0)
         canonical.isBuiltIn = false
+        canonical.library = nil
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -280,7 +291,7 @@ public final class ThemeShareService {
         return try encoder.encode(canonical)
     }
 
-    private static func sha256Hex(_ data: Data) -> String {
+    private nonisolated static func sha256Hex(_ data: Data) -> String {
         let digest = SHA256.hash(data: data)
         return digest.map { String(format: "%02x", $0) }.joined()
     }

--- a/Packages/OsaurusCore/Services/Themes/ThemesAPIClient.swift
+++ b/Packages/OsaurusCore/Services/Themes/ThemesAPIClient.swift
@@ -212,6 +212,10 @@ public actor ThemesAPIClient {
         return data
     }
 
+    public func themeURL(hash: String) -> URL {
+        baseURL.appendingPathComponent("themes/\(hash)")
+    }
+
     // MARK: - Internal
 
     private func perform(_ request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Packages/OsaurusCore/Tests/Theme/ThemeLibraryManagementServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeLibraryManagementServiceTests.swift
@@ -1,0 +1,136 @@
+//
+//  ThemeLibraryManagementServiceTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Theme library management")
+struct ThemeLibraryManagementServiceTests {
+    @Test("validates malformed colors, images, and ranges")
+    func validationFindsThemeProblems() {
+        var theme = CustomTheme.darkDefault
+        theme.metadata.id = UUID()
+        theme.metadata.name = "Broken"
+        theme.isBuiltIn = false
+        theme.colors.accentColor = "not-a-color"
+        theme.background = ThemeBackground(type: .image, imageData: "not-base64")
+        theme.glass.opacityPrimary = 1.4
+
+        let report = ThemeLibraryManagementService.validate(theme)
+
+        #expect(report.errorCount >= 3)
+        #expect(report.issues.contains { $0.field == "colors.accentColor" })
+        #expect(report.issues.contains { $0.field == "background.imageData" })
+        #expect(report.issues.contains { $0.field == "glass.opacityPrimary" })
+    }
+
+    @Test("detects visual duplicates while ignoring local metadata")
+    func duplicateDetectionIgnoresIdentityMetadata() {
+        var first = CustomTheme.darkDefault
+        first.metadata.id = UUID()
+        first.metadata.name = "First Copy"
+        first.metadata.createdAt = Date(timeIntervalSince1970: 1)
+        first.isBuiltIn = false
+
+        var second = first
+        second.metadata.id = UUID()
+        second.metadata.name = "Second Copy"
+        second.metadata.createdAt = Date(timeIntervalSince1970: 2)
+        second.library = ThemeLibraryInfo(source: .imported, importedAt: Date())
+
+        var different = first
+        different.metadata.id = UUID()
+        different.metadata.name = "Different"
+        different.colors.accentColor = "#abcdef"
+
+        let groups = ThemeLibraryManagementService.duplicateGroups(in: [first, second, different])
+
+        #expect(groups.count == 1)
+        #expect(groups[0].members.map(\.id).contains(first.metadata.id))
+        #expect(groups[0].members.map(\.id).contains(second.metadata.id))
+        #expect(!groups[0].members.map(\.id).contains(different.metadata.id))
+    }
+
+    @Test("import diagnostics parses supported IDs and finds installed shared themes")
+    func importDiagnosticsParseAndMatch() {
+        let hash = String(repeating: "a", count: 64)
+        var installed = CustomTheme.darkDefault
+        installed.metadata.id = UUID()
+        installed.metadata.name = "Installed Shared"
+        installed.isBuiltIn = false
+        installed.library = ThemeLibraryInfo(source: .shared, remoteHash: hash)
+
+        let raw = ThemeLibraryManagementService.diagnoseImportInput(hash.uppercased(), installedThemes: [installed])
+        #expect(raw.kind == .rawHash)
+        #expect(raw.normalizedHash == hash)
+        #expect(raw.installedMatches.map(\.name) == ["Installed Shared"])
+
+        let deepLink = ThemeShareService.deepLink(for: hash).absoluteString
+        let linked = ThemeLibraryManagementService.diagnoseImportInput(deepLink, installedThemes: [])
+        #expect(linked.kind == .deepLink)
+        #expect(linked.normalizedHash == hash)
+
+        let web = ThemeLibraryManagementService.diagnoseImportInput(
+            "https://themes.osaurus.ai/themes/\(hash)",
+            installedThemes: []
+        )
+        #expect(web.kind == .webURL)
+        #expect(web.normalizedHash == hash)
+    }
+
+    @Test("file import, duplicate, share marker, and rollback persist provenance")
+    func provenancePersistsThroughStoreOperations() async throws {
+        try await StoragePathsTestLock.shared.run {
+            try await MainActor.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-theme-library-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                var source = CustomTheme.darkDefault
+                source.metadata.id = UUID()
+                source.metadata.name = "Import Source"
+                source.isBuiltIn = false
+
+                let sourceURL = root.appendingPathComponent("source.osaurus-theme")
+                let json = try ThemeJSONEditorCodec.encode(source)
+                let data = try #require(json.data(using: .utf8))
+                try data.write(to: sourceURL, options: .atomic)
+
+                let imported = try ThemeConfigurationStore.importTheme(from: sourceURL)
+                #expect(imported.library?.source == .imported)
+                #expect(imported.library?.sourceDetail == "source.osaurus-theme")
+                #expect(ThemeConfigurationStore.loadTheme(id: imported.metadata.id)?.library?.source == .imported)
+
+                let duplicated = ThemeConfigurationStore.duplicateTheme(imported, newName: "Local Copy")
+                #expect(duplicated.library?.source == .local)
+                #expect(duplicated.library?.remoteHash == nil)
+
+                let hash = String(repeating: "b", count: 64)
+                let shared = ThemeConfigurationStore.markThemeShared(
+                    id: imported.metadata.id,
+                    hash: hash,
+                    serverURL: URL(string: "https://themes.osaurus.ai/themes/\(hash)")!
+                )
+                #expect(shared?.library?.source == .shared)
+                #expect(shared?.library?.remoteHash == hash)
+
+                ThemeConfigurationStore.saveActiveThemeId(imported.metadata.id)
+                let previous = ThemeConfigurationStore.rollbackActiveThemeToDefault()
+                #expect(previous == imported.metadata.id)
+                #expect(ThemeConfigurationStore.loadActiveThemeId() == nil)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Theme/ThemePreviewImageCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemePreviewImageCacheTests.swift
@@ -1,0 +1,70 @@
+//
+//  ThemePreviewImageCacheTests.swift
+//  OsaurusCoreTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Theme preview image cache")
+struct ThemePreviewImageCacheTests {
+    @Test("records decoded images, failures, and clears health state")
+    func cacheHealthTracksDecodedImagesAndFailures() async throws {
+        let cache = ThemePreviewImageCache(countLimit: 4, totalCostLimit: 4096)
+
+        var imageTheme = CustomTheme.darkDefault
+        imageTheme.metadata.id = UUID()
+        imageTheme.isBuiltIn = false
+        imageTheme.background = ThemeBackground(type: .image, imageData: try Self.pngBase64())
+
+        let decoded = await cache.image(for: imageTheme)
+        #expect(decoded != nil)
+        #expect(cache.cachedImage(for: imageTheme.metadata.id.uuidString) != nil)
+
+        let healthy = await cache.healthSnapshot()
+        #expect(healthy.cachedEntryCount == 1)
+        #expect(healthy.cachedCostBytes > 0)
+        #expect(healthy.failedDecodeCount == 0)
+        #expect(healthy.isHealthy)
+
+        var brokenTheme = imageTheme
+        brokenTheme.metadata.id = UUID()
+        brokenTheme.background.imageData = "not-base64"
+
+        let failed = await cache.image(for: brokenTheme)
+        #expect(failed == nil)
+
+        let unhealthy = await cache.healthSnapshot()
+        #expect(unhealthy.failedDecodeCount == 1)
+        #expect(!unhealthy.isHealthy)
+
+        await cache.removeAll()
+        let empty = await cache.healthSnapshot()
+        #expect(empty.cachedEntryCount == 0)
+        #expect(empty.cachedCostBytes == 0)
+        #expect(empty.failedDecodeCount == 0)
+    }
+
+    private static func pngBase64() throws -> String {
+        let rep = try #require(
+            NSBitmapImageRep(
+                bitmapDataPlanes: nil,
+                pixelsWide: 1,
+                pixelsHigh: 1,
+                bitsPerSample: 8,
+                samplesPerPixel: 4,
+                hasAlpha: true,
+                isPlanar: false,
+                colorSpaceName: .deviceRGB,
+                bytesPerRow: 0,
+                bitsPerPixel: 0
+            )
+        )
+        rep.setColor(NSColor(calibratedRed: 0, green: 0.25, blue: 1, alpha: 1), atX: 0, y: 0)
+        let data = try #require(rep.representation(using: .png, properties: [:]))
+        return data.base64EncodedString()
+    }
+}

--- a/Packages/OsaurusCore/Tests/Theme/ThemeShareServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeShareServiceTests.swift
@@ -1,0 +1,46 @@
+//
+//  ThemeShareServiceTests.swift
+//  OsaurusCoreTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Theme share service")
+struct ThemeShareServiceTests {
+    @Test("deep links and public URLs round trip to normalized hashes")
+    func parseHashAcceptsSupportedInputs() {
+        let hash = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+        let normalized = hash.lowercased()
+
+        #expect(ThemeShareService.parseHash(from: hash) == normalized)
+        #expect(ThemeShareService.parseHash(from: ThemeShareService.deepLink(for: normalized).absoluteString) == normalized)
+        #expect(ThemeShareService.parseHash(from: "https://themes.osaurus.ai/themes/\(hash)") == normalized)
+        #expect(ThemeShareService.parseHash(from: "not-a-theme-id") == nil)
+    }
+
+    @Test("canonical share encoding ignores local import identity")
+    func canonicalEncodeIgnoresLocalIdentity() throws {
+        var first = CustomTheme.darkDefault
+        first.metadata.id = UUID()
+        first.metadata.name = "Shared Look"
+        first.metadata.createdAt = Date(timeIntervalSince1970: 100)
+        first.metadata.updatedAt = Date(timeIntervalSince1970: 200)
+        first.isBuiltIn = false
+        first.library = ThemeLibraryInfo(source: .imported, importedAt: Date())
+
+        var second = first
+        second.metadata.id = UUID()
+        second.metadata.createdAt = Date(timeIntervalSince1970: 300)
+        second.metadata.updatedAt = Date(timeIntervalSince1970: 400)
+        second.isBuiltIn = true
+        second.library = ThemeLibraryInfo(source: .shared, remoteHash: String(repeating: "c", count: 64))
+
+        let firstData = try ThemeShareService.canonicalEncode(first)
+        let secondData = try ThemeShareService.canonicalEncode(second)
+
+        #expect(firstData == secondData)
+    }
+}

--- a/Packages/OsaurusCore/Views/Theme/ImportThemeByIdSheet.swift
+++ b/Packages/OsaurusCore/Views/Theme/ImportThemeByIdSheet.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct ImportThemeByIdSheet: View {
     @Environment(\.theme) private var theme
     @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var themeManager = ThemeManager.shared
 
     /// Optional pre-supplied input. When non-empty (e.g. set from a deep link)
     /// the sheet starts directly in the importing phase.
@@ -49,6 +50,13 @@ struct ImportThemeByIdSheet: View {
         ThemeShareService.parseHash(from: input) != nil
     }
 
+    private var diagnostics: ThemeImportDiagnostics {
+        ThemeLibraryManagementService.diagnoseImportInput(
+            input,
+            installedThemes: themeManager.installedThemes
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             header
@@ -66,7 +74,7 @@ struct ImportThemeByIdSheet: View {
 
             footer
         }
-        .frame(width: 520, height: 360)
+        .frame(width: 520, height: 430)
         .background(theme.cardBackground)
         .onAppear { applyInitialInput() }
     }
@@ -165,6 +173,10 @@ struct ImportThemeByIdSheet: View {
                 .foregroundColor(theme.warningColor)
             }
 
+            if !input.isEmpty {
+                diagnosticsView(diagnostics)
+            }
+
             HStack(spacing: 6) {
                 Image(systemName: "info.circle")
                     .font(.system(size: 10))
@@ -240,6 +252,74 @@ struct ImportThemeByIdSheet: View {
                 .font(.system(size: 11))
                 .foregroundColor(theme.warningColor)
             }
+
+            if !input.isEmpty {
+                diagnosticsView(diagnostics)
+            }
+        }
+    }
+
+    private func diagnosticsView(_ diagnostics: ThemeImportDiagnostics) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: diagnostics.canImport ? "checkmark.seal.fill" : "stethoscope")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(diagnostics.canImport ? theme.successColor : theme.secondaryText)
+                Text("Import diagnostics", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(LocalizedStringKey(diagnosticKindLabel(diagnostics.kind)), bundle: .module)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(theme.tertiaryBackground))
+            }
+
+            if let hash = diagnostics.normalizedHash {
+                Text(verbatim: hash)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if diagnostics.installedMatches.isEmpty {
+                    Text("No installed theme has this shared ID yet.", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                } else {
+                    Text(
+                        "Already installed as \(diagnostics.installedMatches.map(\.name).joined(separator: ", ")).",
+                        bundle: .module
+                    )
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.warningColor)
+                    .lineLimit(2)
+                }
+            } else {
+                Text("Paste a valid ID or link to see normalized server details.", bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.tertiaryText)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.primaryBorder.opacity(0.6), lineWidth: 1)
+                )
+        )
+    }
+
+    private func diagnosticKindLabel(_ kind: ThemeImportInputKind) -> String {
+        switch kind {
+        case .empty: return "Waiting"
+        case .rawHash: return "Raw ID"
+        case .deepLink: return "Deep link"
+        case .webURL: return "Web URL"
+        case .invalid: return "Invalid"
         }
     }
 

--- a/Packages/OsaurusCore/Views/Theme/ThemePreviewImageCache.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemePreviewImageCache.swift
@@ -12,6 +12,28 @@
 
 import AppKit
 
+struct ThemePreviewCacheHealth: Equatable, Sendable {
+    let cachedEntryCount: Int
+    let cachedCostBytes: Int
+    let countLimit: Int
+    let totalCostLimit: Int
+    let inFlightDecodeCount: Int
+    let failedDecodeCount: Int
+
+    static let empty = ThemePreviewCacheHealth(
+        cachedEntryCount: 0,
+        cachedCostBytes: 0,
+        countLimit: 0,
+        totalCostLimit: 0,
+        inFlightDecodeCount: 0,
+        failedDecodeCount: 0
+    )
+
+    var isHealthy: Bool {
+        failedDecodeCount == 0 && cachedEntryCount <= countLimit
+    }
+}
+
 final class ThemePreviewImageCache: @unchecked Sendable {
 
     static let shared = ThemePreviewImageCache()
@@ -19,18 +41,30 @@ final class ThemePreviewImageCache: @unchecked Sendable {
     private let cache = NSCache<NSString, NSImage>()
     private let state = CacheState()
 
-    private init() {
-        cache.countLimit = 64
+    init(countLimit: Int = 64, totalCostLimit: Int = 50 * 1024 * 1024) {
+        cache.countLimit = countLimit
         // ~50 MB cap. Themes with image backgrounds typically encode
         // ~200KB-2MB JPEG/PNG payloads; this leaves room for a generous
         // gallery without keeping every theme alive forever.
-        cache.totalCostLimit = 50 * 1024 * 1024
+        cache.totalCostLimit = totalCostLimit
     }
 
     // MARK: - Synchronous lookup
 
     func cachedImage(for id: String) -> NSImage? {
         cache.object(forKey: id as NSString)
+    }
+
+    func healthSnapshot() async -> ThemePreviewCacheHealth {
+        await state.snapshot(
+            countLimit: cache.countLimit,
+            totalCostLimit: cache.totalCostLimit
+        )
+    }
+
+    func removeAll() async {
+        cache.removeAllObjects()
+        await state.removeAll()
     }
 
     // MARK: - Async decode
@@ -68,7 +102,11 @@ final class ThemePreviewImageCache: @unchecked Sendable {
         if let img = result {
             // Cost roughly tracks the encoded payload size, which is a
             // reasonable proxy for the decoded bitmap's footprint here.
-            cache.setObject(img, forKey: id as NSString, cost: payload.utf8.count)
+            let cost = payload.utf8.count
+            cache.setObject(img, forKey: id as NSString, cost: cost)
+            await state.recordCached(id: id, cost: cost)
+        } else {
+            await state.recordFailure()
         }
         return result
     }
@@ -78,8 +116,29 @@ final class ThemePreviewImageCache: @unchecked Sendable {
 
 private actor CacheState {
     private var inFlight: [String: Task<NSImage?, Never>] = [:]
+    private var cachedCosts: [String: Int] = [:]
+    private var failedDecodeCount = 0
 
     func inFlight(for id: String) -> Task<NSImage?, Never>? { inFlight[id] }
     func setInFlight(_ task: Task<NSImage?, Never>, for id: String) { inFlight[id] = task }
     func removeInFlight(for id: String) { inFlight.removeValue(forKey: id) }
+    func recordCached(id: String, cost: Int) { cachedCosts[id] = cost }
+    func recordFailure() { failedDecodeCount += 1 }
+
+    func removeAll() {
+        inFlight.removeAll()
+        cachedCosts.removeAll()
+        failedDecodeCount = 0
+    }
+
+    func snapshot(countLimit: Int, totalCostLimit: Int) -> ThemePreviewCacheHealth {
+        ThemePreviewCacheHealth(
+            cachedEntryCount: cachedCosts.count,
+            cachedCostBytes: cachedCosts.values.reduce(0, +),
+            countLimit: countLimit,
+            totalCostLimit: totalCostLimit,
+            inFlightDecodeCount: inFlight.count,
+            failedDecodeCount: failedDecodeCount
+        )
+    }
 }

--- a/Packages/OsaurusCore/Views/Theme/ThemesView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemesView.swift
@@ -20,6 +20,39 @@ struct IdentifiableTheme: Identifiable {
     }
 }
 
+private enum ThemeLibraryFilter: String, CaseIterable, Identifiable {
+    case all
+    case local
+    case imported
+    case shared
+    case needsReview
+    case duplicates
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return "All"
+        case .local: return "Local"
+        case .imported: return "Imported"
+        case .shared: return "Shared"
+        case .needsReview: return "Needs Review"
+        case .duplicates: return "Duplicates"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .all: return "square.grid.2x2"
+        case .local: return "paintbrush.pointed"
+        case .imported: return "tray.and.arrow.down"
+        case .shared: return "link"
+        case .needsReview: return "exclamationmark.triangle"
+        case .duplicates: return "doc.on.doc"
+        }
+    }
+}
+
 struct ThemesView: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @ObservedObject private var managementState = ManagementStateManager.shared
@@ -53,6 +86,12 @@ struct ThemesView: View {
     @State private var installedThemes: [CustomTheme] = []
     @State private var builtInThemes: [CustomTheme] = []
     @State private var customThemes: [CustomTheme] = []
+    @State private var libraryFilter: ThemeLibraryFilter = .all
+    @State private var validationReports: [UUID: ThemeValidationReport] = [:]
+    @State private var duplicateGroups: [ThemeDuplicateGroup] = []
+    @State private var librarySummary: ThemeLibrarySummary = .empty
+    @State private var previewCacheHealth: ThemePreviewCacheHealth = .empty
+    @State private var showRollbackConfirmation = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -73,8 +112,10 @@ struct ThemesView: View {
                 } else {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 24) {
-                            // Community gallery discovery banner
-                            communityThemesBanner
+                            let visibleBuiltInThemes = filteredThemes(builtInThemes)
+                            let visibleCustomThemes = filteredThemes(customThemes)
+
+                            themeLibraryManagementCenter
                                 .transition(.opacity)
 
                             // Active theme indicator
@@ -84,28 +125,36 @@ struct ThemesView: View {
                             }
 
                             // Built-in themes
-                            if !builtInThemes.isEmpty {
+                            if !visibleBuiltInThemes.isEmpty {
                                 themesSection(
                                     title: L("Built-in Themes"),
-                                    count: builtInThemes.count,
-                                    themes: builtInThemes
+                                    count: visibleBuiltInThemes.count,
+                                    themes: visibleBuiltInThemes
                                 )
                                 .transition(.opacity)
                             }
 
                             // Custom themes
-                            if !customThemes.isEmpty {
+                            if !visibleCustomThemes.isEmpty {
                                 themesSection(
-                                    title: L("Custom Themes"),
-                                    count: customThemes.count,
-                                    themes: customThemes
+                                    title: customSectionTitle,
+                                    count: visibleCustomThemes.count,
+                                    themes: visibleCustomThemes
                                 )
                                 .transition(.opacity)
                             }
 
+                            // Community gallery discovery banner
+                            communityThemesBanner
+                                .transition(.opacity)
+
                             // Empty state for custom themes
-                            if customThemes.isEmpty && !builtInThemes.isEmpty {
+                            if customThemes.isEmpty && !builtInThemes.isEmpty && libraryFilter == .all {
                                 emptyCustomThemesView
+                            }
+
+                            if libraryFilter != .all && visibleBuiltInThemes.isEmpty && visibleCustomThemes.isEmpty {
+                                emptyFilteredThemesView
                             }
                         }
                         .padding(24)
@@ -156,7 +205,8 @@ struct ThemesView: View {
             handleExport(result)
         }
         .sheet(item: $sharingTheme) { identifiable in
-            ShareThemeSheet(themeToShare: identifiable.theme) { _ in
+            ShareThemeSheet(themeToShare: identifiable.theme) { outcome in
+                markThemeShared(identifiable.theme, outcome: outcome)
                 showToast(L("Theme shared"))
             }
         }
@@ -211,6 +261,19 @@ struct ThemesView: View {
                 showDeleteConfirmation = false
                 themeToDelete = nil
             }
+        )
+        .themedAlert(
+            String(localized: "Rollback to Default", bundle: .module),
+            isPresented: $showRollbackConfirmation,
+            message: String(
+                localized:
+                    "Clear the active custom theme and return to the built-in theme for the current appearance mode? Installed themes will stay in the library.",
+                bundle: .module
+            ),
+            primaryButton: .destructive(String(localized: "Rollback", bundle: .module)) {
+                rollbackToDefaultTheme()
+            },
+            secondaryButton: .cancel(L("Cancel")) {}
         )
     }
 
@@ -389,6 +452,284 @@ struct ThemesView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    // MARK: - Library Management Center
+
+    private var themeLibraryManagementCenter: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Theme Library", bundle: .module)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text("Validate, filter, deduplicate, and recover installed themes.", bundle: .module)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                }
+
+                Spacer(minLength: 12)
+
+                HStack(spacing: 8) {
+                    libraryActionButton(
+                        title: "Rollback",
+                        icon: "arrow.uturn.backward",
+                        disabled: themeManager.activeCustomTheme == nil
+                    ) {
+                        showRollbackConfirmation = true
+                    }
+
+                    libraryActionButton(title: "Clear Cache", icon: "trash") {
+                        clearPreviewCache()
+                    }
+                }
+            }
+
+            libraryStatGrid
+            previewCacheHealthRow
+            libraryFilterBar
+
+            if !duplicateGroups.isEmpty {
+                duplicateOverview
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.secondaryBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.primaryBorder.opacity(0.55), lineWidth: 1)
+                )
+        )
+    }
+
+    private var libraryStatGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 132, maximum: 180), spacing: 10)],
+            spacing: 10
+        ) {
+            libraryStatTile("Local", count: librarySummary.localCount, icon: "paintbrush.pointed", color: theme.accentColor)
+            libraryStatTile("Imported", count: librarySummary.importedCount, icon: "tray.and.arrow.down", color: theme.infoColor)
+            libraryStatTile("Shared", count: librarySummary.sharedCount, icon: "link", color: theme.successColor)
+            libraryStatTile("Issues", count: librarySummary.validationErrorCount + librarySummary.validationWarningCount, icon: "exclamationmark.triangle", color: issueStatColor)
+            libraryStatTile("Duplicate Sets", count: librarySummary.duplicateGroupCount, icon: "doc.on.doc", color: duplicateGroups.isEmpty ? theme.tertiaryText : theme.warningColor)
+        }
+    }
+
+    private func libraryStatTile(_ title: String, count: Int, icon: String, color: Color) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(color)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(color.opacity(0.14)))
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(count)", bundle: .module)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.cardBorder.opacity(0.8), lineWidth: 1)
+                )
+        )
+    }
+
+    private var previewCacheHealthRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: previewCacheHealth.isHealthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(previewCacheHealth.isHealthy ? theme.successColor : theme.warningColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Preview cache health", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Text(verbatim: cacheHealthSummary)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                refreshPreviewCacheHealth()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(theme.tertiaryBackground)
+                    )
+            }
+            .buttonStyle(.plain)
+            .help(Text("Refresh cache health", bundle: .module))
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.cardBorder.opacity(0.75), lineWidth: 1)
+                )
+        )
+    }
+
+    private var libraryFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(ThemeLibraryFilter.allCases) { filter in
+                    Button {
+                        withAnimation(theme.animationQuick()) {
+                            libraryFilter = filter
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: filter.icon)
+                                .font(.system(size: 11, weight: .semibold))
+                            Text(LocalizedStringKey(filter.title), bundle: .module)
+                                .font(.system(size: 12, weight: .medium))
+                                .lineLimit(1)
+                        }
+                        .foregroundColor(libraryFilter == filter ? Color.white : theme.secondaryText)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            Capsule()
+                                .fill(libraryFilter == filter ? theme.accentColor : theme.tertiaryBackground)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var duplicateOverview: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.on.doc.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.warningColor)
+                Text("Duplicate detection", bundle: .module)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                Spacer()
+                Button {
+                    withAnimation(theme.animationQuick()) {
+                        libraryFilter = .duplicates
+                    }
+                } label: {
+                    Text("Review", bundle: .module)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.accentColor)
+                }
+                .buttonStyle(.plain)
+            }
+
+            ForEach(duplicateGroups.prefix(2)) { group in
+                Text(group.members.map(\.name).joined(separator: "  •  "))
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.warningColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.warningColor.opacity(0.22), lineWidth: 1)
+                )
+        )
+    }
+
+    private var emptyFilteredThemesView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 30))
+                .foregroundColor(theme.tertiaryText)
+            Text("No themes match this filter", bundle: .module)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+            Button {
+                withAnimation(theme.animationQuick()) {
+                    libraryFilter = .all
+                }
+            } label: {
+                Text("Show All Themes", bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 36)
+    }
+
+    private func libraryActionButton(
+        title: String,
+        icon: String,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundColor(disabled ? theme.tertiaryText : theme.primaryText)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(theme.tertiaryBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(theme.inputBorder.opacity(disabled ? 0.35 : 1), lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+    }
+
+    private var issueStatColor: Color {
+        if librarySummary.validationErrorCount > 0 { return theme.errorColor }
+        if librarySummary.validationWarningCount > 0 { return theme.warningColor }
+        return theme.successColor
+    }
+
+    private var cacheHealthSummary: String {
+        let cost = ByteCountFormatter.string(
+            fromByteCount: Int64(previewCacheHealth.cachedCostBytes),
+            countStyle: .file
+        )
+        let limit = ByteCountFormatter.string(
+            fromByteCount: Int64(previewCacheHealth.totalCostLimit),
+            countStyle: .file
+        )
+        return "\(previewCacheHealth.cachedEntryCount) images, \(cost) tracked of \(limit), \(previewCacheHealth.inFlightDecodeCount) decoding, \(previewCacheHealth.failedDecodeCount) failed decodes"
+    }
+
     private func showToast(_ message: String, type: SimpleToastType = .success) {
         withAnimation(theme.springAnimation()) {
             toastType = type
@@ -420,6 +761,17 @@ struct ThemesView: View {
         }
     }
 
+    private var customSectionTitle: String {
+        switch libraryFilter {
+        case .all: return L("Custom Themes")
+        case .local: return "Local Themes"
+        case .imported: return "Imported Themes"
+        case .shared: return "Shared Themes"
+        case .needsReview: return "Themes Needing Review"
+        case .duplicates: return "Duplicate Themes"
+        }
+    }
+
     /// Sort once, partition once. Called on initial load and whenever
     /// `ThemeManager` republishes its installed list.
     private func refreshPartitions(from themes: [CustomTheme]) {
@@ -427,6 +779,86 @@ struct ThemesView: View {
         installedThemes = sorted
         builtInThemes = sorted.filter { $0.isBuiltIn }
         customThemes = sorted.filter { !$0.isBuiltIn }
+        let reports = ThemeLibraryManagementService.validationReports(for: sorted)
+        let reportMap = Dictionary(uniqueKeysWithValues: reports.map { ($0.themeID, $0) })
+        let duplicates = ThemeLibraryManagementService.duplicateGroups(in: sorted)
+        validationReports = reportMap
+        duplicateGroups = duplicates
+        librarySummary = ThemeLibraryManagementService.summary(
+            for: sorted,
+            reports: reports,
+            duplicateGroups: duplicates
+        )
+        refreshPreviewCacheHealth()
+    }
+
+    private func filteredThemes(_ themes: [CustomTheme]) -> [CustomTheme] {
+        themes.filter(shouldShowTheme(_:))
+    }
+
+    private func shouldShowTheme(_ themeItem: CustomTheme) -> Bool {
+        switch libraryFilter {
+        case .all:
+            return true
+        case .local:
+            return ThemeLibraryManagementService.source(for: themeItem) == .local
+        case .imported:
+            return ThemeLibraryManagementService.source(for: themeItem) == .imported
+        case .shared:
+            return ThemeLibraryManagementService.source(for: themeItem) == .shared
+        case .needsReview:
+            return validationReports[themeItem.metadata.id]?.needsReview == true
+        case .duplicates:
+            return duplicateThemeIDs.contains(themeItem.metadata.id)
+        }
+    }
+
+    private var duplicateThemeIDs: Set<UUID> {
+        Set(duplicateGroups.flatMap { $0.members.map(\.id) })
+    }
+
+    private func duplicateGroupSize(for themeItem: CustomTheme) -> Int {
+        duplicateGroups.first { group in
+            group.members.contains { $0.id == themeItem.metadata.id }
+        }?.count ?? 0
+    }
+
+    private func refreshPreviewCacheHealth() {
+        Task {
+            let snapshot = await ThemePreviewImageCache.shared.healthSnapshot()
+            await MainActor.run {
+                previewCacheHealth = snapshot
+            }
+        }
+    }
+
+    private func clearPreviewCache() {
+        Task {
+            await ThemePreviewImageCache.shared.removeAll()
+            let snapshot = await ThemePreviewImageCache.shared.healthSnapshot()
+            await MainActor.run {
+                previewCacheHealth = snapshot
+                showToast(String(localized: "Preview cache cleared", bundle: .module))
+            }
+        }
+    }
+
+    private func rollbackToDefaultTheme() {
+        ThemeConfigurationStore.rollbackActiveThemeToDefault()
+        themeManager.clearCustomTheme()
+        themeManager.refreshInstalledThemes()
+        refreshPartitions(from: themeManager.installedThemes)
+        showToast(String(localized: "Rolled back to the default theme", bundle: .module))
+    }
+
+    private func markThemeShared(_ themeItem: CustomTheme, outcome: ThemeShareOutcome) {
+        guard !themeItem.isBuiltIn else { return }
+        _ = ThemeConfigurationStore.markThemeShared(
+            id: themeItem.metadata.id,
+            hash: outcome.hash,
+            serverURL: outcome.serverURL
+        )
+        themeManager.refreshInstalledThemes()
     }
 
     // MARK: - Active Theme Section
@@ -522,6 +954,9 @@ struct ThemesView: View {
                     ThemePreviewCard(
                         theme: themeItem,
                         isActive: isActive,
+                        source: ThemeLibraryManagementService.source(for: themeItem),
+                        validationReport: validationReports[themeItem.metadata.id],
+                        duplicateGroupSize: duplicateGroupSize(for: themeItem),
                         onApply: {
                             themeManager.applyCustomTheme(themeItem)
                             showToast(L("Applied \"\(themeItem.metadata.name)\""))
@@ -700,6 +1135,7 @@ struct ThemesView: View {
             author: "User"
         )
         newTheme.isBuiltIn = false
+        newTheme.library = ThemeLibraryInfo(source: .local)
         openEditor(for: newTheme)
     }
 
@@ -797,6 +1233,9 @@ struct ThemesView: View {
 struct ThemePreviewCard: View {
     let theme: CustomTheme
     let isActive: Bool
+    let source: ThemeLibrarySource
+    let validationReport: ThemeValidationReport?
+    let duplicateGroupSize: Int
     let onApply: () -> Void
     let onEdit: () -> Void
     let onExport: () -> Void
@@ -817,6 +1256,9 @@ struct ThemePreviewCard: View {
     init(
         theme: CustomTheme,
         isActive: Bool,
+        source: ThemeLibrarySource,
+        validationReport: ThemeValidationReport?,
+        duplicateGroupSize: Int,
         onApply: @escaping () -> Void,
         onEdit: @escaping () -> Void,
         onExport: @escaping () -> Void,
@@ -826,6 +1268,9 @@ struct ThemePreviewCard: View {
     ) {
         self.theme = theme
         self.isActive = isActive
+        self.source = source
+        self.validationReport = validationReport
+        self.duplicateGroupSize = duplicateGroupSize
         self.onApply = onApply
         self.onEdit = onEdit
         self.onExport = onExport
@@ -903,15 +1348,17 @@ struct ThemePreviewCard: View {
                 }
 
                 if theme.isBuiltIn {
-                    Text("Built-in", bundle: .module)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(currentTheme.secondaryText)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(currentTheme.tertiaryBackground)
-                        )
+                    sourceBadge("Built-in", color: currentTheme.secondaryText)
+                } else {
+                    sourceBadge(sourceLabel(source), color: sourceColor(source))
+                }
+
+                if let validationReport, validationReport.needsReview {
+                    validationBadge(validationReport)
+                }
+
+                if duplicateGroupSize > 1 {
+                    sourceBadge("Duplicate", color: currentTheme.warningColor)
                 }
             }
 
@@ -1006,6 +1453,60 @@ struct ThemePreviewCard: View {
                 Circle()
                     .stroke(currentTheme.primaryBorder, lineWidth: 1)
             )
+    }
+
+    private func sourceBadge(_ label: String, color: Color) -> some View {
+        Text(LocalizedStringKey(label), bundle: .module)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(color.opacity(0.14))
+            )
+    }
+
+    private func validationBadge(_ report: ThemeValidationReport) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: report.errorCount > 0 ? "xmark.octagon.fill" : "exclamationmark.triangle.fill")
+                .font(.system(size: 8, weight: .bold))
+            Text(LocalizedStringKey(report.errorCount > 0 ? "Invalid" : "Review"), bundle: .module)
+                .font(.system(size: 10, weight: .medium))
+        }
+        .foregroundColor(report.errorCount > 0 ? currentTheme.errorColor : currentTheme.warningColor)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(
+            Capsule()
+                .fill((report.errorCount > 0 ? currentTheme.errorColor : currentTheme.warningColor).opacity(0.14))
+        )
+        .help(Text(verbatim: validationHelp(report)))
+    }
+
+    private func sourceLabel(_ source: ThemeLibrarySource) -> String {
+        switch source {
+        case .builtIn: return "Built-in"
+        case .local: return "Local"
+        case .imported: return "Imported"
+        case .shared: return "Shared"
+        }
+    }
+
+    private func sourceColor(_ source: ThemeLibrarySource) -> Color {
+        switch source {
+        case .builtIn: return currentTheme.secondaryText
+        case .local: return currentTheme.accentColor
+        case .imported: return currentTheme.infoColor
+        case .shared: return currentTheme.successColor
+        }
+    }
+
+    private func validationHelp(_ report: ThemeValidationReport) -> String {
+        if let first = report.issues.first {
+            return "\(first.field): \(first.message)"
+        }
+        return "Theme validation passed"
     }
 }
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -9,6 +9,7 @@ This document describes the JSON schema for Osaurus custom themes. Themes can be
 - **`metadata.id`** is ignored on import -- a new UUID is always generated.
 - **`isBuiltIn`** is forced to `false` on import.
 - All top-level sections are required unless noted otherwise.
+- `library` is optional provenance metadata managed by Osaurus. It is safe to omit in hand-written themes.
 
 ## Top-Level Structure
 
@@ -23,6 +24,7 @@ This document describes the JSON schema for Osaurus custom themes. Themes can be
   "shadows": { ... },
   "messages": { ... },
   "borders": { ... },
+  "library": { ... },
   "isBuiltIn": false,
   "isDark": true
 }
@@ -33,7 +35,7 @@ This document describes the JSON schema for Osaurus custom themes. Themes can be
 | `isBuiltIn` | Bool | Always set to `false` for custom themes. Forced to `false` on import. |
 | `isDark` | Bool | Whether this is a dark theme. Affects system appearance matching. |
 
-`messages` and `borders` are optional -- they fall back to defaults if omitted.
+`messages`, `borders`, and `library` are optional -- missing `messages` and `borders` fall back to defaults, and missing `library` is treated as a local custom theme.
 
 ---
 
@@ -209,6 +211,23 @@ Optional section -- defaults are used if omitted.
 | `cardCornerRadius` | Double | `12` | Corner radius for card-style elements. |
 | `inputCornerRadius` | Double | `8` | Corner radius for input fields. |
 | `borderOpacity` | Double | `0.3` | Default border opacity applied to border colors. |
+
+---
+
+## library
+
+Optional section managed by the Theme Library view. Imports and shares may rewrite it so the UI can distinguish local, imported, and shared themes.
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | String | One of `"local"`, `"imported"`, `"shared"`, or `"builtIn"`. Built-in presets ignore this field. |
+| `importedAt` | String? (ISO 8601) | When Osaurus imported the theme from a file or shared ID. |
+| `sharedAt` | String? (ISO 8601) | When Osaurus last marked the theme as shared. |
+| `remoteHash` | String? | 64-character shared theme ID when installed or uploaded through the theme sharing service. |
+| `remoteURL` | String? | Public theme server URL for the shared theme ID. |
+| `sourceDetail` | String? | Human-readable source note such as the imported filename. |
+
+Theme sharing canonicalization strips `library`, local UUIDs, and local timestamps before hashing so the same theme JSON does not get a different shared ID simply because it was imported on another machine.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a theme library management center for browsing installed themes, preview metadata, and theme operations.
- Adds theme service/model support and preview cache coverage.
- Updates theme documentation and focused tests.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter Theme`
- `swift test --package-path Packages/OsaurusCore --filter ThemePreviewImageCacheTests`

## Notes
- The localization check still reports the existing stale-key warning set from main.
