### PR TITLE
decouple sandbox tools from the agent Tools toggle and compact sandbox prompt sections

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
@@ -33,6 +33,13 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     /// `requestToolsDisabled` to `capture(...)` (e.g. `ChatView`).
     public let toolsDisabled: Bool
 
+    /// The session-global `ChatConfiguration.disableTools` switch in
+    /// isolation (the `requestToolsDisabled` the caller folded in), kept
+    /// separable from the per-agent Tools toggle. This is an absolute
+    /// kill-switch: unlike the per-agent toggle, sandbox mode does NOT
+    /// override it (see `SystemPromptComposer.resolveEffectiveToolsOff`).
+    public let globalToolsDisabled: Bool
+
     /// Mirrors `AgentManager.effectiveMemoryDisabled` (folds in the
     /// global `MemoryConfiguration.enabled` switch).
     public let memoryDisabled: Bool
@@ -99,6 +106,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     public init(
         agentId: UUID,
         toolsDisabled: Bool,
+        globalToolsDisabled: Bool = false,
         memoryDisabled: Bool,
         autonomousConfig: AutonomousExecConfig?,
         toolMode: ToolSelectionMode,
@@ -114,6 +122,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     ) {
         self.agentId = agentId
         self.toolsDisabled = toolsDisabled
+        self.globalToolsDisabled = globalToolsDisabled
         self.memoryDisabled = memoryDisabled
         self.autonomousConfig = autonomousConfig
         self.toolMode = toolMode
@@ -151,6 +160,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         return AgentConfigSnapshot(
             agentId: agentId,
             toolsDisabled: requestToolsDisabled || !caps.toolsEnabled,
+            globalToolsDisabled: requestToolsDisabled,
             memoryDisabled: !caps.memoryEnabled,
             autonomousConfig: mgr.effectiveAutonomousExec(for: agentId),
             toolMode: mgr.effectiveToolSelectionMode(for: agentId),

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -454,6 +454,32 @@ public struct SystemPromptComposer: Sendable {
         }
     }
 
+    /// Whether tools are suppressed for this compose.
+    ///
+    /// The per-agent "Tools" toggle (Configure tab) is a chat-only kill-switch.
+    /// In sandbox mode the user has already made an explicit execution grant via
+    /// Autonomous Execution (that's what resolves the mode to `.sandbox` in the
+    /// first place), so the sandbox tool surface — and the operational baseline
+    /// the agent loop needs to drive it — stays exposed even when that per-agent
+    /// toggle is off.
+    ///
+    /// Two signals are NOT overridable and win in every mode:
+    ///   - `globalToolsDisabled`: the session-global `ChatConfiguration`
+    ///     "Disable tools" switch, an absolute kill-switch.
+    ///   - `sizeClassDisablesTools`: the small-context auto-disable, a hard
+    ///     capability limit.
+    static func resolveEffectiveToolsOff(
+        toolsDisabled: Bool,
+        globalToolsDisabled: Bool,
+        sizeClassDisablesTools: Bool,
+        executionMode: ExecutionMode
+    ) -> Bool {
+        if globalToolsDisabled || sizeClassDisablesTools { return true }
+        // Global switch is excluded above, so `toolsDisabled` now reflects the
+        // per-agent Tools toggle alone — which sandbox mode overrides.
+        return toolsDisabled && !executionMode.usesSandboxTools
+    }
+
     /// Assemble every tool-axis decision for the request: size-class
     /// auto-disable, final tool set, always-loaded snapshot, and the frozen
     /// enabled-capabilities manifest.
@@ -475,7 +501,12 @@ public struct SystemPromptComposer: Sendable {
         // creator) cascades correctly without each gate having to know
         // about the size class itself.
         let window = ContextSizeResolver.resolve(modelId: snapshot.model)
-        let effectiveToolsOff = snapshot.toolsDisabled || window.sizeClass.disablesTools
+        let effectiveToolsOff = resolveEffectiveToolsOff(
+            toolsDisabled: snapshot.toolsDisabled,
+            globalToolsDisabled: snapshot.globalToolsDisabled,
+            sizeClassDisablesTools: window.sizeClass.disablesTools,
+            executionMode: executionMode
+        )
         let contextDisable = ContextDisableInfo.from(
             sizeClass: window.sizeClass,
             modelId: snapshot.model,
@@ -717,7 +748,8 @@ public struct SystemPromptComposer: Sendable {
                     id: "selfImprovement",
                     label: L("Self-Improvement"),
                     content: SystemPromptTemplates.selfImprovementGuidance(
-                        canCreatePlugins: snapshot.canCreatePlugins
+                        canCreatePlugins: snapshot.canCreatePlugins,
+                        compact: toolset.prefersCompactPrompt
                     )
                 )
             )
@@ -789,7 +821,8 @@ public struct SystemPromptComposer: Sendable {
                     id: "grounding",
                     label: L("Grounding"),
                     content: SystemPromptTemplates.groundingDirective(
-                        discoveryAvailable: resolvedNames.contains("capabilities_discover")
+                        discoveryAvailable: resolvedNames.contains("capabilities_discover"),
+                        compact: toolset.prefersCompactPrompt
                     )
                 )
             )
@@ -807,7 +840,9 @@ public struct SystemPromptComposer: Sendable {
                 .static(
                     id: "codeStyle",
                     label: L("Code Style"),
-                    content: SystemPromptTemplates.codeStyleGuidance
+                    content: toolset.prefersCompactPrompt
+                        ? SystemPromptTemplates.codeStyleGuidanceCompact
+                        : SystemPromptTemplates.codeStyleGuidance
                 )
             )
         }
@@ -818,7 +853,9 @@ public struct SystemPromptComposer: Sendable {
                 .static(
                     id: "riskAware",
                     label: L("Risk-Aware Actions"),
-                    content: SystemPromptTemplates.riskAwareGuidance
+                    content: toolset.prefersCompactPrompt
+                        ? SystemPromptTemplates.riskAwareGuidanceCompact
+                        : SystemPromptTemplates.riskAwareGuidance
                 )
             )
         }
@@ -834,7 +871,9 @@ public struct SystemPromptComposer: Sendable {
                 .static(
                     id: "secretHandling",
                     label: L("Secret Handling"),
-                    content: SystemPromptTemplates.secretHandlingGuidance
+                    content: toolset.prefersCompactPrompt
+                        ? SystemPromptTemplates.secretHandlingGuidanceCompact
+                        : SystemPromptTemplates.secretHandlingGuidance
                 )
             )
         }
@@ -873,7 +912,9 @@ public struct SystemPromptComposer: Sendable {
                 .static(
                     id: "agentLoopGuidance",
                     label: L("Agent Loop"),
-                    content: SystemPromptTemplates.agentLoopGuidance
+                    content: toolset.prefersCompactPrompt
+                        ? SystemPromptTemplates.agentLoopGuidanceCompact
+                        : SystemPromptTemplates.agentLoopGuidance
                 )
             )
         }
@@ -902,7 +943,8 @@ public struct SystemPromptComposer: Sendable {
                     content: SystemPromptTemplates.sandbox(
                         home: sandboxHome,
                         hostReadCombined: executionMode.hostReadContext != nil,
-                        backgroundEnabled: snapshot.autonomousConfig?.backgroundProcessEnabled ?? false
+                        backgroundEnabled: snapshot.autonomousConfig?.backgroundProcessEnabled ?? false,
+                        compact: toolset.prefersCompactPrompt
                     )
                 )
             )
@@ -969,7 +1011,8 @@ public struct SystemPromptComposer: Sendable {
             let nudge =
                 executionMode.usesSandboxTools
                 ? SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
-                    canCreatePlugins: snapshot.canCreatePlugins
+                    canCreatePlugins: snapshot.canCreatePlugins,
+                    compact: toolset.prefersCompactPrompt
                 )
                 : SystemPromptTemplates.capabilityDiscoveryNudge
             composer.append(
@@ -1538,7 +1581,12 @@ public struct SystemPromptComposer: Sendable {
         executionMode: ExecutionMode
     ) -> ResolvedToolset {
         let window = ContextSizeResolver.resolve(modelId: snapshot.model)
-        let effectiveToolsOff = snapshot.toolsDisabled || window.sizeClass.disablesTools
+        let effectiveToolsOff = resolveEffectiveToolsOff(
+            toolsDisabled: snapshot.toolsDisabled,
+            globalToolsDisabled: snapshot.globalToolsDisabled,
+            sizeClassDisablesTools: window.sizeClass.disablesTools,
+            executionMode: executionMode
+        )
         let contextDisable = ContextDisableInfo.from(
             sizeClass: window.sizeClass,
             modelId: snapshot.model,
@@ -1912,6 +1960,25 @@ public struct SystemPromptComposer: Sendable {
             for name in ToolRegistry.configureToolNames {
                 byName.removeValue(forKey: name)
             }
+        }
+
+        // Sandbox-override surface: when the per-agent Tools toggle is off and
+        // the ONLY reason tools resolved at all is the sandbox execution grant
+        // (see `resolveEffectiveToolsOff` — reaching here past the guard with
+        // `snapshot.toolsDisabled` set means it can't be the global/size-class
+        // path), expose only the sandbox primitives + the agent-loop tools.
+        // The capability-discovery gateway (`capabilities_discover` /
+        // `capabilities_load`) and every per-agent plugin capability are
+        // dropped, so a "chat-only + sandbox" agent runs code and curls live
+        // data itself but can't reach the plugin ecosystem. Any plugin tools a
+        // prior turn loaded into `additionalToolNames` are filtered out too.
+        // The composer's discovery / grounding / nudge sections gate on the
+        // resolved schema, so removing discovery here cascades automatically
+        // (no nudge; the tool-name-free base grounding variant).
+        if snapshot.toolsDisabled, executionMode.usesSandboxTools {
+            let allowed = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+                .union(Self.agentLoopToolNames)
+            byName = byName.filter { allowed.contains($0.key) }
         }
 
         return canonicalToolOrder(Array(byName.values))

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -69,6 +69,19 @@ public enum SystemPromptTemplates {
         - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
         """
 
+    /// Compact agent-loop cheat-sheet for small-context / small local models
+    /// (`prefersCompactPrompt`). Same four tools and the load-bearing rules
+    /// (3+ step todo, complete-alone-at-end, one-question clarify, file-exists
+    /// artifact), one line each.
+    public static let agentLoopGuidanceCompact = """
+        ## Agent loop
+
+        - `todo(markdown)` — user-visible checklist. For 3+ step tasks, write it before starting, then re-send the full list with each box checked as you finish.
+        - `complete(summary)` — once at the very end, never alongside other tools: WHAT you did + HOW you verified. No vague placeholders.
+        - `clarify(question)` — ask one concrete question only when guessing wrong would change the result; otherwise pick a sensible default.
+        - `share_artifact(path | content+filename)` — the only way the user sees a file/image/report; the file MUST exist first. Sandbox: save under home, not `/tmp`.
+        """
+
     // MARK: - Grounding
 
     /// Anti-fabrication directive injected whenever tools are present
@@ -100,11 +113,26 @@ public enum SystemPromptTemplates {
         - Say what you can't do only after genuinely trying with the tools you have, and never invent a tool name or fabricate a value to fill a gap.
         """
 
-    /// Select the grounding variant for the resolved schema. The flag is
-    /// session-constant (the schema is frozen at session start), so the
-    /// choice is KV-cache safe.
-    public static func groundingDirective(discoveryAvailable: Bool) -> String {
-        discoveryAvailable ? groundingDirectiveFull : groundingDirectiveBase
+    /// Compact discovery-aware grounding for small-context / small local
+    /// models (`prefersCompactPrompt`). Keeps the three load-bearing claims
+    /// (ground live data, try-before-you-deny, capability-claims must be
+    /// backed) — just tighter. Still names `capabilities_discover` / the
+    /// Enabled list, so it is only chosen when discovery is in the schema.
+    public static let groundingDirectiveFullCompact = """
+        ## Grounding
+
+        - Ground live-data and factual claims (weather, prices, web, file contents, command output, current state) in a tool result, not memory.
+        - You can almost always get there: a shell/network tool fetches external data and `capabilities_discover` finds tools you lack. Try before saying you can't, and never invent a tool name or fabricate a value.
+        - "I can't do X" / "I don't have a tool for X" must be backed by the Enabled capabilities list or an empty `capabilities_discover` — never by X being absent from your current schema (a fixed subset, not the full enabled set).
+        """
+
+    /// Select the grounding variant for the resolved schema. The flags are
+    /// session-constant (the schema + size class are frozen at session start),
+    /// so the choice is KV-cache safe. `compact` only narrows the
+    /// discovery-aware variant — the tool-name-free base is already minimal.
+    public static func groundingDirective(discoveryAvailable: Bool, compact: Bool = false) -> String {
+        guard discoveryAvailable else { return groundingDirectiveBase }
+        return compact ? groundingDirectiveFullCompact : groundingDirectiveFull
     }
 
     // MARK: - Capability Discovery Nudge
@@ -142,7 +170,42 @@ public enum SystemPromptTemplates {
     /// create plugins, step 4 (build a sandbox plugin) and the "build when
     /// reusable" closing line are dropped and the ladder renumbers so the
     /// terminus stays last — no wasted context on an unavailable path.
-    public static func capabilityDiscoveryNudgeSandbox(canCreatePlugins: Bool) -> String {
+    public static func capabilityDiscoveryNudgeSandbox(
+        canCreatePlugins: Bool,
+        compact: Bool = false
+    ) -> String {
+        if compact {
+            // Same escalation, prose-folded: discover/load, then build from
+            // sandbox primitives, then (optionally) a plugin, then the
+            // unavailable terminus. Drops the per-shape sub-bullets and the
+            // coding-agent preamble that dominate the full ladder's tokens.
+            let buildStep =
+                "build it from sandbox primitives (network, python3, node, sqlite3, curl, "
+                + "`sandbox_install`) — most APIs are authenticated HTTP, DBs need a driver + "
+                + "connection string, CLIs install and run; read unfamiliar API docs over the "
+                + "network first"
+            var rungs = [
+                "check the Enabled capabilities list",
+                "`capabilities_discover` then `capabilities_load` anything returned",
+                buildStep,
+            ]
+            if canCreatePlugins {
+                rungs.append("if it's reusable, build a sandbox plugin (see Building new tools)")
+            }
+            rungs.append(
+                "only after these come up empty tell the user it's unavailable and say what you tried"
+            )
+            let numbered = rungs.enumerated()
+                .map { "\($0.offset + 1)) \($0.element)" }
+                .joined(separator: "; ")
+            return """
+                ## Discovering more tools
+
+                Your tool list is a fixed starting set, not exhaustive. The Enabled capabilities list names more to load by id with `capabilities_load`; when something is missing and NOT listed, `capabilities_discover({"query": "<what you need>"})` searches the rest. Do not invent tool names.
+
+                A missing capability is the start of work, not a dead end. In order: \(numbered). Credentials follow Secret handling; destructive actions follow Risk-aware actions.
+                """
+        }
         let intro = """
             ## Discovering more tools
 
@@ -227,6 +290,15 @@ public enum SystemPromptTemplates {
         - Never record a secret value in SOUL.md, memory, or any persisted note; reference it by its env var instead.
         """
 
+    /// Compact secret-handling discipline for small-context / small local
+    /// models (`prefersCompactPrompt`). Same rules — collect out-of-band, read
+    /// via env var, never leak — folded into two bullets.
+    public static let secretHandlingGuidanceCompact = """
+        ## Secret handling
+        - Never have the user paste a secret into chat (it's persisted). Collect via `sandbox_secret_set` (key, description, instructions; OMIT value) — the harness prompts out-of-band. Call `sandbox_secret_check` first; skip if it exists.
+        - Secrets surface as env vars named by key: read them from the environment (e.g. `os.environ["SHOPIFY_TOKEN"]`), never inline; no tool returns a value. Never echo, write in plaintext, pass as a tool argument, or record in SOUL.md/memory — reference by env var.
+        """
+
     // MARK: - Self-improvement
 
     /// Self-improvement discipline. Sandbox-only: it references workspace
@@ -237,22 +309,33 @@ public enum SystemPromptTemplates {
     /// `canCreatePlugins` toggles the two plugin-build bullets: when the agent
     /// cannot create plugins, they are dropped so the section spends no context
     /// describing an unavailable path.
-    public static func selfImprovementGuidance(canCreatePlugins: Bool) -> String {
+    public static func selfImprovementGuidance(
+        canCreatePlugins: Bool,
+        compact: Bool = false
+    ) -> String {
         let persistence =
-            "- Workspace files persist across messages. Save reusable scripts and clients there rather than rebuilding them."
+            compact
+            ? "- Workspace files persist across messages — save reusable scripts and clients there instead of rebuilding."
+            : "- Workspace files persist across messages. Save reusable scripts and clients there rather than rebuilding them."
         let pluginBuild =
-            "- Build or update a sandbox plugin when you notice any of these: you just completed a multi-step integration that worked, you found the working path after hitting dead ends, the user corrected your approach, or the same integration is coming up again. Capture the working path while you still have it."
+            compact
+            ? "- Build or fix a sandbox plugin when a multi-step integration works, you find the path after dead ends, or the user corrects you — capture the working path while you have it."
+            : "- Build or update a sandbox plugin when you notice any of these: you just completed a multi-step integration that worked, you found the working path after hitting dead ends, the user corrected your approach, or the same integration is coming up again. Capture the working path while you still have it."
         let pluginFix =
             "- When a plugin you built turns out wrong or incomplete, fix the plugin itself rather than working around it. Plugins improve through use."
         let soul =
-            "- When you observe a durable, cross-session pattern in how the user works, record it in `~/SOUL.md` with `sandbox_write_file` (edits apply on the next session). Capture stable preferences, conventions, environment facts, and lessons learned; keep session facts, one-off paths, and project details out."
+            compact
+            ? "- Record durable cross-session patterns in `~/SOUL.md` via `sandbox_write_file` (applies next session); keep session facts and one-off paths out."
+            : "- When you observe a durable, cross-session pattern in how the user works, record it in `~/SOUL.md` with `sandbox_write_file` (edits apply on the next session). Capture stable preferences, conventions, environment facts, and lessons learned; keep session facts, one-off paths, and project details out."
         let secret =
             "- Anything you build that touches a secret follows Secret handling."
 
         var bullets = [persistence]
         if canCreatePlugins {
             bullets.append(pluginBuild)
-            bullets.append(pluginFix)
+            // The "fix the plugin you built" rung is a refinement of the build
+            // rung above; compact folds it away to save the line.
+            if !compact { bullets.append(pluginFix) }
         }
         bullets.append(soul)
         bullets.append(secret)
@@ -488,6 +571,15 @@ public enum SystemPromptTemplates {
         - Do not add docstrings, comments, or type annotations to code you did not modify.
         """
 
+    /// Compact code-style discipline for small-context / small local models
+    /// (`prefersCompactPrompt`). Same scope-creep guardrails, folded.
+    public static let codeStyleGuidanceCompact = """
+        ## Code style
+
+        - Limit changes to what was requested — no adjacent refactoring or style cleanup, no defensive handling for conditions that can't arise here.
+        - Don't extract helpers for single-use logic. Comment only genuinely non-obvious reasoning; don't annotate code you didn't modify.
+        """
+
     /// Risk-aware action discipline. Fires on the broader
     /// `SystemPromptComposer.mutationToolNames` gate (any tool that can
     /// mutate the filesystem OR run arbitrary code / install deps) — wider
@@ -499,6 +591,15 @@ public enum SystemPromptTemplates {
         - Local, reversible work — reading, editing a file, running a command or test, installing into the sandbox — needs no permission; just do it.
         - Only pause to confirm for genuinely destructive or hard-to-undo actions: deleting the user's files, `rm -rf`, dropping data, force-pushing. The test is reversibility — if it's reversible, proceed.
         - When encountering unexpected state (unfamiliar files, unknown processes), investigate before removing anything.
+        """
+
+    /// Compact risk-aware discipline for small-context / small local models
+    /// (`prefersCompactPrompt`). Keeps the reversibility test, folded.
+    public static let riskAwareGuidanceCompact = """
+        ## Risk-aware actions
+
+        - Local, reversible work (read, edit a file, run a command or test, install into the sandbox) needs no permission — just do it.
+        - Pause to confirm only for destructive or hard-to-undo actions (deleting the user's files, `rm -rf`, dropping data, force-push); the test is reversibility. Investigate unexpected state before removing anything.
         """
 
     /// Computer Use grounding. Rendered only when the `computer_use` tool
@@ -579,9 +680,28 @@ public enum SystemPromptTemplates {
     public static func sandbox(
         home: String = "",
         hostReadCombined: Bool = false,
-        backgroundEnabled: Bool = false
+        backgroundEnabled: Bool = false,
+        compact: Bool = false
     ) -> String {
-        """
+        if compact {
+            // Same load-bearing facts (absolute home path so `cwd` isn't
+            // guessed, internet-is-available, the dispatch table) folded into
+            // the environment paragraph + one dispatch list, with the runtime
+            // hints absorbed into the dispatch tail.
+            let dispatch =
+                hostReadCombined
+                ? sandboxToolGuideCombinedCompact(backgroundEnabled: backgroundEnabled)
+                : sandboxToolGuideCompact(backgroundEnabled: backgroundEnabled)
+            return """
+
+                \(sandboxSectionHeading)
+
+                \(sandboxEnvironmentBlockCompact(home: home, hostReadCombined: hostReadCombined))
+
+                \(dispatch)
+                """
+        }
+        return """
 
         \(sandboxSectionHeading)
 
@@ -693,6 +813,49 @@ public enum SystemPromptTemplates {
             \(shellBullet)
             - Multi-line code/scripts: `sandbox_write_file` the script, then `sandbox_exec` to run it (e.g. `python3 script.py`). NEVER embed multi-line code in `python3 -c` / `node -e`: the JSON→shell→code escaping breaks.
             - Run independent calls in parallel; chain dependent shell steps with `&&`.
+            """
+    }
+
+    /// Compact environment framing (`prefersCompactPrompt`). Folds the
+    /// home-path, internet, and installed-tools lines into one paragraph.
+    /// The absolute home line is preserved verbatim in intent — dropping it
+    /// makes models guess `/root` for `cwd` and eat a rejection.
+    private static func sandboxEnvironmentBlockCompact(home: String, hostReadCombined: Bool) -> String {
+        let homeLine =
+            home.isEmpty
+            ? "Your home (`~`) is your sandbox home"
+            : "Home: `\(home)` (`~` / `$HOME`); commands run there by default — no `cwd` needed"
+        return """
+            Isolated Alpine Linux ARM64 sandbox. \(homeLine). Files persist across messages. Internet works — fetch live data (weather, web pages, APIs) directly with `curl`, `wget`, Python `requests`, or Node `fetch`. Installed: bash, python3, node, git, curl, wget, jq, rg, sqlite3, build-base, cmake, vim, tree.
+            """
+    }
+
+    /// Compact non-combined dispatch + absorbed runtime hints.
+    private static func sandboxToolGuideCompact(backgroundEnabled: Bool) -> String {
+        let shell =
+            backgroundEnabled
+            ? "`sandbox_exec` (single-line; `background:true` + `sandbox_process` for servers)"
+            : "`sandbox_exec` (single-line)"
+        return """
+            Tool dispatch:
+            - Files: `sandbox_read_file` (read/list); `sandbox_write_file` (`content` whole-file, or `old_string`+`new_string` to edit). Search: `sandbox_search_files` (`target="content"|"files"`).
+            - Shell: \(shell). Multi-line code: `sandbox_write_file` a script then `sandbox_exec` it (e.g. `python3 script.py`) — never `python3 -c` / `node -e`.
+            - Install deps with `sandbox_install` (`pip`/`npm`/`apk`); inspect large logs with \(sandboxReadFileHint). Run independent calls in parallel; chain dependent steps with `&&`. Sandbox is disposable.
+            """
+    }
+
+    /// Compact combined-mode dispatch + absorbed runtime hints. Mirrors
+    /// `sandboxToolGuideCombined` (host `file_*` read family, sandbox writes).
+    private static func sandboxToolGuideCombinedCompact(backgroundEnabled: Bool) -> String {
+        let shell =
+            backgroundEnabled
+            ? "`sandbox_exec` (single-line; `background:true` + `sandbox_process` for servers)"
+            : "`sandbox_exec` (single-line)"
+        return """
+            Tool dispatch:
+            - Read/list/search: `file_read`, `file_search` (reach your workspace and `/workspace/...` sandbox paths — see `## Files`). Sandbox writes: `sandbox_write_file` (`content` whole-file or `old_string`+`new_string` edit; workspace is read-only).
+            - Shell: \(shell). Multi-line code: `sandbox_write_file` a script then `sandbox_exec` it (e.g. `python3 script.py`) — never `python3 -c` / `node -e`.
+            - Install deps with `sandbox_install` (`pip`/`npm`/`apk`); inspect large logs with \(sandboxReadFileHintCombined). Run independent calls in parallel; chain dependent steps with `&&`. Sandbox is disposable.
             """
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
@@ -143,4 +143,79 @@ struct SandboxSectionTokenAuditTests {
         #expect(state.contains("Configured secrets"))
         #expect(state.contains("Already installed"))
     }
+
+    /// Small local models (<20B) / small-context windows get `compact`
+    /// variants of the heaviest sandbox-mode sections. This pins that compact
+    /// is materially smaller than full AND still carries each section's
+    /// load-bearing facts — so a future edit can't silently un-compact (losing
+    /// the prefill win) or over-trim (dropping a contract the model needs).
+    @Test("compact sandbox-mode sections shrink but keep their contracts")
+    func compactSectionsShrinkButKeepContracts() {
+        func smaller(_ full: String, _ compact: String, label: String) {
+            let f = TokenEstimator.estimate(full)
+            let c = TokenEstimator.estimate(compact)
+            #expect(c < f, "\(label) compact (\(c)) is not smaller than full (\(f))")
+        }
+
+        // Sandbox framing: compact must still name the absolute home path
+        // (models guess `/root` for `cwd` without it) and that internet works.
+        let home = "/workspace/agents/test-home"
+        let fullSandbox = SystemPromptTemplates.sandbox(home: home)
+        let compactSandbox = SystemPromptTemplates.sandbox(home: home, compact: true)
+        smaller(fullSandbox, compactSandbox, label: "sandbox")
+        #expect(compactSandbox.contains(home))
+        #expect(compactSandbox.contains("Internet"))
+        #expect(compactSandbox.contains("sandbox_exec"))
+        #expect(compactSandbox.contains("never `python3 -c`"))
+
+        // Discovery ladder: compact keeps discover/load + the "start of work"
+        // framing + the Secret/Risk pointers.
+        let fullNudge = SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: false)
+        let compactNudge = SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+            canCreatePlugins: false,
+            compact: true
+        )
+        smaller(fullNudge, compactNudge, label: "discovery nudge")
+        #expect(compactNudge.contains("capabilities_discover"))
+        #expect(compactNudge.contains("Secret handling"))
+
+        // Secret handling: compact keeps out-of-band collection + env-var read.
+        smaller(
+            SystemPromptTemplates.secretHandlingGuidance,
+            SystemPromptTemplates.secretHandlingGuidanceCompact,
+            label: "secret handling"
+        )
+        #expect(SystemPromptTemplates.secretHandlingGuidanceCompact.contains("sandbox_secret_set"))
+        #expect(SystemPromptTemplates.secretHandlingGuidanceCompact.contains("env var"))
+
+        // Agent loop: compact keeps all four tools.
+        let compactLoop = SystemPromptTemplates.agentLoopGuidanceCompact
+        smaller(SystemPromptTemplates.agentLoopGuidance, compactLoop, label: "agent loop")
+        for tool in ["todo", "complete", "clarify", "share_artifact"] {
+            #expect(compactLoop.contains(tool), "compact agent loop dropped \(tool)")
+        }
+
+        // Grounding (discovery-aware): compact keeps the capability-claim rule.
+        smaller(
+            SystemPromptTemplates.groundingDirectiveFull,
+            SystemPromptTemplates.groundingDirectiveFullCompact,
+            label: "grounding"
+        )
+        #expect(SystemPromptTemplates.groundingDirectiveFullCompact.contains("capabilities_discover"))
+
+        // Self-improvement: compact keeps the SOUL.md contract the existing
+        // audit pins for the full variant.
+        let compactSelf = SystemPromptTemplates.selfImprovementGuidance(
+            canCreatePlugins: false,
+            compact: true
+        )
+        smaller(
+            SystemPromptTemplates.selfImprovementGuidance(canCreatePlugins: false),
+            compactSelf,
+            label: "self-improvement"
+        )
+        #expect(compactSelf.contains("~/SOUL.md"))
+        #expect(compactSelf.contains("sandbox_write_file"))
+        #expect(compactSelf.contains("next session"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/SandboxToolsOverrideTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SandboxToolsOverrideTests.swift
@@ -1,0 +1,146 @@
+//
+//  SandboxToolsOverrideTests.swift
+//  OsaurusCoreTests
+//
+//  Pins `SystemPromptComposer.resolveEffectiveToolsOff` — the rule that
+//  decides whether tools are suppressed for a compose.
+//
+//  The per-agent "Tools" toggle (Configure tab) is a chat-only kill-switch.
+//  When the agent is in sandbox mode (Autonomous Execution on, which is what
+//  resolves the execution mode to `.sandbox`), that toggle is overridden so
+//  the sandbox tool surface stays exposed — the user already granted
+//  execution. Two signals stay absolute and are NOT overridable: the
+//  session-global "Disable tools" switch and the small-context auto-disable.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SandboxToolsOverrideTests {
+
+    private let sandbox = ExecutionMode.sandbox(hostRead: nil)
+
+    @Test
+    func perAgentToggleOff_inSandbox_keepsToolsOn() {
+        // The reported case: Tools toggle off, sandbox + autonomous on.
+        let off = SystemPromptComposer.resolveEffectiveToolsOff(
+            toolsDisabled: true,
+            globalToolsDisabled: false,
+            sizeClassDisablesTools: false,
+            executionMode: sandbox
+        )
+        #expect(off == false)
+    }
+
+    @Test
+    func perAgentToggleOff_outsideSandbox_stillDisablesTools() {
+        // Non-sandbox modes keep the per-agent toggle as a real kill-switch.
+        let off = SystemPromptComposer.resolveEffectiveToolsOff(
+            toolsDisabled: true,
+            globalToolsDisabled: false,
+            sizeClassDisablesTools: false,
+            executionMode: .none
+        )
+        #expect(off == true)
+    }
+
+    @Test
+    func globalSwitch_isAbsolute_evenInSandbox() {
+        let off = SystemPromptComposer.resolveEffectiveToolsOff(
+            toolsDisabled: true,
+            globalToolsDisabled: true,
+            sizeClassDisablesTools: false,
+            executionMode: sandbox
+        )
+        #expect(off == true)
+    }
+
+    @Test
+    func sizeClassDisable_isAbsolute_evenInSandbox() {
+        let off = SystemPromptComposer.resolveEffectiveToolsOff(
+            toolsDisabled: false,
+            globalToolsDisabled: false,
+            sizeClassDisablesTools: true,
+            executionMode: sandbox
+        )
+        #expect(off == true)
+    }
+
+    @Test
+    func allEnabled_keepsToolsOn() {
+        let off = SystemPromptComposer.resolveEffectiveToolsOff(
+            toolsDisabled: false,
+            globalToolsDisabled: false,
+            sizeClassDisablesTools: false,
+            executionMode: sandbox
+        )
+        #expect(off == false)
+    }
+
+    /// With the per-agent Tools toggle off, the sandbox override exposes only
+    /// sandbox primitives + agent-loop tools — NOT the capability-discovery
+    /// gateway. Otherwise a "chat-only + sandbox" agent could discover and load
+    /// arbitrary enabled plugins (Search, Calendar, …), which is wider than the
+    /// toggle's chat-only intent.
+    @Test
+    @MainActor
+    func toolsToggleOff_inSandbox_dropsCapabilityDiscoveryGateway() {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        let snapshot = AgentConfigSnapshot(
+            agentId: UUID(),
+            toolsDisabled: true,  // per-agent toggle off
+            memoryDisabled: false,
+            autonomousConfig: nil,
+            toolMode: .auto,
+            model: nil,
+            manualToolNames: nil,
+            systemPrompt: "",
+            dbEnabled: false
+        )
+        // `toolsDisabled: false` here mirrors the resolved `effectiveToolsOff`
+        // after the sandbox override flips it; the snapshot still records the
+        // per-agent toggle as off, which is what triggers the restriction.
+        let names = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
+                executionMode: .sandbox(hostRead: nil),
+                toolsDisabled: false
+            ).map { $0.function.name }
+        )
+        #expect(!names.contains("capabilities_discover"))
+        #expect(!names.contains("capabilities_load"))
+        // The agent-loop tools survive so the sandbox loop can still run.
+        #expect(names.contains("complete"))
+    }
+
+    /// Contrast: with the toggle ON (snapshot.toolsDisabled false), the full
+    /// surface — including the discovery gateway — stays exposed in sandbox.
+    @Test
+    @MainActor
+    func toolsToggleOn_inSandbox_keepsCapabilityDiscoveryGateway() {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        let snapshot = AgentConfigSnapshot(
+            agentId: UUID(),
+            toolsDisabled: false,  // per-agent toggle on
+            memoryDisabled: false,
+            autonomousConfig: nil,
+            toolMode: .auto,
+            model: nil,
+            manualToolNames: nil,
+            systemPrompt: "",
+            dbEnabled: false
+        )
+        let names = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
+                executionMode: .sandbox(hostRead: nil),
+                toolsDisabled: false
+            ).map { $0.function.name }
+        )
+        #expect(names.contains("capabilities_discover"))
+        #expect(names.contains("capabilities_load"))
+    }
+}


### PR DESCRIPTION
## Summary

enabling sandbox even with tools turned off should now work

<img width="1157" height="762" alt="image" src="https://github.com/user-attachments/assets/4f5f1a13-7524-4043-b7d0-332bf795edfe" />

  - fixed sandbox having no effect when the agent's Tools toggle was off. Enabling Sandbox now exposes sandbox execution regardless of that toggle while the session global disable-tools switch and the  small-context auto-disable stay absolute
  - limited the tools off sandbox surface to sandbox primitives and the agent loop so a chat only sandbox agent runs code and fetches live data itself but cannot discover or load other plugin capabilities
  - added compact variants of the heaviest sandbox prompt sections for small local models

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
