### PR TITLE
Fix and harden remote agent (Mode 2) runs

### DIFF
--- a/Packages/OsaurusCore/Managers/BlockMemoizer.swift
+++ b/Packages/OsaurusCore/Managers/BlockMemoizer.swift
@@ -21,6 +21,12 @@ final class BlockMemoizer {
     private var lastThinkingLen = 0
     private var lastPendingToolName: String?
     private var lastPendingToolArgSize = 0
+    /// Remote-agent (Mode 2) tool-activity counter of the streaming turn. A
+    /// trace can change the persistent remote tool chips without touching
+    /// content/thinking length or `pendingToolName`, so without this the fast
+    /// path would keep returning the stale cached blocks and the chips would
+    /// never appear/transition during a remote run.
+    private var lastRemoteToolTick = 0
     private var lastVersion = -1
     /// The agent name baked into cached header blocks. A change (e.g. switching
     /// from a local agent to a remote one) must force a full rebuild so stale
@@ -48,6 +54,7 @@ final class BlockMemoizer {
         let thinkingLen = turns.last?.thinkingLength ?? 0
         let pendingToolName = turns.last?.pendingToolName
         let pendingToolArgSize = turns.last?.pendingToolArgSize ?? 0
+        let remoteToolTick = turns.last?.remoteToolActivityTick ?? 0
         // The header name is baked into cached blocks; a change must invalidate
         // the fast / incremental / append paths so headers re-render with it.
         let agentNameChanged = agentName != lastAgentName
@@ -58,6 +65,7 @@ final class BlockMemoizer {
             && contentLen == lastContentLen && thinkingLen == lastThinkingLen
             && pendingToolName == lastPendingToolName
             && pendingToolArgSize == lastPendingToolArgSize
+            && remoteToolTick == lastRemoteToolTick
             && version == lastVersion && !cached.isEmpty
             && streamingTurnId == lastStreamingTurnId
         {
@@ -121,6 +129,7 @@ final class BlockMemoizer {
         lastThinkingLen = thinkingLen
         lastPendingToolName = pendingToolName
         lastPendingToolArgSize = pendingToolArgSize
+        lastRemoteToolTick = remoteToolTick
         lastVersion = version
         lastStreamingTurnId = streamingTurnId
         lastAgentName = agentName

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -762,9 +762,15 @@ struct ChatCompletionRequest: Codable, Sendable {
     /// instead of the local prefixed fallback (e.g. `coco/foundation`) the
     /// picker pinned when the agent's real model isn't in the device catalog.
     /// Only meaningful for Mode 2 (`runAsRemoteAgent`); over the wire Mode 2
-    /// still sends `model: "default"`. Not decoded from OpenAI JSON and not
-    /// forwarded to remote providers.
+    /// omits `model` entirely (the peer resolves its own effective model).
+    /// Not decoded from OpenAI JSON and not forwarded to remote providers.
     var remoteAgentLogModel: String? = nil
+    /// Local-only: the `RemoteProvider` id of the remote agent this Mode 2 run
+    /// targets. With `runAsRemoteAgent`, `ChatEngine` routes directly to this
+    /// provider's service instead of by model string, so a stale `selectedModel`
+    /// (e.g. a leftover prefix like `fugu/...`) can't redirect an agent run to a
+    /// different provider. Not decoded from OpenAI JSON, not sent to providers.
+    var remoteAgentProviderId: UUID? = nil
 
     /// Resolved max tokens, preferring max_tokens then max_completion_tokens.
     var resolvedMaxTokens: Int? { max_tokens ?? max_completion_tokens }
@@ -808,6 +814,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.idempotencyKey = idempotencyKey
         copy.runAsRemoteAgent = runAsRemoteAgent
         copy.remoteAgentLogModel = remoteAgentLogModel
+        copy.remoteAgentProviderId = remoteAgentProviderId
         return copy
     }
 
@@ -846,6 +853,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         copy.idempotencyKey = idempotencyKey
         copy.runAsRemoteAgent = runAsRemoteAgent
         copy.remoteAgentLogModel = remoteAgentLogModel
+        copy.remoteAgentProviderId = remoteAgentProviderId
         return copy
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -192,6 +192,33 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// id. Recorded by `setToolResult(_:for:)` and persisted so a reloaded chat
     /// still shows "· 1.2s" next to the tool title.
     @Published var toolCallDurations: [String: TimeInterval] = [:]
+
+    // MARK: - Remote-agent (Mode 2) tool activity — display only
+
+    /// Tools the *remote agent* (Mode 2) executed, reconstructed from the
+    /// sanitized `osaurus_agent_tool` traces it streams back (name + phase +
+    /// error state only — never raw args/results). Rendered as a tool-call
+    /// group so the observer watches each remote tool transition
+    /// running → done/failed instead of a chip that vanishes the instant the
+    /// tool finishes.
+    ///
+    /// IMPORTANT: this is display-only and deliberately NOT serialized into
+    /// outgoing messages (`turnToMessage` reads `toolCalls`, never this). A
+    /// Mode 2 history must never carry synthetic, unpaired `tool_calls` — the
+    /// peer runs statelessly and re-deriving them client-side would corrupt the
+    /// next turn's history.
+    @Published var remoteToolActivity: [ToolCall] = []
+    /// Sanitized terminal state per remote tool call id. Absent ⇒ still running
+    /// (renders the live shimmer); a failure envelope ⇒ red node; any other
+    /// non-error string ⇒ green/done node.
+    @Published var remoteToolResults: [String: String] = [:]
+    /// Bumped on every `remoteToolActivity` / `remoteToolResults` mutation so
+    /// `BlockMemoizer`'s streaming fast-path can't short-circuit a trace that
+    /// changed neither visible content nor thinking. Read-only to callers;
+    /// mutated only through the helpers below.
+    private(set) var remoteToolActivityTick: Int = 0
+    /// True when this turn carries any remote-agent tool activity.
+    var hasRemoteToolActivity: Bool { !remoteToolActivity.isEmpty }
     /// How long the model spent thinking (seconds) — from the first reasoning
     /// token to the first content/tool that follows. Drives "Thought for 30s";
     /// persisted so it survives reload.
@@ -295,6 +322,71 @@ final class ChatTurn: ObservableObject, Identifiable {
         if elapsed >= Self.minDisplayableToolDuration {
             toolCallDurations[callId] = elapsed
         }
+    }
+
+    // MARK: - Remote-agent (Mode 2) tool activity helpers
+
+    /// Sanitized placeholder result for a remote tool that succeeded. The peer
+    /// never ships raw output, so the row records only that it ran.
+    private static let remoteToolSuccessResult = "Completed on the remote agent."
+
+    /// Record that the remote agent *started* a tool. Idempotent per call id;
+    /// the row renders as "running" (shimmer) until `noteRemoteToolFinished`.
+    @MainActor
+    func noteRemoteToolStarted(callId: String, name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard !remoteToolActivity.contains(where: { $0.id == callId }) else { return }
+        remoteToolActivity.append(
+            ToolCall(
+                id: callId,
+                type: "function",
+                function: ToolCallFunction(name: trimmed, arguments: "")
+            )
+        )
+        remoteToolActivityTick &+= 1
+    }
+
+    /// Record that a remote tool *finished*. Materializes the row if we never
+    /// saw its "started" (some peers may only emit terminal traces) and stamps a
+    /// sanitized success/failure result so the chip flips to done/failed. The
+    /// failure case uses a `ToolEnvelope` error so the row renders red without
+    /// ever exposing the remote's raw tool output.
+    @MainActor
+    func noteRemoteToolFinished(callId: String, name: String, isError: Bool) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !remoteToolActivity.contains(where: { $0.id == callId }) {
+            remoteToolActivity.append(
+                ToolCall(
+                    id: callId,
+                    type: "function",
+                    function: ToolCallFunction(name: trimmed.isEmpty ? "tool" : trimmed, arguments: "")
+                )
+            )
+        }
+        remoteToolResults[callId] =
+            isError
+            ? ToolEnvelope.failure(
+                kind: .executionError,
+                message: "The remote agent reported this tool call failed.",
+                tool: trimmed.isEmpty ? nil : trimmed
+            )
+            : Self.remoteToolSuccessResult
+        remoteToolActivityTick &+= 1
+    }
+
+    /// Flip any still-"running" remote tool rows to a neutral completed state.
+    /// Called when a Mode 2 stream ends (or is cancelled) so a missing terminal
+    /// trace can't leave a row shimmering forever.
+    @MainActor
+    func finalizeRemoteToolActivity() {
+        guard !remoteToolActivity.isEmpty else { return }
+        var changed = false
+        for call in remoteToolActivity where remoteToolResults[call.id] == nil {
+            remoteToolResults[call.id] = Self.remoteToolSuccessResult
+            changed = true
+        }
+        if changed { remoteToolActivityTick &+= 1 }
     }
 
     /// Appends a tool-argument fragment to the preview, keeping only the trailing window.

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -204,6 +204,22 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         )
     }
 
+    /// Display-only tool-call group for remote-agent (Mode 2) activity. Reuses
+    /// the `.toolCallGroup` kind (same rendering / height / caching), but with a
+    /// distinct id so it can never collide with a turn's real tool group in the
+    /// table/diff (it never coexists in Mode 2 — the client runs no tools — but
+    /// the id space stays unambiguous regardless).
+    static func remoteToolActivityGroup(turnId: UUID, calls: [ToolCallItem], position: BlockPosition)
+        -> ContentBlock
+    {
+        ContentBlock(
+            id: "remote-toolgroup-\(turnId.uuidString)",
+            turnId: turnId,
+            kind: .toolCallGroup(calls: calls),
+            position: position
+        )
+    }
+
     /// Stable id for a turn's thinking block. Shared by the factory and the
     /// reasoning-only auto-expand seeding so the two never drift apart.
     static func thinkingBlockId(turnId: UUID, index: Int = 0) -> String {
@@ -410,6 +426,30 @@ extension ContentBlock {
                 )
             }
 
+            // Mode 2 remote-agent tool activity, rendered above the answer so it
+            // reads chronologically ("called these tools, then replied"). Each
+            // row is reconstructed from sanitized traces: a missing result keeps
+            // it shimmering ("running"), a failure envelope turns it red, any
+            // other result marks it done. Agent-loop control tools (todo /
+            // complete / clarify) are filtered to match local behavior.
+            if turn.hasRemoteToolActivity {
+                let remoteItems =
+                    turn.remoteToolActivity
+                    .filter { !Self.isAgentLoopToolName($0.function.name) }
+                    .map { call in
+                        ToolCallItem(
+                            call: call,
+                            result: turn.remoteToolResults[call.id],
+                            duration: nil
+                        )
+                    }
+                if !remoteItems.isEmpty {
+                    turnBlocks.append(
+                        .remoteToolActivityGroup(turnId: turn.id, calls: remoteItems, position: .middle)
+                    )
+                }
+            }
+
             if hasVisibleContent {
                 // during streaming, skip the regex-based metadata strip (O(n) on every sync).
                 // visibleContent is used for the final render once streaming ends.
@@ -431,9 +471,12 @@ extension ContentBlock {
 
             if isStreaming && !hasVisibleContent && !hasRenderableThinking
                 && !hasSharedArtifacts && (turn.toolCalls ?? []).isEmpty && turn.pendingToolName == nil
+                && !turn.hasRemoteToolActivity
             {
                 // During prefill (no content/thinking/tools yet), always show the typing
-                // indicator so the interface doesn't appear frozen.
+                // indicator so the interface doesn't appear frozen. Skipped once a
+                // Mode 2 remote tool is running — the running tool chip already
+                // signals progress, so a typing indicator on top would be noise.
                 // Only add the thinking placeholder when thinking is actually enabled for
                 // this model — non-thinking models don't need it.
                 if thinkingEnabled {
@@ -452,7 +495,8 @@ extension ContentBlock {
             }
 
             if !isStreaming && !hasVisibleContent && !hasRenderableThinking
-                && !hasSharedArtifacts && (turn.toolCalls ?? []).isEmpty && turn.pendingToolName == nil,
+                && !hasSharedArtifacts && (turn.toolCalls ?? []).isEmpty && turn.pendingToolName == nil
+                && !turn.hasRemoteToolActivity,
                 let billing = turn.routerBilling
             {
                 // The router billed this turn but it produced no visible text,
@@ -463,6 +507,7 @@ extension ContentBlock {
                 )
             } else if !isStreaming && !hasVisibleContent && !hasRenderableThinking
                 && !hasSharedArtifacts && (turn.toolCalls ?? []).isEmpty && turn.pendingToolName == nil
+                && !turn.hasRemoteToolActivity
                 && (turn.generationTokenCount != nil || turn.generationTokensPerSecond != nil)
             {
                 turnBlocks.append(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -4356,6 +4356,23 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         return (url, context)
     }
 
+    /// Make a `/agents/{id}/run` body decodable when the caller omitted the
+    /// `model` key. Mode 2 callers intentionally do not send a model (the agent
+    /// runs its own effective model server-side), but the shared
+    /// `ChatCompletionRequest` decoder requires `model`. Inject an empty string
+    /// so decode succeeds; the run handler resolves empty/"default" → the
+    /// agent's effective model. Returns the original bytes unchanged when the
+    /// body isn't a JSON object or already carries a non-null `model`.
+    static func injectingEmptyModelIfMissing(_ data: Data) -> Data {
+        guard var obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return data
+        }
+        guard obj["model"] == nil || obj["model"] is NSNull else { return data }
+        obj["model"] = ""
+        guard let patched = try? JSONSerialization.data(withJSONObject: obj) else { return data }
+        return patched
+    }
+
     /// POST /agents/{id}/run — run the full agent chat loop server-side.
     ///
     /// Accepts a `ChatCompletionRequest` body. Runs inference with the agent's
@@ -4398,7 +4415,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             requestBodyString = nil
         }
 
-        guard let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: data) else {
+        // `/agents/{id}/run` does NOT require a `model`: a Mode 2 caller omits
+        // it on purpose because the agent runs its own effective model
+        // server-side. The shared `ChatCompletionRequest` decoder requires
+        // `model`, so inject an empty value when the caller omitted it; the
+        // resolver below maps empty/"default" → the agent's effective model.
+        let runDecodeData = Self.injectingEmptyModelIfMissing(data)
+        guard let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: runDecodeData) else {
             sendResponse(
                 context: context,
                 version: head.version,
@@ -4559,7 +4582,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         runRequestTask(priority: .userInitiated) {
             defer { admissionToken.release() }
-            // Resolve model: client sends "default" when no specific model was known
+            // Resolve model: a Mode 2 caller omits `model` (decoded as empty),
+            // and older clients send the "default" sentinel. Both resolve to
+            // the agent's effective model server-side.
             let model: String
             if req.model.isEmpty || req.model == "default" {
                 let agentModel = await MainActor.run { AgentManager.shared.effectiveModel(for: agentId) }
@@ -4568,6 +4593,37 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 model = req.model
             }
             cancelModelBox.value = model
+
+            // No model on the request and none resolvable for the agent: fail
+            // fast with an in-band SSE error (the 200 head is already on the
+            // wire) instead of running the loop with an empty model and hitting
+            // an opaque downstream routing failure. An empty resolution is the
+            // canonical "agent has no model configured" signal. ("default" is
+            // left intact — it resolves to the host's local Foundation model.)
+            if model.isEmpty {
+                let msg =
+                    "This agent has no model configured. Set the agent's default model on the host and try again."
+                RemoteAgentRunLog.serverError(
+                    "run agent=\(agentId.uuidString) FAILED reqModel=\(req.model.isEmpty ? "<omitted>" : req.model) error=no_model_resolved"
+                )
+                hop {
+                    writerBound.value.writeError(msg, context: ctx.value)
+                    writerBound.value.writeEnd(ctx.value)
+                }
+                logSelf.logRequest(
+                    method: "POST",
+                    path: path,
+                    userAgent: logUserAgent,
+                    requestBody: logRequestBody,
+                    responseStatus: 200,
+                    startTime: logStartTime,
+                    errorMessage: msg
+                )
+                return
+            }
+            RemoteAgentRunLog.server(
+                "run start agent=\(agentId.uuidString) model=\(model) reqModel=\(req.model.isEmpty ? "<omitted>" : req.model)"
+            )
 
             // KPI: one agent run initiated via the HTTP endpoint. The
             // per-turn `message_sent` is emitted separately by ChatEngine on
@@ -4925,6 +4981,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                                     ).first ?? AgentLoopToolExecution(result: "")
                                 let execution = interceptAware(call.invocation, single)
                                 if emitAgentToolTrace {
+                                    RemoteAgentRunLog.server(
+                                        "tool completed agent=\(agentId.uuidString) name=\(call.invocation.toolName) "
+                                            + "callId=\(call.callId) isError=\(execution.isError) endRun=\(execution.endRun)"
+                                    )
                                     hop {
                                         writerBound.value.writeAgentToolTrace(
                                             phase: "completed",
@@ -4946,6 +5006,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         }
                         if emitAgentToolTrace {
                             for call in calls {
+                                RemoteAgentRunLog.server(
+                                    "tool started agent=\(agentId.uuidString) name=\(call.invocation.toolName) callId=\(call.callId)"
+                                )
                                 hop {
                                     writerBound.value.writeAgentToolTrace(
                                         phase: "started",
@@ -4976,6 +5039,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     var toolResultsByCallId: [(String, String)] = []
                     for outcome in outcomes {
                         if emitAgentToolTrace {
+                            RemoteAgentRunLog.server(
+                                "tool completed agent=\(agentId.uuidString) name=\(outcome.invocation.toolName) "
+                                    + "callId=\(outcome.callId) isError=\(outcome.wasError)"
+                            )
                             hop {
                                 writerBound.value.writeAgentToolTrace(
                                     phase: "completed",
@@ -5053,8 +5120,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         )
                     }
                 exitState = runResult.exit
+                RemoteAgentRunLog.server(
+                    "run loop done agent=\(agentId.uuidString) model=\(model) exit=\(String(describing: exitState))"
+                )
             } catch {
                 await releaseHostFolder()
+                RemoteAgentRunLog.serverError(
+                    "run loop FAILED agent=\(agentId.uuidString) model=\(model) error=\(error.localizedDescription)"
+                )
                 // SSE response head was already written as 200 — the
                 // failure surfaces as an in-band SSE error chunk. Log
                 // the actual on-wire status (200) so dashboards don't

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -48,6 +48,12 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             /// Routing returned `.none` for a non-empty model request for some
             /// other reason (e.g. provider marked disconnected). Maps to 503.
             case noServiceAvailable(requested: String)
+            /// A Mode 2 remote-agent run was requested but the paired agent's
+            /// provider isn't among the connected services (e.g. it
+            /// disconnected mid-flight). Fails closed instead of falling back
+            /// to model-string routing, which could silently retarget a
+            /// different local provider. Maps to 503.
+            case remoteAgentUnavailable
         }
 
         let kind: Kind
@@ -58,6 +64,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 return "Model '\(requested)' is not installed or registered with any provider."
             case .noServiceAvailable(let requested):
                 return "No service is currently available to handle model '\(requested)'."
+            case .remoteAgentUnavailable:
+                return "The selected remote agent isn't connected. Reconnect to the agent and try again."
             }
         }
 
@@ -66,6 +74,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             switch kind {
             case .modelNotFound: return 404
             case .noServiceAvailable: return 503
+            case .remoteAgentUnavailable: return 503
             }
         }
     }
@@ -160,6 +169,33 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             idempotencyKey: request.idempotencyKey,
             runAsRemoteAgent: request.runAsRemoteAgent
         )
+
+        // Mode 2 (remote agent run): route to the *selected agent's provider*,
+        // never by the model string. A stale `selectedModel` left over from
+        // earlier local testing (e.g. "fugu/...") must not redirect an agent
+        // run to a different local provider — that produced opaque upstream
+        // 404s ("Model default not found"). The peer resolves its own
+        // effective model server-side, so the model field here is irrelevant.
+        if request.runAsRemoteAgent, let agentProviderId = request.remoteAgentProviderId {
+            let remoteServices = await remoteServicesProvider()
+            if let agentService = Self.remoteAgentService(
+                providerId: agentProviderId, in: remoteServices
+            ) {
+                let effective = request.remoteAgentLogModel ?? request.model
+                RemoteAgentRunLog.client(
+                    "dispatch route=provider providerId=\(agentProviderId.uuidString) effectiveModel=\(effective) reqModel=\(request.model)"
+                )
+                return Dispatch(
+                    route: .service(service: agentService, effectiveModel: effective),
+                    params: params,
+                    remoteServices: remoteServices
+                )
+            }
+            RemoteAgentRunLog.clientError(
+                "dispatch remote agent providerId=\(agentProviderId.uuidString) not in connected services; failing closed"
+            )
+            return Dispatch(route: .none, params: params, remoteServices: remoteServices)
+        }
 
         let services = self.services
         trace?.mark("route_resolve_local")
@@ -643,6 +679,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             )
 
         case .none:
+            if request.runAsRemoteAgent, request.remoteAgentProviderId != nil {
+                throw EngineError(kind: .remoteAgentUnavailable)
+            }
             throw EngineError(kind: .modelNotFound(requested: request.model))
         }
     }
@@ -692,6 +731,18 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             debugLog("[ChatEngine] streamChat: streamDeltas returned")
             return plainStream
         }
+    }
+
+    /// Mode 2 routing primitive: pick the paired agent's `RemoteProviderService`
+    /// by its `provider.id`, never by the model string — a stale `selectedModel`
+    /// (e.g. a leftover local provider prefix) must not redirect a remote-agent
+    /// run to a different provider. `static` and pure over the immutable
+    /// `provider` `let`, so it's unit-testable without standing up an engine.
+    static func remoteAgentService(
+        providerId: UUID,
+        in remoteServices: [ModelService]
+    ) -> ModelService? {
+        remoteServices.first { ($0 as? RemoteProviderService)?.provider.id == providerId }
     }
 
     /// Build Insights connection + attribution metadata for a remote send so a
@@ -1347,6 +1398,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
 
             return response
         case .none:
+            if request.runAsRemoteAgent, request.remoteAgentProviderId != nil {
+                throw EngineError(kind: .remoteAgentUnavailable)
+            }
             throw EngineError(kind: .modelNotFound(requested: request.model))
         }
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteAgentRunLog.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteAgentRunLog.swift
@@ -1,0 +1,50 @@
+//
+//  RemoteAgentRunLog.swift
+//  osaurus
+//
+//  Always-on (info-level) structured logging for remote agent (Mode 2) runs,
+//  split by side (caller vs host) so a single run can be traced end-to-end in
+//  Console.app without flipping a debug flag. Metadata only — provider ids,
+//  resolved model, endpoint, tool names/phases, counts, exit state, and error
+//  descriptions. Never log message content here: the privacy specifier marks
+//  the composed string `.public`, so callers must pass only metadata.
+//
+
+import Foundation
+import os
+
+enum RemoteAgentRunLog {
+    private static let clientLogger = Logger(
+        subsystem: "ai.osaurus",
+        category: "RemoteAgentRun.client"
+    )
+    private static let serverLogger = Logger(
+        subsystem: "ai.osaurus",
+        category: "RemoteAgentRun.server"
+    )
+
+    /// Caller side (the device initiating the Mode 2 run): routing decision,
+    /// endpoint selection, SSE/tool-trace progress, terminal status.
+    ///
+    /// These are always-on (info/error level), so the message is composed
+    /// eagerly at the call site — a plain `String` (not an `@autoclosure`)
+    /// keeps it out of the escaping OSLog interpolation closure, which can't
+    /// capture a non-escaping autoclosure parameter.
+    static func client(_ message: String) {
+        clientLogger.info("\(message, privacy: .public)")
+    }
+
+    static func clientError(_ message: String) {
+        clientLogger.error("\(message, privacy: .public)")
+    }
+
+    /// Host side (the device running `/agents/{id}/run`): agent + model
+    /// resolution, per-tool start/complete, run exit state, errors.
+    static func server(_ message: String) {
+        serverLogger.info("\(message, privacy: .public)")
+    }
+
+    static func serverError(_ message: String) {
+        serverLogger.error("\(message, privacy: .public)")
+    }
+}

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -523,6 +523,11 @@ public actor RemoteProviderService: ToolCapableService {
         // peer as a plain OpenAI-compatible inference backend, keeping tools so
         // the *local* agent loop executes them.
         if provider.providerType == .osaurus && parameters.runAsRemoteAgent {
+            RemoteAgentRunLog.client(
+                "stream start provider=\(provider.name) type=\(provider.providerType.rawValue) "
+                    + "endpoint=\(osaurusEndpointURL(runAsRemoteAgent: true)?.absoluteString ?? "<unresolved>") "
+                    + "modelOnWire=omitted msgs=\(messages.count)"
+            )
             return try await streamDeltas(
                 messages: messages,
                 parameters: parameters,
@@ -2261,9 +2266,9 @@ public actor RemoteProviderService: ToolCapableService {
     /// Build a chat completion request structure.
     ///
     /// `internal` (not `private`) so the Mode 1 / Mode 2 wire-shape contract can
-    /// be asserted in tests: Mode 2 (`parameters.runAsRemoteAgent`) forces
-    /// `model: "default"` and stamps `runAsRemoteAgent`; Mode 1 preserves the
-    /// resolved model and tools.
+    /// be asserted in tests: Mode 2 (`parameters.runAsRemoteAgent`) OMITS the
+    /// `model` field on the wire and stamps `runAsRemoteAgent`; Mode 1 preserves
+    /// the resolved model and tools.
     func buildChatRequest(
         messages: [ChatMessage],
         parameters: GenerationParameters,
@@ -2299,23 +2304,17 @@ public actor RemoteProviderService: ToolCapableService {
             wireTools = tools
         }
 
-        // Mode 2 (remote agent run): send `model: "default"` so the peer
-        // resolves the agent's *live* effective model server-side, faithful to
-        // "the agent runs from its own selected default model" even if the
-        // owner changes it after pairing. Provider routing already happened
-        // upstream off the prefixed model, so the wire value is free to be the
-        // sentinel here.
-        let wireModel = parameters.runAsRemoteAgent ? "default" : model
         // Mode 2 (remote agent run): the remote agent owns its generation
-        // config — sampling and reasoning come from its own model bundle /
-        // agent settings, not the caller. Send only `model: "default"` + the
-        // conversation and strip every caller-supplied sampling/reasoning
-        // field. Without this the server's run loop applies the caller's local
+        // config. The `model` field is omitted on the wire (see
+        // `RemoteChatRequest.encode`) so the peer resolves its own live
+        // effective model, and we strip every caller-supplied sampling/reasoning
+        // field below — otherwise the host's run loop applies the caller's local
         // defaults and silently overrides the agent's native
-        // `generation_config.json` (faithfulness regression).
+        // `generation_config.json` (faithfulness regression). `model` is passed
+        // through for Mode 1 and for local reasoning-profile checks only.
         let isAgentRun = parameters.runAsRemoteAgent
         var request = RemoteChatRequest(
-            model: wireModel,
+            model: model,
             messages: messages,
             // Reasoning models (o1, gpt-5) forbid temperature/top_p when reasoning is active as inferred from
             // https://community.openai.com/t/gpt-5-nano-accepted-parameters/1355086/2
@@ -2567,13 +2566,34 @@ public actor RemoteProviderService: ToolCapableService {
         return provider.url(for: "/agents/\(identifier)/run")
     }
 
-    /// Build a URLRequest for the chat completions endpoint
-    private func buildURLRequest(for request: RemoteChatRequest) async throws -> URLRequest {
+    /// Build a URLRequest for the chat completions endpoint.
+    ///
+    /// `internal` (not `private`) so the Mode 2 defense-in-depth guard — a
+    /// `runAsRemoteAgent` request against a non-`.osaurus` provider must throw
+    /// rather than POST `/chat/completions` — can be asserted directly in tests.
+    func buildURLRequest(for request: RemoteChatRequest) async throws -> URLRequest {
         let url: URL
         let requestProviderType = Self.effectiveRequestProviderType(
             configuredProviderType: provider.providerType,
             request: request
         )
+
+        // Mode 2 hard guard (defense-in-depth): a remote-agent run must only
+        // ever target a native Osaurus peer's `/agents/{address}/run`. If
+        // routing ever lands a `runAsRemoteAgent` request on a non-Osaurus
+        // provider (e.g. a stale model prefix pointing at a local third-party
+        // provider), fail fast with a clear error instead of POSTing
+        // `/chat/completions` — that path produced the opaque upstream 404
+        // ("Model default not found ['fugu', ...]") this guard exists to stop.
+        if request.runAsRemoteAgent && provider.providerType != .osaurus {
+            RemoteAgentRunLog.clientError(
+                "agent run blocked: provider '\(provider.name)' type=\(provider.providerType.rawValue) is not an Osaurus agent endpoint"
+            )
+            throw RemoteProviderServiceError.requestFailed(
+                "Remote agent run cannot use provider '\(provider.name)' — it is not an Osaurus agent endpoint. "
+                    + "Reconnect to the remote agent and try again."
+            )
+        }
 
         if requestProviderType == .gemini {
             // Gemini uses model-in-URL pattern: /models/{model}:generateContent or :streamGenerateContent
@@ -3369,7 +3389,15 @@ struct RemoteChatRequest: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(model, forKey: .model)
+        // Mode 2 (remote agent run): omit `model` entirely. The peer resolves
+        // the agent's own effective model server-side; sending any caller-side
+        // model — even the "default" sentinel — is wrong and previously leaked
+        // to a mis-routed upstream as an opaque 404 ("Model default not
+        // found"). The endpoint choice (/agents/{address}/run) already encodes
+        // the intent. Every other path keeps its exact current wire bytes.
+        if !runAsRemoteAgent {
+            try container.encode(model, forKey: .model)
+        }
         try container.encode(messages, forKey: .messages)
         try container.encodeIfPresent(temperature, forKey: .temperature)
 

--- a/Packages/OsaurusCore/Tests/Chat/RemoteToolActivityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/RemoteToolActivityTests.swift
@@ -1,0 +1,124 @@
+//
+//  RemoteToolActivityTests.swift
+//  osaurusTests
+//
+//  Pins the display-only contract for remote-agent (Mode 2) tool activity on
+//  `ChatTurn`. The remote peer executes tools server-side and streams back only
+//  a sanitized `osaurus_agent_tool` trace (name + phase + error state — never
+//  raw args/results). These helpers reconstruct a per-turn tool-call group so
+//  the observer watches each remote tool transition running → done/failed,
+//  while guaranteeing the activity:
+//    • is never written into `toolCalls` (the field `turnToMessage` serializes),
+//      so a Mode 2 multi-turn history can't carry synthetic, unpaired tool_calls;
+//    • renders running (no result) until a terminal trace lands;
+//    • marks failures with a `ToolEnvelope` error so the chip renders red;
+//    • advances `remoteToolActivityTick` on every mutation so `BlockMemoizer`'s
+//      streaming fast-path re-renders the chips.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite("Remote-agent (Mode 2) tool activity — display only")
+struct RemoteToolActivityTests {
+
+    private func makeTurn() -> ChatTurn {
+        ChatTurn(role: .assistant, content: "")
+    }
+
+    @Test func startedThenFinished_recordsRunningThenResult() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "get_weather")
+
+        // Started but not finished → no result yet, so the chip renders as the
+        // live "running" shimmer.
+        #expect(turn.remoteToolActivity.count == 1)
+        #expect(turn.remoteToolActivity.first?.function.name == "get_weather")
+        #expect(turn.remoteToolResults["c1"] == nil)
+        #expect(turn.hasRemoteToolActivity)
+
+        turn.noteRemoteToolFinished(callId: "c1", name: "get_weather", isError: false)
+        let result = turn.remoteToolResults["c1"]
+        #expect(result != nil)
+        // Success result is a plain, non-error string → green/done node.
+        #expect(ToolEnvelope.isError(result ?? "") == false)
+    }
+
+    @Test func failure_recordsErrorEnvelope_soChipRendersRed() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "shell")
+        turn.noteRemoteToolFinished(callId: "c1", name: "shell", isError: true)
+        // The row carries a ToolEnvelope error so `NativeToolCallRowView`'s
+        // `isErrorResult` paints it red — without ever exposing the remote's
+        // raw tool output.
+        #expect(ToolEnvelope.isError(turn.remoteToolResults["c1"] ?? ""))
+    }
+
+    @Test func doesNotPopulateToolCalls_soHistoryStaysClean() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "get_weather")
+        turn.noteRemoteToolFinished(callId: "c1", name: "get_weather", isError: false)
+        // The serialized history field (`toolCalls`) is never touched: a Mode 2
+        // turn must not re-send synthetic, unpaired tool_calls on the next turn.
+        #expect(turn.toolCalls == nil)
+        #expect(turn.toolResults.isEmpty)
+        #expect(turn.remoteToolActivity.count == 1)
+    }
+
+    @Test func finishedWithoutStarted_materializesRow() {
+        // Some peers may only emit a terminal trace — the row is still created.
+        let turn = makeTurn()
+        turn.noteRemoteToolFinished(callId: "c9", name: "search", isError: false)
+        #expect(turn.remoteToolActivity.count == 1)
+        #expect(turn.remoteToolActivity.first?.id == "c9")
+        #expect(turn.remoteToolResults["c9"] != nil)
+    }
+
+    @Test func started_isIdempotentPerCallId() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "get_weather")
+        turn.noteRemoteToolStarted(callId: "c1", name: "get_weather")
+        #expect(turn.remoteToolActivity.count == 1)
+    }
+
+    @Test func started_ignoresBlankName() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "   ")
+        #expect(turn.remoteToolActivity.isEmpty)
+        #expect(turn.hasRemoteToolActivity == false)
+    }
+
+    @Test func finalize_settlesRunningRows() {
+        let turn = makeTurn()
+        turn.noteRemoteToolStarted(callId: "c1", name: "search")
+        #expect(turn.remoteToolResults["c1"] == nil)  // shimmering
+
+        turn.finalizeRemoteToolActivity()
+        // No longer running → a result is stamped so it can't shimmer forever.
+        #expect(turn.remoteToolResults["c1"] != nil)
+    }
+
+    @Test func tick_advancesOnEveryMutation() {
+        let turn = makeTurn()
+        let t0 = turn.remoteToolActivityTick
+        turn.noteRemoteToolStarted(callId: "c1", name: "search")
+        let t1 = turn.remoteToolActivityTick
+        turn.noteRemoteToolFinished(callId: "c1", name: "search", isError: false)
+        let t2 = turn.remoteToolActivityTick
+        // The memoizer folds this counter into its streaming fast-path signature,
+        // so a trace that changes neither content nor thinking still re-renders.
+        #expect(t1 > t0)
+        #expect(t2 > t1)
+    }
+
+    @Test func finalize_isNoOpWhenNoActivity() {
+        let turn = makeTurn()
+        let before = turn.remoteToolActivityTick
+        turn.finalizeRemoteToolActivity()
+        #expect(turn.remoteToolActivityTick == before)
+        #expect(turn.hasRemoteToolActivity == false)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/RemoteAgentRoutingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteAgentRoutingTests.swift
@@ -4,12 +4,16 @@
 //
 //  Pins the Mode 1 / Mode 2 split for native `.osaurus` peers:
 //    • Mode 2 (remote agent run, `runAsRemoteAgent == true`) routes to
-//      `/agents/{address}/run`, sends `model: "default"` so the peer resolves
-//      the agent's live effective model, and stamps the local-only routing flag.
+//      `/agents/{address}/run`, OMITS the `model` field on the wire so the peer
+//      resolves the agent's live effective model, and stamps the local-only
+//      routing flag.
 //    • Mode 1 (remote inference, `runAsRemoteAgent == false`) routes to the
 //      OpenAI-compatible `/chat/completions` endpoint and preserves the
 //      caller's model + tools so the local agent loop drives the turn.
 //    • The routing flag is local-only and never crosses the wire.
+//    • Mode 2 routing is resolved by the selected agent's provider id, never by
+//      the (possibly stale) model string, and a non-`.osaurus` provider can
+//      never accept an agent run.
 //
 
 import Foundation
@@ -56,6 +60,20 @@ struct RemoteAgentRoutingTests {
             ),
             models: ["coco/model-a"],
             resolvedHeaders: [:]
+        )
+    }
+
+    /// A non-`.osaurus` provider — the local third-party shape (e.g. a llama.cpp
+    /// / "fugu" server) that a remote-agent run must never be routed to.
+    private static func makeNonOsaurusProvider(models: [String] = ["fugu/fugu"]) -> RemoteProvider {
+        RemoteProvider(
+            name: "fugu-local",
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 1234,
+            basePath: "/v1",
+            authType: .none,
+            providerType: .openaiLegacy
         )
     }
 
@@ -133,7 +151,7 @@ struct RemoteAgentRoutingTests {
 
     // MARK: - Wire request shape
 
-    @Test func mode2_buildChatRequest_pinsModelDefaultAndStampsFlag() async {
+    @Test func mode2_buildChatRequest_omitsModelOnWireAndStampsFlag() async throws {
         let service = Self.makeService(basePath: "/v1")
         let req = await service.buildChatRequest(
             messages: [ChatMessage(role: "user", content: "hi")],
@@ -143,9 +161,16 @@ struct RemoteAgentRoutingTests {
             tools: nil,
             toolChoice: nil
         )
-        // The agent resolves its own model server-side from the "default" sentinel.
-        #expect(req.model == "default")
+        // The local routing flag is stamped so `buildURLRequest` targets
+        // `/agents/{address}/run`...
         #expect(req.runAsRemoteAgent == true)
+        // ...and the `model` field is OMITTED on the wire — the peer resolves
+        // the agent's live effective model server-side. Sending any caller-side
+        // value (a stale prefix, or the old "default" sentinel) was exactly what
+        // surfaced as the opaque upstream 404.
+        let data = try JSONEncoder().encode(req)
+        let obj = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(obj["model"] == nil)
     }
 
     @Test func mode1_buildChatRequest_keepsModelAndTools() async {
@@ -181,7 +206,7 @@ struct RemoteAgentRoutingTests {
         )
     }
 
-    @Test func mode2_buildChatRequest_stripsSamplingAndReasoning() async {
+    @Test func mode2_buildChatRequest_stripsSamplingAndReasoning() async throws {
         let service = Self.makeService(basePath: "/v1")
         let req = await service.buildChatRequest(
             messages: [ChatMessage(role: "user", content: "hi")],
@@ -195,8 +220,11 @@ struct RemoteAgentRoutingTests {
             toolChoice: nil
         )
         // The remote agent owns its generation config: none of the caller's
-        // sampling/reasoning controls may ride along, only `model: "default"`.
-        #expect(req.model == "default")
+        // sampling/reasoning controls may ride along, and the `model` field is
+        // omitted from the wire entirely.
+        let data = try JSONEncoder().encode(req)
+        let obj = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(obj["model"] == nil)
         #expect(req.temperature == nil)
         #expect(req.top_p == nil)
         #expect(req.frequency_penalty == nil)
@@ -245,9 +273,9 @@ struct RemoteAgentRoutingTests {
         let obj = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(obj["runAsRemoteAgent"] == nil)
         #expect(obj["run_as_remote_agent"] == nil)
-        // The sentinel model IS on the wire — that's how the peer resolves the
-        // agent's live effective model.
-        #expect(obj["model"] as? String == "default")
+        // The `model` field is OMITTED on the wire for an agent run — the peer
+        // resolves the agent's live effective model server-side.
+        #expect(obj["model"] == nil)
     }
 
     // MARK: - ChatCompletionRequest threading
@@ -386,5 +414,150 @@ struct RemoteAgentRoutingTests {
         #expect(conn.info.mode == .remoteInference)
         #expect(conn.info.transport == .secureChannel)
         #expect(conn.path == "/v1/chat/completions")
+    }
+
+    // MARK: - Root-cause fix: route Mode 2 by provider id, never by model string
+
+    @Test func mode2_routesByProviderId_ignoringStaleModel() {
+        // The `fugu` 404 reproduction: a remote-agent run is selected while a
+        // stale `selectedModel` ("fugu/...") still names a *different* local
+        // provider. Routing must resolve the paired agent by its provider id,
+        // not by the model string, so the decoy never wins.
+        let cocoProvider = Self.makeProvider(basePath: "/v1", remoteAgentAddress: "coco-addr")
+        let coco = RemoteProviderService(
+            provider: cocoProvider, models: ["coco/model-a"], resolvedHeaders: [:]
+        )
+        let decoy = RemoteProviderService(
+            provider: Self.makeNonOsaurusProvider(), models: ["fugu/fugu"], resolvedHeaders: [:]
+        )
+
+        let picked = ChatEngine.remoteAgentService(
+            providerId: cocoProvider.id,
+            in: [decoy, coco]
+        )
+        // Reference identity (no actor-isolated `provider` read) proves the
+        // paired service won over the model-string decoy.
+        #expect((picked as? RemoteProviderService) === coco)
+    }
+
+    @Test func mode2_unknownProviderId_resolvesToNil() {
+        // Provider disconnected mid-flight: the lookup returns nil so dispatch
+        // can fail closed (EngineError.remoteAgentUnavailable) instead of
+        // silently retargeting a different provider by model string.
+        let coco = Self.makeService(basePath: "/v1", remoteAgentAddress: "coco-addr")
+        let picked = ChatEngine.remoteAgentService(providerId: UUID(), in: [coco])
+        #expect(picked == nil)
+    }
+
+    // MARK: - Defense-in-depth: a non-.osaurus provider can't accept an agent run
+
+    @Test func mode2_nonOsaurusProvider_buildURLRequestThrows() async {
+        // Even if routing ever regressed and landed a `runAsRemoteAgent` request
+        // on a third-party provider, the URL builder must throw rather than POST
+        // `/chat/completions` (the path that produced "Model default not found").
+        let service = RemoteProviderService(
+            provider: Self.makeNonOsaurusProvider(), models: ["fugu/fugu"], resolvedHeaders: [:]
+        )
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "hi")],
+            parameters: Self.makeParams(runAsRemoteAgent: true),
+            model: "fugu/fugu",
+            stream: true,
+            tools: nil,
+            toolChoice: nil
+        )
+        #expect(req.runAsRemoteAgent == true)
+        await #expect(throws: RemoteProviderServiceError.self) {
+            _ = try await service.buildURLRequest(for: req)
+        }
+    }
+
+    @Test func mode1_nonOsaurusProvider_buildURLRequestSucceeds() async throws {
+        // Sanity: plain remote inference (Mode 1) against the same third-party
+        // provider must still build a `/chat/completions` URL — the guard only
+        // fires for agent runs.
+        let service = RemoteProviderService(
+            provider: Self.makeNonOsaurusProvider(), models: ["fugu/fugu"], resolvedHeaders: [:]
+        )
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "hi")],
+            parameters: Self.makeParams(runAsRemoteAgent: false),
+            model: "fugu/fugu",
+            stream: true,
+            tools: nil,
+            toolChoice: nil
+        )
+        let urlRequest = try await service.buildURLRequest(for: req)
+        #expect(urlRequest.url?.path == "/v1/chat/completions")
+    }
+
+    // MARK: - Server decode tolerance: /agents/{id}/run accepts an omitted model
+
+    @Test func agentRunDecode_injectsEmptyModelWhenOmitted() throws {
+        // A Mode 2 caller omits `model` entirely. The shared decoder requires it,
+        // so the run handler pre-injects an empty value; the resolver then maps
+        // empty → the agent's effective model (or fails fast if none).
+        let json = #"{"messages":[{"role":"user","content":"hi"}]}"#
+        let patched = HTTPHandler.injectingEmptyModelIfMissing(Data(json.utf8))
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: patched)
+        #expect(req.model == "")
+        #expect(req.messages.count == 1)
+    }
+
+    @Test func agentRunDecode_treatsNullModelAsOmitted() throws {
+        let json = #"{"model":null,"messages":[]}"#
+        let patched = HTTPHandler.injectingEmptyModelIfMissing(Data(json.utf8))
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: patched)
+        #expect(req.model == "")
+    }
+
+    @Test func agentRunDecode_preservesProvidedModel() throws {
+        // A concrete model (or the legacy "default" sentinel) must pass through
+        // untouched — only a missing/null model is patched.
+        let json = #"{"model":"coco/gemma-3-12b","messages":[]}"#
+        let patched = HTTPHandler.injectingEmptyModelIfMissing(Data(json.utf8))
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: patched)
+        #expect(req.model == "coco/gemma-3-12b")
+    }
+
+    @Test func agentRunDecode_passesThroughNonJSONUnchanged() {
+        // Not a JSON object → returned as-is (the decode will fail downstream
+        // with the normal invalid-body path, not here).
+        let raw = Data("not json".utf8)
+        #expect(HTTPHandler.injectingEmptyModelIfMissing(raw) == raw)
+    }
+
+    // MARK: - ChatCompletionRequest threading: remoteAgentProviderId is local-only
+
+    @Test func chatCompletionRequest_copyHelpersPreserveRemoteAgentProviderId() {
+        let providerId = UUID()
+        var req = ChatCompletionRequest(
+            model: "m",
+            messages: [],
+            temperature: nil,
+            max_tokens: nil,
+            stream: true,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+        req.remoteAgentProviderId = providerId
+        #expect(req.withModel("other").remoteAgentProviderId == providerId)
+        #expect(
+            req.withContext(messages: [], tools: nil, toolChoice: nil).remoteAgentProviderId
+                == providerId
+        )
+    }
+
+    @Test func chatCompletionRequest_remoteAgentProviderIdNotDecodedFromJSON() throws {
+        // Local-only routing field — inbound OpenAI JSON must never set it.
+        let json = #"{"model":"m","messages":[],"remoteAgentProviderId":"\#(UUID().uuidString)"}"#
+        let req = try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+        #expect(req.remoteAgentProviderId == nil)
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2611,21 +2611,39 @@ final class ChatSession: ObservableObject {
             for try await delta in stream {
                 if !isRunActive(runId) {
                     await processor.finalize()
+                    // Cancelled mid-run: don't leave a remote tool chip
+                    // shimmering forever — settle any still-running rows.
+                    currentTurn.finalizeRemoteToolActivity()
                     return ([], currentTurn)
                 }
                 // Mode 2 (remote agent run): the remote device executes the
-                // tools and streams back only a sanitized trace. Surface it as
-                // a transient "running <tool>" chip so the observer sees
-                // progress during the silent tool phase. `pendingToolName` is
-                // display-only (never persisted); cleared when the tool ends.
+                // tools and streams back only a sanitized trace (name + phase +
+                // error state — never raw args/results). Accumulate it into a
+                // persistent per-turn tool-call group so the observer keeps a
+                // visible record of every tool the remote agent ran
+                // (running → done/failed), instead of a chip that vanished the
+                // instant the tool finished. The activity is display-only and is
+                // never re-sent as history (see `ChatTurn.remoteToolActivity`).
                 if let trace = StreamingAgentToolHint.decode(delta) {
+                    let callKey =
+                        (trace.callId?.isEmpty == false) ? trace.callId! : trace.name
                     switch trace.phase {
                     case "started":
-                        currentTurn.pendingToolName = trace.name.isEmpty ? nil : trace.name
+                        currentTurn.noteRemoteToolStarted(callId: callKey, name: trace.name)
                     default:
-                        // "completed" (or anything terminal) clears the chip.
-                        currentTurn.pendingToolName = nil
+                        // "completed" (or anything terminal) stamps the result.
+                        currentTurn.noteRemoteToolFinished(
+                            callId: callKey, name: trace.name, isError: trace.isError
+                        )
                     }
+                    if trace.endRun {
+                        currentTurn.finalizeRemoteToolActivity()
+                    }
+                    RemoteAgentRunLog.client(
+                        "tool trace phase=\(trace.phase) "
+                            + "name=\(trace.name.isEmpty ? "<unknown>" : trace.name) "
+                            + "isError=\(trace.isError) endRun=\(trace.endRun)"
+                    )
                     rebuildVisibleBlocks()
                     continue
                 }
@@ -2781,6 +2799,19 @@ final class ChatSession: ObservableObject {
         // `send()`'s return so the residual buffer is rendered, not
         // dropped on dealloc.
         await processor.finalize()
+
+        // Mode 2 safety net: if the stream ended without an explicit
+        // `endRun` trace (clean end, network cutoff, or a peer that doesn't
+        // send one), settle any remote tool rows still marked "running" so
+        // none shimmer indefinitely. No-op for non-remote turns.
+        currentTurn.finalizeRemoteToolActivity()
+        if currentTurn.hasRemoteToolActivity {
+            RemoteAgentRunLog.client(
+                "stream end remoteTools=\(currentTurn.remoteToolActivity.count) "
+                    + "contentDeltas=\(uiDeltaCount) reasoningDeltas=\(uiReasoningDeltaCount) "
+                    + "finalContentLen=\(currentTurn.contentLength)"
+            )
+        }
 
         if let first = firstDeltaTime {
             currentTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
@@ -3889,7 +3920,12 @@ final class ChatSession: ObservableObject {
                                 attempt: attempt
                             )
                             var req = ChatCompletionRequest(
-                                model: self.selectedModel ?? "default",
+                                // Mode 2: the wire omits the model and routing is
+                                // by provider id, so don't pass the local
+                                // `selectedModel` — it can lag the async agent pin
+                                // and would only leak a stale prefix internally.
+                                model: self.isRemoteAgentTarget
+                                    ? "default" : (self.selectedModel ?? "default"),
                                 messages: msgs,
                                 temperature: effectiveTemp,
                                 max_tokens: effectiveMaxTokensForAgent,
@@ -3906,14 +3942,25 @@ final class ChatSession: ObservableObject {
                             req.samplingParametersAreImplicit = true
                             // Mode 2 routing signal: tells `RemoteProviderService`
                             // to target the peer's `/agents/{address}/run`
-                            // endpoint (remote agent runs fully server-side) and
-                            // to send `model: "default"` so the agent's live
-                            // effective model is used. False = Mode 1 (plain
-                            // remote inference via `/chat/completions`).
+                            // endpoint (remote agent runs fully server-side). The
+                            // local `model` placeholder above is dropped from the
+                            // wire entirely (`RemoteChatRequest.encode`), so the
+                            // peer resolves its own live effective model. False =
+                            // Mode 1 (plain remote inference via
+                            // `/chat/completions`).
                             req.runAsRemoteAgent = self.isRemoteAgentTarget
-                            // Insights fidelity: in Mode 2 the wire model is
-                            // `default`, so log the agent's live effective
-                            // model instead of the local prefixed fallback.
+                            // Mode 2 routing: target the selected agent's
+                            // provider directly (by id), so a stale
+                            // `selectedModel` can never redirect the run to a
+                            // different local provider. `ChatEngine` resolves
+                            // the service from this id and ignores the model
+                            // string for agent runs.
+                            req.remoteAgentProviderId =
+                                self.isRemoteAgentTarget
+                                ? self.windowState?.selectedDiscoveredAgentProviderId : nil
+                            // Insights fidelity: in Mode 2 the wire omits the
+                            // model, so log the agent's live effective model
+                            // instead of the local prefixed fallback.
                             req.remoteAgentLogModel =
                                 self.isRemoteAgentTarget
                                 ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
@@ -4167,6 +4214,14 @@ final class ChatSession: ObservableObject {
                             )
                             finalReq.samplingParametersAreImplicit = true
                             finalReq.runAsRemoteAgent = isRemoteAgentTarget
+                            // Carry the agent provider id on this path too so
+                            // the route-by-provider invariant holds for *every*
+                            // Mode 2 request — a `runAsRemoteAgent` send with no
+                            // provider id would fall back to model-string
+                            // routing (the exact mis-route this fix removes).
+                            finalReq.remoteAgentProviderId =
+                                isRemoteAgentTarget
+                                ? windowState?.selectedDiscoveredAgentProviderId : nil
                             finalReq.remoteAgentLogModel =
                                 isRemoteAgentTarget
                                 ? windowState?.pinnedRemoteAgentEffectiveModel : nil


### PR DESCRIPTION
## Summary

Remote-agent (Mode 2) runs were effectively unusable: a run could be misrouted to a local provider and rejected with an opaque `Model default not found` 404, tool calls never appeared in the UI, and neither side produced useful logs.

**Root cause:** Mode 2 dispatch was driven entirely by `request.model`. A stale `selectedModel` (e.g. a leftover local `fugu/...` prefix from earlier local testing) routed the agent run to the wrong local provider, which then forced `model: "default"` onto the wire — and that server rejected it.

**Fixes**
- **Route by provider, not model string.** New local-only `ChatCompletionRequest.remoteAgentProviderId`; `ChatEngine` resolves the paired agent's `RemoteProviderService` directly and ignores the model string for agent runs. Also stamped on the post-cap summarization request so *every* Mode 2 send is provider-routed.
- **Stop sending/requiring a model.** The client omits `model` on the wire for agent runs; the host tolerates a missing/empty model and resolves the agent's effective model, failing fast with a clear typed error if none is configured (no silent fallback).
- **Defense-in-depth guard.** A `runAsRemoteAgent` request against a non-`.osaurus` provider throws a typed error instead of POSTing `/chat/completions`, making this class of misroute impossible even if routing regresses.
- **Persistent tool-call stream in the UI.** Sanitized `osaurus_agent_tool` traces accumulate into per-turn rows (running → done/failed) instead of a chip that vanished the instant a tool finished — without leaking raw args/results or polluting chat history.
- **Structured logging.** Always-on, metadata-only `RemoteAgentRun` OSLog category on both client (dispatch + Mode 2 lifecycle) and server (model resolution, per-tool start/complete, run exit, catch-path errors).

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` — clean, no warnings on changed files
- [x] Extended `RemoteAgentRoutingTests` (provider-routed dispatch with stale model, model omitted on wire, non-osaurus typed error, server decode of missing/null model) + new `RemoteToolActivityTests` (display-only `ChatTurn` contract)
- [x] Focused suites pass: `RemoteAgentRouting`, `RemoteToolActivity`, `ChatEngineTests`, `ContentBlockDisplay`, `StreamingHint` (99 tests)
- [x] Full `make test` (OsaurusCore): the only failures are pre-existing/environmental (keychain-disabled mode + tool-registry drift), all in subsystems untouched by this PR
- [x] Manual: run a discovered remote agent end-to-end and confirm tool rows stream and persist

Made with [Cursor](https://cursor.com)