### PR TITLE
Add plugin marketplace trust preview

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/ClaudeMarketplaceImportabilityCatalog.swift
+++ b/Packages/OsaurusCore/Services/Plugin/ClaudeMarketplaceImportabilityCatalog.swift
@@ -30,17 +30,48 @@ public struct ClaudeMarketplaceImportabilityCatalog: Sendable {
         public let agents: [String]
         public let commands: [String]
         public let mcp: Bool
+        public let hooks: Bool
+        public let unsupportedComponents: [String]
 
-        public init(skills: [String], agents: [String], commands: [String], mcp: Bool) {
+        public init(
+            skills: [String],
+            agents: [String],
+            commands: [String],
+            mcp: Bool,
+            hooks: Bool = false,
+            unsupportedComponents: [String] = []
+        ) {
             self.skills = skills
             self.agents = agents
             self.commands = commands
             self.mcp = mcp
+            self.hooks = hooks
+            self.unsupportedComponents = unsupportedComponents
         }
 
         /// True when the plugin ships nothing Osaurus can import.
         public var isEmpty: Bool {
             skills.isEmpty && agents.isEmpty && commands.isEmpty && !mcp
+        }
+
+        /// Total count of components Osaurus knows how to import.
+        public var importableCount: Int {
+            skills.count + agents.count + commands.count + (mcp ? 1 : 0)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case skills, agents, commands, mcp, hooks, unsupportedComponents
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            skills = try container.decodeIfPresent([String].self, forKey: .skills) ?? []
+            agents = try container.decodeIfPresent([String].self, forKey: .agents) ?? []
+            commands = try container.decodeIfPresent([String].self, forKey: .commands) ?? []
+            mcp = try container.decodeIfPresent(Bool.self, forKey: .mcp) ?? false
+            hooks = try container.decodeIfPresent(Bool.self, forKey: .hooks) ?? false
+            unsupportedComponents =
+                try container.decodeIfPresent([String].self, forKey: .unsupportedComponents) ?? []
         }
     }
 
@@ -72,6 +103,43 @@ public struct ClaudeMarketplaceImportabilityCatalog: Sendable {
     /// Precomputed importable components for a plugin, or `nil` if unclassified.
     public func components(for name: String) -> ComponentSummary? {
         componentsByName[name]
+    }
+
+    /// Build the trust/provenance preview used by Browse cards, detail, and
+    /// install-time guardrails. This is intentionally catalog-backed: opening
+    /// Browse should not probe every plugin's repo.
+    public func trustPreview(
+        for entry: MarketplacePlugin,
+        marketplaceRepo: GitHubRepo = ClaudeMarketplaceTrustPreview.Source.defaultMarketplaceRepo
+    ) -> ClaudeMarketplaceTrustPreview {
+        let summary = components(for: entry.name)
+        let source = ClaudeMarketplaceTrustPreview.Source(
+            marketplaceRepo: marketplaceRepo,
+            marketplaceURLLabel: "github.com/\(marketplaceRepo.owner)/\(marketplaceRepo.name)",
+            source: entry.source,
+            pluginName: entry.name
+        )
+
+        let status: ClaudeMarketplaceTrustPreview.ImportabilityStatus
+        let reason: String
+        if isNonImportable(name: entry.name) || summary?.isEmpty == true {
+            status = .blocked
+            reason = "No importable skills, agents, commands, or MCP servers were found in the bundled catalog."
+        } else if summary == nil {
+            status = .requiresReview
+            reason = "This entry is not in the bundled importability catalog yet, so Osaurus cannot preview what would be installed."
+        } else {
+            status = .importable
+            reason = "The bundled catalog found importable plugin components."
+        }
+
+        return ClaudeMarketplaceTrustPreview(
+            pluginName: entry.name,
+            source: source,
+            componentSummary: summary,
+            importabilityStatus: status,
+            reason: reason
+        )
     }
 
     // MARK: - Bundled instance
@@ -114,5 +182,231 @@ public struct ClaudeMarketplaceImportabilityCatalog: Sendable {
             assertionFailure("Failed to parse importability catalog: \(error)")
             return ClaudeMarketplaceImportabilityCatalog(nonImportable: [])
         }
+    }
+}
+
+public struct ClaudeMarketplaceTrustPreview: Sendable, Hashable {
+    public enum ImportabilityStatus: String, Sendable, Hashable {
+        case importable
+        case requiresReview
+        case blocked
+    }
+
+    public struct Source: Sendable, Hashable {
+        public static let defaultMarketplaceRepo = GitHubRepo(
+            owner: "anthropics",
+            name: "claude-plugins-official"
+        )
+
+        public let marketplaceOwner: String
+        public let marketplaceName: String
+        public let marketplaceURLLabel: String
+        public let owner: String
+        public let repository: String
+        public let path: String?
+        public let isOfficialMarketplace: Bool
+        public let isMarketplaceRepo: Bool
+
+        public var repositoryLabel: String { "\(owner)/\(repository)" }
+        public var repositoryURLLabel: String { "github.com/\(owner)/\(repository)" }
+
+        public init(
+            marketplaceRepo: GitHubRepo,
+            marketplaceURLLabel: String,
+            source: MarketplaceSource?,
+            pluginName: String
+        ) {
+            self.marketplaceOwner = marketplaceRepo.owner
+            self.marketplaceName = marketplaceRepo.name
+            self.marketplaceURLLabel = marketplaceURLLabel
+            self.isOfficialMarketplace =
+                marketplaceRepo.owner == Self.defaultMarketplaceRepo.owner
+                && marketplaceRepo.name == Self.defaultMarketplaceRepo.name
+
+            switch source {
+            case .localDirectory(let directory):
+                self.owner = marketplaceRepo.owner
+                self.repository = marketplaceRepo.name
+                self.path = Self.normalizedPath(directory)
+            case .externalRepo(let repo, _):
+                self.owner = repo.owner
+                self.repository = repo.name
+                self.path = nil
+            case .externalSubdir(let repo, let path, _):
+                self.owner = repo.owner
+                self.repository = repo.name
+                self.path = Self.normalizedPath(path)
+            case nil:
+                self.owner = marketplaceRepo.owner
+                self.repository = marketplaceRepo.name
+                self.path = Self.normalizedPath(pluginName)
+            }
+
+            self.isMarketplaceRepo =
+                owner == marketplaceRepo.owner && repository == marketplaceRepo.name
+        }
+
+        private static func normalizedPath(_ value: String) -> String? {
+            var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            while trimmed.hasPrefix("./") { trimmed.removeFirst(2) }
+            trimmed = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    public struct CapabilityIndicator: Sendable, Hashable, Identifiable {
+        public enum Severity: String, Sendable, Hashable {
+            case normal
+            case sensitive
+            case unsupported
+        }
+
+        public let id: String
+        public let label: String
+        public let count: Int?
+        public let severity: Severity
+    }
+
+    public let pluginName: String
+    public let source: Source
+    public let componentSummary: ClaudeMarketplaceImportabilityCatalog.ComponentSummary?
+    public let importabilityStatus: ImportabilityStatus
+    public let reason: String
+
+    public var canInstallWithoutReview: Bool {
+        importabilityStatus == .importable
+    }
+
+    public var installGuardError: ClaudeMarketplaceInstallPreviewError? {
+        switch importabilityStatus {
+        case .importable, .requiresReview:
+            return nil
+        case .blocked:
+            return .blocked(pluginName: pluginName, reason: reason)
+        }
+    }
+
+    public var statusTitle: String {
+        switch importabilityStatus {
+        case .importable:
+            return "Ready to install"
+        case .requiresReview:
+            return "Review required"
+        case .blocked:
+            return "Not importable"
+        }
+    }
+
+    public var capabilityIndicators: [CapabilityIndicator] {
+        guard let summary = componentSummary else { return [] }
+        var indicators: [CapabilityIndicator] = []
+        if !summary.skills.isEmpty {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "skills",
+                    label: "Skills",
+                    count: summary.skills.count,
+                    severity: .normal
+                )
+            )
+        }
+        if !summary.agents.isEmpty {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "agents",
+                    label: "Agents",
+                    count: summary.agents.count,
+                    severity: .sensitive
+                )
+            )
+        }
+        if !summary.commands.isEmpty {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "commands",
+                    label: "Commands",
+                    count: summary.commands.count,
+                    severity: .sensitive
+                )
+            )
+        }
+        if summary.mcp {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "mcp",
+                    label: "MCP",
+                    count: nil,
+                    severity: .sensitive
+                )
+            )
+        }
+        if summary.hooks {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "hooks",
+                    label: "Hooks",
+                    count: nil,
+                    severity: .unsupported
+                )
+            )
+        }
+        for component in summary.unsupportedComponents {
+            indicators.append(
+                CapabilityIndicator(
+                    id: "unsupported-\(component)",
+                    label: Self.displayName(forUnsupportedComponent: component),
+                    count: nil,
+                    severity: .unsupported
+                )
+            )
+        }
+        return indicators
+    }
+
+    private static func displayName(forUnsupportedComponent component: String) -> String {
+        switch component {
+        case "outputStyles":
+            return "Output styles"
+        case "lspServers":
+            return "LSP servers"
+        default:
+            return component
+                .replacingOccurrences(of: "-", with: " ")
+                .split(separator: " ")
+                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+                .joined(separator: " ")
+        }
+    }
+}
+
+public enum ClaudeMarketplaceInstallPreviewError: Error, LocalizedError, Equatable, Sendable {
+    case blocked(pluginName: String, reason: String)
+    case reviewRequired(pluginName: String, reason: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .blocked(let pluginName, let reason):
+            return "\(Self.safePluginLabel(pluginName)) cannot be installed: \(reason)"
+        case .reviewRequired(let pluginName, let reason):
+            return "\(Self.safePluginLabel(pluginName)) requires review before install: \(reason)"
+        }
+    }
+
+    private static func safePluginLabel(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+            !trimmed.localizedCaseInsensitiveContains("://"),
+            !trimmed.localizedCaseInsensitiveContains("token"),
+            !trimmed.localizedCaseInsensitiveContains("secret")
+        else {
+            return "This plugin"
+        }
+
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: " -_."))
+        let scalars = trimmed.unicodeScalars.filter { allowed.contains($0) }
+        let sanitized = String(String.UnicodeScalarView(scalars))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitized.isEmpty else { return "This plugin" }
+        return String(sanitized.prefix(80))
     }
 }

--- a/Packages/OsaurusCore/Services/Plugin/ClaudeMarketplaceService.swift
+++ b/Packages/OsaurusCore/Services/Plugin/ClaudeMarketplaceService.swift
@@ -43,6 +43,7 @@ public final class ClaudeMarketplaceService: ObservableObject {
 
     /// Official, Anthropic-managed marketplace.
     public static let officialURL = "https://github.com/anthropics/claude-plugins-official"
+    public static let officialRepo = GitHubRepo(owner: "anthropics", name: "claude-plugins-official")
 
     @Published public private(set) var entries: [MarketplacePlugin] = []
     @Published public private(set) var repo: GitHubRepo?
@@ -88,7 +89,7 @@ public final class ClaudeMarketplaceService: ObservableObject {
 
     /// Normalized category key for an entry, falling back to the
     /// uncategorized sentinel.
-    public nonisolated static func categoryKey(for entry: MarketplacePlugin) -> String {
+    nonisolated public static func categoryKey(for entry: MarketplacePlugin) -> String {
         let raw = entry.category?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard let raw, !raw.isEmpty else { return ClaudeMarketplaceCategory.otherKey }
         return raw
@@ -142,20 +143,35 @@ public final class ClaudeMarketplaceService: ObservableObject {
         return ClaudePluginInstaller.pluginId(repo: repo, pluginName: entry.name)
     }
 
+    public func trustPreview(for entry: MarketplacePlugin) -> ClaudeMarketplaceTrustPreview {
+        importabilityCatalog.trustPreview(for: entry, marketplaceRepo: repo ?? Self.officialRepo)
+    }
+
     // MARK: - Install
 
     /// Resolve a single entry's full manifest and install it. Returns the
     /// install report, or `nil` if the catalog repo isn't loaded yet.
-    /// Throws `GitHubSkillError.noImportableComponents` when the plugin ships
-    /// nothing Osaurus can install (hooks / output-styles / etc.), so callers
-    /// surface a clear message instead of creating an empty bundle. This is
-    /// defense-in-depth for entries the bundled catalog hasn't classified yet.
+    /// Throws `ClaudeMarketplaceInstallPreviewError` before manifest resolution
+    /// when the bundled preview says the entry is blocked.
+    /// Unclassified entries still resolve the live manifest so new upstream
+    /// plugins are not blocked until the bundled catalog refreshes.
+    /// Still validates the resolved manifest as defense-in-depth for catalog
+    /// drift, so callers surface a clear message instead of creating an empty
+    /// bundle.
     @discardableResult
     public func install(entry: MarketplacePlugin) async throws -> ClaudePluginInstallReport? {
         guard let repo else { return nil }
+        let preview = trustPreview(for: entry)
+        if let guardError = preview.installGuardError {
+            throw guardError
+        }
         let manifest = try await github.resolveManifest(rootRepo: repo, entry: entry)
         guard manifest.hasImportableComponents else {
-            throw GitHubSkillError.noImportableComponents(pluginName: entry.name)
+            throw ClaudeMarketplaceInstallPreviewError.blocked(
+                pluginName: entry.name,
+                reason:
+                    "The resolved plugin manifest has no importable skills, agents, commands, or MCP servers."
+            )
         }
         let selection = ClaudePluginSelection(manifest: manifest)
         let report = await SkillManager.shared.batchUpdates {

--- a/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/ClaudePluginSpecTests.swift
@@ -304,6 +304,126 @@ struct ClaudePluginSpecTests {
         #expect(!Summary(skills: [], agents: [], commands: [], mcp: true).isEmpty)
     }
 
+    @Test func trustPreviewClassifiesOfficialMarketplaceProvenanceAndCapabilities() {
+        let catalog = ClaudeMarketplaceImportabilityCatalog(
+            nonImportable: [],
+            componentsByName: [
+                "agent-sdk-dev": .init(
+                    skills: [],
+                    agents: ["Agent Sdk Verifier Py"],
+                    commands: ["new-sdk-app"],
+                    mcp: true
+                )
+            ]
+        )
+        let entry = MarketplacePlugin(
+            name: "agent-sdk-dev",
+            source: .localDirectory("./plugins/agent-sdk-dev")
+        )
+
+        let preview = catalog.trustPreview(for: entry)
+
+        #expect(preview.importabilityStatus == .importable)
+        #expect(preview.canInstallWithoutReview)
+        #expect(preview.source.isOfficialMarketplace)
+        #expect(preview.source.isMarketplaceRepo)
+        #expect(preview.source.repositoryLabel == "anthropics/claude-plugins-official")
+        #expect(preview.source.repositoryURLLabel == "github.com/anthropics/claude-plugins-official")
+        #expect(preview.source.path == "plugins/agent-sdk-dev")
+        #expect(preview.componentSummary?.importableCount == 3)
+
+        let sensitive = Set(
+            preview.capabilityIndicators
+                .filter { $0.severity == .sensitive }
+                .map(\.id)
+        )
+        #expect(sensitive == ["agents", "commands", "mcp"])
+    }
+
+    @Test func trustPreviewShowsExternalRepoProvenanceFromOfficialListing() {
+        let catalog = ClaudeMarketplaceImportabilityCatalog(
+            nonImportable: [],
+            componentsByName: [
+                "external-plugin": .init(
+                    skills: ["External Skill"],
+                    agents: [],
+                    commands: [],
+                    mcp: false
+                )
+            ]
+        )
+        let entry = MarketplacePlugin(
+            name: "external-plugin",
+            source: .externalSubdir(
+                GitHubRepo(owner: "vendor", name: "plugin-pack", branch: "abc123"),
+                path: "plugins/external-plugin",
+                ref: "abc123"
+            )
+        )
+
+        let preview = catalog.trustPreview(for: entry)
+
+        #expect(preview.importabilityStatus == .importable)
+        #expect(preview.source.isOfficialMarketplace)
+        #expect(!preview.source.isMarketplaceRepo)
+        #expect(preview.source.owner == "vendor")
+        #expect(preview.source.repositoryLabel == "vendor/plugin-pack")
+        #expect(preview.source.repositoryURLLabel == "github.com/vendor/plugin-pack")
+        #expect(preview.source.path == "plugins/external-plugin")
+    }
+
+    @Test func trustPreviewBlocksNonImportableEntriesBeforeInstall() {
+        let catalog = ClaudeMarketplaceImportabilityCatalog(
+            nonImportable: ["only-hooks-plugin"],
+            componentsByName: [
+                "only-hooks-plugin": .init(
+                    skills: [],
+                    agents: [],
+                    commands: [],
+                    mcp: false,
+                    hooks: true,
+                    unsupportedComponents: ["outputStyles"]
+                )
+            ]
+        )
+        let entry = MarketplacePlugin(name: "only-hooks-plugin")
+
+        let preview = catalog.trustPreview(for: entry)
+
+        #expect(preview.importabilityStatus == .blocked)
+        #expect(!preview.canInstallWithoutReview)
+        #expect(preview.installGuardError != nil)
+        #expect(preview.capabilityIndicators.map(\.id).contains("hooks"))
+        #expect(preview.capabilityIndicators.map(\.label).contains("Output styles"))
+    }
+
+    @Test func trustPreviewRequiresReviewForUnclassifiedEntries() {
+        let catalog = ClaudeMarketplaceImportabilityCatalog(nonImportable: [])
+        let entry = MarketplacePlugin(name: "brand-new-plugin")
+
+        let preview = catalog.trustPreview(for: entry)
+
+        #expect(preview.importabilityStatus == .requiresReview)
+        #expect(!preview.canInstallWithoutReview)
+        #expect(preview.installGuardError == nil)
+        #expect(preview.reason.contains("bundled importability catalog"))
+    }
+
+    @Test func marketplaceInstallPreviewErrorsDoNotExposeRawSecretsOrURLs() {
+        let error = ClaudeMarketplaceInstallPreviewError.reviewRequired(
+            pluginName: "https://example.com/plugin?token=secret-token",
+            reason:
+                "This entry is not in the bundled importability catalog yet, so Osaurus cannot preview what would be installed."
+        )
+
+        let message = error.errorDescription ?? ""
+        #expect(!message.contains("https://"))
+        #expect(!message.contains("example.com"))
+        #expect(!message.localizedCaseInsensitiveContains("token=secret-token"))
+        #expect(!message.localizedCaseInsensitiveContains("secret-token"))
+        #expect(message.contains("This plugin requires review before install"))
+    }
+
     // MARK: - hasImportableComponents
 
     /// A manifest that only carries auxiliary markdown / hooks (no skills,

--- a/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceCard.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceCard.swift
@@ -67,7 +67,11 @@ struct ClaudeMarketplaceCard: View {
     /// MCP) for this plugin, from the bundled catalog. Drives the at-a-glance
     /// "what does this ship" hint without any network access.
     private var componentSummary: ClaudeMarketplaceImportabilityCatalog.ComponentSummary? {
-        ClaudeMarketplaceImportabilityCatalog.bundled.components(for: entry.name)
+        trustPreview.componentSummary
+    }
+
+    private var trustPreview: ClaudeMarketplaceTrustPreview {
+        ClaudeMarketplaceImportabilityCatalog.bundled.trustPreview(for: entry)
     }
 
     /// Compact "6 skills · 1 MCP" hint, or nil when there's nothing to import
@@ -210,6 +214,7 @@ struct ClaudeMarketplaceCard: View {
                 }
                 .foregroundColor(theme.tertiaryText)
             }
+            trustStatusBadge
             if entry.homepage != nil {
                 Image(systemName: "link")
                     .font(.system(size: 9, weight: .medium))
@@ -224,16 +229,79 @@ struct ClaudeMarketplaceCard: View {
             ProgressView()
                 .scaleEffect(0.6)
                 .frame(width: 28, height: 28)
+        } else if trustPreview.importabilityStatus == .blocked {
+            Image(systemName: "minus.circle")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: 28, height: 28)
+                .background(
+                    Circle().fill(theme.tertiaryText.opacity(0.12))
+                )
         } else {
             Button(action: install) {
                 Image(systemName: "arrow.down.circle.fill")
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(accent)
+                    .foregroundColor(
+                        trustPreview.importabilityStatus == .requiresReview
+                            ? theme.warningColor : accent
+                    )
                     .frame(width: 28, height: 28)
-                    .background(Circle().fill(accent.opacity(0.12)))
+                    .background(
+                        Circle().fill(
+                            (trustPreview.importabilityStatus == .requiresReview
+                                ? theme.warningColor : accent).opacity(0.12)
+                        )
+                    )
             }
             .buttonStyle(PlainButtonStyle())
-            .localizedHelp("Install")
+            .localizedHelp(
+                trustPreview.importabilityStatus == .requiresReview
+                    ? "Review manifest and install" : "Install"
+            )
+        }
+    }
+
+    private var trustStatusBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: trustBadgeIcon)
+                .font(.system(size: 9, weight: .medium))
+            Text(trustBadgeText)
+                .font(.system(size: 10, weight: .medium))
+                .lineLimit(1)
+        }
+        .foregroundColor(trustBadgeColor)
+    }
+
+    private var trustBadgeIcon: String {
+        switch trustPreview.importabilityStatus {
+        case .importable:
+            return trustPreview.source.isMarketplaceRepo ? "checkmark.seal" : "arrow.up.right.square"
+        case .requiresReview:
+            return "exclamationmark.triangle"
+        case .blocked:
+            return "minus.circle"
+        }
+    }
+
+    private var trustBadgeText: String {
+        switch trustPreview.importabilityStatus {
+        case .importable:
+            return trustPreview.source.isMarketplaceRepo ? "Official" : "External source"
+        case .requiresReview:
+            return "Review"
+        case .blocked:
+            return "Blocked"
+        }
+    }
+
+    private var trustBadgeColor: Color {
+        switch trustPreview.importabilityStatus {
+        case .importable:
+            return theme.tertiaryText
+        case .requiresReview:
+            return theme.warningColor
+        case .blocked:
+            return theme.tertiaryText
         }
     }
 

--- a/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceDetailView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ClaudeMarketplaceDetailView.swift
@@ -31,7 +31,11 @@ struct ClaudeMarketplaceDetailView: View {
     /// upstream), in which case we show a neutral "details unavailable" state
     /// rather than fetching live.
     private var componentSummary: ClaudeMarketplaceImportabilityCatalog.ComponentSummary? {
-        ClaudeMarketplaceImportabilityCatalog.bundled.components(for: entry.name)
+        trustPreview.componentSummary
+    }
+
+    private var trustPreview: ClaudeMarketplaceTrustPreview {
+        ClaudeMarketplaceImportabilityCatalog.bundled.trustPreview(for: entry)
     }
 
     private var categoryKey: String { ClaudeMarketplaceService.categoryKey(for: entry) }
@@ -64,6 +68,7 @@ struct ClaudeMarketplaceDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     heroHeader.padding(.bottom, 8)
+                    trustSection
                     componentsSection
                     externalLinksSection
                 }
@@ -169,6 +174,11 @@ struct ClaudeMarketplaceDetailView: View {
                             color: theme.accentColor
                         )
                     }
+                    heroStatBadge(
+                        icon: trustStatusIcon,
+                        text: trustPreview.statusTitle,
+                        color: trustStatusColor
+                    )
                 }
             }
 
@@ -185,7 +195,7 @@ struct ClaudeMarketplaceDetailView: View {
 
     @ViewBuilder
     private var installControl: some View {
-        if let summary = componentSummary, summary.isEmpty {
+        if trustPreview.importabilityStatus == .blocked {
             HStack(spacing: 5) {
                 Image(systemName: "minus.circle").font(.system(size: 12))
                 Text("Not importable", bundle: .module).font(.system(size: 13, weight: .semibold))
@@ -206,10 +216,17 @@ struct ClaudeMarketplaceDetailView: View {
                     Image(systemName: "arrow.down.circle.fill").font(.system(size: 12))
                     Text("Install", bundle: .module).font(.system(size: 13, weight: .semibold))
                 }
-                .foregroundColor(.white)
+                .foregroundColor(trustPreview.importabilityStatus == .requiresReview ? theme.warningColor : .white)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
-                .background(RoundedRectangle(cornerRadius: 8).fill(accent))
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(
+                            trustPreview.importabilityStatus == .requiresReview
+                                ? theme.warningColor.opacity(0.12)
+                                : accent
+                        )
+                )
             }
             .buttonStyle(PlainButtonStyle())
         }
@@ -224,6 +241,143 @@ struct ClaudeMarketplaceDetailView: View {
                 .truncationMode(.middle)
         }
         .foregroundColor(color)
+    }
+
+    // MARK: - Trust preview
+
+    private var trustStatusIcon: String {
+        switch trustPreview.importabilityStatus {
+        case .importable:
+            return "checkmark.seal"
+        case .requiresReview:
+            return "exclamationmark.triangle"
+        case .blocked:
+            return "minus.circle"
+        }
+    }
+
+    private var trustStatusColor: Color {
+        switch trustPreview.importabilityStatus {
+        case .importable:
+            return theme.successColor
+        case .requiresReview:
+            return theme.warningColor
+        case .blocked:
+            return theme.tertiaryText
+        }
+    }
+
+    private var trustSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader(title: "Trust preview", icon: "shield.lefthalf.filled")
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: trustStatusIcon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(trustStatusColor)
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(trustPreview.statusTitle)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                    Text(trustPreview.reason)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8).fill(trustStatusColor.opacity(0.10))
+            )
+
+            VStack(spacing: 8) {
+                trustRow(
+                    icon: "checkmark.seal",
+                    title: "Listing",
+                    value: trustPreview.source.isOfficialMarketplace
+                        ? "Official Claude marketplace"
+                        : "Marketplace catalog"
+                )
+                trustRow(
+                    icon: "building.2",
+                    title: "Owner",
+                    value: trustPreview.source.owner
+                )
+                trustRow(
+                    icon: "chevron.left.forwardslash.chevron.right",
+                    title: "Repo",
+                    value: trustPreview.source.repositoryURLLabel
+                )
+                if let path = trustPreview.source.path {
+                    trustRow(icon: "folder", title: "Path", value: path)
+                }
+            }
+
+            let indicators = trustPreview.capabilityIndicators
+            if !indicators.isEmpty {
+                FlowLayout(spacing: 6) {
+                    ForEach(indicators) { indicator in
+                        trustCapabilityBadge(indicator)
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private func trustRow(icon: String, title: LocalizedStringKey, value: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: 16)
+            Text(title, bundle: .module)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+                .frame(width: 54, alignment: .leading)
+            Text(value)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func trustCapabilityBadge(
+        _ indicator: ClaudeMarketplaceTrustPreview.CapabilityIndicator
+    ) -> some View {
+        let color: Color =
+            switch indicator.severity {
+            case .normal:
+                theme.infoColor
+            case .sensitive:
+                theme.warningColor
+            case .unsupported:
+                theme.tertiaryText
+            }
+        let text =
+            if let count = indicator.count {
+                "\(indicator.label) \(count)"
+            } else {
+                indicator.label
+            }
+        return Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(color.opacity(0.12)))
     }
 
     // MARK: - Components
@@ -392,7 +546,9 @@ struct ClaudeMarketplaceDetailView: View {
     }
 
     private func linkRow(icon: String, title: LocalizedStringKey, url: URL) -> some View {
-        Button(action: { NSWorkspace.shared.open(url) }) {
+        Button(
+            action: { NSWorkspace.shared.open(url) },
+            label: {
             HStack(spacing: 8) {
                 Image(systemName: icon)
                     .font(.system(size: 12))
@@ -411,7 +567,8 @@ struct ClaudeMarketplaceDetailView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(theme.primaryBackground.opacity(0.45))
             )
-        }
+            }
+        )
         .buttonStyle(PlainButtonStyle())
     }
 

--- a/scripts/claude-marketplace/generate-importability-catalog.py
+++ b/scripts/claude-marketplace/generate-importability-catalog.py
@@ -176,6 +176,9 @@ def classify_components(base: str, entries: dict[str, str]) -> dict:
       - agents: `agents/<file>.md` files,
       - commands: `commands/<file>.md` files,
       - mcp: a `.mcp.json` file at the plugin root.
+      - hooks / unsupportedComponents: directory-level signals when visible in
+        the tree. `plugin.json`-only declarations are still detected live at
+        manifest resolution time, not by this no-content tree pass.
 
     Display names match the Swift `displayName` derivations: skills + agents
     title-case the dash-separated leaf; commands keep the bare file stem.
@@ -216,13 +219,32 @@ def classify_components(base: str, entries: dict[str, str]) -> dict:
             commands.append(path.rsplit("/", 1)[-1][:-3])  # bare stem
 
     mcp = entries.get(f"{prefix}.mcp.json") is not None
+    hooks = any(
+        path == f"{prefix}hooks" or path.startswith(f"{prefix}hooks/")
+        for path in entries
+    )
+
+    unsupported_components: list[str] = []
+    for component in ("lspServers", "outputStyles", "themes", "monitors", "bin"):
+        if any(
+            path == f"{prefix}{component}" or path.startswith(f"{prefix}{component}/")
+            for path in entries
+        ):
+            unsupported_components.append(component)
 
     # Match the Swift sort order (displayName ascending) for stable output.
     skills.sort()
     agents.sort()
     commands.sort()
 
-    return {"skills": skills, "agents": agents, "commands": commands, "mcp": mcp}
+    return {
+        "skills": skills,
+        "agents": agents,
+        "commands": commands,
+        "mcp": mcp,
+        "hooks": hooks,
+        "unsupportedComponents": unsupported_components,
+    }
 
 
 def main() -> int:
@@ -253,6 +275,8 @@ def main() -> int:
                 "agents": [],
                 "commands": [],
                 "mcp": False,
+                "hooks": False,
+                "unsupportedComponents": [],
             }
             continue
 
@@ -282,7 +306,7 @@ def main() -> int:
     components = dict(sorted(components.items()))
 
     catalog = {
-        "version": 2,
+        "version": 3,
         "generatedAt": datetime.datetime.now(datetime.timezone.utc)
         .replace(microsecond=0)
         .isoformat(),


### PR DESCRIPTION
## Summary
- add a marketplace trust preview with provenance, importability state, and capability indicators before install
- surface source, owner, repository, and capability status in Browse cards and detail
- hard-block known non-importable entries while keeping unclassified entries installable through live manifest validation
- extend the importability catalog generator for future unsupported-component signals

## Validation
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-plugin-marketplace-trust-controller-2 swift test --package-path Packages/OsaurusCore --filter 'ClaudePluginSpecTests'` (43 tests passed)
- `git diff --check`
- `bash scripts/i18n/check.sh` (OK; existing stale-key warnings only)
- scoped `swiftlint lint --quiet` on touched Swift files
- post-fix package test compiled the changed SwiftUI files
- `make app XCODEBUILD_FLAGS="CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO"` completed before the final small review-required install-path adjustment; the rerun after that adjustment stalled in Xcode package-loading/build operations and was interrupted without a compile failure
- independent final diff review completed; actionable findings addressed
