### PR TITLE
Add eval review report artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WORKSPACE := osaurus.xcworkspace
 DERIVED := build/DerivedData
 XCODEBUILD_FLAGS ?=
 
-.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat
+.PHONY: help cli app install-cli serve status test ci-test clean bench-setup bench-ingest bench-ingest-chunks bench-run bench evals-prep evals evals-verbose evals-report evals-all evals-all-verbose evals-all-report evals-capture-screen evals-loop evals-matrix evals-diff evals-contribute evals-compat evals-pr-report evals-pr-report-baseline
 
 help:
 	@echo "Targets:"
@@ -36,6 +36,8 @@ help:
 	@echo "  evals-diff          All-domain before/after diff (BASELINE=, CURRENT=)"
 	@echo "  evals-contribute    Crowdsource: run one model on your Mac -> reports/community/<file>.json (MODEL=)"
 	@echo "  evals-compat        Fold reports/community/* into the COMPATIBILITY.md leaderboard (COMPAT_DIR=)"
+	@echo "  evals-pr-report     Generate local+frontier eval artifact bundle for PR review"
+	@echo "  evals-pr-report-baseline  Same as evals-pr-report plus BASELINE_DIR comparison"
 	@echo "  test           Run OsaurusCore package tests via 'swift test'"
 	@echo "  ci-test        Reproduce the CI test-core job locally (xcodebuild + xcbeautify)"
 	@echo "  clean          Remove DerivedData build output"
@@ -155,6 +157,9 @@ EVALS_ROOT := Packages/OsaurusEvals/Suites
 EVALS_SUITE ?= $(EVALS_ROOT)/CapabilitySearch
 EVALS_OUT ?= build/evals.json
 EVALS_OUT_DIR ?= build/evals
+LOCAL_MODEL ?= foundation
+FRONTIER_MODEL ?= openai/gpt-4o-mini
+EVALS_PR_REPORT_OUT ?= build/evals/pr-report/$(shell date -u +%Y%m%dT%H%M%SZ)
 # Auto-discovered list of every subdirectory under Suites/. Adding a new
 # `Suites/MyDomain/` automatically picks it up here — no Makefile edit
 # required when a new suite lands.
@@ -309,6 +314,37 @@ COMPAT_DIR ?= reports/community
 evals-compat:
 	@swift run --package-path Packages/OsaurusEvals osaurus-evals compat $(COMPAT_DIR) \
 		$(if $(VALIDATE),--validate,--out reports/COMPATIBILITY.json --markdown reports/COMPATIBILITY.md)
+
+# Review-oriented artifact bundle for PRs that affect agent-loop behavior.
+# Defaults to the required local+frontier lanes and AgentLoop +
+# AgentLoopFrontier suites. SandboxFrontier is opt-in because it needs host
+# sandbox prerequisites.
+evals-pr-report: evals-prep
+	@mkdir -p "$(EVALS_PR_REPORT_OUT)"
+	swift run --package-path Packages/OsaurusEvals osaurus-evals report \
+		--local-model "$(LOCAL_MODEL)" \
+		--frontier-model "$(FRONTIER_MODEL)" \
+		--out-dir "$(EVALS_PR_REPORT_OUT)" \
+		$(if $(JUDGE_MODEL),--judge-model "$(JUDGE_MODEL)",) \
+		$(if $(FILTER),--filter "$(FILTER)",) \
+		$(if $(INCLUDE_SANDBOX_FRONTIER),--include-sandbox-frontier,)
+	@echo "Wrote eval PR report to $(EVALS_PR_REPORT_OUT)"
+
+evals-pr-report-baseline: evals-prep
+	@if [[ -z "$(BASELINE_DIR)" ]]; then \
+		echo "BASELINE_DIR is required, e.g. make evals-pr-report-baseline BASELINE_DIR=build/evals/main-report"; \
+		exit 2; \
+	fi
+	@mkdir -p "$(EVALS_PR_REPORT_OUT)"
+	swift run --package-path Packages/OsaurusEvals osaurus-evals report \
+		--local-model "$(LOCAL_MODEL)" \
+		--frontier-model "$(FRONTIER_MODEL)" \
+		--baseline "$(BASELINE_DIR)" \
+		--out-dir "$(EVALS_PR_REPORT_OUT)" \
+		$(if $(JUDGE_MODEL),--judge-model "$(JUDGE_MODEL)",) \
+		$(if $(FILTER),--filter "$(FILTER)",) \
+		$(if $(INCLUDE_SANDBOX_FRONTIER),--include-sandbox-frontier,)
+	@echo "Wrote eval PR report with baseline comparison to $(EVALS_PR_REPORT_OUT)"
 
 ## ── Housekeeping ─────────────────────────────────────────────────
 

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -46,6 +46,8 @@ make evals FILTER=browser-amazon                    # single case while iteratin
 make evals-report                                   # also writes build/evals.json
 make evals-report EVALS_OUT=reports/today.json      # custom output path
 make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop  # other suite
+make evals-pr-report LOCAL_MODEL=foundation FRONTIER_MODEL=openai/gpt-4o-mini
+make evals-pr-report-baseline BASELINE_DIR=build/evals/main-report
 ```
 
 ### Asset prerequisites (handled automatically)
@@ -84,9 +86,61 @@ cd Packages/OsaurusEvals
 swift run osaurus-evals run --suite Suites/CapabilitySearch --model foundation
 swift run osaurus-evals run --suite Suites/CapabilitySearch --filter browser --out report.json
 swift run osaurus-evals run --suite Suites/CapabilitySearch --bootstrap-plugins
+swift run osaurus-evals report --local-model foundation --frontier-model openai/gpt-4o-mini
 ```
 
-For maintainer proof on agent-loop changes, use the regression lab. It runs
+For maintainer proof on agent-loop changes, use the PR report bundle when you
+need local + frontier evidence in one artifact:
+
+```bash
+make evals-pr-report \
+  LOCAL_MODEL=foundation \
+  FRONTIER_MODEL=openai/gpt-4o-mini
+
+make evals-pr-report-baseline \
+  BASELINE_DIR=build/evals/main-report \
+  LOCAL_MODEL=foundation \
+  FRONTIER_MODEL=openai/gpt-4o-mini
+```
+
+The default report runs `AgentLoop` and `AgentLoopFrontier` for both the local
+and frontier lanes. It writes `build/evals/pr-report/<timestamp>/` unless
+`EVALS_PR_REPORT_OUT` or `--out-dir` is set:
+
+- `manifest.json` — commit, branch, date, runner version, suites, models,
+  command provenance, and environment summary.
+- `summary.md` — maintainer-readable totals, failures, skips, regressions, and
+  the exact commands used.
+- `summary.json` — machine-readable aggregate summary.
+- `reports/<model>/<suite>.json` — raw `EvalReport` output for each lane.
+- `compare.md` / `compare.json` — baseline-vs-current diff when a baseline is
+  supplied.
+
+Use this evidence rule for PRs:
+
+- No eval report needed: docs-only changes, UI-only inspection, isolated
+  storage changes, and non-agent diagnostics.
+- Focused eval report needed: eval harness, provider bootstrap, or scoring
+  changes.
+- Local + frontier eval report required: default tools, tool schemas,
+  prompt/tool interaction, agent-loop routing, memory/tool routing, and
+  model-facing defaults.
+
+PR evidence block:
+
+```text
+Eval evidence:
+- Local: <model>, AgentLoop X/Y, AgentLoopFrontier X/Y
+- Frontier: <model>, AgentLoop X/Y, AgentLoopFrontier X/Y
+- Regressions vs baseline: <none/list>
+- Artifact: <path or uploaded artifact>
+```
+
+The `--from-reports <dir>` flag builds the bundle from existing `EvalReport`
+JSON files without model calls, which is useful for CLI smoke tests and docs
+examples.
+
+For lower-level agent-loop baseline work, use the regression lab. It runs
 selected `agent_loop` suites, writes per-suite JSON artifacts, compares the
 current run against a saved baseline report or report directory, and emits a
 concise JSON + Markdown summary:
@@ -401,8 +455,8 @@ make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop MODEL=mlx-communit
 make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/AgentLoop MODEL=openai/gpt-4o-mini JUDGE_MODEL=openai/gpt-4o
 ```
 
-For release or PR proof against a known-good row, prefer the regression lab so
-the raw reports and summary stay together:
+For release proof against a known-good row, the regression lab is still useful
+when you want only one model lane:
 
 ```bash
 scripts/evals/agent-loop-regression-lab.sh \
@@ -550,7 +604,12 @@ When a case in the floor map's accepted-hit count drops below `minMatches`, the 
 
 ## CI isolation
 
-This package is a **separate Swift package**. CI / Xcode builds run `swift build` and `swift test` from `Packages/OsaurusCore`, never from here. Even if someone does `swift test` from inside `Packages/OsaurusEvals`, no test target exists yet — runner unit tests should be added with a `OSAURUS_EVALS_ENABLED=1` env-var gate so they never burn tokens unintentionally.
+This package is a **separate Swift package**. CI / Xcode builds run
+`swift build` and `swift test` from `Packages/OsaurusCore`, never from here.
+`swift test --package-path Packages/OsaurusEvals` runs pure Swift report /
+schema tests only. Tests that would call a live model or provider must stay
+behind an explicit opt-in env-var gate so they never burn tokens
+unintentionally.
 
 ## Future hooks (deliberately stubbed)
 

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -74,10 +74,11 @@ loud warning if the embedder is missing.
 The `CapabilityClaims` browser cases additionally need the `osaurus.browser`
 native plugin installed. Because installing it mutates `~/.osaurus`, the prep
 step does it only when you opt in with `OSAURUS_EVALS_INSTALL_BROWSER=1`
-(`osaurus` CLI required); otherwise those cases skip as "missing plugins". When
-a selected case declares `fixtures.requirePlugins`, the runner now
-auto-bootstraps installed plugins (no `--bootstrap-plugins` needed); pass
-`--no-plugin-bootstrap` to force-skip them.
+(`osaurus` CLI required); otherwise those cases skip as "missing plugins".
+Generic eval runs keep installed plugins explicit; pass `--bootstrap-plugins`
+when you intentionally want plugin-required cases to run. The PR report command
+auto-loads installed plugins only for selected plugin-required cases, and
+`--no-plugin-bootstrap` still forces those cases to skip.
 
 Or call the CLI directly if you need flags the Makefile doesn't expose:
 
@@ -112,7 +113,7 @@ and frontier lanes. It writes `build/evals/pr-report/<timestamp>/` unless
 - `summary.md` — maintainer-readable totals, failures, skips, regressions, and
   the exact commands used.
 - `summary.json` — machine-readable aggregate summary.
-- `reports/<model>/<suite>.json` — raw `EvalReport` output for each lane.
+- `reports/<role>/<model>/<suite>.json` — raw `EvalReport` output for each lane.
 - `compare.md` / `compare.json` — baseline-vs-current diff when a baseline is
   supplied.
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/EvalReviewReportCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/EvalReviewReportCLI.swift
@@ -1,0 +1,677 @@
+//
+//  EvalReviewReportCLI.swift
+//  osaurus-evals
+//
+//  Maintainer-facing eval artifact bundle generation for PR review.
+//
+
+import Darwin
+import Foundation
+import OsaurusEvalsKit
+
+extension OsaurusEvalsCLI {
+    static func runEvalReviewReport(_ args: [String]) async -> Int32 {
+        let opts: EvalReviewReportOptions
+        do {
+            opts = try EvalReviewReportOptions.parse(args)
+        } catch {
+            FileHandle.standardError.write(
+                Data(("argument error: \(error.localizedDescription)\n").utf8)
+            )
+            printEvalReviewReportUsage()
+            return 2
+        }
+
+        if let judgeModel = opts.judgeModel {
+            setenv("JUDGE_MODEL", judgeModel, 1)
+        }
+
+        do {
+            if let fromReports = opts.fromReports {
+                return try writeEvalReviewReportFromExistingReports(
+                    options: opts,
+                    currentRoot: fromReports
+                )
+            }
+            return try await runEvalReviewReportSuites(options: opts)
+        } catch {
+            FileHandle.standardError.write(
+                Data(("eval report failed: \(error.localizedDescription)\n").utf8)
+            )
+            return 2
+        }
+    }
+
+    @MainActor
+    private static func runEvalReviewReportSuites(
+        options opts: EvalReviewReportOptions
+    ) async throws -> Int32 {
+        let suiteURLs = opts.suiteURLsForLiveRun()
+        let loadedSuites = try suiteURLs.map { url in
+            (ref: EvalReviewSuiteRef(name: suiteName(for: url), path: url.path), suite: try EvalSuite.load(from: url))
+        }
+
+        let combinedSuite = EvalSuite(
+            directory: URL(fileURLWithPath: "eval-review-report", isDirectory: true),
+            cases: loadedSuites.flatMap(\.suite.cases),
+            decodeFailures: loadedSuites.flatMap(\.suite.decodeFailures)
+        )
+        let bootstrapPlan = EvalBootstrapPlan.make(
+            suite: combinedSuite,
+            filter: opts.filter,
+            preference: opts.pluginBootstrapPreference
+        )
+        _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
+        let startupWatchdog =
+            bootstrapPlan.requiresWork
+            ? makeEvalReviewStartupWatchdog(options: opts, suite: combinedSuite)
+            : nil
+        await EvalBootstrap.run(bootstrapPlan)
+        startupWatchdog?.cancel()
+
+        let models = [
+            EvalReviewRunModel(
+                role: .local,
+                rawModelId: opts.localModelId,
+                selection: ModelSelection.parse(opts.localModelId)
+            ),
+            EvalReviewRunModel(
+                role: .frontier,
+                rawModelId: opts.frontierModelId,
+                selection: ModelSelection.parse(opts.frontierModelId)
+            ),
+        ]
+
+        var installedProviderIds: [UUID] = []
+        for model in models {
+            let ids = await EvalRemoteProviderBootstrap.connectIfNeeded(
+                modelIds: EvalRemoteProviderBootstrap.candidateModelIds(runModel: model.selection)
+            )
+            installedProviderIds.append(contentsOf: ids)
+        }
+        defer { EvalRemoteProviderBootstrap.teardown(installedProviderIds) }
+
+        var reports: [EvalReviewReportInput] = []
+        var commands: [EvalReviewCommandRecord] = []
+        var usedSuiteNames: [String: Int] = [:]
+
+        for model in models {
+            let modelReportDir = opts.outDir
+                .appendingPathComponent("reports", isDirectory: true)
+                .appendingPathComponent(sanitizedPathSegment(model.rawModelId), isDirectory: true)
+            try FileManager.default.createDirectory(at: modelReportDir, withIntermediateDirectories: true)
+
+            for item in loadedSuites {
+                let stableSuiteName = uniqueSuiteName(item.ref.name, usedNames: &usedSuiteNames)
+                print("running \(model.role.rawValue) \(model.rawModelId) / \(stableSuiteName)...")
+
+                let report = await EvalRunner.run(
+                    suite: item.suite,
+                    model: model.selection,
+                    filter: opts.filter,
+                    bootstrapMode: .alreadyLoaded
+                )
+                let outURL = modelReportDir.appendingPathComponent("\(stableSuiteName).json")
+                try report.toJSON(prettyPrinted: true).write(to: outURL)
+
+                let counts = report.counts
+                let exitCode: Int = (counts.failed + counts.errored == 0) ? 0 : 1
+                reports.append(
+                    EvalReviewReportInput(
+                        role: model.role,
+                        suite: stableSuiteName,
+                        suitePath: item.ref.path,
+                        reportPath: outURL.path,
+                        report: report
+                    )
+                )
+                commands.append(
+                    EvalReviewCommandRecord(
+                        role: model.role,
+                        modelId: model.rawModelId,
+                        suite: stableSuiteName,
+                        suitePath: item.ref.path,
+                        outputPath: outURL.path,
+                        arguments: runArguments(
+                            suitePath: item.ref.path,
+                            modelId: model.rawModelId,
+                            outPath: outURL.path,
+                            filter: opts.filter,
+                            startupTimeoutSeconds: opts.startupTimeoutSeconds,
+                            pluginBootstrapPreference: opts.pluginBootstrapPreference
+                        ),
+                        exitCode: exitCode
+                    )
+                )
+
+                print(
+                    "finished \(model.role.rawValue) \(stableSuiteName): "
+                        + "\(counts.passed) passed, \(counts.failed) failed, "
+                        + "\(counts.errored) errored, \(counts.skipped) skipped"
+                )
+            }
+            usedSuiteNames.removeAll(keepingCapacity: true)
+        }
+
+        let baselineReports = try opts.baseline.map {
+            try EvalReviewReportBuilder.loadReportsRecursively(from: $0)
+        } ?? []
+        let suiteRefs = loadedSuites.map(\.ref)
+        let manifest = makeEvalReviewManifest(
+            options: opts,
+            suiteRefs: suiteRefs,
+            modelRefs: reports.map { EvalReviewModelRef(role: $0.role, modelId: $0.report.modelId) },
+            commands: commands
+        )
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest,
+            reports: reports,
+            baselineReports: baselineReports
+        )
+        try writeEvalReviewBundle(bundle, outDir: opts.outDir)
+        printEvalReviewArtifactSummary(bundle, outDir: opts.outDir)
+        return bundle.hasRunFailures || bundle.hasBlockingRegressions ? 1 : 0
+    }
+
+    private static func writeEvalReviewReportFromExistingReports(
+        options opts: EvalReviewReportOptions,
+        currentRoot: URL
+    ) throws -> Int32 {
+        let loadedReports = try EvalReviewReportBuilder.loadReportsRecursively(from: currentRoot)
+        let reports = try copyEvalReportsIntoArtifact(
+            loadedReports,
+            outDir: opts.outDir
+        )
+        let baselineReports = try opts.baseline.map {
+            try EvalReviewReportBuilder.loadReportsRecursively(from: $0)
+        } ?? []
+        let suiteRefs = opts.suiteRefsForExistingReports(reports)
+        let command = EvalReviewCommandRecord(
+            role: .local,
+            modelId: "existing reports",
+            suite: "existing reports",
+            suitePath: currentRoot.path,
+            outputPath: opts.outDir.path,
+            arguments: existingReportArguments(options: opts, currentRoot: currentRoot),
+            exitCode: 0
+        )
+        let manifest = makeEvalReviewManifest(
+            options: opts,
+            suiteRefs: suiteRefs,
+            modelRefs: reports.map { EvalReviewModelRef(role: $0.role, modelId: $0.report.modelId) },
+            commands: [command]
+        )
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest,
+            reports: reports,
+            baselineReports: baselineReports
+        )
+        try writeEvalReviewBundle(bundle, outDir: opts.outDir)
+        printEvalReviewArtifactSummary(bundle, outDir: opts.outDir)
+        return bundle.hasRunFailures || bundle.hasBlockingRegressions ? 1 : 0
+    }
+
+    private static func copyEvalReportsIntoArtifact(
+        _ reports: [EvalReviewReportInput],
+        outDir: URL
+    ) throws -> [EvalReviewReportInput] {
+        var copied: [EvalReviewReportInput] = []
+        var usedNamesByModel: [String: [String: Int]] = [:]
+        for input in reports {
+            let modelDir = outDir
+                .appendingPathComponent("reports", isDirectory: true)
+                .appendingPathComponent(sanitizedPathSegment(input.report.modelId), isDirectory: true)
+            try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+            let modelKey = "\(input.role.rawValue)\u{1F}\(input.report.modelId)"
+            var usedNames = usedNamesByModel[modelKey, default: [:]]
+            let suite = uniqueSuiteName(input.suite, usedNames: &usedNames)
+            usedNamesByModel[modelKey] = usedNames
+            let outURL = modelDir.appendingPathComponent("\(suite).json")
+            try input.report.toJSON(prettyPrinted: true).write(to: outURL)
+            copied.append(
+                EvalReviewReportInput(
+                    role: input.role,
+                    suite: suite,
+                    suitePath: input.suitePath,
+                    reportPath: outURL.path,
+                    report: input.report
+                )
+            )
+        }
+        return copied
+    }
+
+    private static func makeEvalReviewManifest(
+        options opts: EvalReviewReportOptions,
+        suiteRefs: [EvalReviewSuiteRef],
+        modelRefs: [EvalReviewModelRef],
+        commands: [EvalReviewCommandRecord]
+    ) -> EvalReviewManifest {
+        EvalReviewManifest(
+            generatedAt: isoNowForEvalReviewCLI(),
+            branch: gitValue(["rev-parse", "--abbrev-ref", "HEAD"]) ?? "(unknown)",
+            commit: gitValue(["rev-parse", "HEAD"]) ?? "(unknown)",
+            runner: "osaurus-evals report",
+            artifactPath: opts.outDir.path,
+            suites: uniqueSuiteRefs(suiteRefs),
+            models: uniqueModelRefs(modelRefs),
+            commands: commands,
+            environment: EvalReviewEnvironmentSummary(
+                operatingSystem: ProcessInfo.processInfo.operatingSystemVersionString,
+                ci: isCIEnvironment(),
+                judgeModel: opts.judgeModel ?? ProcessInfo.processInfo.environment["JUDGE_MODEL"],
+                sandboxFrontierIncluded: opts.includeSandboxFrontier
+            ),
+            baselinePath: opts.baseline?.path
+        )
+    }
+
+    private static func writeEvalReviewBundle(
+        _ bundle: EvalReviewReportBundle,
+        outDir: URL
+    ) throws {
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+
+        try encoder.encode(bundle.manifest).write(
+            to: outDir.appendingPathComponent("manifest.json")
+        )
+        try bundle.toJSON(prettyPrinted: true).write(
+            to: outDir.appendingPathComponent("summary.json")
+        )
+        try bundle.formatMarkdown().write(
+            to: outDir.appendingPathComponent("summary.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        if let comparison = bundle.comparison {
+            try encoder.encode(comparison).write(
+                to: outDir.appendingPathComponent("compare.json")
+            )
+            try bundle.formatComparisonMarkdown().write(
+                to: outDir.appendingPathComponent("compare.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+    }
+
+    private static func printEvalReviewArtifactSummary(
+        _ bundle: EvalReviewReportBundle,
+        outDir: URL
+    ) {
+        print("")
+        print("wrote eval review report bundle to \(outDir.path)")
+        print("  manifest: \(outDir.appendingPathComponent("manifest.json").path)")
+        print("  summary:  \(outDir.appendingPathComponent("summary.md").path)")
+        if bundle.comparison != nil {
+            print("  compare:  \(outDir.appendingPathComponent("compare.md").path)")
+        }
+        print("  verdict:  \(bundle.hasBlockingRegressions ? "REGRESSED" : (bundle.hasRunFailures ? "EVAL FAILURES PRESENT" : "PASS"))")
+    }
+
+    @MainActor
+    private static func makeEvalReviewStartupWatchdog(
+        options opts: EvalReviewReportOptions,
+        suite: EvalSuite
+    ) -> EvalStartupWatchdog? {
+        guard let timeoutSeconds = opts.startupTimeoutSeconds else { return nil }
+        let reportData = try? EvalTimeoutReport.makeReport(
+            suite: suite,
+            modelId: "eval-review-report",
+            filter: opts.filter,
+            timeoutSeconds: timeoutSeconds,
+            phase: "startup bootstrap"
+        ).toJSON(prettyPrinted: true)
+
+        return EvalStartupWatchdog(
+            timeoutSeconds: timeoutSeconds,
+            payload: EvalStartupWatchdog.Payload(
+                phase: "startup bootstrap",
+                timeoutLabel: EvalTimeoutReport.formatSeconds(timeoutSeconds),
+                reportData: reportData,
+                outPath: opts.outDir.appendingPathComponent("startup-timeout.json").path
+            )
+        )
+    }
+
+    static func printEvalReviewReportUsage() {
+        let usage = """
+            osaurus-evals report - generate a self-contained eval artifact bundle for PR review
+
+            USAGE:
+                osaurus-evals report [--suite <dir> ...]
+                                      [--local-model <id>]
+                                      [--frontier-model <provider/model>]
+                                      [--baseline <dir>]
+                                      [--out-dir <dir>]
+                                      [--judge-model <provider/model>]
+                                      [--include-sandbox-frontier]
+
+            FLAGS:
+                --suite <dir>              Suite directory. May be repeated. Defaults to
+                                           AgentLoop and AgentLoopFrontier.
+                --local-model <id>         Local/default model evidence lane.
+                                           Default: foundation.
+                --frontier-model <id>      Frontier model evidence lane.
+                                           Default: openai/gpt-4o-mini.
+                --baseline <dir>           Optional baseline EvalReport file/directory.
+                                           Adds compare.json and compare.md.
+                --out-dir <dir>            Artifact directory. Defaults to
+                                           build/evals/pr-report/<timestamp>.
+                --judge-model <id>         Sets JUDGE_MODEL for rubric grading.
+                --filter <substr>          Only run cases whose id contains <substr>.
+                --include-sandbox-frontier Also run SandboxFrontier. Off by default.
+                --from-reports <dir>       Fixture/smoke mode. Builds the bundle from
+                                           existing EvalReport JSON files without model calls.
+                --startup-timeout <s>      Startup bootstrap watchdog. Use 0 to disable.
+                --bootstrap-plugins        Force installed native plugin loading.
+                --no-plugin-bootstrap      Disable installed native plugin loading.
+
+            ARTIFACTS:
+                manifest.json
+                summary.md
+                summary.json
+                reports/<model>/<suite>.json
+                compare.md / compare.json when --baseline is supplied
+
+            EXAMPLES:
+                osaurus-evals report --local-model foundation --frontier-model openai/gpt-4o-mini
+                osaurus-evals report --baseline build/evals/main-report --out-dir build/evals/pr-report/current
+                osaurus-evals report --from-reports Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab
+            """
+        print(usage)
+    }
+
+    struct EvalReviewReportOptions {
+        let suites: [URL]
+        let localModelId: String
+        let frontierModelId: String
+        let baseline: URL?
+        let outDir: URL
+        let judgeModel: String?
+        let filter: String?
+        let includeSandboxFrontier: Bool
+        let fromReports: URL?
+        let startupTimeoutSeconds: Double?
+        let pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference
+
+        static func parse(_ args: [String]) throws -> EvalReviewReportOptions {
+            var suites: [URL] = []
+            var localModelId = "foundation"
+            var frontierModelId = "openai/gpt-4o-mini"
+            var baseline: URL?
+            var outDir: URL?
+            var judgeModel: String?
+            var filter: String?
+            var includeSandboxFrontier = false
+            var fromReports: URL?
+            var startupTimeoutSeconds = EvalTimeoutReport.configuredStartupTimeoutSeconds()
+            var pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference = .automatic
+
+            var i = 0
+            while i < args.count {
+                let arg = args[i]
+                switch arg {
+                case "--suite":
+                    suites.append(try urlForArg(args, after: i, flag: arg))
+                    i += 2
+                case "--local-model":
+                    localModelId = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--frontier-model":
+                    frontierModelId = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--baseline":
+                    baseline = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--out-dir":
+                    outDir = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--judge-model":
+                    judgeModel = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--filter":
+                    filter = try valueForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--include-sandbox-frontier":
+                    includeSandboxFrontier = true
+                    i += 1
+                case "--from-reports":
+                    fromReports = try urlForArg(args, after: i, flag: arg)
+                    i += 2
+                case "--startup-timeout":
+                    let raw = try valueForArg(args, after: i, flag: arg)
+                    guard let value = EvalTimeoutReport.parseTimeoutSeconds(raw) else {
+                        throw CLIError.invalidValue(arg, raw)
+                    }
+                    startupTimeoutSeconds = value > 0 ? value : nil
+                    i += 2
+                case "--bootstrap-plugins":
+                    pluginBootstrapPreference = .force
+                    i += 1
+                case "--no-plugin-bootstrap":
+                    pluginBootstrapPreference = .disabled
+                    i += 1
+                case "--help", "-h":
+                    printEvalReviewReportUsage()
+                    Darwin.exit(0)
+                default:
+                    throw CLIError.unknownArg(arg)
+                }
+            }
+
+            return EvalReviewReportOptions(
+                suites: suites,
+                localModelId: localModelId,
+                frontierModelId: frontierModelId,
+                baseline: baseline,
+                outDir: outDir ?? defaultEvalReviewOutDir(),
+                judgeModel: judgeModel,
+                filter: filter,
+                includeSandboxFrontier: includeSandboxFrontier,
+                fromReports: fromReports,
+                startupTimeoutSeconds: startupTimeoutSeconds,
+                pluginBootstrapPreference: pluginBootstrapPreference
+            )
+        }
+
+        func suiteURLsForLiveRun() -> [URL] {
+            var selected = suites.isEmpty ? defaultEvalReviewSuiteURLs() : suites
+            if includeSandboxFrontier {
+                selected.append(defaultSandboxFrontierSuiteURL())
+            }
+            return selected
+        }
+
+        func suiteRefsForExistingReports(_ reports: [EvalReviewReportInput]) -> [EvalReviewSuiteRef] {
+            if !suites.isEmpty {
+                return suites.map { EvalReviewSuiteRef(name: suiteName(for: $0), path: $0.path) }
+            }
+            return reports.map {
+                EvalReviewSuiteRef(name: $0.suite, path: $0.suitePath)
+            }
+        }
+    }
+
+    private struct EvalReviewRunModel {
+        let role: EvalReviewModelRole
+        let rawModelId: String
+        let selection: ModelSelection
+    }
+
+    private static func defaultEvalReviewOutDir() -> URL {
+        URL(fileURLWithPath: "build/evals/pr-report", isDirectory: true)
+            .appendingPathComponent(timestampForEvalReviewPath(), isDirectory: true)
+    }
+
+    private static func defaultEvalReviewSuiteURLs() -> [URL] {
+        [
+            defaultSuiteURL(named: "AgentLoop"),
+            defaultSuiteURL(named: "AgentLoopFrontier"),
+        ]
+    }
+
+    private static func defaultSandboxFrontierSuiteURL() -> URL {
+        defaultSuiteURL(named: "SandboxFrontier")
+    }
+
+    private static func defaultSuiteURL(named name: String) -> URL {
+        let repoRoot = URL(
+            fileURLWithPath: "Packages/OsaurusEvals/Suites/\(name)",
+            isDirectory: true
+        )
+        if FileManager.default.fileExists(atPath: repoRoot.path) {
+            return repoRoot
+        }
+        return URL(fileURLWithPath: "Suites/\(name)", isDirectory: true)
+    }
+
+    private static func suiteName(for url: URL) -> String {
+        let name = url.lastPathComponent
+        return name.isEmpty ? url.deletingLastPathComponent().lastPathComponent : name
+    }
+
+    private static func uniqueSuiteName(
+        _ base: String,
+        usedNames: inout [String: Int]
+    ) -> String {
+        let count = usedNames[base, default: 0]
+        usedNames[base] = count + 1
+        return count == 0 ? base : "\(base)-\(count + 1)"
+    }
+
+    private static func uniqueSuiteRefs(_ refs: [EvalReviewSuiteRef]) -> [EvalReviewSuiteRef] {
+        var seen: Set<String> = []
+        var result: [EvalReviewSuiteRef] = []
+        for ref in refs.sorted(by: { $0.name < $1.name }) {
+            let key = "\(ref.name)\u{1F}\(ref.path)"
+            guard seen.insert(key).inserted else { continue }
+            result.append(ref)
+        }
+        return result
+    }
+
+    private static func uniqueModelRefs(_ refs: [EvalReviewModelRef]) -> [EvalReviewModelRef] {
+        var seen: Set<String> = []
+        var result: [EvalReviewModelRef] = []
+        for ref in refs.sorted(by: { lhs, rhs in
+            if lhs.role == rhs.role { return lhs.modelId < rhs.modelId }
+            return lhs.role < rhs.role
+        }) {
+            let key = "\(ref.role.rawValue)\u{1F}\(ref.modelId)"
+            guard seen.insert(key).inserted else { continue }
+            result.append(ref)
+        }
+        return result
+    }
+
+    private static func sanitizedPathSegment(_ raw: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = raw.unicodeScalars.map { scalar -> String in
+            allowed.contains(scalar) ? String(scalar) : "_"
+        }
+        let segment = scalars.joined()
+        return segment.isEmpty ? "model" : segment
+    }
+
+    private static func runArguments(
+        suitePath: String,
+        modelId: String,
+        outPath: String,
+        filter: String?,
+        startupTimeoutSeconds: Double?,
+        pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference
+    ) -> [String] {
+        var args = [
+            "osaurus-evals",
+            "run",
+            "--suite",
+            suitePath,
+            "--model",
+            modelId,
+            "--out",
+            outPath,
+        ]
+        if let filter {
+            args += ["--filter", filter]
+        }
+        if let startupTimeoutSeconds {
+            args += ["--startup-timeout", String(startupTimeoutSeconds)]
+        } else {
+            args += ["--startup-timeout", "0"]
+        }
+        switch pluginBootstrapPreference {
+        case .automatic:
+            break
+        case .force:
+            args.append("--bootstrap-plugins")
+        case .disabled:
+            args.append("--no-plugin-bootstrap")
+        }
+        return args
+    }
+
+    private static func existingReportArguments(
+        options opts: EvalReviewReportOptions,
+        currentRoot: URL
+    ) -> [String] {
+        var args = [
+            "osaurus-evals",
+            "report",
+            "--from-reports",
+            currentRoot.path,
+            "--out-dir",
+            opts.outDir.path,
+        ]
+        if let baseline = opts.baseline {
+            args += ["--baseline", baseline.path]
+        }
+        if let filter = opts.filter {
+            args += ["--filter", filter]
+        }
+        return args
+    }
+
+    private static func gitValue(_ args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let value = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return value?.isEmpty == false ? value : nil
+        } catch {
+            return nil
+        }
+    }
+
+    private static func isCIEnvironment() -> Bool {
+        let value = ProcessInfo.processInfo.environment["CI"]?.lowercased()
+        return value == "true" || value == "1"
+    }
+
+    private static func timestampForEvalReviewPath() -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        return formatter.string(from: Date())
+    }
+}
+
+private func isoNowForEvalReviewCLI() -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: Date())
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/EvalReviewReportCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/EvalReviewReportCLI.swift
@@ -56,10 +56,15 @@ extension OsaurusEvalsCLI {
             cases: loadedSuites.flatMap(\.suite.cases),
             decodeFailures: loadedSuites.flatMap(\.suite.decodeFailures)
         )
+        try FileManager.default.createDirectory(at: opts.outDir, withIntermediateDirectories: true)
+        let pluginBootstrapPreference = effectiveEvalReviewPluginBootstrapPreference(
+            options: opts,
+            suite: combinedSuite
+        )
         let bootstrapPlan = EvalBootstrapPlan.make(
             suite: combinedSuite,
             filter: opts.filter,
-            preference: opts.pluginBootstrapPreference
+            preference: pluginBootstrapPreference
         )
         _ = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(for: bootstrapPlan)
         let startupWatchdog =
@@ -98,11 +103,18 @@ extension OsaurusEvalsCLI {
         for model in models {
             let modelReportDir = opts.outDir
                 .appendingPathComponent("reports", isDirectory: true)
-                .appendingPathComponent(sanitizedPathSegment(model.rawModelId), isDirectory: true)
+                .appendingPathComponent(model.role.rawValue, isDirectory: true)
+                .appendingPathComponent(
+                    EvalReviewReportPaths.sanitizedSegment(model.rawModelId),
+                    isDirectory: true
+                )
             try FileManager.default.createDirectory(at: modelReportDir, withIntermediateDirectories: true)
 
             for item in loadedSuites {
-                let stableSuiteName = uniqueSuiteName(item.ref.name, usedNames: &usedSuiteNames)
+                let stableSuiteName = EvalReviewReportPaths.uniqueSuiteName(
+                    item.ref.name,
+                    usedNames: &usedSuiteNames
+                )
                 print("running \(model.role.rawValue) \(model.rawModelId) / \(stableSuiteName)...")
 
                 let report = await EvalRunner.run(
@@ -138,7 +150,7 @@ extension OsaurusEvalsCLI {
                             outPath: outURL.path,
                             filter: opts.filter,
                             startupTimeoutSeconds: opts.startupTimeoutSeconds,
-                            pluginBootstrapPreference: opts.pluginBootstrapPreference
+                            pluginBootstrapPreference: pluginBootstrapPreference
                         ),
                         exitCode: exitCode
                     )
@@ -220,11 +232,15 @@ extension OsaurusEvalsCLI {
         for input in reports {
             let modelDir = outDir
                 .appendingPathComponent("reports", isDirectory: true)
-                .appendingPathComponent(sanitizedPathSegment(input.report.modelId), isDirectory: true)
+                .appendingPathComponent(input.role.rawValue, isDirectory: true)
+                .appendingPathComponent(
+                    EvalReviewReportPaths.sanitizedSegment(input.report.modelId),
+                    isDirectory: true
+                )
             try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
             let modelKey = "\(input.role.rawValue)\u{1F}\(input.report.modelId)"
             var usedNames = usedNamesByModel[modelKey, default: [:]]
-            let suite = uniqueSuiteName(input.suite, usedNames: &usedNames)
+            let suite = EvalReviewReportPaths.uniqueSuiteName(input.suite, usedNames: &usedNames)
             usedNamesByModel[modelKey] = usedNames
             let outURL = modelDir.appendingPathComponent("\(suite).json")
             try input.report.toJSON(prettyPrinted: true).write(to: outURL)
@@ -369,12 +385,14 @@ extension OsaurusEvalsCLI {
                 --startup-timeout <s>      Startup bootstrap watchdog. Use 0 to disable.
                 --bootstrap-plugins        Force installed native plugin loading.
                 --no-plugin-bootstrap      Disable installed native plugin loading.
+                                           In automatic mode, report runs load installed
+                                           plugins only when selected cases require them.
 
             ARTIFACTS:
                 manifest.json
                 summary.md
                 summary.json
-                reports/<model>/<suite>.json
+                reports/<role>/<model>/<suite>.json
                 compare.md / compare.json when --baseline is supplied
 
             EXAMPLES:
@@ -534,15 +552,6 @@ extension OsaurusEvalsCLI {
         return name.isEmpty ? url.deletingLastPathComponent().lastPathComponent : name
     }
 
-    private static func uniqueSuiteName(
-        _ base: String,
-        usedNames: inout [String: Int]
-    ) -> String {
-        let count = usedNames[base, default: 0]
-        usedNames[base] = count + 1
-        return count == 0 ? base : "\(base)-\(count + 1)"
-    }
-
     private static func uniqueSuiteRefs(_ refs: [EvalReviewSuiteRef]) -> [EvalReviewSuiteRef] {
         var seen: Set<String> = []
         var result: [EvalReviewSuiteRef] = []
@@ -566,15 +575,6 @@ extension OsaurusEvalsCLI {
             result.append(ref)
         }
         return result
-    }
-
-    private static func sanitizedPathSegment(_ raw: String) -> String {
-        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
-        let scalars = raw.unicodeScalars.map { scalar -> String in
-            allowed.contains(scalar) ? String(scalar) : "_"
-        }
-        let segment = scalars.joined()
-        return segment.isEmpty ? "model" : segment
     }
 
     private static func runArguments(
@@ -667,6 +667,16 @@ extension OsaurusEvalsCLI {
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
         return formatter.string(from: Date())
+    }
+
+    private static func effectiveEvalReviewPluginBootstrapPreference(
+        options opts: EvalReviewReportOptions,
+        suite: EvalSuite
+    ) -> EvalInstalledPluginBootstrapPreference {
+        guard opts.pluginBootstrapPreference == .automatic else {
+            return opts.pluginBootstrapPreference
+        }
+        return suite.selectedCasesRequireInstalledPlugins(filter: opts.filter) ? .force : .automatic
     }
 }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -558,8 +558,8 @@ struct OsaurusEvalsCLI {
         /// happens before the first case can run. `nil` disables it.
         let startupTimeoutSeconds: Double?
         /// Controls native installed-plugin bootstrap. Automatic mode
-        /// loads plugins only when a suite requires them; capability-search
-        /// suites initialize indices without dlopen-ing local plugins.
+        /// keeps installed plugins explicit; capability-search suites
+        /// initialize indices without dlopen-ing local plugins.
         let pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference
 
         static func parse(_ args: [String]) throws -> Options {
@@ -747,8 +747,7 @@ struct OsaurusEvalsCLI {
                                       when CI=true. Env override:
                                       OSAURUS_EVALS_STARTUP_TIMEOUT_SECONDS.
                 --bootstrap-plugins  Force installed native plugin loading
-                                      before the suite. Automatic mode loads
-                                      plugins only when a suite requires them.
+                                      before the suite.
                 --no-plugin-bootstrap
                                       Disable installed native plugin loading.
                                       Capability-search suites initialize only

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -10,6 +10,7 @@
 //
 //  Usage:
 //    osaurus-evals run --suite Suites/CapabilitySearch [--model foundation] [--filter browser] [--out report.json]
+//    osaurus-evals report [--local-model foundation] [--frontier-model openai/gpt-4o-mini]
 //
 //  Exit codes:
 //    0  every non-skipped case passed (or no cases ran)
@@ -56,6 +57,13 @@ struct OsaurusEvalsCLI {
         case "compat":
             // Pure file aggregation over reports/community/* — no model load.
             exit(runCompat(Array(args.dropFirst())))
+        case "report":
+            let reportArgs = Array(args.dropFirst())
+            let reportExitCode = await runEvalReviewReport(reportArgs)
+            if reportArgs.contains("--from-reports") {
+                exit(reportExitCode)
+            }
+            await shutdownAndExit(reportExitCode)
         case "--help", "-h":
             printUsage()
             exit(0)
@@ -669,6 +677,8 @@ struct OsaurusEvalsCLI {
                                               [--fail-on-regression]
                 osaurus-evals matrix <reports-dir> [--out <p>] [--markdown <p>]
                 osaurus-evals compat <community-dir> [--out <p>] [--markdown <p>] [--validate]
+                osaurus-evals report [--suite <dir> ...] [--local-model <id>] [--frontier-model <id>]
+                                      [--baseline <dir>] [--out-dir <dir>]
 
             FLAGS:
                 --suite <dir>         Required. Directory of *.json eval cases
@@ -752,6 +762,7 @@ struct OsaurusEvalsCLI {
                 osaurus-evals run --suite Suites/CapabilitySearch --threshold 0.25 --report-forensics
                 osaurus-evals run --suite Suites/CapabilitySearch --fail-on-floor
                 osaurus-evals agent-loop-lab --baseline reports/main-agentloop
+                osaurus-evals report --local-model foundation --frontier-model openai/gpt-4o-mini
             """
         print(usage)
     }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalBootstrap.swift
@@ -96,20 +96,13 @@ public struct EvalBootstrapPlan: Sendable, Equatable {
         case .force:
             return EvalBootstrapPlan(loadInstalledPlugins: true, searchIndexScope: .empty)
         case .automatic:
-            // Auto-load installed native plugins when a selected case
-            // explicitly requires one (`fixtures.requirePlugins`, e.g. the
-            // capability_claims browser cases). Without this those cases skip
-            // as "missing plugins" even when the plugin is installed on disk.
-            // Plugin bootstrap (`EvalHostBootstrap.loadInstalledPlugins`) also
-            // brings up the search indices, so no extra index scope is needed.
-            // Suites with no plugin-required selected case keep avoiding the
-            // dlopen cost and only bring up the index lanes they need.
-            // `--bootstrap-plugins` (`.force`) still forces loading;
-            // `--no-bootstrap-plugins` (`.disabled`) opts out even when cases
-            // request plugins.
-            if suite.selectedCasesRequireInstalledPlugins(filter: filter) {
-                return EvalBootstrapPlan(loadInstalledPlugins: true, searchIndexScope: .empty)
-            }
+            // Automatic run mode keeps installed native plugins explicit:
+            // plugin-required cases skip unless the caller opts into
+            // `--bootstrap-plugins`. This avoids making ordinary eval runs
+            // depend on local plugin dylibs or a developer's host-app state.
+            // Callers with a narrower contract, such as PR report generation,
+            // may promote their effective preference to `.force` after
+            // inspecting the selected suite.
             return EvalBootstrapPlan(
                 loadInstalledPlugins: false,
                 searchIndexScope: suite.searchIndexBootstrapScopeWithoutPluginBootstrap(filter: filter)
@@ -429,10 +422,9 @@ public enum EvalBootstrap {
 
 public extension EvalSuite {
     /// True when any selected case explicitly requires an installed native
-    /// plugin (`fixtures.requirePlugins`). Drives the automatic plugin
-    /// bootstrap so plugin-gated cases (e.g. the capability_claims browser
-    /// cases) actually run instead of skipping as "missing plugins" when the
-    /// plugin is installed on disk.
+    /// plugin (`fixtures.requirePlugins`). Generic eval runs use this only to
+    /// decide which cases will skip without plugin bootstrap; narrower callers
+    /// can use it to opt into `.force` for their own evidence contract.
     func selectedCasesRequireInstalledPlugins(filter: String?) -> Bool {
         selectedCases(filter: filter).contains {
             !($0.fixtures.requirePlugins?.isEmpty ?? true)

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
@@ -1,0 +1,757 @@
+//
+//  EvalReviewReport.swift
+//  OsaurusEvalsKit
+//
+//  PR-review artifact bundling for local + frontier eval evidence.
+//
+
+import Foundation
+
+public enum EvalReviewModelRole: String, Sendable, Codable, Equatable, Comparable {
+    case local
+    case frontier
+
+    public static func < (lhs: EvalReviewModelRole, rhs: EvalReviewModelRole) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+public struct EvalReviewModelRef: Sendable, Codable, Equatable, Hashable {
+    public let role: EvalReviewModelRole
+    public let modelId: String
+
+    public init(role: EvalReviewModelRole, modelId: String) {
+        self.role = role
+        self.modelId = modelId
+    }
+}
+
+public struct EvalReviewSuiteRef: Sendable, Codable, Equatable {
+    public let name: String
+    public let path: String
+
+    public init(name: String, path: String) {
+        self.name = name
+        self.path = path
+    }
+}
+
+public struct EvalReviewCommandRecord: Sendable, Codable, Equatable {
+    public let role: EvalReviewModelRole
+    public let modelId: String
+    public let suite: String
+    public let suitePath: String
+    public let outputPath: String
+    public let arguments: [String]
+    public let exitCode: Int
+
+    public init(
+        role: EvalReviewModelRole,
+        modelId: String,
+        suite: String,
+        suitePath: String,
+        outputPath: String,
+        arguments: [String],
+        exitCode: Int
+    ) {
+        self.role = role
+        self.modelId = modelId
+        self.suite = suite
+        self.suitePath = suitePath
+        self.outputPath = outputPath
+        self.arguments = arguments
+        self.exitCode = exitCode
+    }
+}
+
+public struct EvalReviewEnvironmentSummary: Sendable, Codable, Equatable {
+    public let operatingSystem: String
+    public let ci: Bool
+    public let judgeModel: String?
+    public let sandboxFrontierIncluded: Bool
+
+    public init(
+        operatingSystem: String,
+        ci: Bool,
+        judgeModel: String?,
+        sandboxFrontierIncluded: Bool
+    ) {
+        self.operatingSystem = operatingSystem
+        self.ci = ci
+        self.judgeModel = judgeModel
+        self.sandboxFrontierIncluded = sandboxFrontierIncluded
+    }
+}
+
+public struct EvalReviewManifest: Sendable, Codable, Equatable {
+    public let generatedAt: String
+    public let branch: String
+    public let commit: String
+    public let runner: String
+    public let artifactPath: String
+    public let suites: [EvalReviewSuiteRef]
+    public let models: [EvalReviewModelRef]
+    public let commands: [EvalReviewCommandRecord]
+    public let environment: EvalReviewEnvironmentSummary
+    public let baselinePath: String?
+
+    public init(
+        generatedAt: String,
+        branch: String,
+        commit: String,
+        runner: String,
+        artifactPath: String,
+        suites: [EvalReviewSuiteRef],
+        models: [EvalReviewModelRef],
+        commands: [EvalReviewCommandRecord],
+        environment: EvalReviewEnvironmentSummary,
+        baselinePath: String?
+    ) {
+        self.generatedAt = generatedAt
+        self.branch = branch
+        self.commit = commit
+        self.runner = runner
+        self.artifactPath = artifactPath
+        self.suites = suites
+        self.models = models
+        self.commands = commands
+        self.environment = environment
+        self.baselinePath = baselinePath
+    }
+}
+
+public struct EvalReviewOutcomeCounts: Sendable, Codable, Equatable {
+    public let total: Int
+    public let passed: Int
+    public let failed: Int
+    public let skipped: Int
+    public let errored: Int
+
+    public init(total: Int, passed: Int, failed: Int, skipped: Int, errored: Int) {
+        self.total = total
+        self.passed = passed
+        self.failed = failed
+        self.skipped = skipped
+        self.errored = errored
+    }
+
+    public init(cases: [EvalCaseReport]) {
+        self.init(
+            total: cases.count,
+            passed: cases.filter { $0.outcome == .passed }.count,
+            failed: cases.filter { $0.outcome == .failed }.count,
+            skipped: cases.filter { $0.outcome == .skipped }.count,
+            errored: cases.filter { $0.outcome == .errored }.count
+        )
+    }
+
+    public static let zero = EvalReviewOutcomeCounts(
+        total: 0,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        errored: 0
+    )
+
+    public func adding(_ other: EvalReviewOutcomeCounts) -> EvalReviewOutcomeCounts {
+        EvalReviewOutcomeCounts(
+            total: total + other.total,
+            passed: passed + other.passed,
+            failed: failed + other.failed,
+            skipped: skipped + other.skipped,
+            errored: errored + other.errored
+        )
+    }
+}
+
+public struct EvalReviewCaseSummary: Sendable, Codable, Equatable {
+    public let id: String
+    public let label: String
+    public let outcome: EvalCaseOutcome
+    public let notes: [String]
+
+    public init(row: EvalCaseReport) {
+        id = row.id
+        label = row.label
+        outcome = row.outcome
+        notes = row.notes
+    }
+}
+
+public struct EvalReviewSuiteSummary: Sendable, Codable, Equatable {
+    public let suite: String
+    public let reportPath: String
+    public let counts: EvalReviewOutcomeCounts
+    public let failures: [EvalReviewCaseSummary]
+    public let errors: [EvalReviewCaseSummary]
+    public let skipped: [EvalReviewCaseSummary]
+
+    public init(suite: String, reportPath: String, report: EvalReport) {
+        self.suite = suite
+        self.reportPath = reportPath
+        counts = EvalReviewOutcomeCounts(cases: report.cases)
+        failures = report.cases
+            .filter { $0.outcome == .failed }
+            .map(EvalReviewCaseSummary.init(row:))
+        errors = report.cases
+            .filter { $0.outcome == .errored }
+            .map(EvalReviewCaseSummary.init(row:))
+        skipped = report.cases
+            .filter { $0.outcome == .skipped }
+            .map(EvalReviewCaseSummary.init(row:))
+    }
+}
+
+public struct EvalReviewModelSummary: Sendable, Codable, Equatable {
+    public let role: EvalReviewModelRole
+    public let modelId: String
+    public let counts: EvalReviewOutcomeCounts
+    public let suites: [EvalReviewSuiteSummary]
+
+    public init(role: EvalReviewModelRole, modelId: String, suites: [EvalReviewSuiteSummary]) {
+        self.role = role
+        self.modelId = modelId
+        self.suites = suites
+        counts = suites.reduce(.zero) { $0.adding($1.counts) }
+    }
+}
+
+public struct EvalReviewReportInput: Sendable {
+    public let role: EvalReviewModelRole
+    public let suite: String
+    public let suitePath: String
+    public let reportPath: String
+    public let report: EvalReport
+
+    public init(
+        role: EvalReviewModelRole,
+        suite: String,
+        suitePath: String,
+        reportPath: String,
+        report: EvalReport
+    ) {
+        self.role = role
+        self.suite = suite
+        self.suitePath = suitePath
+        self.reportPath = reportPath
+        self.report = report
+    }
+}
+
+public struct EvalReviewCaseDelta: Sendable, Codable, Equatable {
+    public let modelId: String
+    public let suite: String
+    public let id: String
+    public let baselineOutcome: EvalCaseOutcome?
+    public let currentOutcome: EvalCaseOutcome?
+    public let baselineNotes: [String]
+    public let currentNotes: [String]
+
+    public init(baseline: EvalReviewCaseSnapshot?, current: EvalReviewCaseSnapshot?) {
+        modelId = current?.modelId ?? baseline?.modelId ?? "(unknown)"
+        suite = current?.suite ?? baseline?.suite ?? "(unknown)"
+        id = current?.id ?? baseline?.id ?? "(unknown)"
+        baselineOutcome = baseline?.outcome
+        currentOutcome = current?.outcome
+        baselineNotes = baseline?.notes ?? []
+        currentNotes = current?.notes ?? []
+    }
+}
+
+public struct EvalReviewComparisonSummary: Sendable, Codable, Equatable {
+    public let baselinePath: String
+    public let regressions: [EvalReviewCaseDelta]
+    public let newFailures: [EvalReviewCaseDelta]
+    public let fixed: [EvalReviewCaseDelta]
+    public let persistentFailures: [EvalReviewCaseDelta]
+    public let changedSkips: [EvalReviewCaseDelta]
+    public let newCases: [EvalReviewCaseDelta]
+    public let removedCases: [EvalReviewCaseDelta]
+    public let warnings: [String]
+
+    public var hasBlockingRegressions: Bool {
+        !regressions.isEmpty || !newFailures.isEmpty
+    }
+}
+
+public struct EvalReviewReportBundle: Sendable, Codable, Equatable {
+    public let manifest: EvalReviewManifest
+    public let models: [EvalReviewModelSummary]
+    public let comparison: EvalReviewComparisonSummary?
+
+    public var hasRunFailures: Bool {
+        models.contains { $0.counts.failed > 0 || $0.counts.errored > 0 }
+    }
+
+    public var hasBlockingRegressions: Bool {
+        comparison?.hasBlockingRegressions ?? false
+    }
+
+    public func toJSON(prettyPrinted: Bool = true) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting =
+            prettyPrinted
+            ? [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            : [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(self)
+    }
+
+    public func formatMarkdown() -> String {
+        var lines: [String] = []
+        lines.append("# Eval Review Report")
+        lines.append("")
+        lines.append("- Generated: \(manifest.generatedAt)")
+        lines.append("- Branch: `\(manifest.branch)`")
+        lines.append("- Commit: `\(manifest.commit)`")
+        lines.append("- Artifact: `\(manifest.artifactPath)`")
+        lines.append("- Verdict: \(verdictLabel())")
+        if let baseline = manifest.baselinePath {
+            lines.append("- Baseline: `\(baseline)`")
+        }
+        if let judge = manifest.environment.judgeModel {
+            lines.append("- Judge model: `\(judge)`")
+        }
+        lines.append("")
+        lines.append("## PR Evidence")
+        lines.append("")
+        appendPREvidence(into: &lines)
+        lines.append("")
+        lines.append("## Model Totals")
+        lines.append("")
+        lines.append("| Role | Model | Total | Passed | Failed | Errored | Skipped |")
+        lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: |")
+        for model in models.sorted(by: modelSort) {
+            lines.append(
+                "| \(model.role.rawValue) | \(markdownCell(model.modelId)) | "
+                    + "\(model.counts.total) | \(model.counts.passed) | "
+                    + "\(model.counts.failed) | \(model.counts.errored) | \(model.counts.skipped) |"
+            )
+        }
+        lines.append("")
+        lines.append("## Suite Reports")
+        lines.append("")
+        lines.append("| Role | Model | Suite | Passed | Failed | Errored | Skipped | Report |")
+        lines.append("| --- | --- | --- | ---: | ---: | ---: | ---: | --- |")
+        for model in models.sorted(by: modelSort) {
+            for suite in model.suites.sorted(by: { $0.suite < $1.suite }) {
+                lines.append(
+                    "| \(model.role.rawValue) | \(markdownCell(model.modelId)) | "
+                        + "\(markdownCell(suite.suite)) | \(suite.counts.passed) | "
+                        + "\(suite.counts.failed) | \(suite.counts.errored) | "
+                        + "\(suite.counts.skipped) | `\(suite.reportPath)` |"
+                )
+            }
+        }
+        appendCasesSection(title: "Failures", outcomes: [.failed], into: &lines)
+        appendCasesSection(title: "Errors", outcomes: [.errored], into: &lines)
+        appendCasesSection(title: "Skipped Cases", outcomes: [.skipped], into: &lines)
+        appendComparison(into: &lines)
+        lines.append("")
+        lines.append("## Commands")
+        lines.append("")
+        for command in manifest.commands {
+            lines.append("- `\(command.arguments.joined(separator: " "))`")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    public func formatComparisonMarkdown() -> String {
+        guard let comparison else {
+            return "# Eval Review Comparison\n\nNo baseline comparison was requested.\n"
+        }
+        var lines: [String] = []
+        lines.append("# Eval Review Comparison")
+        lines.append("")
+        lines.append("- Baseline: `\(comparison.baselinePath)`")
+        lines.append("- Verdict: \(comparison.hasBlockingRegressions ? "REGRESSED" : "PASS")")
+        appendDeltaSection("Blocking Regressions", comparison.regressions, into: &lines)
+        appendDeltaSection("New Failing Cases", comparison.newFailures, into: &lines)
+        appendDeltaSection("Fixed Cases", comparison.fixed, into: &lines)
+        appendDeltaSection("Persistent Failures", comparison.persistentFailures, into: &lines)
+        appendDeltaSection("Changed Skips", comparison.changedSkips, into: &lines)
+        appendDeltaSection("Suite Drift", comparison.newCases + comparison.removedCases, into: &lines)
+        if !comparison.warnings.isEmpty {
+            lines.append("")
+            lines.append("## Warnings")
+            lines.append("")
+            for warning in comparison.warnings {
+                lines.append("- \(markdownCell(warning))")
+            }
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private func verdictLabel() -> String {
+        if hasBlockingRegressions { return "REGRESSED" }
+        if hasRunFailures { return "EVAL FAILURES PRESENT" }
+        return "PASS"
+    }
+
+    private func appendPREvidence(into lines: inout [String]) {
+        let local = models.first { $0.role == .local }
+        let frontier = models.first { $0.role == .frontier }
+        lines.append("Eval evidence:")
+        lines.append("- Local: \(evidenceLine(local))")
+        lines.append("- Frontier: \(evidenceLine(frontier))")
+        if let comparison {
+            let regressions = comparison.regressions.count + comparison.newFailures.count
+            lines.append("- Regressions vs baseline: \(regressions == 0 ? "none" : "\(regressions)")")
+        } else {
+            lines.append("- Regressions vs baseline: not run")
+        }
+        lines.append("- Artifact: \(manifest.artifactPath)")
+    }
+
+    private func evidenceLine(_ model: EvalReviewModelSummary?) -> String {
+        guard let model else { return "not run" }
+        let suiteParts = model.suites.sorted(by: { $0.suite < $1.suite }).map { suite in
+            "\(suite.suite) \(suite.counts.passed)/\(suite.counts.total)"
+        }
+        return "\(model.modelId), \(suiteParts.joined(separator: ", "))"
+    }
+
+    private func appendCasesSection(
+        title: String,
+        outcomes: Set<EvalCaseOutcome>,
+        into lines: inout [String]
+    ) {
+        let rows = models.flatMap { model in
+            model.suites.flatMap { suite in
+                cases(for: suite, outcomes: outcomes).map { row in
+                    (model: model, suite: suite, row: row)
+                }
+            }
+        }
+        guard !rows.isEmpty else { return }
+        lines.append("")
+        lines.append("## \(title)")
+        lines.append("")
+        lines.append("| Role | Model | Suite | Case | Notes |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for item in rows {
+            lines.append(
+                "| \(item.model.role.rawValue) | \(markdownCell(item.model.modelId)) | "
+                    + "\(markdownCell(item.suite.suite)) | \(markdownCell(item.row.id)) | "
+                    + "\(markdownCell(item.row.notes.prefix(2).joined(separator: " / "))) |"
+            )
+        }
+    }
+
+    private func cases(
+        for suite: EvalReviewSuiteSummary,
+        outcomes: Set<EvalCaseOutcome>
+    ) -> [EvalReviewCaseSummary] {
+        var rows: [EvalReviewCaseSummary] = []
+        if outcomes.contains(.failed) { rows.append(contentsOf: suite.failures) }
+        if outcomes.contains(.errored) { rows.append(contentsOf: suite.errors) }
+        if outcomes.contains(.skipped) { rows.append(contentsOf: suite.skipped) }
+        return rows.sorted { $0.id < $1.id }
+    }
+
+    private func appendComparison(into lines: inout [String]) {
+        guard let comparison else { return }
+        lines.append("")
+        lines.append("## Baseline Comparison")
+        lines.append("")
+        lines.append("- Blocking regressions: \(comparison.regressions.count)")
+        lines.append("- New failing cases: \(comparison.newFailures.count)")
+        lines.append("- Fixed cases: \(comparison.fixed.count)")
+        lines.append("- Persistent failures: \(comparison.persistentFailures.count)")
+        lines.append("- Changed skips: \(comparison.changedSkips.count)")
+    }
+
+    private func appendDeltaSection(
+        _ title: String,
+        _ rows: [EvalReviewCaseDelta],
+        into lines: inout [String]
+    ) {
+        guard !rows.isEmpty else { return }
+        lines.append("")
+        lines.append("## \(title)")
+        lines.append("")
+        lines.append("| Model | Suite | Case | Baseline | Current | Notes |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        for row in rows {
+            let notes = row.currentNotes.isEmpty ? row.baselineNotes : row.currentNotes
+            lines.append(
+                "| \(markdownCell(row.modelId)) | \(markdownCell(row.suite)) | "
+                    + "\(markdownCell(row.id)) | \(outcomeLabel(row.baselineOutcome)) | "
+                    + "\(outcomeLabel(row.currentOutcome)) | "
+                    + "\(markdownCell(notes.prefix(2).joined(separator: " / "))) |"
+            )
+        }
+    }
+
+    private func outcomeLabel(_ outcome: EvalCaseOutcome?) -> String {
+        outcome?.rawValue ?? "missing"
+    }
+
+    private func markdownCell(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "|", with: "\\|")
+    }
+
+    private func modelSort(_ lhs: EvalReviewModelSummary, _ rhs: EvalReviewModelSummary) -> Bool {
+        if lhs.role == rhs.role { return lhs.modelId < rhs.modelId }
+        return lhs.role < rhs.role
+    }
+}
+
+public enum EvalReviewReportBuilder {
+    public static func build(
+        manifest: EvalReviewManifest,
+        reports: [EvalReviewReportInput],
+        baselineReports: [EvalReviewReportInput] = []
+    ) -> EvalReviewReportBundle {
+        let grouped = Dictionary(grouping: reports) { input in
+            EvalReviewModelRef(role: input.role, modelId: input.report.modelId)
+        }
+        let unsortedModels = grouped.map { key, inputs in
+            EvalReviewModelSummary(
+                role: key.role,
+                modelId: key.modelId,
+                suites: inputs
+                    .sorted { $0.suite < $1.suite }
+                    .map {
+                        EvalReviewSuiteSummary(
+                            suite: $0.suite,
+                            reportPath: $0.reportPath,
+                            report: $0.report
+                        )
+                    }
+            )
+        }
+        let models = unsortedModels.sorted { lhs, rhs in
+            if lhs.role == rhs.role { return lhs.modelId < rhs.modelId }
+            return lhs.role < rhs.role
+        }
+
+        let comparison = manifest.baselinePath.map { baselinePath in
+            compare(
+                baselinePath: baselinePath,
+                baselineReports: baselineReports,
+                currentReports: reports
+            )
+        }
+
+        return EvalReviewReportBundle(
+            manifest: manifest,
+            models: models,
+            comparison: comparison
+        )
+    }
+
+    public static func missingReport(
+        role: EvalReviewModelRole,
+        modelId: String,
+        suite: EvalReviewSuiteRef,
+        reportPath: String,
+        note: String
+    ) -> EvalReviewReportInput {
+        let row = EvalCaseReport.terminal(
+            id: "missing-report.\(suite.name)",
+            label: "missing report for \(suite.name)",
+            domain: "agent_loop",
+            outcome: .errored,
+            notes: [note],
+            modelId: modelId
+        )
+        return EvalReviewReportInput(
+            role: role,
+            suite: suite.name,
+            suitePath: suite.path,
+            reportPath: reportPath,
+            report: EvalReport(
+                modelId: modelId,
+                startedAt: isoNowForEvalReviewReport(),
+                cases: [row]
+            )
+        )
+    }
+
+    public static func loadReportsRecursively(
+        from root: URL,
+        role: EvalReviewModelRole = .local
+    ) throws -> [EvalReviewReportInput] {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: root.path, isDirectory: &isDirectory) else {
+            throw EvalReviewReportError.pathNotFound(root.path)
+        }
+
+        let urls: [URL]
+        if isDirectory.boolValue {
+            guard let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                throw EvalReviewReportError.noReports(root.path)
+            }
+            urls = enumerator.compactMap { item in
+                guard let url = item as? URL, url.pathExtension.lowercased() == "json" else {
+                    return nil
+                }
+                return url
+            }
+            .sorted { $0.path < $1.path }
+        } else {
+            urls = [root]
+        }
+
+        let decoder = JSONDecoder()
+        let reports = urls.compactMap { url -> EvalReviewReportInput? in
+            guard let data = try? Data(contentsOf: url),
+                  let report = try? decoder.decode(EvalReport.self, from: data)
+            else {
+                return nil
+            }
+            return EvalReviewReportInput(
+                role: roleFromPath(url, fallback: role),
+                suite: url.deletingPathExtension().lastPathComponent,
+                suitePath: url.path,
+                reportPath: url.path,
+                report: report
+            )
+        }
+
+        guard !reports.isEmpty else {
+            throw EvalReviewReportError.noReports(root.path)
+        }
+        return reports
+    }
+
+    private static func compare(
+        baselinePath: String,
+        baselineReports: [EvalReviewReportInput],
+        currentReports: [EvalReviewReportInput]
+    ) -> EvalReviewComparisonSummary {
+        let baseline = index(baselineReports)
+        let current = index(currentReports)
+        let baselineKeys = Set(baseline.byKey.keys)
+        let currentKeys = Set(current.byKey.keys)
+
+        var regressions: [EvalReviewCaseDelta] = []
+        var newFailures: [EvalReviewCaseDelta] = []
+        var fixed: [EvalReviewCaseDelta] = []
+        var persistentFailures: [EvalReviewCaseDelta] = []
+        var changedSkips: [EvalReviewCaseDelta] = []
+        var newCases: [EvalReviewCaseDelta] = []
+        var removedCases: [EvalReviewCaseDelta] = []
+
+        for key in baselineKeys.intersection(currentKeys).sorted() {
+            let lhs = baseline.byKey[key]
+            let rhs = current.byKey[key]
+            let delta = EvalReviewCaseDelta(baseline: lhs, current: rhs)
+            if lhs?.outcome == .passed && isFailing(rhs?.outcome) {
+                regressions.append(delta)
+            } else if isFailing(lhs?.outcome) && rhs?.outcome == .passed {
+                fixed.append(delta)
+            } else if isFailing(lhs?.outcome) && isFailing(rhs?.outcome) {
+                persistentFailures.append(delta)
+            } else if lhs?.outcome == .skipped || rhs?.outcome == .skipped,
+                      lhs?.outcome != rhs?.outcome {
+                changedSkips.append(delta)
+            }
+        }
+
+        for key in currentKeys.subtracting(baselineKeys).sorted() {
+            let rhs = current.byKey[key]
+            let delta = EvalReviewCaseDelta(baseline: nil, current: rhs)
+            if isFailing(rhs?.outcome) {
+                newFailures.append(delta)
+            } else {
+                newCases.append(delta)
+            }
+        }
+
+        for key in baselineKeys.subtracting(currentKeys).sorted() {
+            removedCases.append(
+                EvalReviewCaseDelta(baseline: baseline.byKey[key], current: nil)
+            )
+        }
+
+        return EvalReviewComparisonSummary(
+            baselinePath: baselinePath,
+            regressions: regressions,
+            newFailures: newFailures,
+            fixed: fixed,
+            persistentFailures: persistentFailures,
+            changedSkips: changedSkips,
+            newCases: newCases,
+            removedCases: removedCases,
+            warnings: (baseline.warnings + current.warnings).sorted()
+        )
+    }
+
+    private static func index(
+        _ reports: [EvalReviewReportInput]
+    ) -> (byKey: [String: EvalReviewCaseSnapshot], warnings: [String]) {
+        var byKey: [String: EvalReviewCaseSnapshot] = [:]
+        var warnings: [String] = []
+        for input in reports {
+            for row in input.report.cases {
+                let snapshot = EvalReviewCaseSnapshot(suite: input.suite, row: row)
+                let key = snapshot.key
+                if let existing = byKey[key] {
+                    warnings.append(
+                        "duplicate case '\(snapshot.id)' for \(snapshot.modelId)/\(snapshot.suite); keeping \(existing.suite)"
+                    )
+                } else {
+                    byKey[key] = snapshot
+                }
+            }
+        }
+        return (byKey, warnings)
+    }
+
+    private static func isFailing(_ outcome: EvalCaseOutcome?) -> Bool {
+        outcome == .failed || outcome == .errored
+    }
+
+    private static func roleFromPath(_ url: URL, fallback: EvalReviewModelRole) -> EvalReviewModelRole {
+        let parts = url.pathComponents.map { $0.lowercased() }
+        if parts.contains(EvalReviewModelRole.frontier.rawValue) { return .frontier }
+        if parts.contains(EvalReviewModelRole.local.rawValue) { return .local }
+        return fallback
+    }
+}
+
+public enum EvalReviewReportError: Error, LocalizedError, Equatable {
+    case pathNotFound(String)
+    case noReports(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .pathNotFound(let path):
+            return "path does not exist: \(path)"
+        case .noReports(let path):
+            return "no eval report JSON files found at: \(path)"
+        }
+    }
+}
+
+public struct EvalReviewCaseSnapshot: Sendable, Codable, Equatable {
+    public let modelId: String
+    public let suite: String
+    public let id: String
+    public let outcome: EvalCaseOutcome
+    public let notes: [String]
+
+    public var key: String { "\(modelId)\u{1F}\(suite)\u{1F}\(id)" }
+
+    public init(suite: String, row: EvalCaseReport) {
+        modelId = row.modelId
+        self.suite = suite
+        id = row.id
+        outcome = row.outcome
+        notes = row.notes
+    }
+}
+
+private func isoNowForEvalReviewReport() -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: Date())
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift
@@ -238,7 +238,30 @@ public struct EvalReviewReportInput: Sendable {
     }
 }
 
+public enum EvalReviewReportPaths {
+    public static func sanitizedSegment(_ raw: String) -> String {
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+        let segment = raw.map { character -> Character in
+            allowed.contains(character) ? character : "_"
+        }
+        .reduce(into: "") { partial, character in
+            partial.append(character)
+        }
+        return segment.isEmpty || segment == "." || segment == ".." ? "model" : segment
+    }
+
+    public static func uniqueSuiteName(
+        _ base: String,
+        usedNames: inout [String: Int]
+    ) -> String {
+        let count = usedNames[base, default: 0]
+        usedNames[base] = count + 1
+        return count == 0 ? base : "\(base)-\(count + 1)"
+    }
+}
+
 public struct EvalReviewCaseDelta: Sendable, Codable, Equatable {
+    public let role: EvalReviewModelRole
     public let modelId: String
     public let suite: String
     public let id: String
@@ -248,6 +271,7 @@ public struct EvalReviewCaseDelta: Sendable, Codable, Equatable {
     public let currentNotes: [String]
 
     public init(baseline: EvalReviewCaseSnapshot?, current: EvalReviewCaseSnapshot?) {
+        role = current?.role ?? baseline?.role ?? .local
         modelId = current?.modelId ?? baseline?.modelId ?? "(unknown)"
         suite = current?.suite ?? baseline?.suite ?? "(unknown)"
         id = current?.id ?? baseline?.id ?? "(unknown)"
@@ -469,12 +493,12 @@ public struct EvalReviewReportBundle: Sendable, Codable, Equatable {
         lines.append("")
         lines.append("## \(title)")
         lines.append("")
-        lines.append("| Model | Suite | Case | Baseline | Current | Notes |")
-        lines.append("| --- | --- | --- | --- | --- | --- |")
+        lines.append("| Role | Model | Suite | Case | Baseline | Current | Notes |")
+        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
         for row in rows {
             let notes = row.currentNotes.isEmpty ? row.baselineNotes : row.currentNotes
             lines.append(
-                "| \(markdownCell(row.modelId)) | \(markdownCell(row.suite)) | "
+                "| \(row.role.rawValue) | \(markdownCell(row.modelId)) | \(markdownCell(row.suite)) | "
                     + "\(markdownCell(row.id)) | \(outcomeLabel(row.baselineOutcome)) | "
                     + "\(outcomeLabel(row.currentOutcome)) | "
                     + "\(markdownCell(notes.prefix(2).joined(separator: " / "))) |"
@@ -692,11 +716,11 @@ public enum EvalReviewReportBuilder {
         var warnings: [String] = []
         for input in reports {
             for row in input.report.cases {
-                let snapshot = EvalReviewCaseSnapshot(suite: input.suite, row: row)
+                let snapshot = EvalReviewCaseSnapshot(role: input.role, suite: input.suite, row: row)
                 let key = snapshot.key
                 if let existing = byKey[key] {
                     warnings.append(
-                        "duplicate case '\(snapshot.id)' for \(snapshot.modelId)/\(snapshot.suite); keeping \(existing.suite)"
+                        "duplicate case '\(snapshot.id)' for \(snapshot.role.rawValue)/\(snapshot.modelId)/\(snapshot.suite); keeping \(existing.role.rawValue)/\(existing.suite)"
                     )
                 } else {
                     byKey[key] = snapshot
@@ -733,15 +757,17 @@ public enum EvalReviewReportError: Error, LocalizedError, Equatable {
 }
 
 public struct EvalReviewCaseSnapshot: Sendable, Codable, Equatable {
+    public let role: EvalReviewModelRole
     public let modelId: String
     public let suite: String
     public let id: String
     public let outcome: EvalCaseOutcome
     public let notes: [String]
 
-    public var key: String { "\(modelId)\u{1F}\(suite)\u{1F}\(id)" }
+    public var key: String { "\(role.rawValue)\u{1F}\(modelId)\u{1F}\(suite)\u{1F}\(id)" }
 
-    public init(suite: String, row: EvalCaseReport) {
+    public init(role: EvalReviewModelRole, suite: String, row: EvalCaseReport) {
+        self.role = role
         modelId = row.modelId
         self.suite = suite
         id = row.id

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 @Suite(.serialized)
 struct EvalBootstrapPlanTests {
-    @Test func pluginRequiredCapabilitySearchLoadsInstalledPluginsByDefault() {
+    @Test func pluginRequiredCapabilitySearchDoesNotLoadInstalledPluginsByDefault() {
         let suite = makeSuite(
             cases: [
                 makeCase(
@@ -23,8 +23,9 @@ struct EvalBootstrapPlanTests {
             preference: .automatic
         )
 
-        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
-        #expect(plan.usesIsolatedSearchStorage)
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+        #expect(!plan.requiresWork)
+        #expect(!plan.usesIsolatedSearchStorage)
     }
 
     @Test func capabilitySearchInitializesIndicesWithoutPluginLoadingByDefault() {

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 @Suite(.serialized)
 struct EvalBootstrapPlanTests {
-    @Test func pluginRequiredCapabilitySearchSkipsBootstrapByDefault() {
+    @Test func pluginRequiredCapabilitySearchLoadsInstalledPluginsByDefault() {
         let suite = makeSuite(
             cases: [
                 makeCase(
@@ -23,7 +23,8 @@ struct EvalBootstrapPlanTests {
             preference: .automatic
         )
 
-        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
+        #expect(plan.usesIsolatedSearchStorage)
     }
 
     @Test func capabilitySearchInitializesIndicesWithoutPluginLoadingByDefault() {
@@ -170,7 +171,7 @@ struct EvalBootstrapPlanTests {
     }
 
     @MainActor
-    @Test func nonIsolatedBootstrapDoesNotReplaceExistingRootOverride() {
+    @Test func noWorkBootstrapDoesNotReplaceExistingRootOverride() {
         let previousRoot = OsaurusPaths.overrideRoot
         let existingRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-evals-existing-\(UUID().uuidString)", isDirectory: true)
@@ -180,7 +181,7 @@ struct EvalBootstrapPlanTests {
         }
 
         let root = EvalBootstrap.configureIsolatedSearchStorageIfNeeded(
-            for: EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false)
+            for: EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false)
         )
 
         #expect(root == nil)

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct EvalReviewReportTests {
+    @Test func aggregateSummaryCountsOutcomesAcrossModelsAndSuites() throws {
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest(commands: [
+                EvalReviewCommandRecord(
+                    role: .local,
+                    modelId: "foundation",
+                    suite: "AgentLoop",
+                    suitePath: "Suites/AgentLoop",
+                    outputPath: "build/evals/pr-report/reports/foundation/AgentLoop.json",
+                    arguments: ["osaurus-evals", "run", "--suite", "Suites/AgentLoop"],
+                    exitCode: 1
+                ),
+            ]),
+            reports: [
+                input(
+                    role: .local,
+                    suite: "AgentLoop",
+                    report: report(
+                        modelId: "foundation",
+                        rows: [
+                            ("agent_loop.pass", .passed, []),
+                            ("agent_loop.fail", .failed, ["missing expected edit"]),
+                            ("agent_loop.skip", .skipped, ["sandbox unavailable"]),
+                        ]
+                    )
+                ),
+                input(
+                    role: .local,
+                    suite: "AgentLoopFrontier",
+                    report: report(
+                        modelId: "foundation",
+                        rows: [
+                            ("agent_loop.frontier-pass", .passed, []),
+                            ("agent_loop.frontier-error", .errored, ["agent loop error"]),
+                        ]
+                    )
+                ),
+                input(
+                    role: .frontier,
+                    suite: "AgentLoop",
+                    report: report(
+                        modelId: "openai/gpt-4o-mini",
+                        rows: [
+                            ("agent_loop.pass", .passed, []),
+                            ("agent_loop.second-pass", .passed, []),
+                        ]
+                    )
+                ),
+            ]
+        )
+
+        let local = try #require(bundle.models.first { $0.role == .local })
+        let frontier = try #require(bundle.models.first { $0.role == .frontier })
+
+        #expect(local.counts.total == 5)
+        #expect(local.counts.passed == 2)
+        #expect(local.counts.failed == 1)
+        #expect(local.counts.errored == 1)
+        #expect(local.counts.skipped == 1)
+        #expect(frontier.counts.passed == 2)
+        #expect(bundle.hasRunFailures)
+
+        let markdown = bundle.formatMarkdown()
+        #expect(markdown.contains("Eval evidence:"))
+        #expect(markdown.contains("foundation, AgentLoop 1/3, AgentLoopFrontier 1/2"))
+        #expect(markdown.contains("openai/gpt-4o-mini, AgentLoop 2/2"))
+        #expect(markdown.contains("agent_loop.fail"))
+        #expect(markdown.contains("sandbox unavailable"))
+        #expect(markdown.contains("osaurus-evals run --suite Suites/AgentLoop"))
+        #expect(markdown.contains("build/evals/pr-report"))
+    }
+
+    @Test func baselineComparisonClassifiesRegressionsAndDrift() throws {
+        let baselineReports = [
+            input(
+                role: .local,
+                suite: "AgentLoop",
+                report: report(
+                    modelId: "foundation",
+                    rows: [
+                        ("regression", .passed, []),
+                        ("fixed", .failed, ["old failure"]),
+                        ("persistent", .failed, ["still failing before"]),
+                        ("changed-skip", .skipped, ["missing sandbox before"]),
+                        ("removed", .passed, []),
+                    ]
+                )
+            ),
+        ]
+        let currentReports = [
+            input(
+                role: .local,
+                suite: "AgentLoop",
+                report: report(
+                    modelId: "foundation",
+                    rows: [
+                        ("regression", .failed, ["new failure"]),
+                        ("fixed", .passed, []),
+                        ("persistent", .errored, ["still failing now"]),
+                        ("changed-skip", .passed, []),
+                        ("new-failure", .errored, ["new error"]),
+                        ("new-pass", .passed, []),
+                    ]
+                )
+            ),
+        ]
+
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest(baselinePath: "build/evals/baseline"),
+            reports: currentReports,
+            baselineReports: baselineReports
+        )
+        let comparison = try #require(bundle.comparison)
+
+        #expect(comparison.hasBlockingRegressions)
+        #expect(comparison.regressions.map(\.id) == ["regression"])
+        #expect(comparison.newFailures.map(\.id) == ["new-failure"])
+        #expect(comparison.fixed.map(\.id) == ["fixed"])
+        #expect(comparison.persistentFailures.map(\.id) == ["persistent"])
+        #expect(comparison.changedSkips.map(\.id) == ["changed-skip"])
+        #expect(comparison.newCases.map(\.id) == ["new-pass"])
+        #expect(comparison.removedCases.map(\.id) == ["removed"])
+
+        let compareMarkdown = bundle.formatComparisonMarkdown()
+        #expect(compareMarkdown.contains("## Blocking Regressions"))
+        #expect(compareMarkdown.contains("new-failure"))
+        #expect(compareMarkdown.contains("changed-skip"))
+    }
+
+    @Test func missingReportProducesExplicitErroredSummaryRow() throws {
+        let missing = EvalReviewReportBuilder.missingReport(
+            role: .frontier,
+            modelId: "openai/gpt-4o-mini",
+            suite: EvalReviewSuiteRef(name: "AgentLoopFrontier", path: "Suites/AgentLoopFrontier"),
+            reportPath: "build/evals/pr-report/reports/openai_gpt-4o-mini/AgentLoopFrontier.json",
+            note: "frontier report did not finish"
+        )
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest(),
+            reports: [missing]
+        )
+        let frontier = try #require(bundle.models.first)
+        let suite = try #require(frontier.suites.first)
+
+        #expect(bundle.hasRunFailures)
+        #expect(frontier.counts.errored == 1)
+        #expect(suite.errors.first?.id == "missing-report.AgentLoopFrontier")
+        #expect(suite.errors.first?.notes == ["frontier report did not finish"])
+    }
+
+    @Test func existingEvalReportJSONRemainsCompatible() throws {
+        let original = report(
+            modelId: "foundation",
+            rows: [
+                ("agent_loop.pass", .passed, []),
+                ("agent_loop.error", .errored, ["boom"]),
+            ]
+        )
+        let encoded = try original.toJSON(prettyPrinted: true)
+        let decoded = try JSONDecoder().decode(EvalReport.self, from: encoded)
+
+        #expect(decoded.modelId == original.modelId)
+        #expect(decoded.cases.map(\.id) == ["agent_loop.pass", "agent_loop.error"])
+        #expect(decoded.counts.errored == 1)
+    }
+
+    private func input(
+        role: EvalReviewModelRole,
+        suite: String,
+        report: EvalReport
+    ) -> EvalReviewReportInput {
+        EvalReviewReportInput(
+            role: role,
+            suite: suite,
+            suitePath: "Suites/\(suite)",
+            reportPath: "build/evals/pr-report/reports/\(report.modelId)/\(suite).json",
+            report: report
+        )
+    }
+
+    private func report(
+        modelId: String,
+        rows: [(id: String, outcome: EvalCaseOutcome, notes: [String])]
+    ) -> EvalReport {
+        EvalReport(
+            modelId: modelId,
+            startedAt: "2026-06-18T12:00:00Z",
+            cases: rows.map { row in
+                EvalCaseReport(
+                    id: row.id,
+                    label: row.id,
+                    domain: "agent_loop",
+                    query: "do work",
+                    outcome: row.outcome,
+                    notes: row.notes,
+                    modelId: modelId,
+                    latencyMs: 10
+                )
+            }
+        )
+    }
+
+    private func manifest(
+        baselinePath: String? = nil,
+        commands: [EvalReviewCommandRecord] = []
+    ) -> EvalReviewManifest {
+        EvalReviewManifest(
+            generatedAt: "2026-06-18T12:00:00Z",
+            branch: "feature/eval-report",
+            commit: "abc123",
+            runner: "osaurus-evals report",
+            artifactPath: "build/evals/pr-report",
+            suites: [
+                EvalReviewSuiteRef(name: "AgentLoop", path: "Suites/AgentLoop"),
+                EvalReviewSuiteRef(name: "AgentLoopFrontier", path: "Suites/AgentLoopFrontier"),
+            ],
+            models: [
+                EvalReviewModelRef(role: .local, modelId: "foundation"),
+                EvalReviewModelRef(role: .frontier, modelId: "openai/gpt-4o-mini"),
+            ],
+            commands: commands,
+            environment: EvalReviewEnvironmentSummary(
+                operatingSystem: "macOS",
+                ci: false,
+                judgeModel: "openai/gpt-4o-mini",
+                sandboxFrontierIncluded: false
+            ),
+            baselinePath: baselinePath
+        )
+    }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift
@@ -12,7 +12,7 @@ struct EvalReviewReportTests {
                     modelId: "foundation",
                     suite: "AgentLoop",
                     suitePath: "Suites/AgentLoop",
-                    outputPath: "build/evals/pr-report/reports/foundation/AgentLoop.json",
+                    outputPath: "build/evals/pr-report/reports/local/foundation/AgentLoop.json",
                     arguments: ["osaurus-evals", "run", "--suite", "Suites/AgentLoop"],
                     exitCode: 1
                 ),
@@ -133,12 +133,56 @@ struct EvalReviewReportTests {
         #expect(compareMarkdown.contains("changed-skip"))
     }
 
+    @Test func baselineComparisonKeepsRolesSeparateWhenModelIdsMatch() throws {
+        let baselineReports = [
+            input(
+                role: .local,
+                suite: "AgentLoop",
+                report: report(modelId: "foundation", rows: [("same-model-case", .passed, [])])
+            ),
+            input(
+                role: .frontier,
+                suite: "AgentLoop",
+                report: report(modelId: "foundation", rows: [("same-model-case", .passed, [])])
+            ),
+        ]
+        let currentReports = [
+            input(
+                role: .frontier,
+                suite: "AgentLoop",
+                report: report(modelId: "foundation", rows: [("same-model-case", .passed, [])])
+            ),
+            input(
+                role: .local,
+                suite: "AgentLoop",
+                report: report(modelId: "foundation", rows: [("same-model-case", .failed, ["local regressed"])])
+            ),
+        ]
+
+        let bundle = EvalReviewReportBuilder.build(
+            manifest: manifest(baselinePath: "build/evals/baseline"),
+            reports: currentReports,
+            baselineReports: baselineReports
+        )
+        let comparison = try #require(bundle.comparison)
+
+        #expect(comparison.regressions.count == 1)
+        #expect(comparison.regressions.first?.role == .local)
+        #expect(comparison.regressions.first?.modelId == "foundation")
+        #expect(comparison.regressions.first?.id == "same-model-case")
+        #expect(comparison.warnings.isEmpty)
+
+        let compareMarkdown = bundle.formatComparisonMarkdown()
+        #expect(compareMarkdown.contains("| Role | Model | Suite | Case | Baseline | Current | Notes |"))
+        #expect(compareMarkdown.contains("| local | foundation | AgentLoop | same-model-case | passed | failed | local regressed |"))
+    }
+
     @Test func missingReportProducesExplicitErroredSummaryRow() throws {
         let missing = EvalReviewReportBuilder.missingReport(
             role: .frontier,
             modelId: "openai/gpt-4o-mini",
             suite: EvalReviewSuiteRef(name: "AgentLoopFrontier", path: "Suites/AgentLoopFrontier"),
-            reportPath: "build/evals/pr-report/reports/openai_gpt-4o-mini/AgentLoopFrontier.json",
+            reportPath: "build/evals/pr-report/reports/frontier/openai_gpt-4o-mini/AgentLoopFrontier.json",
             note: "frontier report did not finish"
         )
         let bundle = EvalReviewReportBuilder.build(
@@ -170,6 +214,64 @@ struct EvalReviewReportTests {
         #expect(decoded.counts.errored == 1)
     }
 
+    @Test func reportPathSegmentSanitizesUnsafeModelIds() {
+        #expect(EvalReviewReportPaths.sanitizedSegment("openai/gpt-4o mini") == "openai_gpt-4o_mini")
+        #expect(EvalReviewReportPaths.sanitizedSegment("provider:model?x=1") == "provider_model_x_1")
+        #expect(EvalReviewReportPaths.sanitizedSegment("") == "model")
+        #expect(EvalReviewReportPaths.sanitizedSegment("..") == "model")
+    }
+
+    @Test func uniqueSuiteNameDisambiguatesRepeatedSuiteNames() {
+        var usedNames: [String: Int] = [:]
+
+        #expect(EvalReviewReportPaths.uniqueSuiteName("AgentLoop", usedNames: &usedNames) == "AgentLoop")
+        #expect(EvalReviewReportPaths.uniqueSuiteName("AgentLoop", usedNames: &usedNames) == "AgentLoop-2")
+        #expect(EvalReviewReportPaths.uniqueSuiteName("AgentLoop", usedNames: &usedNames) == "AgentLoop-3")
+        #expect(EvalReviewReportPaths.uniqueSuiteName("CapabilitySearch", usedNames: &usedNames) == "CapabilitySearch")
+    }
+
+    @Test func loadReportsRecursivelyInfersRoleFromReportPath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("eval-review-from-reports-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let localURL = root
+            .appendingPathComponent("reports", isDirectory: true)
+            .appendingPathComponent("local", isDirectory: true)
+            .appendingPathComponent("foundation", isDirectory: true)
+            .appendingPathComponent("AgentLoop.json")
+        let frontierURL = root
+            .appendingPathComponent("reports", isDirectory: true)
+            .appendingPathComponent("frontier", isDirectory: true)
+            .appendingPathComponent("foundation", isDirectory: true)
+            .appendingPathComponent("AgentLoop.json")
+        try FileManager.default.createDirectory(
+            at: localURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: frontierURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try report(modelId: "foundation", rows: [("local-case", .passed, [])])
+            .toJSON(prettyPrinted: true)
+            .write(to: localURL)
+        try report(modelId: "foundation", rows: [("frontier-case", .passed, [])])
+            .toJSON(prettyPrinted: true)
+            .write(to: frontierURL)
+
+        let reports = try EvalReviewReportBuilder.loadReportsRecursively(from: root)
+            .sorted { lhs, rhs in lhs.role.rawValue < rhs.role.rawValue }
+
+        #expect(reports.map(\.role) == [.frontier, .local])
+        #expect(reports.map(\.suite) == ["AgentLoop", "AgentLoop"])
+        #expect(reports.map(\.report.modelId) == ["foundation", "foundation"])
+        #expect(
+            Set(reports.map { URL(fileURLWithPath: $0.reportPath).resolvingSymlinksInPath().path })
+                == Set([localURL, frontierURL].map { $0.resolvingSymlinksInPath().path })
+        )
+    }
+
     private func input(
         role: EvalReviewModelRole,
         suite: String,
@@ -179,7 +281,7 @@ struct EvalReviewReportTests {
             role: role,
             suite: suite,
             suitePath: "Suites/\(suite)",
-            reportPath: "build/evals/pr-report/reports/\(report.modelId)/\(suite).json",
+            reportPath: "build/evals/pr-report/reports/\(role.rawValue)/\(report.modelId)/\(suite).json",
             report: report
         )
     }

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -586,8 +586,8 @@ make evals-pr-report-baseline \
 ```
 
 The bundle writes `manifest.json`, `summary.md`, `summary.json`, raw
-`reports/<model>/<suite>.json`, and baseline `compare.md` / `compare.json` when
-`BASELINE_DIR` is supplied. Required default suites are `AgentLoop` and
+`reports/<role>/<model>/<suite>.json`, and baseline `compare.md` / `compare.json`
+when `BASELINE_DIR` is supplied. Required default suites are `AgentLoop` and
 `AgentLoopFrontier` for both local and frontier lanes. `SandboxFrontier` remains
 off by default because it needs sandbox host prerequisites.
 

--- a/docs/HARNESS_COMPATIBILITY.md
+++ b/docs/HARNESS_COMPATIBILITY.md
@@ -569,6 +569,42 @@ harness bugs; they're scored honestly and tracked across model versions.
   blocked by the provider). Headless/automated secret seeding with gpt-5.5
   is unreliable; store secrets via the UI prompt flow instead.
 
+## PR eval evidence
+
+Agent-loop-impacting changes should attach a standard eval report bundle rather
+than ad hoc terminal output. From the repo root:
+
+```bash
+make evals-pr-report \
+  LOCAL_MODEL=foundation \
+  FRONTIER_MODEL=openai/gpt-4o-mini
+
+make evals-pr-report-baseline \
+  BASELINE_DIR=build/evals/main-report \
+  LOCAL_MODEL=foundation \
+  FRONTIER_MODEL=openai/gpt-4o-mini
+```
+
+The bundle writes `manifest.json`, `summary.md`, `summary.json`, raw
+`reports/<model>/<suite>.json`, and baseline `compare.md` / `compare.json` when
+`BASELINE_DIR` is supplied. Required default suites are `AgentLoop` and
+`AgentLoopFrontier` for both local and frontier lanes. `SandboxFrontier` remains
+off by default because it needs sandbox host prerequisites.
+
+Use this rule:
+
+- No report: docs-only changes, UI-only inspection, isolated storage, and
+  non-agent diagnostics.
+- Focused report: eval harness, provider bootstrap, or scoring changes.
+- Local + frontier report: default tools, tool schemas, prompt/tool
+  interaction, agent-loop routing, memory/tool routing, and model-facing
+  defaults.
+
+The short PR evidence block should include the local model result, frontier
+model result, baseline regression count, and artifact path. Full all-model
+scoreboards are a later compute-backed workflow; per-PR review evidence should
+stay small enough to run intentionally.
+
 ## Testing a new model
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `osaurus-evals report` to produce review bundles with `manifest.json`, `summary.md`, `summary.json`, per-model suite JSON, and optional baseline comparison artifacts.
- Add local + frontier PR report Make targets for `AgentLoop` and `AgentLoopFrontier` evidence.
- Add aggregate and comparison report types with tests for pass/fail/skip/error counts, baseline deltas, missing-report rows, and existing `EvalReport` JSON compatibility.
- Document when eval evidence is required and the copy-paste PR evidence block.

## Positioning
This is the report artifact layer for local development loops, dedicated Mac watcher runs, and release-candidate eval gates. It does not change model behavior, prompts, tools, or agent-loop semantics.

## Validation
- `git diff --check origin/main...HEAD`
- `swiftlint lint Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReviewReport.swift Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/EvalReviewReportCLI.swift Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalReviewReportTests.swift Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift`
- `swift test --package-path Packages/OsaurusEvals`
- Fixture smoke: `swift run --package-path Packages/OsaurusEvals osaurus-evals report --from-reports Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/current.json --baseline Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/Fixtures/AgentLoopRegressionLab/baseline.json --out-dir build/evals/pr-report-smoke` wrote the expected bundle and exited 1 because the fixture intentionally contains regressions.

Live frontier evidence was not run locally because `OPENAI_API_KEY` is not present in this environment. With credentials, run:

```bash
make evals-pr-report LOCAL_MODEL=foundation FRONTIER_MODEL=openai/gpt-4o-mini
```
