### PR TITLE
Add Agent Channel async substrate

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelAsyncModels.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelAsyncModels.swift
@@ -1,0 +1,491 @@
+//
+//  AgentChannelAsyncModels.swift
+//  osaurus
+//
+//  Provider-neutral contracts for async Agent Channel ingress and replies.
+//
+
+import Foundation
+
+enum AgentChannelAsyncStatus: String, Codable, CaseIterable, Sendable, Equatable {
+    case accepted
+    case duplicate
+    case ignored
+    case rejected
+    case dispatched
+    case awaitingAgent = "awaiting_agent"
+    case awaitingClarification = "awaiting_clarification"
+    case replied
+    case completed
+    case failed
+}
+
+enum AgentChannelFailureCode: String, Codable, CaseIterable, Sendable, Equatable {
+    case verificationFailed = "verification_failed"
+    case senderNotAllowed = "sender_not_allowed"
+    case duplicateEvent = "duplicate_event"
+    case invalidPayload = "invalid_payload"
+    case invalidDeduplicationKey = "invalid_deduplication_key"
+    case replyTokenUnknown = "reply_token_unknown"
+    case replyTokenExpired = "reply_token_expired"
+    case replyTokenAgentMismatch = "reply_token_agent_mismatch"
+    case artifactForwardingUnsupported = "artifact_forwarding_unsupported"
+    case artifactTooLarge = "artifact_too_large"
+    case dispatchUnavailable = "dispatch_unavailable"
+    case storageUnavailable = "storage_unavailable"
+    case providerUnavailable = "provider_unavailable"
+    case rateLimited = "rate_limited"
+    case internalFailure = "internal_failure"
+}
+
+struct AgentChannelFailure: Codable, Equatable, Sendable, LocalizedError {
+    var code: AgentChannelFailureCode
+    var message: String
+    var retryable: Bool
+
+    init(
+        code: AgentChannelFailureCode,
+        message: String,
+        retryable: Bool = false
+    ) {
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+    }
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+enum AgentChannelSourceVerificationMethod: String, Codable, CaseIterable, Sendable, Equatable {
+    case none
+    case sharedSecretHeader = "shared_secret_header"
+    case hmacSHA256 = "hmac_sha256"
+}
+
+enum AgentChannelSourceVerificationStatus: String, Codable, CaseIterable, Sendable, Equatable {
+    case verified
+    case skipped
+    case failed
+}
+
+struct AgentChannelSourceVerificationPolicy: Codable, Equatable, Sendable {
+    var method: AgentChannelSourceVerificationMethod
+    var headerName: String?
+    var secret: String?
+    var signaturePrefix: String?
+
+    init(
+        method: AgentChannelSourceVerificationMethod,
+        headerName: String? = nil,
+        secret: String? = nil,
+        signaturePrefix: String? = nil
+    ) {
+        self.method = method
+        self.headerName = headerName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.secret = secret
+        self.signaturePrefix = signaturePrefix
+    }
+
+    static let unverified = AgentChannelSourceVerificationPolicy(method: .none)
+}
+
+struct AgentChannelWebhookVerificationRequest: Equatable, Sendable {
+    var headers: [String: String]
+    var body: Data
+    var sourceAddress: String?
+    var receivedAt: Date
+
+    init(
+        headers: [String: String],
+        body: Data = Data(),
+        sourceAddress: String? = nil,
+        receivedAt: Date = Date()
+    ) {
+        self.headers = headers
+        self.body = body
+        self.sourceAddress = sourceAddress?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.receivedAt = receivedAt
+    }
+}
+
+struct AgentChannelSourceVerificationResult: Codable, Equatable, Sendable {
+    var status: AgentChannelSourceVerificationStatus
+    var method: AgentChannelSourceVerificationMethod
+    var verifiedAt: Date
+    var failure: AgentChannelFailure?
+
+    var isVerified: Bool {
+        status == .verified || status == .skipped
+    }
+
+    static func verified(
+        method: AgentChannelSourceVerificationMethod,
+        at date: Date = Date()
+    ) -> AgentChannelSourceVerificationResult {
+        AgentChannelSourceVerificationResult(
+            status: method == .none ? .skipped : .verified,
+            method: method,
+            verifiedAt: date,
+            failure: nil
+        )
+    }
+
+    static func failed(
+        method: AgentChannelSourceVerificationMethod,
+        message: String,
+        at date: Date = Date()
+    ) -> AgentChannelSourceVerificationResult {
+        AgentChannelSourceVerificationResult(
+            status: .failed,
+            method: method,
+            verifiedAt: date,
+            failure: AgentChannelFailure(code: .verificationFailed, message: message)
+        )
+    }
+}
+
+struct AgentChannelSenderIdentity: Codable, Equatable, Sendable {
+    var providerSenderId: String?
+    var normalizedAddress: String?
+    var displayName: String?
+    var isBot: Bool
+
+    init(
+        providerSenderId: String? = nil,
+        normalizedAddress: String? = nil,
+        displayName: String? = nil,
+        isBot: Bool = false
+    ) {
+        self.providerSenderId = Self.normalized(providerSenderId)
+        self.normalizedAddress = Self.normalized(normalizedAddress)?.lowercased()
+        self.displayName = Self.normalized(displayName)
+        self.isBot = isBot
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+enum AgentChannelSenderPolicyDisposition: String, Codable, CaseIterable, Sendable, Equatable {
+    case allow
+    case reject
+}
+
+struct AgentChannelSenderPolicy: Codable, Equatable, Sendable {
+    var defaultDisposition: AgentChannelSenderPolicyDisposition
+    var allowedSenderIds: [String]
+    var blockedSenderIds: [String]
+    var allowedAddresses: [String]
+    var blockedAddresses: [String]
+    var allowBots: Bool
+
+    init(
+        defaultDisposition: AgentChannelSenderPolicyDisposition = .reject,
+        allowedSenderIds: [String] = [],
+        blockedSenderIds: [String] = [],
+        allowedAddresses: [String] = [],
+        blockedAddresses: [String] = [],
+        allowBots: Bool = false
+    ) {
+        self.defaultDisposition = defaultDisposition
+        self.allowedSenderIds = Self.normalizedIds(allowedSenderIds)
+        self.blockedSenderIds = Self.normalizedIds(blockedSenderIds)
+        self.allowedAddresses = Self.normalizedAddresses(allowedAddresses)
+        self.blockedAddresses = Self.normalizedAddresses(blockedAddresses)
+        self.allowBots = allowBots
+    }
+
+    var hasAllowlist: Bool {
+        !allowedSenderIds.isEmpty || !allowedAddresses.isEmpty
+    }
+
+    private static func normalizedIds(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    private static func normalizedAddresses(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+}
+
+struct AgentChannelSenderPolicyEvaluation: Codable, Equatable, Sendable {
+    var disposition: AgentChannelSenderPolicyDisposition
+    var failure: AgentChannelFailure?
+    var matchedPolicy: String
+
+    var isAllowed: Bool {
+        disposition == .allow
+    }
+
+    static func allowed(_ matchedPolicy: String) -> AgentChannelSenderPolicyEvaluation {
+        AgentChannelSenderPolicyEvaluation(
+            disposition: .allow,
+            failure: nil,
+            matchedPolicy: matchedPolicy
+        )
+    }
+
+    static func rejected(_ matchedPolicy: String, message: String) -> AgentChannelSenderPolicyEvaluation {
+        AgentChannelSenderPolicyEvaluation(
+            disposition: .reject,
+            failure: AgentChannelFailure(code: .senderNotAllowed, message: message),
+            matchedPolicy: matchedPolicy
+        )
+    }
+}
+
+struct AgentChannelDeduplicationKey: Codable, Hashable, Sendable {
+    var connectionId: String
+    var providerEventId: String
+    var sourceId: String?
+
+    init?(connectionId: String, providerEventId: String, sourceId: String? = nil) {
+        let connectionId = Self.normalized(connectionId)
+        let providerEventId = Self.normalized(providerEventId)
+        guard !connectionId.isEmpty, !providerEventId.isEmpty else { return nil }
+        self.connectionId = connectionId
+        self.providerEventId = providerEventId
+        self.sourceId = Self.normalizedOptional(sourceId)
+    }
+
+    var storageEventId: String {
+        if let sourceId {
+            return "\(sourceId):\(providerEventId)"
+        }
+        return providerEventId
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = Self.normalized(value)
+        return normalized.isEmpty ? nil : normalized
+    }
+}
+
+enum AgentChannelDeduplicationOutcome: String, Codable, CaseIterable, Sendable, Equatable {
+    case firstSeen = "first_seen"
+    case duplicate
+    case invalidKey = "invalid_key"
+}
+
+struct AgentChannelProviderRoute: Codable, Equatable, Sendable {
+    var conversationId: String
+    var threadId: String?
+    var replyAddress: String?
+    var displayName: String?
+
+    init(
+        conversationId: String,
+        threadId: String? = nil,
+        replyAddress: String? = nil,
+        displayName: String? = nil
+    ) {
+        self.conversationId = conversationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.threadId = Self.normalizedOptional(threadId)
+        self.replyAddress = Self.normalizedOptional(replyAddress)
+        self.displayName = Self.normalizedOptional(displayName)
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+struct AgentChannelReplyToken: RawRepresentable, Codable, Hashable, Sendable, CustomStringConvertible {
+    var rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var description: String {
+        rawValue
+    }
+}
+
+struct AgentChannelReplyBindingInput: Equatable, Sendable {
+    var agentId: UUID?
+    var connectionId: String
+    var providerRoute: AgentChannelProviderRoute
+    var sessionId: UUID
+    var taskId: UUID?
+    var timeToLive: TimeInterval
+
+    init(
+        agentId: UUID?,
+        connectionId: String,
+        providerRoute: AgentChannelProviderRoute,
+        sessionId: UUID,
+        taskId: UUID? = nil,
+        timeToLive: TimeInterval = 600
+    ) {
+        self.agentId = agentId
+        self.connectionId = connectionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.providerRoute = providerRoute
+        self.sessionId = sessionId
+        self.taskId = taskId
+        self.timeToLive = max(1, timeToLive)
+    }
+}
+
+struct AgentChannelReplyTokenBinding: Codable, Equatable, Sendable {
+    var token: AgentChannelReplyToken
+    var agentId: UUID?
+    var connectionId: String
+    var providerRoute: AgentChannelProviderRoute
+    var sessionId: UUID
+    var taskId: UUID?
+    var issuedAt: Date
+    var expiresAt: Date
+
+    var agentVisiblePayload: [String: String] {
+        [
+            "reply_token": token.rawValue,
+            "expires_at": Self.iso8601String(from: expiresAt),
+        ]
+    }
+
+    func isExpired(at date: Date = Date()) -> Bool {
+        date >= expiresAt
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+struct AgentChannelSessionPartition: Codable, Equatable, Sendable {
+    var agentId: UUID?
+    var connectionId: String
+    var conversationHash: String
+    var salt: Int
+    var externalSessionKey: String
+    var sessionId: UUID
+}
+
+enum AgentChannelArtifactForwardingStatus: String, Codable, CaseIterable, Sendable, Equatable {
+    case notRequested = "not_requested"
+    case queued
+    case forwarded
+    case skipped
+    case blocked
+    case failed
+}
+
+struct AgentChannelArtifactForwardingRecord: Codable, Equatable, Sendable {
+    var artifactId: String
+    var filename: String?
+    var status: AgentChannelArtifactForwardingStatus
+    var failure: AgentChannelFailure?
+    var updatedAt: Date
+
+    init(
+        artifactId: String,
+        filename: String? = nil,
+        status: AgentChannelArtifactForwardingStatus,
+        failure: AgentChannelFailure? = nil,
+        updatedAt: Date = Date()
+    ) {
+        self.artifactId = artifactId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.filename = filename?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.status = status
+        self.failure = failure
+        self.updatedAt = updatedAt
+    }
+}
+
+struct AgentChannelArtifactForwardingReport: Codable, Equatable, Sendable {
+    var records: [AgentChannelArtifactForwardingRecord]
+
+    init(records: [AgentChannelArtifactForwardingRecord] = []) {
+        self.records = records
+    }
+
+    var status: AgentChannelArtifactForwardingStatus {
+        if records.isEmpty { return .notRequested }
+        if records.contains(where: { $0.status == .failed }) { return .failed }
+        if records.contains(where: { $0.status == .blocked }) { return .blocked }
+        if records.contains(where: { $0.status == .queued }) { return .queued }
+        if records.contains(where: { $0.status == .forwarded }) { return .forwarded }
+        return .skipped
+    }
+}
+
+enum AgentChannelAuditEventKind: String, Codable, CaseIterable, Sendable, Equatable {
+    case webhookReceived = "webhook_received"
+    case sourceVerified = "source_verified"
+    case sourceRejected = "source_rejected"
+    case senderAccepted = "sender_accepted"
+    case senderRejected = "sender_rejected"
+    case eventAccepted = "event_accepted"
+    case eventDuplicate = "event_duplicate"
+    case replyTokenIssued = "reply_token_issued"
+    case dispatchStarted = "dispatch_started"
+    case artifactForwardingChanged = "artifact_forwarding_changed"
+    case replySent = "reply_sent"
+    case replyFailed = "reply_failed"
+    case taskCompleted = "task_completed"
+    case taskFailed = "task_failed"
+}
+
+struct AgentChannelAuditEvent: Codable, Equatable, Identifiable, Sendable {
+    var id: UUID
+    var timestamp: Date
+    var kind: AgentChannelAuditEventKind
+    var status: AgentChannelAsyncStatus
+    var connectionId: String
+    var agentId: UUID?
+    var sessionId: UUID?
+    var auditKey: String?
+    var replyToken: AgentChannelReplyToken?
+    var artifactStatus: AgentChannelArtifactForwardingStatus?
+    var failure: AgentChannelFailure?
+    var metadata: [String: String]
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        kind: AgentChannelAuditEventKind,
+        status: AgentChannelAsyncStatus,
+        connectionId: String,
+        agentId: UUID? = nil,
+        sessionId: UUID? = nil,
+        auditKey: String? = nil,
+        replyToken: AgentChannelReplyToken? = nil,
+        artifactStatus: AgentChannelArtifactForwardingStatus? = nil,
+        failure: AgentChannelFailure? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.kind = kind
+        self.status = status
+        self.connectionId = connectionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.agentId = agentId
+        self.sessionId = sessionId
+        self.auditKey = auditKey
+        self.replyToken = replyToken
+        self.artifactStatus = artifactStatus
+        self.failure = failure
+        self.metadata = metadata
+    }
+}

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAsyncSubstrate.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAsyncSubstrate.swift
@@ -1,0 +1,368 @@
+//
+//  AgentChannelAsyncSubstrate.swift
+//  osaurus
+//
+//  Shared async ingress/reply helpers for provider-backed Agent Channels.
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+final class AgentChannelAsyncSubstrate: @unchecked Sendable {
+    static let shared = AgentChannelAsyncSubstrate()
+
+    func verifyWebhookSource(
+        request: AgentChannelWebhookVerificationRequest,
+        policy: AgentChannelSourceVerificationPolicy
+    ) -> AgentChannelSourceVerificationResult {
+        switch policy.method {
+        case .none:
+            return .verified(method: .none, at: request.receivedAt)
+        case .sharedSecretHeader:
+            return verifySharedSecretHeader(request: request, policy: policy)
+        case .hmacSHA256:
+            return verifyHMACSHA256(request: request, policy: policy)
+        }
+    }
+
+    func evaluateSender(
+        _ sender: AgentChannelSenderIdentity,
+        policy: AgentChannelSenderPolicy
+    ) -> AgentChannelSenderPolicyEvaluation {
+        if sender.isBot, !policy.allowBots {
+            return .rejected("bot_sender", message: "Automated channel sender is not allowed.")
+        }
+        if let senderId = sender.providerSenderId,
+           policy.blockedSenderIds.contains(senderId) {
+            return .rejected("blocked_sender_id", message: "Channel sender is blocked.")
+        }
+        if let address = sender.normalizedAddress,
+           policy.blockedAddresses.contains(address) {
+            return .rejected("blocked_address", message: "Channel sender address is blocked.")
+        }
+        if let senderId = sender.providerSenderId,
+           policy.allowedSenderIds.contains(senderId) {
+            return .allowed("allowed_sender_id")
+        }
+        if let address = sender.normalizedAddress,
+           policy.allowedAddresses.contains(address) {
+            return .allowed("allowed_address")
+        }
+        if policy.hasAllowlist {
+            return .rejected("allowlist_miss", message: "Channel sender is not on the allowlist.")
+        }
+        if policy.defaultDisposition == .allow {
+            return .allowed("default_allow")
+        }
+        return .rejected("default_reject", message: "Channel sender is not allowed by default.")
+    }
+
+    func makeDeduplicationKey(
+        connectionId: String,
+        providerEventId: String,
+        sourceId: String? = nil
+    ) -> AgentChannelDeduplicationKey? {
+        AgentChannelDeduplicationKey(
+            connectionId: connectionId,
+            providerEventId: providerEventId,
+            sourceId: sourceId
+        )
+    }
+
+    func auditKey(for key: AgentChannelDeduplicationKey) -> String {
+        "ack_\(Self.sha256Hex("\(key.connectionId)|\(key.storageEventId)").prefix(24))"
+    }
+
+    func makeSessionPartition(
+        agentId: UUID?,
+        connectionId: String,
+        providerRoute: AgentChannelProviderRoute,
+        salt: Int = 0
+    ) -> AgentChannelSessionPartition {
+        let normalizedConnectionId = connectionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let agentComponent = agentId?.uuidString.lowercased() ?? "default-agent"
+        let routeMaterial = [
+            "agent-channel-session",
+            agentComponent,
+            normalizedConnectionId,
+            providerRoute.conversationId,
+            providerRoute.threadId ?? "",
+            String(salt),
+        ].joined(separator: "\u{1F}")
+        let conversationHash = String(Self.sha256Hex(routeMaterial).prefix(32))
+        let externalSessionKey = "agent-channel:\(normalizedConnectionId):\(conversationHash):s\(salt)"
+        return AgentChannelSessionPartition(
+            agentId: agentId,
+            connectionId: normalizedConnectionId,
+            conversationHash: conversationHash,
+            salt: salt,
+            externalSessionKey: externalSessionKey,
+            sessionId: Self.stableUUID(material: externalSessionKey)
+        )
+    }
+
+    private func verifySharedSecretHeader(
+        request: AgentChannelWebhookVerificationRequest,
+        policy: AgentChannelSourceVerificationPolicy
+    ) -> AgentChannelSourceVerificationResult {
+        let headerName = policy.headerName?.isEmpty == false
+            ? policy.headerName!
+            : "X-Osaurus-Channel-Secret"
+        guard let expected = policy.secret, !expected.isEmpty else {
+            return .failed(
+                method: .sharedSecretHeader,
+                message: "Agent Channel webhook secret is not configured.",
+                at: request.receivedAt
+            )
+        }
+        guard let received = Self.headerValue(named: headerName, in: request.headers),
+              Self.constantTimeEqual(received, expected)
+        else {
+            return .failed(
+                method: .sharedSecretHeader,
+                message: "Agent Channel webhook secret did not verify.",
+                at: request.receivedAt
+            )
+        }
+        return .verified(method: .sharedSecretHeader, at: request.receivedAt)
+    }
+
+    private func verifyHMACSHA256(
+        request: AgentChannelWebhookVerificationRequest,
+        policy: AgentChannelSourceVerificationPolicy
+    ) -> AgentChannelSourceVerificationResult {
+        let headerName = policy.headerName?.isEmpty == false
+            ? policy.headerName!
+            : "X-Osaurus-Channel-Signature"
+        guard let secret = policy.secret, !secret.isEmpty else {
+            return .failed(
+                method: .hmacSHA256,
+                message: "Agent Channel HMAC secret is not configured.",
+                at: request.receivedAt
+            )
+        }
+        guard let received = Self.headerValue(named: headerName, in: request.headers) else {
+            return .failed(
+                method: .hmacSHA256,
+                message: "Agent Channel HMAC signature header is missing.",
+                at: request.receivedAt
+            )
+        }
+        let expectedHex = Self.hmacSHA256Hex(body: request.body, secret: secret)
+        let expected = (policy.signaturePrefix ?? "sha256=") + expectedHex
+        guard Self.constantTimeEqual(received.lowercased(), expected.lowercased())
+            || Self.constantTimeEqual(received.lowercased(), expectedHex.lowercased())
+        else {
+            return .failed(
+                method: .hmacSHA256,
+                message: "Agent Channel HMAC signature did not verify.",
+                at: request.receivedAt
+            )
+        }
+        return .verified(method: .hmacSHA256, at: request.receivedAt)
+    }
+
+    static func hmacSHA256Hex(body: Data, secret: String) -> String {
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let signature = HMAC<SHA256>.authenticationCode(for: body, using: key)
+        return signature.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func sha256Hex(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func stableUUID(material: String) -> UUID {
+        var bytes = Array(SHA256.hash(data: Data(material.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        let tuple: uuid_t = (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        )
+        return UUID(uuid: tuple)
+    }
+
+    private static func headerValue(named name: String, in headers: [String: String]) -> String? {
+        let normalized = name.lowercased()
+        return headers.first { key, _ in
+            key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalized
+        }?.value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func constantTimeEqual(_ lhs: String, _ rhs: String) -> Bool {
+        let left = Array(lhs.utf8)
+        let right = Array(rhs.utf8)
+        let count = max(left.count, right.count)
+        var diff = left.count == right.count ? 0 : 1
+        for index in 0..<count {
+            let l = index < left.count ? left[index] : 0
+            let r = index < right.count ? right[index] : 0
+            diff |= Int(l ^ r)
+        }
+        return diff == 0
+    }
+}
+
+actor AgentChannelReplyTokenRegistry {
+    typealias TokenGenerator = @Sendable () throws -> String
+
+    private var bindings: [AgentChannelReplyToken: AgentChannelReplyTokenBinding] = [:]
+    private let tokenGenerator: TokenGenerator
+
+    init(tokenGenerator: @escaping TokenGenerator = AgentChannelReplyTokenRegistry.randomToken) {
+        self.tokenGenerator = tokenGenerator
+    }
+
+    func issue(
+        _ input: AgentChannelReplyBindingInput,
+        issuedAt: Date = Date()
+    ) throws -> AgentChannelReplyTokenBinding {
+        removeExpired(at: issuedAt)
+        let token = try uniqueToken()
+        let binding = AgentChannelReplyTokenBinding(
+            token: token,
+            agentId: input.agentId,
+            connectionId: input.connectionId,
+            providerRoute: input.providerRoute,
+            sessionId: input.sessionId,
+            taskId: input.taskId,
+            issuedAt: issuedAt,
+            expiresAt: issuedAt.addingTimeInterval(input.timeToLive)
+        )
+        bindings[token] = binding
+        return binding
+    }
+
+    func resolve(
+        token: AgentChannelReplyToken,
+        agentId: UUID?,
+        at date: Date = Date()
+    ) -> Result<AgentChannelReplyTokenBinding, AgentChannelFailure> {
+        guard let binding = bindings[token] else {
+            removeExpired(at: date)
+            return .failure(
+                AgentChannelFailure(
+                    code: .replyTokenUnknown,
+                    message: "Reply token is unknown or already cleared."
+                )
+            )
+        }
+        guard !binding.isExpired(at: date) else {
+            bindings.removeValue(forKey: token)
+            removeExpired(at: date)
+            return .failure(
+                AgentChannelFailure(
+                    code: .replyTokenExpired,
+                    message: "Reply token has expired."
+                )
+            )
+        }
+        guard binding.agentId == agentId else {
+            return .failure(
+                AgentChannelFailure(
+                    code: .replyTokenAgentMismatch,
+                    message: "Reply token is scoped to a different agent."
+                )
+            )
+        }
+        removeExpired(at: date)
+        return .success(binding)
+    }
+
+    func revoke(token: AgentChannelReplyToken) {
+        bindings.removeValue(forKey: token)
+    }
+
+    @discardableResult
+    func pruneExpired(at date: Date = Date()) -> Int {
+        removeExpired(at: date)
+    }
+
+    func count() -> Int {
+        bindings.count
+    }
+
+    @discardableResult
+    private func removeExpired(at date: Date) -> Int {
+        let previousCount = bindings.count
+        bindings = bindings.filter { _, binding in
+            !binding.isExpired(at: date)
+        }
+        return previousCount - bindings.count
+    }
+
+    private func uniqueToken() throws -> AgentChannelReplyToken {
+        for _ in 0..<5 {
+            let token = AgentChannelReplyToken(rawValue: try tokenGenerator())
+            if !token.rawValue.isEmpty, bindings[token] == nil {
+                return token
+            }
+        }
+        throw AgentChannelFailure(
+            code: .internalFailure,
+            message: "Unable to mint a unique Agent Channel reply token."
+        )
+    }
+
+    private static func randomToken() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw AgentChannelFailure(
+                code: .internalFailure,
+                message: "Secure random generator failed while minting reply token."
+            )
+        }
+        let encoded = Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "acr_\(encoded)"
+    }
+}
+
+final class AgentChannelDeduplicationService: @unchecked Sendable {
+    private let store: AgentChannelMessageStore
+
+    init(store: AgentChannelMessageStore = .shared) {
+        self.store = store
+    }
+
+    func register(_ key: AgentChannelDeduplicationKey?) throws -> AgentChannelDeduplicationOutcome {
+        guard let key else { return .invalidKey }
+        let inserted = try store.markEventSeen(
+            connectionId: key.connectionId,
+            providerEventId: key.storageEventId
+        )
+        return inserted ? .firstSeen : .duplicate
+    }
+}
+
+actor AgentChannelAuditLog {
+    private var events: [AgentChannelAuditEvent] = []
+    private let maxEvents: Int
+
+    init(maxEvents: Int = 1_000) {
+        self.maxEvents = max(maxEvents, 1)
+    }
+
+    func record(_ event: AgentChannelAuditEvent) {
+        events.append(event)
+        if events.count > maxEvents {
+            events.removeFirst(events.count - maxEvents)
+        }
+    }
+
+    func snapshot() -> [AgentChannelAuditEvent] {
+        events
+    }
+
+    func clear() {
+        events.removeAll()
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelAsyncSubstrateTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelAsyncSubstrateTests.swift
@@ -1,0 +1,432 @@
+//
+//  AgentChannelAsyncSubstrateTests.swift
+//  osaurusTests
+//
+//  Focused coverage for provider-neutral async Agent Channel contracts.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct AgentChannelAsyncSubstrateTests {
+
+    @Test func webhookVerificationSupportsSharedSecretAndHMACWithoutSecretLeakage() {
+        let substrate = AgentChannelAsyncSubstrate()
+        let receivedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let secret = "webhook-secret-do-not-leak"
+
+        let sharedSecretResult = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["x-telegram-bot-api-secret-token": secret],
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(
+                method: .sharedSecretHeader,
+                headerName: "X-Telegram-Bot-Api-Secret-Token",
+                secret: secret
+            )
+        )
+        #expect(sharedSecretResult.status == .verified)
+        #expect(sharedSecretResult.method == .sharedSecretHeader)
+
+        let failedSharedSecret = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["x-telegram-bot-api-secret-token": "wrong"],
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(
+                method: .sharedSecretHeader,
+                headerName: "X-Telegram-Bot-Api-Secret-Token",
+                secret: secret
+            )
+        )
+        #expect(failedSharedSecret.status == .failed)
+        #expect(failedSharedSecret.failure?.code == .verificationFailed)
+        #expect(failedSharedSecret.failure?.message.contains(secret) == false)
+
+        let body = Data(#"{"event":"message.created"}"#.utf8)
+        let signature = AgentChannelAsyncSubstrate.hmacSHA256Hex(body: body, secret: secret)
+        let hmacResult = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["X-Resend-Signature": "sha256=\(signature)"],
+                body: body,
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(
+                method: .hmacSHA256,
+                headerName: "x-resend-signature",
+                secret: secret
+            )
+        )
+        #expect(hmacResult.status == .verified)
+        #expect(hmacResult.method == .hmacSHA256)
+    }
+
+    @Test func webhookVerificationReportsSkippedAndFailureStates() {
+        let substrate = AgentChannelAsyncSubstrate()
+        let receivedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let body = Data(#"{"event":"message.created"}"#.utf8)
+        let secret = "webhook-secret"
+
+        let skipped = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(headers: [:], receivedAt: receivedAt),
+            policy: .unverified
+        )
+        #expect(skipped.status == .skipped)
+        #expect(skipped.isVerified)
+
+        let missingSharedSecret = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["X-Osaurus-Channel-Secret": "received"],
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(method: .sharedSecretHeader)
+        )
+        #expect(missingSharedSecret.status == .failed)
+        #expect(missingSharedSecret.failure?.code == .verificationFailed)
+
+        let missingHMACSecret = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["X-Osaurus-Channel-Signature": "sha256=abc"],
+                body: body,
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(method: .hmacSHA256)
+        )
+        #expect(missingHMACSecret.status == .failed)
+
+        let missingHMACHeader = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(headers: [:], body: body, receivedAt: receivedAt),
+            policy: AgentChannelSourceVerificationPolicy(method: .hmacSHA256, secret: secret)
+        )
+        #expect(missingHMACHeader.status == .failed)
+
+        let badHMAC = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["X-Osaurus-Channel-Signature": "sha256=bad"],
+                body: body,
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(method: .hmacSHA256, secret: secret)
+        )
+        #expect(badHMAC.status == .failed)
+
+        let bareSignature = AgentChannelAsyncSubstrate.hmacSHA256Hex(body: body, secret: secret)
+        let bareHMAC = substrate.verifyWebhookSource(
+            request: AgentChannelWebhookVerificationRequest(
+                headers: ["X-Osaurus-Channel-Signature": bareSignature],
+                body: body,
+                receivedAt: receivedAt
+            ),
+            policy: AgentChannelSourceVerificationPolicy(method: .hmacSHA256, secret: secret)
+        )
+        #expect(bareHMAC.status == .verified)
+    }
+
+    @Test func senderPolicyBlocksBeforeAllowlistAndRejectsAllowlistMisses() {
+        let substrate = AgentChannelAsyncSubstrate()
+        let policy = AgentChannelSenderPolicy(
+            defaultDisposition: .allow,
+            allowedSenderIds: ["user-1"],
+            blockedSenderIds: ["blocked-user"],
+            allowedAddresses: ["Allowed@Example.COM"],
+            blockedAddresses: ["blocked@example.com"],
+            allowBots: false
+        )
+
+        let blocked = substrate.evaluateSender(
+            AgentChannelSenderIdentity(providerSenderId: "blocked-user"),
+            policy: policy
+        )
+        #expect(blocked.disposition == .reject)
+        #expect(blocked.matchedPolicy == "blocked_sender_id")
+
+        let allowedByAddress = substrate.evaluateSender(
+            AgentChannelSenderIdentity(normalizedAddress: "allowed@example.com"),
+            policy: policy
+        )
+        #expect(allowedByAddress.disposition == .allow)
+        #expect(allowedByAddress.matchedPolicy == "allowed_address")
+
+        let bot = substrate.evaluateSender(
+            AgentChannelSenderIdentity(providerSenderId: "user-1", isBot: true),
+            policy: policy
+        )
+        #expect(bot.disposition == .reject)
+        #expect(bot.matchedPolicy == "bot_sender")
+
+        let allowlistMiss = substrate.evaluateSender(
+            AgentChannelSenderIdentity(providerSenderId: "stranger"),
+            policy: policy
+        )
+        #expect(allowlistMiss.disposition == .reject)
+        #expect(allowlistMiss.matchedPolicy == "allowlist_miss")
+
+        let defaultAllow = substrate.evaluateSender(
+            AgentChannelSenderIdentity(providerSenderId: "stranger"),
+            policy: AgentChannelSenderPolicy(defaultDisposition: .allow, allowBots: true)
+        )
+        #expect(defaultAllow.disposition == .allow)
+        #expect(defaultAllow.matchedPolicy == "default_allow")
+    }
+
+    @Test func replyTokenRegistryKeepsProviderRouteOpaqueAgentScopedAndExpiring() async throws {
+        let agentId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let otherAgentId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let sessionId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let issuedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let registry = AgentChannelReplyTokenRegistry(tokenGenerator: { "acr_test_token" })
+        let route = AgentChannelProviderRoute(
+            conversationId: "telegram-chat-5544332211",
+            threadId: "topic-42",
+            replyAddress: "5544332211",
+            displayName: "Dana"
+        )
+
+        let binding = try await registry.issue(
+            AgentChannelReplyBindingInput(
+                agentId: agentId,
+                connectionId: "telegram",
+                providerRoute: route,
+                sessionId: sessionId,
+                timeToLive: 60
+            ),
+            issuedAt: issuedAt
+        )
+
+        #expect(binding.token.rawValue == "acr_test_token")
+        #expect(!binding.token.rawValue.contains(route.conversationId))
+        #expect(!String(describing: binding.agentVisiblePayload).contains(route.conversationId))
+        #expect(!String(describing: binding.agentVisiblePayload).contains(route.replyAddress ?? ""))
+
+        switch await registry.resolve(token: binding.token, agentId: agentId, at: issuedAt.addingTimeInterval(30)) {
+        case .success(let resolved):
+            #expect(resolved.providerRoute == route)
+            #expect(resolved.sessionId == sessionId)
+        case .failure(let failure):
+            Issue.record("Expected reply token to resolve, got \(failure.code.rawValue)")
+        }
+
+        switch await registry.resolve(token: binding.token, agentId: otherAgentId, at: issuedAt.addingTimeInterval(30)) {
+        case .success:
+            Issue.record("Reply token resolved for the wrong agent")
+        case .failure(let failure):
+            #expect(failure.code == .replyTokenAgentMismatch)
+        }
+
+        switch await registry.resolve(token: binding.token, agentId: agentId, at: issuedAt.addingTimeInterval(61)) {
+        case .success:
+            Issue.record("Expired reply token resolved")
+        case .failure(let failure):
+            #expect(failure.code == .replyTokenExpired)
+        }
+        #expect(await registry.count() == 0)
+
+        let expiredForOtherAgent = try await registry.issue(
+            AgentChannelReplyBindingInput(
+                agentId: agentId,
+                connectionId: "telegram",
+                providerRoute: route,
+                sessionId: sessionId,
+                timeToLive: 1
+            ),
+            issuedAt: issuedAt.addingTimeInterval(100)
+        )
+        switch await registry.resolve(
+            token: expiredForOtherAgent.token,
+            agentId: otherAgentId,
+            at: issuedAt.addingTimeInterval(102)
+        ) {
+        case .success:
+            Issue.record("Expired reply token resolved for the wrong agent")
+        case .failure(let failure):
+            #expect(failure.code == .replyTokenExpired)
+        }
+    }
+
+    @Test func replyTokenRegistrySupportsRevokePruneAndCollisionFailure() async throws {
+        let agentId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let sessionId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let route = AgentChannelProviderRoute(conversationId: "telegram-chat-5544332211")
+        let input = AgentChannelReplyBindingInput(
+            agentId: agentId,
+            connectionId: "telegram",
+            providerRoute: route,
+            sessionId: sessionId,
+            timeToLive: 60
+        )
+
+        let registry = AgentChannelReplyTokenRegistry()
+        _ = try await registry.issue(input, issuedAt: now.addingTimeInterval(-120))
+        let active = try await registry.issue(input, issuedAt: now)
+        #expect(await registry.count() == 1)
+
+        let pruned = await registry.pruneExpired(at: now)
+        #expect(pruned == 0)
+        await registry.revoke(token: active.token)
+        #expect(await registry.count() == 0)
+
+        let collidingRegistry = AgentChannelReplyTokenRegistry(tokenGenerator: { "acr_collision" })
+        _ = try await collidingRegistry.issue(input, issuedAt: now)
+        do {
+            _ = try await collidingRegistry.issue(input, issuedAt: now.addingTimeInterval(1))
+            Issue.record("Expected colliding reply token generator to fail")
+        } catch let failure as AgentChannelFailure {
+            #expect(failure.code == .internalFailure)
+        }
+    }
+
+    @Test func sessionPartitionIsStablePerAgentAndDoesNotExposeProviderRoute() {
+        let substrate = AgentChannelAsyncSubstrate()
+        let route = AgentChannelProviderRoute(
+            conversationId: "email-thread-raw-provider-id",
+            threadId: "message-raw-provider-id"
+        )
+        let agentA = UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!
+        let agentB = UUID(uuidString: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")!
+
+        let first = substrate.makeSessionPartition(
+            agentId: agentA,
+            connectionId: "resend",
+            providerRoute: route,
+            salt: 2
+        )
+        let repeatFirst = substrate.makeSessionPartition(
+            agentId: agentA,
+            connectionId: "resend",
+            providerRoute: route,
+            salt: 2
+        )
+        let otherAgent = substrate.makeSessionPartition(
+            agentId: agentB,
+            connectionId: "resend",
+            providerRoute: route,
+            salt: 2
+        )
+        let otherSalt = substrate.makeSessionPartition(
+            agentId: agentA,
+            connectionId: "resend",
+            providerRoute: route,
+            salt: 3
+        )
+
+        #expect(first == repeatFirst)
+        #expect(first.sessionId != otherAgent.sessionId)
+        #expect(first.externalSessionKey != otherAgent.externalSessionKey)
+        #expect(first.sessionId != otherSalt.sessionId)
+        #expect(first.externalSessionKey != otherSalt.externalSessionKey)
+        #expect(!first.externalSessionKey.contains(route.conversationId))
+        #expect(!first.externalSessionKey.contains(route.threadId ?? ""))
+        #expect(first.externalSessionKey.hasPrefix("agent-channel:resend:"))
+        #expect(first.sessionId.uuidString.split(separator: "-")[2].hasPrefix("5"))
+    }
+
+    @Test func deduplicationServicePersistsFirstSeenAndDuplicateOutcomes() throws {
+        let store = AgentChannelMessageStore()
+        try store.openInMemory()
+        defer { store.close() }
+
+        let substrate = AgentChannelAsyncSubstrate()
+        let deduplication = AgentChannelDeduplicationService(store: store)
+        let key = try #require(
+            substrate.makeDeduplicationKey(
+                connectionId: "telegram",
+                providerEventId: "update-123456",
+                sourceId: "bot-a"
+            )
+        )
+
+        #expect(substrate.makeDeduplicationKey(connectionId: " ", providerEventId: "update") == nil)
+        #expect(substrate.makeDeduplicationKey(connectionId: "telegram", providerEventId: " ") == nil)
+        #expect(try deduplication.register(key) == .firstSeen)
+        #expect(try deduplication.register(key) == .duplicate)
+        #expect(try deduplication.register(nil) == .invalidKey)
+
+        let auditKey = substrate.auditKey(for: key)
+        #expect(auditKey.hasPrefix("ack_"))
+        #expect(!auditKey.contains(key.providerEventId))
+        #expect(!auditKey.contains(key.sourceId ?? ""))
+    }
+
+    @Test func artifactForwardingRollupAndAuditEventsUseTypedStatus() async {
+        let report = AgentChannelArtifactForwardingReport(records: [
+            AgentChannelArtifactForwardingRecord(
+                artifactId: "artifact-1",
+                filename: "summary.pdf",
+                status: .forwarded
+            ),
+            AgentChannelArtifactForwardingRecord(
+                artifactId: "artifact-2",
+                filename: "large.mov",
+                status: .failed,
+                failure: AgentChannelFailure(
+                    code: .artifactTooLarge,
+                    message: "Artifact exceeds channel forwarding limit."
+                )
+            ),
+        ])
+        #expect(report.status == .failed)
+        #expect(AgentChannelArtifactForwardingReport(records: []).status == .notRequested)
+        #expect(AgentChannelArtifactForwardingReport(records: [
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-1", status: .skipped),
+        ]).status == .skipped)
+        #expect(AgentChannelArtifactForwardingReport(records: [
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-1", status: .forwarded),
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-2", status: .skipped),
+        ]).status == .forwarded)
+        #expect(AgentChannelArtifactForwardingReport(records: [
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-1", status: .queued),
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-2", status: .forwarded),
+        ]).status == .queued)
+        #expect(AgentChannelArtifactForwardingReport(records: [
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-1", status: .blocked),
+            AgentChannelArtifactForwardingRecord(artifactId: "artifact-2", status: .queued),
+        ]).status == .blocked)
+
+        let audit = AgentChannelAuditLog()
+        let event = AgentChannelAuditEvent(
+            kind: .artifactForwardingChanged,
+            status: .failed,
+            connectionId: "resend",
+            artifactStatus: report.status,
+            failure: report.records[1].failure,
+            metadata: ["artifact_count": "\(report.records.count)"]
+        )
+        await audit.record(event)
+
+        let events = await audit.snapshot()
+        #expect(events.count == 1)
+        #expect(events[0].kind == .artifactForwardingChanged)
+        #expect(events[0].artifactStatus == .failed)
+        #expect(events[0].failure?.code == .artifactTooLarge)
+
+        let cappedAudit = AgentChannelAuditLog(maxEvents: 2)
+        await cappedAudit.record(
+            AgentChannelAuditEvent(kind: .eventAccepted, status: .accepted, connectionId: "resend-1")
+        )
+        await cappedAudit.record(
+            AgentChannelAuditEvent(kind: .eventAccepted, status: .accepted, connectionId: "resend-2")
+        )
+        await cappedAudit.record(
+            AgentChannelAuditEvent(kind: .eventAccepted, status: .accepted, connectionId: "resend-3")
+        )
+        let cappedEvents = await cappedAudit.snapshot()
+        #expect(cappedEvents.map(\.connectionId) == ["resend-2", "resend-3"])
+    }
+
+    @Test func asyncModelsCodableRoundTripKeepsStableShapes() throws {
+        let token = AgentChannelReplyToken(rawValue: " acr_roundtrip ")
+        let tokenData = try JSONEncoder().encode(token)
+        let decodedToken = try JSONDecoder().decode(AgentChannelReplyToken.self, from: tokenData)
+        #expect(decodedToken.rawValue == "acr_roundtrip")
+
+        let failure = AgentChannelFailure(code: .duplicateEvent, message: "Duplicate event", retryable: false)
+        let failureData = try JSONEncoder().encode(failure)
+        let decodedFailure = try JSONDecoder().decode(AgentChannelFailure.self, from: failureData)
+        #expect(decodedFailure == failure)
+    }
+}

--- a/docs/AGENT_CHANNELS.md
+++ b/docs/AGENT_CHANNELS.md
@@ -136,3 +136,41 @@ plugin pattern:
 This PR does not add a live Discord receive relay. It adds the durable message
 and duplicate-filtering foundation that a relay, webhook receiver, Slack
 adapter, or Telegram adapter can share.
+
+## Async Channel Substrate
+
+Async inbound channels should build on the shared substrate in
+`Models/AgentChannel` and `Services/AgentChannel` before dispatching an agent
+turn. The substrate captures the reusable contracts from Telegram-style chat
+bridges and email-style resend bridges:
+
+- Verify the webhook or source first with either a shared-secret header or an
+  HMAC-SHA256 body signature. Verification failures are typed and never include
+  the configured secret in diagnostics.
+- Evaluate sender policy with blocklists, allowlists, default disposition, and
+  bot-sender handling before parsing user-visible content into a prompt.
+- Create an idempotency key from the connection plus the provider event id and
+  register it through the Agent Channel message store. Duplicates should be
+  acknowledged without creating another dispatch.
+- Derive the chat session partition from `(agent_id, connection_id,
+  provider_conversation_id, provider_thread_id, salt)` using a hash-backed
+  external session key. Provider routing ids stay out of model-visible prompt
+  text and sidebar grouping keys.
+- Mint an opaque reply token for each inbound turn. The token is what the agent
+  sees; the token registry holds the provider conversation/thread/reply address,
+  agent scope, session id, task id, issue time, and expiry. The registry prunes
+  expired bindings on issue/resolve activity and exposes explicit pruning for
+  adapter maintenance jobs.
+- Track artifact forwarding with typed statuses (`queued`, `forwarded`,
+  `skipped`, `blocked`, `failed`) so adapters can report whether shared
+  artifacts were actually delivered to the remote channel.
+- Emit bounded in-memory audit events with typed status/failure values and
+  hashed audit keys rather than raw provider event or routing ids. Adapters
+  that need durable audit evidence should drain these events into their own
+  channel store or support artifact.
+
+The substrate is not a provider implementation. Discord, Telegram, Slack,
+email, and custom adapters still own provider payload parsing, provider API
+calls, rate-limit behavior, and channel-specific formatting. They should share
+these contracts so retries, reply routing, session partitioning, and audit
+event semantics behave consistently across channel families.


### PR DESCRIPTION
## Summary
- Adds provider-neutral async Agent Channel models and services for webhook verification, sender policy, deduplication, reply tokens, session partitioning, audit events, and artifact forwarding status.
- Keeps provider route IDs opaque to agent-visible payloads.
- Adds docs for the async channel contracts and safety boundaries.

## Validation
- swift test --package-path Packages/OsaurusCore --filter AgentChannelAsyncSubstrateTests
- swiftlint lint --quiet Packages/OsaurusCore/Models/AgentChannel/AgentChannelAsyncModels.swift Packages/OsaurusCore/Services/AgentChannel/AgentChannelAsyncSubstrate.swift Packages/OsaurusCore/Tests/AgentChannel/AgentChannelAsyncSubstrateTests.swift
- git diff --check
- External review pass completed; actionable findings were incorporated before publication.
- GitHub checks are green.

## Notes
- Ready for review as a provider-neutral Agent Channel foundation. This branch does not change default tools, prompts, routing, or model behavior.