### PR TITLE
Add workspace context source workbench

### DIFF
--- a/Packages/OsaurusCore/Models/Workspace/ContextSource/WorkspaceContextSourceModels.swift
+++ b/Packages/OsaurusCore/Models/Workspace/ContextSource/WorkspaceContextSourceModels.swift
@@ -14,6 +14,7 @@ public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable,
     case memory
     case agentDatabase = "agent_database"
     case sandboxContext = "sandbox_context"
+    case screenContext = "screen_context"
     case uploadedFile = "uploaded_file"
     case workspaceKnowledge = "workspace_knowledge"
     case citation
@@ -23,9 +24,27 @@ public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable,
         case .memory: return "Memory"
         case .agentDatabase: return "Agent DB"
         case .sandboxContext: return "Sandbox Context"
+        case .screenContext: return "Screen Context"
         case .uploadedFile: return "Uploaded File"
         case .workspaceKnowledge: return "Workspace Knowledge"
         case .citation: return "Citation"
+        }
+    }
+
+    public var category: WorkspaceContextSourceCategory {
+        switch self {
+        case .uploadedFile, .workspaceKnowledge:
+            return .files
+        case .memory:
+            return .memory
+        case .agentDatabase:
+            return .agentDatabase
+        case .sandboxContext:
+            return .sandboxContext
+        case .screenContext:
+            return .screenContext
+        case .citation:
+            return .citations
         }
     }
 
@@ -34,6 +53,7 @@ public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable,
         case .memory: return .memoryService
         case .agentDatabase: return .agentDatabase
         case .sandboxContext: return .sandboxInjection
+        case .screenContext: return .screenContextInjection
         case .uploadedFile: return .chatAttachment
         case .workspaceKnowledge: return .workspaceKnowledgeIndex
         case .citation: return .citationResolver
@@ -59,6 +79,13 @@ public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable,
         case .sandboxContext:
             return WorkspaceContextBoundaryContract(
                 authority: .sandboxContextInjection,
+                payloadPolicy: .executionEnvelopeOnly,
+                contextPolicy: .userMessagePrefixOwnedElsewhere,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .screenContext:
+            return WorkspaceContextBoundaryContract(
+                authority: .screenContextInjection,
                 payloadPolicy: .executionEnvelopeOnly,
                 contextPolicy: .userMessagePrefixOwnedElsewhere,
                 dedupePolicy: .withinKindByProvenance
@@ -91,8 +118,37 @@ public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable,
         switch self {
         case .uploadedFile, .workspaceKnowledge:
             return true
-        case .memory, .agentDatabase, .sandboxContext, .citation:
+        case .memory, .agentDatabase, .sandboxContext, .screenContext, .citation:
             return false
+        }
+    }
+
+    public var requiresFrozenSnapshot: Bool {
+        switch self {
+        case .screenContext:
+            return true
+        case .memory, .agentDatabase, .sandboxContext, .uploadedFile, .workspaceKnowledge, .citation:
+            return false
+        }
+    }
+}
+
+public enum WorkspaceContextSourceCategory: String, Codable, CaseIterable, Hashable, Sendable {
+    case files
+    case memory
+    case agentDatabase = "agent_database"
+    case sandboxContext = "sandbox_context"
+    case screenContext = "screen_context"
+    case citations
+
+    public var displayName: String {
+        switch self {
+        case .files: return "Files"
+        case .memory: return "Memory"
+        case .agentDatabase: return "Agent DB"
+        case .sandboxContext: return "Sandbox Context"
+        case .screenContext: return "Screen Context"
+        case .citations: return "Citations"
         }
     }
 }
@@ -101,6 +157,7 @@ public enum WorkspaceContextSourceAuthority: String, Codable, Hashable, Sendable
     case memoryService
     case agentDatabase
     case sandboxContextInjection
+    case screenContextInjection
     case chatAttachmentStore
     case workspaceKnowledgeIndex
     case citationResolver
@@ -148,6 +205,7 @@ public enum WorkspaceContextSourceOrigin: String, Codable, Hashable, Sendable {
     case memoryService
     case agentDatabase
     case sandboxInjection
+    case screenContextInjection
     case chatAttachment
     case workspaceKnowledgeIndex
     case citationResolver
@@ -197,6 +255,45 @@ public struct WorkspaceContextSourceProvenance: Codable, Equatable, Hashable, Se
     }
 }
 
+public enum WorkspaceContextSnapshotFreezeState: String, Codable, Hashable, Sendable {
+    case live
+    case frozen
+}
+
+public struct WorkspaceContextSnapshotProvenance: Codable, Equatable, Hashable, Sendable {
+    public var freezeState: WorkspaceContextSnapshotFreezeState
+    public var snapshotId: String
+    public var capturedAt: Date?
+    public var frozenAt: Date?
+    public var sourceVersion: String?
+    public var citationVersion: String?
+    public var contextDigest: String?
+
+    public init(
+        freezeState: WorkspaceContextSnapshotFreezeState,
+        snapshotId: String,
+        capturedAt: Date? = nil,
+        frozenAt: Date? = nil,
+        sourceVersion: String? = nil,
+        citationVersion: String? = nil,
+        contextDigest: String? = nil
+    ) {
+        self.freezeState = freezeState
+        self.snapshotId = snapshotId
+        self.capturedAt = capturedAt
+        self.frozenAt = frozenAt
+        self.sourceVersion = sourceVersion
+        self.citationVersion = citationVersion
+        self.contextDigest = contextDigest
+    }
+
+    public var isFrozen: Bool {
+        freezeState == .frozen
+            && !snapshotId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && frozenAt != nil
+    }
+}
+
 public enum WorkspaceContextIndexStatus: String, Codable, Hashable, Sendable {
     case notIndexed = "not_indexed"
     case indexing
@@ -236,6 +333,7 @@ public enum WorkspaceContextCitationAnchorKind: String, Codable, Hashable, Senda
     case databaseRow = "database_row"
     case memoryEpisode = "memory_episode"
     case sandboxSnapshot = "sandbox_snapshot"
+    case screenSnapshot = "screen_snapshot"
     case externalReference = "external_reference"
 }
 
@@ -287,6 +385,7 @@ public struct WorkspaceContextSourceInput: Codable, Equatable, Hashable, Sendabl
     public var agentId: UUID?
     public var isEnabled: Bool
     public var provenance: WorkspaceContextSourceProvenance?
+    public var snapshot: WorkspaceContextSnapshotProvenance?
     public var index: WorkspaceContextIndexState?
     public var citations: [WorkspaceContextCitation]
     public var metadata: [String: String]
@@ -298,6 +397,7 @@ public struct WorkspaceContextSourceInput: Codable, Equatable, Hashable, Sendabl
         agentId: UUID? = nil,
         isEnabled: Bool = true,
         provenance: WorkspaceContextSourceProvenance? = nil,
+        snapshot: WorkspaceContextSnapshotProvenance? = nil,
         index: WorkspaceContextIndexState? = nil,
         citations: [WorkspaceContextCitation] = [],
         metadata: [String: String] = [:]
@@ -308,6 +408,7 @@ public struct WorkspaceContextSourceInput: Codable, Equatable, Hashable, Sendabl
         self.agentId = agentId
         self.isEnabled = isEnabled
         self.provenance = provenance
+        self.snapshot = snapshot
         self.index = index
         self.citations = citations
         self.metadata = metadata
@@ -323,6 +424,10 @@ public enum WorkspaceContextWarningKind: String, Codable, Hashable, Sendable {
     case duplicateSource = "duplicate_source"
     case provenanceOriginMismatch = "provenance_origin_mismatch"
     case staleProvenance = "stale_provenance"
+    case snapshotMissing = "snapshot_missing"
+    case snapshotLive = "snapshot_live"
+    case snapshotIncomplete = "snapshot_incomplete"
+    case snapshotStale = "snapshot_stale"
     case indexMissing = "index_missing"
     case indexInProgress = "index_in_progress"
     case indexFailed = "index_failed"
@@ -355,6 +460,10 @@ public struct WorkspaceContextSourceWarning: Codable, Equatable, Hashable, Senda
 public enum WorkspaceContextStalenessReason: String, Codable, Hashable, Sendable {
     case sourceMissing = "source_missing"
     case provenanceExpired = "provenance_expired"
+    case snapshotMissing = "snapshot_missing"
+    case snapshotNotFrozen = "snapshot_not_frozen"
+    case snapshotVersionMismatch = "snapshot_version_mismatch"
+    case snapshotModifiedAfterFreeze = "snapshot_modified_after_freeze"
     case indexMissing = "index_missing"
     case indexInProgress = "index_in_progress"
     case indexFailed = "index_failed"

--- a/Packages/OsaurusCore/Models/Workspace/ContextSource/WorkspaceContextSourceModels.swift
+++ b/Packages/OsaurusCore/Models/Workspace/ContextSource/WorkspaceContextSourceModels.swift
@@ -1,0 +1,521 @@
+//
+//  WorkspaceContextSourceModels.swift
+//  osaurus
+//
+//  Descriptive inventory models for context sources that can influence a
+//  workspace chat. These types intentionally carry metadata, provenance, and
+//  citation anchors only. Memory facts, agent DB rows, attachment bytes, and
+//  sandbox snapshots remain owned by their existing services.
+//
+
+import Foundation
+
+public enum WorkspaceContextSourceKind: String, Codable, CaseIterable, Hashable, Sendable {
+    case memory
+    case agentDatabase = "agent_database"
+    case sandboxContext = "sandbox_context"
+    case uploadedFile = "uploaded_file"
+    case workspaceKnowledge = "workspace_knowledge"
+    case citation
+
+    public var displayName: String {
+        switch self {
+        case .memory: return "Memory"
+        case .agentDatabase: return "Agent DB"
+        case .sandboxContext: return "Sandbox Context"
+        case .uploadedFile: return "Uploaded File"
+        case .workspaceKnowledge: return "Workspace Knowledge"
+        case .citation: return "Citation"
+        }
+    }
+
+    public var expectedOrigin: WorkspaceContextSourceOrigin {
+        switch self {
+        case .memory: return .memoryService
+        case .agentDatabase: return .agentDatabase
+        case .sandboxContext: return .sandboxInjection
+        case .uploadedFile: return .chatAttachment
+        case .workspaceKnowledge: return .workspaceKnowledgeIndex
+        case .citation: return .citationResolver
+        }
+    }
+
+    public var boundaryContract: WorkspaceContextBoundaryContract {
+        switch self {
+        case .memory:
+            return WorkspaceContextBoundaryContract(
+                authority: .memoryService,
+                payloadPolicy: .metadataOnly,
+                contextPolicy: .userMessagePrefixOwnedElsewhere,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .agentDatabase:
+            return WorkspaceContextBoundaryContract(
+                authority: .agentDatabase,
+                payloadPolicy: .metadataOnly,
+                contextPolicy: .toolMediated,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .sandboxContext:
+            return WorkspaceContextBoundaryContract(
+                authority: .sandboxContextInjection,
+                payloadPolicy: .executionEnvelopeOnly,
+                contextPolicy: .userMessagePrefixOwnedElsewhere,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .uploadedFile:
+            return WorkspaceContextBoundaryContract(
+                authority: .chatAttachmentStore,
+                payloadPolicy: .metadataAndAnchorsOnly,
+                contextPolicy: .attachmentPayloadOwnedElsewhere,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .workspaceKnowledge:
+            return WorkspaceContextBoundaryContract(
+                authority: .workspaceKnowledgeIndex,
+                payloadPolicy: .metadataAndAnchorsOnly,
+                contextPolicy: .retrievalIndexOwnedElsewhere,
+                dedupePolicy: .withinKindByProvenance
+            )
+        case .citation:
+            return WorkspaceContextBoundaryContract(
+                authority: .citationResolver,
+                payloadPolicy: .citationAnchorsOnly,
+                contextPolicy: .citationOnly,
+                dedupePolicy: .withinKindByProvenance
+            )
+        }
+    }
+
+    public var requiresIndexFreshness: Bool {
+        switch self {
+        case .uploadedFile, .workspaceKnowledge:
+            return true
+        case .memory, .agentDatabase, .sandboxContext, .citation:
+            return false
+        }
+    }
+}
+
+public enum WorkspaceContextSourceAuthority: String, Codable, Hashable, Sendable {
+    case memoryService
+    case agentDatabase
+    case sandboxContextInjection
+    case chatAttachmentStore
+    case workspaceKnowledgeIndex
+    case citationResolver
+}
+
+public enum WorkspaceContextPayloadPolicy: String, Codable, Hashable, Sendable {
+    case metadataOnly
+    case metadataAndAnchorsOnly
+    case citationAnchorsOnly
+    case executionEnvelopeOnly
+}
+
+public enum WorkspaceContextInjectionPolicy: String, Codable, Hashable, Sendable {
+    case userMessagePrefixOwnedElsewhere
+    case toolMediated
+    case attachmentPayloadOwnedElsewhere
+    case retrievalIndexOwnedElsewhere
+    case citationOnly
+}
+
+public enum WorkspaceContextDedupePolicy: String, Codable, Hashable, Sendable {
+    case withinKindByProvenance
+}
+
+public struct WorkspaceContextBoundaryContract: Codable, Equatable, Hashable, Sendable {
+    public var authority: WorkspaceContextSourceAuthority
+    public var payloadPolicy: WorkspaceContextPayloadPolicy
+    public var contextPolicy: WorkspaceContextInjectionPolicy
+    public var dedupePolicy: WorkspaceContextDedupePolicy
+
+    public init(
+        authority: WorkspaceContextSourceAuthority,
+        payloadPolicy: WorkspaceContextPayloadPolicy,
+        contextPolicy: WorkspaceContextInjectionPolicy,
+        dedupePolicy: WorkspaceContextDedupePolicy
+    ) {
+        self.authority = authority
+        self.payloadPolicy = payloadPolicy
+        self.contextPolicy = contextPolicy
+        self.dedupePolicy = dedupePolicy
+    }
+}
+
+public enum WorkspaceContextSourceOrigin: String, Codable, Hashable, Sendable {
+    case memoryService
+    case agentDatabase
+    case sandboxInjection
+    case chatAttachment
+    case workspaceKnowledgeIndex
+    case citationResolver
+    case unknown
+}
+
+public struct WorkspaceContextSourceProvenance: Codable, Equatable, Hashable, Sendable {
+    public var stableId: String
+    public var origin: WorkspaceContextSourceOrigin
+    public var displayPath: String?
+    public var sourceVersion: String?
+    public var contentHash: String?
+    public var observedAt: Date?
+    public var modifiedAt: Date?
+    public var sourceExists: Bool
+
+    public init(
+        stableId: String,
+        origin: WorkspaceContextSourceOrigin,
+        displayPath: String? = nil,
+        sourceVersion: String? = nil,
+        contentHash: String? = nil,
+        observedAt: Date? = nil,
+        modifiedAt: Date? = nil,
+        sourceExists: Bool = true
+    ) {
+        self.stableId = stableId
+        self.origin = origin
+        self.displayPath = displayPath
+        self.sourceVersion = sourceVersion
+        self.contentHash = contentHash
+        self.observedAt = observedAt
+        self.modifiedAt = modifiedAt
+        self.sourceExists = sourceExists
+    }
+
+    public var versionFingerprint: String? {
+        let trimmedVersion = sourceVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedVersion, !trimmedVersion.isEmpty {
+            return trimmedVersion
+        }
+        let trimmedHash = contentHash?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedHash, !trimmedHash.isEmpty {
+            return trimmedHash
+        }
+        return nil
+    }
+}
+
+public enum WorkspaceContextIndexStatus: String, Codable, Hashable, Sendable {
+    case notIndexed = "not_indexed"
+    case indexing
+    case indexed
+    case failed
+}
+
+public struct WorkspaceContextIndexState: Codable, Equatable, Hashable, Sendable {
+    public var status: WorkspaceContextIndexStatus
+    public var indexedAt: Date?
+    public var indexedSourceVersion: String?
+    public var indexedCitationVersion: String?
+    public var citationCount: Int
+    public var lastError: String?
+
+    public init(
+        status: WorkspaceContextIndexStatus,
+        indexedAt: Date? = nil,
+        indexedSourceVersion: String? = nil,
+        indexedCitationVersion: String? = nil,
+        citationCount: Int = 0,
+        lastError: String? = nil
+    ) {
+        self.status = status
+        self.indexedAt = indexedAt
+        self.indexedSourceVersion = indexedSourceVersion
+        self.indexedCitationVersion = indexedCitationVersion
+        self.citationCount = max(0, citationCount)
+        self.lastError = lastError
+    }
+}
+
+public enum WorkspaceContextCitationAnchorKind: String, Codable, Hashable, Sendable {
+    case fileRange = "file_range"
+    case documentPage = "document_page"
+    case spreadsheetCell = "spreadsheet_cell"
+    case databaseRow = "database_row"
+    case memoryEpisode = "memory_episode"
+    case sandboxSnapshot = "sandbox_snapshot"
+    case externalReference = "external_reference"
+}
+
+public struct WorkspaceContextCitationAnchor: Codable, Equatable, Hashable, Sendable {
+    public var kind: WorkspaceContextCitationAnchorKind
+    public var locator: String
+    public var startLine: Int?
+    public var endLine: Int?
+
+    public init(
+        kind: WorkspaceContextCitationAnchorKind,
+        locator: String,
+        startLine: Int? = nil,
+        endLine: Int? = nil
+    ) {
+        self.kind = kind
+        self.locator = locator
+        self.startLine = startLine
+        self.endLine = endLine
+    }
+}
+
+public struct WorkspaceContextCitation: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var sourceId: String
+    public var label: String
+    public var sourceVersion: String?
+    public var anchor: WorkspaceContextCitationAnchor?
+
+    public init(
+        id: String,
+        sourceId: String,
+        label: String,
+        sourceVersion: String? = nil,
+        anchor: WorkspaceContextCitationAnchor? = nil
+    ) {
+        self.id = id
+        self.sourceId = sourceId
+        self.label = label
+        self.sourceVersion = sourceVersion
+        self.anchor = anchor
+    }
+}
+
+public struct WorkspaceContextSourceInput: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var kind: WorkspaceContextSourceKind
+    public var displayName: String
+    public var agentId: UUID?
+    public var isEnabled: Bool
+    public var provenance: WorkspaceContextSourceProvenance?
+    public var index: WorkspaceContextIndexState?
+    public var citations: [WorkspaceContextCitation]
+    public var metadata: [String: String]
+
+    public init(
+        id: String,
+        kind: WorkspaceContextSourceKind,
+        displayName: String,
+        agentId: UUID? = nil,
+        isEnabled: Bool = true,
+        provenance: WorkspaceContextSourceProvenance? = nil,
+        index: WorkspaceContextIndexState? = nil,
+        citations: [WorkspaceContextCitation] = [],
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.kind = kind
+        self.displayName = displayName
+        self.agentId = agentId
+        self.isEnabled = isEnabled
+        self.provenance = provenance
+        self.index = index
+        self.citations = citations
+        self.metadata = metadata
+    }
+}
+
+public enum WorkspaceContextWarningKind: String, Codable, Hashable, Sendable {
+    case malformedSource = "malformed_source"
+    case sourceMissing = "source_missing"
+    case sourceDisabled = "source_disabled"
+    case agentScopeMismatch = "agent_scope_mismatch"
+    case disabledForAgent = "disabled_for_agent"
+    case duplicateSource = "duplicate_source"
+    case provenanceOriginMismatch = "provenance_origin_mismatch"
+    case staleProvenance = "stale_provenance"
+    case indexMissing = "index_missing"
+    case indexInProgress = "index_in_progress"
+    case indexFailed = "index_failed"
+    case indexStale = "index_stale"
+    case malformedCitation = "malformed_citation"
+    case citationSourceMissing = "citation_source_missing"
+    case citationAnchorMissing = "citation_anchor_missing"
+    case citationStale = "citation_stale"
+}
+
+public struct WorkspaceContextSourceWarning: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var sourceId: String?
+    public var kind: WorkspaceContextWarningKind
+    public var message: String
+
+    public init(
+        id: String = UUID().uuidString,
+        sourceId: String? = nil,
+        kind: WorkspaceContextWarningKind,
+        message: String
+    ) {
+        self.id = id
+        self.sourceId = sourceId
+        self.kind = kind
+        self.message = message
+    }
+}
+
+public enum WorkspaceContextStalenessReason: String, Codable, Hashable, Sendable {
+    case sourceMissing = "source_missing"
+    case provenanceExpired = "provenance_expired"
+    case indexMissing = "index_missing"
+    case indexInProgress = "index_in_progress"
+    case indexFailed = "index_failed"
+    case indexVersionMismatch = "index_version_mismatch"
+    case malformedCitation = "malformed_citation"
+    case citationSourceMissing = "citation_source_missing"
+    case citationAnchorMissing = "citation_anchor_missing"
+    case citationVersionMismatch = "citation_version_mismatch"
+}
+
+public enum WorkspaceContextFreshnessStatus: String, Codable, Hashable, Sendable {
+    case current
+    case unindexed
+    case stale
+    case missing
+    case malformed
+}
+
+public struct WorkspaceContextSourceStaleness: Codable, Equatable, Hashable, Sendable {
+    public var status: WorkspaceContextFreshnessStatus
+    public var reasons: Set<WorkspaceContextStalenessReason>
+
+    public init(
+        status: WorkspaceContextFreshnessStatus,
+        reasons: Set<WorkspaceContextStalenessReason> = []
+    ) {
+        self.status = status
+        self.reasons = reasons
+    }
+
+    public var isActionable: Bool {
+        status != .current
+    }
+}
+
+public enum WorkspaceContextSourceRecordState: String, Codable, Hashable, Sendable {
+    case active
+    case disabled
+    case duplicate
+    case stale
+    case missing
+    case malformed
+}
+
+public struct WorkspaceContextSourceRecord: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String { source.id }
+
+    public var source: WorkspaceContextSourceInput
+    public var dedupeKey: String
+    public var boundaryContract: WorkspaceContextBoundaryContract
+    public var enabledForAgent: Bool
+    public var duplicateOf: String?
+    public var staleness: WorkspaceContextSourceStaleness
+    public var warnings: [WorkspaceContextSourceWarning]
+
+    public init(
+        source: WorkspaceContextSourceInput,
+        dedupeKey: String,
+        boundaryContract: WorkspaceContextBoundaryContract,
+        enabledForAgent: Bool,
+        duplicateOf: String? = nil,
+        staleness: WorkspaceContextSourceStaleness,
+        warnings: [WorkspaceContextSourceWarning] = []
+    ) {
+        self.source = source
+        self.dedupeKey = dedupeKey
+        self.boundaryContract = boundaryContract
+        self.enabledForAgent = enabledForAgent
+        self.duplicateOf = duplicateOf
+        self.staleness = staleness
+        self.warnings = warnings
+    }
+
+    public var state: WorkspaceContextSourceRecordState {
+        if staleness.status == .malformed { return .malformed }
+        if duplicateOf != nil { return .duplicate }
+        if !enabledForAgent { return .disabled }
+        switch staleness.status {
+        case .current:
+            return .active
+        case .unindexed, .stale:
+            return .stale
+        case .missing:
+            return .missing
+        case .malformed:
+            return .malformed
+        }
+    }
+
+    public var isEffective: Bool {
+        enabledForAgent
+            && duplicateOf == nil
+            && staleness.status != .missing
+            && staleness.status != .malformed
+    }
+}
+
+public struct WorkspaceContextRejectedSource: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String
+    public var sourceId: String?
+    public var kind: WorkspaceContextSourceKind?
+    public var message: String
+
+    public init(
+        id: String = UUID().uuidString,
+        sourceId: String?,
+        kind: WorkspaceContextSourceKind?,
+        message: String
+    ) {
+        self.id = id
+        self.sourceId = sourceId
+        self.kind = kind
+        self.message = message
+    }
+}
+
+public struct WorkspaceContextDuplicateGroup: Codable, Equatable, Hashable, Sendable {
+    public var dedupeKey: String
+    public var canonicalSourceId: String
+    public var duplicateSourceIds: [String]
+
+    public init(
+        dedupeKey: String,
+        canonicalSourceId: String,
+        duplicateSourceIds: [String]
+    ) {
+        self.dedupeKey = dedupeKey
+        self.canonicalSourceId = canonicalSourceId
+        self.duplicateSourceIds = duplicateSourceIds
+    }
+}
+
+public struct WorkspaceContextSourceInventory: Codable, Equatable, Sendable {
+    public var activeAgentId: UUID?
+    public var generatedAt: Date
+    public var records: [WorkspaceContextSourceRecord]
+    public var rejectedSources: [WorkspaceContextRejectedSource]
+    public var duplicateGroups: [WorkspaceContextDuplicateGroup]
+    public var warnings: [WorkspaceContextSourceWarning]
+
+    public init(
+        activeAgentId: UUID?,
+        generatedAt: Date,
+        records: [WorkspaceContextSourceRecord],
+        rejectedSources: [WorkspaceContextRejectedSource],
+        duplicateGroups: [WorkspaceContextDuplicateGroup],
+        warnings: [WorkspaceContextSourceWarning]
+    ) {
+        self.activeAgentId = activeAgentId
+        self.generatedAt = generatedAt
+        self.records = records
+        self.rejectedSources = rejectedSources
+        self.duplicateGroups = duplicateGroups
+        self.warnings = warnings
+    }
+
+    public var effectiveSources: [WorkspaceContextSourceRecord] {
+        records.filter(\.isEffective)
+    }
+
+    public func record(id: String) -> WorkspaceContextSourceRecord? {
+        records.first { $0.id == id }
+    }
+}

--- a/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbench.swift
+++ b/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbench.swift
@@ -13,18 +13,23 @@ import Foundation
 public struct WorkspaceContextSourceWorkbenchPolicy: Sendable {
     public var defaultEnabledKinds: Set<WorkspaceContextSourceKind>
     public var enabledKindsByAgent: [UUID: Set<WorkspaceContextSourceKind>]
+    public var disabledSourceIds: Set<String>
     public var disabledSourceIdsByAgent: [UUID: Set<String>]
     public var provenanceMaxAge: TimeInterval?
 
     public init(
         defaultEnabledKinds: Set<WorkspaceContextSourceKind>? = nil,
         enabledKindsByAgent: [UUID: Set<WorkspaceContextSourceKind>] = [:],
+        disabledSourceIds: Set<String> = [],
         disabledSourceIdsByAgent: [UUID: Set<String>] = [:],
         provenanceMaxAge: TimeInterval? = nil
     ) {
         self.defaultEnabledKinds = defaultEnabledKinds ?? Set(WorkspaceContextSourceKind.allCases)
         self.enabledKindsByAgent = enabledKindsByAgent
-        self.disabledSourceIdsByAgent = disabledSourceIdsByAgent
+        self.disabledSourceIds = Set(disabledSourceIds.map(\.normalizedContextSourceKey))
+        self.disabledSourceIdsByAgent = disabledSourceIdsByAgent.mapValues {
+            Set($0.map(\.normalizedContextSourceKey))
+        }
         self.provenanceMaxAge = provenanceMaxAge
     }
 
@@ -34,10 +39,23 @@ public struct WorkspaceContextSourceWorkbenchPolicy: Sendable {
     }
 
     func isSourceExplicitlyDisabled(_ source: WorkspaceContextSourceInput, for agentId: UUID?) -> Bool {
-        guard let agentId else { return false }
-        let disabled = disabledSourceIdsByAgent[agentId] ?? []
+        if isSourceGloballyDisabled(source) {
+            return true
+        }
+        return isSourceDisabledForAgent(source, agentId: agentId)
+    }
+
+    func isSourceGloballyDisabled(_ source: WorkspaceContextSourceInput) -> Bool {
         let sourceId = source.id.normalizedContextSourceKey
         let stableId = source.provenance?.stableId.normalizedContextSourceKey
+        return disabledSourceIds.contains(sourceId) || stableId.map(disabledSourceIds.contains) == true
+    }
+
+    func isSourceDisabledForAgent(_ source: WorkspaceContextSourceInput, agentId: UUID?) -> Bool {
+        guard let agentId else { return false }
+        let sourceId = source.id.normalizedContextSourceKey
+        let stableId = source.provenance?.stableId.normalizedContextSourceKey
+        let disabled = disabledSourceIdsByAgent[agentId] ?? []
         return disabled.contains(sourceId) || stableId.map(disabled.contains) == true
     }
 }
@@ -281,7 +299,15 @@ private extension WorkspaceContextSourceWorkbench {
                 )
             )
         }
-        if policy.isSourceExplicitlyDisabled(source, for: activeAgentId) {
+        if policy.isSourceGloballyDisabled(source) {
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .sourceDisabled,
+                    message: "\(source.displayName) is disabled by workspace context policy."
+                )
+            )
+        } else if policy.isSourceDisabledForAgent(source, agentId: activeAgentId) {
             warnings.append(
                 warning(
                     sourceId: source.id,
@@ -342,6 +368,7 @@ private extension WorkspaceContextSourceWorkbench {
             )
         }
 
+        evaluateSnapshotFreshness(source: source, reasons: &reasons, warnings: &warnings)
         evaluateIndexFreshness(source: source, reasons: &reasons, warnings: &warnings)
         evaluateCitationFreshness(
             source: source,
@@ -363,6 +390,84 @@ private extension WorkspaceContextSourceWorkbench {
             return WorkspaceContextSourceStaleness(status: .stale, reasons: reasons)
         }
         return WorkspaceContextSourceStaleness(status: .current)
+    }
+
+    static func evaluateSnapshotFreshness(
+        source: WorkspaceContextSourceInput,
+        reasons: inout Set<WorkspaceContextStalenessReason>,
+        warnings: inout [WorkspaceContextSourceWarning]
+    ) {
+        guard source.kind.requiresFrozenSnapshot else { return }
+        guard let snapshot = source.snapshot else {
+            reasons.insert(.snapshotMissing)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .snapshotMissing,
+                    message: "\(source.displayName) has no frozen snapshot metadata."
+                )
+            )
+            return
+        }
+
+        if !snapshot.isFrozen {
+            reasons.insert(.snapshotNotFrozen)
+            switch snapshot.freezeState {
+            case .live:
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .snapshotLive,
+                        message: "\(source.displayName) is still live; freeze the snapshot before using it as turn context."
+                    )
+                )
+            case .frozen:
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .snapshotIncomplete,
+                        message: "\(source.displayName) frozen snapshot metadata is incomplete."
+                    )
+                )
+            }
+        }
+
+        if let currentVersion = source.provenance?.sourceVersion?.normalizedNonEmptyContextSourceKey {
+            if let snapshotVersion = snapshot.sourceVersion?.normalizedNonEmptyContextSourceKey {
+                if snapshotVersion != currentVersion {
+                    reasons.insert(.snapshotVersionMismatch)
+                    warnings.append(
+                        warning(
+                            sourceId: source.id,
+                            kind: .snapshotStale,
+                            message: "\(source.displayName) snapshot was captured for an older source version."
+                        )
+                    )
+                }
+            } else {
+                reasons.insert(.snapshotVersionMismatch)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .snapshotStale,
+                        message: "\(source.displayName) snapshot has no source version metadata."
+                    )
+                )
+            }
+        }
+
+        if let modifiedAt = source.provenance?.modifiedAt,
+            let frozenAt = snapshot.frozenAt,
+            modifiedAt > frozenAt {
+            reasons.insert(.snapshotModifiedAfterFreeze)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .snapshotStale,
+                    message: "\(source.displayName) changed after its snapshot was frozen."
+                )
+            )
+        }
     }
 
     static func evaluateIndexFreshness(

--- a/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbench.swift
+++ b/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbench.swift
@@ -1,0 +1,579 @@
+//
+//  WorkspaceContextSourceWorkbench.swift
+//  osaurus
+//
+//  Evaluates context-source metadata for the workspace context workbench.
+//  This service does not read MemoryDatabase, AgentDatabase, attachments, or
+//  sandbox state. Callers supply source descriptors from those owners, and
+//  the workbench only proves boundaries, provenance, dedupe, and freshness.
+//
+
+import Foundation
+
+public struct WorkspaceContextSourceWorkbenchPolicy: Sendable {
+    public var defaultEnabledKinds: Set<WorkspaceContextSourceKind>
+    public var enabledKindsByAgent: [UUID: Set<WorkspaceContextSourceKind>]
+    public var disabledSourceIdsByAgent: [UUID: Set<String>]
+    public var provenanceMaxAge: TimeInterval?
+
+    public init(
+        defaultEnabledKinds: Set<WorkspaceContextSourceKind>? = nil,
+        enabledKindsByAgent: [UUID: Set<WorkspaceContextSourceKind>] = [:],
+        disabledSourceIdsByAgent: [UUID: Set<String>] = [:],
+        provenanceMaxAge: TimeInterval? = nil
+    ) {
+        self.defaultEnabledKinds = defaultEnabledKinds ?? Set(WorkspaceContextSourceKind.allCases)
+        self.enabledKindsByAgent = enabledKindsByAgent
+        self.disabledSourceIdsByAgent = disabledSourceIdsByAgent
+        self.provenanceMaxAge = provenanceMaxAge
+    }
+
+    func enabledKinds(for agentId: UUID?) -> Set<WorkspaceContextSourceKind> {
+        guard let agentId else { return defaultEnabledKinds }
+        return enabledKindsByAgent[agentId] ?? defaultEnabledKinds
+    }
+
+    func isSourceExplicitlyDisabled(_ source: WorkspaceContextSourceInput, for agentId: UUID?) -> Bool {
+        guard let agentId else { return false }
+        let disabled = disabledSourceIdsByAgent[agentId] ?? []
+        let sourceId = source.id.normalizedContextSourceKey
+        let stableId = source.provenance?.stableId.normalizedContextSourceKey
+        return disabled.contains(sourceId) || stableId.map(disabled.contains) == true
+    }
+}
+
+public enum WorkspaceContextSourceWorkbench {
+    public static func buildInventory(
+        sources: [WorkspaceContextSourceInput],
+        activeAgentId: UUID? = nil,
+        policy: WorkspaceContextSourceWorkbenchPolicy = WorkspaceContextSourceWorkbenchPolicy(),
+        now: Date = Date()
+    ) -> WorkspaceContextSourceInventory {
+        var rejected: [WorkspaceContextRejectedSource] = []
+        var warnings: [WorkspaceContextSourceWarning] = []
+        var validated: [ValidatedSource] = []
+
+        for source in sources {
+            switch validate(source) {
+            case .success(let validatedSource):
+                validated.append(validatedSource)
+            case .failure(let rejection):
+                rejected.append(rejection)
+                warnings.append(
+                    warning(
+                        sourceId: rejection.sourceId,
+                        kind: .malformedSource,
+                        message: rejection.message
+                    )
+                )
+            }
+        }
+
+        let sourceLookup = SourceLookup(validatedSources: validated)
+        let canonicalByKey = canonicalSourcesByDedupeKey(
+            validated,
+            activeAgentId: activeAgentId,
+            policy: policy
+        )
+        let duplicateGroups = duplicateGroups(from: validated, canonicalByKey: canonicalByKey)
+
+        var records: [WorkspaceContextSourceRecord] = []
+        for item in validated {
+            let canonical = canonicalByKey[item.dedupeKey]
+            let duplicateOf = canonical?.id == item.source.id ? nil : canonical?.id
+            var sourceWarnings = evaluateEnablementWarnings(
+                source: item.source,
+                activeAgentId: activeAgentId,
+                policy: policy
+            )
+            sourceWarnings.append(
+                contentsOf: evaluateBoundaryWarnings(source: item.source)
+            )
+
+            let staleness = evaluateStaleness(
+                source: item.source,
+                lookup: sourceLookup,
+                policy: policy,
+                now: now,
+                warnings: &sourceWarnings
+            )
+
+            if let duplicateOf {
+                sourceWarnings.append(
+                    warning(
+                        sourceId: item.source.id,
+                        kind: .duplicateSource,
+                        message: "\(item.source.displayName) duplicates \(duplicateOf) for \(item.source.kind.displayName)."
+                    )
+                )
+            }
+
+            let enabled = isEnabledForAgent(
+                item.source,
+                activeAgentId: activeAgentId,
+                policy: policy
+            )
+            records.append(
+                WorkspaceContextSourceRecord(
+                    source: item.source,
+                    dedupeKey: item.dedupeKey,
+                    boundaryContract: item.source.kind.boundaryContract,
+                    enabledForAgent: enabled,
+                    duplicateOf: duplicateOf,
+                    staleness: staleness,
+                    warnings: sourceWarnings
+                )
+            )
+            warnings.append(contentsOf: sourceWarnings)
+        }
+
+        return WorkspaceContextSourceInventory(
+            activeAgentId: activeAgentId,
+            generatedAt: now,
+            records: records,
+            rejectedSources: rejected,
+            duplicateGroups: duplicateGroups,
+            warnings: warnings
+        )
+    }
+}
+
+private extension WorkspaceContextSourceWorkbench {
+    struct ValidatedSource {
+        var source: WorkspaceContextSourceInput
+        var dedupeKey: String
+    }
+
+    enum ValidationResult {
+        case success(ValidatedSource)
+        case failure(WorkspaceContextRejectedSource)
+    }
+
+    struct SourceLookup {
+        var byId: [String: WorkspaceContextSourceInput] = [:]
+        var byStableId: [String: WorkspaceContextSourceInput] = [:]
+
+        init(validatedSources: [ValidatedSource]) {
+            for item in validatedSources {
+                byId[item.source.id.normalizedContextSourceKey] = item.source
+                if let stableId = item.source.provenance?.stableId.normalizedNonEmptyContextSourceKey {
+                    byStableId[stableId] = item.source
+                }
+            }
+        }
+
+        func resolve(_ sourceId: String) -> WorkspaceContextSourceInput? {
+            let key = sourceId.normalizedContextSourceKey
+            return byId[key] ?? byStableId[key]
+        }
+    }
+
+    static func validate(_ source: WorkspaceContextSourceInput) -> ValidationResult {
+        let trimmedId = source.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedId.isEmpty else {
+            return .failure(
+                WorkspaceContextRejectedSource(
+                    sourceId: nil,
+                    kind: source.kind,
+                    message: "Context source is missing a source id."
+                )
+            )
+        }
+        guard var provenance = source.provenance else {
+            return .failure(
+                WorkspaceContextRejectedSource(
+                    sourceId: trimmedId,
+                    kind: source.kind,
+                    message: "Context source \(trimmedId) is missing provenance."
+                )
+            )
+        }
+        let stableId = provenance.stableId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stableId.isEmpty else {
+            return .failure(
+                WorkspaceContextRejectedSource(
+                    sourceId: trimmedId,
+                    kind: source.kind,
+                    message: "Context source \(trimmedId) has blank provenance stableId."
+                )
+            )
+        }
+
+        provenance.stableId = stableId
+        var normalized = source
+        normalized.id = trimmedId
+        normalized.displayName = normalized.displayName.trimmedContextSourceFallback(trimmedId)
+        normalized.provenance = provenance
+        let dedupeKey = "\(normalized.kind.rawValue)|\(stableId.normalizedContextSourceKey)"
+        return .success(ValidatedSource(source: normalized, dedupeKey: dedupeKey))
+    }
+
+    static func canonicalSourcesByDedupeKey(
+        _ sources: [ValidatedSource],
+        activeAgentId: UUID?,
+        policy: WorkspaceContextSourceWorkbenchPolicy
+    ) -> [String: WorkspaceContextSourceInput] {
+        var canonicalByKey: [String: WorkspaceContextSourceInput] = [:]
+        for item in sources {
+            guard let existing = canonicalByKey[item.dedupeKey] else {
+                canonicalByKey[item.dedupeKey] = item.source
+                continue
+            }
+            if item.source.isPreferredCanonical(
+                over: existing,
+                activeAgentId: activeAgentId,
+                policy: policy
+            ) {
+                canonicalByKey[item.dedupeKey] = item.source
+            }
+        }
+        return canonicalByKey
+    }
+
+    static func duplicateGroups(
+        from sources: [ValidatedSource],
+        canonicalByKey: [String: WorkspaceContextSourceInput]
+    ) -> [WorkspaceContextDuplicateGroup] {
+        let grouped = Dictionary(grouping: sources, by: \.dedupeKey)
+        return grouped.compactMap { key, items in
+            guard items.count > 1, let canonical = canonicalByKey[key] else { return nil }
+            let duplicates = items.map(\.source.id).filter { $0 != canonical.id }
+            guard !duplicates.isEmpty else { return nil }
+            return WorkspaceContextDuplicateGroup(
+                dedupeKey: key,
+                canonicalSourceId: canonical.id,
+                duplicateSourceIds: duplicates
+            )
+        }
+        .sorted { $0.dedupeKey < $1.dedupeKey }
+    }
+
+    static func evaluateEnablementWarnings(
+        source: WorkspaceContextSourceInput,
+        activeAgentId: UUID?,
+        policy: WorkspaceContextSourceWorkbenchPolicy
+    ) -> [WorkspaceContextSourceWarning] {
+        var warnings: [WorkspaceContextSourceWarning] = []
+        if !source.isEnabled {
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .sourceDisabled,
+                    message: "\(source.displayName) is disabled by its owning source."
+                )
+            )
+        }
+        if let activeAgentId, let sourceAgentId = source.agentId, sourceAgentId != activeAgentId {
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .agentScopeMismatch,
+                    message: "\(source.displayName) belongs to a different agent."
+                )
+            )
+        }
+        if !policy.enabledKinds(for: activeAgentId).contains(source.kind) {
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .disabledForAgent,
+                    message: "\(source.kind.displayName) is disabled for the active agent."
+                )
+            )
+        }
+        if policy.isSourceExplicitlyDisabled(source, for: activeAgentId) {
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .disabledForAgent,
+                    message: "\(source.displayName) is disabled for the active agent."
+                )
+            )
+        }
+        return warnings
+    }
+
+    static func evaluateBoundaryWarnings(
+        source: WorkspaceContextSourceInput
+    ) -> [WorkspaceContextSourceWarning] {
+        guard let provenance = source.provenance else { return [] }
+        guard provenance.origin != .unknown, provenance.origin != source.kind.expectedOrigin else {
+            return []
+        }
+        return [
+            warning(
+                sourceId: source.id,
+                kind: .provenanceOriginMismatch,
+                message: "\(source.displayName) reports \(provenance.origin.rawValue) provenance for \(source.kind.displayName)."
+            )
+        ]
+    }
+
+    static func evaluateStaleness(
+        source: WorkspaceContextSourceInput,
+        lookup: SourceLookup,
+        policy: WorkspaceContextSourceWorkbenchPolicy,
+        now: Date,
+        warnings: inout [WorkspaceContextSourceWarning]
+    ) -> WorkspaceContextSourceStaleness {
+        var reasons: Set<WorkspaceContextStalenessReason> = []
+
+        if source.provenance?.sourceExists == false {
+            reasons.insert(.sourceMissing)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .sourceMissing,
+                    message: "\(source.displayName) no longer resolves at its recorded source."
+                )
+            )
+        }
+
+        if let maxAge = policy.provenanceMaxAge,
+            let observedAt = source.provenance?.observedAt,
+            now.timeIntervalSince(observedAt) > maxAge {
+            reasons.insert(.provenanceExpired)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .staleProvenance,
+                    message: "\(source.displayName) provenance has not been verified recently."
+                )
+            )
+        }
+
+        evaluateIndexFreshness(source: source, reasons: &reasons, warnings: &warnings)
+        evaluateCitationFreshness(
+            source: source,
+            lookup: lookup,
+            reasons: &reasons,
+            warnings: &warnings
+        )
+
+        if reasons.contains(.sourceMissing) {
+            return WorkspaceContextSourceStaleness(status: .missing, reasons: reasons)
+        }
+        if reasons.contains(.malformedCitation) {
+            return WorkspaceContextSourceStaleness(status: .malformed, reasons: reasons)
+        }
+        if reasons == [.indexMissing] || reasons == [.indexInProgress] {
+            return WorkspaceContextSourceStaleness(status: .unindexed, reasons: reasons)
+        }
+        if !reasons.isEmpty {
+            return WorkspaceContextSourceStaleness(status: .stale, reasons: reasons)
+        }
+        return WorkspaceContextSourceStaleness(status: .current)
+    }
+
+    static func evaluateIndexFreshness(
+        source: WorkspaceContextSourceInput,
+        reasons: inout Set<WorkspaceContextStalenessReason>,
+        warnings: inout [WorkspaceContextSourceWarning]
+    ) {
+        guard source.kind.requiresIndexFreshness else { return }
+        guard let index = source.index else {
+            reasons.insert(.indexMissing)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .indexMissing,
+                    message: "\(source.displayName) has no index metadata."
+                )
+            )
+            return
+        }
+
+        switch index.status {
+        case .notIndexed:
+            reasons.insert(.indexMissing)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .indexMissing,
+                    message: "\(source.displayName) has not been indexed."
+                )
+            )
+        case .indexing:
+            reasons.insert(.indexInProgress)
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .indexInProgress,
+                    message: "\(source.displayName) is still indexing."
+                )
+            )
+        case .failed:
+            reasons.insert(.indexFailed)
+            let detail = index.lastError?.trimmedContextSourceFallback("unknown error") ?? "unknown error"
+            warnings.append(
+                warning(
+                    sourceId: source.id,
+                    kind: .indexFailed,
+                    message: "\(source.displayName) index failed: \(detail)."
+                )
+            )
+        case .indexed:
+            let currentVersion = source.provenance?.versionFingerprint
+            let indexedVersion = index.indexedSourceVersion?.normalizedNonEmptyContextSourceKey
+            if let currentVersion = currentVersion?.normalizedNonEmptyContextSourceKey,
+                indexedVersion != nil,
+                indexedVersion != currentVersion {
+                reasons.insert(.indexVersionMismatch)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .indexStale,
+                        message: "\(source.displayName) index was built for an older source version."
+                    )
+                )
+            }
+        }
+    }
+
+    static func evaluateCitationFreshness(
+        source: WorkspaceContextSourceInput,
+        lookup: SourceLookup,
+        reasons: inout Set<WorkspaceContextStalenessReason>,
+        warnings: inout [WorkspaceContextSourceWarning]
+    ) {
+        for (index, citation) in source.citations.enumerated() {
+            let citationId = citation.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            let citedSourceId = citation.sourceId.trimmingCharacters(in: .whitespacesAndNewlines)
+            if citationId.isEmpty || citedSourceId.isEmpty {
+                reasons.insert(.malformedCitation)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .malformedCitation,
+                        message: "\(source.displayName) has a malformed citation reference.",
+                        disambiguator: "citation:\(index):\(citation.id):\(citation.sourceId)"
+                    )
+                )
+                continue
+            }
+
+            guard let citedSource = lookup.resolve(citedSourceId) else {
+                reasons.insert(.citationSourceMissing)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .citationSourceMissing,
+                        message: "\(source.displayName) cites missing source \(citedSourceId).",
+                        disambiguator: "citation:\(index):\(citationId):\(citedSourceId)"
+                    )
+                )
+                continue
+            }
+
+            if citation.anchor?.locator.normalizedNonEmptyContextSourceKey == nil {
+                reasons.insert(.citationAnchorMissing)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .citationAnchorMissing,
+                        message: "\(source.displayName) citation \(citationId) has no stable anchor.",
+                        disambiguator: "citation:\(index):\(citationId):anchor"
+                    )
+                )
+            }
+
+            if let citationVersion = citation.sourceVersion?.normalizedNonEmptyContextSourceKey,
+                let currentVersion = citedSource.provenance?.versionFingerprint?.normalizedNonEmptyContextSourceKey,
+                citationVersion != currentVersion {
+                reasons.insert(.citationVersionMismatch)
+                warnings.append(
+                    warning(
+                        sourceId: source.id,
+                        kind: .citationStale,
+                        message: "\(source.displayName) citation \(citationId) points at an older source version.",
+                        disambiguator: "citation:\(index):\(citationId):\(citedSourceId)"
+                    )
+                )
+            }
+        }
+    }
+
+    static func isEnabledForAgent(
+        _ source: WorkspaceContextSourceInput,
+        activeAgentId: UUID?,
+        policy: WorkspaceContextSourceWorkbenchPolicy
+    ) -> Bool {
+        guard source.isEnabled else { return false }
+        if let activeAgentId, let sourceAgentId = source.agentId, sourceAgentId != activeAgentId {
+            return false
+        }
+        guard policy.enabledKinds(for: activeAgentId).contains(source.kind) else { return false }
+        return !policy.isSourceExplicitlyDisabled(source, for: activeAgentId)
+    }
+
+    static func warning(
+        sourceId: String?,
+        kind: WorkspaceContextWarningKind,
+        message: String,
+        disambiguator: String? = nil
+    ) -> WorkspaceContextSourceWarning {
+        let normalizedSourceId = sourceId?.normalizedContextSourceKey ?? "global"
+        let idMaterial = [message, disambiguator ?? ""].joined(separator: "\u{1F}")
+        return WorkspaceContextSourceWarning(
+            id: "\(normalizedSourceId):\(kind.rawValue):\(stableWarningIDComponent(idMaterial))",
+            sourceId: sourceId,
+            kind: kind,
+            message: message
+        )
+    }
+
+    static func stableWarningIDComponent(_ message: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in message.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+}
+
+private extension WorkspaceContextSourceInput {
+    func isPreferredCanonical(
+        over other: WorkspaceContextSourceInput,
+        activeAgentId: UUID?,
+        policy: WorkspaceContextSourceWorkbenchPolicy
+    ) -> Bool {
+        let selfEnabled = WorkspaceContextSourceWorkbench.isEnabledForAgent(
+            self,
+            activeAgentId: activeAgentId,
+            policy: policy
+        )
+        let otherEnabled = WorkspaceContextSourceWorkbench.isEnabledForAgent(
+            other,
+            activeAgentId: activeAgentId,
+            policy: policy
+        )
+        if selfEnabled != otherEnabled { return selfEnabled }
+
+        let selfExists = provenance?.sourceExists ?? false
+        let otherExists = other.provenance?.sourceExists ?? false
+        if selfExists != otherExists { return selfExists }
+
+        let selfDate = provenance?.modifiedAt ?? provenance?.observedAt ?? .distantPast
+        let otherDate = other.provenance?.modifiedAt ?? other.provenance?.observedAt ?? .distantPast
+        if selfDate != otherDate { return selfDate > otherDate }
+
+        return id < other.id
+    }
+}
+
+private extension String {
+    var normalizedContextSourceKey: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    var normalizedNonEmptyContextSourceKey: String? {
+        let normalized = normalizedContextSourceKey
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    func trimmedContextSourceFallback(_ fallback: String) -> String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+}

--- a/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbenchPresenter.swift
+++ b/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbenchPresenter.swift
@@ -1,0 +1,133 @@
+//
+//  WorkspaceContextSourceWorkbenchPresenter.swift
+//  osaurus
+//
+//  Presentation helpers for the workspace context source inventory. Kept
+//  separate from SwiftUI so the proof layer can be tested without UI scope.
+//
+
+import Foundation
+
+public struct WorkspaceContextSourceWorkbenchRow: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var title: String
+    public var subtitle: String
+    public var kindLabel: String
+    public var statusLabel: String
+    public var badges: [String]
+    public var warningText: String?
+    public var isEffective: Bool
+
+    public init(
+        id: String,
+        title: String,
+        subtitle: String,
+        kindLabel: String,
+        statusLabel: String,
+        badges: [String],
+        warningText: String?,
+        isEffective: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.kindLabel = kindLabel
+        self.statusLabel = statusLabel
+        self.badges = badges
+        self.warningText = warningText
+        self.isEffective = isEffective
+    }
+}
+
+public struct WorkspaceContextSourceWorkbenchSummary: Equatable, Sendable {
+    public var totalSources: Int
+    public var effectiveSources: Int
+    public var rejectedSources: Int
+    public var duplicateSources: Int
+    public var staleSources: Int
+    public var missingSources: Int
+    public var disabledSources: Int
+
+    public init(
+        totalSources: Int,
+        effectiveSources: Int,
+        rejectedSources: Int,
+        duplicateSources: Int,
+        staleSources: Int,
+        missingSources: Int,
+        disabledSources: Int
+    ) {
+        self.totalSources = totalSources
+        self.effectiveSources = effectiveSources
+        self.rejectedSources = rejectedSources
+        self.duplicateSources = duplicateSources
+        self.staleSources = staleSources
+        self.missingSources = missingSources
+        self.disabledSources = disabledSources
+    }
+}
+
+public enum WorkspaceContextSourceWorkbenchPresenter {
+    public static func rows(
+        for inventory: WorkspaceContextSourceInventory
+    ) -> [WorkspaceContextSourceWorkbenchRow] {
+        inventory.records.map { record in
+            let provenance = record.source.provenance
+            let subtitle = provenance?.displayPath
+                ?? provenance?.stableId
+                ?? record.source.id
+            var badges = [
+                record.boundaryContract.authority.rawValue,
+                record.boundaryContract.payloadPolicy.rawValue,
+            ]
+            if record.duplicateOf != nil {
+                badges.append("duplicate")
+            }
+            if !record.enabledForAgent {
+                badges.append("disabled")
+            }
+
+            return WorkspaceContextSourceWorkbenchRow(
+                id: record.id,
+                title: record.source.displayName,
+                subtitle: subtitle,
+                kindLabel: record.source.kind.displayName,
+                statusLabel: statusLabel(for: record),
+                badges: badges,
+                warningText: record.warnings.first?.message,
+                isEffective: record.isEffective
+            )
+        }
+    }
+
+    public static func summary(
+        for inventory: WorkspaceContextSourceInventory
+    ) -> WorkspaceContextSourceWorkbenchSummary {
+        WorkspaceContextSourceWorkbenchSummary(
+            totalSources: inventory.records.count,
+            effectiveSources: inventory.effectiveSources.count,
+            rejectedSources: inventory.rejectedSources.count,
+            duplicateSources: inventory.records.filter { $0.duplicateOf != nil }.count,
+            staleSources: inventory.records.filter { $0.state == .stale }.count,
+            missingSources: inventory.records.filter { $0.state == .missing }.count,
+            disabledSources: inventory.records.filter { $0.state == .disabled }.count
+        )
+    }
+
+    private static func statusLabel(for record: WorkspaceContextSourceRecord) -> String {
+        switch record.state {
+        case .active:
+            return "Current"
+        case .disabled:
+            return "Disabled"
+        case .duplicate:
+            return "Duplicate"
+        case .stale:
+            return record.staleness.status == .unindexed ? "Unindexed" : "Stale"
+        case .missing:
+            return "Missing"
+        case .malformed:
+            return "Malformed"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbenchPresenter.swift
+++ b/Packages/OsaurusCore/Services/Workspace/WorkspaceContextSourceWorkbenchPresenter.swift
@@ -13,8 +13,12 @@ public struct WorkspaceContextSourceWorkbenchRow: Equatable, Sendable, Identifia
     public var title: String
     public var subtitle: String
     public var kindLabel: String
+    public var categoryLabel: String
     public var statusLabel: String
     public var badges: [String]
+    public var provenanceLabel: String
+    public var citationLabel: String?
+    public var snapshotLabel: String?
     public var warningText: String?
     public var isEffective: Bool
 
@@ -23,8 +27,12 @@ public struct WorkspaceContextSourceWorkbenchRow: Equatable, Sendable, Identifia
         title: String,
         subtitle: String,
         kindLabel: String,
+        categoryLabel: String,
         statusLabel: String,
         badges: [String],
+        provenanceLabel: String,
+        citationLabel: String?,
+        snapshotLabel: String?,
         warningText: String?,
         isEffective: Bool
     ) {
@@ -32,8 +40,12 @@ public struct WorkspaceContextSourceWorkbenchRow: Equatable, Sendable, Identifia
         self.title = title
         self.subtitle = subtitle
         self.kindLabel = kindLabel
+        self.categoryLabel = categoryLabel
         self.statusLabel = statusLabel
         self.badges = badges
+        self.provenanceLabel = provenanceLabel
+        self.citationLabel = citationLabel
+        self.snapshotLabel = snapshotLabel
         self.warningText = warningText
         self.isEffective = isEffective
     }
@@ -47,6 +59,7 @@ public struct WorkspaceContextSourceWorkbenchSummary: Equatable, Sendable {
     public var staleSources: Int
     public var missingSources: Int
     public var disabledSources: Int
+    public var categoryCounts: [WorkspaceContextSourceCategory: Int]
 
     public init(
         totalSources: Int,
@@ -55,7 +68,8 @@ public struct WorkspaceContextSourceWorkbenchSummary: Equatable, Sendable {
         duplicateSources: Int,
         staleSources: Int,
         missingSources: Int,
-        disabledSources: Int
+        disabledSources: Int,
+        categoryCounts: [WorkspaceContextSourceCategory: Int] = [:]
     ) {
         self.totalSources = totalSources
         self.effectiveSources = effectiveSources
@@ -64,6 +78,7 @@ public struct WorkspaceContextSourceWorkbenchSummary: Equatable, Sendable {
         self.staleSources = staleSources
         self.missingSources = missingSources
         self.disabledSources = disabledSources
+        self.categoryCounts = categoryCounts
     }
 }
 
@@ -86,14 +101,21 @@ public enum WorkspaceContextSourceWorkbenchPresenter {
             if !record.enabledForAgent {
                 badges.append("disabled")
             }
+            if record.source.snapshot?.isFrozen == true {
+                badges.append("frozen")
+            }
 
             return WorkspaceContextSourceWorkbenchRow(
                 id: record.id,
                 title: record.source.displayName,
                 subtitle: subtitle,
                 kindLabel: record.source.kind.displayName,
+                categoryLabel: record.source.kind.category.displayName,
                 statusLabel: statusLabel(for: record),
                 badges: badges,
+                provenanceLabel: provenanceLabel(for: record),
+                citationLabel: citationLabel(for: record),
+                snapshotLabel: snapshotLabel(for: record),
                 warningText: record.warnings.first?.message,
                 isEffective: record.isEffective
             )
@@ -110,7 +132,9 @@ public enum WorkspaceContextSourceWorkbenchPresenter {
             duplicateSources: inventory.records.filter { $0.duplicateOf != nil }.count,
             staleSources: inventory.records.filter { $0.state == .stale }.count,
             missingSources: inventory.records.filter { $0.state == .missing }.count,
-            disabledSources: inventory.records.filter { $0.state == .disabled }.count
+            disabledSources: inventory.records.filter { $0.state == .disabled }.count,
+            categoryCounts: Dictionary(grouping: inventory.records, by: { $0.source.kind.category })
+                .mapValues { $0.count }
         )
     }
 
@@ -128,6 +152,33 @@ public enum WorkspaceContextSourceWorkbenchPresenter {
             return "Missing"
         case .malformed:
             return "Malformed"
+        }
+    }
+
+    private static func provenanceLabel(for record: WorkspaceContextSourceRecord) -> String {
+        guard let provenance = record.source.provenance else { return "No provenance" }
+        if let version = provenance.versionFingerprint {
+            return "\(provenance.origin.rawValue) @ \(version)"
+        }
+        return provenance.origin.rawValue
+    }
+
+    private static func citationLabel(for record: WorkspaceContextSourceRecord) -> String? {
+        guard !record.source.citations.isEmpty else { return nil }
+        return record.source.citations.count == 1 ? "1 citation" : "\(record.source.citations.count) citations"
+    }
+
+    private static func snapshotLabel(for record: WorkspaceContextSourceRecord) -> String? {
+        guard let snapshot = record.source.snapshot else {
+            return record.source.kind.requiresFrozenSnapshot ? "No frozen snapshot" : nil
+        }
+        let id = snapshot.snapshotId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffix = id.isEmpty ? "" : " \(id)"
+        switch snapshot.freezeState {
+        case .frozen:
+            return snapshot.isFrozen ? "Frozen snapshot\(suffix)" : "Incomplete frozen snapshot\(suffix)"
+        case .live:
+            return "Live snapshot\(suffix)"
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Workspace/WorkspaceContextSourceWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Workspace/WorkspaceContextSourceWorkbenchTests.swift
@@ -18,6 +18,64 @@ struct WorkspaceContextSourceWorkbenchTests {
     private let now = Date(timeIntervalSince1970: 10_000)
 
     @Test
+    func inventoryCoversUserVisibleSourceCategories() {
+        let uploaded = source(
+            id: "upload-a",
+            kind: .uploadedFile,
+            stableId: "attachment:upload-a",
+            version: "u1",
+            observedAt: now
+        )
+        let memory = source(
+            id: "memory-a",
+            kind: .memory,
+            stableId: "memory:agent-a",
+            version: "m1",
+            observedAt: now
+        )
+        let agentDB = source(
+            id: "db-a",
+            kind: .agentDatabase,
+            stableId: "agent-db:agent-a",
+            version: "db1",
+            observedAt: now
+        )
+        let sandbox = source(
+            id: "sandbox-a",
+            kind: .sandboxContext,
+            stableId: "sandbox:agent-a",
+            version: "s1",
+            observedAt: now
+        )
+        let screen = source(
+            id: "screen-a",
+            kind: .screenContext,
+            stableId: "screen:frontmost",
+            version: "sc1",
+            observedAt: now
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [uploaded, memory, agentDB, sandbox, screen],
+            now: now
+        )
+        let summary = WorkspaceContextSourceWorkbenchPresenter.summary(for: inventory)
+        let rows = WorkspaceContextSourceWorkbenchPresenter.rows(for: inventory)
+
+        #expect(inventory.effectiveSources.map(\.id) == ["upload-a", "memory-a", "db-a", "sandbox-a", "screen-a"])
+        #expect(summary.categoryCounts[.files] == 1)
+        #expect(summary.categoryCounts[.memory] == 1)
+        #expect(summary.categoryCounts[.agentDatabase] == 1)
+        #expect(summary.categoryCounts[.sandboxContext] == 1)
+        #expect(summary.categoryCounts[.screenContext] == 1)
+
+        let screenRow = rows.first { $0.id == "screen-a" }
+        #expect(screenRow?.categoryLabel == "Screen Context")
+        #expect(screenRow?.badges.contains("frozen") == true)
+        #expect(screenRow?.snapshotLabel == "Frozen snapshot screen-a-snapshot")
+    }
+
+    @Test
     func deduplicatesWithinKindButKeepsBoundaryKindsSeparate() {
         let oldKnowledge = source(
             id: "kb-old",
@@ -56,6 +114,152 @@ struct WorkspaceContextSourceWorkbenchTests {
         #expect(effectiveIds == ["kb-new", "memory-readme"])
         #expect(inventory.record(id: "memory-readme")?.boundaryContract.payloadPolicy == .metadataOnly)
         #expect(inventory.record(id: "kb-new")?.boundaryContract.payloadPolicy == .metadataAndAnchorsOnly)
+    }
+
+    @Test
+    func frozenSnapshotProvenanceWarningsAreRecorded() {
+        let liveScreen = source(
+            id: "screen-live",
+            kind: .screenContext,
+            stableId: "screen:frontmost",
+            version: "screen-v1",
+            observedAt: now,
+            snapshot: WorkspaceContextSnapshotProvenance(
+                freezeState: .live,
+                snapshotId: "screen-live",
+                capturedAt: now,
+                sourceVersion: "screen-v1",
+                contextDigest: "digest-live"
+            )
+        )
+        let staleScreen = source(
+            id: "screen-stale",
+            kind: .screenContext,
+            stableId: "screen:stale",
+            version: "screen-v2",
+            observedAt: now,
+            modifiedAt: now,
+            snapshot: WorkspaceContextSnapshotProvenance(
+                freezeState: .frozen,
+                snapshotId: "screen-stale",
+                capturedAt: now.addingTimeInterval(-20),
+                frozenAt: now.addingTimeInterval(-10),
+                sourceVersion: "screen-v1",
+                contextDigest: "digest-stale"
+            ),
+            citations: [
+                WorkspaceContextCitation(
+                    id: "cite-screen",
+                    sourceId: "screen-stale",
+                    label: "Screen snapshot",
+                    sourceVersion: "screen-v2",
+                    anchor: WorkspaceContextCitationAnchor(
+                        kind: .screenSnapshot,
+                        locator: "screen-stale"
+                    )
+                )
+            ]
+        )
+        let sandboxWithoutSnapshot = source(
+            id: "sandbox-current",
+            kind: .sandboxContext,
+            stableId: "sandbox:agent-a",
+            version: "sandbox-v1",
+            observedAt: now
+        )
+        let missingScreenSnapshot = WorkspaceContextSourceInput(
+            id: "screen-missing",
+            kind: .screenContext,
+            displayName: "Screen Missing",
+            provenance: WorkspaceContextSourceProvenance(
+                stableId: "screen:missing",
+                origin: .screenContextInjection,
+                displayPath: "screen:missing",
+                sourceVersion: "screen-v1",
+                observedAt: now,
+                modifiedAt: now
+            )
+        )
+        let incompleteFrozenScreen = source(
+            id: "screen-incomplete",
+            kind: .screenContext,
+            stableId: "screen:incomplete",
+            version: "screen-v1",
+            observedAt: now,
+            snapshot: WorkspaceContextSnapshotProvenance(
+                freezeState: .frozen,
+                snapshotId: "",
+                capturedAt: now
+            )
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [liveScreen, staleScreen, sandboxWithoutSnapshot, missingScreenSnapshot, incompleteFrozenScreen],
+            now: now
+        )
+
+        #expect(inventory.record(id: "screen-live")?.state == .stale)
+        #expect(inventory.record(id: "screen-live")?.staleness.reasons.contains(.snapshotNotFrozen) == true)
+        #expect(inventory.record(id: "screen-stale")?.staleness.reasons.contains(.snapshotVersionMismatch) == true)
+        #expect(inventory.record(id: "screen-stale")?.staleness.reasons.contains(.snapshotModifiedAfterFreeze) == true)
+        #expect(inventory.record(id: "sandbox-current")?.state == .active)
+        #expect(inventory.record(id: "screen-missing")?.staleness.reasons.contains(.snapshotMissing) == true)
+        #expect(inventory.record(id: "screen-incomplete")?.staleness.reasons.contains(.snapshotNotFrozen) == true)
+        #expect(inventory.record(id: "screen-incomplete")?.staleness.reasons.contains(.snapshotVersionMismatch) == true)
+
+        let warningKinds = Set(inventory.warnings.map(\.kind))
+        #expect(warningKinds.contains(.snapshotLive))
+        #expect(warningKinds.contains(.snapshotIncomplete))
+        #expect(warningKinds.contains(.snapshotMissing))
+        #expect(warningKinds.contains(.snapshotStale))
+
+        let incompleteRow = WorkspaceContextSourceWorkbenchPresenter.rows(for: inventory)
+            .first { $0.id == "screen-incomplete" }
+        #expect(incompleteRow?.snapshotLabel == "Incomplete frozen snapshot")
+    }
+
+    @Test
+    func globalPerSourceDisableControlsEffectiveSourcesWithoutAgentScope() {
+        let memory = source(
+            id: "memory-a",
+            kind: .memory,
+            stableId: "memory:agent-a",
+            version: "m1",
+            observedAt: now
+        )
+        let screen = source(
+            id: "screen-a",
+            kind: .screenContext,
+            stableId: "screen:frontmost",
+            version: "sc1",
+            observedAt: now
+        )
+        let uploaded = source(
+            id: "upload-a",
+            kind: .uploadedFile,
+            stableId: "attachment:upload-a",
+            version: "u1",
+            observedAt: now
+        )
+        let policy = WorkspaceContextSourceWorkbenchPolicy(
+            disabledSourceIds: [" MEMORY:AGENT-A ", "upload-a"]
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [memory, screen, uploaded],
+            policy: policy,
+            now: now
+        )
+
+        #expect(inventory.record(id: "memory-a")?.state == .disabled)
+        #expect(inventory.record(id: "screen-a")?.state == .active)
+        #expect(inventory.record(id: "upload-a")?.state == .disabled)
+        #expect(inventory.effectiveSources.map(\.id) == ["screen-a"])
+
+        let uploadWarning = inventory.record(id: "upload-a")?.warnings.first {
+            $0.kind == .sourceDisabled
+        }
+        #expect(uploadWarning?.message == "Uploaded File upload-a is disabled by workspace context policy.")
     }
 
     @Test
@@ -356,6 +560,8 @@ struct WorkspaceContextSourceWorkbenchTests {
         sourceExists: Bool = true,
         agentId: UUID? = nil,
         observedAt: Date,
+        modifiedAt: Date? = nil,
+        snapshot: WorkspaceContextSnapshotProvenance? = nil,
         index: WorkspaceContextIndexState? = nil,
         citations: [WorkspaceContextCitation] = []
     ) -> WorkspaceContextSourceInput {
@@ -370,9 +576,10 @@ struct WorkspaceContextSourceWorkbenchTests {
                 displayPath: stableId,
                 sourceVersion: version,
                 observedAt: observedAt,
-                modifiedAt: observedAt,
+                modifiedAt: modifiedAt ?? observedAt,
                 sourceExists: sourceExists
             ),
+            snapshot: snapshot ?? defaultSnapshot(for: kind, id: id, version: version, at: observedAt),
             index: index ?? defaultIndex(for: kind, version: version, at: observedAt),
             citations: citations
         )
@@ -385,6 +592,23 @@ struct WorkspaceContextSourceWorkbenchTests {
     ) -> WorkspaceContextIndexState? {
         guard kind.requiresIndexFreshness else { return nil }
         return .indexed(version: version, at: date)
+    }
+
+    private func defaultSnapshot(
+        for kind: WorkspaceContextSourceKind,
+        id: String,
+        version: String,
+        at date: Date
+    ) -> WorkspaceContextSnapshotProvenance? {
+        guard kind.requiresFrozenSnapshot else { return nil }
+        return WorkspaceContextSnapshotProvenance(
+            freezeState: .frozen,
+            snapshotId: "\(id)-snapshot",
+            capturedAt: date,
+            frozenAt: date,
+            sourceVersion: version,
+            contextDigest: "\(id)-digest"
+        )
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Workspace/WorkspaceContextSourceWorkbenchTests.swift
+++ b/Packages/OsaurusCore/Tests/Workspace/WorkspaceContextSourceWorkbenchTests.swift
@@ -1,0 +1,400 @@
+//
+//  WorkspaceContextSourceWorkbenchTests.swift
+//  osaurusTests
+//
+//  Locks the model boundary between memory, agent DB, sandbox context,
+//  uploaded files, workspace knowledge, and citations. The workbench should
+//  inventory provenance and freshness without reading or duplicating the
+//  underlying source payloads.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct WorkspaceContextSourceWorkbenchTests {
+    private let now = Date(timeIntervalSince1970: 10_000)
+
+    @Test
+    func deduplicatesWithinKindButKeepsBoundaryKindsSeparate() {
+        let oldKnowledge = source(
+            id: "kb-old",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/README.md",
+            version: "v1",
+            observedAt: now.addingTimeInterval(-60)
+        )
+        let newKnowledge = source(
+            id: "kb-new",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/README.md",
+            version: "v1",
+            observedAt: now
+        )
+        let memory = source(
+            id: "memory-readme",
+            kind: .memory,
+            stableId: "file:/repo/README.md",
+            version: "v1",
+            observedAt: now
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [oldKnowledge, newKnowledge, memory],
+            now: now
+        )
+
+        #expect(inventory.duplicateGroups.count == 1)
+        #expect(inventory.duplicateGroups.first?.canonicalSourceId == "kb-new")
+        #expect(inventory.duplicateGroups.first?.duplicateSourceIds == ["kb-old"])
+        #expect(inventory.record(id: "kb-old")?.duplicateOf == "kb-new")
+        #expect(inventory.record(id: "memory-readme")?.duplicateOf == nil)
+
+        let effectiveIds = Set(inventory.effectiveSources.map(\.id))
+        #expect(effectiveIds == ["kb-new", "memory-readme"])
+        #expect(inventory.record(id: "memory-readme")?.boundaryContract.payloadPolicy == .metadataOnly)
+        #expect(inventory.record(id: "kb-new")?.boundaryContract.payloadPolicy == .metadataAndAnchorsOnly)
+    }
+
+    @Test
+    func staleIndexCitationAndProvenanceWarningsAreRecorded() {
+        let uploaded = source(
+            id: "upload-1",
+            kind: .uploadedFile,
+            stableId: "attachment:upload-1",
+            version: "upload-v2",
+            observedAt: now,
+            index: .indexed(version: "upload-v2", at: now)
+        )
+        let knowledge = source(
+            id: "kb-1",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/Guide.md",
+            version: "guide-v2",
+            observedAt: now.addingTimeInterval(-600),
+            index: .indexed(version: "guide-v1", at: now.addingTimeInterval(-590)),
+            citations: [
+                WorkspaceContextCitation(
+                    id: "cite-upload",
+                    sourceId: "upload-1",
+                    label: "Upload citation",
+                    sourceVersion: "upload-v1",
+                    anchor: WorkspaceContextCitationAnchor(
+                        kind: .fileRange,
+                        locator: "Upload.txt:1-2",
+                        startLine: 1,
+                        endLine: 2
+                    )
+                )
+            ]
+        )
+        let policy = WorkspaceContextSourceWorkbenchPolicy(provenanceMaxAge: 120)
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [uploaded, knowledge],
+            policy: policy,
+            now: now
+        )
+
+        let record = inventory.record(id: "kb-1")
+        #expect(record?.state == .stale)
+        #expect(
+            record?.staleness.reasons.isSuperset(
+                of: Set([
+                    .indexVersionMismatch,
+                    .citationVersionMismatch,
+                    .provenanceExpired,
+                ])
+            ) == true
+        )
+
+        let warningKinds = Set(record?.warnings.map(\.kind) ?? [])
+        #expect(warningKinds.contains(.indexStale))
+        #expect(warningKinds.contains(.citationStale))
+        #expect(warningKinds.contains(.staleProvenance))
+        #expect(inventory.record(id: "upload-1")?.state == .active)
+    }
+
+    @Test
+    func malformedMissingAndMissingCitationSourcesAreHandled() {
+        let blankId = source(
+            id: "  ",
+            kind: .uploadedFile,
+            stableId: "attachment:bad",
+            version: "v1",
+            observedAt: now
+        )
+        let missingProvenance = WorkspaceContextSourceInput(
+            id: "no-provenance",
+            kind: .workspaceKnowledge,
+            displayName: "No Provenance"
+        )
+        let missingSource = source(
+            id: "missing-file",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/Missing.md",
+            version: "missing-v1",
+            sourceExists: false,
+            observedAt: now,
+            index: .indexed(version: "missing-v1", at: now)
+        )
+        let citationCarrier = source(
+            id: "citation-carrier",
+            kind: .citation,
+            stableId: "citation-set:1",
+            version: "citations-v1",
+            observedAt: now,
+            citations: [
+                WorkspaceContextCitation(
+                    id: "",
+                    sourceId: "missing-file",
+                    label: "Malformed citation"
+                ),
+                WorkspaceContextCitation(
+                    id: "cite-absent",
+                    sourceId: "absent-source",
+                    label: "Missing source",
+                    anchor: WorkspaceContextCitationAnchor(
+                        kind: .externalReference,
+                        locator: "absent-source"
+                    )
+                ),
+                WorkspaceContextCitation(
+                    id: "cite-no-anchor",
+                    sourceId: "missing-file",
+                    label: "No anchor"
+                ),
+            ]
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [blankId, missingProvenance, missingSource, citationCarrier],
+            now: now
+        )
+
+        #expect(inventory.rejectedSources.count == 2)
+        #expect(inventory.record(id: "missing-file")?.state == .missing)
+        #expect(inventory.record(id: "missing-file")?.isEffective == false)
+        #expect(inventory.record(id: "citation-carrier")?.state == .malformed)
+
+        let warningKinds = Set(inventory.warnings.map(\.kind))
+        #expect(warningKinds.contains(.malformedSource))
+        #expect(warningKinds.contains(.sourceMissing))
+        #expect(warningKinds.contains(.malformedCitation))
+        #expect(warningKinds.contains(.citationSourceMissing))
+        #expect(warningKinds.contains(.citationAnchorMissing))
+    }
+
+    @Test
+    func duplicateCitationWarningsReceiveStableUniqueIds() {
+        let carrier = source(
+            id: "citation-carrier",
+            kind: .citation,
+            stableId: "citation-set:dupes",
+            version: "citations-v1",
+            observedAt: now,
+            citations: [
+                WorkspaceContextCitation(id: "", sourceId: "missing-file", label: "Malformed A"),
+                WorkspaceContextCitation(id: "", sourceId: "missing-file", label: "Malformed B"),
+                WorkspaceContextCitation(
+                    id: "missing-a",
+                    sourceId: "same-missing-source",
+                    label: "Missing A",
+                    anchor: WorkspaceContextCitationAnchor(kind: .externalReference, locator: "missing")
+                ),
+                WorkspaceContextCitation(
+                    id: "missing-b",
+                    sourceId: "same-missing-source",
+                    label: "Missing B",
+                    anchor: WorkspaceContextCitationAnchor(kind: .externalReference, locator: "missing")
+                ),
+            ]
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [carrier],
+            now: now
+        )
+
+        let citationWarnings = inventory.record(id: "citation-carrier")?.warnings.filter {
+            $0.kind == .malformedCitation || $0.kind == .citationSourceMissing
+        } ?? []
+        #expect(citationWarnings.count == 4)
+        #expect(Set(citationWarnings.map(\.id)).count == citationWarnings.count)
+        #expect(inventory.record(id: "citation-carrier")?.state == .malformed)
+    }
+
+    @Test
+    func perAgentEnablementControlsEffectiveSources() {
+        let agentA = UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!
+        let agentB = UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!
+        let memoryA = source(
+            id: "memory-a",
+            kind: .memory,
+            stableId: "memory:agent-a",
+            version: "m1",
+            agentId: agentA,
+            observedAt: now
+        )
+        let dbA = source(
+            id: "db-a",
+            kind: .agentDatabase,
+            stableId: "db:agent-a",
+            version: "db1",
+            agentId: agentA,
+            observedAt: now
+        )
+        let sandboxA = source(
+            id: "sandbox-a",
+            kind: .sandboxContext,
+            stableId: "sandbox:agent-a",
+            version: "s1",
+            agentId: agentA,
+            observedAt: now
+        )
+        let memoryB = source(
+            id: "memory-b",
+            kind: .memory,
+            stableId: "memory:agent-b",
+            version: "m1",
+            agentId: agentB,
+            observedAt: now
+        )
+        let policy = WorkspaceContextSourceWorkbenchPolicy(
+            enabledKindsByAgent: [agentA: [.memory, .sandboxContext]],
+            disabledSourceIdsByAgent: [agentA: ["sandbox-a"]]
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [memoryA, dbA, sandboxA, memoryB],
+            activeAgentId: agentA,
+            policy: policy,
+            now: now
+        )
+
+        #expect(inventory.effectiveSources.map(\.id) == ["memory-a"])
+        #expect(inventory.record(id: "db-a")?.state == .disabled)
+        #expect(inventory.record(id: "sandbox-a")?.state == .disabled)
+        #expect(inventory.record(id: "memory-b")?.state == .disabled)
+
+        let warningKinds = Set(inventory.warnings.map(\.kind))
+        #expect(warningKinds.contains(.disabledForAgent))
+        #expect(warningKinds.contains(.agentScopeMismatch))
+    }
+
+    @Test
+    func canonicalDedupePrefersEnabledSourceForActiveAgent() {
+        let agentA = UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!
+        let disabledNewer = source(
+            id: "kb-disabled-newer",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/Shared.md",
+            version: "v2",
+            agentId: UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!,
+            observedAt: now.addingTimeInterval(60)
+        )
+        let enabledOlder = source(
+            id: "kb-enabled-older",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/Shared.md",
+            version: "v1",
+            agentId: agentA,
+            observedAt: now
+        )
+
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [disabledNewer, enabledOlder],
+            activeAgentId: agentA,
+            now: now
+        )
+
+        #expect(inventory.duplicateGroups.first?.canonicalSourceId == "kb-enabled-older")
+        #expect(inventory.record(id: "kb-disabled-newer")?.duplicateOf == "kb-enabled-older")
+        #expect(inventory.record(id: "kb-enabled-older")?.duplicateOf == nil)
+        #expect(inventory.effectiveSources.map(\.id) == ["kb-enabled-older"])
+    }
+
+    @Test
+    func presenterSummarizesInventoryWithoutRecomputingBoundaries() {
+        let current = source(
+            id: "memory-a",
+            kind: .memory,
+            stableId: "memory:agent-a",
+            version: "m1",
+            observedAt: now
+        )
+        let stale = source(
+            id: "kb-a",
+            kind: .workspaceKnowledge,
+            stableId: "file:/repo/A.md",
+            version: "v2",
+            observedAt: now,
+            index: .indexed(version: "v1", at: now)
+        )
+        let inventory = WorkspaceContextSourceWorkbench.buildInventory(
+            sources: [current, stale],
+            now: now
+        )
+
+        let rows = WorkspaceContextSourceWorkbenchPresenter.rows(for: inventory)
+        let summary = WorkspaceContextSourceWorkbenchPresenter.summary(for: inventory)
+
+        #expect(rows.map(\.statusLabel) == ["Current", "Stale"])
+        #expect(rows.first?.badges.contains(WorkspaceContextSourceAuthority.memoryService.rawValue) == true)
+        #expect(summary.totalSources == 2)
+        #expect(summary.effectiveSources == 2)
+        #expect(summary.staleSources == 1)
+    }
+
+    private func source(
+        id: String,
+        kind: WorkspaceContextSourceKind,
+        stableId: String,
+        version: String,
+        sourceExists: Bool = true,
+        agentId: UUID? = nil,
+        observedAt: Date,
+        index: WorkspaceContextIndexState? = nil,
+        citations: [WorkspaceContextCitation] = []
+    ) -> WorkspaceContextSourceInput {
+        WorkspaceContextSourceInput(
+            id: id,
+            kind: kind,
+            displayName: "\(kind.displayName) \(id.trimmingCharacters(in: .whitespacesAndNewlines))",
+            agentId: agentId,
+            provenance: WorkspaceContextSourceProvenance(
+                stableId: stableId,
+                origin: kind.expectedOrigin,
+                displayPath: stableId,
+                sourceVersion: version,
+                observedAt: observedAt,
+                modifiedAt: observedAt,
+                sourceExists: sourceExists
+            ),
+            index: index ?? defaultIndex(for: kind, version: version, at: observedAt),
+            citations: citations
+        )
+    }
+
+    private func defaultIndex(
+        for kind: WorkspaceContextSourceKind,
+        version: String,
+        at date: Date
+    ) -> WorkspaceContextIndexState? {
+        guard kind.requiresIndexFreshness else { return nil }
+        return .indexed(version: version, at: date)
+    }
+}
+
+private extension WorkspaceContextIndexState {
+    static func indexed(version: String, at date: Date) -> WorkspaceContextIndexState {
+        WorkspaceContextIndexState(
+            status: .indexed,
+            indexedAt: date,
+            indexedSourceVersion: version,
+            citationCount: 0
+        )
+    }
+}

--- a/docs/WORKSPACE_CONTEXT_SOURCE_WORKBENCH.md
+++ b/docs/WORKSPACE_CONTEXT_SOURCE_WORKBENCH.md
@@ -1,0 +1,48 @@
+# Workspace Context Source Workbench
+
+The Workspace Context Source Workbench is the user-visible inventory for
+context that can influence a workspace chat turn. It tracks descriptors for:
+
+- Files, including uploaded attachments and workspace knowledge index entries.
+- Memory.
+- Agent DB.
+- Sandbox context.
+- Screen context.
+- Citation-only carriers.
+
+The workbench is metadata-only. It does not read memory facts, Agent DB rows,
+file bytes, sandbox payloads, or screen-capture payloads. Those systems remain
+the source of truth for hidden context and injection. Callers pass
+`WorkspaceContextSourceInput` descriptors, and the workbench reports boundaries,
+enablement, provenance, citations, dedupe, and freshness.
+
+## Frozen Snapshots
+
+Sandbox context and screen context require frozen snapshot metadata before they
+are considered current. A source is marked stale when snapshot metadata is
+missing, live instead of frozen, captured for a different source version, or
+older than the source modification time.
+
+Frozen snapshot provenance is intentionally small:
+
+- `snapshotId` identifies the owner-system snapshot.
+- `capturedAt` and `frozenAt` describe the source-owner freeze point.
+- `sourceVersion`, `citationVersion`, and `contextDigest` let the workbench
+  detect stale descriptors without copying payloads.
+
+## Toggles
+
+The policy layer supports:
+
+- Enabled source kinds by active agent.
+- Global per-source disables by source id or provenance stable id.
+- Agent-scoped per-source disables by source id or provenance stable id.
+
+Disabled sources remain visible in the inventory with warnings. They are not
+included in `effectiveSources`.
+
+## Citations
+
+Citations are validated as anchors only. The workbench checks that citation ids,
+referenced source ids, anchors, and cited source versions are stable. It does
+not dereference or duplicate cited payloads.


### PR DESCRIPTION
## Disposition

**Closure recommended. Do not merge this PR in its current form.**

## Reason

This branch defines a metadata-only inventory for context sources, but it does not deliver a complete production workflow. Current main now has active Knowledge Collections, Agent DB, attachment, memory, and sandbox-context paths; retaining another standalone context abstraction would increase overlap without resolving the user-facing integration boundary.

The underlying provenance and source-visibility problem remains valid, but it should be addressed within the canonical context/knowledge workflow rather than by rebasing this branch.

## State

- Kept as draft for historical reference.
- No remote branch has been deleted.
- Closing the PR requires explicit approval.