### PR TITLE
Repin vmlx-swift: L2 disk-cache orphan-row + solo seed-boundary fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
+        "revision" : "21274aba047046f0b2586315cacfaf2e1d27c572"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,7 +356,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "21274aba047046f0b2586315cacfaf2e1d27c572"
+        "revision" : "1b7d3ef14e213f09f855667d031535222267eb98"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
+            revision: "1b7d3ef14e213f09f855667d031535222267eb98"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -622,7 +622,7 @@ struct RuntimePolicySourceTests {
         // plus the Gemma nested-object tool-call argument parse fix
         // (vmlx-swift#76): GemmaFunctionParser now recurses into `{...}` values
         // so object-typed tool parameters arrive as objects, not raw strings.
-        let expectedRuntimeHardenedRevision = "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
+        let expectedRuntimeHardenedRevision = "1b7d3ef14e213f09f855667d031535222267eb98"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "21274aba047046f0b2586315cacfaf2e1d27c572"
+        "revision" : "1b7d3ef14e213f09f855667d031535222267eb98"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
+        "revision" : "21274aba047046f0b2586315cacfaf2e1d27c572"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to pick up **osaurus-ai/vmlx-swift#79** (two live-verified cache-correctness fixes). No osaurus code changes.

## What #79 fixes
- **DiskCache orphan rows:** corrupt-file fetch deleted the file but kept the `cache_entries` row, so its `file_size` permanently inflated the `SUM(file_size)` eviction quota → unbounded on-disk growth + premature eviction of live entries. Now deletes the row too.
- **Solo seed-boundary leak:** the required-tool disk-backed seed-boundary suppression ran only on the batched path; the solo `TokenIterator` path (default for single-user serving) still persisted the `promptLen-1` seed entry. Now gated on both paths.

## No osaurus changes needed (verified live)
- TurboQuant KV already defaults **off** (`shouldUseTurboQuantByDefault == false`; engine-selected → fp16).
- Model **detection** (49 models incl. both AppleScript flagships), **loading** (incl. switch/eviction), **cache** (accounting delta 0, warm reuse), and **multiturn** (coherent + cross-turn recall) all live-verified unaffected on the patched build.

## Merge order
Depends on #79. Bump the pin to #79's merge commit before merging this.