### PR TITLE
Harden Computer Use privacy, autonomy gate, and consent UX

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Feed/ComputerUsePromptQueue.swift
+++ b/Packages/OsaurusCore/ComputerUse/Feed/ComputerUsePromptQueue.swift
@@ -26,26 +26,76 @@ public struct ConfirmRequest: Identifiable, Sendable, Equatable {
     }
 }
 
-/// MainActor-confined queue of pending confirmations. SwiftUI observes
-/// `pending` and renders the overlay; `requestConfirmation` is the async
-/// seam the loop's confirm closure calls.
+/// The user's answer to a just-in-time cloud-vision consent prompt.
+public enum CloudVisionConsentChoice: String, Sendable, Equatable {
+    /// Allow for this run only (session grant).
+    case allowOnce
+    /// Allow and remember (persistent grant).
+    case allowAlways
+    /// Don't allow; stay on-device for the rest of the run.
+    case deny
+}
+
+/// One pending cloud-vision consent prompt, surfaced when a run would benefit
+/// from a screenshot but the user hasn't granted cloud-vision consent yet.
+public struct CloudVisionConsentRequest: Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let toolCallId: String
+
+    public init(id: UUID = UUID(), toolCallId: String) {
+        self.id = id
+        self.toolCallId = toolCallId
+    }
+}
+
+/// MainActor-confined queue of pending prompts. SwiftUI observes `pending` /
+/// `pendingConsent` and renders the overlay; `requestConfirmation` and
+/// `requestCloudVisionConsent` are the async seams the loop awaits.
 @MainActor
 public final class ComputerUsePromptQueue: ObservableObject {
     public static let shared = ComputerUsePromptQueue()
 
     @Published public private(set) var pending: [ConfirmRequest] = []
+    @Published public private(set) var pendingConsent: [CloudVisionConsentRequest] = []
 
     private var continuations: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var consentContinuations: [UUID: CheckedContinuation<CloudVisionConsentChoice, Never>] =
+        [:]
+    /// Per-run "approve remaining" thresholds: `toolCallId → normalized app →
+    /// highest effect auto-approved`. An action confirms automatically when its
+    /// effect is `<=` the recorded ceiling for its app. Cleared on teardown.
+    private var autoApprove: [String: [String: EffectClass]] = [:]
 
     private init() {}
 
-    /// Park a confirmation and suspend until the user (or a teardown)
-    /// resolves it. Returns whether the action was approved.
+    // MARK: - Confirmation
+
+    /// Park a confirmation and suspend until the user (or a teardown) resolves
+    /// it. Returns whether the action was approved. Auto-approves without a
+    /// prompt when the user previously chose "approve remaining" for this app at
+    /// this effect or higher. Cancellation-aware: if the run's Task is cancelled
+    /// while suspended, the call resolves as denied so the loop never hangs.
     public func requestConfirmation(_ preview: ActionPreview, toolCallId: String) async -> Bool {
+        if let app = preview.appName, !app.isEmpty,
+            let ceiling = autoApprove[toolCallId]?[AutonomyPolicy.normalize(app)],
+            preview.effect <= ceiling
+        {
+            return true
+        }
         let request = ConfirmRequest(toolCallId: toolCallId, preview: preview)
-        return await withCheckedContinuation { continuation in
-            continuations[request.id] = continuation
-            pending.append(request)
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                    return
+                }
+                continuations[request.id] = continuation
+                pending.append(request)
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.resolve(id: request.id, approved: false)
+            }
         }
     }
 
@@ -56,12 +106,70 @@ public final class ComputerUsePromptQueue: ObservableObject {
         continuation.resume(returning: approved)
     }
 
-    /// Deny + clear every pending request for a run (interrupt / teardown).
+    /// Approve a request AND auto-approve subsequent same-or-lower-effect actions
+    /// in the same app for the rest of this run. A no-op for a request whose
+    /// preview has no app (nothing safe to scope the blanket approval to).
+    public func resolveApprovingRest(id: UUID) {
+        guard let request = pending.first(where: { $0.id == id }) else { return }
+        if let app = request.preview.appName, !app.isEmpty {
+            let key = AutonomyPolicy.normalize(app)
+            var perApp = autoApprove[request.toolCallId] ?? [:]
+            perApp[key] =
+                perApp[key].map { EffectClass.max($0, request.preview.effect) }
+                ?? request.preview.effect
+            autoApprove[request.toolCallId] = perApp
+        }
+        resolve(id: id, approved: true)
+    }
+
+    // MARK: - Cloud-vision consent
+
+    /// Park a cloud-vision consent prompt and suspend until the user resolves it.
+    /// Cancellation-aware (resolves as `.deny`) so the loop never hangs.
+    public func requestCloudVisionConsent(toolCallId: String) async -> CloudVisionConsentChoice {
+        let request = CloudVisionConsentRequest(toolCallId: toolCallId)
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation {
+                (continuation: CheckedContinuation<CloudVisionConsentChoice, Never>) in
+                if Task.isCancelled {
+                    continuation.resume(returning: .deny)
+                    return
+                }
+                consentContinuations[request.id] = continuation
+                pendingConsent.append(request)
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.resolveConsent(id: request.id, choice: .deny)
+            }
+        }
+    }
+
+    /// Resolve a specific pending consent prompt (user picked allow/deny).
+    public func resolveConsent(id: UUID, choice: CloudVisionConsentChoice) {
+        pendingConsent.removeAll { $0.id == id }
+        guard let continuation = consentContinuations.removeValue(forKey: id) else { return }
+        continuation.resume(returning: choice)
+    }
+
+    // MARK: - Teardown
+
+    /// Deny + clear every pending prompt (confirm + consent) for a run and drop
+    /// its "approve remaining" thresholds. Called on interrupt / teardown, and
+    /// by the feed's Stop control so Stop works even while a card is up.
     public func cancelAll(forToolCallId toolCallId: String) {
+        autoApprove.removeValue(forKey: toolCallId)
+
         let affected = pending.filter { $0.toolCallId == toolCallId }
         pending.removeAll { $0.toolCallId == toolCallId }
         for request in affected {
             continuations.removeValue(forKey: request.id)?.resume(returning: false)
+        }
+
+        let affectedConsent = pendingConsent.filter { $0.toolCallId == toolCallId }
+        pendingConsent.removeAll { $0.toolCallId == toolCallId }
+        for request in affectedConsent {
+            consentContinuations.removeValue(forKey: request.id)?.resume(returning: .deny)
         }
     }
 }

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -198,6 +198,9 @@ public enum ComputerUseLoop {
         feed: ComputerUseFeed,
         interrupt: InterruptToken,
         confirm: @escaping @Sendable (ActionPreview) async -> Bool,
+        requestCloudVisionConsent: @escaping @Sendable () async -> CloudVisionConsentChoice = {
+            .deny
+        },
         limits: RunLimits = RunLimits(),
         policySummary: String = "",
         vision: VisionContext = .none,
@@ -244,6 +247,9 @@ public enum ComputerUseLoop {
         var hintedApps: Set<String> = []
         // Estimated tokens of the single screenshot currently in context (0 = none).
         var imageTokensInContext = 0
+        // Cloud-vision consent state for THIS run. Seeded from the snapshot taken
+        // at run start; a just-in-time prompt can flip `granted` true mid-run.
+        var runConsent = RunCloudVisionConsent(granted: vision.cloudConsent, asked: false)
 
         // Initial perception so the model's first turn has something to act on.
         // An empty AX tree (Electron, custom-drawn UI) escalates ax→som→vision
@@ -276,6 +282,8 @@ public enum ComputerUseLoop {
             await attachFrame(
                 image: frame,
                 vision: vision,
+                consent: &runConsent,
+                requestConsent: requestCloudVisionConsent,
                 availability: availability,
                 messages: &messages,
                 imageTokensInContext: &imageTokensInContext,
@@ -680,6 +688,8 @@ public enum ComputerUseLoop {
                     action: action,
                     resolvedRole: resolvedElement?.role,
                     resolvedLabel: resolvedElement?.label,
+                    resolvedValue: resolvedElement?.value,
+                    resolvedRoleDescription: resolvedElement?.roleDescription,
                     appName: currentApp,
                     recipeSignals: AppRecipes.signals(for: currentApp)
                 )
@@ -735,6 +745,8 @@ public enum ComputerUseLoop {
                 await attachFrame(
                     image: frame,
                     vision: vision,
+                    consent: &runConsent,
+                    requestConsent: requestCloudVisionConsent,
                     availability: availability,
                     messages: &messages,
                     imageTokensInContext: &imageTokensInContext,
@@ -1377,6 +1389,14 @@ public enum ComputerUseLoop {
 
     // MARK: - Vision frame attachment
 
+    /// Mutable cloud-vision consent state for a single run. Seeded from the
+    /// `VisionContext` snapshot; `asked` ensures the just-in-time prompt fires at
+    /// most once per run, and `granted` records a mid-run grant.
+    private struct RunCloudVisionConsent {
+        var granted: Bool
+        var asked: Bool
+    }
+
     /// Attach a freshly captured frame to the model conversation when the
     /// `VisionContext` allows it. Local models receive the frame directly; remote
     /// models receive a `FrameScrubber`-redacted frame routed through
@@ -1385,6 +1405,8 @@ public enum ComputerUseLoop {
     private static func attachFrame(
         image: CUImage,
         vision: VisionContext,
+        consent: inout RunCloudVisionConsent,
+        requestConsent: @Sendable () async -> CloudVisionConsentChoice,
         availability: MacDriverAvailability,
         messages: inout [ChatMessage],
         imageTokensInContext: inout Int,
@@ -1392,9 +1414,25 @@ public enum ComputerUseLoop {
         feed: ComputerUseFeed,
         step: Int
     ) async {
-        switch VisionAttachment.decide(image: image, context: vision, availability: availability) {
+        let effective = vision.withConsent(consent.granted)
+        switch VisionAttachment.decide(image: image, context: effective, availability: availability) {
         case .none:
-            return
+            // The frame can't attach as-is. If the ONLY thing missing is
+            // cloud-vision consent (remote image model + Screen Recording on),
+            // offer a just-in-time prompt once per run rather than silently
+            // dropping to AX-only.
+            await offerJustInTimeCloudConsent(
+                image: image,
+                vision: vision,
+                consent: &consent,
+                requestConsent: requestConsent,
+                availability: availability,
+                messages: &messages,
+                imageTokensInContext: &imageTokensInContext,
+                metrics: &metrics,
+                feed: feed,
+                step: step
+            )
         case .localFrame(let img):
             appendImageMessage(
                 img,
@@ -1413,34 +1451,159 @@ public enum ComputerUseLoop {
                 )
             )
         case .needsScrubForCloud(let img):
-            // Scrub, then build the consented cloud route. The route is the only way
-            // to reach `.cloudVision`, and it only accepts a `ScrubbedFrame`, so a
-            // raw or unconsented frame can never be attached here.
-            guard let frame = await FrameScrubber.scrub(img, mode: .pii),
-                let route = CaptureRouter.cloudRoute(
-                    scrubbed: frame,
-                    consentGranted: vision.cloudConsent,
-                    availability: availability
-                ),
-                case .cloudVision(let scrubbed) = route
-            else { return }
-            appendImageMessage(
-                scrubbed.image,
-                note:
-                    "Screenshot of the current view (sensitive text was redacted before it left the device). "
-                    + "Use it to locate the element, then address it by `describe`.",
-                into: &messages,
-                imageTokensInContext: &imageTokensInContext
+            await attachScrubbedForCloud(
+                img,
+                vision: vision,
+                availability: availability,
+                messages: &messages,
+                imageTokensInContext: &imageTokensInContext,
+                metrics: &metrics,
+                feed: feed,
+                step: step
             )
-            metrics.cloudVisionUsed = true
+        }
+    }
+
+    /// Offer a one-per-run just-in-time cloud-vision prompt when a frame would
+    /// reach a remote model if only consent were granted. On grant, scrub +
+    /// attach through the cloud route; on decline (or if consent isn't the sole
+    /// blocker) stay on accessibility text. Records that the prompt fired so it
+    /// doesn't nag again this run.
+    private static func offerJustInTimeCloudConsent(
+        image: CUImage,
+        vision: VisionContext,
+        consent: inout RunCloudVisionConsent,
+        requestConsent: @Sendable () async -> CloudVisionConsentChoice,
+        availability: MacDriverAvailability,
+        messages: inout [ChatMessage],
+        imageTokensInContext: inout Int,
+        metrics: inout ComputerUseRunMetrics,
+        feed: ComputerUseFeed,
+        step: Int
+    ) async {
+        let effective = vision.withConsent(consent.granted)
+        guard
+            !consent.asked,
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: effective,
+                availability: availability
+            )
+        else { return }
+        consent.asked = true
+        feed.emit(
+            FeedEvent(
+                step: step,
+                kind: .perceive,
+                title: "Asked to use Cloud vision",
+                detail: "a screenshot would help here — waiting for your choice"
+            )
+        )
+        switch await requestConsent() {
+        case .deny:
             feed.emit(
                 FeedEvent(
                     step: step,
                     kind: .perceive,
-                    title: "Attached a screenshot",
-                    detail: "redacted \(frame.report.maskedRegions) region(s) before cloud vision"
+                    title: "Staying on-device",
+                    detail: "Cloud vision declined; continuing from accessibility text"
                 )
             )
+            return
+        case .allowOnce:
+            await MainActor.run { CloudVisionConsent.shared.grantForSession() }
+            consent.granted = true
+        case .allowAlways:
+            await MainActor.run { CloudVisionConsent.shared.grantPersistently() }
+            consent.granted = true
+        }
+        guard
+            case .needsScrubForCloud(let img) = VisionAttachment.decide(
+                image: image,
+                context: vision.withConsent(true),
+                availability: availability
+            )
+        else { return }
+        await attachScrubbedForCloud(
+            img,
+            vision: vision,
+            availability: availability,
+            messages: &messages,
+            imageTokensInContext: &imageTokensInContext,
+            metrics: &metrics,
+            feed: feed,
+            step: step
+        )
+    }
+
+    /// Scrub a frame in the run's resolved cloud mode and attach it through the
+    /// consented cloud route. The route is the only way to reach `.cloudVision`
+    /// and only accepts a `ScrubbedFrame`, so a raw or unconsented frame can
+    /// never be attached here. Only called once consent is effectively granted.
+    private static func attachScrubbedForCloud(
+        _ img: CUImage,
+        vision: VisionContext,
+        availability: MacDriverAvailability,
+        messages: inout [ChatMessage],
+        imageTokensInContext: inout Int,
+        metrics: inout ComputerUseRunMetrics,
+        feed: ComputerUseFeed,
+        step: Int
+    ) async {
+        let mode = vision.cloudScrubMode
+        guard
+            let frame = await FrameScrubber.scrub(
+                img,
+                mode: mode,
+                honorUserRules: true,
+                useModelDetection: mode == .pii
+            ),
+            let route = CaptureRouter.cloudRoute(
+                scrubbed: frame,
+                consentGranted: true,
+                availability: availability
+            ),
+            case .cloudVision(let scrubbed) = route
+        else { return }
+        appendImageMessage(
+            scrubbed.image,
+            note: cloudFrameNote(mode: mode),
+            into: &messages,
+            imageTokensInContext: &imageTokensInContext
+        )
+        metrics.cloudVisionUsed = true
+        feed.emit(
+            FeedEvent(
+                step: step,
+                kind: .perceive,
+                title: "Attached a screenshot",
+                detail: cloudFrameFeedDetail(mode: mode, masked: frame.report.maskedRegions)
+            )
+        )
+    }
+
+    /// The note attached to a cloud-bound screenshot, honest about what the
+    /// resolved scrub mode actually masked (so neither the model nor the user
+    /// is told more was redacted than was).
+    private static func cloudFrameNote(mode: ScrubMode) -> String {
+        switch mode {
+        case .allText:
+            return
+                "Screenshot of the current view. All on-screen text was masked on-device before it "
+                + "left the machine, so rely on layout and the accessibility text already provided to "
+                + "locate the element, then address it by `describe`."
+        case .pii:
+            return
+                "Screenshot of the current view. Detected sensitive text (names, contacts, account "
+                + "numbers, secrets) was masked on-device before it left the machine; other on-screen "
+                + "text is still visible. Use it to locate the element, then address it by `describe`."
+        }
+    }
+
+    private static func cloudFrameFeedDetail(mode: ScrubMode, masked: Int) -> String {
+        switch mode {
+        case .allText: return "masked all \(masked) text region(s) before cloud vision"
+        case .pii: return "masked \(masked) sensitive region(s) before cloud vision"
         }
     }
 

--- a/Packages/OsaurusCore/ComputerUse/Model/AgentAction.swift
+++ b/Packages/OsaurusCore/ComputerUse/Model/AgentAction.swift
@@ -189,6 +189,18 @@ public struct AgentAction: Sendable, Equatable {
         }
     }
 
+    /// The full text payload a confirm card can show expandably (the feed label
+    /// truncates it at 40 chars). `nil` for verbs that carry no typed payload.
+    public var typedTextForPreview: String? {
+        switch verb {
+        case .type, .setValue:
+            guard let text, !text.isEmpty else { return nil }
+            return text
+        default:
+            return nil
+        }
+    }
+
     private var targetLabel: String { Self.label(for: target) }
     private var destinationLabel: String { Self.label(for: to) }
 

--- a/Packages/OsaurusCore/ComputerUse/Perception/CloudVisionConsent.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/CloudVisionConsent.swift
@@ -21,6 +21,7 @@ public final class CloudVisionConsent: ObservableObject {
     public static let shared = CloudVisionConsent()
 
     private let defaultsKey = "ai.osaurus.computeruse.cloudVisionConsent"
+    private let piiOnlyKey = "ai.osaurus.computeruse.cloudVisionPIIOnly"
     private let defaults: UserDefaults
 
     /// Persisted opt-in. Default `false` — pixels never leave the device until
@@ -28,14 +29,30 @@ public final class CloudVisionConsent: ObservableObject {
     @Published public private(set) var isPersistentlyGranted: Bool
     /// This-launch-only grant; never written to disk.
     @Published public private(set) var isSessionGranted: Bool = false
+    /// When `true`, a consented cloud screenshot masks only detected sensitive
+    /// text (`.pii`) instead of every recognized region (`.allText`). Default
+    /// `false` (`.allText`) so the safest redaction is the out-of-box behavior;
+    /// the user opts into the less-strict mode knowingly.
+    @Published public private(set) var masksOnlyDetectedPII: Bool
 
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         self.isPersistentlyGranted = defaults.bool(forKey: defaultsKey)
+        self.masksOnlyDetectedPII = defaults.bool(forKey: piiOnlyKey)
     }
 
     /// The single value the router consults.
     public var isGranted: Bool { isPersistentlyGranted || isSessionGranted }
+
+    /// The redaction mode a consented cloud screenshot uses, derived from the
+    /// user's preference. `.allText` by default (mask everything).
+    public var scrubMode: ScrubMode { masksOnlyDetectedPII ? .pii : .allText }
+
+    /// Bindable setter for the redaction-mode preference.
+    public func setMasksOnlyDetectedPII(_ on: Bool) {
+        masksOnlyDetectedPII = on
+        defaults.set(on, forKey: piiOnlyKey)
+    }
 
     public func grantPersistently() {
         isPersistentlyGranted = true

--- a/Packages/OsaurusCore/ComputerUse/Perception/FrameScrubber.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/FrameScrubber.swift
@@ -64,32 +64,96 @@ public struct ScrubbedFrame: Sendable, Equatable {
 
 public enum FrameScrubber {
 
+    /// Upper bound on how many OCR'd text regions get an on-device model pass
+    /// in `.pii` mode. The model forward pass runs once per region, so this
+    /// caps the latency of the (opt-in, non-default) precise-PII scrub on a
+    /// text-dense screen. `.allText` mode masks everything and never needs it.
+    static let maxModelObservations = 200
+
     /// Scrub a contract `CUImage`. Returns `nil` only if the bytes can't be
     /// decoded; an image with no detected PII still returns a (visually
     /// identical) `ScrubbedFrame` so the type guarantee holds.
-    public static func scrub(_ image: CUImage, mode: ScrubMode = .pii) async -> ScrubbedFrame? {
+    ///
+    /// - `honorUserRules`: build the regex layer from the user's configured
+    ///   Privacy Filter ruleset (custom rules / presets / per-category toggles)
+    ///   instead of all built-ins, so a screenshot scrub matches what the text
+    ///   filter would mask. `false` keeps the all-built-ins behaviour callers
+    ///   (and tests) relied on.
+    /// - `useModelDetection`: in `.pii` mode, also run the on-device NER
+    ///   classifier so `person` / `address` / `date` / `secret` spans — which
+    ///   have no regex — are masked, not just the regex-detectable categories.
+    public static func scrub(
+        _ image: CUImage,
+        mode: ScrubMode = .pii,
+        honorUserRules: Bool = false,
+        useModelDetection: Bool = false
+    ) async -> ScrubbedFrame? {
         guard let cg = decode(image) else { return nil }
-        guard let (masked, report) = await scrub(cgImage: cg, mode: mode) else { return nil }
+        let ruleset = effectiveRuleset(honorUserRules: honorUserRules)
+        guard
+            let (masked, report) = await scrub(
+                cgImage: cg,
+                mode: mode,
+                ruleset: ruleset,
+                useModelDetection: useModelDetection
+            )
+        else { return nil }
         guard let encoded = encode(masked, width: image.width, height: image.height) else {
             return nil
         }
         return ScrubbedFrame(image: encoded, report: report)
     }
 
-    /// Core scrub over a `CGImage`. Exposed for callers that already hold pixels
-    /// (and for tests). Returns the redacted image + a report.
+    /// Back-compat core scrub over a `CGImage` (all built-ins, regex only, no
+    /// model). Kept for callers/tests that hold pixels and want the
+    /// deterministic, engine-free behaviour.
     public static func scrub(
         cgImage: CGImage,
         mode: ScrubMode = .pii
     ) async -> (CGImage, ScrubReport)? {
-        let scan = await recognizeAndDetect(in: cgImage, mode: mode)
-        let masked = paintMasks(over: cgImage, normalizedRegions: scan.regions) ?? cgImage
+        await scrub(cgImage: cgImage, mode: mode, ruleset: .allBuiltins(), useModelDetection: false)
+    }
+
+    /// Core scrub over a `CGImage` with an explicit regex ruleset and optional
+    /// on-device model pass. Returns the redacted image + a report.
+    static func scrub(
+        cgImage: CGImage,
+        mode: ScrubMode,
+        ruleset: RegexEntityDetector.EffectiveRuleSet,
+        useModelDetection: Bool
+    ) async -> (CGImage, ScrubReport)? {
+        let scan = await recognizeAndDetect(in: cgImage, mode: mode, ruleset: ruleset)
+        var regions = scan.regions
+        var categories = scan.categories
+        // The regex pass (inside the Vision handler) masks the precise spans it
+        // can. The model owns `person`/`address`/`date`/`secret`, which have no
+        // regex — run it per OCR region and mask the whole region on a hit
+        // (recall over precision, the same philosophy the regex line-fallback
+        // uses). `.allText` already masks every region, so the model adds nothing.
+        if mode == .pii, useModelDetection, !scan.observations.isEmpty {
+            let candidates = scan.observations.prefix(maxModelObservations)
+            for obs in candidates where obs.text.count >= 2 {
+                let spans = await PrivacyFilterEngine.shared.modelSpans(in: obs.text)
+                guard !spans.isEmpty else { continue }
+                regions.append(obs.box)
+                for span in spans { categories[categoryToken(span.category), default: 0] += 1 }
+            }
+        }
+        let masked = paintMasks(over: cgImage, normalizedRegions: regions) ?? cgImage
         let report = ScrubReport(
             textRegions: scan.textRegions,
-            maskedRegions: scan.regions.count,
-            categories: scan.categories
+            maskedRegions: regions.count,
+            categories: categories
         )
         return (masked, report)
+    }
+
+    /// The regex ruleset to run over OCR'd text: the user's configured set when
+    /// `honorUserRules`, else every built-in.
+    private static func effectiveRuleset(
+        honorUserRules: Bool
+    ) -> RegexEntityDetector.EffectiveRuleSet {
+        honorUserRules ? .build(from: PrivacyFilterStore.snapshot()) : .allBuiltins()
     }
 
     // MARK: - Vision OCR
@@ -102,14 +166,33 @@ public enum FrameScrubber {
         let regions: [CGRect]
         let categories: [String: Int]
         let textRegions: Int
+        /// One per recognized line: its text + normalized bounding box. Used by
+        /// the `.pii` model pass, which runs the NER classifier per region and
+        /// masks the whole region on a hit. Empty in `.allText` (every region
+        /// is already masked, so the model pass is skipped).
+        let observations: [OCRObservation]
     }
 
-    private static func recognizeAndDetect(in image: CGImage, mode: ScrubMode) async -> OCRScan {
+    /// A single recognized text region carried out of the Vision handler as
+    /// `Sendable` geometry, so an async (`@MainActor`) model pass can run after
+    /// the non-`Sendable` Vision objects are gone.
+    private struct OCRObservation: Sendable {
+        let text: String
+        /// Normalized (0…1, bottom-left) bounding box.
+        let box: CGRect
+    }
+
+    private static func recognizeAndDetect(
+        in image: CGImage,
+        mode: ScrubMode,
+        ruleset: RegexEntityDetector.EffectiveRuleSet
+    ) async -> OCRScan {
         await withCheckedContinuation { (continuation: CheckedContinuation<OCRScan, Never>) in
             let request = VNRecognizeTextRequest { request, _ in
                 let observations = (request.results as? [VNRecognizedTextObservation]) ?? []
                 var regions: [CGRect] = []
                 var categories: [String: Int] = [:]
+                var scanned: [OCRObservation] = []
                 for observation in observations {
                     guard let candidate = observation.topCandidates(1).first else { continue }
                     switch mode {
@@ -119,7 +202,7 @@ public enum FrameScrubber {
                         let text = candidate.string
                         // The detector's ranges index `candidate.string` directly, so
                         // they pass straight to Vision's `boundingBox(for:)`.
-                        for match in RegexEntityDetector.detect(in: text) {
+                        for match in RegexEntityDetector.detect(in: text, ruleset: ruleset) {
                             categories[categoryToken(match.category), default: 0] += 1
                             if let rect = (try? candidate.boundingBox(for: match.range)) ?? nil {
                                 regions.append(rect.boundingBox)
@@ -129,13 +212,16 @@ public enum FrameScrubber {
                                 regions.append(observation.boundingBox)
                             }
                         }
+                        // Carry the region out for the optional model pass.
+                        scanned.append(OCRObservation(text: text, box: observation.boundingBox))
                     }
                 }
                 continuation.resume(
                     returning: OCRScan(
                         regions: regions,
                         categories: categories,
-                        textRegions: observations.count
+                        textRegions: observations.count,
+                        observations: scanned
                     )
                 )
             }
@@ -145,7 +231,14 @@ public enum FrameScrubber {
             do {
                 try handler.perform([request])
             } catch {
-                continuation.resume(returning: OCRScan(regions: [], categories: [:], textRegions: 0))
+                continuation.resume(
+                    returning: OCRScan(
+                        regions: [],
+                        categories: [:],
+                        textRegions: 0,
+                        observations: []
+                    )
+                )
             }
         }
     }

--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
@@ -282,9 +282,13 @@ public struct ScreenContextDistiller: Sendable {
         snapshot: CUSnapshot
     ) -> ScreenContextSnapshot.FocusedElement? {
         if let direct {
-            let viewing = contentValue(direct.viewport, limit: maxViewingChars)
-            let value = contentValue(direct.value, limit: maxValueChars)
-            let selected = contentValue(direct.selectedText, limit: maxValueChars)
+            // Secure fields: never surface value/selection/viewport even if the
+            // driver somehow read one (it shouldn't). Defense-in-depth so a
+            // password never reaches the model via screen context.
+            let isSecure = Self.secureFieldRoles.contains(direct.role.lowercased())
+            let viewing = isSecure ? nil : contentValue(direct.viewport, limit: maxViewingChars)
+            let value = isSecure ? nil : contentValue(direct.value, limit: maxValueChars)
+            let selected = isSecure ? nil : contentValue(direct.selectedText, limit: maxValueChars)
             let label = labelValue(direct.label, limit: maxItemChars)
             let placeholder = labelValue(direct.placeholder, limit: maxItemChars)
             if viewing != nil || value != nil || selected != nil || label != nil
@@ -316,8 +320,11 @@ public struct ScreenContextDistiller: Sendable {
         }
 
         guard let element = snapshot.elements.first(where: { $0.focused }) else { return nil }
-        let value = contentValue(element.value, limit: maxValueChars)
-        let selected = contentValue(element.selectedText, limit: maxValueChars)
+        // Same secure-field guard on the breadth-limited traversal fallback: a
+        // focused password field surfaces only its role/label, never its value.
+        let isSecure = Self.secureFieldRoles.contains(element.role.lowercased())
+        let value = isSecure ? nil : contentValue(element.value, limit: maxValueChars)
+        let selected = isSecure ? nil : contentValue(element.selectedText, limit: maxValueChars)
         let label = labelValue(element.label, limit: maxItemChars)
         let placeholder = labelValue(element.placeholder, limit: maxItemChars)
         if value == nil, selected == nil, label == nil, placeholder == nil,
@@ -613,6 +620,13 @@ public struct ScreenContextDistiller: Sendable {
     /// a "Focused field: <role>" line even when the content is unreadable.
     private static let rawInputRoles: Set<String> = [
         "textfield", "textarea", "searchfield", "securetextfield", "combobox",
+    ]
+
+    /// Secure-text roles whose `value`/`selectedText` must never be surfaced —
+    /// raw AX + friendly forms. The driver already refuses to read these; this is
+    /// a belt-and-suspenders guard in the distiller.
+    private static let secureFieldRoles: Set<String> = [
+        "securetextfield", "axsecuretextfield", "securefield",
     ]
 
     /// Characters that carry no signal alone: keyboard-shortcut glyphs plus the

--- a/Packages/OsaurusCore/ComputerUse/Perception/VisionAttachment.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/VisionAttachment.swift
@@ -35,11 +35,35 @@ public struct VisionContext: Sendable, Equatable {
     /// Whether the user granted cloud-vision consent. Only consulted for remote
     /// models — a local model never crosses the trust boundary.
     public let cloudConsent: Bool
+    /// How a screenshot bound for a cloud model is redacted. Defaults to
+    /// `.allText` (mask every recognized region — nothing readable leaves the
+    /// device); a user can opt into `.pii` (mask only detected sensitive text)
+    /// from Settings → Computer Use. Resolved once at run start so it can't
+    /// change under a running loop. Ignored for on-device models.
+    public let cloudScrubMode: ScrubMode
 
-    public init(modelAcceptsImages: Bool, modelIsLocal: Bool, cloudConsent: Bool) {
+    public init(
+        modelAcceptsImages: Bool,
+        modelIsLocal: Bool,
+        cloudConsent: Bool,
+        cloudScrubMode: ScrubMode = .allText
+    ) {
         self.modelAcceptsImages = modelAcceptsImages
         self.modelIsLocal = modelIsLocal
         self.cloudConsent = cloudConsent
+        self.cloudScrubMode = cloudScrubMode
+    }
+
+    /// A copy with cloud-vision consent overridden — used when a run obtains
+    /// just-in-time consent mid-loop (the snapshot taken at run start stays
+    /// otherwise unchanged).
+    public func withConsent(_ granted: Bool) -> VisionContext {
+        VisionContext(
+            modelAcceptsImages: modelAcceptsImages,
+            modelIsLocal: modelIsLocal,
+            cloudConsent: granted,
+            cloudScrubMode: cloudScrubMode
+        )
     }
 
     /// A context that never attaches pixels — the safe default for non-chat
@@ -85,5 +109,21 @@ public enum VisionAttachment {
             )
         else { return .none }
         return .needsScrubForCloud(image)
+    }
+
+    /// Whether this frame WOULD reach a cloud model if the user granted consent.
+    /// True only when pixels exist, the model is remote + image-capable, and
+    /// Screen Recording is on — i.e. consent is the only thing standing between
+    /// the run and a (scrubbed) cloud-vision attach. The loop uses this to offer
+    /// a just-in-time "enable Cloud vision" prompt instead of silently staying
+    /// AX-only. Pure + synchronous for testability.
+    public static func wouldAttachWithConsent(
+        image: CUImage?,
+        context: VisionContext,
+        availability: MacDriverAvailability
+    ) -> Bool {
+        guard image != nil, context.modelAcceptsImages, !context.modelIsLocal else { return false }
+        guard !context.cloudConsent else { return false }
+        return availability.screenRecording
     }
 }

--- a/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
@@ -232,14 +232,31 @@ public struct AutonomyPolicy: Codable, Sendable, Equatable {
         case allowlist
     }
 
-    /// Normalize an app name / bundle id for case-insensitive matching.
+    /// Normalize an app name / bundle id for case-insensitive matching: trim,
+    /// lowercase, drop a trailing `.app`, and collapse internal whitespace runs
+    /// so "Safari.app", "safari", and "System  Settings" compare cleanly against
+    /// "Safari" / "system settings". Deliberately does NOT alias a bundle id to
+    /// its last path component (e.g. `com.evil.notes` → `notes`): that would let
+    /// a non-allowlisted app match an allowlist entry, weakening a security
+    /// control. Matching stays exact on the normalized form.
     public static func normalize(_ app: String) -> String {
-        app.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        var s = app.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if s.hasSuffix(".app") { s = String(s.dropLast(4)) }
+        let parts = s.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+        return parts.joined(separator: " ")
     }
 
     /// Whether an app may be driven at all. The allowlist is checked first,
     /// before any disposition. An unknown (`nil`) app under an active
     /// allowlist is rejected — we can't confirm it's permitted.
+    ///
+    /// Scope decision: the allowlist gates ACTIONS (and `open`), not perception.
+    /// `observe` / `find` / the initial perceive are read-only and never mutate
+    /// an app; what may LEAVE the device from perception is governed separately
+    /// by the cloud-vision consent + `FrameScrubber` boundary. Gating perception
+    /// on the allowlist would only block the agent from reading an
+    /// already-frontmost window the user can see themselves, with no privacy
+    /// gain, so it is intentionally not gated here.
     public func isAppAllowed(_ app: String?) -> Bool {
         guard let allowlist, !allowlist.isEmpty else { return true }
         guard let app, !app.isEmpty else { return false }
@@ -268,4 +285,35 @@ public struct AutonomyPolicy: Codable, Sendable, Equatable {
     /// The shipped default policy: balanced everywhere, no per-app overrides,
     /// no allowlist.
     public static var defaultPolicy: AutonomyPolicy { AutonomyPolicy() }
+
+    // MARK: - Dangerous-app guardrail
+
+    /// Apps where an action can run code, change system state, or expose
+    /// secrets — so an action there ALWAYS confirms, regardless of the preset,
+    /// per-app override, or ceiling. This is a safety FLOOR that's independent
+    /// of the (often-empty) user allowlist: it can only make an action stricter,
+    /// never weaken one, and the user can still approve at the prompt. Matched
+    /// against the normalized app name or bundle id, by substring, so
+    /// "Terminal", "com.apple.Terminal", and "Apple Terminal" all match.
+    public static let forcedConfirmAppNeedles: Set<String> = [
+        "terminal", "iterm", "ghostty", "alacritty", "kitty", "warp",
+        "xterm", "console",
+        "keychain access", "com.apple.keychainaccess",
+        "system settings", "system preferences", "com.apple.systempreferences",
+        "activity monitor", "com.apple.activitymonitor",
+        "disk utility", "com.apple.diskutility",
+        "script editor", "com.apple.scripteditor",
+        "automator", "com.apple.automator",
+        "1password", "bitwarden", "dashlane", "lastpass",
+    ]
+
+    /// Whether driving `app` must always confirm because it's a sensitive app
+    /// (see `forcedConfirmAppNeedles`). `nil`/empty apps don't match — the
+    /// allowlist already rejects unknown apps under a restricted policy.
+    public func requiresForcedConfirm(app: String?) -> Bool {
+        guard let app else { return false }
+        let n = Self.normalize(app)
+        guard !n.isEmpty else { return false }
+        return Self.forcedConfirmAppNeedles.contains { n.contains($0) }
+    }
 }

--- a/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseGate.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseGate.swift
@@ -43,8 +43,17 @@ public struct ComputerUseGate: ComputerUseGating {
             )
         }
 
-        // 2) Strictest-wins disposition for the classified effect.
-        switch policy.disposition(for: effect, app: appName, ceiling: ceiling) {
+        // 2) Strictest-wins disposition for the classified effect, then a
+        //    dangerous-app guardrail: driving a sensitive app (Terminal, System
+        //    Settings, Keychain, a password manager, …) always confirms at least
+        //    once, regardless of preset/override/ceiling and independent of the
+        //    (often-empty) allowlist. Reads never reach here, so this only ever
+        //    affects navigate/edit/consequential actions.
+        var disposition = policy.disposition(for: effect, app: appName, ceiling: ceiling)
+        if effect >= .navigate, policy.requiresForcedConfirm(app: appName) {
+            disposition = AutonomyDisposition.strictest(disposition, .confirm)
+        }
+        switch disposition {
         case .allow:
             return .run
         case .confirm:
@@ -54,7 +63,8 @@ public struct ComputerUseGate: ComputerUseGating {
                     actionLabel: action.feedLabel,
                     targetLabel: targetLabel,
                     effect: effect,
-                    note: action.note
+                    note: action.note,
+                    typedText: action.typedTextForPreview
                 )
             )
         case .deny:

--- a/Packages/OsaurusCore/ComputerUse/Policy/EffectClassifier.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/EffectClassifier.swift
@@ -33,6 +33,8 @@ public enum EffectClassifier {
         action: AgentAction,
         resolvedRole: String? = nil,
         resolvedLabel: String? = nil,
+        resolvedValue: String? = nil,
+        resolvedRoleDescription: String? = nil,
         appName: String? = nil,
         recipeSignals: RecipeSignals = .empty
     ) -> EffectClass {
@@ -42,16 +44,31 @@ public enum EffectClassifier {
         let consequential = Self.consequentialSignals.union(recipeSignals.consequential)
         let commit = Self.commitSignals.union(recipeSignals.commit)
 
-        // Intent signals come from the TARGET (what the control is), not the
-        // typed payload — typing the word "delete" into a search box must not
-        // escalate. We scan the resolved label, the model's natural-language
-        // target, and its stated rationale.
+        let role = (resolvedRole ?? "").lowercased()
+        let isTextInput = Self.textInputRoles.contains(role)
+        // An element's `value` is intent-bearing for controls (a button whose
+        // label lives in `AXValue`, a checkbox/segment state) but is USER
+        // CONTENT for text inputs — folding a field's contents into the signal
+        // would re-escalate "type the word delete into a search box", which must
+        // stay an edit. So `value` joins the signal only for non-text-input roles.
+        let valueSignal = isTextInput ? nil : resolvedValue
+
+        // Target text = what the control IS (label + roleDescription + value +
+        // the model's `describe`), excluding the free-text rationale (`note`) so
+        // an icon-only control with a descriptive note isn't treated as labeled.
+        let targetText =
+            [resolvedLabel, resolvedRoleDescription, valueSignal, action.target?.describe]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+
+        // The vocabulary scan also folds in the rationale (`note`), which often
+        // names the real intent ("send the email", "save with the invitees").
         let signal =
-            [resolvedLabel, action.target?.describe, action.note]
+            [targetText, action.note]
             .compactMap { $0 }
             .joined(separator: " ")
             .lowercased()
-        let role = (resolvedRole ?? "").lowercased()
 
         // 1) Irreversible / cross-boundary commit verbs.
         if baseline >= .navigate, containsAny(signal, consequential) {
@@ -67,7 +84,16 @@ public enum EffectClassifier {
             effect = EffectClass.max(effect, .consequential)
         }
 
-        // 3) ⌘Return / ⌘Enter — the conventional submit/send chord.
+        // 3) A bare commit control (Save / OK / Done / Apply / Create / …) with no
+        //    recipient still commits SOMETHING the user may want to review, so
+        //    raise it to at least `edit`. It then confirms under cautious/balanced
+        //    (the default) but still auto-runs under trusted/autonomous — closing
+        //    the gap where a solo "Save"/"OK" silently auto-ran as `navigate`.
+        if baseline >= .navigate, containsAny(signal, commit) {
+            effect = EffectClass.max(effect, .edit)
+        }
+
+        // 4) ⌘Return / ⌘Enter — the conventional submit/send chord.
         if action.verb == .pressKey {
             let key = (action.key ?? "").lowercased()
             let mods = Set(action.modifiers.map { $0.lowercased() })
@@ -78,14 +104,15 @@ public enum EffectClassifier {
             }
         }
 
-        // 4) Default-stricter on ambiguity: an unidentifiable click target could
-        //    do anything, so confirm it rather than auto-run.
-        if action.verb == .click,
-            (resolvedLabel?.trimmingCharacters(in: .whitespaces).isEmpty ?? true),
-            role.isEmpty,
-            (action.target?.describe?.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
-        {
-            effect = EffectClass.max(effect, .edit)
+        // 5) Default-stricter on ambiguity / icon-only controls: a click whose
+        //    target exposes no readable text — an unidentifiable hit (empty role)
+        //    OR an icon-only button (a known control role with no label/value/
+        //    description) — could do anything, so confirm it rather than auto-run.
+        if action.verb == .click || action.verb == .doubleClick || action.verb == .rightClick {
+            let isControl = role.isEmpty || Self.actionableControlRoles.contains(role)
+            if targetText.isEmpty, isControl {
+                effect = EffectClass.max(effect, .edit)
+            }
         }
 
         return effect
@@ -133,5 +160,26 @@ public enum EffectClassifier {
     static let recipientSignals: Set<String> = [
         "recipient", "recipients", "invitee", "invitees", "attendee", "attendees",
         "guests", "cc", "bcc", "everyone",
+    ]
+
+    /// Roles that act on click (so an UNLABELED one is an icon-only button worth
+    /// confirming). Includes both raw AX (`AXButton`) and friendly (`button`)
+    /// forms since `CUElement.role` carries either depending on the driver.
+    static let actionableControlRoles: Set<String> = [
+        "button", "axbutton",
+        "menubutton", "axmenubutton",
+        "popupbutton", "axpopupbutton",
+        "togglebutton", "axtogglebutton",
+    ]
+
+    /// Text-input roles whose `value` is user content, not control intent — see
+    /// `valueSignal`. Raw AX + friendly forms.
+    static let textInputRoles: Set<String> = [
+        "textfield", "axtextfield",
+        "textarea", "axtextarea",
+        "textview", "axtextview",
+        "searchfield", "axsearchfield",
+        "securefield", "securetextfield", "axsecuretextfield",
+        "combobox", "axcombobox",
     ]
 }

--- a/Packages/OsaurusCore/ComputerUse/Policy/Gate.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/Gate.swift
@@ -20,19 +20,25 @@ public struct ActionPreview: Sendable, Equatable {
     public let targetLabel: String?
     public let effect: EffectClass
     public let note: String?
+    /// The full text payload for type/set actions, shown expandably on the
+    /// confirm card so a long string isn't hidden behind the feed's 40-char
+    /// truncation. `nil` for actions that type nothing.
+    public let typedText: String?
 
     public init(
         appName: String?,
         actionLabel: String,
         targetLabel: String?,
         effect: EffectClass,
-        note: String?
+        note: String?,
+        typedText: String? = nil
     ) {
         self.appName = appName
         self.actionLabel = actionLabel
         self.targetLabel = targetLabel
         self.effect = effect
         self.note = note
+        self.typedText = typedText
     }
 
     /// One-line summary for the feed / prompt.
@@ -83,7 +89,8 @@ public struct HardwiredGate: ComputerUseGating {
                 actionLabel: action.feedLabel,
                 targetLabel: targetLabel,
                 effect: effect,
-                note: action.note
+                note: action.note,
+                typedText: action.typedTextForPreview
             )
         )
     }

--- a/Packages/OsaurusCore/ComputerUse/Tool/ComputerUseTool.swift
+++ b/Packages/OsaurusCore/ComputerUse/Tool/ComputerUseTool.swift
@@ -164,7 +164,8 @@ final class ComputerUseTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
                 vision = VisionContext(
                     modelAcceptsImages: ComputerUseTool.modelAcceptsImages(model),
                     modelIsLocal: ModelManager.findInstalledModel(named: model) != nil,
-                    cloudConsent: CloudVisionConsent.shared.isGranted
+                    cloudConsent: CloudVisionConsent.shared.isGranted,
+                    cloudScrubMode: CloudVisionConsent.shared.scrubMode
                 )
             } else {
                 vision = .none
@@ -222,6 +223,9 @@ final class ComputerUseTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
             interrupt: interrupt,
             confirm: { preview in
                 await ComputerUsePromptQueue.shared.requestConfirmation(preview, toolCallId: toolCallId)
+            },
+            requestCloudVisionConsent: {
+                await ComputerUsePromptQueue.shared.requestCloudVisionConsent(toolCallId: toolCallId)
             },
             limits: limits,
             policySummary: policySummary,

--- a/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterEngine.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/PrivacyFilterEngine.swift
@@ -254,6 +254,44 @@ public final class PrivacyFilterEngine {
         return out
     }
 
+    /// Model-only NER spans (`person` / `address` / `date` / `secret`, plus
+    /// any other category the on-device classifier emits) for a single text,
+    /// with NO regex layer and NO `RedactionMap` interning. Returns `[]` when
+    /// the engine isn't loaded.
+    ///
+    /// This is the seam the screenshot `FrameScrubber` uses: it already runs
+    /// the deterministic `RegexEntityDetector` layer itself (over OCR'd text),
+    /// and only needs the model's categories on top so a screenshot bound for
+    /// a cloud model masks the same `person`/`address`/`secret` spans the text
+    /// Privacy Filter would — not just the regex-detectable ones. Best-effort
+    /// warms the bundle once (same posture as `applyOutbound`'s lazy load) so a
+    /// cold engine doesn't silently degrade a consented cloud-vision scrub.
+    public func modelSpans(in text: String)
+        async -> [(category: EntityCategory, range: Range<String.Index>)]
+    {
+        guard !text.isEmpty else { return [] }
+        if kit == nil {
+            let bundleDir = PrivacyFilterModelBundle.directoryURL()
+            if PrivacyFilterModelBundle.exists(at: bundleDir) {
+                try? await loadIfNeeded(bundle: bundleDir)
+            }
+        }
+        guard let kit else { return [] }
+        let entities: [Entity]
+        do {
+            entities = try await kit.extractEntities(from: text)
+        } catch {
+            return []
+        }
+        var out: [(category: EntityCategory, range: Range<String.Index>)] = []
+        out.reserveCapacity(entities.count)
+        for entity in entities {
+            guard let category = EntityCategory(entity.type) else { continue }
+            out.append((category, entity.range))
+        }
+        return out
+    }
+
     /// Merge model + regex matches into a non-overlapping set.
     ///
     /// Sort start-ascending, ties by longer span. On overlap, keep

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -66214,6 +66214,134 @@
           }
         }
       }
+    },
+    "Allow once" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einmal erlauben"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许一次"
+          }
+        }
+      }
+    },
+    "Always allow" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immer erlauben"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终允许"
+          }
+        }
+      }
+    },
+    "App" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
+          }
+        }
+      }
+    },
+    "Don't ask again for similar actions in %@ this run" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bei ähnlichen Aktionen in %@ in diesem Lauf nicht erneut fragen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次运行中不再询问 %@ 中的类似操作"
+          }
+        }
+      }
+    },
+    "Mask only detected sensitive text" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur erkannten sensiblen Text maskieren"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅遮罩检测到的敏感文本"
+          }
+        }
+      }
+    },
+    "Show full text" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vollständigen Text anzeigen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示完整文本"
+          }
+        }
+      }
+    },
+    "Show less" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weniger anzeigen"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示更少"
+          }
+        }
+      }
+    },
+    "Target" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ziel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -254,7 +254,36 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         guard let data = try? encoder.encode(request),
             let s = String(data: data, encoding: .utf8)
         else { return nil }
-        return s
+        return redactInlineImagePayloads(in: s)
+    }
+
+    /// Replace inline base64 image payloads (e.g. Computer Use screenshots) with
+    /// a short marker before the request is handed to the Insights ring buffer.
+    /// Even a `FrameScrubber`-redacted frame shouldn't be retained verbatim in a
+    /// local debug buffer — the marker keeps the request shape inspectable
+    /// without persisting pixels. Text content is left intact (it's already on
+    /// the user's screen, and the panel exists to inspect the request).
+    static func redactInlineImagePayloads(in json: String) -> String {
+        guard
+            let regex = try? NSRegularExpression(pattern: "(;base64,)([A-Za-z0-9+/=]{64,})")
+        else { return json }
+        let matches = regex.matches(
+            in: json,
+            range: NSRange(location: 0, length: (json as NSString).length)
+        )
+        guard !matches.isEmpty else { return json }
+        var result = json as NSString
+        // Apply replacements back-to-front so earlier ranges stay valid.
+        for match in matches.reversed() {
+            let payload = match.range(at: 2)
+            guard payload.location != NSNotFound else { continue }
+            result =
+                result.replacingCharacters(
+                    in: payload,
+                    with: "[redacted \(payload.length)-char image]"
+                ) as NSString
+        }
+        return result as String
     }
 
     /// Pretty-print a `ChatCompletionResponse` for the Insights ring buffer.

--- a/Packages/OsaurusCore/Tests/Chat/InsightsImageRedactionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/InsightsImageRedactionTests.swift
@@ -1,0 +1,52 @@
+//
+//  InsightsImageRedactionTests.swift
+//  OsaurusCoreTests — Chat
+//
+//  Audit-remediation coverage (P2): inline base64 image payloads (e.g.
+//  Computer Use screenshots, scrubbed or not) must not be retained verbatim in
+//  the Chat-UI Insights request-body buffer. `ChatEngine.redactInlineImagePayloads`
+//  replaces the payload with a short marker while leaving the request shape —
+//  and ordinary text content — intact for debugging.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class InsightsImageRedactionTests: XCTestCase {
+    func testRedactsInlineBase64ImagePayload() {
+        let payload = String(repeating: "A", count: 200)
+        let json = "{\"image_url\":{\"url\":\"data:image/png;base64,\(payload)\"}}"
+        let out = ChatEngine.redactInlineImagePayloads(in: json)
+
+        XCTAssertFalse(out.contains(payload), "the raw base64 payload must not survive")
+        XCTAssertTrue(out.contains(";base64,"), "the request shape (the data-URL prefix) is kept")
+        XCTAssertTrue(out.contains("[redacted 200-char image]"))
+    }
+
+    func testLeavesOrdinaryTextContentIntact() {
+        // No data-URL payload → returned unchanged (the panel still inspects text).
+        let json = "{\"content\":\"Reach me about base64 encoding at jane@example.com\"}"
+        XCTAssertEqual(ChatEngine.redactInlineImagePayloads(in: json), json)
+    }
+
+    func testIgnoresShortBase64LikeStrings() {
+        // Below the 64-char threshold there's no image to redact.
+        let json = "{\"url\":\"data:image/png;base64,AAAABBBBCCCC\"}"
+        XCTAssertEqual(ChatEngine.redactInlineImagePayloads(in: json), json)
+    }
+
+    func testRedactsEveryImageInTheRequest() {
+        let p1 = String(repeating: "B", count: 80)
+        let p2 = String(repeating: "C", count: 120)
+        let json =
+            "[\"data:image/jpeg;base64,\(p1)\",\"data:image/png;base64,\(p2)\"]"
+        let out = ChatEngine.redactInlineImagePayloads(in: json)
+
+        XCTAssertFalse(out.contains(p1))
+        XCTAssertFalse(out.contains(p2))
+        XCTAssertTrue(out.contains("[redacted 80-char image]"))
+        XCTAssertTrue(out.contains("[redacted 120-char image]"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Feed/ComputerUsePromptQueueTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Feed/ComputerUsePromptQueueTests.swift
@@ -1,0 +1,180 @@
+//
+//  ComputerUsePromptQueueTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  Audit-remediation coverage for the consent surface (P1 "the Stop that
+//  doesn't stop" + the confirm-overlay affordances):
+//    • A pending confirm resolves as DENIED when the run is torn down
+//      (`cancelAll`) — so the feed's Stop button works even while a card is up.
+//    • A pending confirm resolves as DENIED when the awaiting Task is
+//      cancelled (`withTaskCancellationHandler`), so the loop never hangs.
+//    • "Approve, don't ask again" auto-approves same-or-lower-effect actions in
+//      the same app for the rest of the run, while higher-effect actions still
+//      prompt.
+//    • The just-in-time cloud-vision consent prompt resolves and is
+//      teardown-safe.
+//
+//  Drives `ComputerUsePromptQueue.shared` (a MainActor singleton) with
+//  per-test tool-call ids so tests don't interfere.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+@MainActor
+final class ComputerUsePromptQueueTests: XCTestCase {
+    private var queue: ComputerUsePromptQueue { .shared }
+
+    private func preview(_ app: String = "Notes", effect: EffectClass = .edit) -> ActionPreview {
+        ActionPreview(
+            appName: app,
+            actionLabel: "Type",
+            targetLabel: "Body",
+            effect: effect,
+            note: nil
+        )
+    }
+
+    /// Spin the run loop until `predicate` holds (the parked child task has run)
+    /// or we time out. Sleeping yields the MainActor so the suspended
+    /// `requestConfirmation` task gets a turn to append to `pending`.
+    private func waitUntil(
+        _ predicate: () -> Bool,
+        timeout: TimeInterval = 2.0,
+        _ what: String = "condition",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let start = Date()
+        while !predicate() {
+            if Date().timeIntervalSince(start) > timeout {
+                XCTFail("timed out waiting for \(what)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 3_000_000)
+        }
+    }
+
+    private func pendingId(forToolCallId id: String) -> UUID? {
+        queue.pending.first { $0.toolCallId == id }?.id
+    }
+
+    // MARK: Confirm resolution
+
+    func testApproveResolvesTrue() async {
+        let id = "approve-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestConfirmation(self.preview(), toolCallId: id) }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the prompt to park")
+        guard let reqId = pendingId(forToolCallId: id) else { return }
+        queue.resolve(id: reqId, approved: true)
+        let approved = await task.value
+        XCTAssertTrue(approved)
+        XCTAssertNil(pendingId(forToolCallId: id))
+    }
+
+    func testDeclineResolvesFalse() async {
+        let id = "decline-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestConfirmation(self.preview(), toolCallId: id) }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the prompt to park")
+        guard let reqId = pendingId(forToolCallId: id) else { return }
+        queue.resolve(id: reqId, approved: false)
+        let approved = await task.value
+        XCTAssertFalse(approved)
+    }
+
+    // MARK: Stop-during-confirm
+
+    /// The feed's Stop calls `cancelAll(forToolCallId:)`; a confirm that's still
+    /// on screen must resolve as DENIED and clear, so the loop unblocks.
+    func testCancelAllResolvesPendingConfirmAsDenied() async {
+        let id = "stop-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestConfirmation(self.preview(), toolCallId: id) }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the prompt to park")
+        queue.cancelAll(forToolCallId: id)
+        let approved = await task.value
+        XCTAssertFalse(approved)
+        XCTAssertNil(pendingId(forToolCallId: id))
+    }
+
+    /// Structured cancellation of the awaiting Task (the loop's own teardown
+    /// path) resolves the suspended call as DENIED via the cancellation handler.
+    func testTaskCancellationResolvesConfirmAsDenied() async {
+        let id = "cancel-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestConfirmation(self.preview(), toolCallId: id) }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the prompt to park")
+        task.cancel()
+        let approved = await task.value
+        XCTAssertFalse(approved)
+        await waitUntil({ self.pendingId(forToolCallId: id) == nil }, "the prompt to clear")
+    }
+
+    // MARK: Approve-remaining
+
+    func testApproveRemainingAutoApprovesSameOrLowerEffectInApp() async {
+        let id = "auto-\(UUID().uuidString)"
+
+        // First edit in Notes → approve the rest.
+        let first = Task { await self.queue.requestConfirmation(self.preview(), toolCallId: id) }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the first prompt to park")
+        guard let firstId = pendingId(forToolCallId: id) else { return }
+        queue.resolveApprovingRest(id: firstId)
+        let firstApproved = await first.value
+        XCTAssertTrue(firstApproved)
+
+        // A second edit in the same app auto-approves WITHOUT ever parking.
+        let secondApproved = await queue.requestConfirmation(preview(), toolCallId: id)
+        XCTAssertTrue(secondApproved)
+        XCTAssertNil(pendingId(forToolCallId: id))
+
+        // A higher-effect action (consequential) still prompts.
+        let third = Task {
+            await self.queue.requestConfirmation(
+                self.preview("Notes", effect: .consequential),
+                toolCallId: id
+            )
+        }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the consequential prompt to park")
+        guard let thirdId = pendingId(forToolCallId: id) else { return }
+        queue.resolve(id: thirdId, approved: false)
+        let thirdApproved = await third.value
+        XCTAssertFalse(thirdApproved)
+
+        // Auto-approve is scoped per app: a different app still prompts.
+        let other = Task {
+            await self.queue.requestConfirmation(self.preview("Mail"), toolCallId: id)
+        }
+        await waitUntil({ self.pendingId(forToolCallId: id) != nil }, "the other-app prompt to park")
+        queue.cancelAll(forToolCallId: id)
+        _ = await other.value
+    }
+
+    // MARK: Cloud-vision consent
+
+    func testConsentResolvesToChoice() async {
+        let id = "consent-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestCloudVisionConsent(toolCallId: id) }
+        await waitUntil(
+            { self.queue.pendingConsent.contains { $0.toolCallId == id } },
+            "the consent prompt to park"
+        )
+        guard let reqId = queue.pendingConsent.first(where: { $0.toolCallId == id })?.id else { return }
+        queue.resolveConsent(id: reqId, choice: .allowOnce)
+        let choice = await task.value
+        XCTAssertEqual(choice, .allowOnce)
+        XCTAssertFalse(queue.pendingConsent.contains { $0.toolCallId == id })
+    }
+
+    func testCancelAllResolvesPendingConsentAsDeny() async {
+        let id = "consent-stop-\(UUID().uuidString)"
+        let task = Task { await self.queue.requestCloudVisionConsent(toolCallId: id) }
+        await waitUntil(
+            { self.queue.pendingConsent.contains { $0.toolCallId == id } },
+            "the consent prompt to park"
+        )
+        queue.cancelAll(forToolCallId: id)
+        let choice = await task.value
+        XCTAssertEqual(choice, .deny)
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/CloudVisionScrubModeTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/CloudVisionScrubModeTests.swift
@@ -1,0 +1,153 @@
+//
+//  CloudVisionScrubModeTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  Audit-remediation coverage for the cloud-vision redaction posture (P0/P1):
+//    • `CloudVisionConsent` exposes a persisted scrub-mode preference that
+//      defaults to `.allText` (mask everything) — so non-PII on-screen text
+//      never ships readable out of the box — and only flips to `.pii` when the
+//      user knowingly opts in.
+//    • `VisionContext.withConsent` flips just-in-time consent without losing the
+//      run's resolved scrub mode.
+//    • `VisionAttachment.wouldAttachWithConsent` recognizes exactly the case
+//      where consent is the only thing between the run and a (scrubbed) cloud
+//      attach, so the loop can offer the just-in-time prompt.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+// MARK: - Persisted scrub-mode preference
+
+final class CloudVisionScrubModeTests: XCTestCase {
+    @MainActor
+    func testDefaultsToAllTextAndPersistsOptIn() {
+        let suite = "cu-scrub-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let consent = CloudVisionConsent(defaults: defaults)
+        // Out of the box: mask everything (safest).
+        XCTAssertFalse(consent.masksOnlyDetectedPII)
+        XCTAssertEqual(consent.scrubMode, .allText)
+
+        consent.setMasksOnlyDetectedPII(true)
+        XCTAssertEqual(consent.scrubMode, .pii)
+        // A fresh instance over the same defaults sees the persisted choice.
+        XCTAssertTrue(CloudVisionConsent(defaults: defaults).masksOnlyDetectedPII)
+
+        consent.setMasksOnlyDetectedPII(false)
+        XCTAssertEqual(consent.scrubMode, .allText)
+        XCTAssertFalse(CloudVisionConsent(defaults: defaults).masksOnlyDetectedPII)
+    }
+}
+
+// MARK: - VisionContext consent override
+
+final class VisionContextConsentTests: XCTestCase {
+    func testWithConsentFlipsConsentButKeepsScrubMode() {
+        let base = VisionContext(
+            modelAcceptsImages: true,
+            modelIsLocal: false,
+            cloudConsent: false,
+            cloudScrubMode: .pii
+        )
+        let granted = base.withConsent(true)
+        XCTAssertTrue(granted.cloudConsent)
+        XCTAssertEqual(granted.cloudScrubMode, .pii)
+        XCTAssertEqual(granted.modelAcceptsImages, base.modelAcceptsImages)
+        XCTAssertEqual(granted.modelIsLocal, base.modelIsLocal)
+        // Original is unchanged (value semantics).
+        XCTAssertFalse(base.cloudConsent)
+    }
+
+    func testDefaultScrubModeIsAllText() {
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: false, cloudConsent: true)
+        XCTAssertEqual(ctx.cloudScrubMode, .allText)
+    }
+}
+
+// MARK: - Just-in-time consent eligibility
+
+final class WouldAttachWithConsentTests: XCTestCase {
+    private let image = CUImage(base64: "AAAA", mimeType: "image/png", width: 1, height: 1)
+
+    private func availability(screenRecording: Bool) -> MacDriverAvailability {
+        MacDriverAvailability(accessibility: true, screenRecording: screenRecording, skyLight: true)
+    }
+
+    /// The canonical case: pixels in hand, a remote image model, Screen
+    /// Recording on, but consent OFF → consent is the only blocker, so prompt.
+    func testTrueWhenOnlyConsentIsMissing() {
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: false, cloudConsent: false)
+        XCTAssertTrue(
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: ctx,
+                availability: availability(screenRecording: true)
+            )
+        )
+    }
+
+    func testFalseWhenConsentAlreadyGranted() {
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: false, cloudConsent: true)
+        XCTAssertFalse(
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: ctx,
+                availability: availability(screenRecording: true)
+            )
+        )
+    }
+
+    func testFalseForLocalModel() {
+        // A local model never needs cloud consent (and never prompts for it).
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: true, cloudConsent: false)
+        XCTAssertFalse(
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: ctx,
+                availability: availability(screenRecording: true)
+            )
+        )
+    }
+
+    func testFalseWithoutScreenRecording() {
+        // Without Screen Recording there are no pixels to send, so consent
+        // wouldn't help — don't prompt.
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: false, cloudConsent: false)
+        XCTAssertFalse(
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: ctx,
+                availability: availability(screenRecording: false)
+            )
+        )
+    }
+
+    func testFalseWhenNoImageOrNonVisionModel() {
+        let ctx = VisionContext(modelAcceptsImages: true, modelIsLocal: false, cloudConsent: false)
+        XCTAssertFalse(
+            VisionAttachment.wouldAttachWithConsent(
+                image: nil,
+                context: ctx,
+                availability: availability(screenRecording: true)
+            )
+        )
+
+        let nonVision = VisionContext(
+            modelAcceptsImages: false,
+            modelIsLocal: false,
+            cloudConsent: false
+        )
+        XCTAssertFalse(
+            VisionAttachment.wouldAttachWithConsent(
+                image: image,
+                context: nonVision,
+                availability: availability(screenRecording: true)
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
@@ -1053,4 +1053,83 @@ final class ScreenContextDistillerTests: XCTestCase {
         XCTAssertFalse(text.contains("Active:"))
         XCTAssertFalse(text.contains("Status:"))
     }
+
+    // MARK: Secure-field guard
+
+    /// A focused secure text field never surfaces its value/selection/viewport
+    /// through the DIRECT focused-content read — even if the driver somehow
+    /// reads one — so a password can't reach the model via screen context.
+    func testSecureFieldDirectReadNeverSurfacesValue() async {
+        let secret = "hunter2-topsecret"
+        let driver = editorDriver(
+            app: "Safari",
+            bundleId: "com.apple.Safari",
+            title: "Sign in — Example",
+            elements: [
+                CUElement(
+                    id: "pw",
+                    role: "securetextfield",
+                    label: "Password",
+                    value: secret,
+                    windowId: 1,
+                    focused: true
+                )
+            ],
+            focusedContent: CUFocusedContent(
+                role: "securetextfield",
+                label: "Password",
+                value: secret,
+                selectedText: secret,
+                viewport: secret
+            )
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertNil(snap.focusedElement?.value)
+        XCTAssertNil(snap.focusedElement?.selectedText)
+        XCTAssertNil(snap.focusedElement?.viewing)
+        // The label still surfaces (it's not secret) so the field is represented.
+        XCTAssertEqual(snap.focusedElement?.label, "Password")
+        XCTAssertFalse(snap.render().contains(secret))
+    }
+
+    /// Same guard on the breadth-limited TRAVERSAL fallback (no direct read): a
+    /// focused secure field surfaces only its role/label, never its value.
+    func testSecureFieldTraversalFallbackNeverSurfacesValue() async {
+        let secret = "p@ssw0rd-do-not-leak"
+        let driver = editorDriver(
+            app: "Safari",
+            bundleId: "com.apple.Safari",
+            title: "Sign in — Example",
+            elements: [
+                CUElement(
+                    id: "pw",
+                    role: "axsecuretextfield",
+                    label: "Password",
+                    value: secret,
+                    windowId: 1,
+                    focused: true
+                )
+            ],
+            focusedContent: nil
+        )
+
+        let snap = await ScreenContextDistiller().capture(
+            using: driver,
+            selfPid: selfPid,
+            selfBundleId: selfBundleId,
+            preferredPid: nil
+        )
+
+        XCTAssertNil(snap.focusedElement?.value)
+        XCTAssertNil(snap.focusedElement?.selectedText)
+        XCTAssertFalse(snap.render().contains(secret))
+        XCTAssertFalse(snap.sampledContents.contains { $0.contains(secret) })
+    }
 }

--- a/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
@@ -1,0 +1,317 @@
+//
+//  GateHardeningTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  Audit-remediation coverage for the autonomy gate's default-preset
+//  auto-run bypasses (P0). Pins the new escalations that close them:
+//    • `EffectClassifier` now folds `value` + `roleDescription` into the
+//      signal, so a value-titled or description-only control is classified.
+//    • Icon-only / unidentifiable click targets escalate to at least `edit`.
+//    • A bare commit control (Save / OK / Done / …) escalates to at least
+//      `edit` — so it confirms under the default `balanced` preset instead of
+//      silently auto-running as `navigate` — without over-escalating to
+//      `consequential` (that still needs recipients), so `trusted` users keep
+//      their auto-run.
+//    • `ComputerUseGate` enforces a dangerous-app guardrail (Terminal, System
+//      Settings, Keychain, password managers, …) that always confirms,
+//      independent of the (often-empty) allowlist and any preset/ceiling.
+//    • `AutonomyPolicy.normalize` strips `.app` + collapses whitespace without
+//      aliasing a bundle id to its last path component.
+//
+//  All pure over their inputs — no driver, no permissions, no UI.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+// MARK: - Classifier: richer signal + new escalations
+
+final class EffectClassifierHardeningTests: XCTestCase {
+    private func click(_ target: AgentTarget = AgentTarget(mark: 1)) -> AgentAction {
+        AgentAction(verb: .click, target: target)
+    }
+
+    /// An icon-only button (a known control role with no readable
+    /// label/value/description) must escalate to at least `edit` so it confirms
+    /// under `balanced` rather than auto-running as `navigate`.
+    func testIconOnlyButtonEscalatesToEdit() {
+        let effect = EffectClassifier.classify(
+            action: click(),
+            resolvedRole: "AXButton",
+            resolvedLabel: ""
+        )
+        XCTAssertGreaterThanOrEqual(effect, .edit)
+    }
+
+    /// A genuinely unidentifiable click (no role, no label, no describe) is the
+    /// strictest ambiguity case and also escalates.
+    func testUnidentifiableClickEscalatesToEdit() {
+        let blind = AgentAction(verb: .click, target: AgentTarget(describe: ""))
+        XCTAssertGreaterThanOrEqual(EffectClassifier.classify(action: blind), .edit)
+    }
+
+    /// A button whose title lives in `AXValue` (no `AXTitle`) is now seen: a
+    /// value of "Send" reaches the consequential vocabulary.
+    func testValueTitledControlFeedsTheSignal() {
+        let consequential = EffectClassifier.classify(
+            action: click(),
+            resolvedRole: "AXButton",
+            resolvedValue: "Send"
+        )
+        XCTAssertEqual(consequential, .consequential)
+
+        // A value-only commit ("Save") escalates to at least edit (→ confirm
+        // under balanced) — the "value-only commit → confirm" bypass case.
+        let commit = EffectClassifier.classify(
+            action: click(),
+            resolvedRole: "AXButton",
+            resolvedValue: "Save"
+        )
+        XCTAssertGreaterThanOrEqual(commit, .edit)
+    }
+
+    /// `roleDescription` is part of the signal too — a control described as a
+    /// "delete button" with no title still escalates.
+    func testRoleDescriptionFeedsTheSignal() {
+        let effect = EffectClassifier.classify(
+            action: click(),
+            resolvedRole: "AXButton",
+            resolvedRoleDescription: "Delete button"
+        )
+        XCTAssertEqual(effect, .consequential)
+    }
+
+    /// A field's `value` is USER CONTENT, not control intent: typing the word
+    /// "save" into a text field must NOT escalate via the value path (it stays
+    /// the edit baseline), or every draft would re-trigger the commit rule.
+    func testTextInputValueIsNotTreatedAsCommitSignal() {
+        let effect = EffectClassifier.classify(
+            action: AgentAction(verb: .type, target: AgentTarget(mark: 1), text: "save the world"),
+            resolvedRole: "AXTextField",
+            resolvedLabel: "Message",
+            resolvedValue: "save the world"
+        )
+        XCTAssertEqual(effect, .edit)
+    }
+
+    /// A bare "Save" commit (no recipients) escalates to exactly `edit` — enough
+    /// to confirm under `balanced`, but NOT `consequential`, so `trusted` keeps
+    /// auto-running edits. This is the deliberate middle ground.
+    func testSoloCommitEscalatesToEditNotConsequential() {
+        let effect = EffectClassifier.classify(
+            action: click(AgentTarget(describe: "Save")),
+            resolvedRole: "AXButton",
+            resolvedLabel: "Save"
+        )
+        XCTAssertEqual(effect, .edit)
+    }
+
+    /// HONEST LIMITATION (documented, not faked): the classifier vocabulary is
+    /// English-only, so a foreign-language commit label with no recipe and no
+    /// commit-token coincidence stays `navigate`. We do NOT fake foreign-word
+    /// detection; the real safety nets are the icon-only rule (foreign UIs often
+    /// use icons), the dangerous-app guardrail, and the user raising the preset
+    /// to `cautious` — all covered below.
+    func testForeignLabelStaysNavigate_DocumentsEnglishOnlyVocabulary() {
+        let effect = EffectClassifier.classify(
+            action: click(AgentTarget(describe: "Senden")),
+            resolvedRole: "AXButton",
+            resolvedLabel: "Senden"  // German "Send"
+        )
+        XCTAssertEqual(effect, .navigate)
+    }
+}
+
+// MARK: - Gate: dangerous-app guardrail
+
+final class DangerousAppGuardrailTests: XCTestCase {
+    private let click = AgentAction(verb: .click, target: AgentTarget(describe: "x"))
+
+    /// Even fully autonomous, driving Terminal confirms at least once.
+    func testTerminalAlwaysConfirmsEvenUnderAutonomous() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        let decision = await gate.evaluate(
+            action: click,
+            effect: .navigate,
+            appName: "Terminal",
+            targetLabel: "x"
+        )
+        guard case .confirm = decision else {
+            return XCTFail("dangerous app should force a confirm under autonomous")
+        }
+    }
+
+    /// Matches on the normalized name OR bundle id, by substring, across
+    /// variants and a few representative sensitive apps.
+    func testGuardrailMatchesVariantsAndBundleIds() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        for app in [
+            "Terminal.app", "com.apple.Terminal", "iTerm", "Ghostty",
+            "System Settings", "com.apple.systempreferences",
+            "Keychain Access", "1Password", "Bitwarden",
+        ] {
+            let decision = await gate.evaluate(
+                action: click,
+                effect: .navigate,
+                appName: app,
+                targetLabel: "x"
+            )
+            guard case .confirm = decision else {
+                return XCTFail("\(app) should be guardrailed to confirm")
+            }
+        }
+    }
+
+    /// The guardrail only TIGHTENS: a read-only policy that denies edits still
+    /// denies them in a dangerous app (a confirm floor can't loosen a deny).
+    func testGuardrailCannotLoosenADeny() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .readOnly))
+        let decision = await gate.evaluate(
+            action: AgentAction(verb: .type, target: AgentTarget(mark: 1), text: "rm -rf /"),
+            effect: .edit,
+            appName: "Terminal",
+            targetLabel: "shell"
+        )
+        guard case .reject = decision else {
+            return XCTFail("read-only deny must survive the dangerous-app guardrail")
+        }
+    }
+
+    /// Reads never reach the guardrail (perception is always safe), so looking
+    /// at Terminal still auto-runs.
+    func testGuardrailDoesNotAffectReads() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        let decision = await gate.evaluate(
+            action: AgentAction(verb: .observe),
+            effect: .read,
+            appName: "Terminal",
+            targetLabel: nil
+        )
+        XCTAssertEqual(decision, .run)
+    }
+
+    /// A non-sensitive app under autonomous is unaffected — the guardrail is
+    /// targeted, not a blanket "confirm everything".
+    func testNonDangerousAppUnaffected() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        let decision = await gate.evaluate(
+            action: click,
+            effect: .navigate,
+            appName: "Notes",
+            targetLabel: "x"
+        )
+        XCTAssertEqual(decision, .run)
+    }
+
+    /// The allowlist is still checked first: a dangerous app that isn't on an
+    /// active allowlist is rejected outright, not merely confirmed.
+    func testAllowlistRejectionPrecedesGuardrail() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(allowlist: ["notes"]))
+        let decision = await gate.evaluate(
+            action: click,
+            effect: .navigate,
+            appName: "Terminal",
+            targetLabel: "x"
+        )
+        guard case .reject = decision else {
+            return XCTFail("allowlist should reject Terminal before the guardrail")
+        }
+    }
+}
+
+// MARK: - Gate: solo-commit confirms under balanced
+
+final class SoloCommitGatingTests: XCTestCase {
+    private func saveClick() -> AgentAction {
+        AgentAction(verb: .click, target: AgentTarget(describe: "Save"))
+    }
+
+    /// End-to-end: a solo "Save" classifies as `edit` and therefore CONFIRMS
+    /// under the default `balanced` preset (the closed bypass).
+    func testSoloSaveConfirmsUnderBalanced() async {
+        let action = saveClick()
+        let effect = EffectClassifier.classify(
+            action: action,
+            resolvedRole: "AXButton",
+            resolvedLabel: "Save"
+        )
+        XCTAssertEqual(effect, .edit)
+
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .balanced))
+        let decision = await gate.evaluate(
+            action: action,
+            effect: effect,
+            appName: "Notes",
+            targetLabel: "Save"
+        )
+        guard case .confirm = decision else {
+            return XCTFail("a solo Save should confirm under balanced")
+        }
+    }
+
+    /// …but a `trusted` user (edits auto-run) still gets auto-run for that same
+    /// solo Save — proving we didn't over-escalate it to `consequential`.
+    func testSoloSaveAutoRunsUnderTrusted() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted))
+        let decision = await gate.evaluate(
+            action: saveClick(),
+            effect: .edit,
+            appName: "Notes",
+            targetLabel: "Save"
+        )
+        XCTAssertEqual(decision, .run)
+    }
+
+    /// The foreign-label gap is closed by raising the preset: under `cautious`,
+    /// navigation itself confirms, so even an unrecognized commit label pauses.
+    func testForeignLabelConfirmsUnderCautious() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .cautious))
+        let decision = await gate.evaluate(
+            action: AgentAction(verb: .click, target: AgentTarget(describe: "Senden")),
+            effect: .navigate,
+            appName: "Mail",
+            targetLabel: "Senden"
+        )
+        guard case .confirm = decision else {
+            return XCTFail("cautious should confirm navigation regardless of label language")
+        }
+    }
+}
+
+// MARK: - Allowlist name normalization
+
+final class AutonomyPolicyNormalizeTests: XCTestCase {
+    func testStripsDotAppAndCollapsesWhitespace() {
+        XCTAssertEqual(AutonomyPolicy.normalize("Safari.app"), "safari")
+        XCTAssertEqual(AutonomyPolicy.normalize("Safari.app"), AutonomyPolicy.normalize("safari"))
+        XCTAssertEqual(AutonomyPolicy.normalize("System   Settings"), "system settings")
+        XCTAssertEqual(AutonomyPolicy.normalize("  Notes \t"), "notes")
+    }
+
+    /// A `.app`-suffixed allowlist entry matches the bare display name and back.
+    func testAllowlistMatchesAcrossDotAppForms() {
+        let policy = AutonomyPolicy(allowlist: ["Safari.app", "Notes"])
+        XCTAssertTrue(policy.isAppAllowed("Safari"))
+        XCTAssertTrue(policy.isAppAllowed("safari.app"))
+        XCTAssertTrue(policy.isAppAllowed("NOTES"))
+    }
+
+    /// SECURITY: normalize must NOT alias a bundle id to its last path component
+    /// — otherwise `com.evil.notes` would match an allowlist entry of "notes".
+    func testDoesNotAliasBundleIdToLastComponent() {
+        XCTAssertEqual(AutonomyPolicy.normalize("com.evil.notes"), "com.evil.notes")
+        let policy = AutonomyPolicy(allowlist: ["notes"])
+        XCTAssertFalse(policy.isAppAllowed("com.evil.notes"))
+    }
+
+    func testForcedConfirmMatchingIsNormalized() {
+        let policy = AutonomyPolicy()
+        XCTAssertTrue(policy.requiresForcedConfirm(app: "Terminal.app"))
+        XCTAssertTrue(policy.requiresForcedConfirm(app: "com.apple.Terminal"))
+        XCTAssertFalse(policy.requiresForcedConfirm(app: "Notes"))
+        XCTAssertFalse(policy.requiresForcedConfirm(app: nil))
+        XCTAssertFalse(policy.requiresForcedConfirm(app: ""))
+    }
+}

--- a/Packages/OsaurusCore/Tests/ComputerUse/Recipes/AppRecipeTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Recipes/AppRecipeTests.swift
@@ -105,6 +105,9 @@ final class RecipeClassifierTests: XCTestCase {
 
     func testDialogDontSaveEscalatesViaUniversalRecipe() {
         let action = click("Don't Save")
+        // App-agnostic vocabulary now treats the bare commit token ("save") as
+        // an `edit` (so it confirms under balanced rather than auto-running),
+        // but it does NOT know "Don't Save" discards work — that stays edit.
         XCTAssertEqual(
             EffectClassifier.classify(
                 action: action,
@@ -112,8 +115,10 @@ final class RecipeClassifierTests: XCTestCase {
                 resolvedLabel: "Don't Save",
                 appName: "Notes"
             ),
-            .navigate
+            .edit
         )
+        // The universal dialog recipe is what recognizes "Don't Save" as a
+        // discard and escalates it the rest of the way to consequential.
         XCTAssertEqual(
             EffectClassifier.classify(
                 action: action,

--- a/Packages/OsaurusCore/Tests/Tool/ToolOutputCompressorTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolOutputCompressorTests.swift
@@ -87,7 +87,7 @@ struct ToolOutputCompressorTests {
     @Test func compactJSONIsReturnedByteIdentical() {
         // Already-compact JSON (no insignificant whitespace), padded over the
         // minimum-length gate. The crush must be a true no-op.
-        let pairs = (0..<40).map { "{\"id\":\($0),\"v\":\"item-value-\($0)\"}" }
+        let pairs = (0 ..< 40).map { "{\"id\":\($0),\"v\":\"item-value-\($0)\"}" }
         let compactJSON = "[" + pairs.joined(separator: ",") + "]"
         #expect(compactJSON.utf8.count >= ToolOutputCompressor.minimumLength)
         #expect(ToolOutputCompressor.compact(compactJSON) == compactJSON)
@@ -222,7 +222,7 @@ struct ToolOutputCompressorTests {
         // 2) Log/listing output that carries trailing whitespace (common from
         // shells, formatters, and some loggers).
         let log =
-            (1...60).map { "[\($0)] processing batch \($0) status=ok   \t" }
+            (1 ... 60).map { "[\($0)] processing batch \($0) status=ok   \t" }
             .joined(separator: "\n") + "\n"
         let stripped = ToolOutputCompressor.compact(log)
         let lBefore = ContextBudgetManager.estimateTokens(for: log)

--- a/Packages/OsaurusCore/Views/Chat/ComputerUseFeedView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ComputerUseFeedView.swift
@@ -45,7 +45,12 @@ final class ComputerUseFeedObserver: ObservableObject {
     }
 
     func stop() {
+        // Trip the interrupt token AND resolve any pending prompts. The loop only
+        // polls the token between iterations, so while it's suspended on a confirm
+        // (or consent) card the token alone wouldn't unblock it — denying the
+        // pending prompts lets the loop advance one step and then see the token.
         ComputerUseInterruptCenter.shared.interrupt(toolCallId)
+        ComputerUsePromptQueue.shared.cancelAll(forToolCallId: toolCallId)
     }
 }
 
@@ -181,93 +186,246 @@ struct ComputerUseFeedView: View {
 
 // MARK: - Confirmation overlay
 
-/// Bottom-pinned confirmation card driven by `ComputerUsePromptQueue`.
-/// Shows the first pending gated action and resolves the loop's awaiting
-/// continuation on Approve / Deny.
+/// Bottom-pinned prompt card driven by `ComputerUsePromptQueue`. Shows the
+/// first pending gated action (confirm) or cloud-vision consent request and
+/// resolves the loop's awaiting continuation.
 struct ComputerUseConfirmOverlay: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @ObservedObject private var queue = ComputerUsePromptQueue.shared
+    /// Expand the full typed payload (>1 line) for the current confirm card.
+    @State private var payloadExpanded = false
+    /// When set, Approve also auto-approves similar actions in this app for the run.
+    @State private var approveRemaining = false
 
     private var theme: ThemeProtocol { themeManager.currentTheme }
 
     var body: some View {
         ZStack {
             if let request = queue.pending.first {
-                VStack {
-                    Spacer()
-                    card(for: request)
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 16)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
+                bottomCard { confirmCard(for: request) }
+            } else if let consent = queue.pendingConsent.first {
+                bottomCard { consentCard(for: consent) }
             }
+        }
+        .onChange(of: queue.pending.first?.id) { _, _ in
+            payloadExpanded = false
+            approveRemaining = false
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.85), value: queue.pending.first?.id)
+        .animation(
+            .spring(response: 0.3, dampingFraction: 0.85),
+            value: queue.pendingConsent.first?.id
+        )
     }
 
-    private func card(for request: ConfirmRequest) -> some View {
+    @ViewBuilder
+    private func bottomCard<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack {
+            Spacer()
+            content()
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+
+    // MARK: Confirm card
+
+    private func confirmCard(for request: ConfirmRequest) -> some View {
         let preview = request.preview
-        return VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 8) {
-                Image(systemName: "questionmark.circle.fill")
-                    .font(.system(size: 16))
-                    .foregroundColor(theme.warningColor)
-                Text("Confirm action", bundle: .module)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(theme.primaryText)
-                Spacer()
-                effectBadge(preview.effect)
-            }
+        return cardChrome {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "questionmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(theme.warningColor)
+                    Text("Confirm action", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Spacer()
+                    effectBadge(preview.effect)
+                }
 
-            Text(preview.summary)
-                .font(.system(size: 13))
-                .foregroundColor(theme.primaryText)
-                .fixedSize(horizontal: false, vertical: true)
+                // Structured fields, so the user sees exactly app / action /
+                // target / payload rather than one truncated line.
+                VStack(alignment: .leading, spacing: 6) {
+                    field(label: L("Action"), value: preview.actionLabel, prominent: true)
+                    if let app = preview.appName, !app.isEmpty {
+                        field(label: L("App"), value: app)
+                    }
+                    if let target = preview.targetLabel, !target.isEmpty {
+                        field(label: L("Target"), value: target)
+                    }
+                    if let typed = preview.typedText, !typed.isEmpty {
+                        typedTextField(typed)
+                    }
+                }
 
-            if let note = preview.note, !note.isEmpty {
-                Text(note)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+                if let note = preview.note, !note.isEmpty {
+                    Text(note)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-            HStack(spacing: 10) {
-                Spacer()
-                Button(action: { queue.resolve(id: request.id, approved: false) }) {
-                    Text("Decline", bundle: .module)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(theme.secondaryText)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.tertiaryBackground)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8).stroke(theme.inputBorder, lineWidth: 1)
-                                )
+                if let app = preview.appName, !app.isEmpty {
+                    Toggle(isOn: $approveRemaining) {
+                        Text(
+                            String(
+                                format: L("Don't ask again for similar actions in %@ this run"),
+                                app
+                            )
                         )
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.secondaryText)
+                    }
+                    .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
                 }
-                .buttonStyle(PlainButtonStyle())
 
-                Button(action: { queue.resolve(id: request.id, approved: true) }) {
-                    Text("Approve", bundle: .module)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 7)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
+                HStack(spacing: 10) {
+                    Spacer()
+                    secondaryButton(L("Decline")) {
+                        queue.resolve(id: request.id, approved: false)
+                    }
+                    primaryButton(L("Approve")) {
+                        if approveRemaining {
+                            queue.resolveApprovingRest(id: request.id)
+                        } else {
+                            queue.resolve(id: request.id, approved: true)
+                        }
+                    }
                 }
-                .buttonStyle(PlainButtonStyle())
             }
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(theme.cardBackground)
-                .overlay(RoundedRectangle(cornerRadius: 14).stroke(theme.cardBorder, lineWidth: 1))
-                .shadow(color: Color.black.opacity(0.2), radius: 16, y: 6)
-        )
-        .frame(maxWidth: 420)
+    }
+
+    @ViewBuilder
+    private func field(label: String, value: String, prominent: Bool = false) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: 52, alignment: .leading)
+            Text(value)
+                .font(.system(size: prominent ? 13 : 12, weight: prominent ? .medium : .regular))
+                .foregroundColor(prominent ? theme.primaryText : theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func typedTextField(_ text: String) -> some View {
+        let isLong = text.count > 40
+        let shown = (isLong && !payloadExpanded) ? String(text.prefix(40)) + "…" : text
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Text", bundle: .module)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                    .frame(width: 52, alignment: .leading)
+                Text(shown)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.secondaryText)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            if isLong {
+                Button(action: { payloadExpanded.toggle() }) {
+                    Text(payloadExpanded ? L("Show less") : L("Show full text"))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .padding(.leading, 60)
+            }
+        }
+    }
+
+    // MARK: Consent card
+
+    private func consentCard(for request: CloudVisionConsentRequest) -> some View {
+        cardChrome {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "eye.trianglebadge.exclamationmark")
+                        .font(.system(size: 16))
+                        .foregroundColor(theme.accentColor)
+                    Text("Use Cloud vision?", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Spacer()
+                }
+                Text(
+                    "A screenshot would help here, but this agent uses a cloud model. Osaurus masks sensitive text on-device first, then sends the redacted image. Screenshots need Screen Recording permission.",
+                    bundle: .module
+                )
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    Spacer()
+                    secondaryButton(L("Not now")) {
+                        queue.resolveConsent(id: request.id, choice: .deny)
+                    }
+                    secondaryButton(L("Allow once")) {
+                        queue.resolveConsent(id: request.id, choice: .allowOnce)
+                    }
+                    primaryButton(L("Always allow")) {
+                        queue.resolveConsent(id: request.id, choice: .allowAlways)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: Shared chrome
+
+    @ViewBuilder
+    private func cardChrome<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(theme.cardBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14).stroke(theme.cardBorder, lineWidth: 1)
+                    )
+                    .shadow(color: Color.black.opacity(0.2), radius: 16, y: 6)
+            )
+            .frame(maxWidth: 420)
+    }
+
+    private func secondaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.tertiaryBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8).stroke(theme.inputBorder, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
+        }
+        .buttonStyle(PlainButtonStyle())
     }
 
     private func effectBadge(_ effect: EffectClass) -> some View {

--- a/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
@@ -618,14 +618,20 @@ struct ComputerUseSettingsView: View {
             } else {
                 ForEach(sortedOverrideKeys, id: \.self) { appKey in
                     appRow(icon: "app.dashed", iconColor: theme.secondaryText, name: appKey) {
+                        let current = policy.perApp[appKey] ?? .cautious
                         presetPickerMenu(
                             Binding(
-                                get: { policy.perApp[appKey] ?? .cautious },
+                                get: { current },
                                 set: {
                                     policy.perApp[appKey] = $0
                                     persist()
                                 }
-                            )
+                            ),
+                            // Per-app rules can only TIGHTEN (strictest-wins merge), so
+                            // a looser preset would silently no-op. Only offer presets
+                            // at least as strict as the global default (plus whatever's
+                            // currently selected, so a pre-existing rule stays visible).
+                            options: perAppPresetOptions(current: current)
                         )
                         removeButton(help: L("Remove rule")) { removeOverride(appKey) }
                     }
@@ -692,6 +698,35 @@ struct ComputerUseSettingsView: View {
             }
             .padding(12)
             .surface(cornerRadius: 10, fill: theme.inputBackground, stroke: theme.inputBorder)
+
+            // Redaction mode: mask everything (default, safest) vs. mask only
+            // detected PII (less strict — leaves non-sensitive text readable).
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Mask only detected sensitive text"))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    hintText(
+                        "Off (recommended): mask ALL on-screen text before sending. On: send a screenshot where only detected sensitive text (names, emails, numbers, secrets) is masked — other text stays readable to the model."
+                    )
+                }
+                Spacer(minLength: 12)
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { cloudVisionConsent.masksOnlyDetectedPII },
+                        set: { cloudVisionConsent.setMasksOnlyDetectedPII($0) }
+                    )
+                )
+                .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+                .labelsHidden()
+            }
+            .padding(12)
+            .surface(cornerRadius: 10, fill: theme.inputBackground, stroke: theme.inputBorder)
+
+            hintText(
+                "Masking runs on-device using OCR + the Privacy Filter (your configured rules plus an on-device model for names/addresses/dates/secrets). Detection isn't perfect — it can miss text OCR can't read or the model doesn't recognize — so \"mask only sensitive text\" trades some privacy for the model seeing more context. Screenshots also require Screen Recording permission; without it the agent stays on accessibility text only."
+            )
         }
     }
 
@@ -746,9 +781,12 @@ struct ComputerUseSettingsView: View {
     }
 
     @ViewBuilder
-    private func presetPickerMenu(_ selection: Binding<AutonomyPreset>) -> some View {
+    private func presetPickerMenu(
+        _ selection: Binding<AutonomyPreset>,
+        options: [AutonomyPreset] = AutonomyPreset.allCases
+    ) -> some View {
         Menu {
-            ForEach(AutonomyPreset.allCases) { preset in
+            ForEach(options) { preset in
                 Button {
                     selection.wrappedValue = preset
                 } label: {
@@ -810,6 +848,21 @@ struct ComputerUseSettingsView: View {
 
     private var sortedOverrideKeys: [String] {
         policy.perApp.keys.sorted()
+    }
+
+    /// Presets a per-app rule may pick: those at least as strict as the global
+    /// default on every effect (a looser one would silently no-op under the
+    /// strictest-wins merge), plus the currently selected value so an existing
+    /// rule never vanishes from its own menu.
+    private func perAppPresetOptions(current: AutonomyPreset) -> [AutonomyPreset] {
+        let global = policy.globalPreset
+        let effects: [EffectClass] = [.navigate, .edit, .consequential]
+        return AutonomyPreset.allCases.filter { preset in
+            if preset == current { return true }
+            return effects.allSatisfy {
+                preset.disposition(for: $0) >= global.disposition(for: $0)
+            }
+        }
     }
 
     private func persist() {

--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/safari-secure-login.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/safari-secure-login.json
@@ -1,0 +1,36 @@
+{
+  "apps": [
+    { "pid": 303, "bundleId": "com.apple.Safari", "name": "Safari", "active": true, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 303,
+    "app": "Safari",
+    "title": "Sign in — Example",
+    "x": 0, "y": 0, "w": 1200, "h": 800
+  },
+  "windowsByPid": {
+    "303": [
+      { "windowId": 1, "title": "Sign in — Example", "focused": true, "minimized": false, "x": 0, "y": 0, "w": 1200, "h": 800 }
+    ]
+  },
+  "snapshot": {
+    "app": "Safari",
+    "focusedWindow": "Sign in — Example",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "Sign in — Example", "focused": true, "x": 0, "y": 0, "w": 1200, "h": 800 }
+    ],
+    "elements": [
+      { "id": "intro", "role": "statictext", "value": "Sign in to continue to your team workspace.", "focused": false, "enabled": true, "x": 300, "y": 150, "w": 600, "h": 24, "actions": [] },
+      { "id": "pw", "role": "securetextfield", "label": "Password", "value": "hunter2-DoNotLeak-9921", "focused": true, "enabled": true, "x": 300, "y": 250, "w": 400, "h": 32, "actions": [] },
+      { "id": "oldpw", "role": "securetextfield", "label": "Current password", "value": "old-secret-PleaseHide-7788", "focused": false, "enabled": true, "x": 300, "y": 300, "w": 400, "h": 32, "actions": [] },
+      { "id": "signin", "role": "button", "label": "Sign In", "focused": false, "enabled": true, "x": 300, "y": 360, "w": 120, "h": 32, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "securetextfield",
+    "label": "Password",
+    "value": "hunter2-DoNotLeak-9921",
+    "selectedText": "hunter2-DoNotLeak-9921"
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ScreenContext/secure-field-never-leaks.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/secure-field-never-leaks.json
@@ -1,0 +1,24 @@
+{
+  "id": "screen_context.secure-field-never-leaks",
+  "domain": "screen_context",
+  "label": "Screen context • secure field value never leaks",
+  "query": "(ambient capture)",
+  "notes": "A Safari sign-in scene with a focused password field (direct focused-content read) and a second, non-focused secure field. The distiller's secure-field guard must surface the focused field's role/label but NEVER its value/selection, and the on-screen sampler must render the non-focused secure field as hidden rather than dumping its value. Pins the P2 secure-field traversal guard: neither secret value may appear anywhere in the rendered block, while ordinary on-screen text still flows.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "safari-secure-login.json",
+      "focusedRoleEquals": "secure field",
+      "gistContains": ["In Safari"],
+      "mustContain": [
+        "In Safari",
+        "Focused field:",
+        "Sign in to continue"
+      ],
+      "mustNotContain": [
+        "hunter2-DoNotLeak-9921",
+        "old-secret-PleaseHide-7788"
+      ]
+    }
+  }
+}

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -179,14 +179,26 @@ scrubbing:
   relaunch, `UserDefaults` key `ai.osaurus.computeruse.cloudVisionConsent`) and a
   transient this-launch-only grant. Revoke clears both.
 - **`FrameScrubber`** (`ComputerUse/Perception/FrameScrubber.swift`) — the only
-  producer of a `ScrubbedFrame`. It runs Vision OCR over a frame and finds PII
-  with the same `RegexEntityDetector` engine the Privacy Filter uses, but with
-  **all built-in detectors** (the parameterless `detect(in:)`) rather than the
-  user's configured Privacy Filter ruleset — so frame scrubbing doesn't honor
-  disabled categories, presets, or custom rules the way outbound text filtering
-  does. It paints opaque boxes over the offending regions (or every text region
-  in `.allText` mode) before any frame can leave the device. A `ScrubReport`
-  (counts only) stays on-device for the feed/telemetry.
+  producer of a `ScrubbedFrame`. It runs Vision OCR over a frame and redacts it
+  in one of two modes:
+  - **`.allText` (default for cloud)** — paints opaque boxes over **every**
+    recognized text region, so nothing readable leaves the device. This is what
+    a consented cloud screenshot uses out of the box.
+  - **`.pii`** (opt-in via Settings → Computer Use → *Mask only detected
+    sensitive text*) — masks only regions whose text matched a detector. For
+    parity with outbound text filtering, the cloud path runs **both** the
+    `RegexEntityDetector` layer built from the **user's configured Privacy
+    Filter ruleset** (`honorUserRules: true` — honoring disabled categories,
+    presets, and custom rules) **and** the on-device NER model
+    (`PrivacyFilterEngine.modelSpans`) for `person` / `address` / `date` /
+    `secret`, which have no regex. A region with a model hit is masked whole
+    (recall over precision). Detection isn't perfect — OCR or the model can
+    miss text — which is why `.allText` is the default.
+
+  Either way it paints opaque boxes before any frame can leave the device. A
+  `ScrubReport` (counts only) stays on-device for the feed/telemetry. The mode
+  is resolved once per run into `VisionContext.cloudScrubMode` so a mid-run
+  settings edit can't change it under a running loop.
 - **`CaptureRouter.cloudRoute(...)`** — accepts **only** a `ScrubbedFrame` and
   returns `nil` unless consent is granted and Screen Recording is on. So the
   harness physically cannot reach `.cloudVision` without both a scrubbed frame
@@ -196,7 +208,11 @@ scrubbing:
   into a `Plan`: `.none`, `.localFrame` (local model — attach as-is), or
   `.needsScrubForCloud` (remote model — scrub then route). The loop attaches at
   most one screenshot to the conversation at a time and reserves image tokens
-  against the context budget.
+  against the context budget. When a frame *would* reach a cloud model if only
+  consent were granted (`wouldAttachWithConsent`), the loop surfaces a
+  **just-in-time consent prompt** once per run (Allow once / Always allow / Not
+  now) instead of silently staying AX-only — wiring `grantForSession()` /
+  `grantPersistently()` to the user's choice.
 
 A frame is only ever attached to a model request when **the model accepts
 images** (`ComputerUseTool.modelAcceptsImages`: local VLM detection / media
@@ -264,11 +280,30 @@ The gate decides `allow` / `confirm` / `deny` for every action by combining a
 | `consequential` | Commits something hard to undo or crossing a trust boundary: send, submit, delete, purchase, share with recipients. |
 
 The classifier starts from the verb's baseline and **escalates** using the
-resolved role + app context: consequential signals (Send / Delete / Purchase /
-Submit …) escalate on their own, while commit signals (Save / Done / Apply / OK
-…) escalate only when paired with **recipients** — plus the ⌘Return submit
-chord, ambiguous targets, and per-app recipe signals. It can only raise the
-effect, never lower it.
+resolved role + app context. Its signal string includes the element's `label`,
+`roleDescription`, and (for non-text-input roles) `value` — so an icon-only or
+value-titled control is still classified — plus the model's `describe`/`note`.
+Escalation rules:
+
+- **Consequential signals** (Send / Delete / Purchase / Submit …) escalate to
+  `consequential` on their own.
+- **Commit signals** (Save / Done / Apply / OK / Create / Add …) escalate to
+  `consequential` when paired with **recipients**, and otherwise to at least
+  **`edit`** on their own — so a bare "Save"/"OK" confirms under `balanced`
+  instead of silently auto-running as `navigate`.
+- **Icon-only / ambiguous controls** — a click on a button-like role with no
+  readable label/value/description (or any click with no identifiable target)
+  escalates to at least `edit`.
+- Plus the ⌘Return submit chord and per-app recipe signals.
+
+It can only raise the effect, never lower it.
+
+Independently of the preset/override/ceiling — and of the (often-empty)
+allowlist — `ComputerUseGate` applies a **dangerous-app guardrail**: driving a
+sensitive app (Terminal & friends, System Settings, Keychain Access, Activity
+Monitor, Disk Utility, Script Editor/Automator, password managers, …) always
+requires at least a confirm. It can only tighten, and the user can still
+approve at the prompt (`AutonomyPolicy.forcedConfirmAppNeedles`).
 
 ### Policy stack (strictest-wins)
 
@@ -320,9 +355,12 @@ Vivaldi / Opera).
 ## UI surfaces
 
 - **Settings → Computer Use** (`Views/Settings/ComputerUseSettingsView.swift`) —
-  global preset picker, per-app overrides, app allowlist, the **Cloud vision**
-  consent toggle ("Allow scrubbed screenshots to reach a cloud model", off by
-  default), the **Screen context** opt-in + live preview (see above),
+  global preset picker, per-app overrides (the picker is filtered to presets at
+  least as strict as the global default, since a looser per-app rule would
+  silently no-op), app allowlist, the **Cloud vision** consent toggle (off by
+  default) plus a **Mask only detected sensitive text** toggle (off = `.allText`,
+  the safest) and copy disclosing the on-device scrub's limits and the Screen
+  Recording dependency, the **Screen context** opt-in + live preview (see above),
   Accessibility / Screen Recording permission rows, and an "Enabling Computer
   Use" explainer.
 - **Per-agent** (Agents → Configure → Features) — the `computerUseEnabled`
@@ -331,8 +369,12 @@ Vivaldi / Opera).
   `ComputerUseFeed` renders each perceive/decide/gate/act/verify step in the
   chat row; the inner steps never enter the parent transcript.
 - **Confirm overlay** — `confirm` dispositions pause the loop and surface an
-  `ActionPreview` through the single-slot `ComputerUsePromptQueue`; a [Stop]
-  control interrupts the run (`InterruptToken`).
+  `ActionPreview` (structured app / action / target / expandable typed-text
+  fields, with an optional "don't ask again for similar actions in this app"
+  for the run) through the single-slot `ComputerUsePromptQueue`, which also
+  hosts the just-in-time cloud-vision consent card. A [Stop] control interrupts
+  the run (`InterruptToken`) **and** resolves any pending card, so Stop works
+  even while a confirmation is up.
 
 ## Telemetry
 
@@ -355,6 +397,7 @@ sends.
 |------------|---------|
 | `~/.osaurus/config/computer-use.json` | `AutonomyPolicy` (global preset + per-app overrides + allowlist), via `ComputerUsePolicyStore`. |
 | `UserDefaults` `ai.osaurus.computeruse.cloudVisionConsent` | Persisted cloud-vision opt-in (default `false`). |
+| `UserDefaults` `ai.osaurus.computeruse.cloudVisionPIIOnly` | Cloud screenshot redaction mode: `false` (default) = `.allText` (mask everything), `true` = `.pii` (mask only detected sensitive text). |
 | `UserDefaults` `ai.osaurus.computeruse.screenContextInjection` | Persisted screen-context opt-in (default `false`), via `ScreenContextSettings`. |
 | `Agent.settings.computerUseEnabled` / `computerUseCeiling` | Per-agent enablement + autonomy ceiling (in the agent JSON). |
 


### PR DESCRIPTION
## Summary

Closes the highest-impact gaps found in a Computer Use audit. The marquee privacy claim ("sensitive text was redacted before it left the device") was only partially true, the autonomy gate had default-preset auto-run bypasses, and the feed's **Stop** didn't stop while a confirm card was up. This PR brings the behavior in line with what the feature promises.

Work is grouped by the audit's priority levels (P0 = overstated privacy/security promises, P1 = meaningful hardening, P2 = polish).

### P0 — Cloud-vision redaction now matches its promise
- **ML/NER on frame text, not just regex.** `FrameScrubber` routes OCR'd strings through the same `person`/`address`/`date`/`secret` path the text filter uses (`PrivacyFilterEngine.modelSpans`), so screenshots mask the same categories as text.
- **Cloud screenshots default to `.allText`.** Non-PII confidential text no longer ships readable. Users can opt into the less-strict `.pii` mode knowingly (`CloudVisionConsent.masksOnlyDetectedPII`), surfaced in Settings.
- **Honor the user's Privacy Filter ruleset on frames** (`honorUserRules`), and the attached-frame note + `docs/COMPUTER_USE.md` now state plainly what is and isn't redacted.

### P0 — Autonomy gate: default-preset bypasses closed
- `EffectClassifier` folds `value` + `roleDescription` into its signal, so a value-titled or description-only control is classified.
- Icon-only / unidentifiable click targets escalate to at least `edit`.
- A bare commit control (Save / OK / Done …) escalates to at least `edit` (confirms under `balanced`) without over-escalating to `consequential` (so `trusted` still auto-runs edits).
- New **dangerous-app guardrail** in `ComputerUseGate` (Terminal, System Settings, Keychain, password managers, …) always confirms — independent of the (often-empty) allowlist and any preset/ceiling.
- Allowlist name normalization (strip `.app`, collapse whitespace) without aliasing a bundle id to its last path component.

### P1 — The "Stop" that didn't stop
- `observer.stop()` now also resolves pending prompts via `ComputerUsePromptQueue.cancelAll(forToolCallId:)`, and `requestConfirmation`/`requestCloudVisionConsent` are wrapped in `withTaskCancellationHandler`, so Stop works even while a card is on screen.

### P1 — Consent & confirm UX
- **Just-in-time cloud-vision prompt:** when a screenshot would help but consent is off (remote image model + Screen Recording on), the run offers an inline "enable Cloud vision" prompt once per run instead of silently staying AX-only.
- Confirm overlay: structured app / action / target / payload fields, expandable typed text (>40 chars), and an optional "don't ask again for similar actions in this app this run".
- Cloud-vision settings disclose the scrub limits + Screen Recording dependency.

### P2 — Smaller hardening
- Secure-field guard on both the direct read and the traversal fallback in `ScreenContextDistiller` (a focused password field surfaces role/label, never value/selection).
- Inline base64 image payloads are redacted from the Insights request log (`ChatEngine.redactInlineImagePayloads`).
- Per-app override picker filtered to presets at least as strict as the global default (looser ones silently no-op).
- Documented decision that perception (`observe`/`find`/initial perceive) is intentionally not allowlist-gated.

## Changes

- [x] Behavior change
- [x] UI change (confirm overlay + just-in-time consent card + settings)
- [x] Refactor / chore
- [x] Tests
- [x] Docs

## Test Plan

Local unit + eval validation (keychain-free where applicable):

- `swift build --package-path Packages/OsaurusCore` — clean, no new warnings.
- New/updated suites all green: `EffectClassifierHardeningTests`, `DangerousAppGuardrailTests`, `SoloCommitGatingTests`, `AutonomyPolicyNormalizeTests`, `ComputerUsePromptQueueTests` (incl. Stop-during-confirm + task-cancellation), `CloudVisionScrubModeTests`, `InsightsImageRedactionTests`, `ScreenContextDistillerTests` (incl. 2 new secure-field tests), `AppRecipeTests`, plus the OCR-backed `FrameScrubberTests.testAllTextMasksAtLeastAsMuchAsPII`.
- New CI eval `screen_context.secure-field-never-leaks` passes: render surfaces the field's role/label and ordinary text, but neither secret value (focused field shows `(empty)`, non-focused secure field shows `(hidden)`).
- Full `make test`: the XCTest "All tests" suite passes. The only swift-testing failures are a pre-existing `ResolvedSecretsMergingTests` parallel-keychain-contamination flake, reproduced identically on a clean baseline (this branch stashed) — unrelated to these changes.

Manual: drive a remote vision model with cloud-vision consent off → just-in-time prompt appears; deny → stays on AX text. Hit a Terminal/System Settings action under `autonomous` → still confirms. Press Stop while a confirm card is up → run unblocks.

## Screenshots

_UI changes (confirm overlay, consent card, settings copy) are described above; before/after screenshots to be added if needed._

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+ (verified via `swift build`/`swift test`; xcodebuild lane not run)

Made with [Cursor](https://cursor.com)