### PR TITLE
Add Computer Use diagnostics

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUseGateInspector.swift
+++ b/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUseGateInspector.swift
@@ -1,0 +1,320 @@
+//
+//  ComputerUseGateInspector.swift
+//  OsaurusCore - Computer Use
+//
+//  Observational autonomy diagnostics for Settings -> Computer Use. The
+//  inspector deliberately calls the same classifier and gate used by the live
+//  loop, then annotates the decision with the policy merge inputs.
+//
+
+import Foundation
+
+enum ComputerUseGateDecisionKind: String, Sendable, Equatable {
+    case run
+    case confirm
+    case reject
+}
+
+struct ComputerUseAllowlistInspection: Sendable, Equatable {
+    let isReached: Bool
+    let isActive: Bool
+    let isAllowed: Bool
+    let normalizedApp: String?
+    let entries: [String]
+
+    var displayValue: String {
+        if !isReached { return "Not reached" }
+        if !isActive { return "Open" }
+        return isAllowed ? "Allowed" : "Blocked"
+    }
+}
+
+struct ComputerUseGateContribution: Sendable, Equatable {
+    let label: String
+    let disposition: AutonomyDisposition
+}
+
+struct ComputerUseGateInspectionInput: Sendable, Equatable {
+    var policy: AutonomyPolicy
+    var ceiling: AutonomyCeiling?
+    var appName: String?
+    var verb: AgentVerb
+    var targetLabel: String?
+    var targetRole: String?
+    var targetValue: String?
+    var targetRoleDescription: String?
+    var targetDescription: String?
+    var note: String?
+    var text: String?
+    var key: String?
+    var modifiers: [String]
+
+    init(
+        policy: AutonomyPolicy,
+        ceiling: AutonomyCeiling? = nil,
+        appName: String? = "Notes",
+        verb: AgentVerb = .click,
+        targetLabel: String? = "Save",
+        targetRole: String? = "AXButton",
+        targetValue: String? = nil,
+        targetRoleDescription: String? = nil,
+        targetDescription: String? = nil,
+        note: String? = nil,
+        text: String? = nil,
+        key: String? = nil,
+        modifiers: [String] = []
+    ) {
+        self.policy = policy
+        self.ceiling = ceiling
+        self.appName = appName
+        self.verb = verb
+        self.targetLabel = targetLabel
+        self.targetRole = targetRole
+        self.targetValue = targetValue
+        self.targetRoleDescription = targetRoleDescription
+        self.targetDescription = targetDescription
+        self.note = note
+        self.text = text
+        self.key = key
+        self.modifiers = modifiers
+    }
+}
+
+struct ComputerUseGateInspection: Sendable, Equatable {
+    let action: AgentAction
+    let effect: EffectClass
+    let gateIsReached: Bool
+    let allowlist: ComputerUseAllowlistInspection
+    let globalContribution: ComputerUseGateContribution
+    let perAppContribution: ComputerUseGateContribution?
+    let ceilingContribution: ComputerUseGateContribution?
+    let policyDisposition: AutonomyDisposition
+    let dangerousAppRequiresConfirm: Bool
+    let finalDisposition: AutonomyDisposition?
+    let decision: GateDecision
+    let decisionKind: ComputerUseGateDecisionKind
+    let decisionSummary: String
+}
+
+enum ComputerUseGateInspector {
+    static func inspect(_ input: ComputerUseGateInspectionInput) async -> ComputerUseGateInspection {
+        let action = makeAction(from: input)
+        let appName = appNameForGate(input: input, action: action)
+        let targetLabel = targetLabelForGate(input: input, action: action)
+        let isOpen = action.verb == .open
+        let effect = EffectClassifier.classify(
+            action: action,
+            resolvedRole: isOpen ? nil : nonEmpty(input.targetRole),
+            resolvedLabel: isOpen ? nil : nonEmpty(input.targetLabel),
+            resolvedValue: isOpen ? nil : nonEmpty(input.targetValue),
+            resolvedRoleDescription: isOpen ? nil : nonEmpty(input.targetRoleDescription),
+            appName: appName,
+            recipeSignals: AppRecipes.signals(for: appName)
+        )
+
+        let gateIsReached = isGatedVerb(input.verb)
+        let allowlist = allowlistInspection(
+            policy: input.policy,
+            appName: appName,
+            isReached: gateIsReached
+        )
+        let global = ComputerUseGateContribution(
+            label: input.policy.globalPreset.displayLabel,
+            disposition: input.policy.globalPreset.disposition(for: effect)
+        )
+        let perApp = perAppContribution(policy: input.policy, appName: appName, effect: effect)
+        let ceiling = ceilingContribution(ceiling: input.ceiling, effect: effect)
+        let policyDisposition = input.policy.disposition(
+            for: effect,
+            app: appName,
+            ceiling: input.ceiling
+        )
+        let dangerousConfirm = effect >= .navigate && input.policy.requiresForcedConfirm(app: appName)
+        let finalDisposition: AutonomyDisposition?
+        let decision: GateDecision
+        let decisionText: String
+        if gateIsReached {
+            finalDisposition = allowlist.isAllowed
+                ? (dangerousConfirm
+                    ? AutonomyDisposition.strictest(policyDisposition, .confirm)
+                    : policyDisposition)
+                : nil
+            decision = await ComputerUseGate(policy: input.policy, ceiling: input.ceiling).evaluate(
+                action: action,
+                effect: effect,
+                appName: appName,
+                targetLabel: targetLabel
+            )
+            decisionText = decisionSummary(decision)
+        } else {
+            finalDisposition = nil
+            decision = .run
+            decisionText = "Handled before autonomy gating in the live loop."
+        }
+
+        return ComputerUseGateInspection(
+            action: action,
+            effect: effect,
+            gateIsReached: gateIsReached,
+            allowlist: allowlist,
+            globalContribution: global,
+            perAppContribution: perApp,
+            ceilingContribution: ceiling,
+            policyDisposition: policyDisposition,
+            dangerousAppRequiresConfirm: dangerousConfirm,
+            finalDisposition: finalDisposition,
+            decision: decision,
+            decisionKind: decisionKind(decision),
+            decisionSummary: decisionText
+        )
+    }
+
+    private static func isGatedVerb(_ verb: AgentVerb) -> Bool {
+        switch verb {
+        case .observe, .wait, .find, .done, .giveUp:
+            return false
+        case .click, .doubleClick, .rightClick, .drag, .type, .setValue, .clear, .pressKey, .scroll, .open:
+            return true
+        }
+    }
+
+    private static func makeAction(from input: ComputerUseGateInspectionInput) -> AgentAction {
+        let target = target(from: input)
+        let note = nonEmpty(input.note)
+        switch input.verb {
+        case .observe:
+            return AgentAction(verb: .observe, note: note)
+        case .wait:
+            return AgentAction(verb: .wait, seconds: 1, note: note)
+        case .find:
+            return AgentAction(
+                verb: .find,
+                query: nonEmpty(input.targetLabel) ?? nonEmpty(input.targetDescription),
+                roles: nonEmpty(input.targetRole).map { [$0] } ?? [],
+                note: note
+            )
+        case .click, .doubleClick, .rightClick:
+            return AgentAction(verb: input.verb, target: target, note: note)
+        case .drag:
+            return AgentAction(verb: .drag, target: target, to: AgentTarget(describe: "destination"), note: note)
+        case .type:
+            return AgentAction(
+                verb: .type,
+                target: target,
+                text: nonEmpty(input.text) ?? "sample text",
+                replace: true,
+                note: note
+            )
+        case .setValue:
+            return AgentAction(
+                verb: .setValue,
+                target: target,
+                text: nonEmpty(input.text) ?? "sample value",
+                note: note
+            )
+        case .clear:
+            return AgentAction(verb: .clear, target: target, note: note)
+        case .pressKey:
+            return AgentAction(
+                verb: .pressKey,
+                key: nonEmpty(input.key) ?? "return",
+                modifiers: input.modifiers,
+                note: note
+            )
+        case .scroll:
+            return AgentAction(verb: .scroll, target: target, direction: .down, amount: 3, note: note)
+        case .open:
+            return AgentAction(verb: .open, app: nonEmpty(input.appName), note: note)
+        case .done:
+            return AgentAction(verb: .done, note: note, reason: note)
+        case .giveUp:
+            return AgentAction(verb: .giveUp, note: note, reason: note)
+        }
+    }
+
+    private static func target(from input: ComputerUseGateInspectionInput) -> AgentTarget? {
+        guard let describe = nonEmpty(input.targetDescription) ?? nonEmpty(input.targetLabel) else {
+            return nil
+        }
+        return AgentTarget(describe: describe)
+    }
+
+    private static func appNameForGate(input: ComputerUseGateInspectionInput, action: AgentAction) -> String? {
+        if action.verb == .open {
+            return nonEmpty(action.app) ?? nonEmpty(input.appName)
+        }
+        return nonEmpty(input.appName)
+    }
+
+    private static func targetLabelForGate(input: ComputerUseGateInspectionInput, action: AgentAction) -> String? {
+        if action.verb == .open {
+            return nonEmpty(action.app) ?? nonEmpty(input.appName)
+        }
+        return nonEmpty(input.targetLabel) ?? nonEmpty(input.targetDescription)
+    }
+
+    private static func allowlistInspection(
+        policy: AutonomyPolicy,
+        appName: String?,
+        isReached: Bool
+    ) -> ComputerUseAllowlistInspection {
+        let entries = (policy.allowlist ?? []).map(AutonomyPolicy.normalize).sorted()
+        let normalizedApp = nonEmpty(appName).map(AutonomyPolicy.normalize)
+        return ComputerUseAllowlistInspection(
+            isReached: isReached,
+            isActive: !entries.isEmpty,
+            isAllowed: policy.isAppAllowed(appName),
+            normalizedApp: normalizedApp,
+            entries: entries
+        )
+    }
+
+    private static func perAppContribution(
+        policy: AutonomyPolicy,
+        appName: String?,
+        effect: EffectClass
+    ) -> ComputerUseGateContribution? {
+        guard let appName else { return nil }
+        guard let preset = policy.perApp[AutonomyPolicy.normalize(appName)] else { return nil }
+        return ComputerUseGateContribution(
+            label: preset.displayLabel,
+            disposition: preset.disposition(for: effect)
+        )
+    }
+
+    private static func ceilingContribution(
+        ceiling: AutonomyCeiling?,
+        effect: EffectClass
+    ) -> ComputerUseGateContribution? {
+        guard let cap = ceiling?.cap(for: effect) else { return nil }
+        let label = ceiling?.matchingPreset.map { "At most: \($0.displayLabel)" } ?? "Custom ceiling"
+        return ComputerUseGateContribution(label: label, disposition: cap)
+    }
+
+    private static func decisionKind(_ decision: GateDecision) -> ComputerUseGateDecisionKind {
+        switch decision {
+        case .run:
+            return .run
+        case .confirm:
+            return .confirm
+        case .reject:
+            return .reject
+        }
+    }
+
+    private static func decisionSummary(_ decision: GateDecision) -> String {
+        switch decision {
+        case .run:
+            return "Auto-run"
+        case .confirm(let preview):
+            return "Ask first: \(preview.summary)"
+        case .reject(let reason):
+            return "Blocked: \(reason)"
+        }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUsePermissionDoctor.swift
+++ b/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUsePermissionDoctor.swift
@@ -1,0 +1,321 @@
+//
+//  ComputerUsePermissionDoctor.swift
+//  OsaurusCore - Computer Use
+//
+//  Read-only diagnostics for the Computer Use settings panel. This file keeps
+//  the status mapping pure so the UI can summarize existing cached state
+//  without adding new live Accessibility probes.
+//
+
+import Foundation
+
+enum ComputerUseDiagnosticSeverity: String, Sendable, Equatable {
+    case ready
+    case attention
+    case inactive
+    case info
+}
+
+enum ComputerUsePermissionDoctorRowID: String, Sendable, CaseIterable {
+    case accessibility
+    case screenRecording
+    case axPosture
+    case cloudVision
+    case screenContext
+    case perAgent
+    case dangerousAppGuardrail
+}
+
+struct ComputerUseDiagnosticRow: Identifiable, Sendable, Equatable {
+    let id: ComputerUsePermissionDoctorRowID
+    let title: String
+    let value: String
+    let detail: String
+    let severity: ComputerUseDiagnosticSeverity
+}
+
+struct ComputerUseAgentAvailabilityInput: Sendable, Equatable {
+    let id: UUID
+    let displayName: String
+    let isBuiltIn: Bool
+    let computerUseEnabled: Bool
+    let hasEffectiveModel: Bool
+    let ceilingPreset: AutonomyPreset?
+
+    init(
+        id: UUID = UUID(),
+        displayName: String,
+        isBuiltIn: Bool,
+        computerUseEnabled: Bool,
+        hasEffectiveModel: Bool,
+        ceilingPreset: AutonomyPreset? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.isBuiltIn = isBuiltIn
+        self.computerUseEnabled = computerUseEnabled
+        self.hasEffectiveModel = hasEffectiveModel
+        self.ceilingPreset = ceilingPreset
+    }
+}
+
+struct ComputerUseCloudVisionDoctorInput: Sendable, Equatable {
+    let isGranted: Bool
+    let isPersistentlyGranted: Bool
+    let isSessionGranted: Bool
+    let scrubMode: ScrubMode
+}
+
+struct ComputerUsePermissionDoctorInput: Sendable, Equatable {
+    let availability: MacDriverAvailability
+    let cloudVision: ComputerUseCloudVisionDoctorInput
+    let screenContextEnabled: Bool
+    let agents: [ComputerUseAgentAvailabilityInput]
+}
+
+struct ComputerUseAgentAvailabilityRow: Identifiable, Sendable, Equatable {
+    let id: UUID
+    let name: String
+    let value: String
+    let detail: String
+    let severity: ComputerUseDiagnosticSeverity
+}
+
+struct ComputerUseAgentAvailabilitySummary: Sendable, Equatable {
+    let customAgentCount: Int
+    let enabledCustomAgentCount: Int
+    let rows: [ComputerUseAgentAvailabilityRow]
+}
+
+struct ComputerUsePermissionDoctorSnapshot: Sendable, Equatable {
+    let rows: [ComputerUseDiagnosticRow]
+    let agentAvailability: ComputerUseAgentAvailabilitySummary
+    let dangerousAppNeedleCount: Int
+
+    func row(_ id: ComputerUsePermissionDoctorRowID) -> ComputerUseDiagnosticRow? {
+        rows.first { $0.id == id }
+    }
+}
+
+enum ComputerUsePermissionDoctor {
+    static func snapshot(input: ComputerUsePermissionDoctorInput) -> ComputerUsePermissionDoctorSnapshot {
+        let agentSummary = agentAvailability(from: input.agents)
+        let rows: [ComputerUseDiagnosticRow] = [
+            accessibilityRow(granted: input.availability.accessibility),
+            screenRecordingRow(granted: input.availability.screenRecording),
+            axPostureRow(availability: input.availability),
+            cloudVisionRow(
+                screenRecordingGranted: input.availability.screenRecording,
+                cloudVision: input.cloudVision
+            ),
+            screenContextRow(
+                enabled: input.screenContextEnabled,
+                accessibilityGranted: input.availability.accessibility
+            ),
+            perAgentRow(summary: agentSummary),
+            dangerousAppGuardrailRow(),
+        ]
+        return ComputerUsePermissionDoctorSnapshot(
+            rows: rows,
+            agentAvailability: agentSummary,
+            dangerousAppNeedleCount: AutonomyPolicy.forcedConfirmAppNeedles.count
+        )
+    }
+
+    private static func accessibilityRow(granted: Bool) -> ComputerUseDiagnosticRow {
+        ComputerUseDiagnosticRow(
+            id: .accessibility,
+            title: "Accessibility",
+            value: granted ? "Granted" : "Missing",
+            detail: granted
+                ? "AX tree reads and input control are available to Computer Use."
+                : "Computer Use cannot start until Accessibility is granted.",
+            severity: granted ? .ready : .attention
+        )
+    }
+
+    private static func screenRecordingRow(granted: Bool) -> ComputerUseDiagnosticRow {
+        ComputerUseDiagnosticRow(
+            id: .screenRecording,
+            title: "Screen Recording",
+            value: granted ? "Granted" : "Optional",
+            detail: granted
+                ? "Screenshot tiers are available when AX text is not enough."
+                : "Screenshot tiers are unavailable; the harness stays on AX-only capture.",
+            severity: granted ? .ready : .inactive
+        )
+    }
+
+    private static func axPostureRow(availability: MacDriverAvailability) -> ComputerUseDiagnosticRow {
+        if !availability.accessibility {
+            return ComputerUseDiagnosticRow(
+                id: .axPosture,
+                title: "AX-only posture",
+                value: "Blocked",
+                detail: "AX-only mode still needs Accessibility before any run can start.",
+                severity: .attention
+            )
+        }
+        if availability.screenRecording {
+            return ComputerUseDiagnosticRow(
+                id: .axPosture,
+                title: "AX-only posture",
+                value: "AX-first with screenshot fallback",
+                detail: "Runs start from Accessibility text and may escalate to SOM/Vision when needed.",
+                severity: .ready
+            )
+        }
+        return ComputerUseDiagnosticRow(
+            id: .axPosture,
+            title: "AX-only posture",
+            value: "AX-only",
+            detail: "Runs can read and act through Accessibility text without capturing pixels.",
+            severity: .ready
+        )
+    }
+
+    private static func cloudVisionRow(
+        screenRecordingGranted: Bool,
+        cloudVision: ComputerUseCloudVisionDoctorInput
+    ) -> ComputerUseDiagnosticRow {
+        guard screenRecordingGranted else {
+            return ComputerUseDiagnosticRow(
+                id: .cloudVision,
+                title: "Cloud vision",
+                value: "Unavailable",
+                detail: "Remote image fallback needs Screen Recording plus explicit consent.",
+                severity: .inactive
+            )
+        }
+        guard cloudVision.isGranted else {
+            return ComputerUseDiagnosticRow(
+                id: .cloudVision,
+                title: "Cloud vision",
+                value: "Off",
+                detail: "Remote image models receive no screenshots unless consent is granted.",
+                severity: .inactive
+            )
+        }
+
+        let scope: String
+        if cloudVision.isPersistentlyGranted {
+            scope = "persistent"
+        } else if cloudVision.isSessionGranted {
+            scope = "this launch"
+        } else {
+            scope = "granted"
+        }
+        return ComputerUseDiagnosticRow(
+            id: .cloudVision,
+            title: "Cloud vision",
+            value: "On (\(scope))",
+            detail: "Scrub mode: \(scrubModeLabel(cloudVision.scrubMode)).",
+            severity: cloudVision.scrubMode == .allText ? .ready : .attention
+        )
+    }
+
+    private static func screenContextRow(
+        enabled: Bool,
+        accessibilityGranted: Bool
+    ) -> ComputerUseDiagnosticRow {
+        if enabled, !accessibilityGranted {
+            return ComputerUseDiagnosticRow(
+                id: .screenContext,
+                title: "Screen Context",
+                value: "On, blocked",
+                detail: "The opt-in is enabled, but snapshots need Accessibility before chat send.",
+                severity: .attention
+            )
+        }
+        return ComputerUseDiagnosticRow(
+            id: .screenContext,
+            title: "Screen Context",
+            value: enabled ? "On" : "Off",
+            detail: enabled
+                ? "Chat can receive a frozen AX-text snapshot at send time."
+                : "No ambient screen context is injected into chat.",
+            severity: enabled ? .ready : .inactive
+        )
+    }
+
+    private static func perAgentRow(summary: ComputerUseAgentAvailabilitySummary) -> ComputerUseDiagnosticRow {
+        if summary.customAgentCount == 0 {
+            return ComputerUseDiagnosticRow(
+                id: .perAgent,
+                title: "Per-agent enablement",
+                value: "No custom agents",
+                detail: "Computer Use is hidden for the built-in Default agent.",
+                severity: .inactive
+            )
+        }
+        let enabled = summary.enabledCustomAgentCount
+        return ComputerUseDiagnosticRow(
+            id: .perAgent,
+            title: "Per-agent enablement",
+            value: "\(enabled)/\(summary.customAgentCount) custom enabled",
+            detail: "Only custom agents with the feature enabled can receive the computer_use tool.",
+            severity: enabled > 0 ? .ready : .inactive
+        )
+    }
+
+    private static func dangerousAppGuardrailRow() -> ComputerUseDiagnosticRow {
+        ComputerUseDiagnosticRow(
+            id: .dangerousAppGuardrail,
+            title: "Dangerous-app guardrail",
+            value: "Confirm floor active",
+            detail:
+                "Sensitive apps such as Terminal, System Settings, Keychain Access, and password managers always confirm for actions.",
+            severity: .info
+        )
+    }
+
+    private static func agentAvailability(
+        from agents: [ComputerUseAgentAvailabilityInput]
+    ) -> ComputerUseAgentAvailabilitySummary {
+        let customAgents = agents.filter { !$0.isBuiltIn }
+        let enabledCount = customAgents.filter(\.computerUseEnabled).count
+        let rows = agents.map { agent -> ComputerUseAgentAvailabilityRow in
+            if agent.isBuiltIn {
+                return ComputerUseAgentAvailabilityRow(
+                    id: agent.id,
+                    name: agent.displayName,
+                    value: "Unavailable",
+                    detail: "Built-in agents cannot enable Computer Use.",
+                    severity: .inactive
+                )
+            }
+            if !agent.computerUseEnabled {
+                return ComputerUseAgentAvailabilityRow(
+                    id: agent.id,
+                    name: agent.displayName,
+                    value: "Off",
+                    detail: "Enable Computer Use in this agent's Features tab.",
+                    severity: .inactive
+                )
+            }
+            let ceilingText = agent.ceilingPreset.map { " Ceiling: \($0.displayLabel)." } ?? ""
+            let modelText = agent.hasEffectiveModel ? "Model selected." : "No model selected."
+            return ComputerUseAgentAvailabilityRow(
+                id: agent.id,
+                name: agent.displayName,
+                value: agent.hasEffectiveModel ? "Enabled" : "Enabled, missing model",
+                detail: modelText + ceilingText,
+                severity: agent.hasEffectiveModel ? .ready : .attention
+            )
+        }
+        return ComputerUseAgentAvailabilitySummary(
+            customAgentCount: customAgents.count,
+            enabledCustomAgentCount: enabledCount,
+            rows: rows
+        )
+    }
+
+    private static func scrubModeLabel(_ mode: ScrubMode) -> String {
+        switch mode {
+        case .allText:
+            return "mask all recognized text"
+        case .pii:
+            return "mask only detected sensitive text"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -68674,6 +68674,174 @@
           }
         }
       }
+    },
+    "AXButton" : {
+      "shouldTranslate" : false
+    },
+    "Agent availability" : {
+      "shouldTranslate" : false
+    },
+    "Allowlist" : {
+      "shouldTranslate" : false
+    },
+    "Autonomy Gate Inspector" : {
+      "shouldTranslate" : false
+    },
+    "Ceiling contribution" : {
+      "shouldTranslate" : false
+    },
+    "Click" : {
+      "shouldTranslate" : false
+    },
+    "Dangerous-app confirm" : {
+      "shouldTranslate" : false
+    },
+    "Disposition" : {
+      "shouldTranslate" : false
+    },
+    "Double-click" : {
+      "shouldTranslate" : false
+    },
+    "Drag" : {
+      "shouldTranslate" : false
+    },
+    "Effect class" : {
+      "shouldTranslate" : false
+    },
+    "Find" : {
+      "shouldTranslate" : false
+    },
+    "For press_key" : {
+      "shouldTranslate" : false
+    },
+    "For type/set" : {
+      "shouldTranslate" : false
+    },
+    "Gate decision" : {
+      "shouldTranslate" : false
+    },
+    "Give up" : {
+      "shouldTranslate" : false
+    },
+    "Global %@ -> %@" : {
+      "shouldTranslate" : false
+    },
+    "Modifiers" : {
+      "shouldTranslate" : false
+    },
+    "No app allowlist is active." : {
+      "shouldTranslate" : false
+    },
+    "No forced-confirm app match for this preview." : {
+      "shouldTranslate" : false
+    },
+    "No matching per-app override for the preview app." : {
+      "shouldTranslate" : false
+    },
+    "No preview ceiling is applied." : {
+      "shouldTranslate" : false
+    },
+    "Not reached" : {
+      "shouldTranslate" : false
+    },
+    "Note" : {
+      "shouldTranslate" : false
+    },
+    "Observe" : {
+      "shouldTranslate" : false
+    },
+    "Open app" : {
+      "shouldTranslate" : false
+    },
+    "Optional rationale or surrounding context" : {
+      "shouldTranslate" : false
+    },
+    "Per-app contribution" : {
+      "shouldTranslate" : false
+    },
+    "Permission Doctor" : {
+      "shouldTranslate" : false
+    },
+    "Permission Doctor and autonomy gate inspector." : {
+      "shouldTranslate" : false
+    },
+    "Preparing inspection..." : {
+      "shouldTranslate" : false
+    },
+    "Press key" : {
+      "shouldTranslate" : false
+    },
+    "Preview a proposed app action against the current policy without running it." : {
+      "shouldTranslate" : false
+    },
+    "Preview app: %@. Allowed apps: %@." : {
+      "shouldTranslate" : false
+    },
+    "Preview ceiling" : {
+      "shouldTranslate" : false
+    },
+    "Read-only snapshot of the cached permission and consent state Computer Use already uses." : {
+      "shouldTranslate" : false
+    },
+    "Right-click" : {
+      "shouldTranslate" : false
+    },
+    "Role description" : {
+      "shouldTranslate" : false
+    },
+    "Scroll" : {
+      "shouldTranslate" : false
+    },
+    "Set value" : {
+      "shouldTranslate" : false
+    },
+    "Target label" : {
+      "shouldTranslate" : false
+    },
+    "Target role" : {
+      "shouldTranslate" : false
+    },
+    "Target value" : {
+      "shouldTranslate" : false
+    },
+    "The preview app matches the forced-confirm guardrail." : {
+      "shouldTranslate" : false
+    },
+    "This preview verb is handled before app allowlist gating." : {
+      "shouldTranslate" : false
+    },
+    "This preview verb is handled before autonomy gating." : {
+      "shouldTranslate" : false
+    },
+    "Typed text" : {
+      "shouldTranslate" : false
+    },
+    "Verb" : {
+      "shouldTranslate" : false
+    },
+    "Verb baseline: %@" : {
+      "shouldTranslate" : false
+    },
+    "Wait" : {
+      "shouldTranslate" : false
+    },
+    "allowlist blocks before disposition" : {
+      "shouldTranslate" : false
+    },
+    "ceiling %@ -> %@" : {
+      "shouldTranslate" : false
+    },
+    "cmd, shift" : {
+      "shouldTranslate" : false
+    },
+    "dangerous-app floor -> Ask first" : {
+      "shouldTranslate" : false
+    },
+    "per-app %@ -> %@" : {
+      "shouldTranslate" : false
+    },
+    "unknown app" : {
+      "shouldTranslate" : false
     }
   },
   "version" : "1.1"

--- a/Packages/OsaurusCore/Tests/ComputerUse/Diagnostics/ComputerUseDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Diagnostics/ComputerUseDiagnosticsTests.swift
@@ -1,0 +1,375 @@
+//
+//  ComputerUseDiagnosticsTests.swift
+//  OsaurusCoreTests - Computer Use
+//
+//  Coverage for the read-only Computer Use settings diagnostics.
+//
+
+import Foundation
+import XCTest
+
+@testable import OsaurusCore
+
+final class ComputerUsePermissionDoctorTests: XCTestCase {
+    func testMapsAxOnlyPermissionPosture() {
+        let snapshot = ComputerUsePermissionDoctor.snapshot(
+            input: ComputerUsePermissionDoctorInput(
+                availability: MacDriverAvailability(
+                    accessibility: true,
+                    screenRecording: false,
+                    skyLight: false
+                ),
+                cloudVision: ComputerUseCloudVisionDoctorInput(
+                    isGranted: false,
+                    isPersistentlyGranted: false,
+                    isSessionGranted: false,
+                    scrubMode: .allText
+                ),
+                screenContextEnabled: false,
+                agents: []
+            )
+        )
+
+        XCTAssertEqual(snapshot.row(.accessibility)?.value, "Granted")
+        XCTAssertEqual(snapshot.row(.screenRecording)?.value, "Optional")
+        XCTAssertEqual(snapshot.row(.axPosture)?.value, "AX-only")
+        XCTAssertEqual(snapshot.row(.cloudVision)?.value, "Unavailable")
+        XCTAssertEqual(snapshot.row(.screenContext)?.value, "Off")
+        XCTAssertEqual(snapshot.row(.perAgent)?.value, "No custom agents")
+    }
+
+    func testMapsCloudVisionScreenContextAndAgentAvailability() {
+        let customEnabled = UUID()
+        let customMissingModel = UUID()
+        let snapshot = ComputerUsePermissionDoctor.snapshot(
+            input: ComputerUsePermissionDoctorInput(
+                availability: MacDriverAvailability(
+                    accessibility: true,
+                    screenRecording: true,
+                    skyLight: false
+                ),
+                cloudVision: ComputerUseCloudVisionDoctorInput(
+                    isGranted: true,
+                    isPersistentlyGranted: true,
+                    isSessionGranted: false,
+                    scrubMode: .pii
+                ),
+                screenContextEnabled: true,
+                agents: [
+                    ComputerUseAgentAvailabilityInput(
+                        id: Agent.defaultId,
+                        displayName: "Osaurus",
+                        isBuiltIn: true,
+                        computerUseEnabled: false,
+                        hasEffectiveModel: true
+                    ),
+                    ComputerUseAgentAvailabilityInput(
+                        id: customEnabled,
+                        displayName: "Desk Agent",
+                        isBuiltIn: false,
+                        computerUseEnabled: true,
+                        hasEffectiveModel: true,
+                        ceilingPreset: .balanced
+                    ),
+                    ComputerUseAgentAvailabilityInput(
+                        id: customMissingModel,
+                        displayName: "No Model Agent",
+                        isBuiltIn: false,
+                        computerUseEnabled: true,
+                        hasEffectiveModel: false
+                    ),
+                ]
+            )
+        )
+
+        XCTAssertEqual(snapshot.row(.cloudVision)?.value, "On (persistent)")
+        XCTAssertEqual(snapshot.row(.cloudVision)?.severity, .attention)
+        XCTAssertEqual(snapshot.row(.screenContext)?.value, "On")
+        XCTAssertEqual(snapshot.row(.perAgent)?.value, "2/2 custom enabled")
+        XCTAssertEqual(snapshot.agentAvailability.customAgentCount, 2)
+        XCTAssertEqual(snapshot.agentAvailability.enabledCustomAgentCount, 2)
+        XCTAssertEqual(
+            snapshot.agentAvailability.rows.first { $0.id == Agent.defaultId }?.value,
+            "Unavailable"
+        )
+        XCTAssertEqual(
+            snapshot.agentAvailability.rows.first { $0.id == customMissingModel }?.severity,
+            .attention
+        )
+    }
+}
+
+final class ComputerUseGateInspectorTests: XCTestCase {
+    private struct ParityCase {
+        let name: String
+        let input: ComputerUseGateInspectionInput
+        let expectedEffect: EffectClass
+        let expectedDecision: ComputerUseGateDecisionKind
+        let expectedFinalDisposition: AutonomyDisposition?
+        let expectedAllowlistAllowed: Bool
+        let expectedDangerousConfirm: Bool
+        let expectedPerAppContribution: AutonomyDisposition?
+        let expectedCeilingContribution: AutonomyDisposition?
+    }
+
+    func testInspectorMatchesClassifierPolicyAndGate() async {
+        var trustedWithCautiousNotes = AutonomyPolicy(globalPreset: .trusted)
+        trustedWithCautiousNotes.perApp["notes"] = .cautious
+
+        let cases: [ParityCase] = [
+            ParityCase(
+                name: "send",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .balanced),
+                    appName: "Mail",
+                    verb: .click,
+                    targetLabel: "Send",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .consequential,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "delete",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .trusted),
+                    appName: "Notes",
+                    verb: .click,
+                    targetLabel: "Delete",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .consequential,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "save with per-app override",
+                input: ComputerUseGateInspectionInput(
+                    policy: trustedWithCautiousNotes,
+                    appName: "Notes",
+                    verb: .click,
+                    targetLabel: "Save",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .edit,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: .confirm,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "OK",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .balanced),
+                    appName: "Dialog",
+                    verb: .click,
+                    targetLabel: "OK",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .edit,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "icon-only",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .balanced),
+                    appName: "Notes",
+                    verb: .click,
+                    targetLabel: nil,
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .edit,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "System Settings",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .autonomous),
+                    appName: "System Settings",
+                    verb: .click,
+                    targetLabel: "Displays",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .navigate,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: true,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "open app",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .balanced, allowlist: ["mail"]),
+                    appName: "Mail",
+                    verb: .open,
+                    targetLabel: "Save",
+                    targetRole: "AXButton",
+                    targetValue: "Draft invoice",
+                    targetRoleDescription: "button"
+                ),
+                expectedEffect: .navigate,
+                expectedDecision: .run,
+                expectedFinalDisposition: .allow,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "allowlist",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .balanced, allowlist: ["notes"]),
+                    appName: "Mail",
+                    verb: .click,
+                    targetLabel: "Files",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .navigate,
+                expectedDecision: .reject,
+                expectedFinalDisposition: nil,
+                expectedAllowlistAllowed: false,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
+                name: "read-only ceiling",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .autonomous),
+                    ceiling: AutonomyCeiling.cappedAt(.readOnly),
+                    appName: "Notes",
+                    verb: .click,
+                    targetLabel: "Save",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .edit,
+                expectedDecision: .reject,
+                expectedFinalDisposition: .deny,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: false,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: .deny
+            ),
+        ]
+
+        for testCase in cases {
+            let inspection = await ComputerUseGateInspector.inspect(testCase.input)
+            let appName = appNameForGate(testCase.input, action: inspection.action)
+            let isOpen = inspection.action.verb == .open
+            let directEffect = EffectClassifier.classify(
+                action: inspection.action,
+                resolvedRole: isOpen ? nil : nonEmpty(testCase.input.targetRole),
+                resolvedLabel: isOpen ? nil : nonEmpty(testCase.input.targetLabel),
+                resolvedValue: isOpen ? nil : nonEmpty(testCase.input.targetValue),
+                resolvedRoleDescription: isOpen ? nil : nonEmpty(testCase.input.targetRoleDescription),
+                appName: appName,
+                recipeSignals: AppRecipes.signals(for: appName)
+            )
+            let directDecision = await ComputerUseGate(
+                policy: testCase.input.policy,
+                ceiling: testCase.input.ceiling
+            ).evaluate(
+                action: inspection.action,
+                effect: directEffect,
+                appName: appName,
+                targetLabel: targetLabelForGate(testCase.input, action: inspection.action)
+            )
+
+            XCTAssertTrue(inspection.gateIsReached, testCase.name)
+            XCTAssertEqual(inspection.effect, directEffect, testCase.name)
+            XCTAssertEqual(inspection.decision, directDecision, testCase.name)
+            XCTAssertEqual(inspection.effect, testCase.expectedEffect, testCase.name)
+            XCTAssertEqual(inspection.decisionKind, testCase.expectedDecision, testCase.name)
+            XCTAssertEqual(inspection.finalDisposition, testCase.expectedFinalDisposition, testCase.name)
+            XCTAssertEqual(inspection.allowlist.isAllowed, testCase.expectedAllowlistAllowed, testCase.name)
+            XCTAssertEqual(
+                inspection.dangerousAppRequiresConfirm,
+                testCase.expectedDangerousConfirm,
+                testCase.name
+            )
+            XCTAssertEqual(
+                inspection.perAppContribution?.disposition,
+                testCase.expectedPerAppContribution,
+                testCase.name
+            )
+            XCTAssertEqual(
+                inspection.ceilingContribution?.disposition,
+                testCase.expectedCeilingContribution,
+                testCase.name
+            )
+        }
+    }
+
+    func testReadAndTerminalPreviewVerbsBypassAutonomyGateLikeLiveLoop() async {
+        let policy = AutonomyPolicy(globalPreset: .readOnly, allowlist: ["Notes"])
+        let verbs: [AgentVerb] = [.observe, .wait, .find, .done, .giveUp]
+
+        for verb in verbs {
+            let inspection = await ComputerUseGateInspector.inspect(
+                ComputerUseGateInspectionInput(
+                    policy: policy,
+                    appName: "Mail",
+                    verb: verb,
+                    targetLabel: "Inbox",
+                    targetRole: "AXGroup",
+                    note: "Preview"
+                )
+            )
+
+            XCTAssertFalse(inspection.gateIsReached, verb.rawValue)
+            XCTAssertFalse(inspection.allowlist.isReached, verb.rawValue)
+            XCTAssertEqual(inspection.allowlist.displayValue, "Not reached", verb.rawValue)
+            XCTAssertEqual(inspection.allowlist.isAllowed, false, verb.rawValue)
+            XCTAssertEqual(inspection.finalDisposition, nil, verb.rawValue)
+            XCTAssertEqual(inspection.decision, .run, verb.rawValue)
+            XCTAssertEqual(inspection.decisionKind, .run, verb.rawValue)
+            XCTAssertEqual(
+                inspection.decisionSummary,
+                "Handled before autonomy gating in the live loop.",
+                verb.rawValue
+            )
+        }
+    }
+
+    private func appNameForGate(_ input: ComputerUseGateInspectionInput, action: AgentAction) -> String? {
+        if action.verb == .open {
+            return nonEmpty(action.app) ?? nonEmpty(input.appName)
+        }
+        return nonEmpty(input.appName)
+    }
+
+    private func targetLabelForGate(_ input: ComputerUseGateInspectionInput, action: AgentAction) -> String? {
+        if action.verb == .open {
+            return nonEmpty(action.app) ?? nonEmpty(input.appName)
+        }
+        return nonEmpty(input.targetLabel) ?? nonEmpty(input.targetDescription)
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ComputerUseDiagnosticsPanel.swift
+++ b/Packages/OsaurusCore/Views/Settings/ComputerUseDiagnosticsPanel.swift
@@ -1,0 +1,642 @@
+//
+//  ComputerUseDiagnosticsPanel.swift
+//  OsaurusCore - Computer Use
+//
+//  Read-only diagnostics for Settings -> Computer Use. Local preview fields
+//  can change, but the panel does not mutate policy or tool behavior.
+//
+
+import SwiftUI
+
+struct ComputerUseDiagnosticsPanel: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+    @ObservedObject private var permissionService = SystemPermissionService.shared
+    @ObservedObject private var cloudVisionConsent = CloudVisionConsent.shared
+    @ObservedObject private var screenContext = ScreenContextSettings.shared
+    @ObservedObject private var agentManager = AgentManager.shared
+
+    let policy: AutonomyPolicy
+
+    @State private var isExpanded = false
+    @State private var previewApp = "Notes"
+    @State private var previewVerb: AgentVerb = .click
+    @State private var previewTargetLabel = "Save"
+    @State private var previewTargetRole = "AXButton"
+    @State private var previewTargetValue = ""
+    @State private var previewRoleDescription = ""
+    @State private var previewNote = ""
+    @State private var previewText = ""
+    @State private var previewKey = "return"
+    @State private var previewModifiers = ""
+    @State private var previewCeilingPreset: AutonomyPreset?
+    @State private var inspection: ComputerUseGateInspection?
+
+    private var theme: ThemeProtocol { themeManager.currentTheme }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 18) {
+                permissionDoctorSection
+                Divider().background(theme.cardBorder)
+                gateInspectorSection
+            }
+            .padding(.top, 14)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(theme.accentColor)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(L("Diagnostics"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(L("Permission Doctor and autonomy gate inspector."))
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            }
+        }
+        .accentColor(theme.tertiaryText)
+        .task(id: inspectorFingerprint) {
+            await refreshInspection()
+        }
+    }
+
+    // MARK: - Permission Doctor
+
+    private var permissionDoctorSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionTitle(L("Permission Doctor"))
+            helperText(
+                L("Read-only snapshot of the cached permission and consent state Computer Use already uses.")
+            )
+
+            VStack(spacing: 8) {
+                ForEach(doctorSnapshot.rows) { row in
+                    diagnosticRow(row)
+                }
+            }
+
+            if !doctorSnapshot.agentAvailability.rows.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(L("Agent availability"))
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.secondaryText)
+                    ForEach(doctorSnapshot.agentAvailability.rows) { row in
+                        agentAvailabilityRow(row)
+                    }
+                }
+            }
+        }
+    }
+
+    private var doctorSnapshot: ComputerUsePermissionDoctorSnapshot {
+        ComputerUsePermissionDoctor.snapshot(
+            input: ComputerUsePermissionDoctorInput(
+                availability: MacDriverAvailability(
+                    accessibility: permissionService.cachedIsGranted(.accessibility),
+                    screenRecording: permissionService.cachedIsGranted(.screenRecording),
+                    skyLight: false
+                ),
+                cloudVision: ComputerUseCloudVisionDoctorInput(
+                    isGranted: cloudVisionConsent.isGranted,
+                    isPersistentlyGranted: cloudVisionConsent.isPersistentlyGranted,
+                    isSessionGranted: cloudVisionConsent.isSessionGranted,
+                    scrubMode: cloudVisionConsent.scrubMode
+                ),
+                screenContextEnabled: screenContext.injectionEnabled,
+                agents: agentInputs
+            )
+        )
+    }
+
+    private var agentInputs: [ComputerUseAgentAvailabilityInput] {
+        agentManager.agents.map { agent in
+            let model = agentManager.effectiveModel(for: agent.id)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return ComputerUseAgentAvailabilityInput(
+                id: agent.id,
+                displayName: agent.displayName,
+                isBuiltIn: agent.isBuiltIn,
+                computerUseEnabled: agentManager.effectiveCapabilities(for: agent.id).computerUseEnabled,
+                hasEffectiveModel: model?.isEmpty == false,
+                ceilingPreset: agent.settings.computerUseCeiling?.matchingPreset
+            )
+        }
+    }
+
+    // MARK: - Gate Inspector
+
+    private var gateInspectorSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionTitle(L("Autonomy Gate Inspector"))
+            helperText(
+                L("Preview a proposed app action against the current policy without running it.")
+            )
+
+            inspectorInputs
+
+            if let inspection {
+                inspectorResults(inspection)
+            } else {
+                helperText(L("Preparing inspection..."))
+            }
+        }
+    }
+
+    private var inspectorInputs: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                labeledTextField(L("App"), text: $previewApp, placeholder: L("Notes"))
+                verbPicker
+            }
+            HStack(alignment: .top, spacing: 10) {
+                labeledTextField(L("Target label"), text: $previewTargetLabel, placeholder: L("Save"))
+                labeledTextField(L("Target role"), text: $previewTargetRole, placeholder: L("AXButton"))
+            }
+            HStack(alignment: .top, spacing: 10) {
+                labeledTextField(L("Target value"), text: $previewTargetValue, placeholder: L("Optional"))
+                labeledTextField(
+                    L("Role description"),
+                    text: $previewRoleDescription,
+                    placeholder: L("Optional")
+                )
+            }
+            HStack(alignment: .top, spacing: 10) {
+                labeledTextField(L("Typed text"), text: $previewText, placeholder: L("For type/set"))
+                labeledTextField(L("Key"), text: $previewKey, placeholder: L("For press_key"))
+            }
+            HStack(alignment: .top, spacing: 10) {
+                labeledTextField(
+                    L("Modifiers"),
+                    text: $previewModifiers,
+                    placeholder: L("cmd, shift")
+                )
+                ceilingPicker
+            }
+            labeledTextField(
+                L("Note"),
+                text: $previewNote,
+                placeholder: L("Optional rationale or surrounding context")
+            )
+        }
+    }
+
+    private var verbPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(L("Verb"))
+            Menu {
+                ForEach(AgentVerb.allCases, id: \.self) { verb in
+                    Button {
+                        previewVerb = verb
+                    } label: {
+                        if previewVerb == verb {
+                            Label {
+                                Text(verbatim: verbLabel(verb))
+                            } icon: {
+                                Image(systemName: "checkmark")
+                            }
+                        } else {
+                            Text(verbatim: verbLabel(verb))
+                        }
+                    }
+                }
+            } label: {
+                pickerLabel(verbLabel(previewVerb))
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var ceilingPicker: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(L("Preview ceiling"))
+            Menu {
+                Button {
+                    previewCeilingPreset = nil
+                } label: {
+                    if previewCeilingPreset == nil {
+                        Label {
+                            Text(L("No ceiling"))
+                        } icon: {
+                            Image(systemName: "checkmark")
+                        }
+                    } else {
+                        Text(L("No ceiling"))
+                    }
+                }
+                Divider()
+                ForEach(AutonomyPreset.allCases) { preset in
+                    Button {
+                        previewCeilingPreset = preset
+                    } label: {
+                        if previewCeilingPreset == preset {
+                            Label {
+                                Text(preset.displayLabel)
+                            } icon: {
+                                Image(systemName: "checkmark")
+                            }
+                        } else {
+                            Text(preset.displayLabel)
+                        }
+                    }
+                }
+            } label: {
+                pickerLabel(previewCeilingPreset?.displayLabel ?? L("No ceiling"))
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func inspectorResults(_ inspection: ComputerUseGateInspection) -> some View {
+        VStack(spacing: 8) {
+            resultRow(
+                title: L("Effect class"),
+                value: inspection.effect.displayLabel,
+                detail: String(
+                    format: L("Verb baseline: %@"),
+                    inspection.action.baselineEffect.displayLabel
+                ),
+                severity: severity(for: inspection.effect)
+            )
+            resultRow(
+                title: L("Gate decision"),
+                value: decisionLabel(inspection.decisionKind),
+                detail: inspection.decisionSummary,
+                severity: severity(for: inspection.decisionKind)
+            )
+            resultRow(
+                title: L("Allowlist"),
+                value: inspection.allowlist.displayValue,
+                detail: allowlistDetail(inspection.allowlist),
+                severity: inspection.allowlist.isReached
+                    ? (inspection.allowlist.isAllowed ? .ready : .attention)
+                    : .info
+            )
+            resultRow(
+                title: L("Disposition"),
+                value: inspection.finalDisposition?.displayLabel ?? L("Not reached"),
+                detail: dispositionDetail(inspection),
+                severity: inspection.gateIsReached
+                    ? (inspection.finalDisposition.map(severity(for:)) ?? .attention)
+                    : .info
+            )
+            resultRow(
+                title: L("Per-app contribution"),
+                value: inspection.perAppContribution?.disposition.displayLabel ?? L("None"),
+                detail: inspection.perAppContribution?.label
+                    ?? L("No matching per-app override for the preview app."),
+                severity: inspection.perAppContribution.map { severity(for: $0.disposition) } ?? .info
+            )
+            resultRow(
+                title: L("Ceiling contribution"),
+                value: inspection.ceilingContribution?.disposition.displayLabel ?? L("None"),
+                detail: inspection.ceilingContribution?.label
+                    ?? L("No preview ceiling is applied."),
+                severity: inspection.ceilingContribution.map { severity(for: $0.disposition) } ?? .info
+            )
+            resultRow(
+                title: L("Dangerous-app confirm"),
+                value: inspection.dangerousAppRequiresConfirm ? L("Yes") : L("No"),
+                detail: inspection.dangerousAppRequiresConfirm
+                    ? L("The preview app matches the forced-confirm guardrail.")
+                    : L("No forced-confirm app match for this preview."),
+                severity: inspection.dangerousAppRequiresConfirm ? .attention : .info
+            )
+        }
+    }
+
+    private var inspectorInput: ComputerUseGateInspectionInput {
+        ComputerUseGateInspectionInput(
+            policy: policy,
+            ceiling: previewCeilingPreset.map(AutonomyCeiling.cappedAt),
+            appName: previewApp,
+            verb: previewVerb,
+            targetLabel: previewTargetLabel,
+            targetRole: previewTargetRole,
+            targetValue: previewTargetValue,
+            targetRoleDescription: previewRoleDescription,
+            note: previewNote,
+            text: previewText,
+            key: previewKey,
+            modifiers: parsedModifiers
+        )
+    }
+
+    private var parsedModifiers: [String] {
+        previewModifiers
+            .split { $0 == "," || $0 == "+" || $0 == " " || $0 == "\t" }
+            .map { String($0).lowercased() }
+    }
+
+    private var inspectorFingerprint: InspectorFingerprint {
+        InspectorFingerprint(
+            policy: policy,
+            app: previewApp,
+            verb: previewVerb,
+            targetLabel: previewTargetLabel,
+            targetRole: previewTargetRole,
+            targetValue: previewTargetValue,
+            roleDescription: previewRoleDescription,
+            note: previewNote,
+            text: previewText,
+            key: previewKey,
+            modifiers: previewModifiers,
+            ceilingPreset: previewCeilingPreset
+        )
+    }
+
+    @MainActor
+    private func refreshInspection() async {
+        inspection = await ComputerUseGateInspector.inspect(inspectorInput)
+    }
+
+    // MARK: - Row helpers
+
+    private func diagnosticRow(_ row: ComputerUseDiagnosticRow) -> some View {
+        resultRow(
+            title: row.title,
+            value: row.value,
+            detail: row.detail,
+            severity: row.severity
+        )
+    }
+
+    private func agentAvailabilityRow(_ row: ComputerUseAgentAvailabilityRow) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            statusDot(row.severity)
+                .padding(.top, 4)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(verbatim: row.name)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    Text(verbatim: row.value)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(color(for: row.severity))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(color(for: row.severity).opacity(0.1)))
+                }
+                Text(verbatim: row.detail)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(10)
+        .diagnosticsSurface(cornerRadius: 8, fill: theme.inputBackground, stroke: theme.inputBorder)
+    }
+
+    private func resultRow(
+        title: String,
+        value: String,
+        detail: String,
+        severity: ComputerUseDiagnosticSeverity
+    ) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            statusDot(severity)
+                .padding(.top, 5)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(verbatim: title)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(verbatim: value)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(color(for: severity))
+                }
+                Text(verbatim: detail)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(10)
+        .diagnosticsSurface(cornerRadius: 8, fill: theme.inputBackground, stroke: theme.inputBorder)
+    }
+
+    private func statusDot(_ severity: ComputerUseDiagnosticSeverity) -> some View {
+        Circle()
+            .fill(color(for: severity))
+            .frame(width: 7, height: 7)
+    }
+
+    private func labeledTextField(
+        _ label: String,
+        text: Binding<String>,
+        placeholder: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(label)
+            ZStack(alignment: .leading) {
+                if text.wrappedValue.isEmpty {
+                    Text(verbatim: placeholder)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.placeholderText)
+                        .allowsHitTesting(false)
+                }
+                TextField("", text: text)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.primaryText)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .diagnosticsSurface(cornerRadius: 7, fill: theme.inputBackground, stroke: theme.inputBorder)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func fieldLabel(_ text: String) -> some View {
+        Text(verbatim: text)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(theme.secondaryText)
+    }
+
+    private func pickerLabel(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            Text(verbatim: text)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.primaryText)
+            Spacer(minLength: 6)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 9))
+                .foregroundColor(theme.secondaryText)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .diagnosticsSurface(cornerRadius: 7, fill: theme.inputBackground, stroke: theme.inputBorder)
+    }
+
+    private func sectionTitle(_ text: String) -> some View {
+        Text(verbatim: text)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(theme.primaryText)
+    }
+
+    private func helperText(_ text: String) -> some View {
+        Text(verbatim: text)
+            .font(.system(size: 11))
+            .foregroundColor(theme.tertiaryText)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Formatting
+
+    private func verbLabel(_ verb: AgentVerb) -> String {
+        switch verb {
+        case .observe: return L("Observe")
+        case .wait: return L("Wait")
+        case .find: return L("Find")
+        case .click: return L("Click")
+        case .doubleClick: return L("Double-click")
+        case .rightClick: return L("Right-click")
+        case .drag: return L("Drag")
+        case .type: return L("Type")
+        case .setValue: return L("Set value")
+        case .clear: return L("Clear")
+        case .pressKey: return L("Press key")
+        case .scroll: return L("Scroll")
+        case .open: return L("Open app")
+        case .done: return L("Done")
+        case .giveUp: return L("Give up")
+        }
+    }
+
+    private func decisionLabel(_ kind: ComputerUseGateDecisionKind) -> String {
+        switch kind {
+        case .run: return L("Auto-run")
+        case .confirm: return L("Ask first")
+        case .reject: return L("Block")
+        }
+    }
+
+    private func allowlistDetail(_ allowlist: ComputerUseAllowlistInspection) -> String {
+        guard allowlist.isReached else {
+            return L("This preview verb is handled before app allowlist gating.")
+        }
+        guard allowlist.isActive else {
+            return L("No app allowlist is active.")
+        }
+        let app = allowlist.normalizedApp ?? L("unknown app")
+        let entries = allowlist.entries.joined(separator: ", ")
+        return String(format: L("Preview app: %@. Allowed apps: %@."), app, entries)
+    }
+
+    private func dispositionDetail(_ inspection: ComputerUseGateInspection) -> String {
+        guard inspection.gateIsReached else {
+            return L("This preview verb is handled before autonomy gating.")
+        }
+        var parts = [
+            String(
+                format: L("Global %@ -> %@"),
+                inspection.globalContribution.label,
+                inspection.globalContribution.disposition.displayLabel
+            ),
+        ]
+        if let perApp = inspection.perAppContribution {
+            parts.append(
+                String(
+                    format: L("per-app %@ -> %@"),
+                    perApp.label,
+                    perApp.disposition.displayLabel
+                )
+            )
+        }
+        if let ceiling = inspection.ceilingContribution {
+            parts.append(
+                String(
+                    format: L("ceiling %@ -> %@"),
+                    ceiling.label,
+                    ceiling.disposition.displayLabel
+                )
+            )
+        }
+        if inspection.dangerousAppRequiresConfirm {
+            parts.append(L("dangerous-app floor -> Ask first"))
+        }
+        if !inspection.allowlist.isAllowed {
+            parts.append(L("allowlist blocks before disposition"))
+        }
+        return parts.joined(separator: "; ")
+    }
+
+    private func severity(for effect: EffectClass) -> ComputerUseDiagnosticSeverity {
+        switch effect {
+        case .read, .navigate: return .ready
+        case .edit: return .attention
+        case .consequential: return .attention
+        }
+    }
+
+    private func severity(for disposition: AutonomyDisposition) -> ComputerUseDiagnosticSeverity {
+        switch disposition {
+        case .allow: return .ready
+        case .confirm: return .attention
+        case .deny: return .attention
+        }
+    }
+
+    private func severity(for decision: ComputerUseGateDecisionKind) -> ComputerUseDiagnosticSeverity {
+        switch decision {
+        case .run: return .ready
+        case .confirm, .reject: return .attention
+        }
+    }
+
+    private func color(for severity: ComputerUseDiagnosticSeverity) -> Color {
+        switch severity {
+        case .ready: return theme.successColor
+        case .attention: return theme.warningColor
+        case .inactive: return theme.tertiaryText
+        case .info: return theme.accentColor
+        }
+    }
+}
+
+private struct InspectorFingerprint: Equatable {
+    let policy: AutonomyPolicy
+    let app: String
+    let verb: AgentVerb
+    let targetLabel: String
+    let targetRole: String
+    let targetValue: String
+    let roleDescription: String
+    let note: String
+    let text: String
+    let key: String
+    let modifiers: String
+    let ceilingPreset: AutonomyPreset?
+}
+
+private extension View {
+    func diagnosticsSurface(
+        cornerRadius: CGFloat,
+        fill: Color,
+        stroke: Color = .clear,
+        lineWidth: CGFloat = 1
+    ) -> some View {
+        background(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(fill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .stroke(stroke, lineWidth: lineWidth)
+                )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift
@@ -576,6 +576,8 @@ struct ComputerUseSettingsView: View {
                     allowlistSection
                     Divider().background(theme.cardBorder)
                     cloudVisionSection
+                    Divider().background(theme.cardBorder)
+                    ComputerUseDiagnosticsPanel(policy: policy)
                 }
                 .padding(.top, 16)
             } label: {


### PR DESCRIPTION
## Summary
- Adds a read-only Computer Use diagnostics panel under Settings so users can inspect permission state, consent state, agent capability readiness, and autonomy-gate outcomes.
- Adds a gate inspector that reuses the live classifier/gate path, including open-action and read/terminal verb parity with the live loop.
- Adds tests for policy/gate parity, allowlist behavior, dangerous-app confirmation, ceilings, and verbs that bypass autonomy gating.

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-computer-rebased swift test --package-path Packages/OsaurusCore --scratch-path Packages/OsaurusCore/.build --filter ComputerUseGateInspectorTests`
- `git diff origin/main...HEAD --check`
- `bash scripts/i18n/check.sh`
- `swiftlint lint Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUseGateInspector.swift Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUsePermissionDoctor.swift Packages/OsaurusCore/Views/Settings/ComputerUseDiagnosticsPanel.swift Packages/OsaurusCore/Views/Settings/ComputerUseSettingsView.swift Packages/OsaurusCore/Tests/ComputerUse/Diagnostics/ComputerUseDiagnosticsTests.swift`
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"`

## Notes
- The diagnostics UI is read-only: it does not mutate Computer Use policy, run live AX probes, capture screenshots, or send data externally.
- The local app build succeeds; Xcode emits a machine-level CoreSimulator version warning before building macOS targets.
