### PR TITLE
fix /memory/ingest distillation and harden launch crashes (#1632)

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -176,21 +176,31 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         guard StorageKeyManager.shared.isStorageReadyForWrites else { return }
         didPrewarmChatView = true
 
-        let windowState = ChatWindowState(
-            windowId: UUID(),
-            agentId: AgentManager.shared.activeAgentId
-        )
-        let chatView = ChatView(windowState: windowState)
-            .environment(\.theme, windowState.theme)
-        let hostingController = NSHostingController(rootView: chatView)
-        // Forcing layout evaluates the SwiftUI body once, which realizes the
-        // metadata. The controller is never attached to a visible window, so
-        // `onAppear` / `task` side effects don't fire.
-        hostingController.view.layoutSubtreeIfNeeded()
+        // Wrap the throwaway view tree in an autorelease pool so its teardown
+        // — including SwiftUI's `dismantleNSView` (which clears the prewarmed
+        // message table's hover closures) and the release of every cell's
+        // tracking areas — is drained deterministically when this call
+        // returns, instead of deferring to a later pool drain during the
+        // sensitive launch window where the tracking-area SIGABRT was seen
+        // (issue #1632).
+        autoreleasepool {
+            let windowState = ChatWindowState(
+                windowId: UUID(),
+                agentId: AgentManager.shared.activeAgentId
+            )
+            let chatView = ChatView(windowState: windowState)
+                .environment(\.theme, windowState.theme)
+            let hostingController = NSHostingController(rootView: chatView)
+            // Forcing layout evaluates the SwiftUI body once, which realizes
+            // the metadata. The controller is never attached to a visible
+            // window, so `onAppear` / `task` side effects don't fire.
+            hostingController.view.layoutSubtreeIfNeeded()
 
-        // Tear the throwaway state down so its session/observers don't linger;
-        // `deinit` removes the notification observers as it deallocates.
-        windowState.cleanup()
+            // Tear the throwaway state down so its session/observers don't
+            // linger; `deinit` removes the notification observers as it
+            // deallocates.
+            windowState.cleanup()
+        }
         print("[ChatWindowManager] Prewarmed ChatView metadata")
     }
 

--- a/Packages/OsaurusCore/Models/Memory/MemoryConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Memory/MemoryConfiguration.swift
@@ -28,7 +28,13 @@ public enum MemoryExtractionMode: String, Codable, Sendable {
 /// Strategy for the per-turn relevance gate that decides whether memory
 /// should be injected at all.
 public enum MemoryRelevanceGateMode: String, Codable, Sendable {
-    /// Always inject (legacy behavior; not recommended).
+    /// Always consider memory for every turn (the gate returns `.episode`
+    /// unconditionally). Bypasses the heuristic so recall is never silently
+    /// skipped — set this in the persisted memory config
+    /// (`relevanceGateMode: "off"`) when verifying that stored memory is
+    /// actually retrievable (issue #1632 U2). Heavier per-turn than
+    /// `.heuristic`; intended for testing / always-on recall rather than the
+    /// default chat path.
     case off
     /// Cheap rule-based check: pronouns referencing prior context, entity
     /// hits in the graph, temporal markers, and identity-curious phrases.
@@ -88,6 +94,23 @@ public struct MemoryConfiguration: Codable, Equatable, Sendable {
     /// Minimum combined (user+assistant) char count before distillation
     /// considers a turn worth processing.
     public static let distillNoveltyMinChars = 80
+    /// Max distillation attempts before a session's pending signals are
+    /// dead-lettered (`status='dead_letter'`) so an unparseable / repeatedly
+    /// failing session stops re-distilling on every launch/ingest/debounce
+    /// forever (root cause of the "108 error / 5 empty" `processing_log`
+    /// rows in issue #1632). Transient skips (no core model, breaker open,
+    /// model unavailable) and cancellations deliberately do NOT count toward
+    /// this cap — they stay `pending` and recover once the model is ready.
+    public static let distillMaxAttempts = 3
+    /// Cap on conversation turns folded into a single distillation prompt.
+    /// Oversized sessions are clamped (opening head + most-recent tail) so
+    /// the prompt can't overflow a small core model's context and get stuck
+    /// erroring. Identity-bearing opening turns are preserved via the head.
+    public static let distillMaxTurns = 80
+    /// Per-message character clamp inside the distillation prompt. Long
+    /// individual turns are truncated so one giant paste can't blow the
+    /// context budget on its own.
+    public static let distillMaxTurnChars = 2000
     /// Salience half-life in days, used by the consolidator's decay step.
     public static let salienceHalfLifeDays: Double = 30
     /// Number of episodes a candidate must appear in before the

--- a/Packages/OsaurusCore/Models/Memory/MemoryModels.swift
+++ b/Packages/OsaurusCore/Models/Memory/MemoryModels.swift
@@ -274,6 +274,57 @@ public struct ProcessingStats: Sendable {
     public var errorCount: Int = 0
 }
 
+/// Structured result of a single `MemoryService.distillSession` /
+/// `performDistillSession` run. Returned so callers (notably the
+/// `POST /memory/ingest` handler) can report what actually happened
+/// instead of guessing from a fire-and-forget `Task`. Before this existed
+/// the handler returned `{"status":"ok"}` even when distillation was
+/// silently skipped (issue #1632): the heavy non-resident core-model gate
+/// short-circuited the coordinator with no `processing_log` row at all.
+public enum DistillOutcome: Sendable, Equatable {
+    /// An episode was written. `pinned` / `identityFacts` are the counts
+    /// promoted from this session.
+    case distilled(episodeId: Int, pinned: Int, identityFacts: Int)
+    /// No `pending` signals for the conversation (already distilled, or
+    /// nothing was buffered).
+    case noSignals
+    /// A pre-LLM or transient gate skipped the run without erroring.
+    /// `reason` is a stable token: `memory_disabled`, `not_resident`,
+    /// `core_model_unset`, `core_model_unavailable`, `breaker_open`,
+    /// `low_novelty:<n>chars`, `cancelled`.
+    case skipped(reason: String)
+    /// The model ran but produced no usable episode. `reason` is
+    /// `no_episode` or `empty_summary`. Terminal: the signals are marked
+    /// processed so the session is not retried.
+    case empty(reason: String)
+    /// The session failed `attempts` times and was dead-lettered; its
+    /// signals will no longer be retried.
+    case deadLettered(attempts: Int)
+    /// A retryable error occurred (signals stay `pending` until the
+    /// attempt cap is reached).
+    case error(String)
+
+    /// Compact, machine-readable status token for the `/memory/ingest`
+    /// JSON body (`"distilled" | "skipped:<reason>" | "empty:<reason>" |
+    /// "dead_letter:<attempts>" | "error:<msg>" | "no_signals"`).
+    public var apiStatus: String {
+        switch self {
+        case .distilled: return "distilled"
+        case .noSignals: return "no_signals"
+        case .skipped(let reason): return "skipped:\(reason)"
+        case .empty(let reason): return "empty:\(reason)"
+        case .deadLettered(let attempts): return "dead_letter:\(attempts)"
+        case .error(let msg): return "error:\(msg)"
+        }
+    }
+
+    /// The episode primary key when a row was written, else nil.
+    public var episodeId: Int? {
+        if case .distilled(let id, _, _) = self { return id }
+        return nil
+    }
+}
+
 /// One row from `processing_log`. Surfaces what every distillation /
 /// consolidation pass actually did — including the new `"skipped"` rows
 /// that the distill pipeline writes when it bails before reaching the

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -3024,8 +3024,27 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             let skipExtraction = req.skip_extraction ?? false
 
+            // I3 — agent-id canonicalization. Recall and the per-agent
+            // vector index key off Swift's (uppercase) `UUID.uuidString`, so
+            // a lowercase UUID ingested verbatim would write where recall
+            // never reads. Canonicalize a valid UUID to its uppercase form;
+            // pass non-UUID ids through unchanged.
+            let canonicalAgentId = UUID(uuidString: req.agent_id)?.uuidString ?? req.agent_id
+
             do {
                 try db.deleteTranscriptForConversation(req.conversation_id)
+
+                // I1 — idempotency. `episodes` has no `UNIQUE(conversation_id)`,
+                // so re-ingesting the same conversation (e.g. re-running a
+                // LoCoMo session) would otherwise stack duplicate episodes and
+                // pending signals. Clearing both first makes a re-ingest fully
+                // replace the conversation's prior memory state. Only when we
+                // actually run the extraction pipeline — `skip_extraction`
+                // callers explicitly want transcript-only storage untouched.
+                if !skipExtraction {
+                    try db.deletePendingSignalsForConversation(req.conversation_id)
+                    try db.deleteEpisodesForConversation(req.conversation_id)
+                }
 
                 for (i, turn) in req.turns.enumerated() {
                     let turnDate = turn.date ?? req.session_date
@@ -3042,10 +3061,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             role: role,
                             content: content,
                             tokenCount: tokens,
-                            agentId: req.agent_id
+                            agentId: canonicalAgentId
                         )
                         try db.insertTranscriptTurn(
-                            agentId: req.agent_id,
+                            agentId: canonicalAgentId,
                             conversationId: req.conversation_id,
                             chunkIndex: chunkIndex,
                             role: role,
@@ -3060,7 +3079,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         await MemoryService.shared.bufferTurn(
                             userMessage: turn.user,
                             assistantMessage: turn.assistant,
-                            agentId: req.agent_id,
+                            agentId: canonicalAgentId,
                             conversationId: req.conversation_id,
                             sessionDate: turnDate
                         )
@@ -3102,15 +3121,39 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             // Ingestion always implies "I'm done with this conversation
             // batch": flush distillation immediately so callers (benchmarks,
-            // bulk imports) don't have to wait for the debounce.
+            // bulk imports) don't have to wait for the debounce. We now
+            // *await* the outcome (forcing an on-demand cold load if the core
+            // model isn't resident) and report it, instead of the old
+            // fire-and-forget `flushSession` that returned `{"status":"ok"}`
+            // even when the residency gate silently skipped distillation
+            // entirely (issue #1632). The response is only written after the
+            // distill resolves; cold loads can take tens of seconds, so the
+            // benchmark client allows a long (300s) timeout.
+            var distillation: DistillOutcome? = nil
             if !skipExtraction {
-                await MemoryService.shared.flushSession(
-                    agentId: req.agent_id,
-                    conversationId: req.conversation_id
+                distillation = await MemoryService.shared.flushSessionAndWait(
+                    agentId: canonicalAgentId,
+                    conversationId: req.conversation_id,
+                    sessionDate: req.session_date
                 )
             }
 
-            let responseBody = "{\"status\":\"ok\",\"turns_ingested\":\(req.turns.count)}"
+            // Build via JSONSerialization so the distillation detail string
+            // (which can carry an arbitrary error message) is always escaped.
+            var payload: [String: Any] = [
+                "status": "ok",
+                "turns_ingested": req.turns.count,
+            ]
+            if let distillation {
+                payload["distillation"] = distillation.apiStatus
+                if let episodeId = distillation.episodeId {
+                    payload["episode_id"] = episodeId
+                }
+            }
+            let responseBody: String =
+                (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]))
+                .flatMap { String(data: $0, encoding: .utf8) }
+                ?? "{\"status\":\"ok\",\"turns_ingested\":\(req.turns.count)}"
             var headers: [(String, String)] = [("Content-Type", "application/json")]
             headers.append(contentsOf: cors)
             let headersCopy = headers
@@ -4136,10 +4179,18 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
 
             let db = MemoryDatabase.shared
+            // `memory_entry_count` reflects *stored memory* — distilled
+            // episodes plus active pinned facts — not just pinned facts.
+            // Counting only pinned facts read 0 for an agent whose sessions
+            // distilled into episodes but produced no pinned candidates
+            // (issue #1632 U3: "memory_entry_count stays 0").
             var memoryCounts: [String: Int] = [:]
-            if db.isOpen, let counts = try? db.agentIdsWithPinnedFacts() {
-                for (agentId, count) in counts {
-                    memoryCounts[agentId] = count
+            if db.isOpen {
+                if let pinned = try? db.agentIdsWithPinnedFacts() {
+                    for (agentId, count) in pinned { memoryCounts[agentId, default: 0] += count }
+                }
+                if let episodes = try? db.agentIdsWithEpisodes() {
+                    for (agentId, count) in episodes { memoryCounts[agentId, default: 0] += count }
                 }
             }
 
@@ -4295,6 +4346,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             let supportsVision = effectiveModelId.map { VLMDetection.isVLM(modelId: $0) } ?? false
             let supportsThinking =
                 effectiveModelId.flatMap { ModelProfileRegistry.profile(for: $0)?.thinkingOption } != nil
+            // Same stored-memory count as the `/agents` listing (episodes +
+            // pinned facts) instead of the pre-fix hardcoded 0 (issue #1632 U3).
+            let memoryEntryCount: Int = {
+                let db = MemoryDatabase.shared
+                guard db.isOpen else { return 0 }
+                let episodes = (try? db.episodeCount(agentId: agent.id.uuidString)) ?? 0
+                let pinned = (try? db.pinnedFactCount(agentId: agent.id.uuidString)) ?? 0
+                return episodes + pinned
+            }()
             let item = AgentListItem(
                 id: agent.id.uuidString,
                 name: agent.name,
@@ -4305,7 +4365,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 supports_thinking: supportsThinking,
                 supports_vision: supportsVision,
                 is_built_in: agent.isBuiltIn,
-                memory_entry_count: 0,
+                memory_entry_count: memoryEntryCount,
                 created_at: formatter.string(from: agent.createdAt),
                 updated_at: formatter.string(from: agent.updatedAt)
             )

--- a/Packages/OsaurusCore/Services/Memory/DistillationCoordinator.swift
+++ b/Packages/OsaurusCore/Services/Memory/DistillationCoordinator.swift
@@ -26,6 +26,18 @@
 //
 
 import Foundation
+import os
+
+/// Sendable hand-off box for `DistillationCoordinator.runReturning`'s
+/// generic result. The body runs inside an unstructured child `Task`; the
+/// value is written there and read after `await myTask.value`, so the lock
+/// only guards against the type system's (correct) refusal to share a plain
+/// `var` across the `@Sendable` boundary — there's no real contention.
+private final class ResultBox<T: Sendable>: Sendable {
+    private let lock = OSAllocatedUnfairLock<T?>(initialState: nil)
+    func set(_ value: T) { lock.withLock { $0 = value } }
+    func get() -> T? { lock.withLock { $0 } }
+}
 
 public actor DistillationCoordinator {
     public static let shared = DistillationCoordinator()
@@ -69,15 +81,37 @@ public actor DistillationCoordinator {
     /// the run if the configured core model would require an expensive
     /// cold load. Skipped runs return without invoking `body`.
     ///
-    /// Returns when `body` either finishes, throws (it's `() async`,
-    /// so it doesn't), or was skipped by the residency gate.
+    /// Void-returning entry point (the legacy shape). Kept as a thin
+    /// wrapper over `runReturning` so existing `await coordinator.run { … }`
+    /// call sites — including ones that bind the result as
+    /// `async let x: Void = coordinator.run { … }` — keep their exact
+    /// `Void` type. New callers that need the body's value use
+    /// `runReturning`.
     public func run(
         chatIdleWaitMs: Int = 8000,
         requireResident: Bool = true,
         body: @Sendable @escaping () async -> Void
     ) async {
+        await runReturning(
+            chatIdleWaitMs: chatIdleWaitMs,
+            requireResident: requireResident,
+            body: body
+        )
+    }
+
+    /// Returns the body's result, or `nil` when the run was skipped by the
+    /// residency gate (so callers can distinguish "skipped before running"
+    /// from any value the body itself returns). `@discardableResult` so the
+    /// `Void`-body delegation from `run` doesn't warn.
+    @discardableResult
+    public func runReturning<T: Sendable>(
+        chatIdleWaitMs: Int = 8000,
+        requireResident: Bool = true,
+        body: @Sendable @escaping () async -> T
+    ) async -> T? {
         queuedCount += 1
         let previous = currentTask
+        let box = ResultBox<T>()
         let myTask = Task<Void, Never> { [weak self] in
             // Wait for the previous distill to fully complete before
             // we even check the residency / chat-idle gates — this is
@@ -117,13 +151,14 @@ public actor DistillationCoordinator {
             // briefly observable after `myTask.value` resumes, which
             // would race the diagnostics-panel snapshot.
             await self?.setBodyActive(true)
-            await body()
+            box.set(await body())
             await self?.setBodyActive(false)
         }
 
         currentTask = myTask
         await myTask.value
         queuedCount = max(0, queuedCount - 1)
+        return box.get()
     }
 
     private func setBodyActive(_ active: Bool) {

--- a/Packages/OsaurusCore/Services/Memory/MemoryService.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryService.swift
@@ -130,12 +130,42 @@ public actor MemoryService {
     }
 
     /// Force immediate distillation for a session. Called from the chat UI
-    /// when the user navigates away.
+    /// when the user navigates away. Fire-and-forget: the caller doesn't
+    /// wait for (or learn) the outcome. For the request/response path
+    /// (`POST /memory/ingest`) use `flushSessionAndWait` instead.
     public func flushSession(agentId: String, conversationId: String) {
         debounceTasks[conversationId]?.cancel()
         debounceTasks[conversationId] = Task { [weak self] in
             await self?.distillSession(agentId: agentId, conversationId: conversationId)
         }
+    }
+
+    /// Force immediate distillation for a session and await the outcome.
+    ///
+    /// Used by `POST /memory/ingest` so the HTTP response can report
+    /// whether an episode was actually written (issue #1632) instead of
+    /// returning a blind `{"status":"ok"}` while the coordinator silently
+    /// skipped a heavy, non-resident core model. Forces
+    /// `requireResident: false` so the cold load happens on demand
+    /// (matching the user-driven "Distill pending" / backfill semantics).
+    /// The load still routes through the gated `load:<model>` path, so it
+    /// stays GPU-safe.
+    @discardableResult
+    public func flushSessionAndWait(
+        agentId: String,
+        conversationId: String,
+        sessionDate: String? = nil
+    ) async -> DistillOutcome {
+        // Cancel any armed debounce so we don't double-distill this
+        // session; we drive the distill directly below and await it.
+        debounceTasks[conversationId]?.cancel()
+        debounceTasks[conversationId] = nil
+        return await distillSession(
+            agentId: agentId,
+            conversationId: conversationId,
+            sessionDate: sessionDate,
+            requireResident: false
+        )
     }
 
     /// Distill every pending conversation and run identity regeneration if needed.
@@ -323,22 +353,39 @@ public actor MemoryService {
     /// as the residency gate before yielding to chat-idle. Both live
     /// under `Services/Memory/` so the coupling is intentional.
     func canDistillCheaply() async -> Bool {
-        guard let modelId = await MainActor.run(body: { ChatConfigurationStore.load().coreModelIdentifier }) else {
+        // Resolve via the router first. The pre-fix code matched the raw
+        // `coreModelIdentifier` against `discoverLocalModels()` and returned
+        // `true` on a *miss* — so an unroutable core model (deleted MLX
+        // model, Foundation on pre-26 macOS, disconnected remote) reported
+        // "cheap", the coordinator proceeded, and `generate` threw
+        // `modelUnavailable` on every attempt → endless `error` rows
+        // (issue #1632 D3). Routing through `resolveStatus()` makes an
+        // unroutable / unset / breaker-open model report "not cheap" so the
+        // background path skips it (signals stay pending) instead of looping.
+        let status = await CoreModelService.shared.resolveStatus()
+        switch status {
+        case .unset, .unavailable, .breakerOpen:
+            return false
+        case .available(let modelId, _, let effectiveModel):
+            // Only locally-hosted MLX models carry a cold-load cost. A
+            // routable model that isn't a discoverable local model
+            // (Foundation, remote provider) is cheap — no load required.
+            guard
+                let local = ModelManager.discoverLocalModels()
+                    .first(where: {
+                        $0.id.caseInsensitiveCompare(modelId) == .orderedSame
+                            || $0.name.caseInsensitiveCompare(modelId) == .orderedSame
+                            || $0.id.caseInsensitiveCompare(effectiveModel) == .orderedSame
+                            || $0.name.caseInsensitiveCompare(effectiveModel) == .orderedSame
+                    })
+            else { return true }
+
+            if await ModelRuntime.shared.isResident(name: local.name) { return true }
+            if let params = local.parameterCountBillions, params <= Self.coldLoadParamBudgetBillions {
+                return true
+            }
             return false
         }
-        guard
-            let local = ModelManager.discoverLocalModels()
-                .first(where: {
-                    $0.id.caseInsensitiveCompare(modelId) == .orderedSame
-                        || $0.name.caseInsensitiveCompare(modelId) == .orderedSame
-                })
-        else { return true }
-
-        if await ModelRuntime.shared.isResident(name: local.name) { return true }
-        if let params = local.parameterCountBillions, params <= Self.coldLoadParamBudgetBillions {
-            return true
-        }
-        return false
     }
 
     private static let coldLoadParamBudgetBillions: Double = 2.0
@@ -575,26 +622,33 @@ public actor MemoryService {
     ///   * `false` — user explicitly asked (the "Distill pending"
     ///     button + the chat-history backfill): proceed regardless;
     ///     the user has opted into the cold load.
+    @discardableResult
     private func distillSession(
         agentId: String,
         conversationId: String,
         sessionDate: String? = nil,
         requireResident: Bool = true
-    ) async {
+    ) async -> DistillOutcome {
         // Quick global gate before queuing — signals stale-by-the-time-
         // we-run is not an issue because `performDistillSession`
         // re-reads from `pending_signals` inside the coordinator body.
         let config = MemoryConfigurationStore.load()
-        guard config.enabled else { return }
+        guard config.enabled else { return .skipped(reason: "memory_disabled") }
 
-        await DistillationCoordinator.shared.run(requireResident: requireResident) { [weak self] in
-            guard let self else { return }
-            await self.performDistillSession(
+        let outcome = await DistillationCoordinator.shared.runReturning(
+            requireResident: requireResident
+        ) { [weak self] () -> DistillOutcome in
+            guard let self else { return .error("service_released") }
+            return await self.performDistillSession(
                 agentId: agentId,
                 conversationId: conversationId,
                 sessionDate: sessionDate
             )
         }
+        // `nil` means the coordinator's residency gate short-circuited the
+        // run (`requireResident && !canDistillCheaply`); signals stay
+        // pending and recover next launch / once the model is resident.
+        return outcome ?? .skipped(reason: "not_resident")
     }
 
     /// The actual distillation body. Holds every cheap pre-LLM gate
@@ -604,18 +658,21 @@ public actor MemoryService {
     ///
     /// Called via `DistillationCoordinator` by `distillSession` and
     /// directly (no coordinator) by `flushAllPending` at app quit.
+    @discardableResult
     private func performDistillSession(
         agentId: String,
         conversationId: String,
         sessionDate: String? = nil
-    ) async {
+    ) async -> DistillOutcome {
         let config = MemoryConfigurationStore.load()
-        guard config.enabled else { return }
+        guard config.enabled else { return .skipped(reason: "memory_disabled") }
         guard await hasCoreModel() else {
             // Pre-fix this was an `.info` log, which meant the user
             // had no UI affordance to see why distillation was silently
             // disabled. Now we both warn AND write a `skipped` row to
             // `processing_log` so the diagnostics panel can surface it.
+            // Signals stay pending intentionally (no model yet) and this
+            // does NOT count toward the dead-letter cap.
             MemoryLogger.service.warning(
                 "distill: no core model configured; signals stay pending (configure one in Settings → Core Model)"
             )
@@ -626,7 +683,7 @@ public actor MemoryService {
                 status: "skipped",
                 details: "core_model_unset"
             )
-            return
+            return .skipped(reason: "core_model_unset")
         }
 
         let coreModelId = await coreModelIdentifier()
@@ -635,16 +692,21 @@ public actor MemoryService {
         let signals: [PendingSignal]
         do { signals = try db.loadPendingSignals(conversationId: conversationId) } catch {
             MemoryLogger.service.error("distill: failed to load signals for \(conversationId): \(error)")
-            return
+            return .error(error.localizedDescription)
         }
-        guard !signals.isEmpty else { return }
+        guard !signals.isEmpty else { return .noSignals }
+        // Snapshot the ids so we only ever mark *these* signals processed —
+        // turns buffered while the LLM call is in flight stay pending (D2).
+        let signalIds = signals.map(\.id)
 
         // Cheap pre-LLM gate: combined char count must clear novelty floor.
         let combinedChars = signals.reduce(0) {
             $0 + $1.userMessage.count + ($1.assistantMessage?.count ?? 0)
         }
         guard combinedChars >= MemoryConfiguration.distillNoveltyMinChars else {
-            try? db.markSignalsProcessed(conversationId: conversationId)
+            // Terminal + non-retryable: clear exactly these signals
+            // (id-scoped) so a low-novelty session can't loop forever.
+            try? db.markSignals(ids: signalIds, status: "processed")
             MemoryLogger.service.warning(
                 "distill: skipping low-novelty session \(conversationId) (\(combinedChars) chars)"
             )
@@ -656,7 +718,7 @@ public actor MemoryService {
                 details: "low_novelty:\(combinedChars)chars"
             )
             debounceTasks[conversationId] = nil
-            return
+            return .skipped(reason: "low_novelty:\(combinedChars)chars")
         }
 
         let identity = (try? db.loadIdentity()) ?? Identity()
@@ -682,30 +744,40 @@ public actor MemoryService {
                 systemPrompt: distillSystemPrompt
             )
             let parsed = parseDistillResponse(response)
+            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+
             guard let episode = parsed.episode else {
+                // Terminal: the model ran but produced no usable episode.
+                // Mark these signals processed (id-scoped) so an unparseable
+                // session is not retried on every launch/ingest forever (D1).
+                try? db.markSignals(ids: signalIds, status: "processed")
                 MemoryLogger.service.warning("distill: no episode produced for \(conversationId)")
                 logProcessing(
                     agentId: agentId,
                     taskType: "distill",
                     model: coreModelId,
                     status: "empty",
-                    durationMs: Int(Date().timeIntervalSince(startTime) * 1000)
+                    durationMs: durationMs,
+                    details: "no_episode"
                 )
-                return
+                debounceTasks[conversationId] = nil
+                return .empty(reason: "no_episode")
             }
 
             let summaryText = stripPreamble(episode.summary)
             guard !summaryText.isEmpty else {
+                try? db.markSignals(ids: signalIds, status: "processed")
                 MemoryLogger.service.warning("distill: empty summary for \(conversationId)")
                 logProcessing(
                     agentId: agentId,
                     taskType: "distill",
                     model: coreModelId,
                     status: "empty",
-                    durationMs: Int(Date().timeIntervalSince(startTime) * 1000),
+                    durationMs: durationMs,
                     details: "empty_summary"
                 )
-                return
+                debounceTasks[conversationId] = nil
+                return .empty(reason: "empty_summary")
             }
 
             let tokenCount = max(1, summaryText.count / MemoryConfiguration.charsPerToken)
@@ -731,10 +803,19 @@ public actor MemoryService {
 
             let episodeId: Int
             do {
-                episodeId = try db.insertEpisodeAndMarkProcessed(ep)
+                // Id-scoped marking (D2): only the snapshotted ids are
+                // cleared inside the same transaction as the episode insert.
+                episodeId = try db.insertEpisodeAndMarkProcessed(ep, signalIds: signalIds)
             } catch {
                 MemoryLogger.service.error("distill: failed to insert episode for \(conversationId): \(error)")
-                return
+                return recordRetryableDistillFailure(
+                    message: "episode_insert_failed: \(error.localizedDescription)",
+                    agentId: agentId,
+                    conversationId: conversationId,
+                    coreModelId: coreModelId,
+                    signalIds: signalIds,
+                    durationMs: durationMs
+                )
             }
 
             // Index the episode for search.
@@ -760,7 +841,6 @@ public actor MemoryService {
                 )
             }
 
-            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
             logProcessing(
                 agentId: agentId,
                 taskType: "distill",
@@ -775,18 +855,105 @@ public actor MemoryService {
             )
 
             await MemoryContextAssembler.shared.invalidateCache(agentId: agentId)
-        } catch {
-            MemoryLogger.service.error("distill: failed for \(conversationId): \(error)")
+            debounceTasks[conversationId] = nil
+            return .distilled(
+                episodeId: episodeId,
+                pinned: storedPinned,
+                identityFacts: parsed.identityFacts.count
+            )
+        } catch is CancellationError {
+            // Interrupted (app quitting, caller walked away). Not an error
+            // and NOT counted toward the dead-letter cap — signals stay
+            // pending and recover next launch. Logged as `skipped` so a
+            // mid-flight teardown stops masquerading as a hard `error` row.
+            MemoryLogger.service.info("distill: cancelled for \(conversationId)")
             logProcessing(
                 agentId: agentId,
                 taskType: "distill",
                 model: coreModelId,
-                status: "error",
-                details: error.localizedDescription
+                status: "skipped",
+                durationMs: Int(Date().timeIntervalSince(startTime) * 1000),
+                details: "cancelled"
+            )
+            debounceTasks[conversationId] = nil
+            return .skipped(reason: "cancelled")
+        } catch let coreErr as CoreModelError {
+            let durationMs = Int(Date().timeIntervalSince(startTime) * 1000)
+            switch coreErr {
+            case .modelUnavailable, .circuitBreakerOpen:
+                // Config-level / transient backend state. Stay pending and
+                // recover once the model resolves or the breaker closes; do
+                // NOT count toward the cap (a misconfig shouldn't permanently
+                // lose the user's turns).
+                let reason = (coreErr == .circuitBreakerOpen) ? "breaker_open" : "core_model_unavailable"
+                MemoryLogger.service.warning("distill: \(reason) for \(conversationId)")
+                logProcessing(
+                    agentId: agentId,
+                    taskType: "distill",
+                    model: coreModelId,
+                    status: "skipped",
+                    durationMs: durationMs,
+                    details: reason
+                )
+                debounceTasks[conversationId] = nil
+                return .skipped(reason: reason)
+            case .timedOut:
+                // A persistently-too-slow session DOES count toward the cap so
+                // it eventually dead-letters instead of timing out forever.
+                MemoryLogger.service.error("distill: timed out for \(conversationId)")
+                return recordRetryableDistillFailure(
+                    message: "timed_out",
+                    agentId: agentId,
+                    conversationId: conversationId,
+                    coreModelId: coreModelId,
+                    signalIds: signalIds,
+                    durationMs: durationMs
+                )
+            }
+        } catch {
+            MemoryLogger.service.error("distill: failed for \(conversationId): \(error)")
+            return recordRetryableDistillFailure(
+                message: error.localizedDescription,
+                agentId: agentId,
+                conversationId: conversationId,
+                coreModelId: coreModelId,
+                signalIds: signalIds,
+                durationMs: Int(Date().timeIntervalSince(startTime) * 1000)
             )
         }
+    }
 
+    /// Record one retryable distillation failure and dead-letter the
+    /// session's signals once they exceed `distillMaxAttempts` (D1). Writes
+    /// the matching `processing_log` row (`error` or `dead_letter`) and
+    /// returns the corresponding `DistillOutcome`.
+    private func recordRetryableDistillFailure(
+        message: String,
+        agentId: String,
+        conversationId: String,
+        coreModelId: String,
+        signalIds: [Int],
+        durationMs: Int
+    ) -> DistillOutcome {
+        let failure =
+            (try? db.recordDistillFailure(
+                ids: signalIds,
+                maxAttempts: MemoryConfiguration.distillMaxAttempts
+            )) ?? (attempts: 0, deadLettered: false)
+        logProcessing(
+            agentId: agentId,
+            taskType: "distill",
+            model: coreModelId,
+            status: failure.deadLettered ? "dead_letter" : "error",
+            durationMs: durationMs,
+            details: failure.deadLettered
+                ? "dead_letter_after_\(failure.attempts)_attempts: \(message)"
+                : message
+        )
         debounceTasks[conversationId] = nil
+        return failure.deadLettered
+            ? .deadLettered(attempts: failure.attempts)
+            : .error(message)
     }
 
     // MARK: - Pinned Candidates
@@ -912,16 +1079,48 @@ public actor MemoryService {
             prompt += "\n"
         }
 
+        // I4 — input caps. A session is one LLM call, so an unbounded
+        // concatenation of every buffered turn (bulk LoCoMo imports, giant
+        // pastes) can overflow a small core model's context and get stuck
+        // erroring on every retry. Clamp the turn count (keeping the
+        // identity-bearing opening head + the most-recent tail) and clamp
+        // each individual message, with explicit truncation markers so the
+        // model knows the transcript was trimmed.
+        let maxTurns = MemoryConfiguration.distillMaxTurns
+        let headCount = max(1, maxTurns / 4)
+        let included: [PendingSignal]
+        let omittedCount: Int
+        if signals.count > maxTurns {
+            let tailCount = maxTurns - headCount
+            included = Array(signals.prefix(headCount)) + Array(signals.suffix(tailCount))
+            omittedCount = signals.count - included.count
+        } else {
+            included = signals
+            omittedCount = 0
+        }
+
         prompt += "Conversation turns:\n"
-        for signal in signals {
-            prompt += "\nUser: \(signal.userMessage)"
+        for (i, signal) in included.enumerated() {
+            if omittedCount > 0, i == headCount {
+                prompt += "\n[... \(omittedCount) middle turn(s) omitted to fit the core model's context ...]\n"
+            }
+            prompt += "\nUser: \(Self.clampTurnText(signal.userMessage))"
             if let asst = signal.assistantMessage {
-                prompt += "\nAssistant: \(asst)"
+                prompt += "\nAssistant: \(Self.clampTurnText(asst))"
             }
         }
 
         prompt += "\n\nDistill this session into the JSON digest."
         return prompt
+    }
+
+    /// Clamp a single turn's text to `MemoryConfiguration.distillMaxTurnChars`,
+    /// appending a marker when truncated so the model doesn't mistake the cut
+    /// for the end of the message.
+    private static func clampTurnText(_ text: String) -> String {
+        let limit = MemoryConfiguration.distillMaxTurnChars
+        guard text.count > limit else { return text }
+        return String(text.prefix(limit)) + " …[truncated \(text.count - limit) chars]"
     }
 
     // MARK: - Response Parsing

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -263,6 +263,16 @@ public actor ModelRuntime {
         }
         let box = OutBox()
 
+        // Serialize the audio-encoder `MLX.eval` against every other GPU
+        // producer (generation, embedding, model load) through the shared
+        // Metal gate, owner `gen:<model>` — the same gate
+        // `MLXBatchAdapter.prepareInput` takes for its in-generation
+        // preencode. Without it, a live-voice attach landing while a chat
+        // generation is in flight runs two unsynchronized command buffers and
+        // trips `AGXG17XFamilyCommandBuffer` asserts (issue #1632). Balanced
+        // on every exit path below.
+        await MetalGate.shared.enterGeneration(model: holder.name)
+
         do {
             try await holder.container.perform { context in
                 guard let omni = context.model as? NemotronHOmni else {
@@ -313,6 +323,7 @@ public actor ModelRuntime {
                 )
             }
         } catch {
+            await MetalGate.shared.exitGeneration(model: holder.name)
             await soloLease.release()
             await ModelLease.shared.release(holder.name)
             await scheduleIdleResidency(for: holder.name)
@@ -325,6 +336,7 @@ public actor ModelRuntime {
             )
         }
 
+        await MetalGate.shared.exitGeneration(model: holder.name)
         await soloLease.release()
         await ModelLease.shared.release(holder.name)
         await scheduleIdleResidency(for: holder.name)

--- a/Packages/OsaurusCore/Storage/MemoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/MemoryDatabase.swift
@@ -49,7 +49,7 @@ public enum MemoryDatabaseError: Error, LocalizedError {
 public final class MemoryDatabase: @unchecked Sendable {
     public static let shared = MemoryDatabase()
 
-    private static let schemaVersion = 9
+    private static let schemaVersion = 10
 
     nonisolated(unsafe) private static let iso8601Formatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -198,7 +198,7 @@ public final class MemoryDatabase: @unchecked Sendable {
 
     /// Highest schema version this build knows how to produce. Opening a DB
     /// stamped newer than this is refused (forward-version fail-fast).
-    private static let latestSchemaVersion = 9
+    private static let latestSchemaVersion = 10
 
     private func runMigrations() throws {
         let currentVersion = try getSchemaVersion()
@@ -231,6 +231,11 @@ public final class MemoryDatabase: @unchecked Sendable {
         if currentVersion < 9 {
             // Same self-managed BEGIN/COMMIT as v7/v8 — do not double-wrap.
             try migrateToV9()
+        }
+        if currentVersion < 10 {
+            // Single `ALTER TABLE ... ADD COLUMN`; no rebuild/rename, so it
+            // owns its own (trivial) statement and stamps the version itself.
+            try migrateToV10()
         }
     }
 
@@ -520,6 +525,45 @@ public final class MemoryDatabase: @unchecked Sendable {
         MemoryLogger.database.info("Running v9 migration (rename-free orphan signal_type drop)")
         try dropOrphanSignalTypeColumnIfPresent()
         try setSchemaVersion(9)
+    }
+
+    /// V10 migration: add `pending_signals.attempts` to back the
+    /// distillation retry cap + dead-letter (issue #1632). A session that
+    /// never yields a parseable episode used to be retried on every launch,
+    /// ingest, and debounce forever (the 108 error / 5 empty
+    /// `processing_log` rows). The distiller now bumps `attempts` on each
+    /// retryable failure and flips the rows to `status='dead_letter'` once
+    /// they exceed `MemoryConfiguration.distillMaxAttempts`, dropping them
+    /// out of `loadPendingSignals` / `pendingConversations`.
+    ///
+    /// Implemented as a guarded `ADD COLUMN` rather than the v7-v9
+    /// copy-out/copy-back rebuild: `ADD COLUMN` does not RENAME the table,
+    /// so it can't be tripped by unrelated stale views/triggers. The
+    /// column-presence check keeps it idempotent for fresh installs (which
+    /// already created the canonical table at v5) and for re-runs.
+    private func migrateToV10() throws {
+        MemoryLogger.database.info("Running v10 migration (pending_signals.attempts + dead-letter)")
+        if !pendingSignalsHasColumn("attempts") {
+            try executeRaw(
+                "ALTER TABLE pending_signals ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0"
+            )
+        }
+        try setSchemaVersion(10)
+    }
+
+    /// Whether `pending_signals` currently has `column`. Cheap
+    /// `PRAGMA table_info` scan; used by `migrateToV10` to stay idempotent.
+    private func pendingSignalsHasColumn(_ column: String) -> Bool {
+        var found = false
+        try? executeRaw("PRAGMA table_info(pending_signals)") { stmt in
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if String(cString: sqlite3_column_text(stmt, 1)) == column {
+                    found = true
+                    break
+                }
+            }
+        }
+        return found
     }
 
     /// Detect and drop the orphan `pending_signals.signal_type` column if it
@@ -1515,6 +1559,32 @@ public final class MemoryDatabase: @unchecked Sendable {
         return results
     }
 
+    /// Per-agent count of active episodes. Combined with
+    /// `agentIdsWithPinnedFacts` so the `/agents` listing's
+    /// `memory_entry_count` reflects *stored memory* (a distilled episode
+    /// counts even when it yielded zero pinned candidates) instead of only
+    /// active pinned facts (issue #1632 U3 — "memory_entry_count stays 0").
+    public func agentIdsWithEpisodes() throws -> [(agentId: String, count: Int)] {
+        var results: [(String, Int)] = []
+        try prepareAndExecute(
+            """
+            SELECT agent_id, COUNT(*) FROM episodes
+            WHERE status = 'active'
+            GROUP BY agent_id
+            ORDER BY 2 DESC
+            """,
+            bind: { _ in },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    let id = String(cString: sqlite3_column_text(stmt, 0))
+                    let count = Int(sqlite3_column_int(stmt, 1))
+                    results.append((id, count))
+                }
+            }
+        )
+        return results
+    }
+
     private static let pinnedColumns =
         "id, agent_id, content, salience, source_count, source_episode_id, last_used, use_count, status, created_at, tags_csv"
 
@@ -1576,8 +1646,17 @@ public final class MemoryDatabase: @unchecked Sendable {
         return Int(sqlite3_last_insert_rowid(db))
     }
 
-    /// Atomically insert an episode and mark its pending signals as processed.
-    public func insertEpisodeAndMarkProcessed(_ ep: Episode) throws -> Int {
+    /// Atomically insert an episode and mark exactly the signals folded
+    /// into it as processed.
+    ///
+    /// `signalIds` are the primary keys snapshotted by the distiller before
+    /// the LLM call. Marking only those (rather than every `status='pending'`
+    /// row for the conversation) means a turn buffered *while the LLM call
+    /// was in flight* survives as `pending` and lands in the next episode,
+    /// instead of being silently marked processed without ever appearing in
+    /// any episode (issue #1632 D2). An empty `signalIds` is treated as "mark
+    /// nothing" rather than "mark all".
+    public func insertEpisodeAndMarkProcessed(_ ep: Episode, signalIds: [Int]) throws -> Int {
         try inTransaction { _ in
             var rowid: Int = 0
             var stmt: OpaquePointer?
@@ -1612,13 +1691,18 @@ public final class MemoryDatabase: @unchecked Sendable {
             sqlite3_finalize(s)
             rowid = Int(sqlite3_last_insert_rowid(self.db))
 
+            guard !signalIds.isEmpty else { return rowid }
+
+            let placeholders = signalIds.indices.map { "?\($0 + 1)" }.joined(separator: ", ")
             var clear: OpaquePointer?
             let clearSQL =
-                "UPDATE pending_signals SET status = 'processed' WHERE conversation_id = ?1 AND status = 'pending'"
+                "UPDATE pending_signals SET status = 'processed' WHERE id IN (\(placeholders))"
             guard sqlite3_prepare_v2(self.db, clearSQL, -1, &clear, nil) == SQLITE_OK, let c = clear else {
                 throw MemoryDatabaseError.failedToPrepare(String(cString: sqlite3_errmsg(self.db)))
             }
-            Self.bindText(c, index: 1, value: ep.conversationId)
+            for (i, id) in signalIds.enumerated() {
+                sqlite3_bind_int(c, Int32(i + 1), Int32(id))
+            }
             _ = sqlite3_step(c)
             sqlite3_finalize(c)
             return rowid
@@ -2375,6 +2459,96 @@ public final class MemoryDatabase: @unchecked Sendable {
     public func markSignalsProcessed(conversationId: String) throws {
         _ = try executeUpdate(
             "UPDATE pending_signals SET status = 'processed' WHERE conversation_id = ?1 AND status = 'pending'"
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: conversationId)
+        }
+    }
+
+    /// Set `status` on exactly the given signal ids. Used by the distiller
+    /// to clear only the signals that were folded into an episode (or a
+    /// terminal empty result) without touching turns buffered after the
+    /// snapshot (issue #1632 D2). No-op for an empty id list.
+    public func markSignals(ids: [Int], status: String) throws {
+        guard !ids.isEmpty else { return }
+        let placeholders = ids.indices.map { "?\($0 + 2)" }.joined(separator: ", ")
+        _ = try executeUpdate(
+            "UPDATE pending_signals SET status = ?1 WHERE id IN (\(placeholders))"
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: status)
+            for (i, id) in ids.enumerated() {
+                sqlite3_bind_int(stmt, Int32(i + 2), Int32(id))
+            }
+        }
+    }
+
+    /// Record one failed distillation attempt for `ids` and dead-letter
+    /// them once they exceed `maxAttempts`. Returns the new max attempt
+    /// count across the ids and whether they were dead-lettered.
+    ///
+    /// Dead-lettered rows (`status='dead_letter'`) drop out of
+    /// `loadPendingSignals` / `pendingConversations`, so a session that
+    /// keeps failing stops re-distilling on every launch/ingest/debounce
+    /// forever (issue #1632 D1). Only `pending` rows are dead-lettered, so
+    /// a concurrently-processed row is never clobbered.
+    @discardableResult
+    public func recordDistillFailure(
+        ids: [Int],
+        maxAttempts: Int
+    ) throws -> (attempts: Int, deadLettered: Bool) {
+        guard !ids.isEmpty else { return (0, false) }
+        let placeholders = ids.indices.map { "?\($0 + 1)" }.joined(separator: ", ")
+        let bindIds: (OpaquePointer) -> Void = { stmt in
+            for (i, id) in ids.enumerated() {
+                sqlite3_bind_int(stmt, Int32(i + 1), Int32(id))
+            }
+        }
+
+        _ = try executeUpdate(
+            "UPDATE pending_signals SET attempts = attempts + 1 WHERE id IN (\(placeholders)) AND status = 'pending'",
+            bind: bindIds
+        )
+
+        var maxSoFar = 0
+        try prepareAndExecute(
+            "SELECT COALESCE(MAX(attempts), 0) FROM pending_signals WHERE id IN (\(placeholders))",
+            bind: bindIds,
+            process: { stmt in
+                if sqlite3_step(stmt) == SQLITE_ROW { maxSoFar = Int(sqlite3_column_int(stmt, 0)) }
+            }
+        )
+
+        let deadLettered = maxSoFar >= maxAttempts
+        if deadLettered {
+            _ = try executeUpdate(
+                "UPDATE pending_signals SET status = 'dead_letter' WHERE id IN (\(placeholders)) AND status = 'pending'",
+                bind: bindIds
+            )
+        }
+        return (maxSoFar, deadLettered)
+    }
+
+    /// Delete every pending signal for a conversation regardless of status.
+    /// Used by `/memory/ingest` to make re-ingesting a `conversation_id`
+    /// idempotent (issue #1632 I1) — a fresh ingest fully replaces the
+    /// prior buffered state instead of stacking duplicate signals.
+    public func deletePendingSignalsForConversation(_ conversationId: String) throws {
+        _ = try executeUpdate(
+            "DELETE FROM pending_signals WHERE conversation_id = ?1"
+        ) { stmt in
+            Self.bindText(stmt, index: 1, value: conversationId)
+        }
+    }
+
+    /// Delete every episode for a conversation. Paired with
+    /// `deletePendingSignalsForConversation` so a re-ingested
+    /// `conversation_id` yields exactly one active episode instead of a
+    /// duplicate per run (`episodes` has no `UNIQUE(conversation_id)`).
+    /// Mirrors `deleteEpisode(id:)` semantics (FTS stays trigger-synced;
+    /// any stale vector-index rows resolve to a missing SQL row and are
+    /// filtered on read, same as the consolidator's merge path).
+    public func deleteEpisodesForConversation(_ conversationId: String) throws {
+        _ = try executeUpdate(
+            "DELETE FROM episodes WHERE conversation_id = ?1"
         ) { stmt in
             Self.bindText(stmt, index: 1, value: conversationId)
         }

--- a/Packages/OsaurusCore/Tests/Memory/MemoryIngestRobustnessTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/MemoryIngestRobustnessTests.swift
@@ -1,0 +1,194 @@
+//
+//  MemoryIngestRobustnessTests.swift
+//  osaurus
+//
+//  Coverage for the issue #1632 distillation/ingestion robustness fixes:
+//  id-scoped signal marking (D2), bounded retries + dead-lettering (D1),
+//  per-conversation idempotency deletes (I1), the stored-memory episode
+//  count (U3), and the `DistillOutcome` -> API status mapping (A).
+//
+//  All DB tests use an in-memory `MemoryDatabase` (runs migrations through
+//  v10 on open) so they're deterministic and don't touch the user's
+//  on-disk memory store or any model runtime.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct MemoryIngestRobustnessTests {
+
+    private func makeTempDB() throws -> MemoryDatabase {
+        let db = MemoryDatabase()
+        try db.openInMemory()
+        return db
+    }
+
+    private func episode(_ agentId: String, _ conversationId: String, _ summary: String) -> Episode {
+        Episode(
+            agentId: agentId,
+            conversationId: conversationId,
+            summary: summary,
+            tokenCount: 3,
+            model: "test",
+            conversationAt: "2025-01-01T00:00:00Z"
+        )
+    }
+
+    // MARK: - D2: id-scoped marking
+
+    @Test func markSignals_marksOnlyGivenIds() throws {
+        let db = try makeTempDB()
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "one"))
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "two"))
+        let loaded = try db.loadPendingSignals(conversationId: "c")
+        #expect(loaded.count == 2)
+
+        // Mark only the first signal processed.
+        try db.markSignals(ids: [loaded[0].id], status: "processed")
+
+        let remaining = try db.loadPendingSignals(conversationId: "c")
+        #expect(remaining.count == 1)
+        #expect(remaining[0].id == loaded[1].id)
+        #expect(remaining[0].userMessage == "two")
+    }
+
+    @Test func markSignals_emptyIds_isNoOp() throws {
+        let db = try makeTempDB()
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "one"))
+        try db.markSignals(ids: [], status: "processed")
+        #expect(try db.loadPendingSignals(conversationId: "c").count == 1)
+    }
+
+    @Test func insertEpisodeAndMarkProcessed_leavesNewerSignalsPending() throws {
+        let db = try makeTempDB()
+        // The turn that the distiller snapshots.
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "snapshotted"))
+        let snapshot = try db.loadPendingSignals(conversationId: "c")
+        #expect(snapshot.count == 1)
+
+        // A turn buffered *during* the (simulated) LLM call.
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "buffered mid-distill"))
+
+        // Insert the episode marking only the snapshotted id.
+        _ = try db.insertEpisodeAndMarkProcessed(
+            episode("a", "c", "session summary"),
+            signalIds: snapshot.map(\.id)
+        )
+
+        // The mid-distill turn survives as pending (lands in the next episode).
+        let remaining = try db.loadPendingSignals(conversationId: "c")
+        #expect(remaining.count == 1)
+        #expect(remaining[0].userMessage == "buffered mid-distill")
+        #expect(try db.loadEpisodes(agentId: "a").count == 1)
+    }
+
+    // MARK: - D1: bounded retries + dead-letter
+
+    @Test func recordDistillFailure_incrementsAttempts_belowCap() throws {
+        let db = try makeTempDB()
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "x"))
+        let ids = try db.loadPendingSignals(conversationId: "c").map(\.id)
+
+        let first = try db.recordDistillFailure(ids: ids, maxAttempts: 3)
+        #expect(first.attempts == 1)
+        #expect(first.deadLettered == false)
+        // Still pending — a transient failure must be retried.
+        #expect(try db.loadPendingSignals(conversationId: "c").count == 1)
+
+        let second = try db.recordDistillFailure(ids: ids, maxAttempts: 3)
+        #expect(second.attempts == 2)
+        #expect(second.deadLettered == false)
+        #expect(try db.loadPendingSignals(conversationId: "c").count == 1)
+    }
+
+    @Test func recordDistillFailure_deadLettersAtCap_andDropsFromPending() throws {
+        let db = try makeTempDB()
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "x"))
+        let ids = try db.loadPendingSignals(conversationId: "c").map(\.id)
+
+        _ = try db.recordDistillFailure(ids: ids, maxAttempts: 2)
+        let atCap = try db.recordDistillFailure(ids: ids, maxAttempts: 2)
+        #expect(atCap.attempts == 2)
+        #expect(atCap.deadLettered == true)
+
+        // Dead-lettered signals must not be re-distilled.
+        #expect(try db.loadPendingSignals(conversationId: "c").isEmpty)
+        let stillPendingConvos = try db.pendingConversations().contains { $0.conversationId == "c" }
+        #expect(stillPendingConvos == false)
+    }
+
+    @Test func recordDistillFailure_emptyIds_isNoOp() throws {
+        let db = try makeTempDB()
+        let result = try db.recordDistillFailure(ids: [], maxAttempts: 3)
+        #expect(result.attempts == 0)
+        #expect(result.deadLettered == false)
+    }
+
+    // MARK: - I1: per-conversation idempotency deletes
+
+    @Test func deletePendingSignalsForConversation_clearsRegardlessOfStatus() throws {
+        let db = try makeTempDB()
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "pending"))
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "to-process"))
+        let ids = try db.loadPendingSignals(conversationId: "c").map(\.id)
+        try db.markSignals(ids: [ids[0]], status: "processed")
+        // One pending, one processed — both should be cleared.
+
+        try db.deletePendingSignalsForConversation("c")
+        #expect(try db.loadPendingSignals(conversationId: "c").isEmpty)
+        // Re-buffering after the clear starts fresh.
+        try db.insertPendingSignal(PendingSignal(agentId: "a", conversationId: "c", userMessage: "fresh"))
+        #expect(try db.loadPendingSignals(conversationId: "c").count == 1)
+    }
+
+    @Test func deleteEpisodesForConversation_clearsThatConversationOnly() throws {
+        let db = try makeTempDB()
+        _ = try db.insertEpisode(episode("a", "c1", "first"))
+        _ = try db.insertEpisode(episode("a", "c1", "duplicate of first"))
+        _ = try db.insertEpisode(episode("a", "c2", "other conversation"))
+
+        try db.deleteEpisodesForConversation("c1")
+
+        let remaining = try db.loadEpisodes(agentId: "a")
+        #expect(remaining.count == 1)
+        #expect(remaining[0].conversationId == "c2")
+    }
+
+    // MARK: - U3: stored-memory episode count
+
+    @Test func agentIdsWithEpisodes_countsActivePerAgent() throws {
+        let db = try makeTempDB()
+        _ = try db.insertEpisode(episode("agent-1", "c1", "s1"))
+        _ = try db.insertEpisode(episode("agent-1", "c2", "s2"))
+        _ = try db.insertEpisode(episode("agent-2", "c3", "s3"))
+
+        let counts = Dictionary(
+            uniqueKeysWithValues: try db.agentIdsWithEpisodes().map { ($0.agentId, $0.count) }
+        )
+        #expect(counts["agent-1"] == 2)
+        #expect(counts["agent-2"] == 1)
+    }
+
+    // MARK: - A: DistillOutcome -> API status mapping
+
+    @Test func distillOutcome_apiStatus_mapsEveryCase() {
+        #expect(DistillOutcome.distilled(episodeId: 7, pinned: 1, identityFacts: 0).apiStatus == "distilled")
+        #expect(DistillOutcome.noSignals.apiStatus == "no_signals")
+        #expect(DistillOutcome.skipped(reason: "core_model_unset").apiStatus == "skipped:core_model_unset")
+        #expect(DistillOutcome.empty(reason: "no_episode").apiStatus == "empty:no_episode")
+        #expect(DistillOutcome.deadLettered(attempts: 3).apiStatus == "dead_letter:3")
+        #expect(DistillOutcome.error("boom").apiStatus == "error:boom")
+    }
+
+    @Test func distillOutcome_episodeId_onlyForDistilled() {
+        #expect(DistillOutcome.distilled(episodeId: 42, pinned: 0, identityFacts: 0).episodeId == 42)
+        #expect(DistillOutcome.noSignals.episodeId == nil)
+        #expect(DistillOutcome.skipped(reason: "not_resident").episodeId == nil)
+        #expect(DistillOutcome.empty(reason: "empty_summary").episodeId == nil)
+        #expect(DistillOutcome.deadLettered(attempts: 3).episodeId == nil)
+        #expect(DistillOutcome.error("x").episodeId == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Memory/MemoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/MemoryTests.swift
@@ -313,6 +313,7 @@ struct MemoryDatabaseTests {
         try db.insertPendingSignal(
             PendingSignal(agentId: "a", conversationId: "c1", userMessage: "hi")
         )
+        let loaded = try db.loadPendingSignals(conversationId: "c1")
         let ep = Episode(
             agentId: "a",
             conversationId: "c1",
@@ -321,7 +322,7 @@ struct MemoryDatabaseTests {
             model: "test",
             conversationAt: "2025-01-01T00:00:00Z"
         )
-        _ = try db.insertEpisodeAndMarkProcessed(ep)
+        _ = try db.insertEpisodeAndMarkProcessed(ep, signalIds: loaded.map(\.id))
         let pending = try db.loadPendingSignals(conversationId: "c1")
         #expect(pending.isEmpty)
         let episodes = try db.loadEpisodes(agentId: "a")

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -189,6 +189,18 @@ struct MessageTableRepresentable: NSViewRepresentable {
         coordinator.tableView?.sizeLastColumnToFit()
     }
 
+    /// Break the hover closures (which capture the coordinator) and stop any
+    /// further `mouseMoved`/`mouseExited` dispatch when SwiftUI tears down
+    /// the representable. Belt-and-suspenders against the launch SIGABRT: a
+    /// detached table must not keep firing tracking events into a
+    /// tearing-down coordinator (issue #1632).
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        if let table = scrollView.documentView as? HoverTrackingTableView {
+            table.onMouseMoved = nil
+            table.onMouseExited = nil
+        }
+    }
+
     // MARK: - View Factory Helpers
 
     private func renderingContext(for coordinator: Coordinator) -> CellRenderingContext {
@@ -537,10 +549,18 @@ extension MessageTableRepresentable {
 
         func setupHoverTracking(on tableView: HoverTrackingTableView) {
             tableView.onMouseMoved = { [weak self] event in
-                self?.handleMouseMoved(with: event)
+                // Defer hover handling off AppKit's `mouseMoved:` dispatch.
+                // `setHoveredGroup` can `configureCell` visible rows —
+                // rebuilding their subviews and tracking areas — and
+                // mutating the tracking-area set while the manager is
+                // mid-dispatch can trip `-[_NSTrackingAreaAKManager
+                // mouseMoved:]` (issue #1632). `locationInWindow` is a value
+                // type, safe to carry one runloop tick.
+                let windowPoint = event.locationInWindow
+                DispatchQueue.main.async { self?.handleMouseMoved(windowPoint: windowPoint) }
             }
             tableView.onMouseExited = { [weak self] in
-                self?.setHoveredGroup(nil)
+                DispatchQueue.main.async { self?.setHoveredGroup(nil) }
             }
         }
 
@@ -1122,10 +1142,10 @@ extension MessageTableRepresentable {
 
         // MARK: - Hover Tracking
 
-        private func handleMouseMoved(with event: NSEvent) {
+        private func handleMouseMoved(windowPoint: NSPoint) {
             ChatPerfTrace.shared.count("hover.mouseMoved")
             guard let tableView else { return setHoveredGroup(nil) }
-            let point = tableView.convert(event.locationInWindow, from: nil)
+            let point = tableView.convert(windowPoint, from: nil)
             let row = tableView.row(at: point)
 
             guard row >= 0, row < blockIds.count,

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -904,6 +904,18 @@ final class NativeMarkdownView: NSView {
 
     // MARK: - Cleanup
 
+    /// Deterministic teardown for the owning cell's `removeAllContentViews`.
+    /// AppKit recycles message cells aggressively and a `NativeMarkdownView`
+    /// can linger in an autorelease pool after `removeFromSuperview`, so
+    /// relying on dealloc to detach the redaction hover controller (and
+    /// clear the text view's `.mouseMoved` tracking flag) is too late —
+    /// exactly the teardown window where the launch SIGABRT was observed.
+    /// Calling this before dropping the view releases the hover area +
+    /// closures synchronously.
+    func tearDownForReuse() {
+        removeTextView()
+    }
+
     private func removeTextView() {
         fader.reset()
         hoverController?.detach()

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -2428,6 +2428,11 @@ final class NativeMessageCellView: NSTableCellView {
         spacerView?.removeFromSuperview(); spacerView = nil
         nativeHeaderView?.removeFromSuperview(); nativeHeaderView = nil
         nativeHeaderHeightConstraint = nil
+        // Detach the redaction hover controller (and its text view's
+        // `.mouseMoved` tracking flag) deterministically before dropping
+        // the view — this cell-reuse path otherwise bypasses
+        // `NativeMarkdownView`'s own teardown (issue #1632 launch SIGABRT).
+        nativeMarkdownView?.tearDownForReuse()
         nativeMarkdownView?.removeFromSuperview(); nativeMarkdownView = nil
         nativeThinkingView?.removeFromSuperview(); nativeThinkingView = nil
         // Coordinator-cached views: only call `removeFromSuperview` if
@@ -2451,6 +2456,9 @@ final class NativeMessageCellView: NSTableCellView {
         nativeStatsView?.removeFromSuperview(); nativeStatsView = nil
         nativeAssistantActionsView?.removeFromSuperview(); nativeAssistantActionsView = nil
         nativeEmptyNoticeView?.removeFromSuperview(); nativeEmptyNoticeView = nil
+        // User messages carry outbound redactions (PII the user typed), so
+        // the user text view has the same hover controller to tear down.
+        userTextView?.tearDownForReuse()
         userMessageContainer?.removeFromSuperview(); userMessageContainer = nil
         userTextView = nil
         userInlineEditView = nil

--- a/Packages/OsaurusCore/Views/Chat/RedactionHoverController.swift
+++ b/Packages/OsaurusCore/Views/Chat/RedactionHoverController.swift
@@ -29,7 +29,6 @@ final class RedactionHoverController {
     /// Currently-attached text view. Weak so detaching is enough to
     /// let the cell drop the view; we never hold the view alive.
     private weak var textView: SelectableNSTextView?
-    private var trackingArea: NSTrackingArea?
     private var popover: NSPopover?
     private var ranges: [AppliedRedactionRange] = []
     /// Theme captured at the most recent `attach`. Used by the
@@ -72,19 +71,23 @@ final class RedactionHoverController {
         }
 
         if self.textView !== stv {
-            removeTrackingArea()
+            // Stop the previous view from advertising our hover area.
+            self.textView?.wantsRedactionHoverTracking = false
             self.textView = stv
         }
         installHooksIfNeeded()
-        installTrackingAreaIfNeeded()
+        // The text view owns the `.mouseMoved` area now (installed inside
+        // its `updateTrackingAreas()` when this flag is set), so AppKit
+        // ties the area's lifetime to the view — no manual add/remove.
+        stv.wantsRedactionHoverTracking = true
     }
 
     /// Remove all observers + tracking + the popover. Called when
     /// the cell's redaction map becomes empty or the cell is reused
     /// for a different turn.
     func detach() {
+        textView?.wantsRedactionHoverTracking = false
         clearHooks()
-        removeTrackingArea()
         popover?.close()
         popover = nil
         ranges = []
@@ -94,41 +97,7 @@ final class RedactionHoverController {
         textView = nil
     }
 
-    // MARK: Tracking Area
-
-    private func installTrackingAreaIfNeeded() {
-        guard let tv = textView else { return }
-        if let existing = trackingArea, tv.trackingAreas.contains(existing) {
-            return
-        }
-        // NSTrackingArea with `.mouseMoved` only fires when the
-        // owning window has `acceptsMouseMovedEvents = true`. The
-        // chat window typically already does (NSTextView relies on
-        // this for I-beam cursor tracking) but we set it defensively
-        // so a fresh window that hasn't focused the text view yet
-        // still routes our hover events.
-        tv.window?.acceptsMouseMovedEvents = true
-        let area = NSTrackingArea(
-            rect: tv.bounds,
-            options: [
-                .mouseMoved,
-                .mouseEnteredAndExited,
-                .activeInKeyWindow,
-                .inVisibleRect,
-            ],
-            owner: tv,
-            userInfo: nil
-        )
-        tv.addTrackingArea(area)
-        trackingArea = area
-    }
-
-    private func removeTrackingArea() {
-        if let tv = textView, let area = trackingArea {
-            tv.removeTrackingArea(area)
-        }
-        trackingArea = nil
-    }
+    // MARK: Hooks
 
     private func installHooksIfNeeded() {
         guard let tv = textView else { return }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1189,6 +1189,50 @@ final class SelectableNSTextView: NSTextView {
     /// 80ms hide debounce.
     var onMouseExitedHover: (() -> Void)?
 
+    /// Whether the redaction-hover `.mouseMoved` tracking area should be
+    /// installed. Toggled by `RedactionHoverController`. The area itself is
+    /// created/destroyed inside `updateTrackingAreas()` with `owner: self`,
+    /// so AppKit manages its lifecycle and it is torn down with the view —
+    /// it can never be left dangling for the tracking-area manager to
+    /// dispatch `mouseMoved:` into a freed owner (the
+    /// `-[_NSTrackingAreaAKManager mouseMoved:]` launch SIGABRT, issue
+    /// #1632). The pre-fix code added the area imperatively from the
+    /// controller without reconciling it in `updateTrackingAreas()`, so a
+    /// view moved between windows (prewarm) or torn down via a cell path
+    /// that skipped `detach()` could leave a stale area behind.
+    var wantsRedactionHoverTracking: Bool = false {
+        didSet {
+            guard oldValue != wantsRedactionHoverTracking else { return }
+            if wantsRedactionHoverTracking { window?.acceptsMouseMovedEvents = true }
+            updateTrackingAreas()
+        }
+    }
+
+    /// Our owned hover tracking area. Reconciled on every
+    /// `updateTrackingAreas()` pass; nil when hover tracking is disabled.
+    private var redactionHoverTrackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        // Reconcile only the area we own (tracked by reference). NSTextView
+        // manages its own areas — for the I-beam cursor etc. — via
+        // `super`, and we must not disturb those. Remove-then-add against
+        // the current bounds so the area always matches the live geometry.
+        if let existing = redactionHoverTrackingArea {
+            removeTrackingArea(existing)
+            redactionHoverTrackingArea = nil
+        }
+        guard wantsRedactionHoverTracking else { return }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        redactionHoverTrackingArea = area
+    }
+
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
         onMouseHover?(event)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1274,7 +1274,7 @@ Eight settings total, down from v1's 18. The per-section budget knobs, MMR tunin
 
 **Tool API:** `search_memory(scope, query)` with three scopes: `pinned`, `episodes`, `transcript`. Replaces v1's five-scope tool.
 
-**HTTP API:** `POST /memory/ingest` writes transcripts and triggers an immediate distillation flush after the batch (no need to wait for the writer's debounce). Strict `/chat/completions` requests do not inject read-side memory; app chat, `POST /agents/{id}/run`, and plugin host inference own composed agent context.
+**HTTP API:** `POST /memory/ingest` writes transcripts and then distills synchronously after the batch — it forces an on-demand cold load of the core model when it isn't resident, awaits the single distill call, and reports the outcome (`distillation`, `episode_id`) in the response instead of a blind `{"status":"ok"}`. It is idempotent per `conversation_id` (re-ingest clears that conversation's prior pending signals + episodes), canonicalizes a UUID `agent_id`, and dead-letters sessions that keep failing so they stop re-distilling forever. `GET /agents` / `GET /agents/{id}` report `memory_entry_count` as stored memory (episodes + active pinned facts). Strict `/chat/completions` requests do not inject read-side memory; app chat, `POST /agents/{id}/run`, and plugin host inference own composed agent context.
 
 **Storage:** `~/.osaurus/memory/memory.sqlite` (SQLite with WAL mode), `~/.osaurus/memory/vectura/` (vector index)
 

--- a/docs/INFERENCE_RUNTIME.md
+++ b/docs/INFERENCE_RUNTIME.md
@@ -188,7 +188,7 @@ the `LayerKind.deepseekV4` disk serializer instead of generic paged KV blocks.
 | `ModelLease` | Pins a model name for the lifetime of one stream so eviction (`unload`, `clearAll`, GC) blocks until the lease drops to zero. |
 | `ModelResidencyManager` | Schedules Osaurus-owned idle unload policy after the final lease drops; it never owns execution, KV cache, or disk cache deletion. |
 | `PluginHostAPI` per-plugin in-flight cap | Caps concurrent inference calls per plugin (default 2). Excess returns `plugin_busy`. |
-| `MetalGate.enterEmbedding` | Embedding service (`MetalSafeEmbedder`) opt-in serialization point. The generation surface of the gate was retired; only embeddings call into it today. |
+| `MetalGate` (`enterGeneration` / `enterEmbedding` / `enterModelLoad`) | Serializes GPU producers across families so concurrent command buffers can't trip `AGXG17XFamilyCommandBuffer` asserts. Generation (`gen:<model>`, shared per model) gates `MLXBatchAdapter.prepareInput` and the live-voice audio pre-encode (`ModelRuntime.preencodeLiveVoiceAudioIfResident`); embedding (`MetalSafeEmbedder`) and model load are exclusive. |
 
 ## Residency policy
 
@@ -301,7 +301,7 @@ sentinels.
 | `RuntimeConfig.swift` | Server-side default `topP`. |
 | `InferenceFeatureFlags.swift` | Single user-tunable: `mlxBatchEngineMaxBatchSize`. |
 | `RuntimeProofValidation.swift` | Source-level validation for runtime proof rows and issue-closure evidence. |
-| `MetalGate.swift` | Embedding-only counter (kept as the canonical hook for any future MLX-vs-CoreML interlock). |
+| `MetalGate.swift` | Cross-family GPU serialization gate. `enterGeneration` (shared per model) wraps `MLXBatchAdapter.prepareInput` + the live-voice audio pre-encode; `enterEmbedding` and `enterModelLoad` are exclusive. |
 | `ModelLease.swift` | Per-model refcount; `unload(name)` waits for `count == 0` before freeing buffers. |
 | `ModelResidencyManager.swift` | Per-model idle timers and health snapshots for the Settings residency policy. |
 | `NATIVE_SWIFT_IMAGE_GENERATION_INTEGRATION.md` | Pending native Swift image-generation lane and release gate. |

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -232,7 +232,9 @@ response = client.chat.completions.create(
 
 ### Memory Ingestion — `POST /memory/ingest`
 
-Bulk-ingest conversation turns. Useful for seeding memory from existing chat logs, migrating from another system, or running benchmarks. Ingestion always flushes distillation immediately at the end of the batch — you don't have to wait for the debounce.
+Bulk-ingest conversation turns. Useful for seeding memory from existing chat logs, migrating from another system, or running benchmarks.
+
+Unless `skip_extraction` is set, the request **distills synchronously and waits for the result**: it forces an on-demand cold load of the core model if it isn't already resident, runs the single distillation LLM call, and reports the outcome in the response body. (A cold load can take tens of seconds for a larger core model — allow a long client timeout; the server has no idle cutoff on this path.) This replaces the old fire-and-forget behavior that returned `{"status":"ok"}` even when distillation was silently skipped because the core model wasn't resident.
 
 ```bash
 curl http://127.0.0.1:1337/memory/ingest \
@@ -249,15 +251,31 @@ curl http://127.0.0.1:1337/memory/ingest \
 
 | Parameter | Type | Description |
 |---|---|---|
-| `agent_id` | string | Identifier for the agent whose memory is being populated |
+| `agent_id` | string | Identifier for the agent whose memory is being populated. A UUID is canonicalized (uppercased) so it matches the agent's recall key regardless of input casing. |
 | `conversation_id` | string | Identifier for the conversation session |
 | `turns` | array | Array of turn objects, each with `user` and `assistant` fields |
-| `session_date` | string | Optional ISO 8601 date for the whole batch |
-| `skip_extraction` | bool | When `true`, only insert transcript rows; skip distillation |
+| `session_date` | string | Optional ISO 8601 date for the whole batch (used as the episode timestamp) |
+| `skip_extraction` | bool | When `true`, only insert transcript rows; skip distillation (and the synchronous wait) |
+
+**Response body:**
+
+```json
+{ "status": "ok", "turns_ingested": 2, "distillation": "distilled", "episode_id": 42 }
+```
+
+| Field | Description |
+|---|---|
+| `turns_ingested` | Number of turns stored |
+| `distillation` | Outcome token (omitted when `skip_extraction` is set): `distilled`, `no_signals`, `skipped:<reason>` (`core_model_unset`, `not_resident`, `core_model_unavailable`, `breaker_open`, `low_novelty:<n>chars`, `cancelled`, `memory_disabled`), `empty:<reason>` (`no_episode`, `empty_summary`), `dead_letter:<attempts>`, or `error:<message>` |
+| `episode_id` | Primary key of the written episode (present only when `distillation` is `distilled`) |
+
+**Idempotent per `conversation_id`.** Re-ingesting the same `conversation_id` (e.g. re-running a benchmark) first clears that conversation's prior pending signals and episodes, so you get exactly one active episode per conversation instead of duplicates. `skip_extraction` ingests leave the memory pipeline untouched and only replace transcript rows.
+
+**Bounded retries.** A session that repeatedly fails to distill (unparseable model output, persistent timeouts) is retried a bounded number of times and then dead-lettered (`distillation: "dead_letter:<attempts>"`), so it stops re-distilling on every launch/ingest. Terminal empty results (`no_episode`, `empty_summary`) mark their signals processed immediately. A missing/unavailable core model stays pending and recovers once a model is configured and resident.
 
 ### List Agents — `GET /agents`
 
-Returns all configured agents with their pinned-fact counts. Use this to discover valid agent IDs.
+Returns all configured agents with their `memory_entry_count`. Use this to discover valid agent IDs. The count reflects **stored memory** — distilled episodes plus active pinned facts — so an agent whose sessions distilled into episodes reads non-zero even when no pinned facts were promoted. `GET /agents/{id}` reports the same count for a single agent.
 
 See the [API Guide](OpenAI_API_GUIDE.md#memory-api) for additional examples.
 

--- a/docs/OpenAI_API_GUIDE.md
+++ b/docs/OpenAI_API_GUIDE.md
@@ -603,7 +603,7 @@ print(response.choices[0].message.content)
 
 ### Memory Ingestion — `POST /memory/ingest`
 
-Bulk-ingest conversation turns. Osaurus inserts each turn into the transcript and then flushes session distillation immediately at the end of the batch — you do not have to wait for the writer's debounce. Distillation produces an episode and (when warranted) a small set of pinned facts.
+Bulk-ingest conversation turns. Osaurus inserts each turn into the transcript and then, unless `skip_extraction` is set, **distills synchronously and waits for the result** before responding: it forces an on-demand cold load of the core model if it isn't already resident, runs the single distillation LLM call, and reports the outcome. A cold load can take tens of seconds for a larger core model, so allow a long client timeout (the server applies no idle cutoff on this path). Distillation produces an episode and (when warranted) a small set of pinned facts.
 
 ```bash
 curl http://127.0.0.1:1337/memory/ingest \
@@ -620,21 +620,23 @@ curl http://127.0.0.1:1337/memory/ingest \
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `agent_id` | string | Identifier for the agent whose memory is being populated (required) |
+| `agent_id` | string | Identifier for the agent whose memory is being populated (required). A UUID is canonicalized (uppercased) to match the agent's recall key. |
 | `conversation_id` | string | Identifier for the conversation session (required) |
 | `turns` | array | Array of turn objects, each with `user` and `assistant` string fields (required) |
-| `session_date` | string | Optional ISO 8601 date for the whole batch |
-| `skip_extraction` | bool | When `true`, only insert transcript rows; skip distillation |
+| `session_date` | string | Optional ISO 8601 date for the whole batch (used as the episode timestamp) |
+| `skip_extraction` | bool | When `true`, only insert transcript rows; skip distillation (and the synchronous wait) |
 
 Response:
 
 ```json
-{"status": "ok", "turns_ingested": 2}
+{"status": "ok", "turns_ingested": 2, "distillation": "distilled", "episode_id": 42}
 ```
+
+`distillation` is the outcome token (omitted when `skip_extraction` is set): `distilled`, `no_signals`, `skipped:<reason>`, `empty:<reason>`, `dead_letter:<attempts>`, or `error:<message>`. `episode_id` is present only when an episode was written. Re-ingesting the same `conversation_id` is idempotent (prior pending signals + episodes for that conversation are cleared first), so re-runs yield exactly one active episode instead of duplicates. See [docs/MEMORY.md](MEMORY.md#memory-ingestion--post-memoryingest) for the full outcome table.
 
 ### List Agents — `GET /agents`
 
-Returns all configured agents along with their pinned-fact counts. Use this to discover agent IDs for the `X-Osaurus-Agent-Id` header.
+Returns all configured agents along with their `memory_entry_count`. Use this to discover agent IDs for the `X-Osaurus-Agent-Id` header. The count reflects stored memory (distilled episodes + active pinned facts), so it is non-zero once an agent has any distilled sessions even when no pinned facts were promoted.
 
 ```bash
 curl http://127.0.0.1:1337/agents


### PR DESCRIPTION
## Summary

Fixes #1632. On 0.20.5–0.20.7, `POST /memory/ingest` accepted turns and returned `{"status":"ok"}` but **never distilled** — the `processing_log` showed `Swift.CancellationError` with `duration_ms=0` and signals stayed `pending`. Root cause: the handler triggered `flushSession(requireResident: true)`, the distillation coordinator's residency gate short-circuited because the core model wasn't resident, and the failure was swallowed before any episode was written. While here, this PR also hardens two launch-time crashes the reporter saw and closes several robustness/observability gaps across ingest → distill → recall.

### A — make `/memory/ingest` actually distill (await scope)
- New `DistillOutcome` threaded through `performDistillSession` → `distillSession` → `DistillationCoordinator.runReturning<T>` (legacy `Void run()` kept as a thin wrapper, so existing call sites are untouched).
- New `MemoryService.flushSessionAndWait` forces `requireResident: false` (on-demand cold load) and awaits the result.
- `handleMemoryIngest` now **awaits** distillation and reports it: `{"distillation": "<outcome>", "episode_id": N}`.

### B / C — launch crash hardening (uses the Metal gate, as requested)
- **`-[_NSTrackingAreaAKManager mouseMoved:]` SIGABRT:** redaction hover tracking is now AppKit-managed in `SelectableNSTextView.updateTrackingAreas()` (owner = the view) with deterministic detach on cell reuse, an autorelease pool around `prewarmChatView`, hover-driven `configureCell` deferred off the `mouseMoved:` dispatch, and table hover closures cleared in `dismantleNSView`.
- **`AGXG17XFamilyCommandBuffer` asserts:** `ModelRuntime.preencodeLiveVoiceAudioIfResident` GPU eval is now wrapped in `MetalGate.enterGeneration` / `exitGeneration` on all paths so live-voice audio can't race a concurrent generation.

### D / E — robustness + observability (all scope)
- **D1:** terminal outcomes are marked processed; `pending_signals.attempts` (schema v10) adds bounded retries + dead-lettering so a failing session stops re-distilling forever; cancellation logs as `skipped`, not `error`.
- **D2:** only the snapshotted signal IDs are marked processed, so turns buffered mid-distill survive.
- **D3:** `canDistillCheaply` resolves through `CoreModelService.resolveStatus()` so an unroutable model fails fast instead of looping `error` rows.
- **I1 / I3 / I4:** per-`conversation_id` idempotency, UUID `agent_id` canonicalization on the write path, and turn/char caps in `buildDistillPrompt`.
- **U3:** `memory_entry_count` reflects episodes + pinned facts; `GET /agents/{id}` no longer hardcodes `0`.

### Docs (doc_only scope for recall)
- `MEMORY.md`, `OpenAI_API_GUIDE.md`, `FEATURES.md`, `INFERENCE_RUNTIME.md` updated to match real behavior (synchronous ingest + response body, idempotency, agent-id canonicalization, bounded retries, recall surfaces + relevance gate, active Metal generation gate).

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` — clean.
- [x] `swift test --filter "Memory|Distillation"` — 131 tests / 28 suites, 0 failures (new `MemoryIngestRobustnessTests` covers D1/D2/I1/U3 + `DistillOutcome` mapping; `DistillationCoordinatorTests` confirms the `run`/`runReturning<T>` refactor is backward-compatible).
- [x] Full `swift test` — remaining failures are pre-existing/environmental (keychain-disabled, network-sandboxed MCP, document-parser timeouts) and in suites untouched by this PR.
- [ ] Live runtime checks not possible in this environment: LoCoMo-style `/memory/ingest` distillation against a real model, the `mouseMoved:` SIGABRT, and the AGX assert under live voice. Worth a manual smoke on-device before release.
