### PR TITLE
Repin vmlx-swift -> 643fde27: Kanana-2-30B-A3B (deepseek_v3) support

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "643fde27d5ed7b921a00d1620869e98e79581fa2"
+        "revision" : "4453909ef453f9235fd7e65986ca3ffc62ff904d"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5f6d5b571e5f778f5ad97b0dbfe56d0084d8ae5b929fd43242ec494e237f9ab0",
+  "originHash" : "37a68bc2d053f8cdc70a07660d92f54aadb0c2f504cea16d72f073edaeac05c2",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "b51e53c3b04372c1ed1906b0ec3ba45733953ef4",
         "version" : "9.5.0"
+      }
+    },
+    {
+      "identity" : "aptabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aptabase/aptabase-swift.git",
+      "state" : {
+        "revision" : "cfd67fac2a228d448d9d2ac92ffc71589cc3ef00",
+        "version" : "0.3.11"
       }
     },
     {
@@ -89,6 +98,15 @@
       "state" : {
         "revision" : "766c72235ba795717f57ce5c6b755768a9420dd7",
         "version" : "2.5.2"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
       }
     },
     {
@@ -356,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1b7d3ef14e213f09f855667d031535222267eb98"
+        "revision" : "643fde27d5ed7b921a00d1620869e98e79581fa2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "643fde27d5ed7b921a00d1620869e98e79581fa2"
+        "revision" : "4453909ef453f9235fd7e65986ca3ffc62ff904d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d35c0744a4dec6b9a450ed0b2d02ec2010fd5537"
+        "revision" : "643fde27d5ed7b921a00d1620869e98e79581fa2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1b7d3ef14e213f09f855667d031535222267eb98"
+            revision: "643fde27d5ed7b921a00d1620869e98e79581fa2"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         // live model, cache, parser, API, and UI evidence.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "643fde27d5ed7b921a00d1620869e98e79581fa2"
+            revision: "4453909ef453f9235fd7e65986ca3ffc62ff904d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -622,7 +622,7 @@ struct RuntimePolicySourceTests {
         // plus the Gemma nested-object tool-call argument parse fix
         // (vmlx-swift#76): GemmaFunctionParser now recurses into `{...}` values
         // so object-typed tool parameters arrive as objects, not raw strings.
-        let expectedRuntimeHardenedRevision = "643fde27d5ed7b921a00d1620869e98e79581fa2"
+        let expectedRuntimeHardenedRevision = "4453909ef453f9235fd7e65986ca3ffc62ff904d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -622,7 +622,7 @@ struct RuntimePolicySourceTests {
         // plus the Gemma nested-object tool-call argument parse fix
         // (vmlx-swift#76): GemmaFunctionParser now recurses into `{...}` values
         // so object-typed tool parameters arrive as objects, not raw strings.
-        let expectedRuntimeHardenedRevision = "1b7d3ef14e213f09f855667d031535222267eb98"
+        let expectedRuntimeHardenedRevision = "643fde27d5ed7b921a00d1620869e98e79581fa2"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
         let appRevision = try Self.vmlxPinRevision(in: appResolved)


### PR DESCRIPTION
Repins vmlx-swift to [osaurus-ai/vmlx-swift#80](https://github.com/osaurus-ai/vmlx-swift/pull/80) (`643fde27`) to enable **Kanana-2-30B-A3B-Instruct-JANG_4M** (deepseek_v3 arch — MLA + 128-expert MoE, text-only).

## What vmlx #80 fixes
1. `DeepseekV3Configuration.qLoraRank` optional — deepseek_v3 bundles with `q_lora_rank: null` (direct `q_proj`) load instead of throwing "Missing value at 'q_lora_rank'".
2. `XMLFunctionParser` JSON-form fallback — Kanana's chat template emits the qwen JSON tool-call form `<tool_call>{"name":...,"arguments":...}</tool_call>`; previously dropped (XML-only parser).

## Live proof (this build, default settings)
Built osaurus.app against `643fde27`, ran the model through the HTTP API:
- Recognition: `/v1/models` lists `kanana-2-30b-a3b-instruct-jang_4m`.
- Load + coherence: `17+28` -> `45`; coherent Korean self-intro.
- Multiturn: recall ("Teal. I remember.") + topic switch correct.
- Tool-call round-trip (temp 0): `tool_calls:[get_weather({"location":"Paris"})]` finish=`tool_calls`; fed result -> coherent final answer.
- Reasoning: model reasons in content (Kanana template has no `<think>`/enable_thinking — model property).
- KV mode: default native fp16 (`shouldUseTurboQuantByDefault`=false); TurboQuant only on explicit `liveKVCodec=turboQuant`.
- SSD prefix cache: L1 in-memory live; L2 disk restore proven at engine level (8.4x prompt-eval speedup).

Note: the model bundle also needed a converter-side fix (its `lm_head` was quantized to all-zeros, producing word-salad) — repacked locally; a jang_tools converter fix is a separate follow-up. Engine + serving are correct.

Repins all 4 refs (Package.swift manifest, both Package.resolved, RuntimePolicySource test). Merge after vmlx #80 lands on main; pin can be fast-forwarded to the main SHA.