### PR TITLE
unify local and remote agent detail views

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -327,6 +327,49 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         }
     }
 
+    /// Open (or focus) a chat window and select the paired remote agent that
+    /// owns `providerId`, so the conversation routes to that agent instead of
+    /// whatever the window was last pointed at. Mirrors the toolbar's
+    /// relay-agent picker: we resolve the matching `PairedRelayAgent` from the
+    /// target window's state and post `.chatToolbarSelectRelayAgent`, which the
+    /// window's `ChatView` turns into a real connect via `connectToRelayAgent`.
+    public func openChat(withRemoteAgentProviderId providerId: UUID) {
+        let targetId: UUID
+        let isNewWindow: Bool
+        if let lastId = lastFocusedWindowId, windowStates[lastId] != nil {
+            targetId = lastId
+            isNewWindow = false
+            showWindow(id: lastId)
+        } else if let firstId = windowStates.keys.first {
+            targetId = firstId
+            isNewWindow = false
+            showWindow(id: firstId)
+        } else {
+            targetId = createWindow()
+            isNewWindow = true
+        }
+
+        guard let state = windowStates[targetId] else { return }
+        // Refresh so the relay list reflects the latest paired providers before
+        // we look up the target agent (e.g. just-paired agents).
+        state.refreshPairedRelayAgents()
+        guard let relay = state.pairedRelayAgents.first(where: { $0.providerId == providerId })
+        else { return }
+
+        // A freshly-created window's `ChatView` registers its
+        // `.chatToolbarSelectRelayAgent` listener a runloop turn or two after
+        // creation, so delay the post for new windows. Existing windows are
+        // already listening, so dispatch on the next tick is enough.
+        let delay: TimeInterval = isNewWindow ? 0.35 : 0.0
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            NotificationCenter.default.post(
+                name: .chatToolbarSelectRelayAgent,
+                object: relay,
+                userInfo: ["windowId": targetId]
+            )
+        }
+    }
+
     /// Find windows by agent ID
     public func findWindows(byAgentId agentId: UUID) -> [ChatWindowInfo] {
         windows.values.filter { $0.agentId == agentId }

--- a/Packages/OsaurusCore/Views/Agent/AgentDetailChrome.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentDetailChrome.swift
@@ -1,0 +1,771 @@
+//
+//  AgentDetailChrome.swift
+//  osaurus
+//
+//  Shared structural chrome for the two agent *detail* surfaces so the local
+//  `AgentDetailView` and the paired `RemoteAgentDetailView` read as one
+//  product:
+//
+//    - `AgentDetailHeaderBar` + `AgentDetailIdentityLabel` +
+//      `AgentDetailHeaderActionButton` assemble the compact "back + identity +
+//      actions" title bar both views share.
+//    - `AgentDetailSection` is the icon + UPPERCASE-title card used for every
+//      content block (Identity, Connection, Source, …), with an optional
+//      trailing-action slot for per-section affordances (refresh / "View in
+//      Insights").
+//    - `AgentDetailMetadataRow` / `AgentDetailStatusRow` are the fixed-width
+//      label/value rows used inside those cards.
+//    - `AgentDetailTabStrip` is the horizontally-scrollable tab strip (with
+//      overflow fades + chevrons) that drives the local tab navigation and the
+//      remote Overview/Activity shell.
+//
+//  Sheet-specific chrome (headers, footers, button styles, text fields) lives
+//  in `AgentSheetChrome.swift`; this file is for the persistent detail panes.
+//
+
+import SwiftUI
+
+// MARK: - Detail Header Bar
+
+/// Compact identity bar shared by the local and remote agent detail views.
+/// Owns the back button, hairline divider, padding rhythm (24h / 10v), and the
+/// `secondaryBackground` + bottom-border treatment. Callers fill three slots:
+///   - `identity`: the avatar + name block (often wrapped in a switcher button
+///     or paired with a status badge),
+///   - `status`: a transient indicator on the trailing edge (save pill /
+///     connection state),
+///   - `actions`: the trailing icon buttons (Share/Delete, Chat/Remove).
+struct AgentDetailHeaderBar<Identity: View, Status: View, Actions: View>: View {
+    @Environment(\.theme) private var theme
+
+    let onBack: () -> Void
+    var backTitle: LocalizedStringKey = "Agents"
+    @ViewBuilder let identity: () -> Identity
+    @ViewBuilder let status: () -> Status
+    @ViewBuilder let actions: () -> Actions
+
+    init(
+        onBack: @escaping () -> Void,
+        backTitle: LocalizedStringKey = "Agents",
+        @ViewBuilder identity: @escaping () -> Identity,
+        @ViewBuilder status: @escaping () -> Status,
+        @ViewBuilder actions: @escaping () -> Actions
+    ) {
+        self.onBack = onBack
+        self.backTitle = backTitle
+        self.identity = identity
+        self.status = status
+        self.actions = actions
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: onBack) {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(backTitle, bundle: .module)
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .foregroundColor(theme.accentColor)
+            }
+            .buttonStyle(PlainButtonStyle())
+
+            // Vertical hairline so the back button reads as distinct from the
+            // identity block even when the agent name is long.
+            Rectangle()
+                .fill(theme.primaryBorder)
+                .frame(width: 1, height: 16)
+                .opacity(0.6)
+
+            identity()
+
+            Spacer(minLength: 8)
+
+            status()
+
+            actions()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 10)
+        .background(
+            theme.secondaryBackground
+                .overlay(
+                    Rectangle()
+                        .fill(theme.primaryBorder)
+                        .frame(height: 1),
+                    alignment: .bottom
+                )
+        )
+    }
+}
+
+/// 28x28 circular icon button used by the detail header for Share / Delete /
+/// Chat / Remove. Background is a 12% tint of the foreground color so
+/// destructive vs. accent intent reads at a glance without shouting.
+struct AgentDetailHeaderActionButton: View {
+    @Environment(\.theme) private var theme
+
+    let icon: String
+    let tint: Color
+    let help: LocalizedStringKey
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(tint)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(tint.opacity(0.12)))
+        }
+        .buttonStyle(PlainButtonStyle())
+        .help(Text(help, bundle: .module))
+    }
+}
+
+/// Small "this is a remote agent" antenna badge, designed to overlay the
+/// bottom-trailing corner of an avatar. Matches the decoration on the remote
+/// grid card so remote agents read the same way everywhere (header, switcher
+/// rows, grid). The ring blends the badge into whatever surface hosts it.
+struct RemoteAvatarBadge: View {
+    @Environment(\.theme) private var theme
+
+    var glyphSize: CGFloat = 8
+    var padding: CGFloat = 3
+    /// Color of the 1.5pt ring around the badge — pass the host surface color
+    /// (card vs. header background) so the badge reads as floating above it.
+    var ringColor: Color? = nil
+
+    var body: some View {
+        Image(systemName: "antenna.radiowaves.left.and.right")
+            .font(.system(size: glyphSize, weight: .bold))
+            .foregroundColor(.white)
+            .padding(padding)
+            .background(Circle().fill(theme.accentColor))
+            .overlay(Circle().strokeBorder(ringColor ?? theme.cardBackground, lineWidth: 1.5))
+    }
+}
+
+/// Avatar + name (+ optional subtitle + optional switcher chevron) block used
+/// inside the header's identity slot. Local wraps it in the agent-switcher
+/// button; remote does too, and sets `showsRemoteGlyph` so the avatar carries
+/// the antenna decoration instead of a free-floating "Remote" pill.
+struct AgentDetailIdentityLabel: View {
+    @Environment(\.theme) private var theme
+
+    let mascotId: String?
+    let name: String
+    let tint: Color
+    var subtitle: String? = nil
+    var showsChevron: Bool = false
+    var customImageURL: URL? = nil
+    var diameter: CGFloat = 28
+    var monogramFontSize: CGFloat = 13
+    var maxWidth: CGFloat? = 260
+    /// Overlays the small antenna badge on the avatar to mark a remote agent.
+    var showsRemoteGlyph: Bool = false
+    /// Surface color the avatar sits on, used for the remote badge ring so it
+    /// blends with the header (`secondaryBackground`) vs. a card row.
+    var glyphRingColor: Color? = nil
+
+    var body: some View {
+        HStack(spacing: 10) {
+            AgentAvatarView(
+                mascotId: mascotId,
+                name: name,
+                tint: tint,
+                diameter: diameter,
+                customImageURL: customImageURL,
+                monogramFontSize: monogramFontSize,
+                borderWidth: 1.5
+            )
+            .overlay(alignment: .bottomTrailing) {
+                if showsRemoteGlyph {
+                    RemoteAvatarBadge(
+                        glyphSize: max(6, diameter * 0.26),
+                        padding: max(2, diameter * 0.085),
+                        ringColor: glyphRingColor
+                    )
+                    .offset(x: 2, y: 2)
+                }
+            }
+            .animation(.spring(response: 0.3), value: name)
+            .animation(.spring(response: 0.3), value: mascotId)
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 6) {
+                    Text(name.isEmpty ? L("Untitled Agent") : name)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    if showsChevron {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundColor(theme.tertiaryText)
+                    }
+                }
+                if let subtitle,
+                    !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(maxWidth: maxWidth, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Detail Section Card
+
+/// Icon + UPPERCASE-title card used for every content block on both detail
+/// views. The optional `trailing` slot hosts per-section affordances (a refresh
+/// button, a "Saved" pill, a "View in Insights" link) on the title row.
+struct AgentDetailSection<Trailing: View, Content: View>: View {
+    @Environment(\.theme) private var theme
+
+    let title: String
+    let icon: String
+    var subtitle: String? = nil
+    @ViewBuilder let trailing: () -> Trailing
+    @ViewBuilder let content: () -> Content
+
+    init(
+        title: String,
+        icon: String,
+        subtitle: String? = nil,
+        @ViewBuilder trailing: @escaping () -> Trailing,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.icon = icon
+        self.subtitle = subtitle
+        self.trailing = trailing
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                    .frame(width: 20)
+
+                Text(title.uppercased())
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(theme.primaryText)
+                    .tracking(0.5)
+
+                if let subtitle = subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
+
+                Spacer()
+
+                trailing()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+
+            VStack(alignment: .leading, spacing: 12) {
+                content()
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(theme.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+extension AgentDetailSection where Trailing == EmptyView {
+    /// Convenience for the common case with no trailing action — keeps every
+    /// existing `AgentDetailSection(title:icon:) { … }` call site working.
+    init(
+        title: String,
+        icon: String,
+        subtitle: String? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.init(
+            title: title,
+            icon: icon,
+            subtitle: subtitle,
+            trailing: { EmptyView() },
+            content: content
+        )
+    }
+}
+
+// MARK: - Rows
+
+/// Fixed-width label + value row used inside detail cards (Mode, Encryption,
+/// Model, Relay URL, …). `mono` renders the value in a monospaced font for
+/// addresses / URLs.
+struct AgentDetailMetadataRow: View {
+    @Environment(\.theme) private var theme
+
+    let label: String
+    let value: String
+    var mono: Bool = false
+    var labelWidth: CGFloat = 80
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(LocalizedStringKey(label), bundle: .module)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: labelWidth, alignment: .leading)
+            Text(value)
+                .font(mono ? .system(size: 11, design: .monospaced) : .system(size: 11))
+                .foregroundColor(theme.secondaryText)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+            Spacer()
+        }
+    }
+}
+
+/// Label + colored dot + value row, used for connection/health status inside a
+/// detail card. Matches `AgentDetailMetadataRow`'s label column so a status row
+/// and metadata rows line up in the same section.
+struct AgentDetailStatusRow: View {
+    @Environment(\.theme) private var theme
+
+    let label: String
+    let value: LocalizedStringKey
+    let dotColor: Color
+    var labelWidth: CGFloat = 80
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(LocalizedStringKey(label), bundle: .module)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+                .frame(width: labelWidth, alignment: .leading)
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 7, height: 7)
+                Text(value, bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            }
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Agent Switcher Popover
+
+/// Shared "Switch Agent" popover surfaced from the identity block of BOTH
+/// detail headers. Lists every local (non-built-in) agent and every paired
+/// remote agent so the user can jump between them without going back to the
+/// grid. The host header owns the `isPresented` binding and performs the
+/// actual navigation; this view only renders rows and reports taps.
+struct AgentSwitcherPopover: View {
+    @Environment(\.theme) private var theme
+
+    let localAgents: [Agent]
+    let remoteAgents: [RemoteAgent]
+    /// Marked with a checkmark when the popover is shown from that agent's own
+    /// detail view. At most one of these is non-nil in practice.
+    let currentLocalAgentId: UUID?
+    let currentRemoteAgentId: UUID?
+    let onSelectLocal: (Agent) -> Void
+    let onSelectRemote: (RemoteAgent) -> Void
+    let onDismiss: () -> Void
+
+    private var totalCount: Int { localAgents.count + remoteAgents.count }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            Divider().opacity(0.5)
+
+            ScrollView {
+                VStack(spacing: 2) {
+                    ForEach(localAgents, id: \.id) { agent in
+                        row(
+                            mascotId: agent.avatar,
+                            name: agent.name,
+                            subtitle: agent.description,
+                            customImageURL: agent.customAvatarURL,
+                            isRemote: false,
+                            isCurrent: agent.id == currentLocalAgentId,
+                            select: { onSelectLocal(agent) }
+                        )
+                    }
+
+                    if !remoteAgents.isEmpty {
+                        // Only label the remote group when local agents are
+                        // also present — otherwise the single list speaks for
+                        // itself and the header already says "Switch Agent".
+                        if !localAgents.isEmpty {
+                            sectionLabel("Remote")
+                        }
+                        ForEach(remoteAgents, id: \.id) { agent in
+                            row(
+                                mascotId: agent.avatar,
+                                name: agent.name,
+                                subtitle: agent.description,
+                                customImageURL: nil,
+                                isRemote: true,
+                                isCurrent: agent.id == currentRemoteAgentId,
+                                select: { onSelectRemote(agent) }
+                            )
+                        }
+                    }
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 6)
+            }
+            .frame(maxHeight: 360)
+        }
+        .frame(width: 280)
+        .background(theme.cardBackground)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+            Text("Switch Agent", bundle: .module)
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .tracking(0.5)
+            Spacer()
+            Text("\(totalCount)", bundle: .module)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.tertiaryText)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(Capsule().fill(theme.inputBackground))
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+    }
+
+    private func sectionLabel(_ key: LocalizedStringKey) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .font(.system(size: 8, weight: .bold))
+            Text(key, bundle: .module)
+                .font(.system(size: 9, weight: .bold))
+                .tracking(0.5)
+        }
+        .foregroundColor(theme.tertiaryText)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 8)
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+    }
+
+    /// A single switcher row — avatar (with the antenna badge for remote
+    /// agents) + name + optional subtitle, highlighted with a checkmark when
+    /// it's the agent the popover was opened from. Tapping the current row just
+    /// dismisses; any other row fires `select`.
+    private func row(
+        mascotId: String?,
+        name: String,
+        subtitle: String,
+        customImageURL: URL?,
+        isRemote: Bool,
+        isCurrent: Bool,
+        select: @escaping () -> Void
+    ) -> some View {
+        Button {
+            if isCurrent { onDismiss() } else { select() }
+        } label: {
+            HStack(spacing: 10) {
+                AgentAvatarView(
+                    mascotId: mascotId,
+                    name: name,
+                    tint: agentColorFor(name),
+                    diameter: 26,
+                    customImageURL: customImageURL,
+                    monogramFontSize: 11,
+                    borderWidth: 1.5
+                )
+                .overlay(alignment: .bottomTrailing) {
+                    if isRemote {
+                        RemoteAvatarBadge(glyphSize: 6, padding: 2)
+                            .offset(x: 2, y: 2)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(name.isEmpty ? L("Untitled Agent") : name)
+                        .font(.system(size: 12, weight: isCurrent ? .semibold : .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                    if !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(subtitle)
+                            .font(.system(size: 10))
+                            .foregroundColor(theme.tertiaryText)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 4)
+
+                if isCurrent {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(theme.accentColor)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isCurrent ? theme.accentColor.opacity(0.10) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Tab Strip
+
+/// A single tab in `AgentDetailTabStrip`. `id` doubles as the selection value.
+struct AgentDetailTabItem<Tab: Hashable>: Identifiable {
+    let id: Tab
+    /// Already-localized display label (rendered verbatim).
+    let label: String
+    let icon: String
+    var badgeCount: Int? = nil
+    /// Renders the tab in the system warning color regardless of selection —
+    /// used for failed-plugin tabs so they're spottable in a long strip.
+    var isWarning: Bool = false
+
+    init(
+        id: Tab,
+        label: String,
+        icon: String,
+        badgeCount: Int? = nil,
+        isWarning: Bool = false
+    ) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.badgeCount = badgeCount
+        self.isWarning = isWarning
+    }
+}
+
+/// Horizontally-scrollable tab strip with edge fades + "more" chevrons that
+/// appear only when the strip overflows its viewport. Shared by the local agent
+/// detail (built-in + plugin + failed-plugin tabs) and the remote agent detail
+/// (Overview / Activity).
+struct AgentDetailTabStrip<Tab: Hashable>: View {
+    @Environment(\.theme) private var theme
+
+    let items: [AgentDetailTabItem<Tab>]
+    @Binding var selection: Tab
+
+    // Captured via GeometryReaders so the "scrollable" affordance (edge fade +
+    // chevron) only renders when the content overflows the viewport AND the
+    // user hasn't already scrolled to that edge.
+    @State private var contentWidth: CGFloat = 0
+    @State private var viewportWidth: CGFloat = 0
+    @State private var scrollOffset: CGFloat = 0
+
+    private var overflowsTrailing: Bool {
+        // 1pt fudge so pixel-aligned end-of-scroll positions don't leave a
+        // phantom indicator on screen.
+        contentWidth > viewportWidth + scrollOffset + 1
+    }
+    private var overflowsLeading: Bool {
+        scrollOffset > 1
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    ForEach(items) { item in
+                        tabButton(item)
+                            .id(item.id)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .background(
+                    GeometryReader { inner in
+                        Color.clear.preference(
+                            key: AgentDetailTabContentWidthKey.self,
+                            value: inner.size.width
+                        )
+                    }
+                )
+            }
+            .background(
+                GeometryReader { outer in
+                    Color.clear.preference(
+                        key: AgentDetailTabViewportWidthKey.self,
+                        value: outer.size.width
+                    )
+                }
+            )
+            .onPreferenceChange(AgentDetailTabContentWidthKey.self) { contentWidth = $0 }
+            .onPreferenceChange(AgentDetailTabViewportWidthKey.self) { viewportWidth = $0 }
+            // `onScrollGeometryChange` is the canonical macOS 15+ way to observe
+            // scroll offset; the older GeometryReader-in-named-coordinate-space
+            // pattern is flaky on horizontal AppKit-backed scroll views.
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.x
+            } action: { _, newOffset in
+                scrollOffset = max(0, newOffset)
+            }
+            // Edge fades on whichever side has off-screen content. `mask` runs
+            // before any overlay, so the chevrons sit ON TOP of the fades rather
+            // than being faded themselves.
+            .mask(fadeMask)
+            .overlay(alignment: .leading) {
+                if overflowsLeading { scrollMoreChevron(direction: .leading) }
+            }
+            .overlay(alignment: .trailing) {
+                if overflowsTrailing { scrollMoreChevron(direction: .trailing) }
+            }
+            .animation(.easeOut(duration: 0.2), value: overflowsLeading)
+            .animation(.easeOut(duration: 0.2), value: overflowsTrailing)
+            // Auto-scroll the active tab into view when it changes (tap or programmatic).
+            .onChange(of: selection) { _, newValue in
+                withAnimation(.easeOut(duration: 0.2)) {
+                    proxy.scrollTo(newValue, anchor: .center)
+                }
+            }
+        }
+    }
+
+    /// Linear gradient used as the strip's mask. Fades whichever side has
+    /// content scrolled off; both sides can fade at once mid-strip.
+    private var fadeMask: LinearGradient {
+        let fadeStart: CGFloat = 0.06  // ~6% of the strip on the leading edge
+        let fadeEnd: CGFloat = 0.94  // ~6% on the trailing edge
+        var stops: [Gradient.Stop] = []
+        stops.append(.init(color: overflowsLeading ? .clear : .black, location: 0.0))
+        if overflowsLeading {
+            stops.append(.init(color: .black, location: fadeStart))
+        }
+        if overflowsTrailing {
+            stops.append(.init(color: .black, location: fadeEnd))
+        }
+        stops.append(.init(color: overflowsTrailing ? .clear : .black, location: 1.0))
+        return LinearGradient(stops: stops, startPoint: .leading, endPoint: .trailing)
+    }
+
+    /// Floating "more →"/"← more" affordance pinned to whichever edge has
+    /// off-screen content. Sits above the fade mask so it stays fully opaque,
+    /// and is `allowsHitTesting(false)` so it never swallows tab taps.
+    private func scrollMoreChevron(direction: HorizontalEdge) -> some View {
+        Image(systemName: direction == .leading ? "chevron.left" : "chevron.right")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundColor(theme.accentColor)
+            .frame(width: 20, height: 20)
+            .background(
+                Circle()
+                    .fill(theme.primaryBackground)
+                    .overlay(Circle().strokeBorder(theme.accentColor.opacity(0.25), lineWidth: 1))
+            )
+            .shadow(
+                color: Color.black.opacity(0.08),
+                radius: 4,
+                x: direction == .leading ? 1 : -1,
+                y: 1
+            )
+            .padding(direction == .leading ? .leading : .trailing, 2)
+            .allowsHitTesting(false)
+            .transition(.opacity.combined(with: .scale(scale: 0.7)))
+    }
+
+    private func tabButton(_ item: AgentDetailTabItem<Tab>) -> some View {
+        let isSelected = selection == item.id
+        // Warning tabs use the system warning color regardless of selection so
+        // the user can spot them at a glance even in a long tab strip; the
+        // accent color is reserved for the happy-path "selected" signal.
+        let foreground: Color
+        if item.isWarning {
+            foreground = .orange
+        } else if isSelected {
+            foreground = theme.accentColor
+        } else {
+            foreground = theme.tertiaryText
+        }
+        return Button {
+            selection = item.id
+        } label: {
+            VStack(spacing: 0) {
+                HStack(spacing: 5) {
+                    Image(systemName: item.icon)
+                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
+
+                    Text(item.label)
+                        .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
+
+                    if let count = item.badgeCount {
+                        Text("\(count)", bundle: .module)
+                            .font(.system(size: 9, weight: .bold, design: .rounded))
+                            .foregroundColor(isSelected ? theme.accentColor : theme.tertiaryText)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(
+                                Capsule()
+                                    .fill(
+                                        isSelected
+                                            ? theme.accentColor.opacity(0.12) : theme.inputBackground
+                                    )
+                            )
+                    }
+                }
+                .foregroundColor(foreground)
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 8)
+
+                Rectangle()
+                    .fill(isSelected ? (item.isWarning ? Color.orange : theme.accentColor) : Color.clear)
+                    .frame(height: 2)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+// MARK: - Tab Strip Preference Keys
+
+/// Natural width of the strip's HStack content (before horizontal clipping).
+private struct AgentDetailTabContentWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Visible width of the strip's ScrollView container.
+private struct AgentDetailTabViewportWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -98,6 +98,12 @@ struct AgentsView: View {
                         }
                     },
                     onSwitchAgent: { newAgent in selectedAgent = newAgent },
+                    onSwitchRemoteAgent: { remoteId in
+                        withAnimation(Self.navTransition) {
+                            selectedAgent = nil
+                            selectedRemoteAgentId = remoteId
+                        }
+                    },
                     showSuccess: showSuccess
                 )
                 .id(agent.id)
@@ -114,7 +120,20 @@ struct AgentsView: View {
                         withAnimation(Self.navTransition) { selectedRemoteAgentId = nil }
                         showSuccess("Removed remote agent")
                     },
-                    onChat: { _ in ChatWindowManager.shared.toggleLastFocused() }
+                    onChat: { remote in
+                        ChatWindowManager.shared.openChat(
+                            withRemoteAgentProviderId: remote.providerId
+                        )
+                    },
+                    onSwitchAgent: { newAgent in
+                        withAnimation(Self.navTransition) {
+                            selectedRemoteAgentId = nil
+                            selectedAgent = newAgent
+                        }
+                    },
+                    onSwitchRemoteAgent: { newRemoteId in
+                        selectedRemoteAgentId = newRemoteId
+                    }
                 )
                 .id(remoteId)
                 .transition(.opacity)
@@ -305,7 +324,11 @@ struct AgentsView: View {
             onSelect: {
                 withAnimation(Self.navTransition) { selectedRemoteAgentId = remote.id }
             },
-            onChat: { ChatWindowManager.shared.toggleLastFocused() },
+            onChat: {
+                ChatWindowManager.shared.openChat(
+                    withRemoteAgentProviderId: remote.providerId
+                )
+            },
             onRemove: {
                 _ = remoteAgentManager.remove(id: remote.id)
                 showSuccess("Removed remote agent")
@@ -881,26 +904,6 @@ private enum AgentTab: Hashable {
     case failedPlugin(String)
 }
 
-// MARK: - Tab Bar Preference Keys
-
-/// Reports the natural width of the tab strip's HStack content (i.e. the
-/// width *before* any horizontal scroll clipping). Compared against the
-/// viewport width to decide whether the strip overflows.
-private struct TabBarContentWidthKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-/// Reports the visible width of the tab strip's ScrollView container.
-private struct TabBarViewportWidthKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
 // MARK: - Agent Detail View
 
 struct AgentDetailView: View {
@@ -920,6 +923,9 @@ struct AgentDetailView: View {
     let onBack: () -> Void
     let onDelete: (Agent) -> Void
     let onSwitchAgent: (Agent) -> Void
+    /// Switch the detail pane to a paired remote agent (selected from the
+    /// shared agent switcher). The parent flips its `selectedRemoteAgentId`.
+    let onSwitchRemoteAgent: (UUID) -> Void
     let showSuccess: (String) -> Void
 
     init(
@@ -927,12 +933,14 @@ struct AgentDetailView: View {
         onBack: @escaping () -> Void,
         onDelete: @escaping (Agent) -> Void,
         onSwitchAgent: @escaping (Agent) -> Void,
+        onSwitchRemoteAgent: @escaping (UUID) -> Void,
         showSuccess: @escaping (String) -> Void
     ) {
         self.agent = agent
         self.onBack = onBack
         self.onDelete = onDelete
         self.onSwitchAgent = onSwitchAgent
+        self.onSwitchRemoteAgent = onSwitchRemoteAgent
         self.showSuccess = showSuccess
     }
 
@@ -1085,13 +1093,6 @@ struct AgentDetailView: View {
     /// still-broken plugin.
     @State private var pendingFailedPluginRetry: String?
     @State private var pendingFailedPluginUninstall: String?
-    /// Captured by `GeometryReader`s wrapped around the tab strip so the
-    /// "scrollable" affordance (right-edge fade + chevron) only renders when
-    /// the tab content actually overflows the viewport AND the user hasn't
-    /// already scrolled to the trailing edge.
-    @State private var tabBarContentWidth: CGFloat = 0
-    @State private var tabBarViewportWidth: CGFloat = 0
-    @State private var tabBarScrollOffset: CGFloat = 0
     /// Bumped on `.toolsListChanged` so plugin tabs re-evaluate after async
     /// `PluginManager.loadAll()` — `PluginManager` is not Observable, so without
     /// this the tab strip can stay empty if the user opened this view before
@@ -1106,14 +1107,6 @@ struct AgentDetailView: View {
     @State private var chatSessions: [ChatSessionData] = []
     @State private var agentPlugins: [PluginManager.LoadedPlugin] = []
     @State private var agentFailedPlugins: [PluginManager.FailedPlugin] = []
-    private var tabsOverflowRight: Bool {
-        // 1pt fudge so pixel-aligned end-of-scroll positions don't leave a
-        // phantom indicator on screen.
-        tabBarContentWidth > tabBarViewportWidth + tabBarScrollOffset + 1
-    }
-    private var tabsOverflowLeft: Bool {
-        tabBarScrollOffset > 1
-    }
 
     private var currentAgent: Agent {
         agentManager.agent(for: agent.id) ?? agent
@@ -1543,90 +1536,42 @@ struct AgentDetailView: View {
     /// Tapping the identity block opens the agent switcher popover; editing the
     /// name / description happens inside the Configure tab's Identity section.
     private var detailHeaderBar: some View {
-        HStack(spacing: 12) {
-            Button(action: onBack) {
+        AgentDetailHeaderBar(
+            onBack: onBack,
+            identity: { identityButton },
+            status: {
+                if let indicator = saveIndicator {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 10))
+                        Text(indicator)
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundColor(theme.successColor)
+                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                }
+            },
+            actions: {
                 HStack(spacing: 6) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 12, weight: .semibold))
-                    Text("Agents", bundle: .module)
-                        .font(.system(size: 13, weight: .medium))
+                    AgentDetailHeaderActionButton(
+                        icon: "square.and.arrow.up",
+                        tint: theme.accentColor,
+                        help: "Share Agent",
+                        action: { showingShareSheet = true }
+                    )
+                    AgentDetailHeaderActionButton(
+                        icon: "trash",
+                        tint: theme.errorColor,
+                        help: "Delete",
+                        action: { showDeleteConfirm = true }
+                    )
                 }
-                .foregroundColor(theme.accentColor)
             }
-            .buttonStyle(PlainButtonStyle())
-
-            // Vertical hairline so the back button reads as distinct from the
-            // identity block even when the agent name is long.
-            Rectangle()
-                .fill(theme.primaryBorder)
-                .frame(width: 1, height: 16)
-                .opacity(0.6)
-
-            identityButton
-
-            Spacer(minLength: 8)
-
-            if let indicator = saveIndicator {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10))
-                    Text(indicator)
-                        .font(.system(size: 11, weight: .medium))
-                }
-                .foregroundColor(theme.successColor)
-                .transition(.opacity.combined(with: .scale(scale: 0.9)))
-            }
-
-            HStack(spacing: 6) {
-                headerActionButton(
-                    icon: "square.and.arrow.up",
-                    tint: theme.accentColor,
-                    help: "Share Agent",
-                    action: { showingShareSheet = true }
-                )
-                headerActionButton(
-                    icon: "trash",
-                    tint: theme.errorColor,
-                    help: "Delete",
-                    action: { showDeleteConfirm = true }
-                )
-            }
-        }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 10)
-        .background(
-            theme.secondaryBackground
-                .overlay(
-                    Rectangle()
-                        .fill(theme.primaryBorder)
-                        .frame(height: 1),
-                    alignment: .bottom
-                )
         )
         .sheet(isPresented: $showingShareSheet) {
             ShareAgentSheet(agent: currentAgent)
                 .environment(\.theme, themeManager.currentTheme)
         }
-    }
-
-    /// 28x28 circular icon button used by the detail header for Share / Delete.
-    /// Background is a 10–12% tint of the foreground color so destructive vs.
-    /// accent intent reads at a glance without shouting.
-    private func headerActionButton(
-        icon: String,
-        tint: Color,
-        help: LocalizedStringKey,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(tint)
-                .frame(width: 28, height: 28)
-                .background(Circle().fill(tint.opacity(0.12)))
-        }
-        .buttonStyle(PlainButtonStyle())
-        .help(Text(help, bundle: .module))
     }
 
     /// Compact tappable identity block (avatar + name + optional description) inside
@@ -1637,39 +1582,13 @@ struct AgentDetailView: View {
         Button {
             showingAgentSwitcher = true
         } label: {
-            HStack(spacing: 10) {
-                AgentAvatarView(
-                    mascotId: avatar,
-                    name: name,
-                    tint: agentColor,
-                    diameter: 28,
-                    monogramFontSize: 13,
-                    borderWidth: 1.5
-                )
-                .animation(.spring(response: 0.3), value: name)
-                .animation(.spring(response: 0.3), value: avatar)
-
-                VStack(alignment: .leading, spacing: 1) {
-                    HStack(spacing: 6) {
-                        Text(name.isEmpty ? L("Untitled Agent") : name)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(theme.primaryText)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 8, weight: .semibold))
-                            .foregroundColor(theme.tertiaryText)
-                    }
-                    if !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Text(description)
-                            .font(.system(size: 11))
-                            .foregroundColor(theme.tertiaryText)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-                .frame(maxWidth: 260, alignment: .leading)
-            }
+            AgentDetailIdentityLabel(
+                mascotId: avatar,
+                name: name,
+                tint: agentColor,
+                subtitle: description,
+                showsChevron: true
+            )
             .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
@@ -1679,102 +1598,28 @@ struct AgentDetailView: View {
         }
     }
 
-    /// Popover content listing every custom agent for quick navigation. Tapping a
-    /// row swaps the detail view to that agent (the parent uses `.id(agent.id)` to
-    /// force a clean state reload). Built-in / Default agent is excluded — it has
-    /// its own settings surface elsewhere and isn't represented in the Agents grid.
+    /// Quick-navigation popover listing every custom local agent AND every
+    /// paired remote agent. Tapping a local row swaps the detail view to that
+    /// agent (the parent uses `.id(agent.id)` to force a clean reload); tapping
+    /// a remote row hands off to `onSwitchRemoteAgent`. Built-in / Default agent
+    /// is excluded — it has its own settings surface and isn't in the grid.
     private var agentSwitcherPopover: some View {
-        let switchableAgents = agentManager.agents
-            .filter { !$0.isBuiltIn }
-
-        return VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 6) {
-                Image(systemName: "person.2.fill")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(theme.tertiaryText)
-                Text("Switch Agent", bundle: .module)
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(theme.tertiaryText)
-                    .tracking(0.5)
-                Spacer()
-                Text("\(switchableAgents.count)", bundle: .module)
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(theme.tertiaryText)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 1)
-                    .background(Capsule().fill(theme.inputBackground))
-            }
-            .padding(.horizontal, 14)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            Divider().opacity(0.5)
-
-            ScrollView {
-                VStack(spacing: 2) {
-                    ForEach(switchableAgents, id: \.id) { other in
-                        agentSwitcherRow(other)
-                    }
-                }
-                .padding(.vertical, 6)
-                .padding(.horizontal, 6)
-            }
-            .frame(maxHeight: 360)
-        }
-        .frame(width: 280)
-        .background(theme.cardBackground)
-    }
-
-    private func agentSwitcherRow(_ other: Agent) -> some View {
-        let isCurrent = other.id == agent.id
-        let color = agentColorFor(other.name)
-        return Button {
-            showingAgentSwitcher = false
-            if !isCurrent {
+        AgentSwitcherPopover(
+            localAgents: agentManager.agents.filter { !$0.isBuiltIn },
+            remoteAgents: RemoteAgentManager.shared.remoteAgents,
+            currentLocalAgentId: agent.id,
+            currentRemoteAgentId: nil,
+            onSelectLocal: { other in
+                showingAgentSwitcher = false
                 onSwitchAgent(other)
-            }
-        } label: {
-            HStack(spacing: 10) {
-                AgentAvatarView(
-                    mascotId: other.avatar,
-                    name: other.name,
-                    tint: color,
-                    diameter: 26,
-                    customImageURL: other.customAvatarURL,
-                    monogramFontSize: 11,
-                    borderWidth: 1.5
-                )
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(other.name.isEmpty ? L("Untitled Agent") : other.name)
-                        .font(.system(size: 12, weight: isCurrent ? .semibold : .medium))
-                        .foregroundColor(theme.primaryText)
-                        .lineLimit(1)
-                    if !other.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Text(other.description)
-                            .font(.system(size: 10))
-                            .foregroundColor(theme.tertiaryText)
-                            .lineLimit(1)
-                    }
-                }
-
-                Spacer(minLength: 4)
-
-                if isCurrent {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(theme.accentColor)
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isCurrent ? theme.accentColor.opacity(0.10) : Color.clear)
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
+            },
+            onSelectRemote: { remote in
+                showingAgentSwitcher = false
+                onSwitchRemoteAgent(remote.id)
+            },
+            onDismiss: { showingAgentSwitcher = false }
+        )
+        .environment(\.theme, themeManager.currentTheme)
     }
 
     // MARK: - Tab Bar
@@ -1804,190 +1649,55 @@ struct AgentDetailView: View {
     }
 
     /// Horizontally scrollable tab bar — built-in tabs stay leftmost, then one
-    /// per plugin. Wrapping in `ScrollView(.horizontal)` keeps every tab
-    /// reachable when many plugins are installed; the right-edge fade + chevron
-    /// signal the strip is scrollable when content overflows.
+    /// per plugin, then any failed-plugin warning tabs. The shared
+    /// `AgentDetailTabStrip` owns the scroll / overflow-fade / chevron chrome,
+    /// so this view only maps the agent's tab sources into items.
     private var tabBar: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 0) {
-                    // IMPORTANT: read from `currentAgent`, not the captured
-                    // `agent` prop. The prop is frozen at view construction
-                    // and never reflects toggle changes; `currentAgent`
-                    // re-fetches from `AgentManager` so flipping
-                    // `Enable Database` in Configure causes the DB tabs
-                    // (Home/Schema/Data/Views/Activity) to appear here.
-                    ForEach(DetailTab.allTabsForAgent(currentAgent), id: \.self) { tab in
-                        tabButton(for: .builtIn(tab), label: tab.label, icon: tab.icon)
-                            .id(AgentTab.builtIn(tab))
-                    }
-                    ForEach(agentPlugins, id: \.plugin.id) { loaded in
-                        tabButton(
-                            for: .plugin(loaded.plugin.id),
-                            label: loaded.plugin.manifest.name ?? loaded.plugin.id,
-                            icon: "puzzlepiece.extension"
-                        )
-                        .id(AgentTab.plugin(loaded.plugin.id))
-                    }
-                    // Failed plugins surface AFTER successfully loaded ones
-                    // so the warning tabs cluster on the trailing edge of
-                    // the strip — visually obvious without crowding the
-                    // happy-path tabs. Each shows a structured error +
-                    // Retry button via `failedPluginTabContent`.
-                    ForEach(agentFailedPlugins, id: \.pluginId) { failed in
-                        tabButton(
-                            for: .failedPlugin(failed.pluginId),
-                            label: failedPluginTabLabel(for: failed),
-                            icon: "exclamationmark.triangle.fill"
-                        )
-                        .id(AgentTab.failedPlugin(failed.pluginId))
-                    }
-                }
-                .padding(.horizontal, 4)
-                .background(
-                    GeometryReader { inner in
-                        Color.clear.preference(
-                            key: TabBarContentWidthKey.self,
-                            value: inner.size.width
-                        )
-                    }
+        AgentDetailTabStrip(items: tabItems, selection: $selectedTab)
+    }
+
+    /// Built-in + plugin + failed-plugin tabs as `AgentDetailTabStrip` items.
+    /// IMPORTANT: read from `currentAgent`, not the captured `agent` prop — the
+    /// prop is frozen at view construction, while `currentAgent` re-fetches from
+    /// `AgentManager` so flipping `Enable Database` in Configure causes the DB
+    /// tabs (Home/Schema/Data/Views/Activity) to appear here.
+    private var tabItems: [AgentDetailTabItem<AgentTab>] {
+        var items: [AgentDetailTabItem<AgentTab>] = []
+        for tab in DetailTab.allTabsForAgent(currentAgent) {
+            items.append(
+                AgentDetailTabItem(
+                    id: .builtIn(tab),
+                    label: tab.label,
+                    icon: tab.icon,
+                    badgeCount: tabBadgeCount(for: .builtIn(tab))
                 )
-            }
-            .background(
-                GeometryReader { outer in
-                    Color.clear.preference(
-                        key: TabBarViewportWidthKey.self,
-                        value: outer.size.width
-                    )
-                }
             )
-            .onPreferenceChange(TabBarContentWidthKey.self) { tabBarContentWidth = $0 }
-            .onPreferenceChange(TabBarViewportWidthKey.self) { tabBarViewportWidth = $0 }
-            // `onScrollGeometryChange` is the canonical macOS 15+ way to
-            // observe scroll offset; the older GeometryReader-in-named-
-            // coordinate-space pattern is flaky on horizontal AppKit-backed
-            // scroll views and was leaving the trailing indicator stuck on.
-            .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                geometry.contentOffset.x
-            } action: { _, newOffset in
-                tabBarScrollOffset = max(0, newOffset)
-            }
-            // Edge fades on whichever side has off-screen content. `mask`
-            // runs before any overlay, so the chevrons sit ON TOP of the
-            // fades rather than being faded themselves.
-            .mask(tabBarFadeMask)
-            .overlay(alignment: .leading) {
-                if tabsOverflowLeft { scrollMoreChevron(direction: .leading) }
-            }
-            .overlay(alignment: .trailing) {
-                if tabsOverflowRight { scrollMoreChevron(direction: .trailing) }
-            }
-            .animation(.easeOut(duration: 0.2), value: tabsOverflowLeft)
-            .animation(.easeOut(duration: 0.2), value: tabsOverflowRight)
-            // Auto-scroll the active tab into view when it changes (tap or programmatic).
-            .onChange(of: selectedTab) { _, newValue in
-                withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo(newValue, anchor: .center)
-                }
-            }
         }
-    }
-
-    /// Linear gradient used as the tab strip's mask. Fades whichever side
-    /// has content scrolled off; both sides can fade at once if the user is
-    /// in the middle of an overflowed strip.
-    private var tabBarFadeMask: LinearGradient {
-        let fadeStart: CGFloat = 0.06  // ~6% of the strip on the leading edge
-        let fadeEnd: CGFloat = 0.94  // ~6% on the trailing edge
-        var stops: [Gradient.Stop] = []
-        stops.append(.init(color: tabsOverflowLeft ? .clear : .black, location: 0.0))
-        if tabsOverflowLeft {
-            stops.append(.init(color: .black, location: fadeStart))
-        }
-        if tabsOverflowRight {
-            stops.append(.init(color: .black, location: fadeEnd))
-        }
-        stops.append(.init(color: tabsOverflowRight ? .clear : .black, location: 1.0))
-        return LinearGradient(stops: stops, startPoint: .leading, endPoint: .trailing)
-    }
-
-    /// Floating "more →"/"← more" affordance pinned to whichever edge has
-    /// off-screen content. Sits above the fade mask so it stays fully opaque,
-    /// and is `allowsHitTesting(false)` so it never swallows tab taps.
-    private func scrollMoreChevron(direction: HorizontalEdge) -> some View {
-        Image(systemName: direction == .leading ? "chevron.left" : "chevron.right")
-            .font(.system(size: 10, weight: .bold))
-            .foregroundColor(theme.accentColor)
-            .frame(width: 20, height: 20)
-            .background(
-                Circle()
-                    .fill(theme.primaryBackground)
-                    .overlay(Circle().strokeBorder(theme.accentColor.opacity(0.25), lineWidth: 1))
+        for loaded in agentPlugins {
+            items.append(
+                AgentDetailTabItem(
+                    id: .plugin(loaded.plugin.id),
+                    label: loaded.plugin.manifest.name ?? loaded.plugin.id,
+                    icon: "puzzlepiece.extension",
+                    badgeCount: tabBadgeCount(for: .plugin(loaded.plugin.id))
+                )
             )
-            .shadow(
-                color: Color.black.opacity(0.08),
-                radius: 4,
-                x: direction == .leading ? 1 : -1,
-                y: 1
+        }
+        // Failed plugins surface AFTER successfully loaded ones so the warning
+        // tabs cluster on the trailing edge of the strip — visually obvious
+        // without crowding the happy-path tabs. Each shows a structured error +
+        // Retry button via `failedPluginTabContent`.
+        for failed in agentFailedPlugins {
+            items.append(
+                AgentDetailTabItem(
+                    id: .failedPlugin(failed.pluginId),
+                    label: failedPluginTabLabel(for: failed),
+                    icon: "exclamationmark.triangle.fill",
+                    isWarning: true
+                )
             )
-            .padding(direction == .leading ? .leading : .trailing, 2)
-            .allowsHitTesting(false)
-            .transition(.opacity.combined(with: .scale(scale: 0.7)))
-    }
-
-    private func tabButton(for tab: AgentTab, label: String, icon: String) -> some View {
-        let isSelected = selectedTab == tab
-        // Failed plugin tabs use the system warning color regardless of
-        // selection state so the user can spot them at a glance even
-        // in a long tab strip; the accent color is reserved for the
-        // happy-path "selected" signal.
-        let isFailed: Bool = {
-            if case .failedPlugin = tab { return true }
-            return false
-        }()
-        let foreground: Color
-        if isFailed {
-            foreground = .orange
-        } else if isSelected {
-            foreground = theme.accentColor
-        } else {
-            foreground = theme.tertiaryText
         }
-        return Button {
-            selectedTab = tab
-        } label: {
-            VStack(spacing: 0) {
-                HStack(spacing: 5) {
-                    Image(systemName: icon)
-                        .font(.system(size: 11, weight: isSelected ? .semibold : .regular))
-
-                    Text(label)
-                        .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-
-                    if let count = tabBadgeCount(for: tab) {
-                        Text("\(count)", bundle: .module)
-                            .font(.system(size: 9, weight: .bold, design: .rounded))
-                            .foregroundColor(isSelected ? theme.accentColor : theme.tertiaryText)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 1)
-                            .background(
-                                Capsule()
-                                    .fill(isSelected ? theme.accentColor.opacity(0.12) : theme.inputBackground)
-                            )
-                    }
-                }
-                .foregroundColor(foreground)
-                .padding(.horizontal, 12)
-                .padding(.top, 10)
-                .padding(.bottom, 8)
-
-                Rectangle()
-                    .fill(isSelected ? (isFailed ? Color.orange : theme.accentColor) : Color.clear)
-                    .frame(height: 2)
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(PlainButtonStyle())
+        return items
     }
 
     private func tabHelperText(_ text: String) -> some View {
@@ -6146,57 +5856,6 @@ private struct AgentConnectionsSection: View {
             _ = InsightsService.shared.focus(accessKeyId: nonce)
         }
         ManagementStateManager.shared.selectedTab = .insights
-    }
-}
-
-// MARK: - Detail Section Component
-
-private struct AgentDetailSection<Content: View>: View {
-    @Environment(\.theme) private var theme
-
-    let title: String
-    let icon: String
-    var subtitle: String? = nil
-    @ViewBuilder let content: () -> Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 10) {
-                Image(systemName: icon)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(theme.accentColor)
-                    .frame(width: 20)
-
-                Text(title.uppercased())
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(theme.primaryText)
-                    .tracking(0.5)
-
-                if let subtitle = subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
-                }
-
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-
-            VStack(alignment: .leading, spacing: 12) {
-                content()
-            }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 16)
-        }
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(theme.cardBorder, lineWidth: 1)
-                )
-        )
     }
 }
 

--- a/Packages/OsaurusCore/Views/Agent/RemoteAgentViews.swift
+++ b/Packages/OsaurusCore/Views/Agent/RemoteAgentViews.swift
@@ -112,14 +112,10 @@ struct RemoteAgentCard: View {
             Text(remote.name.prefix(1).uppercased())
                 .font(.system(size: 16, weight: .bold, design: .rounded))
                 .foregroundColor(color)
-            // Tiny "remote" decoration in the bottom-right of the avatar.
-            // Reads at a glance even when the card is dense.
-            Image(systemName: "antenna.radiowaves.left.and.right")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundColor(.white)
-                .padding(3)
-                .background(Circle().fill(theme.accentColor))
-                .overlay(Circle().strokeBorder(theme.cardBackground, lineWidth: 1.5))
+            // Tiny "remote" decoration in the bottom-right of the avatar (same
+            // badge the detail header / switcher rows use). Reads at a glance
+            // even when the card is dense.
+            RemoteAvatarBadge()
                 .offset(x: 12, y: 12)
         }
         .frame(width: 36, height: 36)
@@ -274,8 +270,13 @@ struct RemoteAgentDetailView: View {
     let onBack: () -> Void
     let onRemoved: () -> Void
     let onChat: (RemoteAgent) -> Void
+    /// Switch the detail pane to a local agent picked from the shared switcher.
+    let onSwitchAgent: (Agent) -> Void
+    /// Switch the detail pane to a different paired remote agent.
+    let onSwitchRemoteAgent: (UUID) -> Void
 
     @State private var note: String = ""
+    @State private var showingAgentSwitcher: Bool = false
     @State private var showRemoveConfirm: Bool = false
     /// Live `effective_model` from a `GET /agents/{id}` refresh on appear. The
     /// peer's real runtime model (Mode 2 sends `model:"default"` on the wire),
@@ -296,44 +297,63 @@ struct RemoteAgentDetailView: View {
     /// suppress the initial onChange that fires when `note` is hydrated on
     /// appear, so the user doesn't see a phantom "Saved" pill on every visit.
     @State private var noteHydrated: Bool = false
+    /// Which content tab is showing. Mirrors the local agent detail's tabbed
+    /// shell so both surfaces navigate the same way.
+    @State private var selectedTab: RemoteDetailTab = .overview
 
     private var remote: RemoteAgent? { manager.remoteAgent(for: remoteId) }
     private var color: Color { agentColorFor(remote?.name ?? "") }
 
+    /// The two content tabs for a paired remote agent. Kept deliberately small
+    /// — the remote surface is read-only-ish — but mirrors the local detail
+    /// view's tabbed shell so both navigate the same way.
+    private enum RemoteDetailTab: Hashable {
+        case overview
+        case activity
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            headerBar
+            if let remote {
+                header(for: remote)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    if let remote {
-                        identityCard(for: remote)
-                        connectionCard(for: remote)
-                        activityCard(for: remote)
-                        sourceCard(for: remote)
-                        noteCard(for: remote)
-                        actionCard(for: remote)
-                    } else {
-                        VStack(spacing: 12) {
-                            Image(systemName: "antenna.radiowaves.left.and.right.slash")
-                                .font(.system(size: 32))
-                                .foregroundColor(theme.tertiaryText)
-                            Text("This remote agent is no longer available.", bundle: .module)
-                                .font(.system(size: 12))
-                                .foregroundColor(theme.tertiaryText)
-                            Button {
-                                onBack()
-                            } label: {
-                                Text("Go back", bundle: .module)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, 80)
+                AgentDetailTabStrip(items: tabItems(for: remote), selection: $selectedTab)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+
+                Divider()
+                    .foregroundColor(theme.primaryBorder)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        tabSections(for: remote)
                     }
+                    .padding(24)
+                    .id(selectedTab)
                 }
-                .padding(24)
+                .background(theme.primaryBackground)
+            } else {
+                unavailableHeader
+
+                ScrollView {
+                    VStack(spacing: 12) {
+                        Image(systemName: "antenna.radiowaves.left.and.right.slash")
+                            .font(.system(size: 32))
+                            .foregroundColor(theme.tertiaryText)
+                        Text("This remote agent is no longer available.", bundle: .module)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.tertiaryText)
+                        Button {
+                            onBack()
+                        } label: {
+                            Text("Go back", bundle: .module)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, 80)
+                }
+                .background(theme.primaryBackground)
             }
-            .background(theme.primaryBackground)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.primaryBackground)
@@ -361,94 +381,134 @@ struct RemoteAgentDetailView: View {
         )
     }
 
-    // MARK: Subviews
+    /// Built-in tab descriptors for the strip. The Activity tab carries a badge
+    /// with this session's request count once the agent has been used.
+    private func tabItems(for remote: RemoteAgent) -> [AgentDetailTabItem<RemoteDetailTab>] {
+        let activity = insights.activity(forProviderId: remote.providerId)
+        return [
+            AgentDetailTabItem(id: .overview, label: L("Overview"), icon: "info.circle"),
+            AgentDetailTabItem(
+                id: .activity,
+                label: L("Activity"),
+                icon: "waveform.path.ecg",
+                badgeCount: activity.isEmpty ? nil : activity.requestCount
+            ),
+        ]
+    }
 
-    private var headerBar: some View {
-        HStack(spacing: 12) {
-            Button(action: onBack) {
-                HStack(spacing: 6) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 12, weight: .semibold))
-                    Text("Agents", bundle: .module)
-                        .font(.system(size: 13, weight: .medium))
-                }
-                .foregroundColor(theme.accentColor)
-            }
-            .buttonStyle(.plain)
-
-            Rectangle()
-                .fill(theme.primaryBorder)
-                .frame(width: 1, height: 16)
-                .opacity(0.6)
-
-            HStack(spacing: 6) {
-                Image(systemName: "antenna.radiowaves.left.and.right")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.accentColor)
-                Text(remote?.name ?? "Remote Agent")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(theme.primaryText)
-                    .lineLimit(1)
-            }
-            Spacer()
+    @ViewBuilder
+    private func tabSections(for remote: RemoteAgent) -> some View {
+        switch selectedTab {
+        case .overview:
+            connectionCard(for: remote)
+            sourceCard(for: remote)
+            noteCard(for: remote)
+        case .activity:
+            activityCard(for: remote)
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 10)
-        .background(
-            theme.secondaryBackground
-                .overlay(
-                    Rectangle()
-                        .fill(theme.primaryBorder)
-                        .frame(height: 1),
-                    alignment: .bottom
-                )
+    }
+
+    // MARK: Header
+
+    private func header(for remote: RemoteAgent) -> some View {
+        AgentDetailHeaderBar(
+            onBack: onBack,
+            identity: { identityButton(for: remote) },
+            status: { connectionStatusPill(for: remote) },
+            actions: {
+                HStack(spacing: 6) {
+                    AgentDetailHeaderActionButton(
+                        icon: "bubble.left.and.bubble.right",
+                        tint: theme.accentColor,
+                        help: "Chat with this Agent",
+                        action: { onChat(remote) }
+                    )
+                    AgentDetailHeaderActionButton(
+                        icon: "trash",
+                        tint: theme.errorColor,
+                        help: "Remove",
+                        action: { showRemoveConfirm = true }
+                    )
+                }
+            }
         )
     }
 
-    private func identityCard(for remote: RemoteAgent) -> some View {
-        HStack(spacing: 16) {
-            AgentAvatarView(
+    /// Tappable identity block mirroring the local header: avatar (carrying the
+    /// remote antenna glyph instead of a free-floating "Remote" pill) + name +
+    /// switcher chevron. Tapping opens the shared agent switcher so the user can
+    /// hop between local and remote agents from here too.
+    private func identityButton(for remote: RemoteAgent) -> some View {
+        Button {
+            showingAgentSwitcher = true
+        } label: {
+            AgentDetailIdentityLabel(
                 mascotId: remote.avatar,
                 name: remote.name,
                 tint: color,
-                diameter: 56,
-                monogramFontSize: 22
+                subtitle: remote.description,
+                showsChevron: true,
+                maxWidth: 240,
+                showsRemoteGlyph: true,
+                glyphRingColor: theme.secondaryBackground
             )
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(remote.name)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(theme.primaryText)
-                if !remote.description.isEmpty {
-                    Text(remote.description)
-                        .font(.system(size: 12))
-                        .foregroundColor(theme.secondaryText)
-                        .lineLimit(2)
-                }
-                Text(remote.agentAddress)
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(theme.tertiaryText)
-                    .textSelection(.enabled)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-
-            Spacer()
-            Text("Remote", bundle: .module)
-                .font(.system(size: 10, weight: .bold))
-                .foregroundColor(theme.accentColor)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(theme.accentColor.opacity(0.12)))
+            .contentShape(Rectangle())
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(theme.cardBorder, lineWidth: 1)
-                )
+        .buttonStyle(PlainButtonStyle())
+        .localizedHelp("Switch agent")
+        .popover(isPresented: $showingAgentSwitcher, arrowEdge: .bottom) {
+            AgentSwitcherPopover(
+                localAgents: AgentManager.shared.agents.filter { !$0.isBuiltIn },
+                remoteAgents: manager.remoteAgents,
+                currentLocalAgentId: nil,
+                currentRemoteAgentId: remote.id,
+                onSelectLocal: { agent in
+                    showingAgentSwitcher = false
+                    onSwitchAgent(agent)
+                },
+                onSelectRemote: { other in
+                    showingAgentSwitcher = false
+                    onSwitchRemoteAgent(other.id)
+                },
+                onDismiss: { showingAgentSwitcher = false }
+            )
+            .environment(\.theme, theme)
+        }
+    }
+
+    /// Back-only header shown when the remote agent can no longer be resolved
+    /// (e.g. it was removed in another window) so the user can still navigate
+    /// back.
+    private var unavailableHeader: some View {
+        AgentDetailHeaderBar(
+            onBack: onBack,
+            identity: {
+                HStack(spacing: 6) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(theme.accentColor)
+                    Text("Remote Agent", bundle: .module)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                }
+            },
+            status: { EmptyView() },
+            actions: { EmptyView() }
         )
+    }
+
+    /// Compact connection-state pill for the header's status slot so the live
+    /// link state is visible regardless of which tab is showing.
+    private func connectionStatusPill(for remote: RemoteAgent) -> some View {
+        let currentPhase = phase(for: remote)
+        return HStack(spacing: 5) {
+            Circle()
+                .fill(phaseColor(currentPhase))
+                .frame(width: 6, height: 6)
+            Text(currentPhase.label, bundle: .module)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.secondaryText)
+        }
     }
 
     // MARK: Connection
@@ -494,43 +554,34 @@ struct RemoteAgentDetailView: View {
 
     private func connectionCard(for remote: RemoteAgent) -> some View {
         let currentPhase = phase(for: remote)
-        return VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
-                AgentSheetSectionLabel("Connection")
-                if isRefreshingMetadata {
-                    ProgressView()
-                        .controlSize(.mini)
-                        .scaleEffect(0.7)
-                }
-                Spacer()
-                Button {
-                    refreshLiveMetadata()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(theme.accentColor)
-                }
-                .buttonStyle(.plain)
-                .help(Text("Refresh from the agent", bundle: .module))
-                .disabled(isRefreshingMetadata)
-            }
-
-            // Status row with a colored phase dot.
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Text("Status", bundle: .module)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.tertiaryText)
-                    .frame(width: 80, alignment: .leading)
+        return AgentDetailSection(
+            title: L("Connection"),
+            icon: "antenna.radiowaves.left.and.right",
+            trailing: {
                 HStack(spacing: 6) {
-                    Circle()
-                        .fill(phaseColor(currentPhase))
-                        .frame(width: 7, height: 7)
-                    Text(currentPhase.label, bundle: .module)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(theme.secondaryText)
+                    if isRefreshingMetadata {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .scaleEffect(0.7)
+                    }
+                    Button {
+                        refreshLiveMetadata()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(theme.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                    .help(Text("Refresh from the agent", bundle: .module))
+                    .disabled(isRefreshingMetadata)
                 }
-                Spacer()
             }
+        ) {
+            AgentDetailStatusRow(
+                label: "Status",
+                value: currentPhase.label,
+                dotColor: phaseColor(currentPhase)
+            )
             if case .failed(let message) = currentPhase {
                 Text(message)
                     .font(.system(size: 10))
@@ -539,32 +590,22 @@ struct RemoteAgentDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            metadataRow(
+            AgentDetailMetadataRow(
                 label: "Mode",
-                value: NSLocalizedString("Remote agent run", bundle: .module, comment: ""),
-                mono: false
+                value: NSLocalizedString("Remote agent run", bundle: .module, comment: "")
             )
-            metadataRow(
+            AgentDetailMetadataRow(
                 label: "Encryption",
-                value: NSLocalizedString("Secure Channel (E2E)", bundle: .module, comment: ""),
-                mono: false
+                value: NSLocalizedString("Secure Channel (E2E)", bundle: .module, comment: "")
             )
-            metadataRow(
+            AgentDetailMetadataRow(
                 label: "Model",
-                value: liveEffectiveModel ?? NSLocalizedString("Default (agent decides)", bundle: .module, comment: ""),
-                mono: false
+                value: liveEffectiveModel
+                    ?? NSLocalizedString("Default (agent decides)", bundle: .module, comment: "")
             )
 
             connectionActionRow(for: remote, phase: currentPhase)
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(theme.cardBorder, lineWidth: 1)
-                )
-        )
     }
 
     @ViewBuilder
@@ -603,10 +644,10 @@ struct RemoteAgentDetailView: View {
 
     private func activityCard(for remote: RemoteAgent) -> some View {
         let activity = insights.activity(forProviderId: remote.providerId)
-        return VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 6) {
-                AgentSheetSectionLabel("Activity")
-                Spacer()
+        return AgentDetailSection(
+            title: L("Activity"),
+            icon: "waveform.path.ecg",
+            trailing: {
                 if !activity.isEmpty {
                     Button {
                         viewInInsights(remote)
@@ -622,7 +663,7 @@ struct RemoteAgentDetailView: View {
                     .buttonStyle(.plain)
                 }
             }
-
+        ) {
             if activity.isEmpty {
                 Text("No requests recorded this session.", bundle: .module)
                     .font(.system(size: 11))
@@ -647,14 +688,6 @@ struct RemoteAgentDetailView: View {
                 }
             }
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(theme.cardBorder, lineWidth: 1)
-                )
-        )
     }
 
     private func activityStat(value: String, label: Text) -> some View {
@@ -717,36 +750,27 @@ struct RemoteAgentDetailView: View {
     }
 
     private func sourceCard(for remote: RemoteAgent) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            AgentSheetSectionLabel("Source")
-            metadataRow(label: "Relay URL", value: remote.relayBaseURL, mono: true)
-            metadataRow(
+        AgentDetailSection(title: L("Source"), icon: "globe") {
+            AgentDetailMetadataRow(label: "Address", value: remote.agentAddress, mono: true)
+            AgentDetailMetadataRow(label: "Relay URL", value: remote.relayBaseURL, mono: true)
+            AgentDetailMetadataRow(
                 label: "Paired",
-                value: remote.pairedAt.formatted(date: .abbreviated, time: .shortened),
-                mono: false
+                value: remote.pairedAt.formatted(date: .abbreviated, time: .shortened)
             )
             if let last = remote.lastUsedAt {
-                metadataRow(
+                AgentDetailMetadataRow(
                     label: "Last Used",
-                    value: last.formatted(date: .abbreviated, time: .shortened),
-                    mono: false
+                    value: last.formatted(date: .abbreviated, time: .shortened)
                 )
             }
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(theme.cardBorder, lineWidth: 1)
-                )
-        )
     }
 
     private func noteCard(for remote: RemoteAgent) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                AgentSheetSectionLabel("Your Note")
+        AgentDetailSection(
+            title: L("Your Note"),
+            icon: "note.text",
+            trailing: {
                 if noteSaved {
                     HStack(spacing: 4) {
                         Image(systemName: "checkmark.circle.fill")
@@ -757,9 +781,8 @@ struct RemoteAgentDetailView: View {
                     .foregroundColor(theme.successColor)
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }
-                Spacer()
             }
-
+        ) {
             StyledTextField(
                 placeholder: "e.g., Alice's research agent",
                 text: $note,
@@ -772,14 +795,6 @@ struct RemoteAgentDetailView: View {
                 scheduleNoteSave(newValue, for: remote.id)
             }
         }
-        .padding(16)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(theme.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12).stroke(theme.cardBorder, lineWidth: 1)
-                )
-        )
     }
 
     /// Debounced autosave — mirrors the local-agent header's `debouncedSave`
@@ -798,47 +813,4 @@ struct RemoteAgentDetailView: View {
         }
     }
 
-    private func actionCard(for remote: RemoteAgent) -> some View {
-        HStack(spacing: 10) {
-            Button {
-                onChat(remote)
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "bubble.left.and.bubble.right.fill")
-                        .font(.system(size: 12))
-                    Text("Chat with this Agent", bundle: .module)
-                }
-            }
-            .buttonStyle(PrimaryButtonStyle())
-
-            Spacer()
-
-            Button {
-                showRemoveConfirm = true
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 12))
-                    Text("Remove", bundle: .module)
-                }
-            }
-            .buttonStyle(DestructiveButtonStyle())
-        }
-    }
-
-    private func metadataRow(label: String, value: String, mono: Bool) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Text(LocalizedStringKey(label), bundle: .module)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(theme.tertiaryText)
-                .frame(width: 80, alignment: .leading)
-            Text(value)
-                .font(mono ? .system(size: 11, design: .monospaced) : .system(size: 11))
-                .foregroundColor(theme.secondaryText)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .textSelection(.enabled)
-            Spacer()
-        }
-    }
 }

--- a/Packages/OsaurusCore/Views/Memory/MemoryView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryView.swift
@@ -145,6 +145,12 @@ struct MemoryView: View {
                         // just swap the in-memory selection.
                         selectedAgent = newAgent
                     },
+                    onSwitchRemoteAgent: { remoteId in
+                        // Memory has no remote-agent surface of its own, so hand
+                        // off to the Agents tab and let it open the remote detail.
+                        ManagementStateManager.shared.pendingRemoteAgentDetailId = remoteId
+                        ManagementStateManager.shared.selectedTab = .agents
+                    },
                     showSuccess: { msg in
                         showToast(msg)
                     }


### PR DESCRIPTION
## Summary
- Extract the agent-detail chrome into a new `AgentDetailChrome.swift` so the local `AgentDetailView` and the paired `RemoteAgentDetailView` share one set of building blocks: header bar, identity label, circular action buttons, section card, metadata/status rows, the scrollable tab strip, the agent-switcher popover, and `RemoteAvatarBadge`.
- Refactor the local detail view onto that chrome and rebuild the remote detail view to match — remote now has a tabbed **Overview / Activity** shell and a unified header (avatar + switcher + connection status + Chat/Remove) instead of the oversized identity card.
- The **Switch Agent** popover now lists local **and** paired remote agents, and is reachable from both detail headers; from Memory it hands a remote pick off to the Agents tab.
- A remote agent's **Chat** action (detail header + grid card) now opens/focuses a chat window and auto-selects that agent via the relay-agent path (`ChatWindowManager.openChat(withRemoteAgentProviderId:)`) instead of just toggling the last window.
- Remote agents are marked with a subtle antenna glyph on the avatar (shared `RemoteAvatarBadge`) rather than a free-floating "Remote" pill; the grid card reuses the same badge.

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore` succeeds; touched files are lint-clean.
- [ ] Local agent detail: header, tabs (including plugin / failed-plugin tabs), Share/Delete, and save indicator behave as before.
- [ ] Remote agent detail: Overview/Activity tabs, Connection (connect/disconnect/refresh), Source, and the autosaving Note all work.
- [ ] Switch Agent popover lists local + remote agents from both headers; switching local↔remote navigates correctly and marks the current agent.
- [ ] Remote **Chat** (header icon and grid card) opens a window and selects the right agent, including when no chat window exists yet.
- [ ] Memory → agent detail → switch to a remote agent routes to the Agents tab and opens that remote's detail.

Made with [Cursor](https://cursor.com)