### PR TITLE
Repin vmlx-swift → 14040d24: Gemma nested-object tool-call argument parse fix (#76)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2bd6606f31ec8bc8017ef190dc983e835987e58c"
+        "revision" : "14040d24e9f1dc7b63c22b4cbb4573c5aa4fc506"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2bd6606f31ec8bc8017ef190dc983e835987e58c"
+        "revision" : "14040d24e9f1dc7b63c22b4cbb4573c5aa4fc506"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2bd6606f31ec8bc8017ef190dc983e835987e58c"
+            revision: "14040d24e9f1dc7b63c22b4cbb4573c5aa4fc506"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -616,8 +616,11 @@ struct RuntimePolicySourceTests {
         // plus the quadratic-BPE merge fix (O(n^2) -> O(n log n) on long
         // whitespace-free pre-tokens) that collapses multi-second prefill on
         // tool-heavy prompts while staying byte-identical to canonical output
-        // even on non-monotonic whitespace merge ranks.
-        let expectedRuntimeHardenedRevision = "2bd6606f31ec8bc8017ef190dc983e835987e58c"
+        // even on non-monotonic whitespace merge ranks,
+        // plus the Gemma nested-object tool-call argument parse fix
+        // (vmlx-swift#76): GemmaFunctionParser now recurses into `{...}` values
+        // so object-typed tool parameters arrive as objects, not raw strings.
+        let expectedRuntimeHardenedRevision = "14040d24e9f1dc7b63c22b4cbb4573c5aa4fc506"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2bd6606f31ec8bc8017ef190dc983e835987e58c"
+        "revision" : "14040d24e9f1dc7b63c22b4cbb4573c5aa4fc506"
       }
     },
     {


### PR DESCRIPTION
## What
Repin osaurus's vmlx-swift dependency `2bd6606f → 14040d24` to pick up [osaurus-ai/vmlx-swift#76](https://github.com/osaurus-ai/vmlx-swift/pull/76) — *Parse Gemma nested object tool-call arguments* (by @tpae).

## Why
`GemmaFunctionParser` (used by `.gemma` and, via `Gemma4ToolCallParser`, by `.gemma4`) did not recurse into nested object `{...}` argument values — a call like `agent_action{target:{mark:1}}` decoded `target` as the **string** `"{mark:1}"`, so any tool with an `object`-typed parameter rejected the call (`Property 'target' must be an object`). #76 adds a `parseObject` branch so nested objects (and nested arrays/objects within) parse recursively.

- Computer Use evals: **2/7 → 7/7** (gemma-4 E4B), **2/7 → 6/7** (gemma-4 12B MXFP4).
- #76 ships its own focused unit test (`GemmaNestedObjectArgumentFocusedTests`).

## Changes (minimal repin)
- `Packages/OsaurusCore/Package.swift` — `.package(revision:)` bump.
- All three `Package.resolved` (App project, OsaurusCore, workspace).
- `RuntimePolicySourceTests.swift` — `expectedRuntimeHardenedRevision` + rationale comment updated to the new known-good pin.

## Validation
- `swift package resolve` (OsaurusCore) resolves cleanly against `14040d24`; only the vmlx revision moved — no other dependency drifted.
- Delta vs the prior pin `2bd6606f` is the single vmlx-swift#76 parser change (additive; no sampler/prompt/template/cache changes).

Note: vmlx-swift's own CI jobs are skipped on the fork (`if: github.repository == 'ml-explore/mlx-swift'`), so #76 was validated by its unit test + evals upstream; this repin is where it compiles into osaurus CI.