### PR TITLE
Add Agent Channel Connection Center

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -28,6 +28,13 @@ enum AgentChannelAction: String, Codable, CaseIterable, Sendable {
 struct AgentChannelSecretReference: Codable, Equatable, Sendable {
     var name: String
     var keychainId: String
+
+    var normalized: AgentChannelSecretReference {
+        AgentChannelSecretReference(
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            keychainId: keychainId.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
 }
 
 struct AgentChannelCustomHTTPAction: Codable, Equatable, Sendable {
@@ -77,6 +84,8 @@ struct AgentChannelCustomHTTPConfiguration: Codable, Equatable, Sendable {
 }
 
 struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
+    static let nativeDiscordConnectionId = "discord"
+
     var id: String
     var name: String
     var kind: AgentChannelKind
@@ -114,7 +123,7 @@ struct AgentChannelConnection: Codable, Equatable, Identifiable, Sendable {
         self.writeRoomAllowlist = Self.normalizedIds(writeRoomAllowlist)
         self.writeEnabled = writeEnabled
         self.defaultReadLimit = Self.clampReadLimit(defaultReadLimit)
-        self.secrets = secrets
+        self.secrets = secrets.map(\.normalized)
         self.customHTTP = customHTTP
     }
 

--- a/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ManagementTab.swift
@@ -15,6 +15,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable {
     case providers
     case agents
     case plugins
+    case channels
     case sandbox
     case tools
     case skills
@@ -35,6 +36,10 @@ public enum ManagementTab: String, CaseIterable, Identifiable {
 
     public var id: String { rawValue }
 
+    public static var visibleCases: [ManagementTab] {
+        allCases.filter { $0 != .channels }
+    }
+
     /// Resolves a sidebar tab id, including the legacy `"dashboard"` raw value.
     public static func resolved(from rawValue: String) -> ManagementTab? {
         switch rawValue {
@@ -50,6 +55,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable {
         case .providers: "cloud.fill"
         case .agents: "person.2.fill"
         case .plugins: "puzzlepiece.extension.fill"
+        case .channels: "bubble.left.and.bubble.right.fill"
         case .sandbox: "shippingbox.fill"
         case .tools: "wrench.and.screwdriver.fill"
         case .skills: "sparkles"
@@ -77,6 +83,7 @@ public enum ManagementTab: String, CaseIterable, Identifiable {
         case .providers: L("Providers")
         case .agents: L("Agents")
         case .plugins: L("Plugins")
+        case .channels: L("Channels")
         case .sandbox: L("Sandbox")
         case .tools: L("Tools")
         case .skills: L("Skills")

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -5040,6 +5040,22 @@
         }
       }
     },
+    "Channels" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kanäle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "频道"
+          }
+        }
+      }
+    },
     "Agents execute commands safely" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionManager.swift
@@ -1,0 +1,259 @@
+//
+//  AgentChannelConnectionManager.swift
+//  osaurus
+//
+//  Editable channel configuration support for the management UI.
+//
+
+import Foundation
+
+enum AgentChannelConnectionManagerError: LocalizedError, Equatable, Sendable {
+    case emptyConnectionId
+    case reservedConnectionId(String)
+    case emptyName
+    case missingSupportedActions(String)
+    case missingCustomHTTPConfiguration(String)
+    case invalidCustomHTTPBaseURL(String)
+    case invalidCustomHTTPMethod(action: String, method: String)
+    case invalidCustomHTTPPath(action: String, path: String)
+    case invalidCustomHTTPHeader(action: String, header: String)
+    case unsupportedCustomHTTPAction(String)
+    case invalidSecretReference(String)
+    case duplicateConnectionId(String)
+    case importFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyConnectionId:
+            return "Agent channel connection id is required."
+        case .reservedConnectionId(let id):
+            return "`\(id)` is reserved for the native Discord connection."
+        case .emptyName:
+            return "Agent channel connection name is required."
+        case .missingSupportedActions(let id):
+            return "Agent channel connection `\(id)` must support at least one standard action."
+        case .missingCustomHTTPConfiguration(let id):
+            return "Custom JSON channel `\(id)` requires a custom HTTP configuration."
+        case .invalidCustomHTTPBaseURL(let url):
+            return "`\(url)` is not a valid HTTP or HTTPS base URL."
+        case .invalidCustomHTTPMethod(let action, let method):
+            return "Custom action `\(action)` uses unsupported HTTP method `\(method)`."
+        case .invalidCustomHTTPPath(let action, let path):
+            return "Custom action `\(action)` path `\(path)` must start with `/` and must not contain line breaks."
+        case .invalidCustomHTTPHeader(let action, let header):
+            return "Custom action `\(action)` header `\(header)` must not contain line breaks."
+        case .unsupportedCustomHTTPAction(let action):
+            return "Custom action `\(action)` must be one of the standard Agent Channel actions."
+        case .invalidSecretReference(let name):
+            return "Secret reference `\(name)` must include a non-empty name and Keychain id with no line breaks."
+        case .duplicateConnectionId(let id):
+            return "Agent channel connection id `\(id)` appears more than once."
+        case .importFailed(let message):
+            return "Agent channel configuration import failed: \(message)"
+        }
+    }
+}
+
+final class AgentChannelConnectionManager: @unchecked Sendable {
+    static let shared = AgentChannelConnectionManager()
+
+    private static let reservedConnectionIds = Set([AgentChannelConnection.nativeDiscordConnectionId])
+    private static let supportedHTTPMethods = Set(["GET", "POST", "PUT", "PATCH", "DELETE"])
+
+    func configurationFileURL() -> URL {
+        AgentChannelConfigurationStore.configurationFileURL()
+    }
+
+    func loadConfiguration() -> AgentChannelConfiguration {
+        AgentChannelConfigurationStore.load()
+    }
+
+    func editableConnections() -> [AgentChannelConnection] {
+        loadConfiguration().connections
+            .filter { !Self.reservedConnectionIds.contains($0.id.lowercased()) }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    func connection(id: String) -> AgentChannelConnection? {
+        let normalizedId = AgentChannelConnection.normalizedId(id)
+        return editableConnections().first { $0.id == normalizedId }
+    }
+
+    func upsertConnection(
+        _ connection: AgentChannelConnection,
+        replacingOriginalId originalId: String? = nil
+    ) throws {
+        let validated = try validatedConnection(connection)
+        let normalizedOriginalId = originalId
+            .map(AgentChannelConnection.normalizedId)
+            .flatMap { $0.isEmpty ? nil : $0 }
+        if let normalizedOriginalId,
+           Self.reservedConnectionIds.contains(normalizedOriginalId.lowercased()) {
+            throw AgentChannelConnectionManagerError.reservedConnectionId(normalizedOriginalId)
+        }
+        var configuration = loadConfiguration()
+        if let normalizedOriginalId,
+           normalizedOriginalId != validated.id,
+           configuration.connections.contains(where: { $0.id == validated.id }) {
+            throw AgentChannelConnectionManagerError.duplicateConnectionId(validated.id)
+        }
+        if normalizedOriginalId == nil,
+           configuration.connections.contains(where: { $0.id == validated.id }) {
+            throw AgentChannelConnectionManagerError.duplicateConnectionId(validated.id)
+        }
+        configuration.connections.removeAll { existing in
+            if let normalizedOriginalId {
+                return existing.id == validated.id || existing.id == normalizedOriginalId
+            }
+            return existing.id == validated.id
+        }
+        configuration.connections.append(validated)
+        try AgentChannelConfigurationStore.save(configuration)
+    }
+
+    func deleteConnection(id: String) throws {
+        let normalizedId = AgentChannelConnection.normalizedId(id)
+        guard !Self.reservedConnectionIds.contains(normalizedId.lowercased()) else {
+            throw AgentChannelConnectionManagerError.reservedConnectionId(normalizedId)
+        }
+        var configuration = loadConfiguration()
+        configuration.connections.removeAll { $0.id == normalizedId }
+        try AgentChannelConfigurationStore.save(configuration)
+    }
+
+    func exportConfigurationData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(loadConfiguration().normalized)
+    }
+
+    func importConfigurationData(_ data: Data) throws {
+        do {
+            let decoded = try JSONDecoder().decode(AgentChannelConfiguration.self, from: data)
+            let validated = try validatedConfiguration(decoded)
+            try AgentChannelConfigurationStore.save(validated)
+        } catch let error as AgentChannelConnectionManagerError {
+            throw error
+        } catch {
+            throw AgentChannelConnectionManagerError.importFailed(error.localizedDescription)
+        }
+    }
+
+    private func validatedConfiguration(
+        _ configuration: AgentChannelConfiguration
+    ) throws -> AgentChannelConfiguration {
+        var seen = Set<String>()
+        let validatedConnections = try configuration.connections.map { connection in
+            let normalized = AgentChannelConnection.normalizedId(connection.id)
+            guard seen.insert(normalized).inserted else {
+                throw AgentChannelConnectionManagerError.duplicateConnectionId(normalized)
+            }
+            return try validatedConnection(connection)
+        }
+        return AgentChannelConfiguration(
+            schemaVersion: max(configuration.schemaVersion, 1),
+            connections: validatedConnections
+        )
+    }
+
+    private func validatedConnection(
+        _ connection: AgentChannelConnection
+    ) throws -> AgentChannelConnection {
+        let normalized = connection.normalized
+        guard !normalized.id.isEmpty else {
+            throw AgentChannelConnectionManagerError.emptyConnectionId
+        }
+        guard !Self.reservedConnectionIds.contains(normalized.id.lowercased()) else {
+            throw AgentChannelConnectionManagerError.reservedConnectionId(normalized.id)
+        }
+        guard !normalized.name.isEmpty else {
+            throw AgentChannelConnectionManagerError.emptyName
+        }
+        guard !normalized.supportedActions.isEmpty else {
+            throw AgentChannelConnectionManagerError.missingSupportedActions(normalized.id)
+        }
+        try validateSecretReferences(normalized.secrets)
+        if normalized.kind == .customHTTP {
+            try validateCustomHTTPConfiguration(for: normalized)
+        }
+        return normalized
+    }
+
+    private func validateSecretReferences(
+        _ secrets: [AgentChannelSecretReference]
+    ) throws {
+        var seen = Set<String>()
+        for secret in secrets {
+            let name = secret.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            let keychainId = secret.keychainId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty,
+                  !keychainId.isEmpty,
+                  !name.containsLineBreak,
+                  !keychainId.containsLineBreak,
+                  seen.insert(name).inserted
+            else {
+                throw AgentChannelConnectionManagerError.invalidSecretReference(name)
+            }
+        }
+    }
+
+    private func validateCustomHTTPConfiguration(
+        for connection: AgentChannelConnection
+    ) throws {
+        guard let customHTTP = connection.customHTTP else {
+            throw AgentChannelConnectionManagerError.missingCustomHTTPConfiguration(connection.id)
+        }
+        guard let components = URLComponents(string: customHTTP.baseURL),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              components.host?.isEmpty == false
+        else {
+            throw AgentChannelConnectionManagerError.invalidCustomHTTPBaseURL(customHTTP.baseURL)
+        }
+
+        let supportedActionNames = Set(connection.supportedActions.map(\.rawValue))
+        for (actionName, action) in customHTTP.actions {
+            guard AgentChannelAction(rawValue: actionName) != nil,
+                  supportedActionNames.contains(actionName)
+            else {
+                throw AgentChannelConnectionManagerError.unsupportedCustomHTTPAction(actionName)
+            }
+            guard Self.supportedHTTPMethods.contains(action.method) else {
+                throw AgentChannelConnectionManagerError.invalidCustomHTTPMethod(
+                    action: actionName,
+                    method: action.method
+                )
+            }
+            guard action.path.hasPrefix("/"),
+                  !action.path.containsLineBreak
+            else {
+                throw AgentChannelConnectionManagerError.invalidCustomHTTPPath(
+                    action: actionName,
+                    path: action.path
+                )
+            }
+            try validateHeaderLikeFields(action: actionName, values: action.query)
+            try validateHeaderLikeFields(action: actionName, values: action.headers)
+        }
+    }
+
+    private func validateHeaderLikeFields(
+        action: String,
+        values: [String: String]
+    ) throws {
+        for (key, value) in values where key.containsLineBreak || value.containsLineBreak {
+            throw AgentChannelConnectionManagerError.invalidCustomHTTPHeader(
+                action: action,
+                header: key
+            )
+        }
+    }
+}
+
+private extension String {
+    var containsLineBreak: Bool {
+        rangeOfCharacter(from: .newlines) != nil
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelConnectionService.swift
@@ -33,7 +33,7 @@ enum AgentChannelConnectionServiceError: LocalizedError, Equatable, Sendable {
 final class AgentChannelConnectionService: @unchecked Sendable {
     static let shared = AgentChannelConnectionService(discordService: .shared)
 
-    private static let discordConnectionId = "discord"
+    private static let discordConnectionId = AgentChannelConnection.nativeDiscordConnectionId
     private let discordService: DiscordConnectionService
 
     init(discordService: DiscordConnectionService) {
@@ -43,7 +43,7 @@ final class AgentChannelConnectionService: @unchecked Sendable {
     func listConnections() -> [[String: Any]] {
         var rows = [discordConnectionDictionary()]
         let customRows = AgentChannelConfigurationStore.load().connections
-            .filter { $0.id != Self.discordConnectionId }
+            .filter { $0.id.lowercased() != Self.discordConnectionId }
             .map(connectionDictionary)
         rows.append(contentsOf: customRows)
         return rows

--- a/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Discord/DiscordConnectionTests.swift
@@ -582,6 +582,261 @@ struct DiscordConnectionTests {
         }
     }
 
+    @Test func connectionManagerPersistsValidatedCustomChannel() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let manager = AgentChannelConnectionManager()
+            let connection = AgentChannelConnection(
+                id: " ops-webhook ",
+                name: " Ops Webhook ",
+                kind: .customHTTP,
+                supportedActions: [.diagnostics, .sendMessage, .sendMessage],
+                spaceAllowlist: [" ops ", "ops"],
+                writeRoomAllowlist: ["alerts"],
+                writeEnabled: true,
+                defaultReadLimit: 250,
+                secrets: [
+                    AgentChannelSecretReference(name: " bearer ", keychainId: " ops_webhook_token "),
+                ],
+                customHTTP: AgentChannelCustomHTTPConfiguration(
+                    baseURL: "https://hooks.example.test",
+                    actions: [
+                        "send_message": AgentChannelCustomHTTPAction(
+                            method: "post",
+                            path: "/rooms/{room_id}/messages",
+                            headers: [
+                                "Authorization": "Bearer ${secret:bearer}",
+                            ],
+                            bodyTemplate: #"{"text":"${content}"}"#
+                        ),
+                    ]
+                )
+            )
+
+            try manager.upsertConnection(connection)
+
+            let saved = try #require(manager.connection(id: "ops-webhook"))
+            #expect(saved.name == "Ops Webhook")
+            #expect(saved.supportedActions == [.diagnostics, .sendMessage])
+            #expect(saved.spaceAllowlist == ["ops"])
+            #expect(saved.defaultReadLimit == 100)
+            #expect(saved.secrets == [AgentChannelSecretReference(name: "bearer", keychainId: "ops_webhook_token")])
+            #expect(saved.customHTTP?.actions["send_message"]?.method == "POST")
+
+            let disk = try String(
+                contentsOf: AgentChannelConfigurationStore.configurationFileURL(),
+                encoding: .utf8
+            )
+            #expect(disk.contains("ops_webhook_token"))
+            #expect(!disk.localizedCaseInsensitiveContains("discord-bot-token"))
+        }
+    }
+
+    @Test func connectionManagerRenameRemovesOriginalConnection() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let manager = AgentChannelConnectionManager()
+            try manager.upsertConnection(
+                AgentChannelConnection(
+                    id: "ops-webhook",
+                    name: "Ops Webhook",
+                    kind: .customHTTP,
+                    supportedActions: [.diagnostics],
+                    customHTTP: AgentChannelCustomHTTPConfiguration(
+                        baseURL: "https://hooks.example.test",
+                        actions: [String: AgentChannelCustomHTTPAction]()
+                    )
+                )
+            )
+
+            try manager.upsertConnection(
+                AgentChannelConnection(
+                    id: "incident-webhook",
+                    name: "Incident Webhook",
+                    kind: .customHTTP,
+                    supportedActions: [.diagnostics],
+                    customHTTP: AgentChannelCustomHTTPConfiguration(
+                        baseURL: "https://hooks.example.test",
+                        actions: [String: AgentChannelCustomHTTPAction]()
+                    )
+                ),
+                replacingOriginalId: "ops-webhook"
+            )
+
+            let saved = manager.loadConfiguration().connections
+            #expect(saved.map(\.id) == ["incident-webhook"])
+            #expect(manager.connection(id: "ops-webhook") == nil)
+            #expect(manager.connection(id: "incident-webhook")?.name == "Incident Webhook")
+        }
+    }
+
+    @Test func connectionManagerRejectsDuplicateCreateWithoutRenameContext() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let manager = AgentChannelConnectionManager()
+            let connection = AgentChannelConnection(
+                id: "ops-webhook",
+                name: "Ops Webhook",
+                kind: .customHTTP,
+                supportedActions: [.diagnostics],
+                customHTTP: AgentChannelCustomHTTPConfiguration(
+                    baseURL: "https://hooks.example.test",
+                    actions: [String: AgentChannelCustomHTTPAction]()
+                )
+            )
+
+            try manager.upsertConnection(connection)
+
+            #expect(throws: AgentChannelConnectionManagerError.duplicateConnectionId("ops-webhook")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "ops-webhook",
+                        name: "Replacement",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [String: AgentChannelCustomHTTPAction]()
+                        )
+                    )
+                )
+            }
+
+            #expect(manager.connection(id: "ops-webhook")?.name == "Ops Webhook")
+        }
+    }
+
+    @Test func connectionManagerExportExcludesNativeDiscordCredentials() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let token = "discord-bot-token-super-secret"
+            try DiscordConnectionConfigurationStore.save(
+                DiscordConnectionConfiguration(
+                    configuredGuildIds: ["111111111111111111"],
+                    readableChannelIds: ["222222222222222222"],
+                    writableChannelIds: ["333333333333333333"],
+                    writeEnabled: true
+                )
+            )
+            let manager = AgentChannelConnectionManager()
+            try manager.upsertConnection(
+                AgentChannelConnection(
+                    id: "ops-webhook",
+                    name: "Ops Webhook",
+                    kind: .customHTTP,
+                    supportedActions: [.diagnostics],
+                    secrets: [
+                        AgentChannelSecretReference(name: "bearer", keychainId: "ops_webhook_token"),
+                    ],
+                    customHTTP: AgentChannelCustomHTTPConfiguration(
+                        baseURL: "https://hooks.example.test",
+                        actions: [String: AgentChannelCustomHTTPAction]()
+                    )
+                )
+            )
+
+            let exported = try String(
+                data: manager.exportConfigurationData(),
+                encoding: .utf8
+            )
+            let export = try #require(exported)
+            #expect(export.contains("ops_webhook_token"))
+            #expect(!export.contains(token))
+            #expect(!export.contains(#""name" : "bot_token""#))
+            #expect(!export.contains(#""keychainId" : "bot_token""#))
+            #expect(!export.contains("111111111111111111"))
+            #expect(!export.contains("222222222222222222"))
+        }
+    }
+
+    @Test func connectionManagerRejectsReservedIdsAndUnsafeHTTPFields() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let manager = AgentChannelConnectionManager()
+
+            #expect(throws: AgentChannelConnectionManagerError.reservedConnectionId("discord")) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "discord",
+                        name: "Not Native Discord",
+                        kind: .customHTTP,
+                        supportedActions: [.diagnostics],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [String: AgentChannelCustomHTTPAction]()
+                        )
+                    )
+                )
+            }
+
+            #expect(throws: AgentChannelConnectionManagerError.invalidCustomHTTPHeader(
+                action: "send_message",
+                header: "Authorization"
+            )) {
+                try manager.upsertConnection(
+                    AgentChannelConnection(
+                        id: "unsafe-webhook",
+                        name: "Unsafe Webhook",
+                        kind: .customHTTP,
+                        supportedActions: [.sendMessage],
+                        customHTTP: AgentChannelCustomHTTPConfiguration(
+                            baseURL: "https://hooks.example.test",
+                            actions: [
+                                "send_message": AgentChannelCustomHTTPAction(
+                                    method: "POST",
+                                    path: "/messages",
+                                    headers: [
+                                        "Authorization": "Bearer ok\nInjected: value",
+                                    ]
+                                ),
+                            ]
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    @Test func connectionManagerImportRejectsDuplicateIds() async throws {
+        try await withIsolatedDiscordStores { _ in
+            let manager = AgentChannelConnectionManager()
+            let json = """
+            {
+              "schemaVersion": 1,
+              "connections": [
+                {
+                  "id": "ops-webhook",
+                  "name": "Ops Webhook",
+                  "kind": "custom_http",
+                  "enabled": true,
+                  "supportedActions": ["diagnostics"],
+                  "spaceAllowlist": [],
+                  "readRoomAllowlist": [],
+                  "writeRoomAllowlist": [],
+                  "writeEnabled": false,
+                  "defaultReadLimit": 50,
+                  "secrets": [],
+                  "customHTTP": { "baseURL": "https://hooks.example.test", "actions": {} }
+                },
+                {
+                  "id": "ops-webhook",
+                  "name": "Duplicate",
+                  "kind": "custom_http",
+                  "enabled": true,
+                  "supportedActions": ["diagnostics"],
+                  "spaceAllowlist": [],
+                  "readRoomAllowlist": [],
+                  "writeRoomAllowlist": [],
+                  "writeEnabled": false,
+                  "defaultReadLimit": 50,
+                  "secrets": [],
+                  "customHTTP": { "baseURL": "https://hooks.example.test", "actions": {} }
+                }
+              ]
+            }
+            """
+
+            #expect(throws: AgentChannelConnectionManagerError.duplicateConnectionId("ops-webhook")) {
+                try manager.importConfigurationData(Data(json.utf8))
+            }
+        }
+    }
+
     @Test func findRecentMessagesScansOnlyReadableChannels() async throws {
         try await withIsolatedDiscordStores { credentials in
             let fake = FakeDiscordAPIClient()

--- a/Packages/OsaurusCore/Views/Management/ManagementView.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagementView.swift
@@ -142,7 +142,8 @@ private extension ManagementView {
         Binding(
             get: { stateManager.selectedTab.rawValue },
             set: { newValue in
-                if let tab = ManagementTab.resolved(from: newValue) {
+                if let tab = ManagementTab.resolved(from: newValue),
+                   ManagementTab.visibleCases.contains(tab) {
                     stateManager.selectedTab = tab
                 }
             }
@@ -166,6 +167,8 @@ private extension ManagementView {
             AgentsView(deeplinkAgentId: deeplinkAgentId)
         case .plugins:
             PluginsView()
+        case .channels:
+            AgentsView(deeplinkAgentId: deeplinkAgentId)
         case .sandbox:
             SandboxView()
         case .tools:
@@ -211,7 +214,7 @@ private extension ManagementView {
 private extension ManagementView {
 
     var sidebarItems: [SidebarItemData] {
-        ManagementTab.allCases.map { tab in
+        ManagementTab.visibleCases.map { tab in
             tab.sidebarItem(
                 badge: badgeCount(for: tab),
                 badgeHighlight: badgeHighlight(for: tab)
@@ -234,6 +237,10 @@ private extension ManagementView {
 private extension ManagementView {
 
     func handleAppear() {
+        if !ManagementTab.visibleCases.contains(stateManager.selectedTab) {
+            stateManager.selectedTab = .agents
+        }
+
         // Delay fade-in to prevent initial layout jank
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             withAnimation(.easeOut(duration: 0.2)) {
@@ -244,6 +251,11 @@ private extension ManagementView {
     }
 
     func handleTabChange(to newTab: ManagementTab) {
+        guard ManagementTab.visibleCases.contains(newTab) else {
+            stateManager.selectedTab = .agents
+            return
+        }
+
         // Leave a trail of which screen was on-screen so a layout-engine app
         // hang (no first-party frame in the stack) can be localized to a tab.
         CrashReportingService.recordBreadcrumb(

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
@@ -1,0 +1,815 @@
+//
+//  AgentChannelConnectionCenterView.swift
+//  osaurus
+//
+//  Management UI for provider-neutral agent communication channels.
+//
+
+import SwiftUI
+
+#if os(macOS)
+    import AppKit
+#endif
+
+struct AgentChannelConnectionCenterView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    @State private var connections: [AgentChannelConnection] = []
+    @State private var selectedConnectionId: String?
+    @State private var draft = AgentChannelConnectionDraft()
+    @State private var statusMessage: String?
+    @State private var statusIsError = false
+    @State private var diagnosticsText: String?
+    @State private var isDiagnosing = false
+
+    private let manager = AgentChannelConnectionManager.shared
+    private let service = AgentChannelConnectionService.shared
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                header
+                overview
+                DiscordSettingsView()
+                channelEditorSection
+            }
+            .padding(24)
+        }
+        .background(theme.primaryBackground)
+        .onAppear(perform: reloadConnections)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: "bubble.left.and.bubble.right.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                Text("Agent Channels", bundle: .module)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+            }
+
+            Text(
+                "Configure communication channels agents can inspect or write to through one standard action surface.",
+                bundle: .module
+            )
+            .font(.system(size: 13))
+            .foregroundColor(theme.secondaryText)
+        }
+    }
+
+    private var overview: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                ChannelMetricCard(
+                    title: "Configured",
+                    value: "\(connections.count + 1)",
+                    caption: "including Discord",
+                    icon: "link"
+                )
+                ChannelMetricCard(
+                    title: "Enabled",
+                    value: "\(connections.filter(\.enabled).count + 1)",
+                    caption: "available to diagnose",
+                    icon: "checkmark.seal.fill"
+                )
+                ChannelMetricCard(
+                    title: "JSON Channels",
+                    value: "\(connections.count)",
+                    caption: "from agent-channels.json",
+                    icon: "curlybraces"
+                )
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Config", bundle: .module)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                Text(manager.configurationFileURL().path)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+                Spacer()
+                Button(action: revealConfiguration) {
+                    Label {
+                        Text("Reveal", bundle: .module)
+                    } icon: {
+                        Image(systemName: "folder")
+                    }
+                }
+                .buttonStyle(SettingsButtonStyle())
+            }
+        }
+    }
+
+    private var channelEditorSection: some View {
+        SettingsSubsection(label: "JSON Channel Connections") {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 16) {
+                    connectionList
+                        .frame(width: 300)
+                    editor
+                }
+
+                if let statusMessage {
+                    StatusMessageView(message: statusMessage, isError: statusIsError)
+                }
+            }
+        }
+    }
+
+    private var connectionList: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Button(action: newCustomHTTPConnection) {
+                    Label {
+                        Text("New Custom", bundle: .module)
+                    } icon: {
+                        Image(systemName: "plus")
+                    }
+                }
+                .buttonStyle(SettingsButtonStyle(isPrimary: true))
+
+                Button(action: reloadConnections) {
+                    Label {
+                        Text("Reload", bundle: .module)
+                    } icon: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                .buttonStyle(SettingsButtonStyle())
+            }
+
+            if connections.isEmpty {
+                Text(
+                    "No JSON-backed channels yet. Add a custom HTTP, Slack, or Telegram connection definition to prepare agent communication without storing secrets in the file.",
+                    bundle: .module
+                )
+                .font(.system(size: 12))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(cardBackground)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(connections) { connection in
+                        Button {
+                            select(connection)
+                        } label: {
+                            ChannelConnectionRow(
+                                connection: connection,
+                                isSelected: connection.id == selectedConnectionId
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    private var editor: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                Text(draft.isNew ? "New Connection" : "Edit Connection", bundle: .module)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
+                ServerSettingsStatusBadge(status: draft.kind == .customHTTP ? .partial : .future)
+                Spacer()
+            }
+
+            SettingsToggle(
+                title: "Enabled",
+                description: "Allow this channel definition to be resolved by agent channel diagnostics and tools.",
+                isOn: $draft.enabled
+            )
+
+            HStack(alignment: .top, spacing: 12) {
+                StyledSettingsTextField(
+                    label: "Connection ID",
+                    text: $draft.id,
+                    placeholder: "ops-webhook",
+                    help: "Stable id used by agent_channel tools. The native Discord id is reserved."
+                )
+                StyledSettingsTextField(
+                    label: "Display Name",
+                    text: $draft.name,
+                    placeholder: "Ops Webhook",
+                    help: "Human-readable name shown in the channel list."
+                )
+            }
+
+            kindPicker
+            actionPicker
+
+            HStack(alignment: .top, spacing: 12) {
+                multilineField(
+                    title: "Space Allowlist",
+                    text: $draft.spaceAllowlistText,
+                    help: "Workspace, server, or team ids this connection may inspect."
+                )
+                multilineField(
+                    title: "Read Room Allowlist",
+                    text: $draft.readRoomAllowlistText,
+                    help: "Channel or room ids agents may read or search."
+                )
+                multilineField(
+                    title: "Write Room Allowlist",
+                    text: $draft.writeRoomAllowlistText,
+                    help: "Channel or room ids agents may write to when writes are enabled."
+                )
+            }
+
+            SettingsToggle(
+                title: "Enable Writes",
+                description: "Permit send and reply actions only for write-allowlisted rooms. Tool calls still require confirmation.",
+                isOn: $draft.writeEnabled
+            )
+
+            HStack(alignment: .top, spacing: 12) {
+                StyledSettingsTextField(
+                    label: "Default Read Limit",
+                    text: $draft.defaultReadLimit,
+                    placeholder: "50",
+                    help: "Default recent-message count. Clamped to 1-100."
+                )
+                multilineField(
+                    title: "Secret References",
+                    text: $draft.secretReferencesText,
+                    help: "One per line: name=keychain-id. Raw tokens are not stored in this JSON file."
+                )
+            }
+
+            if draft.kind == .customHTTP {
+                customHTTPSection
+            }
+
+            actionBar
+
+            if let diagnosticsText {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Diagnostics", bundle: .module)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    ScrollView {
+                        Text(diagnosticsText)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.secondaryText)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                    }
+                    .frame(minHeight: 110, maxHeight: 180)
+                    .background(cardBackground)
+                }
+            }
+        }
+        .padding(14)
+        .background(cardBackground)
+    }
+
+    private var kindPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Kind", bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.primaryText)
+            Picker("", selection: $draft.kind) {
+                Text("Custom HTTP", bundle: .module).tag(AgentChannelKind.customHTTP)
+                Text("Slack", bundle: .module).tag(AgentChannelKind.slack)
+                Text("Telegram", bundle: .module).tag(AgentChannelKind.telegram)
+            }
+            .pickerStyle(.segmented)
+            Text(
+                "Slack and Telegram definitions can be prepared now; native execution lands in their adapter PRs.",
+                bundle: .module
+            )
+            .font(.system(size: 11))
+            .foregroundColor(theme.tertiaryText)
+        }
+    }
+
+    private var actionPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Standard Actions", bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.primaryText)
+
+            LazyVGrid(
+                columns: [
+                    GridItem(.adaptive(minimum: 150), spacing: 8),
+                ],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                ForEach(AgentChannelAction.allCases, id: \.self) { action in
+                    Toggle(
+                        action.displayName,
+                        isOn: Binding(
+                            get: { draft.supportedActions.contains(action) },
+                            set: { enabled in
+                                if enabled {
+                                    draft.supportedActions.insert(action)
+                                } else {
+                                    draft.supportedActions.remove(action)
+                                }
+                            }
+                        )
+                    )
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
+                }
+            }
+            .padding(10)
+            .background(cardBackground)
+        }
+    }
+
+    private var customHTTPSection: some View {
+        SettingsSubsection(label: "Custom HTTP") {
+            VStack(alignment: .leading, spacing: 12) {
+                StyledSettingsTextField(
+                    label: "Base URL",
+                    text: $draft.customBaseURL,
+                    placeholder: "https://hooks.example.test",
+                    help: "HTTP or HTTPS origin for this configured channel. Execution remains disabled until the security-reviewed runner lands."
+                )
+                multilineField(
+                    title: "Action Map JSON",
+                    text: $draft.customActionsJSON,
+                    help: "JSON object keyed by standard action names. Values define method, path, optional query, headers, and bodyTemplate."
+                )
+            }
+        }
+    }
+
+    private var actionBar: some View {
+        HStack(spacing: 10) {
+            Button(action: saveDraft) {
+                Label {
+                    Text("Save Connection", bundle: .module)
+                } icon: {
+                    Image(systemName: "checkmark")
+                }
+            }
+            .buttonStyle(SettingsButtonStyle(isPrimary: true))
+
+            Button(action: diagnoseSelected) {
+                Label {
+                    Text(isDiagnosing ? "Diagnosing..." : "Run Diagnostics", bundle: .module)
+                } icon: {
+                    Image(systemName: "stethoscope")
+                }
+            }
+            .buttonStyle(SettingsButtonStyle())
+            .disabled(isDiagnosing || draft.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+            Button(action: deleteSelected) {
+                Label {
+                    Text("Delete", bundle: .module)
+                } icon: {
+                    Image(systemName: "trash")
+                }
+            }
+            .buttonStyle(SettingsButtonStyle(isDestructive: true))
+            .disabled(draft.isNew)
+
+            Spacer()
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(theme.cardBackground)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(theme.cardBorder, lineWidth: 1)
+            )
+    }
+
+    private func multilineField(
+        title: String,
+        text: Binding<String>,
+        help: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(LocalizedStringKey(title), bundle: .module)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.primaryText)
+            TextEditor(text: text)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(theme.primaryText)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 76)
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+            Text(LocalizedStringKey(help), bundle: .module)
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func reloadConnections() {
+        connections = manager.editableConnections()
+        if let selectedConnectionId,
+           let selected = connections.first(where: { $0.id == selectedConnectionId }) {
+            draft = AgentChannelConnectionDraft(connection: selected)
+        } else if let first = connections.first {
+            select(first)
+        } else {
+            newCustomHTTPConnection()
+        }
+    }
+
+    private func select(_ connection: AgentChannelConnection) {
+        selectedConnectionId = connection.id
+        draft = AgentChannelConnectionDraft(connection: connection)
+        diagnosticsText = nil
+    }
+
+    private func newCustomHTTPConnection() {
+        selectedConnectionId = nil
+        draft = AgentChannelConnectionDraft()
+        diagnosticsText = nil
+    }
+
+    private func saveDraft() {
+        do {
+            let connection = try draft.connection()
+            try manager.upsertConnection(connection, replacingOriginalId: draft.originalId)
+            selectedConnectionId = connection.id
+            reloadConnections()
+            showStatus("Agent channel connection saved", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func deleteSelected() {
+        do {
+            try manager.deleteConnection(id: draft.id)
+            selectedConnectionId = nil
+            reloadConnections()
+            showStatus("Agent channel connection deleted", isError: false)
+        } catch {
+            showStatus(error.localizedDescription, isError: true)
+        }
+    }
+
+    private func diagnoseSelected() {
+        let connectionId = draft.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !connectionId.isEmpty else { return }
+        guard let originalId = draft.originalId,
+              AgentChannelConnection.normalizedId(connectionId) == originalId
+        else {
+            showStatus("Save the channel connection before running diagnostics", isError: true)
+            return
+        }
+        isDiagnosing = true
+        Task {
+            let diagnostics = await service.diagnostics(connectionId: connectionId)
+            let rendered = Self.prettyJSON(diagnostics)
+            await MainActor.run {
+                diagnosticsText = rendered
+                isDiagnosing = false
+                if diagnostics["failure"] is String {
+                    showStatus("Agent channel diagnostics reported a failure", isError: true)
+                } else {
+                    showStatus("Agent channel diagnostics complete", isError: false)
+                }
+            }
+        }
+    }
+
+    private func revealConfiguration() {
+        #if os(macOS)
+            NSWorkspace.shared.activateFileViewerSelecting([manager.configurationFileURL()])
+        #endif
+    }
+
+    private func showStatus(_ message: String, isError: Bool) {
+        statusMessage = message
+        statusIsError = isError
+    }
+
+    private static func prettyJSON(_ payload: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(
+                  withJSONObject: payload,
+                  options: [.prettyPrinted, .sortedKeys]
+              ),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return String(describing: payload)
+        }
+        return string
+    }
+}
+
+private struct ChannelMetricCard: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let title: String
+    let value: String
+    let caption: String
+    let icon: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(themeManager.currentTheme.accentColor)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(LocalizedStringKey(title), bundle: .module)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(themeManager.currentTheme.tertiaryText)
+                Text(value)
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundColor(themeManager.currentTheme.primaryText)
+                Text(LocalizedStringKey(caption), bundle: .module)
+                    .font(.system(size: 10))
+                    .foregroundColor(themeManager.currentTheme.tertiaryText)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(themeManager.currentTheme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(themeManager.currentTheme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct ChannelConnectionRow: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let connection: AgentChannelConnection
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: connection.kind.icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(themeManager.currentTheme.accentColor)
+                    .frame(width: 22, height: 22)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(connection.name)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(themeManager.currentTheme.primaryText)
+                        .lineLimit(1)
+                    Text(connection.id)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(themeManager.currentTheme.tertiaryText)
+                        .lineLimit(1)
+                }
+                Spacer()
+                ServerSettingsStatusBadge(status: connection.enabled ? .engineReady : .future)
+            }
+
+            HStack(spacing: 6) {
+                Text(connection.kind.displayName)
+                Text("\(connection.supportedActions.count) actions")
+                if connection.writeEnabled {
+                    Text("writes on")
+                }
+            }
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(themeManager.currentTheme.secondaryText)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(
+                    isSelected
+                        ? themeManager.currentTheme.accentColor.opacity(0.12)
+                        : themeManager.currentTheme.cardBackground
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(
+                            isSelected
+                                ? themeManager.currentTheme.accentColor.opacity(0.45)
+                                : themeManager.currentTheme.cardBorder,
+                            lineWidth: 1
+                        )
+                )
+        )
+    }
+}
+
+private struct StatusMessageView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let message: String
+    let isError: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: isError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+            Text(message)
+                .font(.system(size: 12))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .foregroundColor(isError ? themeManager.currentTheme.warningColor : themeManager.currentTheme.successColor)
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill((isError ? themeManager.currentTheme.warningColor : themeManager.currentTheme.successColor).opacity(0.08))
+        )
+    }
+}
+
+private struct AgentChannelConnectionDraft {
+    var originalId: String?
+    var id = "ops-webhook"
+    var name = "Ops Webhook"
+    var kind: AgentChannelKind = .customHTTP
+    var enabled = true
+    var supportedActions: Set<AgentChannelAction> = [.diagnostics, .sendMessage]
+    var spaceAllowlistText = ""
+    var readRoomAllowlistText = ""
+    var writeRoomAllowlistText = "alerts"
+    var writeEnabled = false
+    var defaultReadLimit = "50"
+    var secretReferencesText = "bearer=ops_webhook_token"
+    var customBaseURL = "https://hooks.example.test"
+    var customActionsJSON = Self.defaultActionsJSON
+
+    var isNew: Bool { originalId == nil }
+
+    init() {}
+
+    init(connection: AgentChannelConnection) {
+        originalId = connection.id
+        id = connection.id
+        name = connection.name
+        kind = connection.kind
+        enabled = connection.enabled
+        supportedActions = Set(connection.supportedActions)
+        spaceAllowlistText = connection.spaceAllowlist.joined(separator: "\n")
+        readRoomAllowlistText = connection.readRoomAllowlist.joined(separator: "\n")
+        writeRoomAllowlistText = connection.writeRoomAllowlist.joined(separator: "\n")
+        writeEnabled = connection.writeEnabled
+        defaultReadLimit = "\(connection.defaultReadLimit)"
+        secretReferencesText = connection.secrets
+            .map { "\($0.name)=\($0.keychainId)" }
+            .joined(separator: "\n")
+        customBaseURL = connection.customHTTP?.baseURL ?? ""
+        customActionsJSON = Self.prettyActionsJSON(connection.customHTTP?.actions ?? [:])
+    }
+
+    func connection() throws -> AgentChannelConnection {
+        let customHTTP: AgentChannelCustomHTTPConfiguration?
+        if kind == .customHTTP {
+            customHTTP = AgentChannelCustomHTTPConfiguration(
+                baseURL: customBaseURL.trimmingCharacters(in: .whitespacesAndNewlines),
+                actions: try Self.parseCustomActionsJSON(customActionsJSON)
+            )
+        } else {
+            customHTTP = nil
+        }
+
+        return AgentChannelConnection(
+            id: id,
+            name: name,
+            kind: kind,
+            enabled: enabled,
+            supportedActions: Array(supportedActions).sorted { $0.rawValue < $1.rawValue },
+            spaceAllowlist: Self.parseList(spaceAllowlistText),
+            readRoomAllowlist: Self.parseList(readRoomAllowlistText),
+            writeRoomAllowlist: Self.parseList(writeRoomAllowlistText),
+            writeEnabled: writeEnabled,
+            defaultReadLimit: Int(defaultReadLimit) ?? 50,
+            secrets: Self.parseSecretReferences(secretReferencesText),
+            customHTTP: customHTTP
+        )
+    }
+
+    private static let defaultActionsJSON = """
+    {
+      "send_message" : {
+        "bodyTemplate" : "{\\"text\\":\\"${content}\\"}",
+        "headers" : {
+          "Authorization" : "Bearer ${secret:bearer}",
+          "Content-Type" : "application/json"
+        },
+        "method" : "POST",
+        "path" : "/rooms/{room_id}/messages",
+        "query" : {
+
+        }
+      }
+    }
+    """
+
+    private static func parseList(_ text: String) -> [String] {
+        text.components(separatedBy: CharacterSet(charactersIn: ", \n\t"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func parseSecretReferences(_ text: String) -> [AgentChannelSecretReference] {
+        text.components(separatedBy: .newlines).compactMap { line in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let parts = trimmed.split(separator: "=", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else {
+                return AgentChannelSecretReference(name: trimmed, keychainId: "")
+            }
+            return AgentChannelSecretReference(
+                name: parts[0].trimmingCharacters(in: .whitespacesAndNewlines),
+                keychainId: parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }
+    }
+
+    private static func parseCustomActionsJSON(
+        _ text: String
+    ) throws -> [String: AgentChannelCustomHTTPAction] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [:] }
+        return try JSONDecoder().decode(
+            [String: AgentChannelCustomHTTPAction].self,
+            from: Data(trimmed.utf8)
+        )
+    }
+
+    private static func prettyActionsJSON(
+        _ actions: [String: AgentChannelCustomHTTPAction]
+    ) -> String {
+        guard !actions.isEmpty,
+              let data = try? JSONEncoder.prettyAgentChannelEncoder.encode(actions),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return defaultActionsJSON
+        }
+        return string
+    }
+}
+
+private extension JSONEncoder {
+    static var prettyAgentChannelEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}
+
+private extension AgentChannelKind {
+    var displayName: String {
+        switch self {
+        case .discord: "Discord"
+        case .slack: "Slack"
+        case .telegram: "Telegram"
+        case .customHTTP: "Custom HTTP"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .discord: "bubble.left.and.bubble.right.fill"
+        case .slack: "number"
+        case .telegram: "paperplane.fill"
+        case .customHTTP: "curlybraces"
+        }
+    }
+}
+
+private extension AgentChannelAction {
+    var displayName: String {
+        switch self {
+        case .diagnostics: "Diagnostics"
+        case .listSpaces: "List spaces"
+        case .listRooms: "List rooms"
+        case .readMessages: "Read messages"
+        case .searchMessages: "Search messages"
+        case .draftMessage: "Draft message"
+        case .sendMessage: "Send message"
+        case .replyThread: "Reply thread"
+        }
+    }
+}

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -24,6 +24,12 @@ provider API. Discord is the first executable adapter.
 Non-secret channel definitions live in `agent-channels.json`. Secrets should be
 stored separately in Keychain and referenced by name.
 
+The connection center implementation can create, edit, delete, export, import,
+and diagnose JSON-backed channel definitions, but the management entry remains
+hidden while Agent Channels are still WIP. This keeps unfinished Discord/channel
+settings out of the normal app surface while preserving the reviewable
+configuration foundation.
+
 ```json
 {
   "schemaVersion": 1,
@@ -64,6 +70,17 @@ Custom HTTP execution is intentionally not enabled until the request templating,
 credential substitution, response mapping, and security review are implemented.
 Until then, JSON custom channels can be loaded and diagnosed, while executable
 actions are provided by native adapters such as Discord.
+
+## Connection Center Validation
+
+The connection center validates channel definitions before saving:
+
+- `discord` is reserved for the native Discord adapter.
+- Custom HTTP connections require an HTTP or HTTPS base URL.
+- Custom action names must match supported standard actions.
+- HTTP action paths must start with `/`.
+- Header/query fields and secret references reject line breaks.
+- Secret references store only `name=keychain-id` pointers, not raw credentials.
 
 ## Discord Connection
 


### PR DESCRIPTION
## Summary
- Adds a hidden Agent Channel Connection Center implementation for JSON-backed channel definitions while keeping the WIP UI out of normal app navigation.
- Builds on the merged native Discord Agent Channel foundation and preserves its SQLite message-store diagnostics and tests.
- Adds editable custom-channel configuration support with validation for reserved ids, duplicate creates/imports, HTTP/S base URLs, action maps, header/query line breaks, and secret-reference-only credential storage.

## Behavior Notes
- The Channels management entry is intentionally filtered out of the sidebar until the channel UI is ready for users.
- Saved or deep-linked `channels` selections are redirected to Agents so unfinished channel settings are not visible by accident.
- Custom HTTP channels can be configured, exported/imported, and diagnosed, but execution remains disabled until the reviewed runner/templating/security boundary is implemented.
- Slack and Telegram definitions can be prepared as configuration, with native execution left to adapter PRs.
- No model behavior, prompt format, or agent-loop execution semantics are changed here.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-pr1616-rebase swift test --package-path Packages/OsaurusCore --filter 'DiscordConnectionTests|AgentChannel'` passed: 28 tests
- `git diff --check`
- `git diff --cached --check`
- `swiftlint lint` on touched Swift files: 0 violations
- `bash scripts/i18n/check.sh` passed; existing stale-key warning remains
- Second-opinion review: no blocking issues; duplicate-create guard added from review feedback
