### PR TITLE
Add unified evidence report registry

### DIFF
--- a/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
+++ b/Packages/OsaurusCore/Models/Evidence/EvidenceReportRegistry.swift
@@ -1,0 +1,302 @@
+//
+//  EvidenceReportRegistry.swift
+//  osaurus
+//
+//  Typed summaries for locally-produced eval, benchmark, runtime, live-proof,
+//  run-trace, and provider evidence artifacts. The registry is intentionally
+//  a projection over existing files; it does not own or move artifacts.
+//
+
+import Foundation
+
+public enum EvidenceReportKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case eval
+    case benchmark
+    case runtime
+    case liveProof = "live_proof"
+    case runTrace = "run_trace"
+    case provider
+    case custom
+}
+
+public enum EvidenceReportStatus: String, Codable, CaseIterable, Hashable, Sendable {
+    case passed
+    case failed
+    case partial
+    case blocked
+    case unavailable
+    case error
+    case unknown
+}
+
+public enum EvidenceArtifactAvailability: String, Codable, CaseIterable, Hashable, Sendable {
+    case available
+    case unavailable
+    case error
+}
+
+public struct EvidenceReportCounts: Codable, Equatable, Hashable, Sendable {
+    public var total: Int
+    public var passed: Int
+    public var failed: Int
+    public var errored: Int
+    public var skipped: Int
+    public var blocked: Int
+    public var warnings: Int
+
+    public init(
+        total: Int = 0,
+        passed: Int = 0,
+        failed: Int = 0,
+        errored: Int = 0,
+        skipped: Int = 0,
+        blocked: Int = 0,
+        warnings: Int = 0
+    ) {
+        self.total = max(0, total)
+        self.passed = max(0, passed)
+        self.failed = max(0, failed)
+        self.errored = max(0, errored)
+        self.skipped = max(0, skipped)
+        self.blocked = max(0, blocked)
+        self.warnings = max(0, warnings)
+    }
+}
+
+public struct EvidenceReportArtifact: Codable, Equatable, Hashable, Sendable {
+    public var path: String
+    public var availability: EvidenceArtifactAvailability
+    public var message: String?
+
+    public init(
+        path: String,
+        availability: EvidenceArtifactAvailability,
+        message: String? = nil
+    ) {
+        self.path = path
+        self.availability = availability
+        self.message = message
+    }
+}
+
+public struct EvidenceReportDescriptor: Codable, Equatable, Sendable {
+    public var id: String?
+    public var kind: EvidenceReportKind
+    public var source: String
+    public var artifactPath: String
+    public var status: EvidenceReportStatus
+    public var counts: EvidenceReportCounts
+    public var startedAt: Date?
+    public var completedAt: Date?
+    public var metadata: [String: String]
+    public var artifactError: String?
+
+    public init(
+        id: String? = nil,
+        kind: EvidenceReportKind,
+        source: String,
+        artifactPath: String,
+        status: EvidenceReportStatus = .unknown,
+        counts: EvidenceReportCounts = EvidenceReportCounts(),
+        startedAt: Date? = nil,
+        completedAt: Date? = nil,
+        metadata: [String: String] = [:],
+        artifactError: String? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.source = source
+        self.artifactPath = artifactPath
+        self.status = status
+        self.counts = counts
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.metadata = metadata
+        self.artifactError = artifactError
+    }
+
+    public init(
+        id: String? = nil,
+        kind: EvidenceReportKind,
+        source: String,
+        artifactURL: URL,
+        status: EvidenceReportStatus = .unknown,
+        counts: EvidenceReportCounts = EvidenceReportCounts(),
+        startedAt: Date? = nil,
+        completedAt: Date? = nil,
+        metadata: [String: String] = [:],
+        artifactError: String? = nil
+    ) {
+        self.init(
+            id: id,
+            kind: kind,
+            source: source,
+            artifactPath: artifactURL.path,
+            status: status,
+            counts: counts,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            metadata: metadata,
+            artifactError: artifactError
+        )
+    }
+}
+
+public struct EvidenceReportSummary: Codable, Equatable, Hashable, Sendable {
+    public var id: String
+    public var kind: EvidenceReportKind
+    public var source: String
+    public var artifact: EvidenceReportArtifact
+    public var status: EvidenceReportStatus
+    public var counts: EvidenceReportCounts
+    public var startedAt: Date?
+    public var completedAt: Date?
+    public var registeredAt: Date
+    public var metadata: [String: String]
+
+    public init(
+        id: String,
+        kind: EvidenceReportKind,
+        source: String,
+        artifact: EvidenceReportArtifact,
+        status: EvidenceReportStatus,
+        counts: EvidenceReportCounts,
+        startedAt: Date? = nil,
+        completedAt: Date? = nil,
+        registeredAt: Date,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.kind = kind
+        self.source = source
+        self.artifact = artifact
+        self.status = status
+        self.counts = counts
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.registeredAt = registeredAt
+        self.metadata = metadata
+    }
+
+    public func stableJSONData(prettyPrinted: Bool = false) throws -> Data {
+        let encoder = JSONEncoder.osaurusCanonical(prettyPrinted: prettyPrinted)
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+}
+
+public struct EvidenceReportFilter: Equatable, Sendable {
+    public var kinds: Set<EvidenceReportKind>
+    public var sources: Set<String>
+    public var statuses: Set<EvidenceReportStatus>
+    public var artifactAvailability: Set<EvidenceArtifactAvailability>
+
+    public init(
+        kinds: Set<EvidenceReportKind> = [],
+        sources: Set<String> = [],
+        statuses: Set<EvidenceReportStatus> = [],
+        artifactAvailability: Set<EvidenceArtifactAvailability> = []
+    ) {
+        self.kinds = kinds
+        self.sources = sources
+        self.statuses = statuses
+        self.artifactAvailability = artifactAvailability
+    }
+
+    public func includes(_ summary: EvidenceReportSummary) -> Bool {
+        if !kinds.isEmpty, !kinds.contains(summary.kind) {
+            return false
+        }
+        if !sources.isEmpty, !sources.contains(summary.source) {
+            return false
+        }
+        if !statuses.isEmpty, !statuses.contains(summary.status) {
+            return false
+        }
+        if !artifactAvailability.isEmpty,
+           !artifactAvailability.contains(summary.artifact.availability) {
+            return false
+        }
+        return true
+    }
+}
+
+public enum EvidenceReportMetadataRedactor {
+    private static let redactedValue = "<redacted>"
+
+    public static func redact(_ metadata: [String: String]) -> [String: String] {
+        metadata.reduce(into: [:]) { output, element in
+            let key = element.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { return }
+            output[key] = redactedValue(forKey: key, value: element.value)
+        }
+    }
+
+    public static func redactedValue(forKey key: String, value: String) -> String {
+        if isSensitiveKey(key) || looksSensitive(value) {
+            return redactedValue
+        }
+        return value
+    }
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let normalized = key
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: ".", with: "")
+
+        if normalized == "token" || normalized == "key" {
+            return true
+        }
+
+        return [
+            "apikey",
+            "authorization",
+            "authtoken",
+            "bearer",
+            "clientsecret",
+            "credential",
+            "password",
+            "privatekey",
+            "refreshtoken",
+            "secret",
+            "sessiontoken",
+            "accesstoken",
+        ].contains { normalized.contains($0) }
+    }
+
+    private static func looksSensitive(_ value: String) -> Bool {
+        let lowercased = value.lowercased()
+        if lowercased.contains("bearer ")
+            || lowercased.contains("token=")
+            || lowercased.contains("api_key=")
+            || lowercased.contains("apikey=")
+            || lowercased.contains("password=")
+            || lowercased.contains("secret=") {
+            return true
+        }
+
+        return [
+            "sk-",
+            "ghp_",
+            "github_pat_",
+            "xoxb-",
+            "xoxp-",
+        ].contains { lowercased.hasPrefix($0) }
+    }
+}
+
+public struct EvidenceReportRegistrySnapshot: Codable, Equatable, Sendable {
+    public var reports: [EvidenceReportSummary]
+
+    public init(reports: [EvidenceReportSummary]) {
+        self.reports = reports
+    }
+
+    public func stableJSONData(prettyPrinted: Bool = false) throws -> Data {
+        let encoder = JSONEncoder.osaurusCanonical(prettyPrinted: prettyPrinted)
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+}

--- a/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
+++ b/Packages/OsaurusCore/Services/Evidence/EvidenceReportRegistryService.swift
@@ -1,0 +1,186 @@
+//
+//  EvidenceReportRegistryService.swift
+//  osaurus
+//
+//  In-memory registry over local evidence report descriptors.
+//
+
+import Foundation
+
+public final class EvidenceReportRegistryService {
+    private var summariesByID: [String: EvidenceReportSummary] = [:]
+    private let fileManager: FileManager
+    private let now: () -> Date
+
+    public init(
+        fileManager: FileManager = .default,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.fileManager = fileManager
+        self.now = now
+    }
+
+    @discardableResult
+    public func register(
+        _ descriptors: [EvidenceReportDescriptor],
+        relativeTo baseURL: URL? = nil
+    ) -> [EvidenceReportSummary] {
+        descriptors.map { register($0, relativeTo: baseURL) }
+    }
+
+    @discardableResult
+    public func register(
+        _ descriptor: EvidenceReportDescriptor,
+        relativeTo baseURL: URL? = nil
+    ) -> EvidenceReportSummary {
+        let summary = makeSummary(from: descriptor, relativeTo: baseURL)
+        if let existing = summariesByID[summary.id] {
+            summariesByID[summary.id] = preferredSummary(existing, summary)
+        } else {
+            summariesByID[summary.id] = summary
+        }
+        return summariesByID[summary.id] ?? summary
+    }
+
+    public func list(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> [EvidenceReportSummary] {
+        summariesByID.values
+            .filter { filter.includes($0) }
+            .sorted(by: Self.sortSummaries)
+    }
+
+    public func snapshot(_ filter: EvidenceReportFilter = EvidenceReportFilter()) -> EvidenceReportRegistrySnapshot {
+        EvidenceReportRegistrySnapshot(reports: list(filter))
+    }
+
+    public func removeAll() {
+        summariesByID.removeAll()
+    }
+
+    private func makeSummary(
+        from descriptor: EvidenceReportDescriptor,
+        relativeTo baseURL: URL?
+    ) -> EvidenceReportSummary {
+        let artifactPath = normalizedArtifactPath(descriptor.artifactPath, relativeTo: baseURL)
+        let artifact = artifactReference(
+            path: artifactPath,
+            descriptorError: descriptor.artifactError
+        )
+        let status = status(for: descriptor.status, artifact: artifact)
+        let id = descriptor.id ?? stableID(
+            kind: descriptor.kind,
+            source: descriptor.source,
+            artifactPath: artifactPath
+        )
+
+        return EvidenceReportSummary(
+            id: id,
+            kind: descriptor.kind,
+            source: descriptor.source,
+            artifact: artifact,
+            status: status,
+            counts: descriptor.counts,
+            startedAt: descriptor.startedAt,
+            completedAt: descriptor.completedAt,
+            registeredAt: now(),
+            metadata: EvidenceReportMetadataRedactor.redact(descriptor.metadata)
+        )
+    }
+
+    private func normalizedArtifactPath(_ path: String, relativeTo baseURL: URL?) -> String {
+        guard let baseURL, !path.hasPrefix("/") else {
+            return URL(fileURLWithPath: path).standardizedFileURL.path
+        }
+        return baseURL
+            .appendingPathComponent(path)
+            .standardizedFileURL
+            .path
+    }
+
+    private func artifactReference(
+        path: String,
+        descriptorError: String?
+    ) -> EvidenceReportArtifact {
+        if let descriptorError, !descriptorError.isEmpty {
+            return EvidenceReportArtifact(
+                path: path,
+                availability: .error,
+                message: descriptorError
+            )
+        }
+
+        guard fileManager.fileExists(atPath: path) else {
+            return EvidenceReportArtifact(
+                path: path,
+                availability: .unavailable,
+                message: "Artifact is not present at the registered path."
+            )
+        }
+
+        return EvidenceReportArtifact(path: path, availability: .available)
+    }
+
+    private func status(
+        for descriptorStatus: EvidenceReportStatus,
+        artifact: EvidenceReportArtifact
+    ) -> EvidenceReportStatus {
+        switch artifact.availability {
+        case .available:
+            return descriptorStatus
+        case .unavailable:
+            return .unavailable
+        case .error:
+            return .error
+        }
+    }
+
+    private func stableID(
+        kind: EvidenceReportKind,
+        source: String,
+        artifactPath: String
+    ) -> String {
+        [kind.rawValue, source, artifactPath]
+            .joined(separator: "|")
+    }
+
+    private func preferredSummary(
+        _ existing: EvidenceReportSummary,
+        _ incoming: EvidenceReportSummary
+    ) -> EvidenceReportSummary {
+        let existingRank = availabilityRank(existing.artifact.availability)
+        let incomingRank = availabilityRank(incoming.artifact.availability)
+        if incomingRank != existingRank {
+            return incomingRank > existingRank ? incoming : existing
+        }
+        if incoming.registeredAt != existing.registeredAt {
+            return incoming.registeredAt > existing.registeredAt ? incoming : existing
+        }
+        return Self.sortSummaries(existing, incoming) ? existing : incoming
+    }
+
+    private func availabilityRank(_ availability: EvidenceArtifactAvailability) -> Int {
+        switch availability {
+        case .available:
+            return 3
+        case .error:
+            return 2
+        case .unavailable:
+            return 1
+        }
+    }
+
+    private static func sortSummaries(
+        _ lhs: EvidenceReportSummary,
+        _ rhs: EvidenceReportSummary
+    ) -> Bool {
+        if lhs.kind.rawValue != rhs.kind.rawValue {
+            return lhs.kind.rawValue < rhs.kind.rawValue
+        }
+        if lhs.source != rhs.source {
+            return lhs.source < rhs.source
+        }
+        if lhs.artifact.path != rhs.artifact.path {
+            return lhs.artifact.path < rhs.artifact.path
+        }
+        return lhs.id < rhs.id
+    }
+}

--- a/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Evidence/EvidenceReportRegistryTests.swift
@@ -1,0 +1,200 @@
+//
+//  EvidenceReportRegistryTests.swift
+//  osaurusTests
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Evidence report registry")
+struct EvidenceReportRegistryTests {
+    @Test
+    func registersMultipleReportKindsThroughOneRegistry() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let evalArtifact = try fixture.writeArtifact(named: "evals/summary.json")
+        let runtimeArtifact = try fixture.writeArtifact(named: "runtime/live-proof.json")
+
+        service.register([
+            EvidenceReportDescriptor(
+                kind: .eval,
+                source: "evals-pr-evidence",
+                artifactURL: evalArtifact,
+                status: .passed,
+                counts: EvidenceReportCounts(total: 3, passed: 3)
+            ),
+            EvidenceReportDescriptor(
+                kind: .runtime,
+                source: "live-app-smoke",
+                artifactURL: runtimeArtifact,
+                status: .partial,
+                counts: EvidenceReportCounts(total: 4, passed: 3, warnings: 1)
+            ),
+        ])
+
+        let all = service.list()
+        #expect(all.count == 2)
+        #expect(Set(all.map(\.kind)) == [.eval, .runtime])
+        #expect(service.list(EvidenceReportFilter(kinds: [.eval])).map(\.kind) == [.eval])
+        #expect(service.list(EvidenceReportFilter(sources: ["live-app-smoke"])).map(\.kind) == [.runtime])
+        #expect(service.list(EvidenceReportFilter(statuses: [.partial])).map(\.source) == ["live-app-smoke"])
+        #expect(service.list(EvidenceReportFilter(artifactAvailability: [.available])).count == 2)
+        #expect(all.allSatisfy { $0.artifact.availability == .available })
+    }
+
+    @Test
+    func dedupesDuplicateDescriptorsByStableIdentity() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let artifact = try fixture.writeArtifact(named: "benchmarks/report.json")
+        let descriptor = EvidenceReportDescriptor(
+            kind: .benchmark,
+            source: "benchmark-suite",
+            artifactURL: artifact,
+            status: .failed,
+            counts: EvidenceReportCounts(total: 2, passed: 1, failed: 1)
+        )
+
+        service.register([descriptor, descriptor])
+        service.register(descriptor)
+
+        let reports = service.list()
+        #expect(reports.count == 1)
+        #expect(reports[0].status == .failed)
+        #expect(reports[0].counts.failed == 1)
+    }
+
+    @Test
+    func missingArtifactsBecomeUnavailableRows() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let missingPath = fixture.root
+            .appendingPathComponent("missing/run-trace.json")
+            .path
+
+        service.register(
+            EvidenceReportDescriptor(
+                kind: .runTrace,
+                source: "agent-run-trace",
+                artifactPath: missingPath,
+                status: .passed,
+                counts: EvidenceReportCounts(total: 1, passed: 1)
+            )
+        )
+
+        let report = try #require(service.list().first)
+        #expect(report.kind == .runTrace)
+        #expect(report.status == .unavailable)
+        #expect(report.artifact.availability == .unavailable)
+        #expect(report.artifact.message?.contains("not present") == true)
+    }
+
+    @Test
+    func descriptorErrorsBecomeErrorRows() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let path = fixture.root.appendingPathComponent("provider/report.json").path
+
+        service.register(
+            EvidenceReportDescriptor(
+                kind: .provider,
+                source: "provider-connectivity",
+                artifactPath: path,
+                status: .passed,
+                artifactError: "Descriptor could not parse summary counts."
+            )
+        )
+
+        let report = try #require(service.list().first)
+        #expect(report.status == .error)
+        #expect(report.artifact.availability == .error)
+        #expect(report.artifact.message == "Descriptor could not parse summary counts.")
+    }
+
+    @Test
+    func redactsSecretsFromMetadata() throws {
+        let fixture = try RegistryFixture()
+        let service = EvidenceReportRegistryService(now: fixture.clock)
+        let artifact = try fixture.writeArtifact(named: "provider/report.json")
+
+        service.register(
+            EvidenceReportDescriptor(
+                kind: .provider,
+                source: "provider-connectivity",
+                artifactURL: artifact,
+                status: .passed,
+                metadata: [
+                    "api_key": "sk-secret-value",
+                    "authorization": "Bearer secret-token",
+                    "model": "qwen3-8b",
+                    "tokens_per_second": "44.2",
+                    "url": "https://example.test/callback?token=secret",
+                ]
+            )
+        )
+
+        let report = try #require(service.list().first)
+        #expect(report.metadata["api_key"] == "<redacted>")
+        #expect(report.metadata["authorization"] == "<redacted>")
+        #expect(report.metadata["url"] == "<redacted>")
+        #expect(report.metadata["model"] == "qwen3-8b")
+        #expect(report.metadata["tokens_per_second"] == "44.2")
+    }
+
+    @Test
+    func stableJSONEncodingSortsKeysAndUsesISO8601Dates() throws {
+        let date = Date(timeIntervalSince1970: 1_750_000_000)
+        let summary = EvidenceReportSummary(
+            id: "report-1",
+            kind: .liveProof,
+            source: "live-proof",
+            artifact: EvidenceReportArtifact(path: "/tmp/live.json", availability: .available),
+            status: .passed,
+            counts: EvidenceReportCounts(total: 1, passed: 1),
+            startedAt: date,
+            completedAt: date,
+            registeredAt: date,
+            metadata: ["z": "last", "a": "first"]
+        )
+
+        let first = try summary.stableJSONData()
+        let second = try summary.stableJSONData()
+        let body = String(decoding: first, as: UTF8.self)
+
+        #expect(first == second)
+        #expect(body.hasPrefix("{\"artifact\""))
+        #expect(body.contains("\"completedAt\":\"2025-06-15T15:06:40Z\""))
+        #expect(body.range(of: "\"a\":\"first\"")?.lowerBound ?? body.endIndex
+            < body.range(of: "\"z\":\"last\"")?.lowerBound ?? body.startIndex)
+    }
+}
+
+private struct RegistryFixture {
+    let root: URL
+    let currentDate = Date(timeIntervalSince1970: 1_750_000_000)
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+    }
+
+    func clock() -> Date {
+        currentDate
+    }
+
+    func writeArtifact(named relativePath: String) throws -> URL {
+        let url = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("{\"ok\":true}".utf8).write(to: url)
+        return url
+    }
+}

--- a/docs/EVIDENCE_REPORT_REGISTRY.md
+++ b/docs/EVIDENCE_REPORT_REGISTRY.md
@@ -1,0 +1,40 @@
+# Evidence Report Registry
+
+The evidence report registry is the shared projection layer for report
+artifacts produced by eval, benchmark, runtime, live-proof, run-trace, and
+provider validation flows. It does not create a new report destination or move
+artifact files; callers register local artifact descriptors and receive typed
+summaries that can be listed, filtered, serialized, and rendered by future
+surfaces.
+
+## Model
+
+`EvidenceReportDescriptor` is the input from a local producer:
+
+- `kind`: one of `eval`, `benchmark`, `runtime`, `live_proof`, `run_trace`,
+  `provider`, or `custom`.
+- `source`: the producing flow, such as `evals-pr-evidence` or
+  `provider-connectivity`.
+- `artifactPath`: the local artifact path. Relative paths can be resolved
+  against a caller-provided base URL.
+- `status` and `counts`: summary outcome fields from the producer.
+- `startedAt`, `completedAt`, and registration time.
+- `metadata`: string metadata, redacted at registration before storage.
+
+`EvidenceReportSummary` is the canonical output. Missing artifact paths are
+kept as explicit rows with `status = unavailable` and
+`artifact.availability = unavailable`. Descriptors that already know they
+failed to parse or validate can pass `artifactError`, which produces an
+explicit `error` row.
+
+## Behavior
+
+`EvidenceReportRegistryService` stores summaries in memory, dedupes repeated
+descriptors by explicit `id` or by `(kind, source, artifactPath)`, and supports
+filters for kind, source, status, and artifact availability. Stable JSON output
+uses the package canonical encoder with sorted keys and ISO-8601 dates.
+
+Metadata is redacted before it reaches the registry. Sensitive keys such as API
+keys, authorization headers, passwords, private keys, credentials, and token
+fields are replaced with `<redacted>`. Values that look like common bearer,
+OpenAI, GitHub, or Slack-style secrets are also replaced.


### PR DESCRIPTION
## Summary
- Add a canonical evidence report registry for eval, benchmark, runtime, live-proof, run-trace, provider, and custom artifact summaries.
- Register existing local report descriptors without moving artifacts, with filtering, dedupe, unavailable/error rows, and stable JSON encoding.
- Redact sensitive metadata before summaries are stored or serialized.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter EvidenceReportRegistryTests` passed: 6 tests
- `git diff --check`
- Scoped SwiftLint on touched Swift files: 0 violations

## Notes
- This is the shared model/service foundation only; persistence and UI wiring are left for follow-up PRs that migrate existing report surfaces onto the registry.
