### PR TITLE
Add agent collaboration protocol contract

### DIFF
--- a/Packages/OsaurusCore/Models/AgentCollaboration/AgentCollaborationAgentConformance.swift
+++ b/Packages/OsaurusCore/Models/AgentCollaboration/AgentCollaborationAgentConformance.swift
@@ -1,0 +1,40 @@
+//
+//  AgentCollaborationAgentConformance.swift
+//  osaurus
+//
+//  Computed adapters from existing agent records into collaboration protocol
+//  participants. These extensions do not alter persistence or UI behavior.
+//
+
+import Foundation
+
+extension Agent {
+    public var agentCollaborationParticipant: AgentCollaborationParticipant {
+        AgentCollaborationParticipant(
+            id: "local:\(id.uuidString.lowercased())",
+            type: .local,
+            displayName: displayName,
+            address: agentAddress
+        )
+    }
+
+    public var agentCollaborationCapabilities: AgentCollaborationCapabilities {
+        .localDefault()
+    }
+}
+
+extension RemoteAgent {
+    public var agentCollaborationParticipant: AgentCollaborationParticipant {
+        AgentCollaborationParticipant(
+            id: "remote:\(id.uuidString.lowercased())",
+            type: .remote,
+            displayName: name,
+            address: agentAddress,
+            endpoint: relayBaseURL
+        )
+    }
+
+    public var agentCollaborationCapabilities: AgentCollaborationCapabilities {
+        .remoteDefault()
+    }
+}

--- a/Packages/OsaurusCore/Models/AgentCollaboration/AgentCollaborationProtocol.swift
+++ b/Packages/OsaurusCore/Models/AgentCollaboration/AgentCollaborationProtocol.swift
@@ -1,0 +1,453 @@
+//
+//  AgentCollaborationProtocol.swift
+//  osaurus
+//
+//  Protocol-level contracts for future local + remote agent teams.
+//
+
+import Foundation
+
+public enum AgentCollaborationProtocolContract {
+    public static let schema = "osaurus.agent-collaboration.v1"
+    public static let version = 1
+}
+
+public enum AgentCollaborationParticipantType: String, Codable, Sendable, Equatable, CaseIterable {
+    case local
+    case remote
+}
+
+public struct AgentCollaborationParticipant: Codable, Sendable, Equatable, Hashable {
+    public var id: String
+    public var type: AgentCollaborationParticipantType
+    public var displayName: String
+    public var address: String?
+    public var endpoint: String?
+
+    public init(
+        id: String,
+        type: AgentCollaborationParticipantType,
+        displayName: String,
+        address: String? = nil,
+        endpoint: String? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.displayName = displayName
+        self.address = address
+        self.endpoint = endpoint
+    }
+}
+
+public struct AgentCollaborationCapability: Codable, Sendable, Equatable, Hashable {
+    public var name: String
+    public var version: Int
+    public var metadata: [String: String]
+
+    public init(name: String, version: Int = 1, metadata: [String: String] = [:]) {
+        self.name = name
+        self.version = version
+        self.metadata = metadata
+    }
+}
+
+public struct AgentCollaborationCapabilities: Codable, Sendable, Equatable {
+    public var protocolVersion: Int
+    public var capabilities: [AgentCollaborationCapability]
+    public var maxPayloadBytes: Int?
+    public var supportsStreamingReplies: Bool
+
+    public init(
+        protocolVersion: Int = AgentCollaborationProtocolContract.version,
+        capabilities: [AgentCollaborationCapability],
+        maxPayloadBytes: Int? = nil,
+        supportsStreamingReplies: Bool = false
+    ) {
+        self.protocolVersion = protocolVersion
+        self.capabilities = Self.normalized(capabilities)
+        self.maxPayloadBytes = maxPayloadBytes
+        self.supportsStreamingReplies = supportsStreamingReplies
+    }
+
+    public var names: [String] {
+        capabilities.map(\.name)
+    }
+
+    public func supports(_ name: String, minimumVersion: Int = 1) -> Bool {
+        capabilities.contains { capability in
+            capability.name == name && capability.version >= minimumVersion
+        }
+    }
+
+    public func commonCapabilities(with other: AgentCollaborationCapabilities) -> [AgentCollaborationCapability] {
+        let otherByName = Dictionary(uniqueKeysWithValues: other.capabilities.map { ($0.name, $0) })
+        let shared = capabilities.compactMap { capability -> AgentCollaborationCapability? in
+            guard let otherCapability = otherByName[capability.name] else { return nil }
+            return AgentCollaborationCapability(
+                name: capability.name,
+                version: min(capability.version, otherCapability.version),
+                metadata: [:]
+            )
+        }
+        return Self.normalized(shared)
+    }
+
+    public static let baselineRequiredNames = [
+        "collaboration.correlation",
+        "collaboration.provenance",
+        "collaboration.request",
+        "collaboration.handoff",
+        "collaboration.reply",
+    ]
+
+    public static func localDefault() -> AgentCollaborationCapabilities {
+        AgentCollaborationCapabilities(
+            capabilities: [
+                AgentCollaborationCapability(name: "agent.local"),
+                AgentCollaborationCapability(name: "collaboration.correlation"),
+                AgentCollaborationCapability(name: "collaboration.provenance"),
+                AgentCollaborationCapability(name: "collaboration.request"),
+                AgentCollaborationCapability(name: "collaboration.handoff"),
+                AgentCollaborationCapability(name: "collaboration.reply"),
+                AgentCollaborationCapability(name: "collaboration.failure-diagnostics"),
+            ],
+            supportsStreamingReplies: false
+        )
+    }
+
+    public static func remoteDefault() -> AgentCollaborationCapabilities {
+        AgentCollaborationCapabilities(
+            capabilities: [
+                AgentCollaborationCapability(name: "agent.remote"),
+                AgentCollaborationCapability(name: "collaboration.correlation"),
+                AgentCollaborationCapability(name: "collaboration.provenance"),
+                AgentCollaborationCapability(name: "collaboration.request"),
+                AgentCollaborationCapability(name: "collaboration.handoff"),
+                AgentCollaborationCapability(name: "collaboration.reply"),
+                AgentCollaborationCapability(name: "collaboration.failure-diagnostics"),
+            ],
+            supportsStreamingReplies: false
+        )
+    }
+
+    private static func normalized(_ capabilities: [AgentCollaborationCapability]) -> [AgentCollaborationCapability] {
+        var bestByName: [String: AgentCollaborationCapability] = [:]
+        for capability in capabilities {
+            guard !capability.name.isEmpty else { continue }
+            if let existing = bestByName[capability.name], existing.version >= capability.version {
+                continue
+            }
+            bestByName[capability.name] = capability
+        }
+        return bestByName.values.sorted { lhs, rhs in
+            if lhs.name == rhs.name {
+                return lhs.version < rhs.version
+            }
+            return lhs.name < rhs.name
+        }
+    }
+}
+
+public struct AgentCollaborationNegotiationResult: Codable, Sendable, Equatable {
+    public var initiator: AgentCollaborationParticipant
+    public var responder: AgentCollaborationParticipant
+    public var protocolVersion: Int
+    public var commonCapabilities: [AgentCollaborationCapability]
+    public var missingRequiredCapabilities: [String]
+
+    public init(
+        initiator: AgentCollaborationParticipant,
+        responder: AgentCollaborationParticipant,
+        protocolVersion: Int,
+        commonCapabilities: [AgentCollaborationCapability],
+        missingRequiredCapabilities: [String]
+    ) {
+        self.initiator = initiator
+        self.responder = responder
+        self.protocolVersion = protocolVersion
+        self.commonCapabilities = commonCapabilities
+        self.missingRequiredCapabilities = missingRequiredCapabilities.sorted()
+    }
+
+    public var isCompatible: Bool {
+        missingRequiredCapabilities.isEmpty && protocolVersion == AgentCollaborationProtocolContract.version
+    }
+}
+
+public enum AgentCollaborationNegotiator {
+    public static func negotiate(
+        initiator: AgentCollaborationParticipant,
+        initiatorCapabilities: AgentCollaborationCapabilities,
+        responder: AgentCollaborationParticipant,
+        responderCapabilities: AgentCollaborationCapabilities,
+        requiredCapabilities: [String] = AgentCollaborationCapabilities.baselineRequiredNames
+    ) -> AgentCollaborationNegotiationResult {
+        let common = initiatorCapabilities.commonCapabilities(with: responderCapabilities)
+        let commonNames = Set(common.map(\.name))
+        let missing = requiredCapabilities
+            .filter { !commonNames.contains($0) }
+            .sorted()
+        let version = min(initiatorCapabilities.protocolVersion, responderCapabilities.protocolVersion)
+        return AgentCollaborationNegotiationResult(
+            initiator: initiator,
+            responder: responder,
+            protocolVersion: version,
+            commonCapabilities: common,
+            missingRequiredCapabilities: missing
+        )
+    }
+}
+
+public struct AgentCollaborationProvenance: Codable, Sendable, Equatable {
+    public var origin: AgentCollaborationParticipant
+    public var sessionId: String?
+    public var parentEnvelopeId: UUID?
+    public var transport: String?
+    public var hops: [String]
+
+    public init(
+        origin: AgentCollaborationParticipant,
+        sessionId: String? = nil,
+        parentEnvelopeId: UUID? = nil,
+        transport: String? = nil,
+        hops: [String] = []
+    ) {
+        self.origin = origin
+        self.sessionId = sessionId
+        self.parentEnvelopeId = parentEnvelopeId
+        self.transport = transport
+        self.hops = hops
+    }
+}
+
+public enum AgentCollaborationEventType: String, Codable, Sendable, Equatable {
+    case capabilities = "capabilities"
+    case request = "request"
+    case handoffRequest = "handoff.request"
+    case reply = "reply"
+    case failure = "failure"
+}
+
+public enum AgentCollaborationPriority: String, Codable, Sendable, Equatable {
+    case low
+    case normal
+    case high
+}
+
+public struct AgentCollaborationRequest: Codable, Sendable, Equatable {
+    public var title: String
+    public var objective: String
+    public var contextSummary: String?
+    public var requiredCapabilities: [String]
+    public var priority: AgentCollaborationPriority
+    public var metadata: [String: String]
+
+    public init(
+        title: String,
+        objective: String,
+        contextSummary: String? = nil,
+        requiredCapabilities: [String] = [],
+        priority: AgentCollaborationPriority = .normal,
+        metadata: [String: String] = [:]
+    ) {
+        self.title = title
+        self.objective = objective
+        self.contextSummary = contextSummary
+        self.requiredCapabilities = requiredCapabilities.sorted()
+        self.priority = priority
+        self.metadata = metadata
+    }
+}
+
+public struct AgentCollaborationHandoffRequest: Codable, Sendable, Equatable {
+    public var handoffId: UUID
+    public var reason: String
+    public var summary: String
+    public var artifactReferences: [String]
+    public var requiredCapabilities: [String]
+    public var metadata: [String: String]
+
+    public init(
+        handoffId: UUID = UUID(),
+        reason: String,
+        summary: String,
+        artifactReferences: [String] = [],
+        requiredCapabilities: [String] = [],
+        metadata: [String: String] = [:]
+    ) {
+        self.handoffId = handoffId
+        self.reason = reason
+        self.summary = summary
+        self.artifactReferences = artifactReferences.sorted()
+        self.requiredCapabilities = requiredCapabilities.sorted()
+        self.metadata = metadata
+    }
+}
+
+public enum AgentCollaborationReplyStatus: String, Codable, Sendable, Equatable {
+    case accepted
+    case rejected
+    case completed
+}
+
+public struct AgentCollaborationReply: Codable, Sendable, Equatable {
+    public var inReplyToEnvelopeId: UUID
+    public var status: AgentCollaborationReplyStatus
+    public var message: String?
+    public var acceptedCapabilities: [String]
+    public var diagnostics: AgentCollaborationFailureDiagnostic?
+
+    public init(
+        inReplyToEnvelopeId: UUID,
+        status: AgentCollaborationReplyStatus,
+        message: String? = nil,
+        acceptedCapabilities: [String] = [],
+        diagnostics: AgentCollaborationFailureDiagnostic? = nil
+    ) {
+        self.inReplyToEnvelopeId = inReplyToEnvelopeId
+        self.status = status
+        self.message = message
+        self.acceptedCapabilities = acceptedCapabilities.sorted()
+        self.diagnostics = diagnostics
+    }
+}
+
+public enum AgentCollaborationFailureSeverity: String, Codable, Sendable, Equatable {
+    case info
+    case warning
+    case error
+}
+
+public struct AgentCollaborationFailureDiagnostic: Codable, Sendable, Equatable, Error {
+    public var code: String
+    public var severity: AgentCollaborationFailureSeverity
+    public var message: String
+    public var retryable: Bool
+    public var relatedEnvelopeId: UUID?
+    public var details: [String: String]
+
+    public init(
+        code: String,
+        severity: AgentCollaborationFailureSeverity = .error,
+        message: String,
+        retryable: Bool,
+        relatedEnvelopeId: UUID? = nil,
+        details: [String: String] = [:]
+    ) {
+        self.code = code
+        self.severity = severity
+        self.message = message
+        self.retryable = retryable
+        self.relatedEnvelopeId = relatedEnvelopeId
+        self.details = details
+    }
+}
+
+public enum AgentCollaborationEvent: Sendable, Equatable {
+    case capabilities(AgentCollaborationCapabilities)
+    case request(AgentCollaborationRequest)
+    case handoffRequest(AgentCollaborationHandoffRequest)
+    case reply(AgentCollaborationReply)
+    case failure(AgentCollaborationFailureDiagnostic)
+
+    public var type: AgentCollaborationEventType {
+        switch self {
+        case .capabilities:
+            return .capabilities
+        case .request:
+            return .request
+        case .handoffRequest:
+            return .handoffRequest
+        case .reply:
+            return .reply
+        case .failure:
+            return .failure
+        }
+    }
+}
+
+extension AgentCollaborationEvent: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case payload
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(AgentCollaborationEventType.self, forKey: .type)
+        switch type {
+        case .capabilities:
+            self = .capabilities(try container.decode(AgentCollaborationCapabilities.self, forKey: .payload))
+        case .request:
+            self = .request(try container.decode(AgentCollaborationRequest.self, forKey: .payload))
+        case .handoffRequest:
+            self = .handoffRequest(try container.decode(AgentCollaborationHandoffRequest.self, forKey: .payload))
+        case .reply:
+            self = .reply(try container.decode(AgentCollaborationReply.self, forKey: .payload))
+        case .failure:
+            self = .failure(try container.decode(AgentCollaborationFailureDiagnostic.self, forKey: .payload))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        switch self {
+        case let .capabilities(payload):
+            try container.encode(payload, forKey: .payload)
+        case let .request(payload):
+            try container.encode(payload, forKey: .payload)
+        case let .handoffRequest(payload):
+            try container.encode(payload, forKey: .payload)
+        case let .reply(payload):
+            try container.encode(payload, forKey: .payload)
+        case let .failure(payload):
+            try container.encode(payload, forKey: .payload)
+        }
+    }
+}
+
+public struct AgentCollaborationEnvelope: Codable, Sendable, Equatable, Identifiable {
+    public var schema: String
+    public var id: UUID
+    public var correlationId: String
+    public var createdAt: Date
+    public var sender: AgentCollaborationParticipant
+    public var recipient: AgentCollaborationParticipant?
+    public var provenance: AgentCollaborationProvenance
+    public var event: AgentCollaborationEvent
+
+    public init(
+        schema: String = AgentCollaborationProtocolContract.schema,
+        id: UUID = UUID(),
+        correlationId: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        sender: AgentCollaborationParticipant,
+        recipient: AgentCollaborationParticipant? = nil,
+        provenance: AgentCollaborationProvenance? = nil,
+        event: AgentCollaborationEvent
+    ) {
+        self.schema = schema
+        self.id = id
+        self.correlationId = correlationId
+        self.createdAt = createdAt
+        self.sender = sender
+        self.recipient = recipient
+        self.provenance = provenance ?? AgentCollaborationProvenance(origin: sender)
+        self.event = event
+    }
+}
+
+public enum AgentCollaborationWireFormat {
+    public static func encoder(prettyPrinted: Bool = false) -> JSONEncoder {
+        let encoder = JSONEncoder.osaurusCanonical(prettyPrinted: prettyPrinted)
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentCollaboration/AgentCollaborationService.swift
+++ b/Packages/OsaurusCore/Services/AgentCollaboration/AgentCollaborationService.swift
@@ -1,0 +1,199 @@
+//
+//  AgentCollaborationService.swift
+//  osaurus
+//
+//  Local-only service and in-memory transport for proving the collaboration
+//  contract before any team UI or network bridge consumes it.
+//
+
+import Foundation
+
+public protocol AgentCollaborationTransport: Sendable {
+    func send(_ envelope: AgentCollaborationEnvelope) async throws
+    func envelopes(for participant: AgentCollaborationParticipant) async -> [AgentCollaborationEnvelope]
+    func allEnvelopes() async -> [AgentCollaborationEnvelope]
+}
+
+public actor AgentCollaborationInMemoryTransport: AgentCollaborationTransport {
+    private var sentEnvelopes: [AgentCollaborationEnvelope] = []
+    private var nextSendFailure: AgentCollaborationFailureDiagnostic?
+
+    public init() {}
+
+    public func failNextSend(with diagnostic: AgentCollaborationFailureDiagnostic) {
+        nextSendFailure = diagnostic
+    }
+
+    public func send(_ envelope: AgentCollaborationEnvelope) async throws {
+        if let diagnostic = nextSendFailure {
+            nextSendFailure = nil
+            throw diagnostic
+        }
+        sentEnvelopes.append(envelope)
+    }
+
+    public func envelopes(for participant: AgentCollaborationParticipant) async -> [AgentCollaborationEnvelope] {
+        sentEnvelopes.filter { envelope in
+            envelope.recipient?.id == participant.id || envelope.sender.id == participant.id
+        }
+    }
+
+    public func allEnvelopes() async -> [AgentCollaborationEnvelope] {
+        sentEnvelopes
+    }
+}
+
+public actor AgentCollaborationService {
+    private let transport: any AgentCollaborationTransport
+    private var registry: [String: RegisteredParticipant] = [:]
+
+    public init(transport: any AgentCollaborationTransport = AgentCollaborationInMemoryTransport()) {
+        self.transport = transport
+    }
+
+    public func register(
+        participant: AgentCollaborationParticipant,
+        capabilities: AgentCollaborationCapabilities
+    ) {
+        registry[participant.id] = RegisteredParticipant(
+            participant: participant,
+            capabilities: capabilities
+        )
+    }
+
+    public func participant(id: String) -> AgentCollaborationParticipant? {
+        registry[id]?.participant
+    }
+
+    public func negotiate(
+        initiatorId: String,
+        responderId: String,
+        requiredCapabilities: [String] = AgentCollaborationCapabilities.baselineRequiredNames
+    ) -> AgentCollaborationNegotiationResult? {
+        guard
+            let initiator = registry[initiatorId],
+            let responder = registry[responderId]
+        else {
+            return nil
+        }
+
+        return AgentCollaborationNegotiator.negotiate(
+            initiator: initiator.participant,
+            initiatorCapabilities: initiator.capabilities,
+            responder: responder.participant,
+            responderCapabilities: responder.capabilities,
+            requiredCapabilities: requiredCapabilities
+        )
+    }
+
+    @discardableResult
+    public func sendRequest(
+        _ request: AgentCollaborationRequest,
+        from sender: AgentCollaborationParticipant,
+        to recipient: AgentCollaborationParticipant,
+        correlationId: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        provenance: AgentCollaborationProvenance? = nil
+    ) async throws -> AgentCollaborationEnvelope {
+        let envelope = AgentCollaborationEnvelope(
+            correlationId: correlationId,
+            createdAt: createdAt,
+            sender: sender,
+            recipient: recipient,
+            provenance: provenance,
+            event: .request(request)
+        )
+        try await transport.send(envelope)
+        return envelope
+    }
+
+    @discardableResult
+    public func requestHandoff(
+        _ handoff: AgentCollaborationHandoffRequest,
+        from sender: AgentCollaborationParticipant,
+        to recipient: AgentCollaborationParticipant,
+        correlationId: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        provenance: AgentCollaborationProvenance? = nil
+    ) async throws -> AgentCollaborationEnvelope {
+        let envelope = AgentCollaborationEnvelope(
+            correlationId: correlationId,
+            createdAt: createdAt,
+            sender: sender,
+            recipient: recipient,
+            provenance: provenance,
+            event: .handoffRequest(handoff)
+        )
+        try await transport.send(envelope)
+        return envelope
+    }
+
+    @discardableResult
+    public func reply(
+        to envelope: AgentCollaborationEnvelope,
+        from sender: AgentCollaborationParticipant,
+        status: AgentCollaborationReplyStatus,
+        message: String? = nil,
+        acceptedCapabilities: [String] = [],
+        diagnostics: AgentCollaborationFailureDiagnostic? = nil,
+        createdAt: Date = Date()
+    ) async throws -> AgentCollaborationEnvelope {
+        let reply = AgentCollaborationReply(
+            inReplyToEnvelopeId: envelope.id,
+            status: status,
+            message: message,
+            acceptedCapabilities: acceptedCapabilities,
+            diagnostics: diagnostics
+        )
+        let replyEnvelope = AgentCollaborationEnvelope(
+            correlationId: envelope.correlationId,
+            createdAt: createdAt,
+            sender: sender,
+            recipient: envelope.sender,
+            provenance: AgentCollaborationProvenance(
+                origin: envelope.provenance.origin,
+                sessionId: envelope.provenance.sessionId,
+                parentEnvelopeId: envelope.id,
+                transport: envelope.provenance.transport,
+                hops: envelope.provenance.hops + [sender.id]
+            ),
+            event: .reply(reply)
+        )
+        try await transport.send(replyEnvelope)
+        return replyEnvelope
+    }
+
+    @discardableResult
+    public func reportFailure(
+        _ diagnostic: AgentCollaborationFailureDiagnostic,
+        from sender: AgentCollaborationParticipant,
+        to recipient: AgentCollaborationParticipant?,
+        correlationId: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        provenance: AgentCollaborationProvenance? = nil
+    ) async throws -> AgentCollaborationEnvelope {
+        let envelope = AgentCollaborationEnvelope(
+            correlationId: correlationId,
+            createdAt: createdAt,
+            sender: sender,
+            recipient: recipient,
+            provenance: provenance,
+            event: .failure(diagnostic)
+        )
+        try await transport.send(envelope)
+        return envelope
+    }
+
+    public func envelopes(for participant: AgentCollaborationParticipant) async -> [AgentCollaborationEnvelope] {
+        await transport.envelopes(for: participant)
+    }
+
+    public func allEnvelopes() async -> [AgentCollaborationEnvelope] {
+        await transport.allEnvelopes()
+    }
+
+    private struct RegisteredParticipant: Sendable {
+        var participant: AgentCollaborationParticipant
+        var capabilities: AgentCollaborationCapabilities
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentCollaboration/AgentCollaborationProtocolTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentCollaboration/AgentCollaborationProtocolTests.swift
@@ -1,0 +1,227 @@
+//
+//  AgentCollaborationProtocolTests.swift
+//  osaurusTests
+//
+//  Contract coverage for the local + remote collaboration protocol foundation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct AgentCollaborationProtocolTests {
+    private let localAgentId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let remoteAgentId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let providerId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+    private let envelopeId = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+    private let createdAt = ISO8601DateFormatter().date(from: "2026-06-21T12:00:00Z")!
+
+    @Test("collaboration envelope has stable JSON wire shape")
+    func stableJSONWireShape() throws {
+        let local = localAgent().agentCollaborationParticipant
+        let remote = remoteAgent().agentCollaborationParticipant
+        let envelope = AgentCollaborationEnvelope(
+            id: envelopeId,
+            correlationId: "corr-123",
+            createdAt: createdAt,
+            sender: local,
+            recipient: remote,
+            provenance: AgentCollaborationProvenance(
+                origin: local,
+                sessionId: "session-1",
+                transport: "in-memory"
+            ),
+            event: .handoffRequest(
+                AgentCollaborationHandoffRequest(
+                    handoffId: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                    reason: "needs remote research",
+                    summary: "Collect release notes",
+                    artifactReferences: ["artifact://b", "artifact://a"],
+                    requiredCapabilities: ["collaboration.reply", "collaboration.request"]
+                )
+            )
+        )
+
+        let data = try AgentCollaborationWireFormat.encoder().encode(envelope)
+        let json = String(decoding: data, as: UTF8.self)
+
+        #expect(json.contains(#""schema":"osaurus.agent-collaboration.v1""#))
+        #expect(json.contains(#""createdAt":"2026-06-21T12:00:00Z""#))
+        #expect(json.contains(#""type":"handoff.request""#))
+        #expect(json.contains(#""correlationId":"corr-123""#))
+
+        let decoded = try AgentCollaborationWireFormat.decoder().decode(AgentCollaborationEnvelope.self, from: data)
+        #expect(decoded == envelope)
+    }
+
+    @Test("local and remote participants negotiate the baseline contract")
+    func localRemoteNegotiation() {
+        let local = localAgent()
+        let remote = remoteAgent()
+
+        let result = AgentCollaborationNegotiator.negotiate(
+            initiator: local.agentCollaborationParticipant,
+            initiatorCapabilities: local.agentCollaborationCapabilities,
+            responder: remote.agentCollaborationParticipant,
+            responderCapabilities: remote.agentCollaborationCapabilities
+        )
+
+        #expect(result.isCompatible)
+        #expect(result.initiator.type == .local)
+        #expect(result.responder.type == .remote)
+        #expect(result.missingRequiredCapabilities.isEmpty)
+        #expect(result.commonCapabilities.map(\.name).contains("collaboration.handoff"))
+        #expect(result.commonCapabilities.map(\.name).contains("collaboration.failure-diagnostics"))
+    }
+
+    @Test("negotiation reports missing required capabilities")
+    func missingRequiredCapabilitiesAreReported() {
+        let local = localAgent().agentCollaborationParticipant
+        let remote = remoteAgent().agentCollaborationParticipant
+        let limitedRemoteCapabilities = AgentCollaborationCapabilities(
+            capabilities: [
+                AgentCollaborationCapability(name: "collaboration.correlation"),
+                AgentCollaborationCapability(name: "collaboration.provenance"),
+            ]
+        )
+
+        let result = AgentCollaborationNegotiator.negotiate(
+            initiator: local,
+            initiatorCapabilities: .localDefault(),
+            responder: remote,
+            responderCapabilities: limitedRemoteCapabilities
+        )
+
+        #expect(!result.isCompatible)
+        #expect(result.missingRequiredCapabilities == [
+            "collaboration.handoff",
+            "collaboration.reply",
+            "collaboration.request",
+        ])
+    }
+
+    @Test("handoff lifecycle preserves correlation and reply provenance")
+    func handoffLifecycle() async throws {
+        let transport = AgentCollaborationInMemoryTransport()
+        let service = AgentCollaborationService(transport: transport)
+        let local = localAgent().agentCollaborationParticipant
+        let remote = remoteAgent().agentCollaborationParticipant
+
+        await service.register(participant: local, capabilities: .localDefault())
+        await service.register(participant: remote, capabilities: .remoteDefault())
+
+        let negotiation = await service.negotiate(initiatorId: local.id, responderId: remote.id)
+        #expect(negotiation?.isCompatible == true)
+
+        let handoffEnvelope = try await service.requestHandoff(
+            AgentCollaborationHandoffRequest(
+                handoffId: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                reason: "remote agent owns the paired endpoint",
+                summary: "Handle the remote-only step",
+                requiredCapabilities: ["collaboration.reply"]
+            ),
+            from: local,
+            to: remote,
+            correlationId: "handoff-corr",
+            createdAt: createdAt
+        )
+
+        let replyEnvelope = try await service.reply(
+            to: handoffEnvelope,
+            from: remote,
+            status: .accepted,
+            message: "Accepted",
+            acceptedCapabilities: ["collaboration.reply"],
+            createdAt: createdAt.addingTimeInterval(1)
+        )
+
+        #expect(replyEnvelope.correlationId == "handoff-corr")
+        #expect(replyEnvelope.recipient == local)
+        #expect(replyEnvelope.provenance.parentEnvelopeId == handoffEnvelope.id)
+        #expect(await transport.allEnvelopes().count == 2)
+
+        guard case let .reply(reply) = replyEnvelope.event else {
+            Issue.record("expected reply event")
+            return
+        }
+        #expect(reply.inReplyToEnvelopeId == handoffEnvelope.id)
+        #expect(reply.status == .accepted)
+    }
+
+    @Test("failure diagnostics round-trip as first-class events")
+    func failureDiagnostics() async throws {
+        let transport = AgentCollaborationInMemoryTransport()
+        let service = AgentCollaborationService(transport: transport)
+        let local = localAgent().agentCollaborationParticipant
+        let remote = remoteAgent().agentCollaborationParticipant
+        let diagnostic = AgentCollaborationFailureDiagnostic(
+            code: "negotiation.missing-capability",
+            severity: .error,
+            message: "Remote participant cannot accept handoff requests.",
+            retryable: false,
+            relatedEnvelopeId: envelopeId,
+            details: ["missing": "collaboration.handoff"]
+        )
+
+        let envelope = try await service.reportFailure(
+            diagnostic,
+            from: local,
+            to: remote,
+            correlationId: "failure-corr",
+            createdAt: createdAt
+        )
+
+        let data = try AgentCollaborationWireFormat.encoder().encode(envelope)
+        let decoded = try AgentCollaborationWireFormat.decoder().decode(AgentCollaborationEnvelope.self, from: data)
+
+        #expect(decoded.correlationId == "failure-corr")
+        guard case let .failure(decodedDiagnostic) = decoded.event else {
+            Issue.record("expected failure event")
+            return
+        }
+        #expect(decodedDiagnostic == diagnostic)
+        #expect(decodedDiagnostic.details["missing"] == "collaboration.handoff")
+    }
+
+    @Test("agent collaboration adapters do not change default agent persistence")
+    func defaultAgentBehaviorUnchanged() throws {
+        let defaultAgent = Agent.default
+        let data = try JSONEncoder().encode(defaultAgent)
+        let json = String(decoding: data, as: UTF8.self)
+
+        #expect(defaultAgent.id == Agent.defaultId)
+        #expect(defaultAgent.isBuiltIn)
+        #expect(defaultAgent.toolsEnabled)
+        #expect(defaultAgent.memoryEnabled)
+        #expect(defaultAgent.bonjourEnabled == false)
+        #expect(!json.contains("agentCollaboration"))
+        #expect(!json.contains("collaboration"))
+
+        let participant = defaultAgent.agentCollaborationParticipant
+        #expect(participant.id == "local:00000000-0000-0000-0000-000000000001")
+        #expect(participant.type == .local)
+    }
+
+    private func localAgent() -> Agent {
+        Agent(
+            id: localAgentId,
+            name: "Local Planner",
+            description: "Plans work",
+            systemPrompt: "Plan local work",
+            agentAddress: "0xLOCAL"
+        )
+    }
+
+    private func remoteAgent() -> RemoteAgent {
+        RemoteAgent(
+            id: remoteAgentId,
+            agentAddress: "0xREMOTE",
+            name: "Remote Researcher",
+            description: "Researches remote context",
+            relayBaseURL: "https://remote.agent.osaurus.ai",
+            providerId: providerId
+        )
+    }
+}

--- a/docs/AGENT_COLLABORATION_PROTOCOL.md
+++ b/docs/AGENT_COLLABORATION_PROTOCOL.md
@@ -1,0 +1,106 @@
+# Agent Collaboration Protocol
+
+This document defines the prerequisite protocol contract for future Osaurus
+agent teams. It is not the final team UI, scheduler, channel integration, or
+remote execution policy. The goal is a stable local contract that local and
+paired remote agents can share before product surfaces coordinate multiple
+agents.
+
+## Scope
+
+The protocol lives in `Packages/OsaurusCore/Models/AgentCollaboration` and
+`Packages/OsaurusCore/Services/AgentCollaboration`.
+
+It provides:
+
+- A stable `Codable` / `Sendable` envelope with schema, event id, correlation
+  id, timestamp, sender, optional recipient, provenance, and typed event
+  payload.
+- Participant identity for local and remote agents without changing the
+  persisted `Agent` or `RemoteAgent` schemas.
+- Capability offers and negotiation helpers for local/remote compatibility.
+- Request, handoff request, reply, and failure diagnostic events.
+- An in-memory transport/service that proves lifecycle behavior without
+  changing default chat, agent-loop, channel, or UI behavior.
+
+## Non-Goals
+
+This protocol does not:
+
+- Choose a team layout or multi-agent UI.
+- Route through Slack, Discord, Agent Channels, or custom runners.
+- Grant workspace, memory, access-key, or data-location permissions.
+- Change model prompting, tool routing, sampler defaults, or agent-loop
+  behavior.
+- Persist collaboration runs.
+
+Those layers can consume this contract later, but they should not redefine the
+wire envelope or negotiation semantics.
+
+## Envelope
+
+The wire schema is `osaurus.agent-collaboration.v1`.
+
+Each envelope contains:
+
+- `id`: UUID for the envelope.
+- `correlationId`: stable id shared by request, handoff, reply, and failure
+  events in one collaboration exchange.
+- `createdAt`: ISO-8601 timestamp when encoded with
+  `AgentCollaborationWireFormat`.
+- `sender`: `AgentCollaborationParticipant`.
+- `recipient`: optional `AgentCollaborationParticipant`.
+- `provenance`: origin participant, optional session id, optional parent
+  envelope id, transport label, and hop ids.
+- `event`: typed payload with an explicit event `type`.
+
+Use `AgentCollaborationWireFormat.encoder()` and `.decoder()` for canonical
+JSON. The encoder sorts keys and writes ISO-8601 dates.
+
+## Participants
+
+Participants have a stable protocol id and type:
+
+- Local agents use `local:<agent-uuid>`.
+- Remote agents use `remote:<remote-agent-record-uuid>`.
+
+Computed adapters on `Agent` and `RemoteAgent` expose participants and default
+capabilities. These adapters are intentionally non-persistent; they do not add
+fields to existing JSON records.
+
+## Capabilities
+
+Baseline collaboration requires both participants to share:
+
+- `collaboration.correlation`
+- `collaboration.provenance`
+- `collaboration.request`
+- `collaboration.handoff`
+- `collaboration.reply`
+
+Both local and remote defaults also advertise
+`collaboration.failure-diagnostics`. Type-specific capabilities
+(`agent.local`, `agent.remote`) describe the participant but are not required
+for a baseline handoff.
+
+Use `AgentCollaborationNegotiator.negotiate(...)` or
+`AgentCollaborationService.negotiate(...)` before creating a handoff. A result
+is compatible only when the protocol version matches and no required
+capability is missing.
+
+## Lifecycle
+
+A minimal handoff flow is:
+
+1. Register or derive local and remote participants plus capabilities.
+2. Negotiate shared baseline capabilities.
+3. Send `handoff.request` with a correlation id, reason, summary, artifacts,
+   and required capabilities.
+4. Send `reply` with the same correlation id and an `accepted`, `rejected`, or
+   `completed` status.
+5. If a participant or transport cannot continue, send `failure` with a typed
+   diagnostic code, severity, retryability, related envelope id, and details.
+
+The in-memory service exists to prove this contract in unit tests. Production
+team orchestration should keep the same envelope semantics when it adds
+persistence, UI, or network transport.


### PR DESCRIPTION
## Summary
- Add Agent Collaboration Protocol v1 envelope, participants, capabilities, negotiation, request/handoff/reply/failure events, provenance, and canonical JSON helpers.
- Add computed local/remote agent adapters without changing Agent or RemoteAgent persistence.
- Add in-memory collaboration transport/service for local contract proof.
- Document the protocol as the prerequisite for future agent teams, not final team UI.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter AgentCollaboration` passed: 6 tests
- `git diff --check`
- Scoped SwiftLint on touched lintable Swift files: 0 violations

## Notes
- No agent-loop behavior changed, so eval evidence was not required.
- This is intentionally not team-management UI, persistence, network transport, or chat/runtime behavior.
