### PR TITLE
Repin vmlx-swift → d35c0744: fix non-JANG Qwen3 tool-calling 'unsupported' regression

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "01d07754352484337606482d1ce6d7ff90db661e"
+        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "01d07754352484337606482d1ce6d7ff90db661e"
+        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "01d07754352484337606482d1ce6d7ff90db661e"
+            revision: "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -317,6 +317,15 @@ actor MLXService: ToolCapableService {
             return false
         }
 
+        // VibeThinker-3B is a qwen2 reasoning fine-tune. Its chat_template is the
+        // standard Qwen2.5 Hermes tool template, so format detection would mark it
+        // tool-capable — but in practice it reasons at length and then wraps the
+        // (otherwise-correct) call in a hallucinated `<assemble>` tag instead of
+        // `<tool_call>`, so nothing parses. Treat it as text/reasoning-only.
+        if combined.contains("vibethinker") {
+            return false
+        }
+
         if ModelFamilyNames.isStepFamily(modelName) || ModelFamilyNames.isStepFamily(modelId) {
             // Step 3.7 tool parsing/template selection is owned by the pinned
             // vMLX runtime. Do not block request preflight on large external

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -205,6 +205,40 @@ struct MLXServiceRuntimePolicyTests {
         )
     }
 
+    @Test func vibeThinkerIsTreatedAsToolUnsupported() {
+        // VibeThinker carries the standard Qwen2.5 Hermes tool template (so format
+        // detection would call it tool-capable), but the reasoning fine-tune wraps
+        // calls in a hallucinated `<assemble>` tag and never parses. It is gated to
+        // text/reasoning-only regardless of quant variant.
+        for id in [
+            "OsaurusAI/VibeThinker-3B-MXFP8",
+            "OsaurusAI/VibeThinker-3B-MXFP4",
+            "OsaurusAI/VibeThinker-3B-JANG_4M",
+        ] {
+            #expect(
+                MLXService.supportsLocalToolCalling(
+                    modelName: "vibethinker-3b", modelId: id) == false)
+        }
+        // A real Qwen2.5 (same qwen2 model_type) stays tool-capable.
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: "qwen2.5-3b-instruct", modelId: "mlx-community/Qwen2.5-3B-Instruct")
+                == true)
+    }
+
+    @Test func policyRejectsVibeThinkerToolsInsteadOfHallucinatingAssembleTag() {
+        #expect(throws: MLXService.RuntimePolicyError.self) {
+            try MLXService.validateRuntimePolicy(
+                modelName: "vibethinker-3b-mxfp8",
+                modelId: "OsaurusAI/VibeThinker-3B-MXFP8",
+                messages: [ChatMessage(role: "user", content: "What's the weather in London?")],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [Self.lineCountTool()],
+                runtime: VMLXServerRuntimeSettings()
+            )
+        }
+    }
+
     @Test func stepToolSupportDoesNotRequireBundleMetadataPreflight() {
         #expect(
             MLXService.supportsLocalToolCalling(

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -622,7 +622,7 @@ struct RuntimePolicySourceTests {
         // plus the Gemma nested-object tool-call argument parse fix
         // (vmlx-swift#76): GemmaFunctionParser now recurses into `{...}` values
         // so object-typed tool parameters arrive as objects, not raw strings.
-        let expectedRuntimeHardenedRevision = "01d07754352484337606482d1ce6d7ff90db661e"
+        let expectedRuntimeHardenedRevision = "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "01d07754352484337606482d1ce6d7ff90db661e"
+        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
       }
     },
     {


### PR DESCRIPTION
## Repin vmlx-swift → d35c0744: recover non-JANG Qwen3 tool-calling

Picks up vmlx-swift #78. Fixes the team-reported regression where a local Qwen3
bundle errored with:

> Request is blocked by local MLX runtime policy for qwen3-4b-4bit: Model
> capability detection reports tool calling as unsupported.

### Cause
Plain (non-JANG) Qwen3 bundles (`model_type=qwen3` / `qwen3_moe`) have no JANG
tool_parser stamp, and `ToolCallFormat.infer` deliberately leaves them nil
(`qwen3_moe` is shared by instruct=Hermes/.json and Qwen3-Coder=.xmlFunction, so
model_type alone can't disambiguate). nil → capability snapshot reports tools
unsupported → 400. Not osaurus-side; fixed in vmlx by recovering the format from
the model's own chat template.

### Proof (live, this dev app, vmlx d35c0744)
- Reproduced the exact 400 on a real mlx-community/Qwen3-4B-4bit, then verified the
  fix: **qwen3-4b** and **qwen3-8b** emit + parse `get_weather` tool calls and
  complete tool-result round-trips.
- Regression-free: gemma-4-12b (text/math/tools), laguna-m.1 (text + multiturn,
  BOS holds), vibethinker-3b (both quants), qwen3.6-27B JANG (xmlFunction path
  undisturbed) all unchanged.
- Note: tiny Qwen2.5-3B-4bit is a weak tool-caller (capability is correctly
  *allowed* now; the small model just declines some tool prompts) — model
  behavior, not this change.
