### PR TITLE
Add Business Document Studio UI

### DIFF
--- a/App/osaurus/osaurusApp.swift
+++ b/App/osaurus/osaurusApp.swift
@@ -95,6 +95,14 @@ private extension osaurusApp {
         CommandGroup(after: .newItem) {
             Divider()
 
+            Button {
+                BusinessDocumentStudioLauncher.openDocumentPicker()
+            } label: {
+                Text(verbatim: L("Open Business Document..."))
+            }
+
+            Divider()
+
             Button(vadToggleLabel) {
                 toggleVAD()
             }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -10134,6 +10134,9 @@
         }
       }
     },
+    "Business Document Studio" : {
+      "shouldTranslate" : false
+    },
     "Bundle" : {
       "localizations" : {
         "de" : {
@@ -11736,6 +11739,9 @@
           }
         }
       }
+    },
+    "Choose a supported document to inspect preview, security, and export availability." : {
+      "shouldTranslate" : false
     },
     "Choose a SKILL.md file or a ZIP bundle to import" : {
       "localizations" : {
@@ -38891,6 +38897,12 @@
           }
         }
       }
+    },
+    "Open Business Document" : {
+      "shouldTranslate" : false
+    },
+    "Open Business Document..." : {
+      "shouldTranslate" : false
     },
     "Open Chat" : {
       "localizations" : {

--- a/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift
@@ -1,0 +1,363 @@
+//
+//  BusinessDocumentStudioPresenterTests.swift
+//  osaurusTests
+//
+//  Focused coverage for the Business Document Studio UI presenter.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite("Business document studio presenter")
+struct BusinessDocumentStudioPresenterTests {
+
+    @Test func csvInspectionBuildsPreviewAndAvailableExportRows() async throws {
+        let registry = DocumentFormatRegistry()
+        DocumentAdaptersBootstrap.registerBuiltIns(registry: registry)
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+        let source = try Self.write(
+            """
+            name,age,active
+            Ada,37,true
+            Ben,41,false
+            """,
+            filename: "people.csv"
+        )
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        await presenter.load(url: source)
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(presentation.title.hasSuffix("people.csv"))
+        #expect(presentation.previewRows.contains(.init(label: "Preview", value: "Delimited table")))
+        #expect(presentation.previewRows.contains(.init(label: "Columns", value: "3")))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("csv"))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("tsv"))
+        #expect(presentation.availableExportOptions.map(\.targetFormatId).contains("txt"))
+        #expect(presentation.unavailableExportOptions.isEmpty)
+    }
+
+    @Test func workbookValidationBlockedExportIsPresented() throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+
+        try presenter.load(document: Self.workbookDocument(includeFormula: true))
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        let xlsx = try #require(presentation.exportOptions.first { $0.targetFormatId == "xlsx" })
+        #expect(xlsx.canExport == false)
+        #expect(xlsx.reason == .validationFailed)
+        #expect(xlsx.reasonLabel == "Validation failed")
+        #expect(presentation.previewRows.contains(.init(label: "Formula cells", value: "1")))
+        #expect(presentation.warnings.contains { warning in
+            warning.severity == .blocked
+                && warning.title == "Export unavailable: XLSX workbook"
+                && warning.message.contains("Validation failed")
+        })
+    }
+
+    @Test func missingEmitterOptionBlocksExportBeforeDestinationWrite() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("report.pdf")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.pdfDocument())
+        let presentation = try Self.loadedPresentation(from: presenter)
+
+        let pdf = try #require(presentation.exportOptions.first { $0.targetFormatId == "pdf" })
+        #expect(pdf.canExport == false)
+        #expect(pdf.reason == .missingEmitter)
+        #expect(pdf.reasonLabel == "Missing emitter")
+
+        await presenter.export(optionID: "pdf", to: target, allowedDirectory: outputDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .unavailableOption)
+        #expect(block.optionID == "pdf")
+        #expect(block.reason == .missingEmitter)
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
+    @Test func availableTextFallbackExportSucceeds() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("notes.txt")
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        let presentation = try Self.loadedPresentation(from: presenter)
+        let text = try #require(presentation.exportOptions.first { $0.targetFormatId == "txt" })
+        #expect(text.canExport)
+
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .succeeded(let receipt) = presenter.exportState else {
+            Issue.record("Expected succeeded export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(receipt.targetFormatId == "txt")
+        #expect(receipt.bytesWritten > 0)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+    }
+
+    @Test func destinationAlreadyExistsIsBlockedByService() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.txt")
+        try "private".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: outputDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .destinationAlreadyExists)
+        #expect(block.path == target.path)
+        #expect(try String(contentsOf: target, encoding: .utf8) == "private")
+    }
+
+    @Test func destinationOverwriteSucceedsWhenInteractiveCallerAllowsIt() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let outputDirectory = try Self.temporaryDirectory()
+        let target = outputDirectory.appendingPathComponent("existing.txt")
+        try "old".write(to: target, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(
+            optionID: "txt",
+            to: target,
+            allowedDirectory: outputDirectory,
+            allowOverwrite: true
+        )
+
+        guard case .succeeded(let receipt) = presenter.exportState else {
+            Issue.record("Expected succeeded export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(receipt.targetFormatId == "txt")
+        #expect(try String(contentsOf: target, encoding: .utf8) == "hello world")
+    }
+
+    @Test func outsideAllowedDirectoryIsBlockedByService() async throws {
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: DocumentFormatRegistry())
+        )
+        let allowedDirectory = try Self.temporaryDirectory()
+        let outsideDirectory = try Self.temporaryDirectory()
+        let target = outsideDirectory.appendingPathComponent("outside.txt")
+        defer {
+            try? FileManager.default.removeItem(at: allowedDirectory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        try presenter.load(document: Self.plainTextDocument())
+        await presenter.export(optionID: "txt", to: target, allowedDirectory: allowedDirectory)
+
+        guard case .blocked(let block) = presenter.exportState else {
+            Issue.record("Expected blocked export state, got \(presenter.exportState)")
+            return
+        }
+        #expect(block.kind == .destinationOutsideAllowedDirectory)
+        #expect(block.path == target.path)
+        #expect(!FileManager.default.fileExists(atPath: target.path))
+    }
+
+    @Test func presentationRowsUseStableUniqueIdentifiers() throws {
+        let registry = DocumentFormatRegistry()
+        registry.register(emitter: XLSXEmitter())
+        let presenter = BusinessDocumentStudioPresenter(
+            service: BusinessDocumentStudioService(registry: registry)
+        )
+
+        try presenter.load(document: Self.workbookDocument())
+
+        let presentation = try Self.loadedPresentation(from: presenter)
+        #expect(Set(presentation.summaryRows.map(\.id)).count == presentation.summaryRows.count)
+        #expect(Set(presentation.structureRows.map(\.id)).count == presentation.structureRows.count)
+        #expect(Set(presentation.securityRows.map(\.id)).count == presentation.securityRows.count)
+        #expect(Set(presentation.previewRows.map(\.id)).count == presentation.previewRows.count)
+        #expect(Set(presentation.previewSections.map(\.id)).count == presentation.previewSections.count)
+        for section in presentation.previewSections {
+            #expect(Set(section.rows.map(\.id)).count == section.rows.count)
+        }
+    }
+
+    // MARK: - Assertions
+
+    private static func loadedPresentation(
+        from presenter: BusinessDocumentStudioPresenter
+    ) throws -> BusinessDocumentStudioPresentation {
+        guard case .loaded(let presentation) = presenter.loadState else {
+            Issue.record("Expected loaded presentation, got \(presenter.loadState)")
+            throw TestFailure.notLoaded
+        }
+        return presentation
+    }
+
+    private enum TestFailure: Error {
+        case notLoaded
+    }
+
+    // MARK: - Fixtures
+
+    private static func write(_ content: String, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-\(filename)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("business-document-studio-presenter-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func plainTextDocument() -> StructuredDocument {
+        StructuredDocument(
+            formatId: "plaintext",
+            filename: "notes.txt",
+            fileSize: 11,
+            representation: AnyStructuredRepresentation(
+                formatId: "plaintext",
+                underlying: PlainTextRepresentation(text: "hello world")
+            ),
+            security: .notInspected(
+                formatId: "plaintext",
+                fileExtension: "txt",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "hello world"
+        )
+    }
+
+    private static func pdfDocument() -> StructuredDocument {
+        let page = PDFPageRepresentation(
+            pageIndex: 0,
+            text: "Quarterly report",
+            anchor: DocumentAnchor(
+                kind: .page,
+                path: [.init(kind: .page, index: 0)],
+                label: "Page 1"
+            )
+        )
+        return StructuredDocument(
+            formatId: "pdf",
+            filename: "report.pdf",
+            fileSize: 128,
+            representation: AnyStructuredRepresentation(
+                formatId: "pdf",
+                underlying: PDFDocumentRepresentation(pages: [page])
+            ),
+            security: .notInspected(
+                formatId: "pdf",
+                fileExtension: "pdf",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Quarterly report"
+        )
+    }
+
+    private static func workbookDocument(includeFormula: Bool = false) -> StructuredDocument {
+        let workbook = Workbook(
+            sheets: [
+                Workbook.Sheet(
+                    name: "Revenue",
+                    index: 0,
+                    rows: [
+                        row(
+                            number: 1,
+                            cells: [
+                                cell("A1", row: 1, column: 1, value: .string("Month")),
+                                cell("B1", row: 1, column: 2, value: .string("Amount")),
+                            ]
+                        ),
+                        row(
+                            number: 2,
+                            cells: [
+                                cell("A2", row: 2, column: 1, value: .string("January")),
+                                cell(
+                                    "B2",
+                                    row: 2,
+                                    column: 2,
+                                    value: .number(1200),
+                                    formula: includeFormula ? "SUM(B2:B2)" : nil
+                                ),
+                            ]
+                        ),
+                    ],
+                    anchor: DocumentAnchor(kind: .sheet, path: [.init(kind: .sheet, index: 0)])
+                ),
+            ]
+        )
+
+        return StructuredDocument(
+            formatId: "xlsx",
+            filename: "workbook.xlsx",
+            fileSize: 256,
+            representation: AnyStructuredRepresentation(formatId: "xlsx", underlying: workbook),
+            security: .notInspected(
+                formatId: "xlsx",
+                fileExtension: "xlsx",
+                sourceTrust: .generatedArtifact
+            ),
+            textFallback: "Month\tAmount\nJanuary\t1200"
+        )
+    }
+
+    private static func row(number: Int, cells: [Workbook.Cell]) -> Workbook.Row {
+        Workbook.Row(
+            number: number,
+            cells: cells,
+            anchor: DocumentAnchor(kind: .row, path: [.init(kind: .row, index: number - 1)])
+        )
+    }
+
+    private static func cell(
+        _ reference: String,
+        row: Int,
+        column: Int,
+        value: Workbook.CellValue,
+        formula: String? = nil
+    ) -> Workbook.Cell {
+        Workbook.Cell(
+            reference: reference,
+            rowNumber: row,
+            columnNumber: column,
+            value: value,
+            formula: formula,
+            anchor: DocumentAnchor(
+                kind: .cell,
+                path: [
+                    .init(kind: .row, index: row - 1),
+                    .init(kind: .cell, index: column - 1),
+                ]
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift
@@ -1,0 +1,103 @@
+//
+//  BusinessDocumentStudioLauncher.swift
+//  osaurus
+//
+//  App-facing entry point for opening Business Document Studio windows.
+//
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+@MainActor
+public enum BusinessDocumentStudioLauncher {
+    private static var windows: [URL: NSWindow] = [:]
+    private static var delegates: [ObjectIdentifier: BusinessDocumentStudioWindowDelegate] = [:]
+
+    public static func openDocumentPicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.resolvesAliases = true
+        panel.title = L("Open Business Document")
+        panel.message = L("Choose a supported document to inspect preview, security, and export availability.")
+        panel.allowedContentTypes = supportedContentTypes
+
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            Task { @MainActor in
+                open(url: url)
+            }
+        }
+    }
+
+    public static func open(url: URL) {
+        let sourceURL = url.standardizedFileURL
+        if let existing = windows[sourceURL] {
+            show(existing)
+            return
+        }
+
+        let root = BusinessDocumentStudioView(sourceURL: sourceURL)
+        let hostingController = NSHostingController(rootView: root)
+        if #available(macOS 13.0, *) {
+            hostingController.sizingOptions = []
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 860, height: 640),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = sourceURL.lastPathComponent.isEmpty
+            ? L("Business Document Studio")
+            : sourceURL.lastPathComponent
+        window.titlebarAppearsTransparent = true
+        window.isReleasedWhenClosed = false
+        window.isRestorable = false
+        window.contentViewController = hostingController
+        window.center()
+
+        let identifier = ObjectIdentifier(window)
+        let delegate = BusinessDocumentStudioWindowDelegate {
+            windows[sourceURL] = nil
+            delegates[identifier] = nil
+        }
+        delegates[identifier] = delegate
+        window.delegate = delegate
+        windows[sourceURL] = window
+
+        show(window)
+    }
+
+    private static var supportedContentTypes: [UTType] {
+        let extensions = ["csv", "tsv", "xlsx", "pdf", "pptx", "potx", "docx", "doc", "rtf", "rtfd", "txt"]
+        let structuredTypes = extensions.compactMap { UTType(filenameExtension: $0) }
+        let parserTypes = DocumentParser.supportedDocumentTypes
+        var seen = Set<String>()
+        return (parserTypes + structuredTypes).filter { seen.insert($0.identifier).inserted }
+    }
+
+    private static func show(_ window: NSWindow) {
+        NSApp.unhide(nil)
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+    }
+}
+
+@MainActor
+private final class BusinessDocumentStudioWindowDelegate: NSObject, NSWindowDelegate {
+    private let onClose: () -> Void
+
+    init(onClose: @escaping () -> Void) {
+        self.onClose = onClose
+        super.init()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onClose()
+    }
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift
@@ -1,0 +1,766 @@
+//
+//  BusinessDocumentStudioPresenter.swift
+//  osaurus
+//
+//  Thin presentation layer for the Business Document Studio surface.
+//  BusinessDocumentStudioService remains the authority for parsing,
+//  availability, and destination safety.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class BusinessDocumentStudioPresenter: ObservableObject {
+    enum LoadState: Equatable {
+        case idle
+        case loading(URL?)
+        case loaded(BusinessDocumentStudioPresentation)
+        case failed(String)
+    }
+
+    enum ExportState: Equatable {
+        case idle
+        case exporting(optionID: String)
+        case succeeded(BusinessDocumentStudioExportReceipt)
+        case blocked(BusinessDocumentStudioExportBlock)
+        case failed(String)
+    }
+
+    @Published private(set) var loadState: LoadState = .idle
+    @Published private(set) var exportState: ExportState = .idle
+
+    private let service: BusinessDocumentStudioService
+    private var document: StructuredDocument?
+    private var inspection: BusinessDocumentStudioInspection?
+
+    init(service: BusinessDocumentStudioService = BusinessDocumentStudioService()) {
+        self.service = service
+    }
+
+    func load(
+        url: URL,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) async {
+        loadState = .loading(url)
+        exportState = .idle
+
+        do {
+            let document = try await service.parse(url: url)
+            try load(document: document, policy: policy)
+        } catch {
+            self.document = nil
+            inspection = nil
+            loadState = .failed(error.localizedDescription)
+        }
+    }
+
+    func load(
+        document: StructuredDocument,
+        policy: BusinessDocumentStudioPolicy = .standard
+    ) throws {
+        let inspection = try service.inspect(document, policy: policy)
+        self.document = document
+        self.inspection = inspection
+        loadState = .loaded(BusinessDocumentStudioPresentation(inspection: inspection))
+        exportState = .idle
+    }
+
+    func export(
+        optionID: String,
+        to destination: URL,
+        allowedDirectory: URL? = nil,
+        allowOverwrite: Bool = false,
+        maxTextExportUTF8Bytes: Int = BusinessDocumentStudioExportPolicy.standard.maxTextExportUTF8Bytes
+    ) async {
+        guard let document, let inspection else {
+            exportState = .failed("No document is loaded.")
+            return
+        }
+
+        guard let option = inspection.exportOptions.first(where: { $0.targetFormatId == optionID }) else {
+            exportState = .failed("Export option '\(optionID)' is not available for this document.")
+            return
+        }
+
+        guard option.canExport else {
+            exportState = .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unavailableOption,
+                    optionID: option.targetFormatId,
+                    message: option.message,
+                    path: nil,
+                    reason: option.reason
+                )
+            )
+            return
+        }
+
+        exportState = .exporting(optionID: option.targetFormatId)
+
+        do {
+            let result = try await service.export(
+                document,
+                as: option.targetFormatId,
+                to: destination,
+                policy: BusinessDocumentStudioExportPolicy(
+                    allowedDirectory: allowedDirectory,
+                    allowOverwrite: allowOverwrite,
+                    maxTextExportUTF8Bytes: maxTextExportUTF8Bytes
+                )
+            )
+            exportState = .succeeded(BusinessDocumentStudioExportReceipt(result: result))
+        } catch let error as BusinessDocumentStudioError {
+            exportState = mapServiceError(error, optionID: option.targetFormatId)
+        } catch {
+            exportState = .failed(error.localizedDescription)
+        }
+    }
+
+    private func mapServiceError(
+        _ error: BusinessDocumentStudioError,
+        optionID: String
+    ) -> ExportState {
+        switch error {
+        case .destinationAlreadyExists(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationAlreadyExists,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.path,
+                    reason: nil
+                )
+            )
+
+        case .destinationOutsideAllowedDirectory(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationOutsideAllowedDirectory,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.path,
+                    reason: nil
+                )
+            )
+
+        case .destinationIsNotFileURL(let url):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .destinationIsNotFileURL,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: url.absoluteString,
+                    reason: nil
+                )
+            )
+
+        case .unsafeTextPackageTarget(let fileExtension):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unsafePackageTarget,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: fileExtension,
+                    reason: nil
+                )
+            )
+
+        case .packageTargetExtensionMismatch(_, let fileExtension):
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .packageExtensionMismatch,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: fileExtension,
+                    reason: nil
+                )
+            )
+
+        case .textExportTooLarge:
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .textFallbackTooLarge,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: nil,
+                    reason: .textFallbackTooLarge
+                )
+            )
+
+        case .unsupportedExport:
+            return .blocked(
+                BusinessDocumentStudioExportBlock(
+                    kind: .unsupportedExport,
+                    optionID: optionID,
+                    message: error.localizedDescription,
+                    path: nil,
+                    reason: .unsupportedFormat
+                )
+            )
+
+        case .unsupportedFormat,
+             .adapterReturnedUnexpectedFormat,
+             .writeFailed:
+            return .failed(error.localizedDescription)
+        }
+    }
+}
+
+struct BusinessDocumentStudioPresentation: Equatable {
+    let title: String
+    let subtitle: String
+    let iconSystemName: String
+    let summaryRows: [BusinessDocumentStudioInfoRow]
+    let structureRows: [BusinessDocumentStudioInfoRow]
+    let securityRows: [BusinessDocumentStudioInfoRow]
+    let previewRows: [BusinessDocumentStudioInfoRow]
+    let previewSections: [BusinessDocumentStudioPreviewSection]
+    let warnings: [BusinessDocumentStudioWarning]
+    let exportOptions: [BusinessDocumentStudioExportOptionPresentation]
+    let registryRoleLabels: [String]
+
+    init(inspection: BusinessDocumentStudioInspection) {
+        let summary = inspection.summary
+        title = summary.filename
+        subtitle = "\(summary.kind.displayName) - \(summary.formatId.uppercased())"
+        iconSystemName = summary.kind.systemImageName
+        summaryRows = Self.summaryRows(for: inspection)
+        structureRows = Self.structureRows(for: summary.structureSummary)
+        securityRows = Self.securityRows(for: inspection.security)
+        previewRows = Self.previewRows(for: inspection.preview)
+        previewSections = Self.previewSections(for: inspection.preview)
+        warnings = Self.warnings(for: inspection)
+        exportOptions = inspection.exportOptions.map(BusinessDocumentStudioExportOptionPresentation.init(option:))
+        registryRoleLabels = inspection.registryRoles.map(Self.roleLabel)
+    }
+
+    var availableExportOptions: [BusinessDocumentStudioExportOptionPresentation] {
+        exportOptions.filter(\.canExport)
+    }
+
+    var unavailableExportOptions: [BusinessDocumentStudioExportOptionPresentation] {
+        exportOptions.filter { !$0.canExport }
+    }
+
+    private static func summaryRows(
+        for inspection: BusinessDocumentStudioInspection
+    ) -> [BusinessDocumentStudioInfoRow] {
+        let summary = inspection.summary
+        var pairs = [
+            ("Kind", summary.kind.displayName),
+            ("Source format", summary.formatId),
+            ("Representation", summary.representationFormatId),
+            ("File size", fileSizeLabel(summary.fileSize)),
+            ("Parse limit", fileSizeLabel(inspection.parseLimitBytes)),
+            ("Text fallback", countLabel(summary.textFallbackUTF16Length, "UTF-16 unit")),
+        ]
+        if let fileExtension = summary.fileExtension {
+            pairs.insert(("Extension", ".\(fileExtension)"), at: 3)
+        }
+        return numberedRows(prefix: "summary", pairs)
+    }
+
+    private static func structureRows(
+        for summary: DocumentStructureSummary
+    ) -> [BusinessDocumentStudioInfoRow] {
+        numberedRows(prefix: "structure", [
+            ("Sheets", "\(summary.sheetCount)"),
+            ("Slides", "\(summary.slideCount)"),
+            ("Pages", "\(summary.pageCount)"),
+            ("Tables", "\(summary.tableCount)"),
+            ("Images", "\(summary.imageCount)"),
+            ("Charts", "\(summary.chartCount)"),
+            ("Text length", countLabel(summary.textLengthUTF16, "UTF-16 unit")),
+        ])
+    }
+
+    private static func securityRows(
+        for security: DocumentSecurityMetadata
+    ) -> [BusinessDocumentStudioInfoRow] {
+        var pairs = [
+            ("Inspection", inspectionLabel(security.inspectionStatus)),
+            ("Source trust", sourceTrustLabel(security.sourceTrust)),
+            ("Active content", security.activeContentTypes.isEmpty ? "None" : activeContentLabel(security.activeContentTypes)),
+            ("External references", "\(security.externalReferences.count)"),
+            ("Findings", "\(security.findings.count)"),
+        ]
+        if let isEncrypted = security.isEncrypted {
+            pairs.append(("Encrypted", isEncrypted ? "Yes" : "No"))
+        }
+        if let sha256 = security.sha256, !sha256.isEmpty {
+            pairs.append(("SHA-256", sha256))
+        }
+        return numberedRows(prefix: "security", pairs)
+    }
+
+    private static func previewRows(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioInfoRow] {
+        switch preview {
+        case .table(let table):
+            return numberedRows(prefix: "preview-table", [
+                ("Preview", "Delimited table"),
+                ("Delimiter", table.delimiter == .tab ? "Tab" : "Comma"),
+                ("Rows scanned", "\(table.rowsScanned)"),
+                ("Sampled rows", "\(table.sampledRowCount)"),
+                ("Columns", "\(table.columnCount)"),
+                ("Header", table.hasHeader ? "Detected" : "Not detected"),
+            ])
+
+        case .workbook(let workbook):
+            return numberedRows(prefix: "preview-workbook", [
+                ("Preview", "Workbook"),
+                ("Sheets", "\(workbook.inspection.sheetSummaries.count)"),
+                ("Rows", "\(workbook.inspection.totalRows)"),
+                ("Cells", "\(workbook.inspection.totalCells)"),
+                ("Formula cells", "\(workbook.inspection.formulaCellCount)"),
+                ("Merged ranges", "\(workbook.inspection.mergedRangeCount)"),
+            ])
+
+        case .pdf(let pdf):
+            return numberedRows(prefix: "preview-pdf", [
+                ("Preview", "PDF"),
+                ("Pages", "\(pdf.pageCount)"),
+                ("Sampled pages", "\(pdf.sampledPageCount)"),
+                ("Tables", "\(pdf.tableCount)"),
+                ("Table cells", "\(pdf.tableCellCount)"),
+                ("Text length", countLabel(pdf.totalTextUTF16Units, "UTF-16 unit")),
+            ])
+
+        case .presentation(let presentation):
+            return numberedRows(prefix: "preview-presentation", [
+                ("Preview", "Presentation"),
+                ("Slides", "\(presentation.slideCount)"),
+                ("Sampled slides", "\(presentation.sampledSlideCount)"),
+                ("Hidden slides", "\(presentation.hiddenSlideCount)"),
+                ("Speaker notes", "\(presentation.speakerNotesCount)"),
+                ("Tables", "\(presentation.tableCount)"),
+            ])
+
+        case .richText(let richText):
+            return numberedRows(prefix: "preview-rich-text", [
+                ("Preview", "Rich text"),
+                ("Source", richText.sourceLabel),
+                ("Blocks", "\(richText.blockCount)"),
+                ("Sampled blocks", "\(richText.sampledBlocks.count)"),
+                ("Text length", countLabel(richText.text.fullUTF16Length, "UTF-16 unit")),
+            ])
+
+        case .text(let text):
+            return numberedRows(prefix: "preview-text", [
+                ("Preview", "Text fallback"),
+                ("Text length", countLabel(text.fullUTF16Length, "UTF-16 unit")),
+                ("Truncated", text.isTruncated ? "Yes" : "No"),
+            ])
+        }
+    }
+
+    private static func previewSections(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioPreviewSection] {
+        switch preview {
+        case .table(let table):
+            let header = BusinessDocumentStudioPreviewSection(
+                id: "table-columns",
+                title: "Columns",
+                rows: table.columns.enumerated().map { offset, column in
+                    BusinessDocumentStudioInfoRow(
+                        id: "table-column-\(offset)",
+                        label: column.name,
+                        value: "\(column.inferredType.rawValue) - \(column.nonEmptyCount) filled"
+                    )
+                }
+            )
+            let samples = BusinessDocumentStudioPreviewSection(
+                id: "table-sample-rows",
+                title: "Sample rows",
+                rows: table.sampledRows.prefix(8).enumerated().map { offset, row in
+                    BusinessDocumentStudioInfoRow(
+                        id: "table-sample-row-\(offset)",
+                        label: "Row \(row.rowIndex + 1)",
+                        value: row.values.joined(separator: " | ")
+                    )
+                }
+            )
+            return [header, samples].filter { !$0.rows.isEmpty }
+
+        case .workbook(let workbook):
+            return workbook.sheets.enumerated().map { sheetOffset, sheet in
+                var rows = numberedRows(prefix: "workbook-sheet-\(sheetOffset)", [
+                    ("Rows", "\(sheet.rowCount)"),
+                    ("Cells", "\(sheet.cellCount)"),
+                    ("Formula cells", "\(sheet.formulaCellCount)"),
+                    ("Merged ranges", "\(sheet.mergedRangeCount)"),
+                ])
+                rows.append(
+                    contentsOf: sheet.sampleRows.prefix(6).enumerated().map { rowOffset, row in
+                        BusinessDocumentStudioInfoRow(
+                            id: "workbook-sheet-\(sheetOffset)-sample-row-\(rowOffset)",
+                            label: "Row \(row.number)",
+                            value: row.cells.map { cell in
+                                "\(cell.reference): \(cell.text.text)"
+                            }.joined(separator: " | ")
+                        )
+                    }
+                )
+                return BusinessDocumentStudioPreviewSection(
+                    id: "workbook-sheet-\(sheetOffset)",
+                    title: sheet.name,
+                    rows: rows
+                )
+            }
+
+        case .pdf(let pdf):
+            return pdf.pages.enumerated().map { offset, page in
+                BusinessDocumentStudioPreviewSection(
+                    id: "pdf-page-\(offset)",
+                    title: "Page \(page.pageIndex + 1)",
+                    rows: numberedRows(prefix: "pdf-page-\(offset)", [
+                        ("Text", page.text.text),
+                        ("Tables", "\(page.tableCount)"),
+                    ])
+                )
+            }
+
+        case .presentation(let presentation):
+            return presentation.slides.enumerated().map { offset, slide in
+                BusinessDocumentStudioPreviewSection(
+                    id: "presentation-slide-\(offset)",
+                    title: slide.label,
+                    rows: numberedRows(prefix: "presentation-slide-\(offset)", [
+                        ("Slide", "\(slide.slideNumber)"),
+                        ("Hidden", slide.isHidden ? "Yes" : "No"),
+                        ("Text", slide.text.text),
+                        ("Tables", "\(slide.tableCount)"),
+                    ])
+                )
+            }
+
+        case .richText(let richText):
+            return [
+                BusinessDocumentStudioPreviewSection(
+                    id: "rich-text-blocks",
+                    title: "Blocks",
+                    rows: richText.sampledBlocks.enumerated().map { offset, block in
+                        BusinessDocumentStudioInfoRow(
+                            id: "rich-text-block-\(offset)",
+                            label: block.kind.rawValue,
+                            value: block.text.text
+                        )
+                    }
+                ),
+            ]
+
+        case .text(let text):
+            return [
+                BusinessDocumentStudioPreviewSection(
+                    id: "text-sample",
+                    title: "Text",
+                    rows: [BusinessDocumentStudioInfoRow(id: "text-sample-row", label: "Sample", value: text.text)]
+                ),
+            ]
+        }
+    }
+
+    private static func warnings(
+        for inspection: BusinessDocumentStudioInspection
+    ) -> [BusinessDocumentStudioWarning] {
+        var warnings: [BusinessDocumentStudioWarning] = []
+        let security = inspection.security
+
+        if security.inspectionStatus != .inspected {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Extraction inspection",
+                    message: "Security inspection is \(inspectionLabel(security.inspectionStatus).lowercased())."
+                )
+            )
+        }
+
+        if let isEncrypted = security.isEncrypted, isEncrypted {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Encrypted content",
+                    message: "The adapter reported encrypted content in this document."
+                )
+            )
+        }
+
+        if !security.activeContentTypes.isEmpty {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "Active content",
+                    message: activeContentLabel(security.activeContentTypes)
+                )
+            )
+        }
+
+        if !security.externalReferences.isEmpty {
+            warnings.append(
+                BusinessDocumentStudioWarning(
+                    severity: .caution,
+                    title: "External references",
+                    message: "\(security.externalReferences.count) external reference(s) were recorded."
+                )
+            )
+        }
+
+        warnings.append(contentsOf: security.findings.map { finding in
+            BusinessDocumentStudioWarning(
+                severity: warningSeverity(for: finding.severity),
+                title: finding.kind.rawValue,
+                message: finding.message
+            )
+        })
+
+        warnings.append(contentsOf: previewWarnings(for: inspection.preview))
+        warnings.append(
+            contentsOf: inspection.exportOptions.filter { !$0.canExport }.map { option in
+                BusinessDocumentStudioWarning(
+                    severity: .blocked,
+                    title: "Export unavailable: \(option.label)",
+                    message: "\(exportReasonLabel(option.reason)) - \(option.message)"
+                )
+            }
+        )
+
+        return warnings
+    }
+
+    private static func previewWarnings(
+        for preview: BusinessDocumentStudioPreview
+    ) -> [BusinessDocumentStudioWarning] {
+        switch preview {
+        case .table(let table):
+            var messages: [String] = []
+            if table.truncatedByByteLimit { messages.append("byte limit") }
+            if table.truncatedByRowLimit { messages.append("row limit") }
+            if table.truncatedByColumnLimit { messages.append("column limit") }
+            return truncationWarnings(messages)
+
+        case .workbook(let workbook):
+            var messages: [String] = []
+            if workbook.isSheetSampleTruncated { messages.append("sheet limit") }
+            if workbook.sheets.contains(where: \.isRowSampleTruncated) { messages.append("row limit") }
+            if workbook.sheets.contains(where: \.isColumnSampleTruncated) { messages.append("column limit") }
+            return truncationWarnings(messages)
+
+        case .pdf(let pdf):
+            return truncationWarnings(pdf.isPageSampleTruncated ? ["page limit"] : [])
+
+        case .presentation(let presentation):
+            return truncationWarnings(presentation.isSlideSampleTruncated ? ["slide limit"] : [])
+
+        case .richText(let richText):
+            var messages: [String] = []
+            if richText.isBlockSampleTruncated { messages.append("block limit") }
+            if richText.text.isTruncated { messages.append("text limit") }
+            return truncationWarnings(messages)
+
+        case .text(let text):
+            return truncationWarnings(text.isTruncated ? ["text limit"] : [])
+        }
+    }
+
+    private static func truncationWarnings(_ reasons: [String]) -> [BusinessDocumentStudioWarning] {
+        guard !reasons.isEmpty else { return [] }
+        return [
+            BusinessDocumentStudioWarning(
+                severity: .info,
+                title: "Preview truncated",
+                message: "The preview sample reached the \(reasons.joined(separator: ", "))."
+            ),
+        ]
+    }
+
+    private static func warningSeverity(
+        for severity: DocumentSecurityFinding.Severity
+    ) -> BusinessDocumentStudioWarning.Severity {
+        switch severity {
+        case .informational, .low:
+            return .info
+        case .medium:
+            return .caution
+        case .high, .critical:
+            return .blocked
+        }
+    }
+
+    private static func roleLabel(_ role: DocumentFormatRegistrationRole) -> String {
+        switch role {
+        case .adapter: return "Adapter"
+        case .emitter: return "Emitter"
+        case .streamer: return "Streamer"
+        }
+    }
+
+    private static func inspectionLabel(_ status: DocumentSecurityMetadata.InspectionStatus) -> String {
+        switch status {
+        case .inspected: return "Inspected"
+        case .partiallyInspected: return "Partially inspected"
+        case .notInspected: return "Not inspected"
+        case .failed: return "Failed"
+        }
+    }
+
+    private static func sourceTrustLabel(_ sourceTrust: DocumentSecurityMetadata.SourceTrust) -> String {
+        switch sourceTrust {
+        case .userSelectedLocalFile: return "User-selected local file"
+        case .generatedArtifact: return "Generated artifact"
+        case .pluginProvided: return "Plugin-provided"
+        case .remoteDownload: return "Remote download"
+        case .pastedContent: return "Pasted content"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    private static func activeContentLabel(_ contentTypes: Set<DocumentActiveContentType>) -> String {
+        contentTypes
+            .map(\.rawValue)
+            .sorted()
+            .joined(separator: ", ")
+    }
+
+    fileprivate static func exportReasonLabel(_ reason: BusinessDocumentStudioExportReason) -> String {
+        switch reason {
+        case .available: return "Ready"
+        case .missingEmitter: return "Missing emitter"
+        case .validationFailed: return "Validation failed"
+        case .unsupportedFormat: return "Unsupported format"
+        case .textFallbackAvailable: return "Text fallback"
+        case .textFallbackTooLarge: return "Text fallback too large"
+        }
+    }
+
+    private static func fileSizeLabel(_ byteCount: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)
+    }
+
+    private static func countLabel(_ count: Int, _ noun: String) -> String {
+        "\(count) \(noun)\(count == 1 ? "" : "s")"
+    }
+
+    private static func numberedRows(
+        prefix: String,
+        _ pairs: [(label: String, value: String)]
+    ) -> [BusinessDocumentStudioInfoRow] {
+        pairs.enumerated().map { offset, pair in
+            BusinessDocumentStudioInfoRow(
+                id: "\(prefix)-\(offset)",
+                label: pair.label,
+                value: pair.value
+            )
+        }
+    }
+}
+
+struct BusinessDocumentStudioInfoRow: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let value: String
+
+    init(id: String? = nil, label: String, value: String) {
+        self.id = id ?? "\(label):\(value)"
+        self.label = label
+        self.value = value
+    }
+
+    static func == (lhs: BusinessDocumentStudioInfoRow, rhs: BusinessDocumentStudioInfoRow) -> Bool {
+        lhs.label == rhs.label && lhs.value == rhs.value
+    }
+}
+
+struct BusinessDocumentStudioPreviewSection: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let rows: [BusinessDocumentStudioInfoRow]
+
+    init(id: String? = nil, title: String, rows: [BusinessDocumentStudioInfoRow]) {
+        self.id = id ?? title
+        self.title = title
+        self.rows = rows
+    }
+}
+
+struct BusinessDocumentStudioWarning: Identifiable, Equatable {
+    enum Severity: String, Equatable {
+        case info
+        case caution
+        case blocked
+    }
+
+    let id: String
+    let severity: Severity
+    let title: String
+    let message: String
+
+    init(severity: Severity, title: String, message: String) {
+        id = "\(severity.rawValue):\(title):\(message)"
+        self.severity = severity
+        self.title = title
+        self.message = message
+    }
+}
+
+struct BusinessDocumentStudioExportOptionPresentation: Identifiable, Equatable {
+    let id: String
+    let targetFormatId: String
+    let fileExtension: String
+    let label: String
+    let canExport: Bool
+    let reason: BusinessDocumentStudioExportReason
+    let reasonLabel: String
+    let statusLabel: String
+    let message: String
+
+    init(option: BusinessDocumentStudioExportOption) {
+        id = option.targetFormatId
+        targetFormatId = option.targetFormatId
+        fileExtension = option.fileExtension
+        label = option.label
+        canExport = option.canExport
+        reason = option.reason
+        reasonLabel = BusinessDocumentStudioPresentation.exportReasonLabel(option.reason)
+        statusLabel = option.canExport ? "Available" : "Unavailable"
+        message = option.message
+    }
+}
+
+struct BusinessDocumentStudioExportReceipt: Equatable {
+    let url: URL
+    let sourceFormatId: String
+    let targetFormatId: String
+    let bytesWritten: Int64
+    let message: String
+
+    init(result: BusinessDocumentStudioExportResult) {
+        url = result.url
+        sourceFormatId = result.sourceFormatId
+        targetFormatId = result.targetFormatId
+        bytesWritten = result.bytesWritten
+        message = result.message
+    }
+}
+
+struct BusinessDocumentStudioExportBlock: Equatable {
+    enum Kind: String, Equatable {
+        case unavailableOption
+        case destinationAlreadyExists
+        case destinationOutsideAllowedDirectory
+        case destinationIsNotFileURL
+        case unsafePackageTarget
+        case packageExtensionMismatch
+        case textFallbackTooLarge
+        case unsupportedExport
+    }
+
+    let kind: Kind
+    let optionID: String
+    let message: String
+    let path: String?
+    let reason: BusinessDocumentStudioExportReason?
+}

--- a/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
+++ b/Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift
@@ -1,0 +1,420 @@
+//
+//  BusinessDocumentStudioView.swift
+//  osaurus
+//
+//  UI for inspecting BusinessDocumentStudioService previews and export
+//  availability without routing the document through chat.
+//
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BusinessDocumentStudioView: View {
+    private let sourceURL: URL?
+
+    @StateObject private var presenter: BusinessDocumentStudioPresenter
+
+    init(
+        sourceURL: URL? = nil,
+        presenter: BusinessDocumentStudioPresenter = BusinessDocumentStudioPresenter()
+    ) {
+        self.sourceURL = sourceURL
+        _presenter = StateObject(wrappedValue: presenter)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            chrome
+            Divider()
+            content
+        }
+        .frame(minWidth: 720, minHeight: 520)
+        .task(id: sourceURL) {
+            guard let sourceURL else { return }
+            await presenter.load(url: sourceURL)
+        }
+    }
+
+    private var chrome: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: "Business Document Studio")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(verbatim: "Preview and export availability")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 16)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch presenter.loadState {
+        case .idle:
+            emptyState(
+                systemImage: "doc.badge.plus",
+                title: "No document loaded",
+                message: "Open a supported business document to inspect preview, security, and export availability."
+            )
+
+        case .loading(let url):
+            VStack(spacing: 12) {
+                ProgressView()
+                Text(verbatim: url?.lastPathComponent ?? "Loading document")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        case .failed(let message):
+            emptyState(
+                systemImage: "exclamationmark.triangle",
+                title: "Document unavailable",
+                message: message
+            )
+
+        case .loaded(let presentation):
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    documentHeader(presentation)
+                    StudioSection(title: "Metadata") {
+                        infoGrid(presentation.summaryRows)
+                    }
+                    StudioSection(title: "Structure") {
+                        infoGrid(presentation.structureRows)
+                    }
+                    StudioSection(title: "Security and Extraction") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            infoGrid(presentation.securityRows)
+                            warningsView(presentation.warnings)
+                        }
+                    }
+                    StudioSection(title: "Preview") {
+                        VStack(alignment: .leading, spacing: 14) {
+                            infoGrid(presentation.previewRows)
+                            previewSections(presentation.previewSections)
+                        }
+                    }
+                    StudioSection(title: "Export Options") {
+                        VStack(alignment: .leading, spacing: 10) {
+                            exportStateView
+                            ForEach(presentation.exportOptions) { option in
+                                exportOptionRow(option, presentation: presentation)
+                            }
+                        }
+                    }
+                }
+                .padding(18)
+            }
+        }
+    }
+
+    private func documentHeader(_ presentation: BusinessDocumentStudioPresentation) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: presentation.iconSystemName)
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(verbatim: presentation.title)
+                    .font(.system(size: 18, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                HStack(spacing: 8) {
+                    Text(verbatim: presentation.subtitle)
+                    if !presentation.registryRoleLabels.isEmpty {
+                        Text(verbatim: presentation.registryRoleLabels.joined(separator: " / "))
+                    }
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            }
+
+            Spacer(minLength: 16)
+        }
+    }
+
+    private func infoGrid(_ rows: [BusinessDocumentStudioInfoRow]) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 7) {
+            ForEach(rows) { row in
+                GridRow(alignment: .firstTextBaseline) {
+                    Text(verbatim: row.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 140, alignment: .leading)
+                    Text(verbatim: row.value)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.primary)
+                        .textSelection(.enabled)
+                        .lineLimit(3)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func warningsView(_ warnings: [BusinessDocumentStudioWarning]) -> some View {
+        if warnings.isEmpty {
+            Label {
+                Text(verbatim: "No extraction or export warnings")
+            } icon: {
+                Image(systemName: "checkmark.circle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(warnings) { warning in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: iconName(for: warning.severity))
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(color(for: warning.severity))
+                            .frame(width: 16, height: 16)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: warning.title)
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(verbatim: warning.message)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func previewSections(_ sections: [BusinessDocumentStudioPreviewSection]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(sections) { section in
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(verbatim: section.title)
+                        .font(.system(size: 12, weight: .semibold))
+                    ForEach(section.rows) { row in
+                        HStack(alignment: .firstTextBaseline, spacing: 10) {
+                            Text(verbatim: row.label)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 96, alignment: .leading)
+                            Text(verbatim: row.value)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.primary)
+                                .lineLimit(3)
+                                .truncationMode(.tail)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var exportStateView: some View {
+        switch presenter.exportState {
+        case .idle:
+            EmptyView()
+
+        case .exporting(let optionID):
+            Label {
+                Text(verbatim: "Exporting \(optionID.uppercased())")
+            } icon: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+        case .succeeded(let receipt):
+            Label {
+                Text(verbatim: receipt.message)
+            } icon: {
+                Image(systemName: "checkmark.circle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.green)
+                .help(receipt.url.path)
+
+        case .blocked(let block):
+            Label {
+                Text(verbatim: block.message)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.orange)
+                .help(block.path ?? block.optionID)
+
+        case .failed(let message):
+            Label {
+                Text(verbatim: message)
+            } icon: {
+                Image(systemName: "xmark.octagon")
+            }
+                .font(.system(size: 12))
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func exportOptionRow(
+        _ option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: option.canExport ? "square.and.arrow.up" : "nosign")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(option.canExport ? Color.secondary : Color.orange)
+                .frame(width: 20, height: 20)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(verbatim: option.label)
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(verbatim: option.statusLabel)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(option.canExport ? Color.secondary : Color.orange)
+                    Text(verbatim: option.reasonLabel)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+                Text(verbatim: option.message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Button {
+                beginExport(option, presentation: presentation)
+            } label: {
+                Label {
+                    Text(verbatim: "Export")
+                } icon: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(!option.canExport)
+            .help(option.canExport ? "Export \(option.label)" : option.message)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+    }
+
+    private func beginExport(
+        _ option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.title = L("Export")
+        panel.message = option.label
+        panel.nameFieldStringValue = defaultExportName(for: option, presentation: presentation)
+        if let contentType = UTType(filenameExtension: option.fileExtension) {
+            panel.allowedContentTypes = [contentType]
+        }
+
+        Task { @MainActor in
+            guard await panel.beginModal() == .OK, let url = panel.url else { return }
+            await presenter.export(
+                optionID: option.id,
+                to: url,
+                allowedDirectory: url.deletingLastPathComponent(),
+                allowOverwrite: true
+            )
+        }
+    }
+
+    private func defaultExportName(
+        for option: BusinessDocumentStudioExportOptionPresentation,
+        presentation: BusinessDocumentStudioPresentation
+    ) -> String {
+        let stem = (presentation.title as NSString).deletingPathExtension
+        let basename = stem.isEmpty ? "document" : stem
+        return "\(basename).\(option.fileExtension)"
+    }
+
+    private func emptyState(
+        systemImage: String,
+        title: String,
+        message: String
+    ) -> some View {
+        VStack(spacing: 9) {
+            Image(systemName: systemImage)
+                .font(.system(size: 24, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(verbatim: title)
+                .font(.system(size: 14, weight: .semibold))
+            Text(verbatim: message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    private func iconName(for severity: BusinessDocumentStudioWarning.Severity) -> String {
+        switch severity {
+        case .info: return "info.circle"
+        case .caution: return "exclamationmark.triangle"
+        case .blocked: return "xmark.octagon"
+        }
+    }
+
+    private func color(for severity: BusinessDocumentStudioWarning.Severity) -> Color {
+        switch severity {
+        case .info: return .secondary
+        case .caution: return .orange
+        case .blocked: return .red
+        }
+    }
+}
+
+private struct StudioSection<Content: View>: View {
+    let title: String
+    private let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(verbatim: title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            content
+            Divider()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a File menu entry for opening supported business documents in a dedicated studio window.
- Builds a presenter and SwiftUI view on top of the existing `BusinessDocumentStudioService` for inspection summaries, previews, export options, and export result states.
- Covers destination safety, blocked exports, stable presentation identifiers, and the interactive overwrite path after save-panel consent.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-business-rebased swift test --package-path Packages/OsaurusCore --scratch-path Packages/OsaurusCore/.build --filter BusinessDocumentStudioPresenterTests`
- `git diff origin/main...HEAD --check`
- `bash scripts/i18n/check.sh`
- `swiftlint lint App/osaurus/osaurusApp.swift Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioLauncher.swift Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioView.swift Packages/OsaurusCore/Views/Documents/BusinessDocumentStudioPresenter.swift Packages/OsaurusCore/Tests/Documents/BusinessDocumentStudioPresenterTests.swift`
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"`

## Notes
- The local app build succeeds; Xcode emits a machine-level CoreSimulator version warning before building macOS targets.
