### PR TITLE
Add opt-in frozen screen context for chat (Computer Use)

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -241,6 +241,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // Set up observers for server state changes
         setupObservers()
 
+        // Start tracking the user's most-recently-active (non-Osaurus) app so
+        // the opt-in screen-context snapshot can recover "what they were doing"
+        // even when Osaurus is itself frontmost at send time. Cheap: a single
+        // NSWorkspace activation observer.
+        FrontmostAppTracker.shared.start()
+
         // Set up distributed control listeners (local-only management)
         setupControlNotifications()
 

--- a/Packages/OsaurusCore/ComputerUse/Perception/FrontmostAppTracker.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/FrontmostAppTracker.swift
@@ -1,0 +1,66 @@
+//
+//  FrontmostAppTracker.swift
+//  OsaurusCore — Computer Use
+//
+//  Records the most-recently-active application that is NOT Osaurus itself.
+//
+//  Why this exists: the screen-context snapshot freezes on the first send of
+//  a chat session, at which point Osaurus is usually the frontmost app (the
+//  user just clicked into the chat input). The interesting "what were you
+//  doing" signal is the app that was frontmost *before* Osaurus took focus —
+//  which macOS does not expose after the fact. So we observe activations from
+//  app launch and remember the last non-self app, giving the distiller a
+//  reliable working-app hint to fall back to.
+//
+
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+public final class FrontmostAppTracker: ObservableObject {
+    public static let shared = FrontmostAppTracker()
+
+    /// pid of the most-recently-active non-Osaurus app, or nil if none has
+    /// been observed since the tracker started.
+    public private(set) var lastNonSelfPid: Int32?
+
+    private var observer: NSObjectProtocol?
+    private let selfPid: Int32 = ProcessInfo.processInfo.processIdentifier
+    private let selfBundleId: String? = Bundle.main.bundleIdentifier
+
+    public init() {}
+
+    /// Begin observing app activations. Idempotent. Call once at launch so we
+    /// capture the user's working-app history before they open the chat.
+    public func start() {
+        guard observer == nil else { return }
+
+        // Seed from the current frontmost app if it isn't us, so a chat opened
+        // immediately after launch still has something to fall back to.
+        if let front = NSWorkspace.shared.frontmostApplication {
+            record(front)
+        }
+
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            let app =
+                note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            // `queue: .main` guarantees this runs on the main thread, so the
+            // hop into MainActor state is safe and synchronous.
+            MainActor.assumeIsolated {
+                FrontmostAppTracker.shared.record(app)
+            }
+        }
+    }
+
+    private func record(_ app: NSRunningApplication?) {
+        guard let app else { return }
+        if app.processIdentifier == selfPid { return }
+        if let bundleId = app.bundleIdentifier, bundleId == selfBundleId { return }
+        lastNonSelfPid = app.processIdentifier
+    }
+}

--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
@@ -1,0 +1,328 @@
+//
+//  ScreenContextDistiller.swift
+//  OsaurusCore — Computer Use
+//
+//  Smart sampling of "what the user is doing" into a compact, text-only
+//  `ScreenContextSnapshot`. Rather than dumping the whole accessibility tree,
+//  it prioritizes the most informative signals: the working app + focused
+//  input (the draft the user is typing), the list of open windows, and a small
+//  ranked sample of on-screen text — all budgeted so the injected block stays
+//  small.
+//
+//  Pure over an injected `MacDriver`, so it is fully unit-testable with
+//  `MockMacDriver`. The production entry point (`captureForChat`) wires in the
+//  real `NativeMacDriver` plus the self-identity and the working-app hint from
+//  `FrontmostAppTracker`.
+//
+
+import Foundation
+
+public struct ScreenContextDistiller: Sendable {
+    /// Max windows listed across all apps.
+    public var maxWindows: Int
+    /// Max apps whose windows we enumerate (bounds AX traversal cost).
+    public var maxAppsToScan: Int
+    /// Max sampled on-screen text items.
+    public var maxContentItems: Int
+    /// Max chars kept for the focused field's value/draft.
+    public var maxValueChars: Int
+    /// Max chars kept per sampled on-screen item / window title.
+    public var maxItemChars: Int
+
+    public init(
+        maxWindows: Int = 12,
+        maxAppsToScan: Int = 12,
+        maxContentItems: Int = 16,
+        maxValueChars: Int = 160,
+        maxItemChars: Int = 100
+    ) {
+        self.maxWindows = maxWindows
+        self.maxAppsToScan = maxAppsToScan
+        self.maxContentItems = maxContentItems
+        self.maxValueChars = maxValueChars
+        self.maxItemChars = maxItemChars
+    }
+
+    /// Osaurus's own identity, used to exclude it from the "what you're doing"
+    /// signal (it's usually frontmost when the user hits send).
+    private struct SelfIdentity {
+        let pid: Int32
+        let bundleId: String?
+
+        func matches(pid: Int32, bundleId: String?) -> Bool {
+            if pid == self.pid { return true }
+            if let bundleId, let mine = self.bundleId, bundleId == mine { return true }
+            return false
+        }
+
+        func owns(_ app: CUAppListing) -> Bool {
+            matches(pid: app.pid, bundleId: app.bundleId)
+        }
+    }
+
+    private struct WorkingApp {
+        let pid: Int32
+        let name: String
+        let windowTitle: String?
+    }
+
+    /// Build a snapshot from the given driver. `selfPid` / `selfBundleId`
+    /// identify Osaurus so it can be excluded from the "what you're doing"
+    /// signal; `preferredPid` is the working-app fallback used when Osaurus is
+    /// itself frontmost (see `FrontmostAppTracker`).
+    public func capture(
+        using driver: MacDriver,
+        selfPid: Int32,
+        selfBundleId: String?,
+        preferredPid: Int32?
+    ) async -> ScreenContextSnapshot {
+        guard await driver.availability().accessibility else {
+            return .unavailable(accessibilityGranted: false)
+        }
+
+        let identity = SelfIdentity(pid: selfPid, bundleId: selfBundleId)
+        let active = await driver.activeWindow()
+        let apps = await driver.listApps()
+
+        let working = resolveWorkingApp(
+            active: active,
+            apps: apps,
+            identity: identity,
+            preferredPid: preferredPid
+        )
+        let windows = await buildWindows(
+            using: driver,
+            apps: apps,
+            active: active,
+            working: working,
+            identity: identity
+        )
+
+        var focused: ScreenContextSnapshot.FocusedElement?
+        var sampled: [String] = []
+        var workingWindowTitle = working?.windowTitle
+
+        if let working {
+            let snap = await driver.capture(
+                pid: working.pid,
+                tier: .ax,
+                windowId: nil,
+                maxElements: 80,
+                focusedWindowOnly: true
+            )
+            if let title = snap.focusedWindow, !title.isEmpty {
+                workingWindowTitle = title
+            }
+            focused = focusedElement(from: snap)
+            sampled = sampleContents(from: snap, windowTitle: workingWindowTitle, focused: focused)
+        }
+
+        return ScreenContextSnapshot(
+            accessibilityGranted: true,
+            workingApp: working?.name,
+            workingWindowTitle: workingWindowTitle,
+            activityGist: buildGist(app: working?.name, windowTitle: workingWindowTitle, focused: focused),
+            focusedElement: focused,
+            windows: windows,
+            sampledContents: sampled
+        )
+    }
+
+    // MARK: - Working app resolution
+
+    private func resolveWorkingApp(
+        active: CUActiveWindow?,
+        apps: [CUAppListing],
+        identity: SelfIdentity,
+        preferredPid: Int32?
+    ) -> WorkingApp? {
+        // 1. The genuine frontmost app, when Osaurus didn't steal focus.
+        if let active, !identity.matches(pid: active.pid, bundleId: nil) {
+            return WorkingApp(pid: active.pid, name: active.app, windowTitle: active.title)
+        }
+        // 2. The app the user was on right before Osaurus took focus.
+        if let preferredPid,
+            let match = apps.first(where: { $0.pid == preferredPid }),
+            !identity.owns(match)
+        {
+            return WorkingApp(pid: match.pid, name: match.name, windowTitle: nil)
+        }
+        // 3. Best-effort: the first visible non-Osaurus app, else any non-Osaurus app.
+        let candidate =
+            apps.first(where: { !$0.hidden && !identity.owns($0) })
+            ?? apps.first(where: { !identity.owns($0) })
+        return candidate.map { WorkingApp(pid: $0.pid, name: $0.name, windowTitle: nil) }
+    }
+
+    // MARK: - Window list
+
+    private func buildWindows(
+        using driver: MacDriver,
+        apps: [CUAppListing],
+        active: CUActiveWindow?,
+        working: WorkingApp?,
+        identity: SelfIdentity
+    ) async -> [ScreenContextSnapshot.WindowRef] {
+        // Scan the working app first so its windows lead the list, then the
+        // rest, skipping Osaurus and hidden apps.
+        var ordered: [CUAppListing] = []
+        if let workingPid = working?.pid, let workingApp = apps.first(where: { $0.pid == workingPid }) {
+            ordered.append(workingApp)
+        }
+        ordered += apps.filter { $0.pid != working?.pid && !$0.hidden && !identity.owns($0) }
+        ordered = Array(ordered.prefix(maxAppsToScan))
+
+        var refs: [ScreenContextSnapshot.WindowRef] = []
+        for app in ordered {
+            if refs.count >= maxWindows { break }
+            for window in await driver.listWindows(pid: app.pid) {
+                if refs.count >= maxWindows { break }
+                if window.minimized { continue }
+                let hasTitle = !(window.title?.isEmpty ?? true)
+                if !hasTitle && !window.focused { continue }
+                refs.append(
+                    ScreenContextSnapshot.WindowRef(
+                        app: app.name,
+                        title: window.title.map { clean($0, limit: maxItemChars) },
+                        frontmost: app.pid == active?.pid && window.focused
+                    )
+                )
+            }
+        }
+        return refs
+    }
+
+    // MARK: - Focused element + contents
+
+    private func focusedElement(from snapshot: CUSnapshot) -> ScreenContextSnapshot.FocusedElement? {
+        guard let element = snapshot.elements.first(where: { $0.focused }) else { return nil }
+        return ScreenContextSnapshot.FocusedElement(
+            role: friendlyRole(element.role),
+            label: cleaned(element.label, limit: maxItemChars),
+            placeholder: cleaned(element.placeholder, limit: maxItemChars),
+            value: cleaned(element.value, limit: maxValueChars)
+        )
+    }
+
+    private func sampleContents(
+        from snapshot: CUSnapshot,
+        windowTitle: String?,
+        focused: ScreenContextSnapshot.FocusedElement?
+    ) -> [String] {
+        // Seed the de-dup set with text we've already surfaced so the sample
+        // only adds new signal.
+        var seen = Set([windowTitle, focused?.value, focused?.label].compactMap { $0?.lowercased() })
+        var items: [String] = []
+
+        for element in snapshot.elements {
+            if items.count >= maxContentItems { break }
+            guard let text = sampleText(for: element) else { continue }
+            let key = text.lowercased()
+            if seen.insert(key).inserted {
+                items.append(text)
+            }
+        }
+        return items
+    }
+
+    /// One sampled line for an element, or nil if it carries no useful text.
+    private func sampleText(for element: CUElement) -> String? {
+        let label = cleaned(element.label, limit: maxItemChars)
+        let value = cleaned(element.value, limit: maxItemChars)
+
+        switch element.role.lowercased() {
+        case "statictext", "heading", "staticrtext":
+            return value ?? label
+        case "button", "link", "menuitem", "menubaritem", "tab", "checkbox", "radiobutton",
+            "popupbutton", "menubutton":
+            return label
+        case "securetextfield":
+            return label.map { "\($0): (hidden)" }
+        case "textfield", "textarea", "searchfield", "combobox":
+            // Non-focused inputs only matter when they already hold something.
+            guard let value else { return nil }
+            return label.map { "\($0): \(value)" } ?? value
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Gist
+
+    private func buildGist(
+        app: String?,
+        windowTitle: String?,
+        focused: ScreenContextSnapshot.FocusedElement?
+    ) -> String? {
+        guard let app else { return nil }
+        var gist = "In \(app)"
+        if let windowTitle, !windowTitle.isEmpty {
+            gist += " — \"\(windowTitle)\""
+        }
+        guard let focused else { return gist }
+
+        if Self.textInputRoles.contains(focused.role) {
+            let hasDraft = !(focused.value?.isEmpty ?? true)
+            gist += hasDraft ? "; editing \(focused.role) (draft present)" : "; \(focused.role) focused (empty)"
+        } else {
+            gist += "; \(focused.role) focused"
+        }
+        return gist
+    }
+
+    // MARK: - Role helpers
+
+    /// Friendly forms of the input roles, matched against `friendlyRole` output.
+    private static let textInputRoles: Set<String> = [
+        "text field", "text area", "search field", "secure field", "combo box",
+    ]
+
+    private func friendlyRole(_ role: String) -> String {
+        switch role.lowercased() {
+        case "textfield": return "text field"
+        case "textarea": return "text area"
+        case "searchfield": return "search field"
+        case "securetextfield": return "secure field"
+        case "combobox": return "combo box"
+        case "popupbutton": return "pop-up button"
+        case "statictext", "staticrtext": return "text"
+        case let other: return other
+        }
+    }
+
+    // MARK: - Text helpers
+
+    /// Collapse whitespace/newlines into a single line and truncate to `limit`.
+    private func clean(_ text: String, limit: Int) -> String {
+        let collapsed = text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        guard collapsed.count > limit else { return collapsed }
+        let end = collapsed.index(collapsed.startIndex, offsetBy: limit)
+        return String(collapsed[..<end]).trimmingCharacters(in: .whitespaces) + "…"
+    }
+
+    /// `clean`, but nil for nil / whitespace-only input.
+    private func cleaned(_ text: String?, limit: Int) -> String? {
+        guard let text else { return nil }
+        let result = clean(text, limit: limit)
+        return result.isEmpty ? nil : result
+    }
+}
+
+// MARK: - Production entry point
+
+extension ScreenContextDistiller {
+    /// Capture a snapshot for the chat send path using the real macOS driver,
+    /// Osaurus's own identity, and the working-app hint from the frontmost
+    /// tracker.
+    @MainActor
+    public static func captureForChat(
+        driver: MacDriver = NativeMacDriver()
+    ) async -> ScreenContextSnapshot {
+        await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: ProcessInfo.processInfo.processIdentifier,
+            selfBundleId: Bundle.main.bundleIdentifier,
+            preferredPid: FrontmostAppTracker.shared.lastNonSelfPid
+        )
+    }
+}

--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextSettings.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextSettings.swift
@@ -1,0 +1,37 @@
+//
+//  ScreenContextSettings.swift
+//  OsaurusCore — Computer Use
+//
+//  The opt-in gate for injecting a frozen screen-context snapshot into chat.
+//  Off by default and never inferred: nothing is captured or injected until
+//  the user explicitly turns it on in Computer Use settings. Mirrors the
+//  shape of `CloudVisionConsent` (a tiny UserDefaults-backed observable) so
+//  the settings toggle and the chat send path read one source of truth.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+public final class ScreenContextSettings: ObservableObject {
+    public static let shared = ScreenContextSettings()
+
+    private let defaultsKey = "ai.osaurus.computeruse.screenContextInjection"
+    private let defaults: UserDefaults
+
+    /// Master opt-in. Default `false` — the screen is never sampled and no
+    /// context is injected until the user turns this on.
+    @Published public private(set) var injectionEnabled: Bool
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.injectionEnabled = defaults.bool(forKey: defaultsKey)
+    }
+
+    /// Bindable convenience for the settings toggle.
+    public func setEnabled(_ on: Bool) {
+        guard on != injectionEnabled else { return }
+        injectionEnabled = on
+        defaults.set(on, forKey: defaultsKey)
+    }
+}

--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextSnapshot.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextSnapshot.swift
@@ -1,0 +1,156 @@
+//
+//  ScreenContextSnapshot.swift
+//  OsaurusCore — Computer Use
+//
+//  A frozen, text-only distillation of what the user is doing on screen at the
+//  moment a chat session starts: the working app, its focused input/draft, the
+//  list of open windows, and a small sample of on-screen text. No pixels — it's
+//  built entirely from the Accessibility tree so it can pass through the
+//  text-based Privacy Filter before reaching any cloud model.
+//
+//  `render()` is the single source of truth for the text that gets shown in the
+//  settings preview AND injected into chat, so the two can never drift.
+//
+
+import Foundation
+
+public struct ScreenContextSnapshot: Sendable, Equatable {
+    /// One open window, addressed by app + title (no ids — this is read-only
+    /// context, never something the model acts on).
+    public struct WindowRef: Sendable, Equatable {
+        public let app: String
+        public let title: String?
+        public let frontmost: Bool
+
+        public init(app: String, title: String?, frontmost: Bool) {
+            self.app = app
+            self.title = title
+            self.frontmost = frontmost
+        }
+    }
+
+    /// The element the user is actively interacting with (usually a text input).
+    public struct FocusedElement: Sendable, Equatable {
+        public let role: String
+        public let label: String?
+        public let placeholder: String?
+        public let value: String?
+
+        public init(role: String, label: String?, placeholder: String?, value: String?) {
+            self.role = role
+            self.label = label
+            self.placeholder = placeholder
+            self.value = value
+        }
+    }
+
+    public let capturedAt: Date
+    public let accessibilityGranted: Bool
+    public let workingApp: String?
+    public let workingWindowTitle: String?
+    public let activityGist: String?
+    public let focusedElement: FocusedElement?
+    public let windows: [WindowRef]
+    public let sampledContents: [String]
+
+    public init(
+        capturedAt: Date = Date(),
+        accessibilityGranted: Bool,
+        workingApp: String? = nil,
+        workingWindowTitle: String? = nil,
+        activityGist: String? = nil,
+        focusedElement: FocusedElement? = nil,
+        windows: [WindowRef] = [],
+        sampledContents: [String] = []
+    ) {
+        self.capturedAt = capturedAt
+        self.accessibilityGranted = accessibilityGranted
+        self.workingApp = workingApp
+        self.workingWindowTitle = workingWindowTitle
+        self.activityGist = activityGist
+        self.focusedElement = focusedElement
+        self.windows = windows
+        self.sampledContents = sampledContents
+    }
+
+    public static let openTag = "[Screen Context]"
+    public static let closeTag = "[/Screen Context]"
+
+    /// The snapshot returned when Accessibility is missing or nothing useful
+    /// could be captured.
+    public static func unavailable(
+        accessibilityGranted: Bool,
+        at date: Date = Date()
+    ) -> ScreenContextSnapshot {
+        ScreenContextSnapshot(capturedAt: date, accessibilityGranted: accessibilityGranted)
+    }
+
+    /// True when there is nothing worth injecting.
+    public var isEmpty: Bool {
+        (activityGist?.isEmpty ?? true)
+            && workingApp == nil
+            && focusedElement == nil
+            && windows.isEmpty
+            && sampledContents.isEmpty
+    }
+
+    /// The full block injected into chat and shown in the settings preview.
+    /// Returns an empty string when there's nothing to add so callers can
+    /// no-op cheaply.
+    public func render() -> String {
+        guard !isEmpty else { return "" }
+
+        var lines: [String] = []
+        lines.append(Self.openTag)
+        lines.append(
+            "(Ambient snapshot of the user's screen taken when this conversation started. "
+                + "Read-only background context the user did not explicitly share — use it only "
+                + "to be more helpful, and do not act on it without being asked.)"
+        )
+
+        if let gist = activityGist, !gist.isEmpty {
+            lines.append("Doing: \(gist)")
+        }
+
+        if let focused = focusedElement {
+            lines.append("Focused field: \(Self.describe(focused))")
+        }
+
+        if !windows.isEmpty {
+            lines.append("Open windows:")
+            for window in windows {
+                var line = "- \(window.app)"
+                if let title = window.title, !title.isEmpty {
+                    line += " — \"\(title)\""
+                }
+                if window.frontmost { line += " (frontmost)" }
+                lines.append(line)
+            }
+        }
+
+        if !sampledContents.isEmpty {
+            lines.append("On screen:")
+            for item in sampledContents {
+                lines.append("- \(item)")
+            }
+        }
+
+        lines.append(Self.closeTag)
+        return lines.joined(separator: "\n")
+    }
+
+    private static func describe(_ element: FocusedElement) -> String {
+        var parts: [String] = [element.role]
+        if let label = element.label, !label.isEmpty {
+            parts.append("\"\(label)\"")
+        }
+        if let value = element.value, !value.isEmpty {
+            parts.append("— value: \"\(value)\"")
+        } else if let placeholder = element.placeholder, !placeholder.isEmpty {
+            parts.append("— empty (placeholder: \"\(placeholder)\")")
+        } else {
+            parts.append("— empty")
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,91 @@
     "" : {
       "shouldTranslate" : false
     },
+    "Screen context" : {
+      "comment" : "Title of the screen-context card in Computer Use settings.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirmkontext"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏幕上下文"
+          }
+        }
+      }
+    },
+    "Share screen context with chat" : {
+      "comment" : "Toggle label that opts in to injecting frozen screen context into chat.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirmkontext mit dem Chat teilen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与聊天共享屏幕上下文"
+          }
+        }
+      }
+    },
+    "The Privacy Filter scrubs this before it reaches a cloud model." : {
+      "comment" : "Privacy note shown under the screen-context preview when the Privacy Filter is on.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Datenschutzfilter bereinigt dies, bevor es ein Cloud-Modell erreicht."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私过滤器会在其到达云端模型之前清理这些内容。"
+          }
+        }
+      }
+    },
+    "~%d items would be masked before cloud send." : {
+      "comment" : "Privacy note: plural count of spans the Privacy Filter would mask before a cloud send.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%d Elemente würden vor dem Senden an die Cloud maskiert."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在发送到云端之前，约 %d 项将被屏蔽。"
+          }
+        }
+      }
+    },
+    "~1 item would be masked before cloud send." : {
+      "comment" : "Privacy note: singular count of the span the Privacy Filter would mask before a cloud send.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~1 Element würde vor dem Senden an die Cloud maskiert."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在发送到云端之前，约 1 项将被屏蔽。"
+          }
+        }
+      }
+    },
     " — %@" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2102,6 +2102,42 @@ public struct SystemPromptComposer: Sendable {
         )
     }
 
+    /// Prepend a frozen screen-context block (already rendered by
+    /// `ScreenContextSnapshot.render()`, tags and all) to the latest user
+    /// message. Placed on the user turn — not the system prompt — for two
+    /// reasons that mirror `injectMemoryPrefix`:
+    ///   1. the system prefix stays byte-stable so the paged KV cache reuses
+    ///      the conversation prefix, and
+    ///   2. the Privacy Filter only scans the latest user turn
+    ///      (`latestUserTurnSegments()`) and skips `system`, so riding on the
+    ///      user message is what actually routes the snapshot through PII
+    ///      scrubbing before a cloud send.
+    /// No-op when the block is nil/blank, no user message exists, or the
+    /// latest user message is multimodal (we leave `contentParts`-bearing
+    /// messages alone to avoid silently dropping images).
+    static func injectScreenContextPrefix(
+        _ block: String?,
+        into messages: inout [ChatMessage]
+    ) {
+        guard let block,
+            case let trimmed = block.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty,
+            let idx = messages.lastIndex(where: { $0.role == "user" })
+        else { return }
+
+        let existing = messages[idx]
+        guard existing.contentParts == nil else { return }
+
+        let original = existing.content ?? ""
+        let prefixed = original.isEmpty ? trimmed : "\(trimmed)\n\n\(original)"
+        messages[idx] = ChatMessage(
+            role: existing.role,
+            content: prefixed,
+            tool_calls: existing.tool_calls,
+            tool_call_id: existing.tool_call_id
+        )
+    }
+
     /// Merge `content` into the message list's system role. When `prepend`
     /// is true the content lands at the top of an existing system message;
     /// false appends to the bottom. With no existing system message, a new

--- a/Packages/OsaurusCore/Tests/Chat/ScreenContextInjectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ScreenContextInjectionTests.swift
@@ -1,0 +1,81 @@
+//
+//  ScreenContextInjectionTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  Coverage for `SystemPromptComposer.injectScreenContextPrefix`: it must ride
+//  on the latest user message (so the Privacy Filter scans it) without
+//  disturbing the system prefix or multimodal turns, and compose cleanly with
+//  the memory prefix that shares the same seam.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class ScreenContextInjectionTests: XCTestCase {
+    private let block = "[Screen Context]\nDoing: In Safari\n[/Screen Context]"
+
+    func testPrependsToLatestUserMessage() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: "hello"),
+        ]
+        SystemPromptComposer.injectScreenContextPrefix(block, into: &msgs)
+        XCTAssertEqual(msgs[0].content, "sys")
+        XCTAssertEqual(msgs[1].content, "\(block)\n\nhello")
+    }
+
+    func testNoOpOnNilOrBlank() {
+        var msgs: [ChatMessage] = [ChatMessage(role: "user", content: "hi")]
+        SystemPromptComposer.injectScreenContextPrefix(nil, into: &msgs)
+        SystemPromptComposer.injectScreenContextPrefix("   \n  ", into: &msgs)
+        XCTAssertEqual(msgs[0].content, "hi")
+    }
+
+    func testNoOpWhenNoUserMessage() {
+        var msgs: [ChatMessage] = [ChatMessage(role: "system", content: "sys")]
+        SystemPromptComposer.injectScreenContextPrefix(block, into: &msgs)
+        XCTAssertEqual(msgs[0].content, "sys")
+    }
+
+    func testSkipsMultimodalUserMessage() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "user", content: "caption", contentParts: [.text("caption")])
+        ]
+        SystemPromptComposer.injectScreenContextPrefix(block, into: &msgs)
+        XCTAssertNotNil(msgs[0].contentParts)
+        XCTAssertEqual(msgs[0].content, "caption")
+    }
+
+    func testTargetsTheLastUserMessage() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "user", content: "first"),
+            ChatMessage(role: "assistant", content: "reply"),
+            ChatMessage(role: "user", content: "second"),
+        ]
+        SystemPromptComposer.injectScreenContextPrefix(block, into: &msgs)
+        XCTAssertEqual(msgs[0].content, "first")
+        XCTAssertEqual(msgs[2].content, "\(block)\n\nsecond")
+    }
+
+    func testComposesWithMemoryPrefix() {
+        var msgs: [ChatMessage] = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: "hello"),
+        ]
+        // Same order the chat loop uses: memory first, then screen context.
+        SystemPromptComposer.injectMemoryPrefix("remember this", into: &msgs)
+        SystemPromptComposer.injectScreenContextPrefix(block, into: &msgs)
+
+        let content = msgs[1].content ?? ""
+        XCTAssertTrue(content.contains("[Screen Context]"))
+        XCTAssertTrue(content.contains("[Memory]"))
+        XCTAssertTrue(content.contains("hello"))
+
+        // Screen context is prepended last, so it sits above the memory block.
+        let screenIdx = content.range(of: "[Screen Context]")!.lowerBound
+        let memoryIdx = content.range(of: "[Memory]")!.lowerBound
+        XCTAssertLessThan(screenIdx, memoryIdx)
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
@@ -1,0 +1,323 @@
+//
+//  ScreenContextDistillerTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  Pure-data coverage for the screen-context smart sampler. Drives the
+//  distiller through `MockMacDriver` so working-app selection, the
+//  Osaurus-exclusion fallback, focused-field extraction, the window list, and
+//  the rendered block are all asserted without touching real Accessibility.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class ScreenContextDistillerTests: XCTestCase {
+    private let selfPid: Int32 = 999
+    private let selfBundleId = "ai.osaurus.osaurus"
+
+    // MARK: Fixtures
+
+    private func safariSnapshot() -> CUSnapshot {
+        CUSnapshot(
+            snapshotId: 1,
+            pid: 100,
+            app: "Safari",
+            focusedWindow: "Weather — Safari",
+            tier: .ax,
+            truncated: false,
+            windows: [
+                CUWindowSummary(id: 1, title: "Weather — Safari", focused: true, x: 0, y: 0, w: 1200, h: 800)
+            ],
+            elements: [
+                CUElement(
+                    id: "e1",
+                    role: "textfield",
+                    label: "Search",
+                    value: "weather tomorrow",
+                    placeholder: "Search or enter address",
+                    windowId: 1,
+                    focused: true
+                ),
+                CUElement(id: "e2", role: "button", label: "Go", windowId: 1),
+                CUElement(id: "e3", role: "statictext", value: "Results for weather", windowId: 1),
+            ],
+            image: nil
+        )
+    }
+
+    private func makeDriver(
+        accessibility: Bool = true,
+        apps: [CUAppListing],
+        active: CUActiveWindow?,
+        windowsByPid: [Int32: [CUWindowInfo]] = [:],
+        snapshots: [Int32: [CUSnapshot]] = [:]
+    ) -> MockMacDriver {
+        MockMacDriver(
+            availability: MacDriverAvailability(
+                accessibility: accessibility,
+                screenRecording: false,
+                skyLight: false
+            ),
+            apps: apps,
+            windowsByPid: windowsByPid,
+            activeWindow: active,
+            snapshots: snapshots
+        )
+    }
+
+    // MARK: Tests
+
+    func testUsesFrontmostNonSelfApp() async {
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: true, hidden: false)
+            ],
+            active: CUActiveWindow(pid: 100, app: "Safari", title: "Weather — Safari", x: 0, y: 0, w: 1200, h: 800),
+            windowsByPid: [
+                100: [
+                    CUWindowInfo(
+                        windowId: 1,
+                        title: "Weather — Safari",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    )
+                ]
+            ],
+            snapshots: [100: [safariSnapshot()]]
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertTrue(snap.accessibilityGranted)
+        XCTAssertEqual(snap.workingApp, "Safari")
+        XCTAssertEqual(snap.workingWindowTitle, "Weather — Safari")
+        XCTAssertEqual(snap.focusedElement?.role, "text field")
+        XCTAssertEqual(snap.focusedElement?.value, "weather tomorrow")
+        XCTAssertEqual(snap.activityGist, "In Safari — \"Weather — Safari\"; editing text field (draft present)")
+        XCTAssertEqual(snap.windows.first?.app, "Safari")
+        XCTAssertTrue(snap.windows.first?.frontmost ?? false)
+        // The focused draft is not repeated in the on-screen sample; other text is.
+        XCTAssertTrue(snap.sampledContents.contains("Go"))
+        XCTAssertTrue(snap.sampledContents.contains("Results for weather"))
+        XCTAssertFalse(snap.sampledContents.contains("weather tomorrow"))
+    }
+
+    func testFallsBackToPreferredAppWhenOsaurusIsFrontmost() async {
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: false, hidden: false)
+            ],
+            // Osaurus itself is frontmost (its pid == selfPid).
+            active: CUActiveWindow(pid: selfPid, app: "Osaurus", title: "Chat", x: 0, y: 0, w: 600, h: 800),
+            windowsByPid: [
+                100: [
+                    CUWindowInfo(
+                        windowId: 1,
+                        title: "Weather — Safari",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    )
+                ]
+            ],
+            snapshots: [100: [safariSnapshot()]]
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: 100
+        )
+
+        XCTAssertEqual(snap.workingApp, "Safari")
+        // No window is frontmost because the genuine frontmost app (Osaurus) is excluded.
+        XCTAssertFalse(snap.windows.contains { $0.frontmost })
+    }
+
+    func testFallsBackToFirstVisibleAppWhenNoHint() async {
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 200, bundleId: "com.apple.mail", name: "Mail", active: false, hidden: false),
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: false, hidden: false),
+            ],
+            active: CUActiveWindow(pid: selfPid, app: "Osaurus", title: "Chat", x: 0, y: 0, w: 600, h: 800),
+            windowsByPid: [
+                200: [
+                    CUWindowInfo(
+                        windowId: 9,
+                        title: "Inbox",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1000,
+                        h: 700
+                    )
+                ]
+            ]
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertEqual(snap.workingApp, "Mail")
+    }
+
+    func testExcludesOsaurusOwnWindowsFromList() async {
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: true, hidden: false),
+                // Osaurus shows up in the app list (dock-icon / .regular mode).
+                CUAppListing(pid: selfPid, bundleId: selfBundleId, name: "Osaurus", active: false, hidden: false),
+            ],
+            active: CUActiveWindow(pid: 100, app: "Safari", title: "Weather — Safari", x: 0, y: 0, w: 1200, h: 800),
+            windowsByPid: [
+                100: [
+                    CUWindowInfo(
+                        windowId: 1,
+                        title: "Weather — Safari",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    )
+                ],
+                selfPid: [
+                    CUWindowInfo(
+                        windowId: 2,
+                        title: "Osaurus Chat",
+                        focused: false,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 600,
+                        h: 800
+                    )
+                ],
+            ],
+            snapshots: [100: [safariSnapshot()]]
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertTrue(snap.windows.allSatisfy { $0.app != "Osaurus" })
+    }
+
+    func testWindowListIsCapped() async {
+        let windows = (1 ... 5).map {
+            CUWindowInfo(
+                windowId: $0,
+                title: "Tab \($0)",
+                focused: $0 == 1,
+                minimized: false,
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100
+            )
+        }
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: true, hidden: false)
+            ],
+            active: CUActiveWindow(pid: 100, app: "Safari", title: "Tab 1", x: 0, y: 0, w: 1200, h: 800),
+            windowsByPid: [100: windows],
+            snapshots: [100: [safariSnapshot()]]
+        )
+
+        let distiller = ScreenContextDistiller(maxWindows: 2)
+        let snap = await distiller.capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertEqual(snap.windows.count, 2)
+    }
+
+    func testRenderedBlockShape() async {
+        let driver = makeDriver(
+            apps: [
+                CUAppListing(pid: 100, bundleId: "com.apple.Safari", name: "Safari", active: true, hidden: false)
+            ],
+            active: CUActiveWindow(pid: 100, app: "Safari", title: "Weather — Safari", x: 0, y: 0, w: 1200, h: 800),
+            windowsByPid: [
+                100: [
+                    CUWindowInfo(
+                        windowId: 1,
+                        title: "Weather — Safari",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    )
+                ]
+            ],
+            snapshots: [100: [safariSnapshot()]]
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+        let text = snap.render()
+
+        XCTAssertTrue(text.hasPrefix(ScreenContextSnapshot.openTag))
+        XCTAssertTrue(text.hasSuffix(ScreenContextSnapshot.closeTag))
+        XCTAssertTrue(text.contains("Doing: In Safari"))
+        XCTAssertTrue(text.contains("Focused field: text field"))
+        XCTAssertTrue(text.contains("Open windows:"))
+        XCTAssertTrue(text.contains("- Safari — \"Weather — Safari\" (frontmost)"))
+        XCTAssertTrue(text.contains("On screen:"))
+    }
+
+    func testNoAccessibilityYieldsEmptySnapshot() async {
+        let driver = makeDriver(
+            accessibility: false,
+            apps: [],
+            active: nil
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertFalse(snap.accessibilityGranted)
+        XCTAssertTrue(snap.isEmpty)
+        XCTAssertEqual(snap.render(), "")
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextSettingsTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextSettingsTests.swift
@@ -1,0 +1,39 @@
+//
+//  ScreenContextSettingsTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  The screen-context opt-in must default OFF and persist across instances,
+//  so a relaunch never silently starts sampling the screen.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+@MainActor
+final class ScreenContextSettingsTests: XCTestCase {
+    func testDefaultsOff() {
+        let suite = "screen-context-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = ScreenContextSettings(defaults: defaults)
+        XCTAssertFalse(settings.injectionEnabled)
+    }
+
+    func testSetEnabledPersistsAcrossInstances() {
+        let suite = "screen-context-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = ScreenContextSettings(defaults: defaults)
+        settings.setEnabled(true)
+        XCTAssertTrue(settings.injectionEnabled)
+        XCTAssertTrue(ScreenContextSettings(defaults: defaults).injectionEnabled)
+
+        settings.setEnabled(false)
+        XCTAssertFalse(settings.injectionEnabled)
+        XCTAssertFalse(ScreenContextSettings(defaults: defaults).injectionEnabled)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -207,6 +207,14 @@ final class ChatSession: ObservableObject {
     private let blockMemoizer = BlockMemoizer()
     private var cachedContext: ComposedContext?
 
+    /// Frozen screen-context snapshot for this session (opt-in Computer Use
+    /// feature). Captured once on the first send and reused unchanged for the
+    /// rest of the session, so it reflects what the user was doing when the
+    /// conversation started. Holds the rendered `[Screen Context]` block (or
+    /// nil when the feature is off or nothing was captured). Cleared on
+    /// `reset()` / `load(from:)`. Not persisted.
+    private var frozenScreenContext: String?
+
     /// Cached welcome/pre-send preview `ComposedContext`, used by
     /// `estimatedContextBreakdown` when no real send context exists yet.
     /// Recomputed by `refreshContextEstimates()` whenever a budget-relevant
@@ -1269,6 +1277,8 @@ final class ChatSession: ObservableObject {
         blockMemoizer.clear()
         cachedContext = nil
         cachedPreviewContext = nil
+        // A new conversation re-freezes its screen context on the next send.
+        frozenScreenContext = nil
         visibleBlocksStore.blocks = []
         visibleBlocksStore.groupHeaderMap = [:]
 
@@ -1564,6 +1574,8 @@ final class ChatSession: ObservableObject {
         blockMemoizer.clear()
         cachedContext = nil
         cachedPreviewContext = nil
+        // A loaded conversation re-freezes its screen context on its next send.
+        frozenScreenContext = nil
         suppressVisibleBlockRebuild = false
         rebuildVisibleBlocks()
 
@@ -2794,6 +2806,22 @@ final class ChatSession: ObservableObject {
                     } else {
                         cachedSession = nil
                     }
+
+                    // Opt-in screen context: freeze a distilled snapshot of
+                    // what the user is doing, once per session on the first
+                    // send, so the assistant has ambient awareness of their
+                    // current task. Reused unchanged for the rest of the
+                    // session and injected onto the latest user message — so it
+                    // flows through the Privacy Filter — in
+                    // `loopHooks.buildMessages` below.
+                    if ScreenContextSettings.shared.injectionEnabled,
+                        self.frozenScreenContext == nil
+                    {
+                        let snapshot = await ScreenContextDistiller.captureForChat()
+                        self.frozenScreenContext = snapshot.render()
+                        guard isRunActive(runId) else { return }
+                    }
+
                     let context = await SystemPromptComposer.composeChatContext(
                         agentId: effectiveAgentId,
                         executionMode: executionMode,
@@ -3486,6 +3514,17 @@ final class ChatSession: ObservableObject {
                             // across turns so the MLX paged KV cache can reuse the
                             // entire conversation prefix.
                             SystemPromptComposer.injectMemoryPrefix(context.memorySection, into: &msgs)
+
+                            // Opt-in: prepend the frozen screen-context snapshot
+                            // to the latest user message (same seam as memory).
+                            // Keeps the system prefix KV-stable and routes the
+                            // snapshot through the Privacy Filter on cloud sends.
+                            if ScreenContextSettings.shared.injectionEnabled {
+                                SystemPromptComposer.injectScreenContextPrefix(
+                                    self.frozenScreenContext,
+                                    into: &msgs
+                                )
+                            }
 
                             let convTokens =
                                 msgs

--- a/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
@@ -17,10 +17,20 @@ struct ComputerUseSettingsView: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @ObservedObject private var permissionService = SystemPermissionService.shared
     @ObservedObject private var cloudVisionConsent = CloudVisionConsent.shared
+    @ObservedObject private var screenContext = ScreenContextSettings.shared
 
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     @State private var hasAppeared = false
+
+    /// Live screen-context preview state for the Screen context card. The
+    /// snapshot is captured on demand (Refresh) so the user can see exactly
+    /// what a new conversation would freeze and share.
+    @State private var screenPreview: ScreenContextSnapshot?
+    @State private var isLoadingScreenPreview = false
+    /// Number of PII spans the Privacy Filter would mask in the preview, when
+    /// the filter is enabled and its model is loaded. nil = not computed.
+    @State private var screenMaskedCount: Int?
 
     /// The editable autonomy policy, loaded from `ComputerUsePolicyStore` on
     /// appear and persisted on every change.
@@ -45,6 +55,7 @@ struct ComputerUseSettingsView: View {
                     setupCard
                     enableCard
                     consentCard
+                    screenContextCard
                     policyCard
                     advancedCard
                 }
@@ -62,6 +73,9 @@ struct ComputerUseSettingsView: View {
             permissionService.startPeriodicRefresh(interval: 2.0)
             withAnimation(.easeOut(duration: 0.25).delay(0.05)) {
                 hasAppeared = true
+            }
+            if screenContext.injectionEnabled, isAccessibilityGranted {
+                refreshScreenPreview()
             }
         }
         .onDisappear {
@@ -243,6 +257,180 @@ struct ComputerUseSettingsView: View {
                 .foregroundColor(theme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    // MARK: - Screen context card
+
+    private var screenContextCard: some View {
+        infoCard(icon: "rectangle.on.rectangle.angled", title: L("Screen context")) {
+            VStack(alignment: .leading, spacing: 14) {
+                bodyText(
+                    "Give the assistant ambient awareness of what you're working on. When on, Osaurus freezes a quick snapshot of your open windows and the field you're focused on at the start of each chat, and shares it as background context. It's built from on-screen text only — no screenshots — and is scrubbed by the Privacy Filter before it reaches a cloud model."
+                )
+
+                screenContextToggleRow
+
+                if screenContext.injectionEnabled {
+                    screenPreviewSection
+                }
+            }
+        }
+    }
+
+    private var screenContextToggleRow: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L("Share screen context with chat"))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                hintText(
+                    "Off by default. Requires Accessibility. Frozen when each conversation starts."
+                )
+            }
+            Spacer(minLength: 12)
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { screenContext.injectionEnabled },
+                    set: { setScreenContextEnabled($0) }
+                )
+            )
+            .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+            .labelsHidden()
+        }
+        .padding(12)
+        .surface(cornerRadius: 10, fill: theme.inputBackground, stroke: theme.inputBorder)
+    }
+
+    @ViewBuilder
+    private var screenPreviewSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                sectionTitle(L("Preview"))
+                Spacer()
+                Button(action: { refreshScreenPreview() }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11))
+                        Text(L("Refresh"))
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    .foregroundColor(theme.secondaryText)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .surface(cornerRadius: 6, fill: theme.tertiaryBackground, stroke: theme.inputBorder)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(!isAccessibilityGranted || isLoadingScreenPreview)
+            }
+
+            if !isAccessibilityGranted {
+                hintText("Grant Accessibility above to preview what would be shared.")
+            } else if isLoadingScreenPreview {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    hintText("Reading the screen…")
+                }
+            } else if let preview = screenPreview {
+                let text = preview.render()
+                if text.isEmpty {
+                    hintText("Nothing shareable detected on screen right now.")
+                } else {
+                    ScrollView {
+                        Text(text)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.secondaryText)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    }
+                    .frame(maxHeight: 220)
+                    .surface(cornerRadius: 8, fill: theme.inputBackground, stroke: theme.inputBorder)
+
+                    privacyNote
+                }
+            } else {
+                hintText("Tap Refresh to see what would be shared.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var privacyNote: some View {
+        if PrivacyFilterStore.snapshot().enabled {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.successColor)
+                    .padding(.top, 1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("The Privacy Filter scrubs this before it reaches a cloud model."))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let count = screenMaskedCount, count > 0 {
+                        Text(maskedCountText(count))
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(theme.warningColor)
+                    }
+                }
+            }
+        } else {
+            hintText(
+                "Local models receive this as-is. Turn on the Privacy Filter to scrub it before cloud sends."
+            )
+        }
+    }
+
+    private func maskedCountText(_ count: Int) -> String {
+        count == 1
+            ? L("~1 item would be masked before cloud send.")
+            : String(format: L("~%d items would be masked before cloud send."), count)
+    }
+
+    private func setScreenContextEnabled(_ enabled: Bool) {
+        screenContext.setEnabled(enabled)
+        if enabled {
+            refreshScreenPreview()
+        } else {
+            screenPreview = nil
+            screenMaskedCount = nil
+        }
+    }
+
+    private func refreshScreenPreview() {
+        guard isAccessibilityGranted else {
+            screenPreview = nil
+            screenMaskedCount = nil
+            return
+        }
+        isLoadingScreenPreview = true
+        screenMaskedCount = nil
+        Task { @MainActor in
+            let snapshot = await ScreenContextDistiller.captureForChat()
+            screenPreview = snapshot
+            isLoadingScreenPreview = false
+            await computeMaskedCount(for: snapshot.render())
+        }
+    }
+
+    /// Best-effort count of spans the Privacy Filter would mask, shown so the
+    /// user can gauge exposure. Only runs when the filter is enabled and its
+    /// on-device model is already loaded — never blocks the preview on a model
+    /// load.
+    private func computeMaskedCount(for text: String) async {
+        let config = PrivacyFilterStore.snapshot()
+        guard config.enabled, !text.isEmpty, PrivacyFilterEngine.shared.isLoaded else {
+            screenMaskedCount = nil
+            return
+        }
+        let map = RedactionMap(conversationID: UUID())
+        let detected = try? await PrivacyFilterEngine.shared.detect(
+            in: text,
+            map: map,
+            skipCodeBlocks: config.skipCodeBlocks
+        )
+        screenMaskedCount = detected?.count
     }
 
     // MARK: - Autonomy card

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -185,6 +185,49 @@ images** (`ComputerUseTool.modelAcceptsImages`: local VLM detection / media
 capabilities, or the remote router's advertised vision support) and the
 perception ladder has escalated past `ax`.
 
+## Screen context (chat)
+
+Separate from the `computer_use` tool, **Screen context** gives the assistant
+ambient awareness of what you're doing *without driving anything*. It's a global
+**opt-in** (off by default) under Settings → Computer Use → *Screen context*,
+independent of the per-agent `computer_use` toggle.
+
+When enabled, the **first send** of a chat session **freezes** a distilled,
+text-only snapshot of your screen and reuses it unchanged for the rest of that
+conversation (a new/loaded chat re-freezes on its next send). The snapshot is
+built entirely from the **accessibility tree** — no screenshots — so it can pass
+through the text-based Privacy Filter.
+
+### Smart sampling — `ScreenContextDistiller`
+
+`ComputerUse/Perception/ScreenContextDistiller.swift`. Rather than dumping the
+AX tree, the distiller samples the highest-signal bits, budgeted small:
+
+- **Working app** — the frontmost app, or, when Osaurus is itself frontmost at
+  send time, the most-recently-active non-Osaurus app. `FrontmostAppTracker`
+  records that app from launch (Osaurus excluded by pid / bundle id) so "what
+  you were doing" survives the chat stealing focus.
+- **Activity gist** — one line, e.g. `In Mail — "Re: Project update"; editing
+  text area (draft present)`.
+- **Focused field** — role + label + placeholder + current value (the draft).
+- **Open windows** — app + title + which is frontmost.
+- **On screen** — a ranked, de-duplicated sample of salient labels / values.
+
+`ScreenContextSnapshot.render()` is the single source of truth for the
+`[Screen Context]…[/Screen Context]` block — the same text shown in the settings
+preview and injected into chat.
+
+### Injection + privacy
+
+The block is prepended to the **latest user message**
+(`SystemPromptComposer.injectScreenContextPrefix`, the same seam memory uses),
+not the system prompt. That keeps the system prefix byte-stable for KV reuse
+**and** routes the snapshot through `RemoteProviderService.applyPrivacyOutbound`
+— the Privacy Filter only scans the latest user turn — so PII is scrubbed before
+any cloud send. Local models receive it as-is, matching the rest of the local
+path. The settings card previews the live snapshot (with a Refresh) and, when
+the Privacy Filter is on and loaded, reports how many spans would be masked.
+
 ## Autonomy model
 
 The gate decides `allow` / `confirm` / `deny` for every action by combining a
@@ -257,8 +300,9 @@ Vivaldi / Opera).
 - **Settings → Computer Use** (`Views/Settings/ComputerUseSettingsView.swift`) —
   global preset picker, per-app overrides, app allowlist, the **Cloud vision**
   consent toggle ("Allow scrubbed screenshots to reach a cloud model", off by
-  default), Accessibility / Screen Recording permission rows, and an "Enabling
-  Computer Use" explainer.
+  default), the **Screen context** opt-in + live preview (see above),
+  Accessibility / Screen Recording permission rows, and an "Enabling Computer
+  Use" explainer.
 - **Per-agent** (Agents → Configure → Features) — the `computerUseEnabled`
   toggle and the per-agent autonomy **ceiling** picker. Custom agents only.
 - **Live activity** (`Views/Chat/ComputerUseFeedView.swift`) — the
@@ -288,6 +332,7 @@ sends.
 |------------|---------|
 | `~/.osaurus/config/computer-use.json` | `AutonomyPolicy` (global preset + per-app overrides + allowlist), via `ComputerUsePolicyStore`. |
 | `UserDefaults` `ai.osaurus.computeruse.cloudVisionConsent` | Persisted cloud-vision opt-in (default `false`). |
+| `UserDefaults` `ai.osaurus.computeruse.screenContextInjection` | Persisted screen-context opt-in (default `false`), via `ScreenContextSettings`. |
 | `Agent.settings.computerUseEnabled` / `computerUseCeiling` | Per-agent enablement + autonomy ceiling (in the agent JSON). |
 
 ## Testing & evals
@@ -313,6 +358,7 @@ OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test make te
 | Driver | `ComputerUse/Driver/MacDriver.swift`, `NativeMacDriver.swift`, `MockMacDriver.swift`, `Driver/Mac/*` |
 | Target resolution | `ComputerUse/Resolver/TargetResolver.swift` |
 | Perception / vision | `ComputerUse/Perception/CaptureRouter.swift`, `CloudVisionConsent.swift`, `FrameScrubber.swift`, `VisionAttachment.swift` |
+| Screen context (chat) | `ComputerUse/Perception/ScreenContextDistiller.swift`, `ScreenContextSnapshot.swift`, `ScreenContextSettings.swift`, `FrontmostAppTracker.swift`, `Services/Chat/SystemPromptComposer.swift` (`injectScreenContextPrefix`) |
 | Policy / gate | `ComputerUse/Policy/EffectClass.swift`, `EffectClassifier.swift`, `AutonomyPolicy.swift`, `Gate.swift`, `ComputerUseGate.swift`, `ComputerUsePolicyStore.swift` |
 | Recipes | `ComputerUse/Recipes/AppRecipe.swift` |
 | Feed / prompts | `ComputerUse/Feed/ComputerUseFeed.swift`, `ComputerUseFeedRegistry.swift`, `ComputerUsePromptQueue.swift` |


### PR DESCRIPTION
## Summary

Adds an opt-in **Screen context** feature to Computer Use: at the start of each chat session, Osaurus freezes a distilled, text-only snapshot of what the user is doing (working app, focused input/draft, open windows, salient on-screen text) and injects it onto the latest user message as ambient background context.

- **Smart sampling, not a dump** — `ScreenContextDistiller` ranks and budgets the highest-signal bits over any `MacDriver` (so it's unit-testable with `MockMacDriver`). `FrontmostAppTracker` records the user's most-recently-active non-Osaurus app so "what you were doing" survives the chat window stealing focus at send time.
- **Local-first & private** — built entirely from the Accessibility tree (no screenshots). Injected onto the **latest user turn** (same seam as memory, via `SystemPromptComposer.injectScreenContextPrefix`), which keeps the system prefix KV-stable **and** routes the snapshot through the existing Privacy Filter before any cloud send. Local models receive it as-is.
- **Opt-in & frozen** — standalone global toggle (`ScreenContextSettings`, default **off**), independent of the per-agent `computer_use` tool. Captured once on the first send of a session and reused unchanged; cleared on `reset()` / `load()` so a new/loaded chat re-freezes on its next send.
- **Settings UI** — a Screen context card with the opt-in toggle, a live refreshable preview (Accessibility empty-state included), and a privacy note showing how many spans would be masked when the Privacy Filter is on.

## Files

- New: `ScreenContextSnapshot`, `ScreenContextDistiller`, `ScreenContextSettings`, `FrontmostAppTracker` (under `ComputerUse/Perception/`).
- Wiring: `AppDelegate` (start tracker), `SystemPromptComposer` (`injectScreenContextPrefix`), `ChatView` (freeze on first send + inject beside memory), `ComputerUseSettingsView` (settings card).
- Docs: new "Screen context (chat)" section in `docs/COMPUTER_USE.md`.

## Test plan

- [x] `ScreenContextDistillerTests` — working-app selection, Osaurus-exclusion fallback, focused-field/draft extraction, gist line, window list + cap, rendered block, no-Accessibility empty state (7 tests).
- [x] `ScreenContextInjectionTests` — lands on latest user message, no-ops on nil/blank/multimodal, composes with memory prefix (6 tests).
- [x] `ScreenContextSettingsTests` — defaults off, persists across instances (2 tests).
- [x] `swift test --filter ScreenContext` → 15/15 pass; no new lint errors.
- [ ] Manual: enable the toggle, confirm preview reflects the frontmost app, and verify the block appears once per session and is scrubbed on a cloud send when the Privacy Filter is on.
