### PR TITLE
Add Screen Context capture lab

### DIFF
--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/browser-form-checkout.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/browser-form-checkout.json
@@ -1,0 +1,38 @@
+{
+  "apps": [
+    { "pid": 506, "bundleId": "com.google.Chrome", "name": "Google Chrome", "active": true, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 506,
+    "app": "Google Chrome",
+    "title": "Request Access - Example",
+    "x": 0, "y": 0, "w": 1280, "h": 820
+  },
+  "windowsByPid": {
+    "506": [
+      { "windowId": 1, "title": "Request Access - Example", "focused": true, "minimized": false, "x": 0, "y": 0, "w": 1280, "h": 820 }
+    ]
+  },
+  "snapshot": {
+    "app": "Google Chrome",
+    "focusedWindow": "Request Access - Example",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "Request Access - Example", "focused": true, "x": 0, "y": 0, "w": 1280, "h": 820 }
+    ],
+    "elements": [
+      { "id": "address", "role": "textfield", "label": "Address and search bar", "value": "https://example.test/request-access", "focused": false, "enabled": true, "x": 120, "y": 18, "w": 820, "h": 30, "actions": [] },
+      { "id": "heading", "role": "heading", "value": "Request access", "focused": false, "enabled": true, "x": 300, "y": 130, "w": 320, "h": 32, "actions": [] },
+      { "id": "intro", "role": "statictext", "value": "Complete this synthetic browser form before submitting the review request.", "focused": false, "enabled": true, "x": 300, "y": 178, "w": 620, "h": 24, "actions": [] },
+      { "id": "team", "role": "textfield", "label": "Team name", "value": "Synthetic Platform Team", "focused": true, "enabled": true, "x": 300, "y": 244, "w": 420, "h": 34, "actions": [] },
+      { "id": "email", "role": "textfield", "label": "Email", "value": "reviewer@example.test", "focused": false, "enabled": true, "x": 300, "y": 312, "w": 420, "h": 34, "actions": [] },
+      { "id": "reason", "role": "textarea", "label": "Justification", "value": "Need temporary access for deterministic fixture validation.", "focused": false, "enabled": true, "x": 300, "y": 380, "w": 620, "h": 120, "actions": [] },
+      { "id": "submit", "role": "button", "label": "Submit request", "focused": false, "enabled": true, "x": 300, "y": 536, "w": 150, "h": 36, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "textfield",
+    "label": "Team name",
+    "value": "Synthetic Platform Team"
+  }
+}

--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/chat-shell-compose.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/chat-shell-compose.json
@@ -1,0 +1,36 @@
+{
+  "apps": [
+    { "pid": 505, "bundleId": "com.example.ChatDesk", "name": "ChatDesk", "active": true, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 505,
+    "app": "ChatDesk",
+    "title": "release-room (Channel) - Synthetic Workspace - ChatDesk",
+    "x": 0, "y": 0, "w": 1400, "h": 900
+  },
+  "windowsByPid": {
+    "505": [
+      { "windowId": 1, "title": "release-room (Channel) - Synthetic Workspace - ChatDesk", "focused": true, "minimized": false, "x": 0, "y": 0, "w": 1400, "h": 900 }
+    ]
+  },
+  "snapshot": {
+    "app": "ChatDesk",
+    "focusedWindow": "release-room (Channel) - Synthetic Workspace - ChatDesk",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "release-room (Channel) - Synthetic Workspace - ChatDesk", "focused": true, "x": 0, "y": 0, "w": 1400, "h": 900 }
+    ],
+    "elements": [
+      { "id": "side1", "role": "statictext", "value": "Threads", "focused": false, "enabled": true, "x": 24, "y": 120, "w": 120, "h": 18, "actions": [] },
+      { "id": "msg1", "role": "statictext", "value": "Ari Example: release checklist is ready for review", "focused": false, "enabled": true, "x": 300, "y": 190, "w": 760, "h": 22, "actions": [] },
+      { "id": "msg2", "role": "statictext", "value": "Blair Example: please confirm the rollback owner", "focused": false, "enabled": true, "x": 300, "y": 226, "w": 760, "h": 22, "actions": [] },
+      { "id": "composer", "role": "textfield", "label": "Message release-room", "value": "Confirmed: the fixture owner is listed in the checklist.", "selectedText": "fixture owner", "focused": true, "enabled": true, "x": 300, "y": 816, "w": 760, "h": 42, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "textfield",
+    "label": "Message release-room",
+    "value": "Confirmed: the fixture owner is listed in the checklist.",
+    "selectedText": "fixture owner"
+  }
+}

--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/finder-selected-file.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/finder-selected-file.json
@@ -1,0 +1,37 @@
+{
+  "apps": [
+    { "pid": 502, "bundleId": "com.apple.finder", "name": "Finder", "active": true, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 502,
+    "app": "Finder",
+    "title": "Design Assets",
+    "x": 20, "y": 40, "w": 1120, "h": 760
+  },
+  "windowsByPid": {
+    "502": [
+      { "windowId": 1, "title": "Design Assets", "focused": true, "minimized": false, "x": 20, "y": 40, "w": 1120, "h": 760 }
+    ]
+  },
+  "snapshot": {
+    "app": "Finder",
+    "focusedWindow": "Design Assets",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "Design Assets", "focused": true, "x": 20, "y": 40, "w": 1120, "h": 760 }
+    ],
+    "elements": [
+      { "id": "sidebar", "role": "statictext", "value": "Favorites", "focused": false, "enabled": true, "x": 42, "y": 120, "w": 120, "h": 18, "actions": [] },
+      { "id": "folder", "role": "statictext", "value": "Design Assets", "focused": false, "enabled": true, "x": 280, "y": 92, "w": 180, "h": 22, "actions": [] },
+      { "id": "file1", "role": "statictext", "value": "Synthetic Strategy Brief.pdf", "focused": false, "enabled": true, "x": 300, "y": 170, "w": 260, "h": 22, "actions": [] },
+      { "id": "file2", "role": "statictext", "value": "Fixture Screenshot Set", "focused": false, "enabled": true, "x": 300, "y": 210, "w": 260, "h": 22, "actions": [] },
+      { "id": "file3", "role": "statictext", "value": "Archive Notes", "focused": false, "enabled": true, "x": 300, "y": 250, "w": 260, "h": 22, "actions": [] },
+      { "id": "outline", "role": "outline", "label": "Files", "selectedText": "Synthetic Strategy Brief.pdf", "focused": true, "enabled": true, "x": 250, "y": 130, "w": 780, "h": 560, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "outline",
+    "label": "Files",
+    "selectedText": "Synthetic Strategy Brief.pdf"
+  }
+}

--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/mail-compose-reply.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/mail-compose-reply.json
@@ -1,0 +1,39 @@
+{
+  "apps": [
+    { "pid": 501, "bundleId": "com.apple.mail", "name": "Mail", "active": true, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 501,
+    "app": "Mail",
+    "title": "Project Update - Reply",
+    "x": 0, "y": 0, "w": 1280, "h": 860
+  },
+  "windowsByPid": {
+    "501": [
+      { "windowId": 1, "title": "Project Update - Reply", "focused": true, "minimized": false, "x": 0, "y": 0, "w": 1280, "h": 860 }
+    ]
+  },
+  "snapshot": {
+    "app": "Mail",
+    "focusedWindow": "Project Update - Reply",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "Project Update - Reply", "focused": true, "x": 0, "y": 0, "w": 1280, "h": 860 }
+    ],
+    "elements": [
+      { "id": "mailbox", "role": "statictext", "value": "Inbox", "focused": false, "enabled": true, "x": 24, "y": 96, "w": 150, "h": 20, "actions": [] },
+      { "id": "message", "role": "statictext", "value": "Maya Example: Please send the launch checklist before noon.", "focused": false, "enabled": true, "x": 260, "y": 112, "w": 650, "h": 24, "actions": [] },
+      { "id": "to", "role": "textfield", "label": "To", "value": "team@example.test", "focused": false, "enabled": true, "x": 300, "y": 188, "w": 720, "h": 28, "actions": [] },
+      { "id": "subject", "role": "textfield", "label": "Subject", "value": "Re: Project Update", "focused": false, "enabled": true, "x": 300, "y": 226, "w": 720, "h": 28, "actions": [] },
+      { "id": "body", "role": "textarea", "label": "Message Body", "value": "Hi team,\nThe draft checklist covers the release notes, owner review, and rollback plan.\nI will send the final version after the fixture pass.", "selectedText": "draft checklist", "focused": true, "enabled": true, "x": 300, "y": 280, "w": 820, "h": 460, "actions": [] },
+      { "id": "send", "role": "button", "label": "Send", "focused": false, "enabled": true, "x": 1120, "y": 792, "w": 72, "h": 32, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "textarea",
+    "label": "Message Body",
+    "value": "Hi team,\nThe draft checklist covers the release notes, owner review, and rollback plan.\nI will send the final version after the fixture pass.",
+    "selectedText": "draft checklist",
+    "viewport": "The draft checklist covers the release notes, owner review, and rollback plan."
+  }
+}

--- a/Packages/OsaurusEvals/Fixtures/ScreenContext/terminal-system-settings-dangerous.json
+++ b/Packages/OsaurusEvals/Fixtures/ScreenContext/terminal-system-settings-dangerous.json
@@ -1,0 +1,38 @@
+{
+  "apps": [
+    { "pid": 503, "bundleId": "com.apple.Terminal", "name": "Terminal", "active": true, "hidden": false },
+    { "pid": 504, "bundleId": "com.apple.systempreferences", "name": "System Settings", "active": false, "hidden": false }
+  ],
+  "activeWindow": {
+    "pid": 503,
+    "app": "Terminal",
+    "title": "zsh - ScreenContext Lab",
+    "x": 0, "y": 0, "w": 1180, "h": 760
+  },
+  "windowsByPid": {
+    "503": [
+      { "windowId": 1, "title": "zsh - ScreenContext Lab", "focused": true, "minimized": false, "x": 0, "y": 0, "w": 1180, "h": 760 }
+    ],
+    "504": [
+      { "windowId": 2, "title": "Privacy & Security - Accessibility", "focused": false, "minimized": false, "x": 118, "y": 92, "w": 980, "h": 700 }
+    ]
+  },
+  "snapshot": {
+    "app": "Terminal",
+    "focusedWindow": "zsh - ScreenContext Lab",
+    "truncated": false,
+    "windows": [
+      { "id": 1, "title": "zsh - ScreenContext Lab", "focused": true, "x": 0, "y": 0, "w": 1180, "h": 760 }
+    ],
+    "elements": [
+      { "id": "terminal", "role": "textarea", "label": "Terminal", "value": "cd /tmp/screen-context-lab\nsudo synthetic-admin-tool --dry-run\n# awaiting explicit user confirmation", "focused": true, "enabled": true, "x": 18, "y": 42, "w": 1140, "h": 660, "actions": [] },
+      { "id": "prompt", "role": "statictext", "value": "Password prompt is not active; command is staged for review.", "focused": false, "enabled": true, "x": 18, "y": 704, "w": 760, "h": 22, "actions": [] }
+    ]
+  },
+  "focusedContent": {
+    "role": "textarea",
+    "label": "Terminal",
+    "value": "cd /tmp/screen-context-lab\nsudo synthetic-admin-tool --dry-run\n# awaiting explicit user confirmation",
+    "viewport": "sudo synthetic-admin-tool --dry-run\n# awaiting explicit user confirmation"
+  }
+}

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -24,6 +24,7 @@ Packages/OsaurusEvals/
     ComputerUseLoop/    — E2E Computer Use over a scripted screen (LLM or scripted)
     PrefixHash/         — KV-cache prefix-hash stability
     RequestValidation/  — RequestValidator.unsupportedSamplerReason
+    ScreenContext/      — deterministic AX-text screen-context distillation (no LLM)
     Schema/             — SchemaValidator.validate pinning
     StreamingHint/      — StreamingToolHint encode/decode round-trips
     ToolEnvelope/       — ToolEnvelope.{success,failure} JSON shape
@@ -85,6 +86,37 @@ swift run osaurus-evals run --suite Suites/CapabilitySearch --model foundation
 swift run osaurus-evals run --suite Suites/CapabilitySearch --filter browser --out report.json
 swift run osaurus-evals run --suite Suites/CapabilitySearch --bootstrap-plugins
 ```
+
+### Screen Context capture lab
+
+`ScreenContext` cases replay a frozen Accessibility-tree fixture through the
+production `ScreenContextDistiller`. This keeps the suite deterministic and
+CI-safe while still matching the live text-only screen-context path.
+
+Use `capture-screen` locally when tuning a new desktop shape:
+
+```bash
+# Capture the frontmost app into the gitignored local fixture directory.
+swift run --package-path Packages/OsaurusEvals osaurus-evals capture-screen --render
+
+# Capture a named running app.
+swift run --package-path Packages/OsaurusEvals osaurus-evals capture-screen \
+  --app Safari --out Packages/OsaurusEvals/Fixtures/ScreenContext/local/safari.json --render
+
+# Inspect a fixture without Accessibility permission.
+swift run --package-path Packages/OsaurusEvals osaurus-evals capture-screen \
+  --describe Packages/OsaurusEvals/Fixtures/ScreenContext/local/safari.json
+
+# Create a sanitized promotion candidate before hand-editing and committing.
+swift run --package-path Packages/OsaurusEvals osaurus-evals capture-screen \
+  --promote Packages/OsaurusEvals/Fixtures/ScreenContext/local/safari.json --render
+```
+
+Real captures contain local screen text and stay under
+`Packages/OsaurusEvals/Fixtures/ScreenContext/local/`, which is ignored. Only
+commit hand-reviewed synthetic or sanitized fixtures. The promotion helper keeps
+roles, geometry, actions, and focus shape, but redacts captured strings, drops
+secure-field values, removes AX paths, and rewrites element ids.
 
 For maintainer proof on agent-loop changes, use the regression lab. It runs
 selected `agent_loop` suites, writes per-suite JSON artifacts, compares the

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCaptureScreenCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCaptureScreenCLI.swift
@@ -9,6 +9,8 @@
 //  eval suite replays deterministically via `FixtureCUDriver`.
 //
 //    osaurus-evals capture-screen [--app <name>] [--out <path>]
+//    osaurus-evals capture-screen --describe <fixture>
+//    osaurus-evals capture-screen --promote <local-fixture> [--out <path>]
 //
 //  Local-only: it needs Accessibility permission (granted to the terminal /
 //  binary running it) and a real desktop session, so it never runs in CI. The
@@ -38,6 +40,8 @@ extension OsaurusEvalsCLI {
         var appName: String?
         var outPath: String?
         var render = false
+        var describePath: String?
+        var promotePath: String?
 
         var i = 0
         while i < args.count {
@@ -55,6 +59,18 @@ extension OsaurusEvalsCLI {
                 }
                 outPath = args[i + 1]
                 i += 2
+            case "--describe":
+                guard i + 1 < args.count else {
+                    return failCapture("flag --describe requires a value")
+                }
+                describePath = args[i + 1]
+                i += 2
+            case "--promote":
+                guard i + 1 < args.count else {
+                    return failCapture("flag --promote requires a value")
+                }
+                promotePath = args[i + 1]
+                i += 2
             case "--render":
                 render = true
                 i += 1
@@ -64,6 +80,20 @@ extension OsaurusEvalsCLI {
             default:
                 return failCapture("unknown argument: \(arg)")
             }
+        }
+
+        if let describePath {
+            guard appName == nil, promotePath == nil, outPath == nil, !render else {
+                return failCapture("--describe cannot be combined with --app, --out, --promote, or --render")
+            }
+            return describeScreenFixture(path: describePath)
+        }
+
+        if let promotePath {
+            guard appName == nil else {
+                return failCapture("--promote reads an existing fixture and cannot be combined with --app")
+            }
+            return await promoteScreenFixture(path: promotePath, outPath: outPath, render: render)
         }
 
         let driver = NativeMacDriver()
@@ -190,18 +220,15 @@ extension OsaurusEvalsCLI {
             return failCapture("failed to write fixture: \(error.localizedDescription)")
         }
 
-        let elementCount = snapshot.elements.count
-        let focusNote = focusedContent.map { "role=\($0.role)" } ?? "none"
         print(
             """
             captured \(target.name) → \(outURL.path)
-              apps=\(apps.count) windows=\(windowsByPid.values.reduce(0) { $0 + $1.count }) \
-            elements=\(elementCount) truncated=\(snapshot.truncated) focused=\(focusNote)
             Point a screen_context case at this file (relative to \
             Packages/OsaurusEvals/Fixtures/ScreenContext/) and run:
               make evals EVALS_SUITE=Packages/OsaurusEvals/Suites/ScreenContext --verbose
             """
         )
+        printCaptureSummary(fixture.captureSummary())
 
         // `--render`: replay the just-captured fixture through the production
         // distiller and print the exact block the chat would inject. This is the
@@ -220,6 +247,138 @@ extension OsaurusEvalsCLI {
     }
 
     // MARK: - Helpers
+
+    private static func describeScreenFixture(path: String) -> Int32 {
+        do {
+            let fixture = try loadFixture(at: URL(fileURLWithPath: path))
+            printCaptureSummary(fixture.captureSummary())
+            return 0
+        } catch {
+            return failCapture("failed to describe fixture: \(error.localizedDescription)")
+        }
+    }
+
+    private static func promoteScreenFixture(
+        path: String,
+        outPath: String?,
+        render: Bool
+    ) async -> Int32 {
+        let inputURL = URL(fileURLWithPath: path)
+        do {
+            let fixture = try loadFixture(at: inputURL)
+            let candidate = fixture.sanitizedForPromotion()
+            let outURL = outPath.map { URL(fileURLWithPath: $0) }
+                ?? defaultPromotionURL(inputURL: inputURL, fixture: fixture)
+            try writeFixture(candidate.fixture, to: outURL)
+
+            print(
+                """
+                wrote sanitized promotion candidate → \(outURL.path)
+                source capture → \(inputURL.path)
+                """
+            )
+            printSanitizationReport(candidate.report)
+            printCaptureSummary(candidate.fixture.captureSummary())
+            print(
+                """
+                Review and hand-edit this candidate before committing it. The helper replaces \
+                captured text with placeholders so you can preserve AX shape without carrying \
+                private screen content into committed fixtures.
+                """
+            )
+
+            if render {
+                let distilled = await ScreenContextDistiller().capture(
+                    using: FixtureCUDriver(fixture: candidate.fixture),
+                    selfPid: Int32.max,
+                    selfBundleId: nil,
+                    preferredPid: nil
+                )
+                print("\n--- rendered sanitized block ---")
+                print(distilled.render())
+            }
+            return 0
+        } catch {
+            return failCapture("failed to promote fixture: \(error.localizedDescription)")
+        }
+    }
+
+    private static func loadFixture(at url: URL) throws -> ScreenContextFixture {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(ScreenContextFixture.self, from: data)
+    }
+
+    private static func writeFixture(_ fixture: ScreenContextFixture, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(fixture)
+        try data.write(to: url)
+    }
+
+    private static func defaultPromotionURL(
+        inputURL: URL,
+        fixture: ScreenContextFixture
+    ) -> URL {
+        let stamp = Self.captureTimestamp()
+        let sourceSlug = Self.fileSlug(inputURL.deletingPathExtension().lastPathComponent)
+        let appSlug = Self.fileSlug(fixture.activeWindow?.app ?? fixture.snapshot.app)
+        return URL(fileURLWithPath: defaultCaptureDir)
+            .appendingPathComponent("sanitized-\(appSlug)-\(sourceSlug)-\(stamp).json")
+    }
+
+    private static func printCaptureSummary(_ summary: ScreenContextFixture.CaptureSummary) {
+        let focusNote: String
+        if let role = summary.focusedRole {
+            if let label = summary.focusedLabel, !label.isEmpty {
+                focusNote = "\(role) \"\(label)\""
+            } else {
+                focusNote = role
+            }
+        } else {
+            focusNote = "none"
+        }
+        let roleText =
+            summary.topRoles.isEmpty
+            ? "none"
+            : summary.topRoles.map { "\($0.role)=\($0.count)" }.joined(separator: ", ")
+        print(
+            """
+            capture summary:
+              app=\(summary.workingApp) window=\(summary.workingWindowTitle ?? "none")
+              apps=\(summary.appCount) windows=\(summary.windowCount) elements=\(summary.elementCount) \
+            textElements=\(summary.textElementCount) secureFields=\(summary.secureFieldCount) \
+            pathFields=\(summary.pathFieldCount) truncated=\(summary.truncated)
+              focused=\(focusNote)
+              topRoles=\(roleText)
+            """
+        )
+        if !summary.localOnlyReasons.isEmpty {
+            print("  localOnly:")
+            for reason in summary.localOnlyReasons {
+                print("    - \(reason)")
+            }
+        }
+    }
+
+    private static func printSanitizationReport(
+        _ report: ScreenContextFixture.PromotionSanitizationReport
+    ) {
+        print(
+            """
+            sanitization:
+              stringFieldsRedacted=\(report.stringFieldsRedacted) \
+            secureValuesDropped=\(report.secureValuesDropped) \
+            elementIDsRewritten=\(report.elementIDsRewritten)
+              pathFieldsDropped=\(report.pathFieldsDropped) \
+            windowTitlesRedacted=\(report.windowTitlesRedacted) \
+            appMetadataRedacted=\(report.appMetadataRedacted)
+            """
+        )
+    }
 
     private static func captureTimestamp() -> String {
         let formatter = DateFormatter()
@@ -253,6 +412,8 @@ extension OsaurusEvalsCLI {
 
             USAGE:
                 osaurus-evals capture-screen [--app <name>] [--out <path>] [--render]
+                osaurus-evals capture-screen --describe <fixture>
+                osaurus-evals capture-screen --promote <local-fixture> [--out <path>] [--render]
 
             FLAGS:
                 --app <name>   Capture this app (exact, then case-insensitive
@@ -264,6 +425,13 @@ extension OsaurusEvalsCLI {
                 --render       After capturing, replay the fixture through the
                                distiller and print the exact injected block (the
                                fast capture→diagnose loop).
+                --describe <fixture>
+                               Print fixture metadata and local-only risk summary.
+                               No Accessibility permission required.
+                --promote <local-fixture>
+                               Write a sanitized promotion candidate. The helper
+                               keeps geometry/roles but replaces captured text
+                               with placeholders; hand-edit before committing.
 
             REQUIRES:
                 Accessibility permission for the running process (terminal/binary),
@@ -274,6 +442,8 @@ extension OsaurusEvalsCLI {
                 osaurus-evals capture-screen
                 osaurus-evals capture-screen --app Xcode
                 osaurus-evals capture-screen --app Safari --out /tmp/safari.json
+                osaurus-evals capture-screen --describe Packages/OsaurusEvals/Fixtures/ScreenContext/local/xcode.json
+                osaurus-evals capture-screen --promote Packages/OsaurusEvals/Fixtures/ScreenContext/local/xcode.json
             """
         print(usage)
     }

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/ScreenContextFixture.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/ScreenContextFixture.swift
@@ -21,6 +21,97 @@ import OsaurusCore
 
 public struct ScreenContextFixture: Sendable, Codable, Equatable {
 
+    public struct CaptureSummary: Sendable, Equatable {
+        public struct RoleCount: Sendable, Equatable {
+            public let role: String
+            public let count: Int
+
+            public init(role: String, count: Int) {
+                self.role = role
+                self.count = count
+            }
+        }
+
+        public let workingApp: String
+        public let workingWindowTitle: String?
+        public let appCount: Int
+        public let windowCount: Int
+        public let elementCount: Int
+        public let textElementCount: Int
+        public let secureFieldCount: Int
+        public let pathFieldCount: Int
+        public let truncated: Bool
+        public let focusedRole: String?
+        public let focusedLabel: String?
+        public let topRoles: [RoleCount]
+        public let localOnlyReasons: [String]
+
+        public init(
+            workingApp: String,
+            workingWindowTitle: String?,
+            appCount: Int,
+            windowCount: Int,
+            elementCount: Int,
+            textElementCount: Int,
+            secureFieldCount: Int,
+            pathFieldCount: Int,
+            truncated: Bool,
+            focusedRole: String?,
+            focusedLabel: String?,
+            topRoles: [RoleCount],
+            localOnlyReasons: [String]
+        ) {
+            self.workingApp = workingApp
+            self.workingWindowTitle = workingWindowTitle
+            self.appCount = appCount
+            self.windowCount = windowCount
+            self.elementCount = elementCount
+            self.textElementCount = textElementCount
+            self.secureFieldCount = secureFieldCount
+            self.pathFieldCount = pathFieldCount
+            self.truncated = truncated
+            self.focusedRole = focusedRole
+            self.focusedLabel = focusedLabel
+            self.topRoles = topRoles
+            self.localOnlyReasons = localOnlyReasons
+        }
+    }
+
+        public struct PromotionSanitizationReport: Sendable, Equatable {
+            public var stringFieldsRedacted: Int
+            public var secureValuesDropped: Int
+            public var elementIDsRewritten: Int
+            public var pathFieldsDropped: Int
+            public var windowTitlesRedacted: Int
+            public var appMetadataRedacted: Int
+
+            public init(
+                stringFieldsRedacted: Int = 0,
+                secureValuesDropped: Int = 0,
+                elementIDsRewritten: Int = 0,
+                pathFieldsDropped: Int = 0,
+                windowTitlesRedacted: Int = 0,
+                appMetadataRedacted: Int = 0
+            ) {
+                self.stringFieldsRedacted = stringFieldsRedacted
+                self.secureValuesDropped = secureValuesDropped
+                self.elementIDsRewritten = elementIDsRewritten
+                self.pathFieldsDropped = pathFieldsDropped
+                self.windowTitlesRedacted = windowTitlesRedacted
+                self.appMetadataRedacted = appMetadataRedacted
+            }
+        }
+
+    public struct PromotionCandidate: Sendable, Equatable {
+        public let fixture: ScreenContextFixture
+        public let report: PromotionSanitizationReport
+
+        public init(fixture: ScreenContextFixture, report: PromotionSanitizationReport) {
+            self.fixture = fixture
+            self.report = report
+        }
+    }
+
     /// The single capture the distiller reads for the working app. Mirrors the
     /// scored fields of `CUSnapshot` (the image and ids are irrelevant to the
     /// text distillation) plus `truncated`, which gates the editor-fallback
@@ -156,5 +247,416 @@ public struct ScreenContextFixture: Sendable, Codable, Equatable {
             elements: clipped,
             image: nil
         )
+    }
+
+    // MARK: - Capture lab helpers
+
+    public func captureSummary(topRoleLimit: Int = 8) -> CaptureSummary {
+        let windows = windowsByPid.values.reduce(0) { $0 + $1.count }
+        let roleCounts = Dictionary(grouping: snapshot.elements, by: { $0.role.lowercased() })
+            .map { CaptureSummary.RoleCount(role: $0.key, count: $0.value.count) }
+            .sorted {
+                if $0.count != $1.count { return $0.count > $1.count }
+                return $0.role < $1.role
+            }
+            .prefix(topRoleLimit)
+
+        let textElements = snapshot.elements.filter(Self.elementCarriesText).count
+        let secureFields = snapshot.elements.filter { Self.isSecureRole($0.role) }.count
+        let pathFields = snapshot.elements.filter { $0.path?.isEmpty == false }.count
+
+        var reasons: [String] = []
+        if textElements > 0 || focusedContentHasText {
+            reasons.append("contains text read from the user's accessibility tree")
+        }
+        if secureFields > 0 || focusedContent.map({ Self.isSecureRole($0.role) }) == true {
+            reasons.append("contains secure-field metadata that must be reviewed")
+        }
+        if pathFields > 0 {
+            reasons.append("contains accessibility paths that can include private labels")
+        }
+        let hasUserWindowTitle = Self.hasUserWindowTitle(activeWindow?.title)
+            || Self.hasUserWindowTitle(snapshot.focusedWindow)
+            || snapshot.windows.contains(where: { Self.hasUserWindowTitle($0.title) })
+            || windowsByPid.values.flatMap({ $0 }).contains(where: { Self.hasUserWindowTitle($0.title) })
+        if hasUserWindowTitle {
+            reasons.append("contains window title metadata from the user's desktop")
+        }
+        if Self.hasUserAppMetadata(apps: apps, activeWindow: activeWindow, snapshot: snapshot) {
+            reasons.append("contains app metadata from the user's desktop")
+        }
+        if !reasons.isEmpty {
+            reasons.append("keep under Fixtures/ScreenContext/local/ until sanitized")
+        }
+
+        return CaptureSummary(
+            workingApp: activeWindow?.app ?? snapshot.app,
+            workingWindowTitle: activeWindow?.title ?? snapshot.focusedWindow,
+            appCount: apps.count,
+            windowCount: windows,
+            elementCount: snapshot.elements.count,
+            textElementCount: textElements,
+            secureFieldCount: secureFields,
+            pathFieldCount: pathFields,
+            truncated: snapshot.truncated,
+            focusedRole: focusedContent?.role,
+            focusedLabel: focusedContent?.label,
+            topRoles: Array(roleCounts),
+            localOnlyReasons: reasons
+        )
+    }
+
+    public func sanitizedForPromotion() -> PromotionCandidate {
+        var report = PromotionSanitizationReport()
+        let appNamesByPid = Self.syntheticAppNames(apps: apps, activeWindow: activeWindow)
+        let syntheticActiveApp =
+            activeWindow.flatMap { appNamesByPid[$0.pid] }
+            ?? appNamesByPid[workingPid]
+            ?? "Synthetic App"
+        let syntheticSnapshotApp = appNamesByPid[workingPid] ?? syntheticActiveApp
+        let syntheticTitle = Self.syntheticWindowTitle(app: syntheticSnapshotApp)
+        let sanitizedApps = apps.enumerated().map { offset, app in
+            Self.sanitize(app: app, replacementName: "Synthetic App \(offset + 1)", report: &report)
+        }
+        Self.recordAppMetadataRedaction(activeWindow?.app, replacement: syntheticActiveApp, report: &report)
+        Self.recordAppMetadataRedaction(snapshot.app, replacement: syntheticSnapshotApp, report: &report)
+
+        let active: CUActiveWindow?
+        if let activeWindow {
+            active = CUActiveWindow(
+                pid: activeWindow.pid,
+                app: syntheticActiveApp,
+                title: Self.redactWindowTitle(activeWindow.title, app: syntheticActiveApp, report: &report),
+                x: activeWindow.x,
+                y: activeWindow.y,
+                w: activeWindow.w,
+                h: activeWindow.h
+            )
+        } else {
+            active = nil
+        }
+
+        var sanitizedWindows: [String: [CUWindowInfo]] = [:]
+        for (pidKey, windows) in windowsByPid {
+            let pid = Int32(pidKey)
+            let syntheticApp = pid.flatMap { appNamesByPid[$0] } ?? syntheticSnapshotApp
+            sanitizedWindows[pidKey] = windows.map { window in
+                CUWindowInfo(
+                    windowId: window.windowId,
+                    title: Self.redactWindowTitle(window.title, app: syntheticApp, report: &report),
+                    focused: window.focused,
+                    minimized: window.minimized,
+                    x: window.x,
+                    y: window.y,
+                    w: window.w,
+                    h: window.h
+                )
+            }
+        }
+
+        let sanitizedSnapshot = Snapshot(
+            app: syntheticSnapshotApp,
+            focusedWindow: snapshot.focusedWindow == nil ? nil : syntheticTitle,
+            truncated: snapshot.truncated,
+            windows: snapshot.windows.map { window in
+                CUWindowSummary(
+                    id: window.id,
+                    title: Self.redactWindowTitle(window.title, app: syntheticSnapshotApp, report: &report),
+                    focused: window.focused,
+                    x: window.x,
+                    y: window.y,
+                    w: window.w,
+                    h: window.h
+                )
+            },
+            elements: snapshot.elements.enumerated().map { offset, element in
+                Self.sanitize(element: element, index: offset + 1, report: &report)
+            }
+        )
+
+        if snapshot.focusedWindow != nil {
+            report.windowTitlesRedacted += 1
+            report.stringFieldsRedacted += 1
+        }
+
+        let sanitized = ScreenContextFixture(
+            apps: sanitizedApps,
+            activeWindow: active,
+            windowsByPid: sanitizedWindows,
+            snapshot: sanitizedSnapshot,
+            focusedContent: focusedContent.map { Self.sanitize(focused: $0, report: &report) }
+        )
+        return PromotionCandidate(fixture: sanitized, report: report)
+    }
+
+    private var focusedContentHasText: Bool {
+        guard let focusedContent else { return false }
+        return [
+            focusedContent.label,
+            focusedContent.placeholder,
+            focusedContent.value,
+            focusedContent.selectedText,
+            focusedContent.viewport,
+        ].contains { $0?.isEmpty == false }
+    }
+
+    private static func hasUserWindowTitle(_ title: String?) -> Bool {
+        guard let title = title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else {
+            return false
+        }
+        return !title.hasPrefix("Synthetic ")
+    }
+
+    private static func hasUserAppMetadata(
+        apps: [CUAppListing],
+        activeWindow: CUActiveWindow?,
+        snapshot: Snapshot
+    ) -> Bool {
+        if apps.contains(where: { app in
+            app.bundleId?.isEmpty == false || !app.name.hasPrefix("Synthetic ")
+        }) {
+            return true
+        }
+        if let activeWindow, !activeWindow.app.hasPrefix("Synthetic ") {
+            return true
+        }
+        return !snapshot.app.hasPrefix("Synthetic ")
+    }
+
+    private static func elementCarriesText(_ element: CUElement) -> Bool {
+        [
+            element.roleDescription,
+            element.label,
+            element.value,
+            element.selectedText,
+            element.placeholder,
+            element.path,
+        ].contains { $0?.isEmpty == false }
+    }
+
+    private static func isSecureRole(_ role: String) -> Bool {
+        switch role.lowercased() {
+        case "securetextfield", "axsecuretextfield", "securefield":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func redactWindowTitle(
+        _ title: String?,
+        app: String,
+        report: inout PromotionSanitizationReport
+    ) -> String? {
+        guard title?.isEmpty == false else { return title }
+        report.windowTitlesRedacted += 1
+        report.stringFieldsRedacted += 1
+        return syntheticWindowTitle(app: app)
+    }
+
+    private static func sanitize(
+        app: CUAppListing,
+        replacementName: String,
+        report: inout PromotionSanitizationReport
+    ) -> CUAppListing {
+        recordAppMetadataRedaction(app.name, replacement: replacementName, report: &report)
+        recordAppMetadataRedaction(app.bundleId, replacement: nil, report: &report)
+        return CUAppListing(
+            pid: app.pid,
+            bundleId: nil,
+            name: replacementName,
+            active: app.active,
+            hidden: app.hidden
+        )
+    }
+
+    private static func sanitize(
+        element: CUElement,
+        index: Int,
+        report: inout PromotionSanitizationReport
+    ) -> CUElement {
+        if element.id != "e\(index)" {
+            report.elementIDsRewritten += 1
+        }
+        let secure = isSecureRole(element.role)
+        if element.path?.isEmpty == false {
+            report.pathFieldsDropped += 1
+        }
+        let roleDescription = redact(
+            element.roleDescription,
+            replacement: "Synthetic role description \(index)",
+            report: &report
+        )
+        let label = redact(
+            element.label,
+            replacement: "Synthetic \(roleLabel(element.role)) label \(index)",
+            report: &report
+        )
+        let placeholder = redact(
+            element.placeholder,
+            replacement: "Synthetic placeholder \(index)",
+            report: &report
+        )
+        let value: String?
+        let selectedText: String?
+        if secure {
+            value = dropSecure(element.value, report: &report)
+            selectedText = dropSecure(element.selectedText, report: &report)
+        } else {
+            value = redact(
+                element.value,
+                replacement: syntheticValue(role: element.role, index: index),
+                report: &report
+            )
+            selectedText = redact(
+                element.selectedText,
+                replacement: "synthetic selection \(index)",
+                report: &report
+            )
+        }
+
+        return CUElement(
+            id: "e\(index)",
+            role: element.role,
+            roleDescription: roleDescription,
+            label: label,
+            value: value,
+            selectedText: selectedText,
+            placeholder: placeholder,
+            path: nil,
+            windowId: element.windowId,
+            focused: element.focused,
+            enabled: element.enabled,
+            x: element.x,
+            y: element.y,
+            w: element.w,
+            h: element.h,
+            actions: element.actions
+        )
+    }
+
+    private static func sanitize(
+        focused: CUFocusedContent,
+        report: inout PromotionSanitizationReport
+    ) -> CUFocusedContent {
+        let secure = isSecureRole(focused.role)
+        return CUFocusedContent(
+            role: focused.role,
+            label: redact(
+                focused.label,
+                replacement: "Synthetic focused \(roleLabel(focused.role))",
+                report: &report
+            ),
+            placeholder: redact(
+                focused.placeholder,
+                replacement: "Synthetic focused placeholder",
+                report: &report
+            ),
+            value: secure
+                ? dropSecure(focused.value, report: &report)
+                : redact(
+                    focused.value,
+                    replacement: syntheticValue(role: focused.role, index: 1),
+                    report: &report
+                ),
+            selectedText: secure
+                ? dropSecure(focused.selectedText, report: &report)
+                : redact(
+                    focused.selectedText,
+                    replacement: "synthetic focused selection",
+                    report: &report
+                ),
+            viewport: secure
+                ? dropSecure(focused.viewport, report: &report)
+                : redact(
+                    focused.viewport,
+                    replacement: "Synthetic viewport excerpt replaces local capture text.",
+                    report: &report
+                )
+        )
+    }
+
+    private static func redact(
+        _ value: String?,
+        replacement: String,
+        report: inout PromotionSanitizationReport
+    ) -> String? {
+        guard value?.isEmpty == false else { return value }
+        report.stringFieldsRedacted += 1
+        return replacement
+    }
+
+    private static func dropSecure(
+        _ value: String?,
+        report: inout PromotionSanitizationReport
+    ) -> String? {
+        guard value?.isEmpty == false else { return value }
+        report.secureValuesDropped += 1
+        report.stringFieldsRedacted += 1
+        return nil
+    }
+
+    private static func recordAppMetadataRedaction(
+        _ value: String?,
+        replacement: String?,
+        report: inout PromotionSanitizationReport
+    ) {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return
+        }
+        guard value != replacement else { return }
+        report.appMetadataRedacted += 1
+        report.stringFieldsRedacted += 1
+    }
+
+    private static func syntheticWindowTitle(app: String) -> String {
+        let name = app.trimmingCharacters(in: .whitespacesAndNewlines)
+        if name.hasPrefix("Synthetic ") {
+            return "\(name) Window"
+        }
+        return "Synthetic \(name.isEmpty ? "App" : name) Window"
+    }
+
+    private static func syntheticAppNames(
+        apps: [CUAppListing],
+        activeWindow: CUActiveWindow?
+    ) -> [Int32: String] {
+        var names: [Int32: String] = [:]
+        for (offset, app) in apps.enumerated() {
+            names[app.pid] = "Synthetic App \(offset + 1)"
+        }
+        if let activeWindow, names[activeWindow.pid] == nil {
+            names[activeWindow.pid] = "Synthetic App \(names.count + 1)"
+        }
+        return names
+    }
+
+    private static func roleLabel(_ role: String) -> String {
+        switch role.lowercased() {
+        case "textfield": return "text field"
+        case "textarea": return "text area"
+        case "searchfield": return "search field"
+        case "securetextfield", "axsecuretextfield", "securefield": return "secure field"
+        case "statictext", "staticrtext": return "text"
+        case let other where other.isEmpty: return "element"
+        case let other: return other
+        }
+    }
+
+    private static func syntheticValue(role: String, index: Int) -> String {
+        switch role.lowercased() {
+        case "heading":
+            return "Synthetic heading \(index)"
+        case "statictext", "staticrtext":
+            return "Synthetic on-screen text \(index)"
+        case "textarea":
+            return "Synthetic editor content \(index). Placeholder text replaces local capture text."
+        case "textfield", "searchfield", "combobox":
+            return "synthetic value \(index)"
+        case "webarea":
+            return "Synthetic web area content \(index)"
+        default:
+            return "Synthetic \(roleLabel(role)) value \(index)"
+        }
     }
 }

--- a/Packages/OsaurusEvals/Suites/ScreenContext/README.md
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/README.md
@@ -40,8 +40,14 @@ noted, so CI stays free.
 | `cursor-working-state` | a fuller Cursor working state: the (unsaved-marked) title names the active file and the bottom status bar composes a `Status:` line — git branch, problems count, language, cursor position — while the inaccessible code body stays absent |
 | `safari-article-beats-chrome` | with no focused input, the large article body leads `On screen:` ahead of nav chrome; bare version tokens dropped |
 | `chrome-webarea-article` | a browser page under an `AXWebArea`: the heading + body paragraphs surface ahead of chrome, while nav links, a single-token nav label, a leaked ARIA `true`, and a bare version token are dropped |
+| `browser-form-checkout` | a browser form with a focused text field surfaces its value, the page title, and relevant sibling form context |
 | `slack-draft-and-selection` | the active channel surfaces (`Active: channel #…`), and the focused composer's draft + selection surface for a non-editor app (text field, no viewport); messages show as on-screen content |
 | `slack-scrolled-messages` | a scrolled channel with no focused composer: the active channel surfaces from the title, the message rows inside the scroll area surface as content, while single-token sidebar chrome (Threads / Drafts) is dropped |
+| `chat-shell-compose` | a generic Slack-like Electron shell pins active-channel parsing, focused draft text, selection text, and message-row context |
+| `mail-compose-reply` | a native Mail compose window surfaces the focused message body, selected draft text, and nearby reply context |
+| `finder-selected-file` | a Finder outline/list shape preserves the selected file and useful surrounding file names while dropping sidebar chrome |
+| `terminal-system-settings-dangerous` | a Terminal/System Settings shaped desktop remains read-only screen context evidence and does not imply action-policy permission |
+| `secure-field-never-leaks` | secure text fields keep role/focus context while dropping secure values, selections, and viewport text |
 | `empty-input-minimal` | an empty focused field stays minimal — no fabricated `Viewing:` / `Selected text:` (uses an INLINE `scene`, exercising that path) |
 
 ## Fixtures (`../../Fixtures/ScreenContext/`)
@@ -64,11 +70,23 @@ Committed fixtures are hand-authored, **synthetic** trees that reproduce real AX
 - `chrome-webarea-article.json` — an `AXWebArea` page (heading + body paragraphs)
   under browser chrome (address bar, reload) + nav link/label, a leaked ARIA
   `true`, and a labeled version token (the real Chrome shape).
+- `browser-form-checkout.json` — a browser form with focused-field value, sibling
+  field labels, page heading, and call-to-action context.
 - `slack-thread.json` — a focused composer `textfield` (draft + selection) +
   message `statictext`s.
 - `slack-scrolled-messages.json` — a `scrollarea` of message `statictext` rows +
   single-token sidebar labels, with no focused composer (the scrolled-history
   shape).
+- `chat-shell-compose.json` — a generic Electron chat shell with channel title,
+  composer draft/selection, and message rows.
+- `mail-compose-reply.json` — a native Mail compose/reply shape with selected text
+  and viewport text in the focused message body.
+- `finder-selected-file.json` — a Finder outline/list shape with selected file
+  text and surrounding file rows.
+- `terminal-system-settings-dangerous.json` — a Terminal window plus System
+  Settings window metadata for read-only distillation proof.
+- `safari-secure-login.json` — a secure-field shape that proves password-like
+  values never surface in rendered screen context.
 
 ## What the distiller does with real apps (the AX reality)
 

--- a/Packages/OsaurusEvals/Suites/ScreenContext/browser-form-checkout.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/browser-form-checkout.json
@@ -1,0 +1,23 @@
+{
+  "id": "screen_context.browser-form-checkout",
+  "domain": "screen_context",
+  "label": "Screen context • browser form focused field",
+  "query": "(ambient capture)",
+  "notes": "Browser form shape: a focused text field surfaces its current value while labeled sibling fields and page copy provide the surrounding form context.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "browser-form-checkout.json",
+      "focusedRoleEquals": "text field",
+      "gistContains": ["In Google Chrome", "Request Access - Example"],
+      "mustContain": [
+        "In Google Chrome",
+        "Focused field: text field \"Team name\"",
+        "Synthetic Platform Team",
+        "Request access",
+        "Justification: Need temporary access"
+      ],
+      "orderedContains": [["Synthetic Platform Team", "Request access"]]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ScreenContext/chat-shell-compose.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/chat-shell-compose.json
@@ -1,0 +1,24 @@
+{
+  "id": "screen_context.chat-shell-compose",
+  "domain": "screen_context",
+  "label": "Screen context • Slack-like shell focused draft",
+  "query": "(ambient capture)",
+  "notes": "Generic Electron chat-shell shape: a Slack-like channel title is parsed as active context, the focused composer draft and selection surface, and message rows remain on-screen content.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "chat-shell-compose.json",
+      "focusedRoleEquals": "text field",
+      "selectedTextContains": "fixture owner",
+      "gistContains": ["In ChatDesk"],
+      "mustContain": [
+        "In ChatDesk",
+        "Active: channel release-room",
+        "Focused field: text field \"Message release-room\"",
+        "Selected text:",
+        "release checklist"
+      ],
+      "mustNotContain": ["Threads"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ScreenContext/finder-selected-file.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/finder-selected-file.json
@@ -1,0 +1,24 @@
+{
+  "id": "screen_context.finder-selected-file",
+  "domain": "screen_context",
+  "label": "Screen context • Finder selected file is visible",
+  "query": "(ambient capture)",
+  "notes": "Finder list/outline shape: the focused outline reports the selected file, and the surrounding file list surfaces as on-screen context without requiring action policy.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "finder-selected-file.json",
+      "focusedRoleEquals": "outline",
+      "selectedTextContains": "Synthetic Strategy Brief.pdf",
+      "gistContains": ["In Finder", "Design Assets"],
+      "mustContain": [
+        "In Finder",
+        "Focused field: outline \"Files\"",
+        "Selected text:",
+        "Synthetic Strategy Brief.pdf",
+        "Fixture Screenshot Set"
+      ],
+      "mustNotContain": ["Favorites"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ScreenContext/mail-compose-reply.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/mail-compose-reply.json
@@ -1,0 +1,24 @@
+{
+  "id": "screen_context.mail-compose-reply",
+  "domain": "screen_context",
+  "label": "Screen context • Mail compose reply surfaces draft",
+  "query": "(ambient capture)",
+  "notes": "Native Mail compose shape: the focused message-body text area carries the draft, selection, and viewport while nearby message text remains secondary on-screen context.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "mail-compose-reply.json",
+      "focusedRoleEquals": "text area",
+      "selectedTextContains": "draft checklist",
+      "viewingContains": ["rollback plan"],
+      "gistContains": ["In Mail", "Project Update - Reply"],
+      "mustContain": [
+        "In Mail",
+        "Focused field: text area \"Message Body\"",
+        "Viewing:",
+        "Selected text:",
+        "Maya Example"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/ScreenContext/terminal-system-settings-dangerous.json
+++ b/Packages/OsaurusEvals/Suites/ScreenContext/terminal-system-settings-dangerous.json
@@ -1,0 +1,23 @@
+{
+  "id": "screen_context.terminal-system-settings-dangerous",
+  "domain": "screen_context",
+  "label": "Screen context • Terminal plus System Settings shape stays read-only",
+  "query": "(ambient capture)",
+  "notes": "Dangerous-app-shaped context only: Terminal is frontmost with a sudo-shaped synthetic command, and System Settings is open in the window list. This suite only verifies read-only distillation; it does not alter action policy.",
+  "fixtures": {},
+  "expect": {
+    "screenContext": {
+      "fixture": "terminal-system-settings-dangerous.json",
+      "focusedRoleEquals": "text area",
+      "viewingContains": ["sudo synthetic-admin-tool --dry-run"],
+      "gistContains": ["In Terminal", "zsh - ScreenContext Lab"],
+      "mustContain": [
+        "In Terminal",
+        "Focused field: text area \"Terminal\"",
+        "sudo synthetic-admin-tool --dry-run",
+        "System Settings",
+        "Privacy & Security - Accessibility"
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ScreenContextCaptureLabTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ScreenContextCaptureLabTests.swift
@@ -1,0 +1,232 @@
+//
+//  ScreenContextCaptureLabTests.swift
+//  OsaurusEvalsKitTests
+//
+//  Security-focused coverage for the screen-context capture lab helpers.
+//
+
+import Foundation
+import OsaurusCore
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct ScreenContextCaptureLabTests {
+
+    @Test func captureSummaryFlagsLocalOnlyScreenText() {
+        let fixture = Self.privateFixture()
+
+        let summary = fixture.captureSummary()
+
+        #expect(summary.workingApp == "Safari")
+        #expect(summary.workingWindowTitle == "Checkout - ada@example.com")
+        #expect(summary.appCount == 1)
+        #expect(summary.windowCount == 1)
+        #expect(summary.elementCount == 3)
+        #expect(summary.textElementCount == 3)
+        #expect(summary.secureFieldCount == 1)
+        #expect(summary.pathFieldCount == 2)
+        #expect(summary.focusedRole == "AXSecureTextField")
+        #expect(summary.localOnlyReasons.contains("contains text read from the user's accessibility tree"))
+        #expect(summary.localOnlyReasons.contains("contains secure-field metadata that must be reviewed"))
+        #expect(summary.localOnlyReasons.contains("contains accessibility paths that can include private labels"))
+        #expect(summary.localOnlyReasons.contains("contains window title metadata from the user's desktop"))
+        #expect(summary.localOnlyReasons.contains("contains app metadata from the user's desktop"))
+        #expect(summary.localOnlyReasons.contains("keep under Fixtures/ScreenContext/local/ until sanitized"))
+    }
+
+    @Test func captureSummaryFlagsTitleOnlyWindowMetadataAsLocalOnly() {
+        let fixture = ScreenContextFixture(
+            apps: [
+                CUAppListing(
+                    pid: 22,
+                    bundleId: "com.apple.Terminal",
+                    name: "Terminal",
+                    active: true,
+                    hidden: false
+                ),
+            ],
+            activeWindow: CUActiveWindow(
+                pid: 22,
+                app: "Terminal",
+                title: "prod-token-reset.txt",
+                x: 0,
+                y: 0,
+                w: 800,
+                h: 500
+            ),
+            windowsByPid: [:],
+            snapshot: ScreenContextFixture.Snapshot(
+                app: "Terminal",
+                focusedWindow: "prod-token-reset.txt",
+                windows: [],
+                elements: []
+            )
+        )
+
+        let summary = fixture.captureSummary()
+
+        #expect(summary.textElementCount == 0)
+        #expect(summary.secureFieldCount == 0)
+        #expect(summary.pathFieldCount == 0)
+        #expect(summary.localOnlyReasons.contains("contains window title metadata from the user's desktop"))
+        #expect(summary.localOnlyReasons.contains("contains app metadata from the user's desktop"))
+        #expect(summary.localOnlyReasons.contains("keep under Fixtures/ScreenContext/local/ until sanitized"))
+    }
+
+    @Test func sanitizedPromotionDropsPrivateScreenContentAndKeepsReplayShape() throws {
+        let fixture = Self.privateFixture()
+
+        let candidate = fixture.sanitizedForPromotion()
+        let sanitized = candidate.fixture
+        let data = try JSONEncoder().encode(sanitized)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(!json.contains("ada@example.com"))
+        #expect(!json.contains("card 4242"))
+        #expect(!json.contains("hunter2"))
+        #expect(!json.contains("/Users/ada"))
+        #expect(!json.contains("Safari"))
+        #expect(!json.contains("com.apple.Safari"))
+        #expect(json.contains("Synthetic"))
+        #expect(candidate.report.stringFieldsRedacted > 0)
+        #expect(candidate.report.secureValuesDropped == 5)
+        #expect(candidate.report.elementIDsRewritten == 3)
+        #expect(candidate.report.pathFieldsDropped == 2)
+        #expect(candidate.report.windowTitlesRedacted >= 3)
+        #expect(candidate.report.appMetadataRedacted >= 4)
+
+        #expect(sanitized.apps.first?.bundleId == nil)
+        #expect(sanitized.apps.first?.name == "Synthetic App 1")
+        #expect(sanitized.activeWindow?.app == "Synthetic App 1")
+        #expect(sanitized.activeWindow?.title == "Synthetic App 1 Window")
+        #expect(sanitized.snapshot.app == "Synthetic App 1")
+        #expect(sanitized.snapshot.elements.map(\.id) == ["e1", "e2", "e3"])
+        #expect(sanitized.snapshot.elements[0].role == "textfield")
+        #expect(sanitized.snapshot.elements[0].x == 40)
+        #expect(sanitized.snapshot.elements[0].actions == ["AXSetValue"])
+        #expect(sanitized.snapshot.elements[1].role == "AXSecureTextField")
+        #expect(sanitized.snapshot.elements[1].value == nil)
+        #expect(sanitized.snapshot.elements.allSatisfy { $0.path == nil })
+        #expect(sanitized.focusedContent?.role == "AXSecureTextField")
+        #expect(sanitized.focusedContent?.value == nil)
+        #expect(sanitized.focusedContent?.viewport == nil)
+    }
+
+    @Test func cuSnapshotAppliesElementBudgetWithoutLosingFixtureTruncation() {
+        let fixture = Self.privateFixture()
+
+        let clipped = fixture.cuSnapshot(pid: 701, snapshotId: 42, maxElements: 2)
+        let full = fixture.cuSnapshot(pid: 701, snapshotId: 43, maxElements: nil)
+
+        #expect(clipped.snapshotId == 42)
+        #expect(clipped.pid == 701)
+        #expect(clipped.elements.map(\.id) == ["email-field", "password-field"])
+        #expect(clipped.truncated)
+        #expect(full.elements.count == 3)
+        #expect(full.truncated)
+    }
+
+    private static func privateFixture() -> ScreenContextFixture {
+        ScreenContextFixture(
+            apps: [
+                CUAppListing(
+                    pid: 701,
+                    bundleId: "com.apple.Safari",
+                    name: "Safari",
+                    active: true,
+                    hidden: false
+                ),
+            ],
+            activeWindow: CUActiveWindow(
+                pid: 701,
+                app: "Safari",
+                title: "Checkout - ada@example.com",
+                x: 0,
+                y: 0,
+                w: 1200,
+                h: 800
+            ),
+            windowsByPid: [
+                "701": [
+                    CUWindowInfo(
+                        windowId: 11,
+                        title: "Checkout - ada@example.com",
+                        focused: true,
+                        minimized: false,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    ),
+                ],
+            ],
+            snapshot: ScreenContextFixture.Snapshot(
+                app: "Safari",
+                focusedWindow: "Checkout - ada@example.com",
+                truncated: true,
+                windows: [
+                    CUWindowSummary(
+                        id: 11,
+                        title: "Checkout - ada@example.com",
+                        focused: true,
+                        x: 0,
+                        y: 0,
+                        w: 1200,
+                        h: 800
+                    ),
+                ],
+                elements: [
+                    CUElement(
+                        id: "email-field",
+                        role: "textfield",
+                        label: "Email",
+                        value: "ada@example.com",
+                        path: "/Users/ada/private/form/email",
+                        windowId: 11,
+                        focused: false,
+                        x: 40,
+                        y: 90,
+                        w: 320,
+                        h: 28,
+                        actions: ["AXSetValue"]
+                    ),
+                    CUElement(
+                        id: "password-field",
+                        role: "AXSecureTextField",
+                        label: "Password",
+                        value: "hunter2",
+                        selectedText: "hunter2",
+                        path: "/Users/ada/private/form/password",
+                        windowId: 11,
+                        focused: true,
+                        x: 40,
+                        y: 128,
+                        w: 320,
+                        h: 28,
+                        actions: ["AXSetValue"]
+                    ),
+                    CUElement(
+                        id: "card-label",
+                        role: "staticText",
+                        label: "Payment note",
+                        value: "card 4242",
+                        windowId: 11,
+                        focused: false,
+                        x: 40,
+                        y: 170,
+                        w: 260,
+                        h: 20
+                    ),
+                ]
+            ),
+            focusedContent: CUFocusedContent(
+                role: "AXSecureTextField",
+                label: "Password",
+                value: "hunter2",
+                selectedText: "hunter2",
+                viewport: "hunter2"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an evals capture-screen workflow for describing local captures and promoting sanitized synthetic fixtures.
- Adds screen-context sanitization helpers that strip local-only text, secure values, paths, window titles, and app metadata before fixture promotion.
- Adds five new synthetic screen-context fixtures/suite cases plus focused tests for redaction, capture summaries, title-only metadata, and element-budget preservation.

## Validation
- `swift test --package-path Packages/OsaurusEvals --scratch-path Packages/OsaurusEvals/.build --filter ScreenContext`
- `git diff origin/main...HEAD --check`
- `swiftlint lint Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCaptureScreenCLI.swift Packages/OsaurusEvals/Sources/OsaurusEvalsKit/ScreenContextFixture.swift Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ScreenContextCaptureLabTests.swift`

## Notes
- Promotion defaults to the ignored local fixture directory, so real local captures are not accidentally committed.
- The committed fixtures are synthetic and the tests verify private content is redacted before promotion.
