### PR TITLE
Fix Computer Use main-thread hangs

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
@@ -208,9 +208,17 @@ struct TraversalResult: Encodable, Sendable {
 final class AccessibilityManager: @unchecked Sendable {
     static let shared = AccessibilityManager()
 
-    /// Maximum time (seconds) any AX call is allowed to block. Without this,
-    /// a wedged target app would hang the agent indefinitely.
-    private static let axMessagingTimeout: Float = 3.0
+    /// Maximum time (seconds) any single AX call is allowed to block before it
+    /// returns a timeout error. Applied per-app via `axApp` (and globally on the
+    /// system-wide element in `init`) so a wedged target app can't stall the
+    /// off-main driver queue indefinitely on any one call.
+    static let axMessagingTimeout: Float = 1.5
+
+    /// Overall wall-clock budget for a single `traverse`. Even when each AX call
+    /// stays under `axMessagingTimeout`, a huge or partially-wedged tree can
+    /// accumulate many slow calls; the traversal bails (marking the result
+    /// `truncated`) once this elapses so a capture still returns promptly.
+    static let traversalDeadline: TimeInterval = 2.0
 
     private var snapshots: [Int: [String: CachedElement]] = [:]
     private var snapshotPids: [Int: Int32] = [:]
@@ -237,6 +245,37 @@ final class AccessibilityManager: @unchecked Sendable {
             AXUIElementCreateSystemWide(),
             Self.axMessagingTimeout
         )
+    }
+
+    // MARK: Off-main execution
+
+    /// Serializes ALL native-driver AX IPC and input synthesis off the main
+    /// thread, so a slow/wedged target app blocks this background queue instead
+    /// of the UI run loop. One operation at a time preserves input-event
+    /// ordering and AX-cache coherence — the same single-threaded guarantee the
+    /// old main-actor hop provided, just off the main thread.
+    static let serialQueue = DispatchQueue(
+        label: "com.osaurus.computeruse.driver",
+        qos: .userInitiated
+    )
+
+    /// Run blocking native-driver work (AX IPC, input synthesis) on
+    /// `serialQueue` and await its result, keeping the main thread responsive.
+    static func runOffMain<T: Sendable>(_ body: @escaping @Sendable () -> T) async -> T {
+        await withCheckedContinuation { continuation in
+            serialQueue.async { continuation.resume(returning: body()) }
+        }
+    }
+
+    /// Create an application AX element with the per-app messaging timeout
+    /// applied. Setting the timeout on the system-wide element alone does not
+    /// reliably propagate to per-application elements, so every site that needs
+    /// an app element goes through here to bound how long a single AX call can
+    /// block.
+    static func axApp(_ pid: Int32) -> AXUIElement {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, axMessagingTimeout)
+        return app
     }
 
     // MARK: Electron / Chromium accessibility
@@ -302,11 +341,11 @@ final class AccessibilityManager: @unchecked Sendable {
     /// The timeout only elapses for an app that exposes no AX text within the
     /// budget (a blank page, or a canvas/WebGL app), and we pay it at most once
     /// per pid — subsequent captures still re-check cheaply (picking up a page
-    /// that built late) but never block again. The poll runs on the main actor
-    /// because it issues AX reads.
+    /// that built late) but never block again. The poll runs on the off-main
+    /// driver queue because it issues blocking AX reads.
     func prepareAndAwaitTree(pid: Int32, timeout: TimeInterval = 1.6) async {
         prepareForAccessibility(pid: pid)
-        if await MainActor.run(body: { Self.focusedWindowHasContent(pid: pid) }) { return }
+        if await Self.runOffMain({ Self.focusedWindowHasContent(pid: pid) }) { return }
 
         // Only pay the timeout once per pid: a contentless app (canvas/blank)
         // shouldn't block every capture, just the first.
@@ -315,7 +354,7 @@ final class AccessibilityManager: @unchecked Sendable {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             try? await Task.sleep(nanoseconds: 80_000_000)
-            if await MainActor.run(body: { Self.focusedWindowHasContent(pid: pid) }) { return }
+            if await Self.runOffMain({ Self.focusedWindowHasContent(pid: pid) }) { return }
         }
     }
 
@@ -331,9 +370,8 @@ final class AccessibilityManager: @unchecked Sendable {
     /// of nodes with no readable text, and treating that as "ready" is exactly
     /// what skipped the wait for the page. Bounded BFS so it stays cheap on huge
     /// trees.
-    @MainActor
     private static func focusedWindowHasContent(pid: Int32) -> Bool {
-        let app = AXUIElementCreateApplication(pid)
+        let app = Self.axApp(pid)
 
         func readableLength(_ element: AXUIElement) -> Int {
             guard let value = axCopyAttribute(element, kAXValueAttribute as String) as? String
@@ -536,8 +574,11 @@ final class AccessibilityManager: @unchecked Sendable {
 
         let snapshotId = beginNewSnapshot(pid: filter.pid)
 
-        let app = AXUIElementCreateApplication(filter.pid)
+        let app = Self.axApp(filter.pid)
         let appName = getAppName(for: filter.pid) ?? "Unknown"
+
+        // Overall wall-clock budget for this traversal (see `traversalDeadline`).
+        let deadline = Date().addingTimeInterval(Self.traversalDeadline)
 
         let maxDepth = filter.maxDepth ?? 20
         let maxElements: Int = {
@@ -609,7 +650,7 @@ final class AccessibilityManager: @unchecked Sendable {
         var truncated = false
 
         for window in orderedWindows {
-            if elements.count >= maxElements {
+            if elements.count >= maxElements || Date() >= deadline {
                 truncated = true
                 break
             }
@@ -627,6 +668,7 @@ final class AccessibilityManager: @unchecked Sendable {
                 depth: 0,
                 maxDepth: maxDepth,
                 maxElements: maxElements,
+                deadline: deadline,
                 interactiveOnly: interactiveOnly,
                 allowedRoles: allowedRoles,
                 textNeedle: textNeedle,
@@ -653,6 +695,7 @@ final class AccessibilityManager: @unchecked Sendable {
                 depth: 0,
                 maxDepth: maxDepth,
                 maxElements: maxElements,
+                deadline: deadline,
                 interactiveOnly: interactiveOnly,
                 allowedRoles: allowedRoles,
                 textNeedle: textNeedle,
@@ -687,6 +730,7 @@ final class AccessibilityManager: @unchecked Sendable {
         depth: Int,
         maxDepth: Int,
         maxElements: Int,
+        deadline: Date,
         interactiveOnly: Bool,
         allowedRoles: Set<String>?,
         textNeedle: String?,
@@ -701,7 +745,10 @@ final class AccessibilityManager: @unchecked Sendable {
         truncated: inout Bool
     ) {
         if depth > maxDepth { return }
-        if elements.count >= maxElements {
+        // Stop at the element cap or the overall wall-clock budget — a huge or
+        // wedged tree can accrue many slow AX calls even under the per-call
+        // timeout, so the deadline still guarantees a prompt (truncated) return.
+        if elements.count >= maxElements || Date() >= deadline {
             truncated = true
             return
         }
@@ -836,7 +883,7 @@ final class AccessibilityManager: @unchecked Sendable {
         }
 
         for child in children {
-            if elements.count >= maxElements {
+            if elements.count >= maxElements || Date() >= deadline {
                 truncated = true
                 break
             }
@@ -845,6 +892,7 @@ final class AccessibilityManager: @unchecked Sendable {
                 depth: depth + 1,
                 maxDepth: maxDepth,
                 maxElements: maxElements,
+                deadline: deadline,
                 interactiveOnly: interactiveOnly,
                 allowedRoles: allowedRoles,
                 textNeedle: textNeedle,
@@ -963,7 +1011,7 @@ struct FocusedElementSummary: Codable, Sendable {
 /// Capture the current focused window title and focused element for a given pid.
 /// Returns nil if pid is unknown or accessibility query fails.
 func computeFocusDelta(pid: Int32) -> FocusDelta? {
-    let app = AXUIElementCreateApplication(pid)
+    let app = AccessibilityManager.axApp(pid)
 
     var focusedWindowTitle: String?
     var winRef: CFTypeRef?
@@ -1034,7 +1082,7 @@ func computeFocusedContent(
     valueCap: Int = 200_000,
     viewportRadius: Int = 1_200
 ) -> FocusedContentInfo? {
-    let app = AXUIElementCreateApplication(pid)
+    let app = AccessibilityManager.axApp(pid)
 
     var elRef: CFTypeRef?
     guard
@@ -1427,7 +1475,7 @@ func listRunningApps() -> AppListResult {
 
 func listWindowsForPid(_ pid: Int32) -> WindowListResult {
     let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
-    let app = AXUIElementCreateApplication(pid)
+    let app = AccessibilityManager.axApp(pid)
 
     // Focused window for the `focused: true` flag.
     var focusedRef: CFTypeRef?
@@ -1530,7 +1578,7 @@ func getActiveWindow() -> MacActiveWindowInfo? {
     let pid = frontApp.processIdentifier
     let appName = frontApp.localizedName ?? "Unknown"
 
-    let app = AXUIElementCreateApplication(pid)
+    let app = AccessibilityManager.axApp(pid)
 
     var windowRef: CFTypeRef?
     guard

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
@@ -220,6 +220,18 @@ final class AccessibilityManager: @unchecked Sendable {
     /// `truncated`) once this elapses so a capture still returns promptly.
     static let traversalDeadline: TimeInterval = 2.0
 
+    /// Osaurus's own process id.
+    static let selfPid: Int32 = ProcessInfo.processInfo.processIdentifier
+
+    /// Whether `pid` is Osaurus itself. The native driver must NEVER resolve the
+    /// current process's AX tree on the off-main driver queue: querying our own
+    /// elements re-enters AppKit/SwiftUI accessibility *in-process*, which
+    /// evaluates SwiftUI `body` and trips its main-thread assertion
+    /// (`_dispatch_assert_queue_fail`) when it runs off the main thread. We also
+    /// never want to perceive or drive our own UI through Computer Use, so every
+    /// AX entry point treats self as "nothing to perceive".
+    static func isSelf(_ pid: Int32) -> Bool { pid == selfPid }
+
     private var snapshots: [Int: [String: CachedElement]] = [:]
     private var snapshotPids: [Int: Int32] = [:]
     private var snapshotOrder: [Int] = []
@@ -294,6 +306,8 @@ final class AccessibilityManager: @unchecked Sendable {
     /// the tree then builds asynchronously (see `prepareAndAwaitTree`).
     @discardableResult
     func prepareForAccessibility(pid: Int32) -> Bool {
+        // Never poke our own process (see `isSelf`).
+        if Self.isSelf(pid) { return false }
         lock.lock()
         if preparedPids.contains(pid) {
             lock.unlock()
@@ -344,6 +358,9 @@ final class AccessibilityManager: @unchecked Sendable {
     /// that built late) but never block again. The poll runs on the off-main
     /// driver queue because it issues blocking AX reads.
     func prepareAndAwaitTree(pid: Int32, timeout: TimeInterval = 1.6) async {
+        // Resolving our own focused window re-enters SwiftUI off-main and traps
+        // (see `isSelf`); there is nothing of ours to wait for.
+        if Self.isSelf(pid) { return }
         prepareForAccessibility(pid: pid)
         if await Self.runOffMain({ Self.focusedWindowHasContent(pid: pid) }) { return }
 
@@ -565,6 +582,22 @@ final class AccessibilityManager: @unchecked Sendable {
     /// Begins a new snapshot. Element IDs in the result are valid until the cache
     /// rotates them out (after the next snapshot beyond the retention limit).
     func traverse(filter: ElementFilter, search: SearchOptions? = nil) -> TraversalResult {
+        // Never traverse our own process: resolving Osaurus's AX tree re-enters
+        // SwiftUI/AppKit accessibility in-process (evaluating `body`), which
+        // traps on the off-main driver queue — and we never perceive our own UI.
+        if Self.isSelf(filter.pid) {
+            return TraversalResult(
+                snapshotId: beginNewSnapshot(pid: filter.pid),
+                pid: filter.pid,
+                app: getAppName(for: filter.pid) ?? "Osaurus",
+                focusedWindow: nil,
+                elementCount: 0,
+                truncated: false,
+                windows: [],
+                elements: []
+            )
+        }
+
         // Ensure Chromium/Electron targets have been asked to expose their tree.
         // Idempotent and cheap after the first call; covers apps reached via a
         // bare capture (not just `open`). The tree may still be settling on the
@@ -1011,6 +1044,8 @@ struct FocusedElementSummary: Codable, Sendable {
 /// Capture the current focused window title and focused element for a given pid.
 /// Returns nil if pid is unknown or accessibility query fails.
 func computeFocusDelta(pid: Int32) -> FocusDelta? {
+    // Never read our own focused element off-main (see `AccessibilityManager.isSelf`).
+    if AccessibilityManager.isSelf(pid) { return nil }
     let app = AccessibilityManager.axApp(pid)
 
     var focusedWindowTitle: String?
@@ -1082,6 +1117,8 @@ func computeFocusedContent(
     valueCap: Int = 200_000,
     viewportRadius: Int = 1_200
 ) -> FocusedContentInfo? {
+    // Never read our own focused element off-main (see `AccessibilityManager.isSelf`).
+    if AccessibilityManager.isSelf(pid) { return nil }
     let app = AccessibilityManager.axApp(pid)
 
     var elRef: CFTypeRef?
@@ -1475,6 +1512,10 @@ func listRunningApps() -> AppListResult {
 
 func listWindowsForPid(_ pid: Int32) -> WindowListResult {
     let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "Unknown"
+    // Never enumerate our own windows off-main (see `AccessibilityManager.isSelf`).
+    if AccessibilityManager.isSelf(pid) {
+        return WindowListResult(pid: pid, app: appName, windows: [])
+    }
     let app = AccessibilityManager.axApp(pid)
 
     // Focused window for the `focused: true` flag.
@@ -1577,6 +1618,13 @@ func getActiveWindow() -> MacActiveWindowInfo? {
 
     let pid = frontApp.processIdentifier
     let appName = frontApp.localizedName ?? "Unknown"
+
+    // When Osaurus itself is frontmost there's no external active window to
+    // report, and resolving our own AX tree off-main traps in SwiftUI (see
+    // `AccessibilityManager.isSelf`). Returning nil also keeps callers that seed
+    // a target pid from the frontmost app (e.g. the Computer Use loop) from
+    // ever pointing at ourselves.
+    if AccessibilityManager.isSelf(pid) { return nil }
 
     let app = AccessibilityManager.axApp(pid)
 

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
@@ -77,10 +77,12 @@ func buildCapture(
     maxElements: Int? = nil,
     focusedWindowOnly: Bool = false
 ) async -> SOMResult {
-    var filter = ElementFilter(pid: pid)
-    if let maxElements = maxElements { filter.maxElements = maxElements }
-    if focusedWindowOnly { filter.focusedWindowOnly = true }
-    let snapshot = await MainActor.run { AccessibilityManager.shared.traverse(filter: filter) }
+    let snapshot = await AccessibilityManager.runOffMain { () -> TraversalResult in
+        var filter = ElementFilter(pid: pid)
+        if let maxElements { filter.maxElements = maxElements }
+        if focusedWindowOnly { filter.focusedWindowOnly = true }
+        return AccessibilityManager.shared.traverse(filter: filter)
+    }
 
     let elementRefs: [SOMElementRef] = snapshot.elements.enumerated().map { idx, info in
         SOMElementRef(

--- a/Packages/OsaurusCore/ComputerUse/Driver/NativeMacDriver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/NativeMacDriver.swift
@@ -7,8 +7,11 @@
 //  `Driver/Mac/*` classes, returning the harness's `CU…` contract types. No
 //  JSON marshalling, no PluginManager / ExternalPlugin.
 //
-//  All AX / input / screenshot work hops to the main actor, matching the
-//  driver's original main-thread affinity.
+//  AX reads and input synthesis run on a dedicated serial background queue
+//  (`AccessibilityManager.runOffMain`) so slow cross-process AX IPC and the
+//  per-character input sleeps never block the UI thread. Only `narrate` stays
+//  on the main actor (it mutates `AutomationSession` UI state); screenshots use
+//  async ScreenCaptureKit.
 //
 
 import AppKit
@@ -22,7 +25,7 @@ public struct NativeMacDriver: MacDriver {
     // MARK: Availability
 
     public func availability() async -> MacDriverAvailability {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             MacDriverAvailability(
                 accessibility: AXIsProcessTrusted(),
                 screenRecording: CGPreflightScreenCaptureAccess(),
@@ -34,7 +37,7 @@ public struct NativeMacDriver: MacDriver {
     // MARK: Perceive (read-only)
 
     public func listApps() async -> [CUAppListing] {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             listRunningApps().apps.map {
                 CUAppListing(
                     pid: $0.pid,
@@ -48,7 +51,7 @@ public struct NativeMacDriver: MacDriver {
     }
 
     public func listWindows(pid: Int32) async -> [CUWindowInfo] {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             listWindowsForPid(pid).windows.map {
                 CUWindowInfo(
                     windowId: $0.windowId,
@@ -65,7 +68,7 @@ public struct NativeMacDriver: MacDriver {
     }
 
     public func activeWindow() async -> CUActiveWindow? {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             guard let info = getActiveWindow() else { return nil }
             return CUActiveWindow(
                 pid: info.pid,
@@ -80,7 +83,7 @@ public struct NativeMacDriver: MacDriver {
     }
 
     public func focusedContent(pid: Int32) async -> CUFocusedContent? {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             guard let info = computeFocusedContent(pid: pid) else { return nil }
             return CUFocusedContent(
                 role: info.role,
@@ -133,7 +136,7 @@ public struct NativeMacDriver: MacDriver {
             // traverse (Cocoa apps + already-built trees return immediately).
             // Without this the first read of Slack/Chrome/VS Code is empty.
             await AccessibilityManager.shared.prepareAndAwaitTree(pid: pid)
-            let snapshot = await MainActor.run { () -> TraversalResult in
+            let snapshot = await AccessibilityManager.runOffMain { () -> TraversalResult in
                 var filter = ElementFilter(pid: pid)
                 if let maxElements { filter.maxElements = maxElements }
                 if focusedWindowOnly { filter.focusedWindowOnly = true }
@@ -162,7 +165,7 @@ public struct NativeMacDriver: MacDriver {
         enabledOnly: Bool,
         limit: Int
     ) async -> CUSnapshot {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             var filter = ElementFilter(pid: pid)
             filter.roles = roles
             filter.maxDepth = 25
@@ -182,7 +185,7 @@ public struct NativeMacDriver: MacDriver {
     // MARK: Act — element-addressed
 
     public func perform(_ action: CUElementAction) async -> CUActionResult {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             switch action {
             case let .click(id, button, doubleClick):
                 let r: ElementActionResult
@@ -257,7 +260,7 @@ public struct NativeMacDriver: MacDriver {
     // MARK: Act — coordinate-addressed
 
     public func coordinate(_ action: CUCoordinateAction) async -> CUActionResult {
-        await MainActor.run {
+        await AccessibilityManager.runOffMain {
             switch action {
             case let .click(x, y, button, doubleClick, pid):
                 let point = CGPoint(x: x, y: y)

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -238,8 +238,16 @@ public enum ComputerUseLoop {
         )
         let watermark = CompactionWatermark()
 
-        // Driver state.
+        // Driver state. Seed the target from the frontmost app, but never
+        // Osaurus itself: `activeWindow()` returns nil when we're frontmost (we
+        // can't — and must not — perceive our own UI). Fall back to the app the
+        // user was on right before switching to Osaurus (the same working-app
+        // hint screen context uses) so a task started from the chat window still
+        // has a sensible target instead of none.
         var currentPid: Int32? = await driver.activeWindow()?.pid
+        if currentPid == nil {
+            currentPid = await FrontmostAppTracker.shared.lastNonSelfPid
+        }
         var currentApp: String? = nil
         var lastView: AgentView? = nil
         var lastSnapshot: CUSnapshot? = nil

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilitySelfGuardTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/AccessibilitySelfGuardTests.swift
@@ -1,0 +1,60 @@
+//
+//  AccessibilitySelfGuardTests.swift
+//  OsaurusCoreTests — Computer Use
+//
+//  The native driver must never resolve Osaurus's OWN accessibility tree on the
+//  off-main driver queue: querying our own elements re-enters AppKit/SwiftUI
+//  accessibility in-process, evaluating SwiftUI `body` and tripping its
+//  main-thread assertion when it runs off the main thread (the production
+//  AppHang/crash this guard fixes). Every AX entry point therefore treats self
+//  as "nothing to perceive". These tests pin the self-identity check and the
+//  empty/nil contract each entry point returns for our own pid; the live AX
+//  behavior is exercised by the opt-in eval suite, not here.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class AccessibilitySelfGuardTests: XCTestCase {
+    func testIsSelfMatchesOwnPidOnly() throws {
+        XCTAssertTrue(AccessibilityManager.isSelf(AccessibilityManager.selfPid))
+        XCTAssertEqual(
+            AccessibilityManager.selfPid,
+            ProcessInfo.processInfo.processIdentifier
+        )
+        // A pid that can't be ours (no process owns Int32.max).
+        XCTAssertFalse(AccessibilityManager.isSelf(Int32.max))
+        // launchd is pid 1 and is never us.
+        XCTAssertFalse(AccessibilityManager.isSelf(1))
+    }
+
+    func testTraverseReturnsEmptyForSelf() throws {
+        let result = AccessibilityManager.shared.traverse(
+            filter: ElementFilter(pid: AccessibilityManager.selfPid)
+        )
+        XCTAssertEqual(result.pid, AccessibilityManager.selfPid)
+        XCTAssertTrue(result.elements.isEmpty)
+        XCTAssertEqual(result.elementCount, 0)
+        XCTAssertTrue(result.windows.isEmpty)
+        XCTAssertFalse(result.truncated)
+        XCTAssertFalse(result.app.isEmpty, "self result should still name the app")
+    }
+
+    func testListWindowsReturnsEmptyForSelf() throws {
+        XCTAssertTrue(listWindowsForPid(AccessibilityManager.selfPid).windows.isEmpty)
+    }
+
+    func testFocusedContentAndDeltaReturnNilForSelf() throws {
+        XCTAssertNil(computeFocusedContent(pid: AccessibilityManager.selfPid))
+        XCTAssertNil(computeFocusDelta(pid: AccessibilityManager.selfPid))
+    }
+
+    func testPrepareForAccessibilityIsNoOpForSelf() throws {
+        XCTAssertFalse(
+            AccessibilityManager.shared.prepareForAccessibility(pid: AccessibilityManager.selfPid),
+            "preparing our own pid must be a no-op (never set AX flags on ourselves)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Production Sentry AppHangs were firing from the Computer Use subsystem because `NativeMacDriver` ran synchronous Accessibility (AX) cross-process IPC — and per-character input synthesis — on the **main thread** via `MainActor.run`. A slow or wedged target app (or a very large AX tree) blocked the main thread long enough to trip the hang detector.

- **Off-main execution:** route all driver reads (`availability`, `listApps`, `listWindows`, `activeWindow`, `focusedContent`, `capture` ax-tier, `find`) and the action path (`perform`, `coordinate`) through a single shared serial executor, `AccessibilityManager.runOffMain`. `narrate` intentionally stays on the main actor since it mutates `AutomationSession` UI state.
- **Bounded AX calls:** apply `AXUIElementSetMessagingTimeout` per app element via `axApp(pid:)` (the timeout was not propagating from the system-wide element) and lower it from `3.0s` to `1.5s`.
- **Traversal deadline:** add a wall-clock deadline so `traverse`/`traverseElement` bail early and mark the capture `truncated` on huge or wedged trees, even when each individual call stays under the per-call timeout.

### Fixes
- `APPLE-MACOS-NK` — AppHang in `find` ([Sentry 7567039735](https://osaurus-inc.sentry.io/issues/7567039735/))
- `APPLE-MACOS-NG` — AppHang in `listWindows` ([Sentry 7566910631](https://osaurus-inc.sentry.io/issues/7566910631/))
- Latent input-path hang: per-character `Thread.sleep` in `type_text` now runs off-main.

## Test plan
- [x] `make test` (OsaurusCore unit suite) — green; the only failures are pre-existing keychain tests, confirmed unrelated by stashing this change.
- [x] `make app` — clean Release build under Swift 6 strict concurrency.
- [x] Computer Use evals with `grok` — no regressions. (Note: evals run against mock drivers, so they validate `MacDriver` contracts and model behavior, not the live AX threading change.)
- [ ] Recommended manual smoke: screen-context against a deliberately slow/unresponsive app + a long `type_text`, and confirm the UI stays responsive (no main-thread hang).

Made with [Cursor](https://cursor.com)