### PR TITLE
make plain-text answers the primary agent-loop exit

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -63,21 +63,24 @@ public enum SystemPromptTemplates {
     public static let agentLoopGuidance = """
         ## Agent loop
 
-        - `todo(markdown)` — write or replace the user-visible task list. For any task with 3+ steps, create it BEFORE starting work, then re-send the full list with the new box checked immediately after finishing each item. Skip only for trivial work.
-        - `complete(summary)` — call once at the very end (never alongside other tools) with WHAT you did + HOW you verified it. Vague placeholders are rejected; report partial work honestly.
+        - Always answer the user in plain text — that reply is what they read and ends the turn.
+        - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it with the next box checked after each item. Skip direct/single-step work.
+        - `complete(summary)` — OPTIONAL: close a `todo` task with a short WHAT+HOW status (not the answer) in the SAME message as your answer. Not for direct questions or other tools; no vague placeholders.
         - `clarify(question)` — pause and ask exactly one concrete question only when guessing wrong would change the result. For minor preferences pick a sensible default and proceed.
         - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
         """
 
     /// Compact agent-loop cheat-sheet for small-context / small local models
     /// (`prefersCompactPrompt`). Same four tools and the load-bearing rules
-    /// (3+ step todo, complete-alone-at-end, one-question clarify, file-exists
-    /// artifact), one line each.
+    /// (always answer in plain text, OPTIONAL 3+ step todo, OPTIONAL complete
+    /// that only closes a todo alongside the answer, one-question clarify,
+    /// file-exists artifact), one line each.
     public static let agentLoopGuidanceCompact = """
         ## Agent loop
 
-        - `todo(markdown)` — user-visible checklist. For 3+ step tasks, write it before starting, then re-send the full list with each box checked as you finish.
-        - `complete(summary)` — once at the very end, never alongside other tools: WHAT you did + HOW you verified. No vague placeholders.
+        - Always answer the user in plain text; that plain-text reply ends the turn.
+        - `todo(markdown)` — OPTIONAL checklist for multi-step (3+) work; re-send it with each box checked as you finish. Skip single-step or direct questions.
+        - `complete(summary)` — OPTIONAL: only to close a `todo`, in the SAME message as your answer; a short WHAT+HOW status, not the answer. No vague placeholders.
         - `clarify(question)` — last resort, NOT for big or multi-step tasks. If the request is fully specified, just do the work. Ask one concrete question only when a required input is missing or contradictory and no sensible default exists (or the user explicitly asks you to); otherwise assume a reasonable default, proceed, and note it.
         - `share_artifact(path | content+filename)` — the only way the user sees a file/image/report; the file MUST exist first. Sandbox: save under home, not `/tmp`.
         """

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -551,13 +551,25 @@ public enum AgentLoopEvaluator {
                 )
             )
             // Agent-loop intercepts, mirroring the chat surface: a
-            // successful `complete` ends the run and its summary is the
-            // final answer; a successful `clarify` ends the run awaiting
-            // user input (headless: no answer ever arrives). Error
-            // envelopes fall through so the model can retry.
+            // successful `complete` ends the run and a successful `clarify`
+            // ends the run awaiting user input (headless: no answer ever
+            // arrives). Error envelopes fall through so the model can retry.
+            //
+            // Under the agent-loop contract the user-facing ANSWER is the
+            // model's visible prose; `complete`'s summary is only a closing
+            // status. Prefer this turn's assistant prose as `finalText` so
+            // rubric grading judges the real answer, falling back to the
+            // summary when the turn carried no visible text (the older
+            // bare-`complete` behavior the chat banner still renders).
             if inv.toolName == "complete", !isError {
                 completedViaTool = true
-                if let summary = CompleteTool.parseSummary(from: inv.jsonArguments) {
+                let answer =
+                    history.last(where: { $0.role == "assistant" })?
+                    .content?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !answer.isEmpty {
+                    finalText = answer
+                } else if let summary = CompleteTool.parseSummary(from: inv.jsonArguments) {
                     finalText = summary
                 }
                 return AgentLoopToolExecution(result: result, endRun: true)

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -29,11 +29,11 @@ import Foundation
 public final class TodoTool: OsaurusTool, @unchecked Sendable {
     public let name = "todo"
     public let description =
-        "Write or replace the current task checklist. For any task with 3+ steps, create the "
-        + "list BEFORE starting work, then re-send it with the new box checked IMMEDIATELY "
+        "Write or replace the OPTIONAL task checklist. Use it for multi-step work (3+ steps): "
+        + "create the list BEFORE starting, then re-send it with the new box checked IMMEDIATELY "
         + "after finishing each item — do not batch updates for the end. Every item is a line "
         + "starting with `- [ ]` (pending) or `- [x]` (done); each call replaces the entire "
-        + "list. Skip only for trivial single-step work."
+        + "list. Skip it for a direct question or single-step work — just answer."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),
@@ -97,7 +97,8 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             text:
                 "Todo updated: \(stored.doneCount)/\(stored.totalCount) complete. "
-                + "Continue with the next pending item, or call `complete(summary)` when all done."
+                + "Continue with the next pending item; when everything is done, write your "
+                + "answer to the user (you may then call `complete(summary)` to close the task)."
         )
     }
 }
@@ -109,11 +110,14 @@ public final class TodoTool: OsaurusTool, @unchecked Sendable {
 public final class CompleteTool: OsaurusTool, @unchecked Sendable {
     public let name = "complete"
     public let description =
-        "End the current task with a one-paragraph summary of WHAT you did and HOW you verified "
-        + "it (the command you ran, the file you checked, the URL you opened). "
-        + "Vague summaries (`done`, `looks good`, `complete`) are rejected. If you couldn't "
-        + "finish, say so honestly in the summary instead of pretending — that's fine; the "
-        + "user understands partial work."
+        "OPTIONAL closure for a multi-step task you tracked with a `todo` list. Write your "
+        + "actual answer/result to the user as a normal message FIRST; this summary is a short "
+        + "status of WHAT you did + HOW you verified it (the command you ran, the file you "
+        + "checked, the URL you opened), NOT the answer itself. Call it in the same message as "
+        + "that final answer and not alongside other tool calls; for a direct question, just "
+        + "answer and do not call complete. Vague summaries (`done`, `looks good`, `complete`) "
+        + "are rejected. If you couldn't finish, say so honestly in the summary instead of "
+        + "pretending — that's fine; the user understands partial work."
 
     public let parameters: JSONValue? = .object([
         "type": .string("object"),

--- a/Packages/OsaurusEvals/Suites/AgentLoop/answer-direct-no-complete.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/answer-direct-no-complete.json
@@ -1,0 +1,19 @@
+{
+  "id": "agent_loop.answer-direct-no-complete",
+  "domain": "agent_loop",
+  "label": "agent loop • answer a direct question in plain text, no todo/complete",
+  "query": "What's the difference between TCP and UDP? Keep it to a few sentences.",
+  "notes": "Direct, single-step question that needs no tools. The contract: the model ANSWERS the user in plain text rather than scaffolding a trivial ask with `todo` or ending the turn with a bare `complete()` (\"done\" banner). mustNotCallTools pins no todo/complete/clarify; the rubric pins a real, direct answer. NOTE: a `complete` ending is mapped to exit=finalResponse (tool- and text-completion score identically), so mustNotCallTools — not allowedExits — is the guard against bare-complete. Off-CI (needs a model).",
+  "fixtures": {},
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 4,
+      "allowedExits": ["finalResponse"],
+      "mustNotCallTools": ["todo", "complete", "clarify"],
+      "rubric": [
+        "Directly answers the question in prose: TCP is connection-oriented, reliable, and ordered, while UDP is connectionless, unreliable, and lower-latency.",
+        "Delivers the answer as the assistant's own message and does not end by merely announcing completion or status (e.g. just saying \"done\")."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Agents were ending turns with a bare `complete()` ("done" banner) instead of actually answering the user. This re-steers the agent loop so the **plain-text answer is the primary exit** — it ends the turn consistently on every surface (chat, headless, evals).

- **Prompt guidance** (`SystemPromptTemplates`, full + compact): always answer in plain text; `todo` is OPTIONAL (multi-step / 3+ only); `complete` is an OPTIONAL closure for `todo`-tracked tasks in the same message as the answer — never a substitute for the answer.
- **Tool contracts** (`AgentLoopTools`): reworded `todo`/`complete` descriptions and the `todo` result nudge to match (answer the user, then optionally `complete`).
- **Eval parity** (`AgentLoopEvaluator`): the `complete` intercept now grades the turn's visible assistant prose as `finalText`, falling back to the summary only when the turn carried no visible text.
- **New eval case**: `agent_loop.answer-direct-no-complete` pins the contract — a direct question is answered in plain text with `mustNotCallTools: [todo, complete, clarify]`.

Net change is 4 files (+58/-20). No behavior is forced in parsers/samplers; this is prompt/contract steering plus eval-grading alignment.

## Test plan

- [x] `swift-format` clean on touched files; no new SwiftLint violations; `OsaurusCore` builds.
- [x] Targeted prompt/budget/tool tests green; full `make test` shows no regressions.
- [x] Live loop run on Qwen3-4B: direct question -> plain-text answer, `toolCalls=[]`, no `complete`.
- [ ] Reviewer sanity-check the compact-prompt budget is still within limits on CI.

Made with [Cursor](https://cursor.com)