### PR TITLE
Add sandbox provisioning diagnostics

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -12835,6 +12835,28 @@
         }
       }
     },
+    "Copy support JSON report" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Support-JSON-Bericht kopieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Copy support JSON report"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "复制支持 JSON 报告"
+          }
+        }
+      }
+    },
     "Copy '%@' for API usage" : {
       "comment" : "Auto-extracted format-string key (Apple String.LocalizationValue canonical form).",
       "extractionState" : "manual",

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxProvisioningDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxProvisioningDiagnostics.swift
@@ -1,0 +1,1058 @@
+//
+//  SandboxProvisioningDiagnostics.swift
+//  osaurus
+//
+//  Host-side preflight for the sandbox provisioning paths and prerequisites.
+//
+
+import Foundation
+
+public enum SandboxProvisioningReadiness: String, Codable, Sendable {
+    case ready
+    case needsSetup = "needs_setup"
+    case blocked
+    case unproven
+
+    public var label: String {
+        switch self {
+        case .ready: "Ready"
+        case .needsSetup: "Needs setup"
+        case .blocked: "Blocked"
+        case .unproven: "Unproven"
+        }
+    }
+}
+
+public enum SandboxProvisioningRootSource: String, Codable, Sendable {
+    case defaultHome = "default_home"
+    case testOverride = "test_override"
+    case environmentOverride = "environment_override"
+}
+
+public enum SandboxProvisioningConfigurationSource: String, Codable, Sendable {
+    case loaded
+    case missingUsingDefaults = "missing_using_defaults"
+    case invalidUsingDefaults = "invalid_using_defaults"
+}
+
+public enum SandboxProvisioningLocationID: String, Codable, Sendable, CaseIterable {
+    case root
+    case configDirectory = "config_directory"
+    case configFile = "config_file"
+    case cacheDirectory = "cache_directory"
+    case temporaryDirectory = "temporary_directory"
+    case containerRoot = "container_root"
+    case containerWorkspace = "container_workspace"
+    case containerAgents = "container_agents"
+    case containerShared = "container_shared"
+    case containerKernelDirectory = "container_kernel_directory"
+    case containerKernelFile = "container_kernel_file"
+    case containerInitFSFile = "container_initfs_file"
+    case containerStateDirectory = "container_state_directory"
+    case containerRootFSFile = "container_rootfs_file"
+    case bridgeSocket = "bridge_socket"
+}
+
+public enum SandboxProvisioningLocationKind: String, Codable, Sendable {
+    case directory
+    case file
+    case socket
+}
+
+public enum SandboxProvisioningLocationStage: String, Codable, Sendable {
+    case hostStorage = "host_storage"
+    case provisioningAsset = "provisioning_asset"
+    case runtime
+}
+
+public enum SandboxProvisioningLocationStatus: String, Codable, Sendable {
+    case ready
+    case missing
+    case wrongType = "wrong_type"
+    case notWritable = "not_writable"
+    case notReadable = "not_readable"
+    case emptyFile = "empty_file"
+    case unproven
+}
+
+public enum SandboxProvisioningFindingSeverity: String, Codable, Sendable {
+    case ok
+    case info
+    case warning
+    case blocked
+}
+
+public enum SandboxProvisioningFindingStatus: String, Codable, Sendable {
+    case passed
+    case missing
+    case failed
+    case unproven
+}
+
+public enum SandboxProvisioningFindingCode: String, Codable, Sendable, CaseIterable {
+    case rootOverrideActive = "root_override_active"
+    case sandboxUnavailable = "sandbox_unavailable"
+    case unsupportedArchitecture = "unsupported_architecture"
+    case configMissing = "config_missing"
+    case configInvalid = "config_invalid"
+    case setupIncomplete = "setup_incomplete"
+    case locationMissing = "location_missing"
+    case locationWrongType = "location_wrong_type"
+    case locationNotWritable = "location_not_writable"
+    case locationNotReadable = "location_not_readable"
+    case locationEmpty = "location_empty"
+    case volumeFreeSpaceLow = "volume_free_space_low"
+    case volumeFreeSpaceUnproven = "volume_free_space_unproven"
+}
+
+public struct SandboxProvisioningConfigurationSnapshot: Codable, Sendable, Equatable {
+    public let path: String
+    public let source: SandboxProvisioningConfigurationSource
+    public let cpus: Int
+    public let memoryGB: Int
+    public let network: String
+    public let autoStart: Bool
+    public let setupComplete: Bool
+    public let error: String?
+}
+
+public struct SandboxProvisioningLocation: Codable, Sendable, Equatable, Identifiable {
+    public let id: SandboxProvisioningLocationID
+    public let title: String
+    public let path: String
+    public let kind: SandboxProvisioningLocationKind
+    public let stage: SandboxProvisioningLocationStage
+    public let status: SandboxProvisioningLocationStatus
+    public let exists: Bool
+    public let readable: Bool?
+    public let writable: Bool?
+    public let fileSizeBytes: Int64?
+    public let volumeFreeBytes: Int64?
+    public let volumeTotalBytes: Int64?
+    public let detail: String
+    public let repairSuggestion: String?
+}
+
+public struct SandboxProvisioningFinding: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let code: SandboxProvisioningFindingCode
+    public let severity: SandboxProvisioningFindingSeverity
+    public let status: SandboxProvisioningFindingStatus
+    public let title: String
+    public let detail: String
+    public let repairSuggestion: String
+    public let locationID: SandboxProvisioningLocationID?
+    public let path: String?
+}
+
+public struct SandboxProvisioningReport: Codable, Sendable, Equatable {
+    public let schemaVersion: Int
+    public let generatedAt: Date
+    public let overallReadiness: SandboxProvisioningReadiness
+    public let rootSource: SandboxProvisioningRootSource
+    public let osMajorVersion: Int
+    public let isAppleSilicon: Bool
+    public let minimumColdProvisionFreeBytes: Int64
+    public let configuration: SandboxProvisioningConfigurationSnapshot
+    public let locations: [SandboxProvisioningLocation]
+    public let findings: [SandboxProvisioningFinding]
+
+    public var blockingFindings: [SandboxProvisioningFinding] {
+        findings.filter { $0.severity == .blocked }
+    }
+
+    public var warningFindings: [SandboxProvisioningFinding] {
+        findings.filter { $0.severity == .warning }
+    }
+
+    public func jsonString(prettyPrinted: Bool = true) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = prettyPrinted ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+        let data = try encoder.encode(self)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    public var plainTextReport: String {
+        let timestamp = ISO8601DateFormatter().string(from: generatedAt)
+        var lines: [String] = [
+            "Sandbox Provisioning Diagnostics",
+            "Generated: \(timestamp)",
+            "Readiness: \(overallReadiness.rawValue)",
+            "Root source: \(rootSource.rawValue)",
+            "OS major: \(osMajorVersion)",
+            "Apple Silicon: \(isAppleSilicon ? "yes" : "no")",
+            "Minimum cold-provision free space: \(Self.formatBytes(minimumColdProvisionFreeBytes))",
+            "",
+            "Configuration:",
+            "- path: \(configuration.path)",
+            "- source: \(configuration.source.rawValue)",
+            "- cpus: \(configuration.cpus)",
+            "- memory_gb: \(configuration.memoryGB)",
+            "- network: \(configuration.network)",
+            "- auto_start: \(configuration.autoStart)",
+            "- setup_complete: \(configuration.setupComplete)",
+        ]
+        if let error = configuration.error {
+            lines.append("- error: \(error)")
+        }
+
+        lines.append("")
+        lines.append("Findings:")
+        if findings.isEmpty {
+            lines.append("- none")
+        } else {
+            for finding in findings {
+                lines.append(
+                    "- [\(finding.severity.rawValue)/\(finding.status.rawValue)] \(finding.code.rawValue): \(finding.title)"
+                )
+                lines.append("  detail: \(finding.detail)")
+                if let path = finding.path {
+                    lines.append("  path: \(path)")
+                }
+                lines.append("  repair: \(finding.repairSuggestion)")
+            }
+        }
+
+        lines.append("")
+        lines.append("Locations:")
+        for location in locations {
+            var row = "- [\(location.status.rawValue)] \(location.id.rawValue): \(location.path)"
+            if let free = location.volumeFreeBytes {
+                row += " (free: \(Self.formatBytes(free)))"
+            }
+            lines.append(row)
+            if !location.detail.isEmpty {
+                lines.append("  detail: \(location.detail)")
+            }
+            if let repair = location.repairSuggestion {
+                lines.append("  repair: \(repair)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        let units = ["B", "KB", "MB", "GB", "TB"]
+        var value = Double(bytes)
+        var index = 0
+        while value >= 1024, index < units.count - 1 {
+            value /= 1024
+            index += 1
+        }
+        if index == 0 {
+            return "\(bytes) \(units[index])"
+        }
+        return String(format: "%.1f %@", value, units[index])
+    }
+}
+
+public enum SandboxProvisioningDiagnostics {
+    public static let schemaVersion = 1
+    public static let defaultMinimumColdProvisionFreeBytes: Int64 = 12 * 1024 * 1024 * 1024
+
+    public static func makeReport(
+        generatedAt: Date = Date(),
+        minimumColdProvisionFreeBytes: Int64 = defaultMinimumColdProvisionFreeBytes,
+        operatingSystemMajorVersion: Int = ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+        isAppleSilicon: Bool = defaultIsAppleSilicon,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager fm: FileManager = .default
+    ) -> SandboxProvisioningReport {
+        let rootSource = resolvedRootSource(environment: environment)
+        let specs = locationSpecs()
+        var locations: [SandboxProvisioningLocation] = []
+        var findings: [SandboxProvisioningFinding] = []
+
+        if rootSource != .defaultHome {
+            findings.append(
+                finding(
+                    code: .rootOverrideActive,
+                    severity: .info,
+                    status: .passed,
+                    title: "Custom sandbox root is active",
+                    detail: "Diagnostics are using \(OsaurusPaths.root().standardizedFileURL.path).",
+                    repairSuggestion: "Unset OSAURUS_TEST_ROOT or clear OsaurusPaths.overrideRoot to return to the default root.",
+                    locationID: .root,
+                    path: OsaurusPaths.root().standardizedFileURL.path
+                )
+            )
+        }
+
+        if operatingSystemMajorVersion < 26 {
+            findings.append(
+                finding(
+                    code: .sandboxUnavailable,
+                    severity: .blocked,
+                    status: .failed,
+                    title: "macOS version does not support sandbox provisioning",
+                    detail: "The sandbox requires macOS 26 or later; this host reports macOS \(operatingSystemMajorVersion).",
+                    repairSuggestion: "Run Osaurus sandbox provisioning on macOS 26 or later.",
+                    locationID: nil,
+                    path: nil
+                )
+            )
+        }
+
+        if !isAppleSilicon {
+            findings.append(
+                finding(
+                    code: .unsupportedArchitecture,
+                    severity: .blocked,
+                    status: .failed,
+                    title: "Apple Silicon is required",
+                    detail: "The sandbox image and Containerization runtime are supported on Apple Silicon.",
+                    repairSuggestion: "Run sandbox provisioning on an Apple Silicon Mac.",
+                    locationID: nil,
+                    path: nil
+                )
+            )
+        }
+
+        let configuration = loadConfigurationSnapshot(fileManager: fm)
+        switch configuration.source {
+        case .loaded:
+            break
+        case .missingUsingDefaults:
+            findings.append(
+                finding(
+                    code: .configMissing,
+                    severity: .info,
+                    status: .missing,
+                    title: "Sandbox configuration file is missing",
+                    detail: "Osaurus will use default sandbox settings until a config file is saved.",
+                    repairSuggestion: "Open Sandbox settings or run setup to write \(configuration.path).",
+                    locationID: .configFile,
+                    path: configuration.path
+                )
+            )
+        case .invalidUsingDefaults:
+            findings.append(
+                finding(
+                    code: .configInvalid,
+                    severity: .warning,
+                    status: .failed,
+                    title: "Sandbox configuration could not be decoded",
+                    detail: configuration.error ?? "The config file is invalid JSON or has an incompatible shape.",
+                    repairSuggestion: "Fix or remove \(configuration.path), then save Sandbox settings again.",
+                    locationID: .configFile,
+                    path: configuration.path
+                )
+            )
+        }
+
+        if !configuration.setupComplete {
+            findings.append(
+                finding(
+                    code: .setupIncomplete,
+                    severity: .warning,
+                    status: .missing,
+                    title: "Sandbox setup has not completed",
+                    detail: "The setupComplete flag is false, so tool and agent startup still require provisioning.",
+                    repairSuggestion: "Use Set Up Sandbox from the Sandbox tab and rerun this preflight after it finishes.",
+                    locationID: .configFile,
+                    path: configuration.path
+                )
+            )
+        }
+
+        for spec in specs {
+            let result = checkLocation(spec: spec, fileManager: fm)
+            locations.append(result.location)
+            findings.append(contentsOf: result.findings)
+        }
+
+        findings.append(
+            contentsOf: volumeFindings(
+                locations: locations,
+                minimumColdProvisionFreeBytes: minimumColdProvisionFreeBytes
+            )
+        )
+
+        let readiness = classifyReadiness(findings: findings)
+        return SandboxProvisioningReport(
+            schemaVersion: schemaVersion,
+            generatedAt: generatedAt,
+            overallReadiness: readiness,
+            rootSource: rootSource,
+            osMajorVersion: operatingSystemMajorVersion,
+            isAppleSilicon: isAppleSilicon,
+            minimumColdProvisionFreeBytes: minimumColdProvisionFreeBytes,
+            configuration: configuration,
+            locations: locations,
+            findings: findings
+        )
+    }
+
+    public static var defaultIsAppleSilicon: Bool {
+        #if arch(arm64)
+            true
+        #else
+            false
+        #endif
+    }
+
+    private struct LocationSpec {
+        let id: SandboxProvisioningLocationID
+        let title: String
+        let url: URL
+        let kind: SandboxProvisioningLocationKind
+        let stage: SandboxProvisioningLocationStage
+        let missingSeverity: SandboxProvisioningFindingSeverity
+        let requiresWritable: Bool
+        let includeVolumeStats: Bool
+        let minimumFileBytes: Int64?
+    }
+
+    private struct LocationCheckResult {
+        let location: SandboxProvisioningLocation
+        let findings: [SandboxProvisioningFinding]
+    }
+
+    private static func locationSpecs() -> [LocationSpec] {
+        let containerState = OsaurusPaths.container()
+            .appendingPathComponent("containers/osaurus-sandbox", isDirectory: true)
+        return [
+            LocationSpec(
+                id: .root,
+                title: "Osaurus root",
+                url: OsaurusPaths.root(),
+                kind: .directory,
+                stage: .hostStorage,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: true,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .configDirectory,
+                title: "Configuration directory",
+                url: OsaurusPaths.config(),
+                kind: .directory,
+                stage: .hostStorage,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .configFile,
+                title: "Sandbox configuration",
+                url: OsaurusPaths.sandboxConfigFile(),
+                kind: .file,
+                stage: .hostStorage,
+                missingSeverity: .info,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .cacheDirectory,
+                title: "Cache directory",
+                url: OsaurusPaths.cache(),
+                kind: .directory,
+                stage: .hostStorage,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: true,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .temporaryDirectory,
+                title: "Temporary directory",
+                url: FileManager.default.temporaryDirectory,
+                kind: .directory,
+                stage: .hostStorage,
+                missingSeverity: .blocked,
+                requiresWritable: true,
+                includeVolumeStats: true,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerRoot,
+                title: "Container root",
+                url: OsaurusPaths.container(),
+                kind: .directory,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: true,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerWorkspace,
+                title: "Workspace mount",
+                url: OsaurusPaths.containerWorkspace(),
+                kind: .directory,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerAgents,
+                title: "Agent workspace root",
+                url: OsaurusPaths.containerAgentsDir(),
+                kind: .directory,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerShared,
+                title: "Shared workspace",
+                url: OsaurusPaths.containerSharedDir(),
+                kind: .directory,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerKernelDirectory,
+                title: "Kernel asset directory",
+                url: OsaurusPaths.containerKernelDir(),
+                kind: .directory,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerKernelFile,
+                title: "Kernel asset",
+                url: OsaurusPaths.containerKernelFile(),
+                kind: .file,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: false,
+                includeVolumeStats: false,
+                minimumFileBytes: 1
+            ),
+            LocationSpec(
+                id: .containerInitFSFile,
+                title: "Init filesystem asset",
+                url: OsaurusPaths.containerInitFSFile(),
+                kind: .file,
+                stage: .provisioningAsset,
+                missingSeverity: .warning,
+                requiresWritable: false,
+                includeVolumeStats: false,
+                minimumFileBytes: 1
+            ),
+            LocationSpec(
+                id: .containerStateDirectory,
+                title: "Container state directory",
+                url: containerState,
+                kind: .directory,
+                stage: .runtime,
+                missingSeverity: .info,
+                requiresWritable: true,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+            LocationSpec(
+                id: .containerRootFSFile,
+                title: "Warm restart rootfs",
+                url: containerState.appendingPathComponent("rootfs.ext4"),
+                kind: .file,
+                stage: .runtime,
+                missingSeverity: .warning,
+                requiresWritable: false,
+                includeVolumeStats: false,
+                minimumFileBytes: 1
+            ),
+            LocationSpec(
+                id: .bridgeSocket,
+                title: "Host bridge socket",
+                url: OsaurusPaths.container().appendingPathComponent("bridge.sock"),
+                kind: .socket,
+                stage: .runtime,
+                missingSeverity: .info,
+                requiresWritable: false,
+                includeVolumeStats: false,
+                minimumFileBytes: nil
+            ),
+        ]
+    }
+
+    private static func checkLocation(
+        spec: LocationSpec,
+        fileManager fm: FileManager
+    ) -> LocationCheckResult {
+        let url = spec.url.standardizedFileURL
+        let path = url.path
+        var isDirectory = ObjCBool(false)
+        let exists = fm.fileExists(atPath: path, isDirectory: &isDirectory)
+        var findings: [SandboxProvisioningFinding] = []
+        var readable: Bool?
+        var writable: Bool?
+        var fileSizeBytes: Int64?
+        var status: SandboxProvisioningLocationStatus = .ready
+        var detail = ""
+        var repair: String?
+
+        let volume = spec.includeVolumeStats ? volumeStats(for: url, fileManager: fm) : (nil, nil)
+
+        guard exists else {
+            let parent = nearestExistingDirectory(for: url.deletingLastPathComponent(), fileManager: fm)
+            let parentWritable = parent.map { probeDirectoryWritable($0, fileManager: fm).passed } ?? false
+            writable = parentWritable
+            status = .missing
+            detail =
+                parentWritable
+                ? "Path is missing; parent directory is writable."
+                : "Path is missing and no writable parent directory was proven."
+            repair = repairSuggestionForMissing(kind: spec.kind, path: path)
+            let severity: SandboxProvisioningFindingSeverity =
+                parentWritable ? spec.missingSeverity : .blocked
+            let code: SandboxProvisioningFindingCode =
+                parentWritable ? .locationMissing : .locationNotWritable
+            findings.append(
+                finding(
+                    code: code,
+                    severity: severity,
+                    status: parentWritable ? .missing : .failed,
+                    title: "\(spec.title) is missing",
+                    detail: detail,
+                    repairSuggestion: repair ?? "Create or repair \(path).",
+                    locationID: spec.id,
+                    path: path
+                )
+            )
+            return LocationCheckResult(
+                location: location(
+                    spec: spec,
+                    url: url,
+                    status: status,
+                    exists: false,
+                    readable: readable,
+                    writable: writable,
+                    fileSizeBytes: fileSizeBytes,
+                    volume: volume,
+                    detail: detail,
+                    repair: repair
+                ),
+                findings: findings
+            )
+        }
+
+        switch spec.kind {
+        case .directory:
+            guard isDirectory.boolValue else {
+                status = .wrongType
+                detail = "Expected a directory but found a file or other non-directory item."
+                repair = "Move or remove \(path), then create the directory with mkdir -p \"\(path)\"."
+                findings.append(wrongTypeFinding(spec: spec, detail: detail, repair: repair, path: path))
+                break
+            }
+            readable = fm.isReadableFile(atPath: path)
+            if spec.requiresWritable {
+                let probe = probeDirectoryWritable(url, fileManager: fm)
+                writable = probe.passed
+                if !probe.passed {
+                    status = .notWritable
+                    detail = probe.detail
+                    repair = permissionRepair(path: path)
+                    findings.append(
+                        finding(
+                            code: .locationNotWritable,
+                            severity: .blocked,
+                            status: .failed,
+                            title: "\(spec.title) is not writable",
+                            detail: detail,
+                            repairSuggestion: repair ?? permissionRepair(path: path),
+                            locationID: spec.id,
+                            path: path
+                        )
+                    )
+                } else {
+                    detail = "Directory exists and accepted a write probe."
+                }
+            } else {
+                writable = fm.isWritableFile(atPath: path)
+                detail = "Directory exists."
+            }
+        case .file:
+            guard !isDirectory.boolValue else {
+                status = .wrongType
+                detail = "Expected a file but found a directory."
+                repair = "Move or remove the directory at \(path), then rerun sandbox setup."
+                findings.append(wrongTypeFinding(spec: spec, detail: detail, repair: repair, path: path))
+                break
+            }
+            readable = fm.isReadableFile(atPath: path)
+            writable = spec.requiresWritable ? fm.isWritableFile(atPath: path) : nil
+            fileSizeBytes = fileSize(at: url, fileManager: fm)
+            if readable == false {
+                status = .notReadable
+                detail = "File exists but is not readable."
+                repair = permissionRepair(path: path)
+                findings.append(
+                    finding(
+                        code: .locationNotReadable,
+                        severity: .blocked,
+                        status: .failed,
+                        title: "\(spec.title) is not readable",
+                        detail: detail,
+                        repairSuggestion: repair ?? permissionRepair(path: path),
+                        locationID: spec.id,
+                        path: path
+                    )
+                )
+            } else if spec.requiresWritable, writable == false {
+                status = .notWritable
+                detail = "File exists but is not writable."
+                repair = permissionRepair(path: path)
+                findings.append(
+                    finding(
+                        code: .locationNotWritable,
+                        severity: .blocked,
+                        status: .failed,
+                        title: "\(spec.title) is not writable",
+                        detail: detail,
+                        repairSuggestion: repair ?? permissionRepair(path: path),
+                        locationID: spec.id,
+                        path: path
+                    )
+                )
+            } else if let minimum = spec.minimumFileBytes, (fileSizeBytes ?? 0) < minimum {
+                status = .emptyFile
+                detail = "File exists but is empty or smaller than the minimum expected size."
+                repair = "Remove \(path) and rerun sandbox setup so Osaurus can download a fresh asset."
+                findings.append(
+                    finding(
+                        code: .locationEmpty,
+                        severity: .blocked,
+                        status: .failed,
+                        title: "\(spec.title) is empty",
+                        detail: detail,
+                        repairSuggestion: repair ?? "Remove \(path) and rerun setup.",
+                        locationID: spec.id,
+                        path: path
+                    )
+                )
+            } else {
+                detail = "File exists and is readable."
+            }
+        case .socket:
+            if isDirectory.boolValue {
+                status = .wrongType
+                detail = "Expected a runtime socket but found a directory."
+                repair = "Stop the sandbox, remove \(path), and start the sandbox again."
+                findings.append(wrongTypeFinding(spec: spec, detail: detail, repair: repair, path: path))
+            } else {
+                readable = fm.isReadableFile(atPath: path)
+                detail = "Runtime socket path exists."
+            }
+        }
+
+        return LocationCheckResult(
+            location: location(
+                spec: spec,
+                url: url,
+                status: status,
+                exists: true,
+                readable: readable,
+                writable: writable,
+                fileSizeBytes: fileSizeBytes,
+                volume: volume,
+                detail: detail,
+                repair: repair
+            ),
+            findings: findings
+        )
+    }
+
+    private static func volumeFindings(
+        locations: [SandboxProvisioningLocation],
+        minimumColdProvisionFreeBytes: Int64
+    ) -> [SandboxProvisioningFinding] {
+        guard minimumColdProvisionFreeBytes > 0 else { return [] }
+        guard let containerRoot = locations.first(where: { $0.id == .containerRoot }) else { return [] }
+
+        if let free = containerRoot.volumeFreeBytes {
+            guard free < minimumColdProvisionFreeBytes else { return [] }
+            return [
+                finding(
+                    code: .volumeFreeSpaceLow,
+                    severity: .blocked,
+                    status: .failed,
+                    title: "Not enough free disk space for cold provisioning",
+                    detail:
+                        "Container root volume has \(SandboxProvisioningReport.formatBytesForDiagnostics(free)) free; cold provisioning expects at least \(SandboxProvisioningReport.formatBytesForDiagnostics(minimumColdProvisionFreeBytes)).",
+                    repairSuggestion: "Free disk space on the volume that contains \(containerRoot.path), then rerun preflight.",
+                    locationID: .containerRoot,
+                    path: containerRoot.path
+                ),
+            ]
+        }
+
+        return [
+            finding(
+                code: .volumeFreeSpaceUnproven,
+                severity: .info,
+                status: .unproven,
+                title: "Free disk space could not be proven",
+                detail: "The preflight could not read volume capacity for \(containerRoot.path).",
+                repairSuggestion: "Check available disk space manually before cold provisioning.",
+                locationID: .containerRoot,
+                path: containerRoot.path
+            ),
+        ]
+    }
+
+    private static func classifyReadiness(
+        findings: [SandboxProvisioningFinding]
+    ) -> SandboxProvisioningReadiness {
+        if findings.contains(where: { $0.severity == .blocked }) {
+            return .blocked
+        }
+        if findings.contains(where: { $0.status == .unproven }) {
+            return .unproven
+        }
+        if findings.contains(where: { $0.severity == .warning }) {
+            return .needsSetup
+        }
+        return .ready
+    }
+
+    private static func loadConfigurationSnapshot(
+        fileManager fm: FileManager
+    ) -> SandboxProvisioningConfigurationSnapshot {
+        let url = OsaurusPaths.sandboxConfigFile().standardizedFileURL
+        guard fm.fileExists(atPath: url.path) else {
+            return configurationSnapshot(
+                path: url.path,
+                source: .missingUsingDefaults,
+                config: .default,
+                error: nil
+            )
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let config = try JSONDecoder().decode(SandboxConfiguration.self, from: data)
+            return configurationSnapshot(path: url.path, source: .loaded, config: config, error: nil)
+        } catch {
+            return configurationSnapshot(
+                path: url.path,
+                source: .invalidUsingDefaults,
+                config: .default,
+                error: error.localizedDescription
+            )
+        }
+    }
+
+    private static func configurationSnapshot(
+        path: String,
+        source: SandboxProvisioningConfigurationSource,
+        config: SandboxConfiguration,
+        error: String?
+    ) -> SandboxProvisioningConfigurationSnapshot {
+        SandboxProvisioningConfigurationSnapshot(
+            path: path,
+            source: source,
+            cpus: config.cpus,
+            memoryGB: config.memoryGB,
+            network: config.network,
+            autoStart: config.autoStart,
+            setupComplete: config.setupComplete,
+            error: error
+        )
+    }
+
+    private static func location(
+        spec: LocationSpec,
+        url: URL,
+        status: SandboxProvisioningLocationStatus,
+        exists: Bool,
+        readable: Bool?,
+        writable: Bool?,
+        fileSizeBytes: Int64?,
+        volume: (free: Int64?, total: Int64?),
+        detail: String,
+        repair: String?
+    ) -> SandboxProvisioningLocation {
+        SandboxProvisioningLocation(
+            id: spec.id,
+            title: spec.title,
+            path: url.path,
+            kind: spec.kind,
+            stage: spec.stage,
+            status: status,
+            exists: exists,
+            readable: readable,
+            writable: writable,
+            fileSizeBytes: fileSizeBytes,
+            volumeFreeBytes: volume.free,
+            volumeTotalBytes: volume.total,
+            detail: detail,
+            repairSuggestion: repair
+        )
+    }
+
+    private static func finding(
+        code: SandboxProvisioningFindingCode,
+        severity: SandboxProvisioningFindingSeverity,
+        status: SandboxProvisioningFindingStatus,
+        title: String,
+        detail: String,
+        repairSuggestion: String,
+        locationID: SandboxProvisioningLocationID?,
+        path: String?
+    ) -> SandboxProvisioningFinding {
+        let idSuffix = locationID?.rawValue ?? "environment"
+        return SandboxProvisioningFinding(
+            id: "\(code.rawValue):\(idSuffix)",
+            code: code,
+            severity: severity,
+            status: status,
+            title: title,
+            detail: detail,
+            repairSuggestion: repairSuggestion,
+            locationID: locationID,
+            path: path
+        )
+    }
+
+    private static func wrongTypeFinding(
+        spec: LocationSpec,
+        detail: String,
+        repair: String?,
+        path: String
+    ) -> SandboxProvisioningFinding {
+        finding(
+            code: .locationWrongType,
+            severity: .blocked,
+            status: .failed,
+            title: "\(spec.title) has the wrong type",
+            detail: detail,
+            repairSuggestion: repair ?? "Remove or move \(path), then rerun sandbox setup.",
+            locationID: spec.id,
+            path: path
+        )
+    }
+
+    private static func resolvedRootSource(
+        environment: [String: String]
+    ) -> SandboxProvisioningRootSource {
+        if OsaurusPaths.overrideRoot != nil {
+            return .testOverride
+        }
+        if let envRoot = environment["OSAURUS_TEST_ROOT"],
+            !envRoot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return .environmentOverride
+        }
+        return .defaultHome
+    }
+
+    private static func repairSuggestionForMissing(
+        kind: SandboxProvisioningLocationKind,
+        path: String
+    ) -> String {
+        switch kind {
+        case .directory:
+            "Create the directory with mkdir -p \"\(path)\" or run Set Up Sandbox to let Osaurus create it."
+        case .file:
+            "Run Set Up Sandbox so Osaurus can create or download \(path)."
+        case .socket:
+            "Start the sandbox; this runtime socket is created only while the host bridge is running."
+        }
+    }
+
+    private static func permissionRepair(path: String) -> String {
+        "Fix ownership or permissions for \(path), then rerun preflight. For user-owned paths, chmod u+rwX \"\(path)\" is usually enough."
+    }
+
+    private static func nearestExistingDirectory(
+        for url: URL,
+        fileManager fm: FileManager
+    ) -> URL? {
+        var current = url.standardizedFileURL
+        while true {
+            var isDirectory = ObjCBool(false)
+            if fm.fileExists(atPath: current.path, isDirectory: &isDirectory),
+                isDirectory.boolValue
+            {
+                return current
+            }
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                return nil
+            }
+            current = parent
+        }
+    }
+
+    private struct WriteProbe {
+        let passed: Bool
+        let detail: String
+    }
+
+    private static func probeDirectoryWritable(
+        _ url: URL,
+        fileManager fm: FileManager
+    ) -> WriteProbe {
+        let probe = url.appendingPathComponent(".osaurus-sandbox-preflight-\(UUID().uuidString)")
+        do {
+            try Data("ok".utf8).write(to: probe, options: .atomic)
+            try? fm.removeItem(at: probe)
+            return WriteProbe(passed: true, detail: "Directory exists and accepted a write probe.")
+        } catch {
+            try? fm.removeItem(at: probe)
+            return WriteProbe(
+                passed: false,
+                detail: "Write probe failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func fileSize(at url: URL, fileManager fm: FileManager) -> Int64? {
+        guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+            let size = attrs[.size] as? NSNumber
+        else {
+            return nil
+        }
+        return size.int64Value
+    }
+
+    private static func volumeStats(
+        for url: URL,
+        fileManager fm: FileManager
+    ) -> (free: Int64?, total: Int64?) {
+        let probeURL: URL
+        if fm.fileExists(atPath: url.path) {
+            probeURL = url
+        } else {
+            probeURL = nearestExistingDirectory(for: url, fileManager: fm) ?? url
+        }
+        return (
+            OsaurusPaths.volumeFreeBytes(forPath: probeURL.path),
+            OsaurusPaths.volumeTotalBytes(forPath: probeURL.path)
+        )
+    }
+}
+
+private extension SandboxProvisioningReport {
+    static func formatBytesForDiagnostics(_ bytes: Int64) -> String {
+        let units = ["B", "KB", "MB", "GB", "TB"]
+        var value = Double(bytes)
+        var index = 0
+        while value >= 1024, index < units.count - 1 {
+            value /= 1024
+            index += 1
+        }
+        if index == 0 {
+            return "\(bytes) \(units[index])"
+        }
+        return String(format: "%.1f %@", value, units[index])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxProvisioningDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxProvisioningDiagnosticsTests.swift
@@ -1,0 +1,173 @@
+//
+//  SandboxProvisioningDiagnosticsTests.swift
+//  OsaurusCoreTests
+//
+
+#if os(macOS)
+
+    import Foundation
+    import Testing
+
+    @testable import OsaurusCore
+
+    @Suite("Sandbox Provisioning Diagnostics")
+    struct SandboxProvisioningDiagnosticsTests {
+        private static let fixedDate = Date(timeIntervalSince1970: 1_800_000_000)
+
+        @Test
+        func freshRootReportsMissingSetupWithRepairSuggestions() async throws {
+            try await Self.withTemporaryRoot { root in
+                let report = SandboxProvisioningDiagnostics.makeReport(
+                    generatedAt: Self.fixedDate,
+                    minimumColdProvisionFreeBytes: 0,
+                    operatingSystemMajorVersion: 26,
+                    isAppleSilicon: true,
+                    environment: [:]
+                )
+
+                #expect(report.rootSource == .testOverride)
+                #expect(report.configuration.source == .missingUsingDefaults)
+                #expect(report.overallReadiness == .needsSetup)
+
+                let workspace = try #require(
+                    report.locations.first { $0.id == .containerWorkspace }
+                )
+                #expect(workspace.status == .missing)
+                #expect(workspace.repairSuggestion?.contains("mkdir -p") == true)
+                #expect(workspace.path.hasPrefix(root.path))
+
+                let setupFinding = try #require(
+                    report.findings.first { $0.code == .setupIncomplete }
+                )
+                #expect(setupFinding.severity == .warning)
+                #expect(setupFinding.repairSuggestion.contains("Set Up Sandbox"))
+            }
+        }
+
+        @Test
+        func wrongTypeWorkspaceBlocksProvisioning() async throws {
+            try await Self.withTemporaryRoot { _ in
+                try Self.createBaseRoot(setupComplete: true)
+                try OsaurusPaths.ensureExists(OsaurusPaths.container())
+                try Data("not a directory".utf8).write(to: OsaurusPaths.containerWorkspace())
+
+                let report = SandboxProvisioningDiagnostics.makeReport(
+                    generatedAt: Self.fixedDate,
+                    minimumColdProvisionFreeBytes: 0,
+                    operatingSystemMajorVersion: 26,
+                    isAppleSilicon: true,
+                    environment: [:]
+                )
+
+                #expect(report.overallReadiness == .blocked)
+                let workspace = try #require(
+                    report.locations.first { $0.id == .containerWorkspace }
+                )
+                #expect(workspace.status == .wrongType)
+
+                let finding = try #require(
+                    report.findings.first {
+                        $0.code == .locationWrongType && $0.locationID == .containerWorkspace
+                    }
+                )
+                #expect(finding.severity == .blocked)
+                #expect(finding.status == .failed)
+                #expect(finding.repairSuggestion.contains("Move or remove"))
+            }
+        }
+
+        @Test
+        func provisionedHostTreeCanReportReadyEvenWhenRuntimeSocketIsAbsent() async throws {
+            try await Self.withTemporaryRoot { _ in
+                try Self.createReadyProvisioningTree()
+
+                let report = SandboxProvisioningDiagnostics.makeReport(
+                    generatedAt: Self.fixedDate,
+                    minimumColdProvisionFreeBytes: 0,
+                    operatingSystemMajorVersion: 26,
+                    isAppleSilicon: true,
+                    environment: [:]
+                )
+
+                #expect(report.overallReadiness == .ready)
+                #expect(!report.findings.contains { $0.severity == .blocked })
+                #expect(!report.findings.contains { $0.severity == .warning })
+
+                let bridge = try #require(report.locations.first { $0.id == .bridgeSocket })
+                #expect(bridge.status == .missing)
+                let rootfs = try #require(
+                    report.locations.first { $0.id == .containerRootFSFile }
+                )
+                #expect(rootfs.status == .ready)
+            }
+        }
+
+        @Test
+        func reportOutputUsesSnakeCaseJSONAndPlainTextFindings() async throws {
+            try await Self.withTemporaryRoot { _ in
+                let report = SandboxProvisioningDiagnostics.makeReport(
+                    generatedAt: Self.fixedDate,
+                    minimumColdProvisionFreeBytes: 0,
+                    operatingSystemMajorVersion: 26,
+                    isAppleSilicon: true,
+                    environment: [:]
+                )
+
+                let json = try report.jsonString()
+                #expect(json.contains(#""overall_readiness" : "needs_setup""#))
+                #expect(json.contains(#""root_source" : "test_override""#))
+                #expect(json.contains(#""minimum_cold_provision_free_bytes" : 0"#))
+                #expect(json.contains(#""setup_complete" : false"#))
+
+                let text = report.plainTextReport
+                #expect(text.contains("Sandbox Provisioning Diagnostics"))
+                #expect(text.contains("setup_incomplete"))
+                #expect(text.contains("repair:"))
+            }
+        }
+
+        private static func withTemporaryRoot(
+            _ body: @Sendable (URL) throws -> Void
+        ) async throws {
+            try await StoragePathsTestLock.shared.run {
+                let fm = FileManager.default
+                let root = fm.temporaryDirectory
+                    .appendingPathComponent("osaurus-sandbox-diag-\(UUID().uuidString)", isDirectory: true)
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    try? fm.removeItem(at: root)
+                }
+                try body(root)
+            }
+        }
+
+        private static func createBaseRoot(setupComplete: Bool) throws {
+            try OsaurusPaths.ensureExists(OsaurusPaths.config())
+            try OsaurusPaths.ensureExists(OsaurusPaths.cache())
+            let config = SandboxConfiguration(setupComplete: setupComplete)
+            try JSONEncoder().encode(config).write(to: OsaurusPaths.sandboxConfigFile(), options: .atomic)
+        }
+
+        private static func createReadyProvisioningTree() throws {
+            try createBaseRoot(setupComplete: true)
+            try OsaurusPaths.ensureExists(OsaurusPaths.container())
+            try OsaurusPaths.ensureExists(OsaurusPaths.containerWorkspace())
+            try OsaurusPaths.ensureExists(OsaurusPaths.containerAgentsDir())
+            try OsaurusPaths.ensureExists(OsaurusPaths.containerSharedDir())
+            try OsaurusPaths.ensureExists(OsaurusPaths.containerKernelDir())
+            try Data("kernel".utf8).write(to: OsaurusPaths.containerKernelFile(), options: .atomic)
+            try Data("initfs".utf8).write(to: OsaurusPaths.containerInitFSFile(), options: .atomic)
+
+            let state = OsaurusPaths.container()
+                .appendingPathComponent("containers/osaurus-sandbox", isDirectory: true)
+            try OsaurusPaths.ensureExists(state)
+            try Data("rootfs".utf8).write(
+                to: state.appendingPathComponent("rootfs.ext4"),
+                options: .atomic
+            )
+        }
+    }
+
+#endif

--- a/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
+++ b/Packages/OsaurusCore/Views/Sandbox/SandboxView.swift
@@ -7,6 +7,7 @@
 //  and sandbox plugin management (library, import, install) into a single tab.
 //
 
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -26,6 +27,9 @@ struct SandboxView: View {
     @State private var showRemoveConfirm = false
     @State private var diagResults: [SandboxManager.DiagnosticResult]?
     @State private var isRunningDiag = false
+    @State private var provisioningReport: SandboxProvisioningReport?
+    @State private var isRunningProvisioningPreflight = false
+    @State private var copiedProvisioningReport = false
     @State private var refreshTask: Task<Void, Never>?
 
     @State private var showProvisionSheet = false
@@ -75,9 +79,11 @@ struct SandboxView: View {
             // The header + content now appear immediately on first frame.
             hasAppeared = true
             needsBridgeMigrationRestart = SandboxBridgeMigrationFlag.needsRestart
+            runProvisioningPreflight()
         }
         .onChange(of: sandboxState.status) { _, _ in
             needsBridgeMigrationRestart = SandboxBridgeMigrationFlag.needsRestart
+            runProvisioningPreflight()
         }
         .onDisappear { stopRefreshLoop() }
         .sheet(isPresented: $showProvisionSheet) {
@@ -133,6 +139,7 @@ private extension SandboxView {
                     if needsBridgeMigrationRestart {
                         bridgeMigrationBanner
                     }
+                    provisioningPreflightCard
                     statusDashboard
                     // Surfaced only while the post-start verifyPlugins
                     // step is active. Self-hides when verify finishes,
@@ -245,34 +252,42 @@ private extension SandboxView {
         if sandboxState.isProvisioning {
             provisioningProgressView
         } else {
-            SettingsEmptyState(
-                icon: "shippingbox",
-                title: L("Set Up Sandbox"),
-                subtitle: L("Run isolated Linux containers for agent plugins and autonomous execution."),
-                examples: [
-                    .init(
-                        icon: "puzzlepiece.extension",
-                        title: L("Sandbox Plugins"),
-                        description: L("Install tools that run inside the VM")
-                    ),
-                    .init(
-                        icon: "terminal",
-                        title: L("Autonomous Exec"),
-                        description: L("Agents run shell commands safely")
-                    ),
-                    .init(
-                        icon: "lock.shield",
-                        title: L("Full Isolation"),
-                        description: L("Separate filesystem per agent")
-                    ),
-                ],
-                primaryAction: .init(
-                    title: L("Set Up Sandbox"),
-                    icon: "shippingbox",
-                    handler: { showProvisionSheet = true }
-                ),
-                hasAppeared: hasAppeared
-            )
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    SettingsEmptyState(
+                        icon: "shippingbox",
+                        title: L("Set Up Sandbox"),
+                        subtitle: L("Run isolated Linux containers for agent plugins and autonomous execution."),
+                        examples: [
+                            .init(
+                                icon: "puzzlepiece.extension",
+                                title: L("Sandbox Plugins"),
+                                description: L("Install tools that run inside the VM")
+                            ),
+                            .init(
+                                icon: "terminal",
+                                title: L("Autonomous Exec"),
+                                description: L("Agents run shell commands safely")
+                            ),
+                            .init(
+                                icon: "lock.shield",
+                                title: L("Full Isolation"),
+                                description: L("Separate filesystem per agent")
+                            ),
+                        ],
+                        primaryAction: .init(
+                            title: L("Set Up Sandbox"),
+                            icon: "shippingbox",
+                            handler: { showProvisionSheet = true }
+                        ),
+                        hasAppeared: hasAppeared
+                    )
+                    .frame(minHeight: 430)
+
+                    provisioningPreflightCard
+                }
+                .padding(24)
+            }
         }
     }
 
@@ -281,6 +296,279 @@ private extension SandboxView {
             provisionError: provisionError,
             onRetry: performProvision
         )
+    }
+}
+
+// MARK: - Provisioning Preflight
+
+private extension SandboxView {
+
+    var provisioningPreflightCard: some View {
+        sectionCard(title: "Provisioning Preflight", icon: "checklist") {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .center, spacing: 10) {
+                    if let report = provisioningReport {
+                        readinessPill(report.overallReadiness)
+                        Text(preflightSummary(report))
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.secondaryText)
+                            .lineLimit(2)
+                    } else {
+                        readinessPill(.unproven)
+                        Text("Run preflight to inspect host paths, permissions, and repair suggestions.", bundle: .module)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.secondaryText)
+                            .lineLimit(2)
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Button(action: runProvisioningPreflight) {
+                        HStack(spacing: 6) {
+                            if isRunningProvisioningPreflight {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .scaleEffect(0.7)
+                                    .frame(width: 12, height: 12)
+                            } else {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.system(size: 11, weight: .semibold))
+                            }
+                            Text(isRunningProvisioningPreflight ? "Checking" : "Run", bundle: .module)
+                                .font(.system(size: 11, weight: .semibold))
+                        }
+                        .foregroundColor(theme.primaryText)
+                        .padding(.horizontal, 10)
+                        .frame(height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(theme.inputBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 7)
+                                        .stroke(theme.inputBorder, lineWidth: 1)
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isRunningProvisioningPreflight)
+
+                    Button(action: copyProvisioningReportJSON) {
+                        Label {
+                            Text(copiedProvisioningReport ? "Copied" : "Copy JSON", bundle: .module)
+                        } icon: {
+                            Image(systemName: "doc.on.doc")
+                        }
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .padding(.horizontal, 10)
+                        .frame(height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(theme.inputBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 7)
+                                        .stroke(theme.inputBorder, lineWidth: 1)
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(provisioningReport == nil)
+                    .localizedHelp("Copy support JSON report")
+                }
+
+                if let report = provisioningReport {
+                    preflightPathList(report)
+                    preflightFindingsList(report)
+                }
+            }
+        }
+    }
+
+    func readinessPill(_ readiness: SandboxProvisioningReadiness) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(preflightColor(readiness))
+                .frame(width: 7, height: 7)
+            Text(readiness.label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(preflightColor(readiness))
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 24)
+        .background(
+            Capsule()
+                .fill(preflightColor(readiness).opacity(0.10))
+                .overlay(Capsule().stroke(preflightColor(readiness).opacity(0.30), lineWidth: 1))
+        )
+    }
+
+    func preflightPathList(_ report: SandboxProvisioningReport) -> some View {
+        let ids: [SandboxProvisioningLocationID] = [
+            .root,
+            .containerWorkspace,
+            .temporaryDirectory,
+            .cacheDirectory,
+        ]
+        let rows = ids.compactMap { id in report.locations.first { $0.id == id } }
+
+        return VStack(spacing: 0) {
+            ForEach(rows) { location in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: preflightLocationIcon(location.status))
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(preflightLocationColor(location.status))
+                        .frame(width: 14)
+                    Text(location.title)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(theme.tertiaryText)
+                        .frame(width: 130, alignment: .leading)
+                    Text(location.path)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(theme.secondaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                    Spacer(minLength: 8)
+                    Text(location.status.rawValue)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(preflightLocationColor(location.status))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.inputBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(theme.inputBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    func preflightFindingsList(_ report: SandboxProvisioningReport) -> some View {
+        let actionable = report.findings
+            .filter { $0.severity == .blocked || $0.severity == .warning || $0.status == .unproven }
+        let visible = Array(actionable.prefix(4))
+        let hiddenCount = max(0, actionable.count - visible.count)
+
+        return VStack(alignment: .leading, spacing: 8) {
+            if visible.isEmpty {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.successColor)
+                    Text("No blocking host storage issues found.", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                }
+            } else {
+                ForEach(visible) { finding in
+                    preflightFindingRow(finding)
+                }
+                if hiddenCount > 0 {
+                    Text("+\(hiddenCount) more findings in copied report", bundle: .module)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.tertiaryText)
+                }
+            }
+        }
+    }
+
+    func preflightFindingRow(_ finding: SandboxProvisioningFinding) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: preflightFindingIcon(finding))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(preflightFindingColor(finding))
+                .frame(width: 14)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(finding.title)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(finding.code.rawValue)
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                }
+                Text(finding.detail)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(finding.repairSuggestion)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(preflightFindingColor(finding))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(preflightFindingColor(finding).opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(preflightFindingColor(finding).opacity(0.18), lineWidth: 1)
+                )
+        )
+    }
+
+    func preflightSummary(_ report: SandboxProvisioningReport) -> String {
+        switch report.overallReadiness {
+        case .ready:
+            return "Host paths and permissions are ready for sandbox tooling."
+        case .needsSetup:
+            return "\(report.warningFindings.count) setup finding(s) need attention before tools are fully ready."
+        case .blocked:
+            return "\(report.blockingFindings.count) blocking finding(s) must be fixed before provisioning."
+        case .unproven:
+            return "One or more checks could not be proven; copy the report for support or CI proof."
+        }
+    }
+
+    func preflightColor(_ readiness: SandboxProvisioningReadiness) -> Color {
+        switch readiness {
+        case .ready: theme.successColor
+        case .needsSetup: theme.warningColor
+        case .blocked: theme.errorColor
+        case .unproven: theme.infoColor
+        }
+    }
+
+    func preflightLocationColor(_ status: SandboxProvisioningLocationStatus) -> Color {
+        switch status {
+        case .ready: theme.successColor
+        case .missing, .unproven: theme.warningColor
+        case .wrongType, .notWritable, .notReadable, .emptyFile: theme.errorColor
+        }
+    }
+
+    func preflightLocationIcon(_ status: SandboxProvisioningLocationStatus) -> String {
+        switch status {
+        case .ready: "checkmark.circle.fill"
+        case .missing, .unproven: "exclamationmark.triangle.fill"
+        case .wrongType, .notWritable, .notReadable, .emptyFile: "xmark.octagon.fill"
+        }
+    }
+
+    func preflightFindingColor(_ finding: SandboxProvisioningFinding) -> Color {
+        switch finding.severity {
+        case .ok: theme.successColor
+        case .info: theme.infoColor
+        case .warning: theme.warningColor
+        case .blocked: theme.errorColor
+        }
+    }
+
+    func preflightFindingIcon(_ finding: SandboxProvisioningFinding) -> String {
+        switch finding.severity {
+        case .ok: "checkmark.circle.fill"
+        case .info: "info.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        case .blocked: "xmark.octagon.fill"
+        }
     }
 }
 
@@ -881,8 +1169,10 @@ private extension SandboxView {
             do {
                 try await SandboxManager.shared.provision()
                 refreshInfo()
+                runProvisioningPreflight()
             } catch {
                 provisionError = error.localizedDescription
+                runProvisioningPreflight()
             }
         }
     }
@@ -893,8 +1183,10 @@ private extension SandboxView {
             do {
                 try await SandboxManager.shared.startContainer()
                 refreshInfo()
+                runProvisioningPreflight()
             } catch {
                 actionError = error.localizedDescription
+                runProvisioningPreflight()
             }
         }
     }
@@ -907,8 +1199,10 @@ private extension SandboxView {
                 // `stopContainer` itself clears `State.shared.containerInfo`
                 // so the dashboard tiles go blank on stop without needing
                 // a manual assignment here.
+                runProvisioningPreflight()
             } catch {
                 actionError = error.localizedDescription
+                runProvisioningPreflight()
             }
         }
     }
@@ -919,8 +1213,10 @@ private extension SandboxView {
             do {
                 try await SandboxManager.shared.resetContainer()
                 refreshInfo()
+                runProvisioningPreflight()
             } catch {
                 actionError = error.localizedDescription
+                runProvisioningPreflight()
             }
         }
     }
@@ -932,8 +1228,10 @@ private extension SandboxView {
                 try await SandboxManager.shared.removeContainer()
                 // `removeContainer` → `stopContainer` clears the published
                 // metrics, so no manual reset needed here.
+                runProvisioningPreflight()
             } catch {
                 actionError = error.localizedDescription
+                runProvisioningPreflight()
             }
         }
     }
@@ -944,6 +1242,7 @@ private extension SandboxView {
         Task {
             try? await SandboxManager.shared.resetContainer()
             refreshInfo()
+            runProvisioningPreflight()
         }
     }
 
@@ -952,6 +1251,41 @@ private extension SandboxView {
         saving.autoStart = pendingConfig.autoStart
         SandboxConfigurationStore.save(saving)
         config = saving
+        runProvisioningPreflight()
+    }
+
+    func runProvisioningPreflight() {
+        guard !isRunningProvisioningPreflight else { return }
+        isRunningProvisioningPreflight = true
+        Task {
+            let report = await Task.detached(priority: .userInitiated) {
+                SandboxProvisioningDiagnostics.makeReport()
+            }.value
+            await MainActor.run {
+                provisioningReport = report
+                isRunningProvisioningPreflight = false
+                copiedProvisioningReport = false
+            }
+        }
+    }
+
+    func copyProvisioningReportJSON() {
+        guard let report = provisioningReport else { return }
+        let reportText = (try? report.jsonString()) ?? report.plainTextReport
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(reportText, forType: .string)
+
+        withAnimation(.easeInOut(duration: 0.2)) {
+            copiedProvisioningReport = true
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            if !Task.isCancelled {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    copiedProvisioningReport = false
+                }
+            }
+        }
     }
 
     func refreshInfo() {

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -63,6 +63,49 @@ Switch to the **Sandbox** tab in the Tools manager to browse, import, or create 
 
 ---
 
+## Provisioning Preflight
+
+Before provisioning, or when a sandbox setup looks unhealthy, open the
+Management window (`⌘ Shift M`) → **Sandbox** and use **Provisioning
+Preflight**. The report inspects the resolved Osaurus root, config directory
+and `sandbox.json`, cache directory, temporary directory, container workspace,
+agent/shared workspace roots, kernel/initfs assets, warm rootfs state, and the
+runtime bridge socket.
+
+Readiness is intentionally typed and conservative:
+
+| Readiness | Meaning |
+|-----------|---------|
+| `ready` | Required host paths exist, are the expected type, and passed read/write checks. |
+| `needs_setup` | Setup is incomplete or provisioning-created paths/assets are missing but repairable. |
+| `blocked` | A required path, permission, platform, architecture, or disk-space check failed. |
+| `unproven` | A check could not be proven and should not be treated as healthy. |
+
+Each finding includes a code, severity, status, affected path when available,
+and a concrete repair suggestion. Missing and unproven checks stay visible in
+the report instead of being coerced to a pass state.
+
+### Support and CI Proof
+
+Use **Copy JSON** on the preflight card to attach a support artifact or CI proof
+record. The JSON uses stable snake-case keys and includes:
+
+- resolved paths and source (`default_home`, `environment_override`, or
+  `test_override`);
+- configuration source and setup state;
+- per-location status, read/write probe result, file size, and volume capacity
+  where available;
+- typed findings with repair suggestions;
+- overall readiness.
+
+Maintainers can exercise the model and report output with:
+
+```bash
+swift test --package-path Packages/OsaurusCore --filter SandboxProvisioningDiagnostics
+```
+
+---
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary
- Adds sandbox provisioning diagnostics for setup state, repair hints, and readiness checks.
- Wires diagnostics into the Sandbox view.
- Adds focused tests and sandbox documentation updates.

## Validation
- `git diff --check`
- `bash scripts/i18n/check.sh`
- `swift test --package-path Packages/OsaurusCore --filter SandboxProvisioningDiagnostics`

## Notes
- The localization check still reports the existing stale-key warning set from main.
