### PR TITLE
Harden Bonjour discovery (security, reliability, discoverability)

### DIFF
--- a/Packages/OsaurusCore/Networking/BonjourAdvertiser.swift
+++ b/Packages/OsaurusCore/Networking/BonjourAdvertiser.swift
@@ -35,9 +35,21 @@ public final class BonjourAdvertiser: NSObject {
     /// REQUESTED (instead of `service.name`) prevents an endless
     /// stop/republish loop after an auto-rename.
     private var requestedNames: [UUID: String] = [:]
+    /// The TXT payload we last pushed to the live service per agent. Diffing
+    /// against this lets a `description`/`address`/`osc` edit reach the wire
+    /// via `setTXTRecord` even when the instance name is unchanged (otherwise
+    /// the name-only guard would silently drop the update).
+    private var publishedTXT: [UUID: Data] = [:]
+    /// Consecutive `didNotPublish` failures per agent, for the bounded retry.
+    /// Reset to 0 on a successful `didPublish`.
+    private var publishRetryCounts: [UUID: Int] = [:]
     private var currentPort: Int = 0
     private var isAdvertising = false
     private var cancellables: Set<AnyCancellable> = []
+
+    /// Max automatic re-publish attempts after `didNotPublish` before giving
+    /// up (each failure is logged regardless).
+    static let maxPublishRetries = 3
 
     private override init() {
         super.init()
@@ -66,6 +78,8 @@ public final class BonjourAdvertiser: NSObject {
         for service in services.values { service.stop() }
         services.removeAll()
         requestedNames.removeAll()
+        publishedTXT.removeAll()
+        publishRetryCounts.removeAll()
     }
 
     // MARK: - Private
@@ -80,19 +94,61 @@ public final class BonjourAdvertiser: NSObject {
             services[id]?.stop()
             services.removeValue(forKey: id)
             requestedNames.removeValue(forKey: id)
+            publishedTXT.removeValue(forKey: id)
+            publishRetryCounts.removeValue(forKey: id)
         }
 
-        // Publish or re-publish services for current agents. Compare against
-        // the name we last REQUESTED, not the live `service.name`: mDNS may
-        // auto-rename on conflict, and reacting to that would stop/republish
-        // the service forever.
+        // Publish, update-in-place, or leave each current agent's service.
+        // We compare against the name we last REQUESTED (mDNS may auto-rename
+        // on conflict, and reacting to the live `service.name` would
+        // stop/republish forever) AND the TXT we last published — so a
+        // `description`/`address`/`osc` edit reaches the wire via
+        // `setTXTRecord` without a disruptive stop/republish.
         for agent in agents where agent.bonjourEnabled {
             let expectedName = Self.instanceName(for: agent)
-            if services[agent.id] == nil || requestedNames[agent.id] != expectedName {
+            let txt = Self.txtRecord(for: agent)
+            switch Self.advertisementAction(
+                hasService: services[agent.id] != nil,
+                requestedName: requestedNames[agent.id],
+                publishedTXT: publishedTXT[agent.id],
+                newName: expectedName,
+                newTXT: txt
+            ) {
+            case .publish:
                 services[agent.id]?.stop()
-                publish(agent: agent, name: expectedName)
+                publish(agent: agent, name: expectedName, txt: txt)
+            case .updateTXT:
+                services[agent.id]?.setTXTRecord(txt)
+                publishedTXT[agent.id] = txt
+            case .none:
+                break
             }
         }
+    }
+
+    /// Whether `syncAdvertisements` should (re)publish a service, update its
+    /// live TXT record in place, or do nothing. A pure function of the cached
+    /// state so the republish-vs-update logic is unit-testable without a live
+    /// `NetService`/mDNS.
+    enum AdvertisementAction: Equatable {
+        /// (Re)publish: the service doesn't exist yet, or the DNS-SD instance
+        /// name changed (mDNS keys a registration by name).
+        case publish
+        /// Name unchanged but the TXT payload changed — update in place.
+        case updateTXT
+        /// Nothing changed.
+        case none
+    }
+
+    static func advertisementAction(
+        hasService: Bool,
+        requestedName: String?,
+        publishedTXT: Data?,
+        newName: String,
+        newTXT: Data
+    ) -> AdvertisementAction {
+        guard hasService, requestedName == newName else { return .publish }
+        return publishedTXT == newTXT ? .none : .updateTXT
     }
 
     /// Build a DNS-SD instance name that fits the 63-byte limit while keeping
@@ -120,37 +176,88 @@ public final class BonjourAdvertiser: NSObject {
         return result
     }
 
-    private func publish(agent: Agent, name: String) {
+    private func publish(agent: Agent, name: String, txt: Data) {
         let service = NetService(
             domain: "",  // empty = local. domain
             type: Self.serviceType,
             name: name,
             port: Int32(currentPort)
         )
-        service.setTXTRecord(txtRecord(for: agent))
+        service.setTXTRecord(txt)
         service.delegate = self
         service.publish()
         services[agent.id] = service
         requestedNames[agent.id] = name
+        publishedTXT[agent.id] = txt
     }
 
-    private func txtRecord(for agent: Agent) -> Data {
+    /// Build the TXT record advertised for an agent. `static` (a pure function
+    /// of the agent) so the payload can be unit-tested without a live
+    /// `NetService`.
+    static func txtRecord(for agent: Agent) -> Data {
         var fields: [String: Data] = [:]
         fields["name"] = agent.name.data(using: .utf8)
         fields["id"] = agent.id.uuidString.data(using: .utf8)
         if !agent.description.isEmpty {
-            let capped = Self.truncateUTF8(agent.description, maxBytes: Self.maxTXTDescriptionBytes)
+            let capped = truncateUTF8(agent.description, maxBytes: maxTXTDescriptionBytes)
             fields["description"] = capped.data(using: .utf8)
         }
-        if let address = agent.agentAddress {
+        // Advertise the address and the Secure Channel flag (`osc=1`) together,
+        // and only when the agent has a derived address: the address is what a
+        // peer pins and signs the handshake with, so claiming `osc=1` without
+        // one would be a false promise (the agent fails closed at run time).
+        // This also keeps an addressless advert unambiguously "legacy plaintext"
+        // rather than a spoof claiming encryption.
+        if let address = agent.agentAddress, !address.isEmpty {
             fields["address"] = address.data(using: .utf8)
+            fields["osc"] = "1".data(using: .utf8)
         }
-        // Secure Channel capability (diagnostic): this peer accepts
-        // `/secure/session` handshakes and requires E2E encryption on agent
-        // run/dispatch. Browsers use it to explain "peer needs upgrade"
-        // instead of a bare handshake 404.
-        fields["osc"] = "1".data(using: .utf8)
         return NetService.data(fromTXTRecord: fields)
+    }
+
+    // MARK: - Publish Retry
+
+    /// Backoff before the `attempt`-th re-publish (0-based): 1s, 2s, 4s, …
+    /// capped at 30s.
+    static func publishRetryDelay(attempt: Int) -> Double {
+        min(pow(2.0, Double(max(0, attempt))), 30.0)
+    }
+
+    /// The agent id whose service we REQUESTED under `serviceName` (the name we
+    /// asked mDNS to publish, before any collision auto-rename).
+    private func agentId(forServiceName serviceName: String) -> UUID? {
+        requestedNames.first(where: { $0.value == serviceName })?.key
+    }
+
+    /// Re-publish an agent's service after a `didNotPublish` failure, bounded
+    /// by `maxPublishRetries`. The retry counter persists across attempts and
+    /// is cleared only by a successful `didPublish`.
+    private func retryPublish(serviceName: String) async {
+        guard isAdvertising, let id = agentId(forServiceName: serviceName) else { return }
+        let attempt = publishRetryCounts[id, default: 0]
+        guard attempt < Self.maxPublishRetries else {
+            Self.delegateLogger.error(
+                "Giving up advertising '\(serviceName, privacy: .public)' after \(Self.maxPublishRetries) failed attempts"
+            )
+            return
+        }
+        publishRetryCounts[id] = attempt + 1
+        try? await Task.sleep(for: .seconds(Self.publishRetryDelay(attempt: attempt)))
+        // Re-validate: the agent may have been removed/renamed/disabled while
+        // we waited.
+        guard isAdvertising,
+            let agent = AgentManager.shared.agents.first(where: { $0.id == id }),
+            agent.bonjourEnabled
+        else { return }
+        services[id]?.stop()
+        publish(agent: agent, name: Self.instanceName(for: agent), txt: Self.txtRecord(for: agent))
+    }
+
+    /// Clear the retry counter for a successfully published service.
+    private func clearPublishRetry(serviceName: String) {
+        if let id = agentId(forServiceName: serviceName) {
+            publishRetryCounts[id] = 0
+        }
     }
 }
 
@@ -165,11 +272,21 @@ extension BonjourAdvertiser: NetServiceDelegate {
         Self.delegateLogger.info(
             "Advertised agent '\(sender.name, privacy: .public)' on port \(sender.port)"
         )
+        let serviceName = sender.name
+        Task { @MainActor [weak self] in
+            self?.clearPublishRetry(serviceName: serviceName)
+        }
     }
 
     public nonisolated func netService(_ sender: NetService, didNotPublish errorDict: [String: NSNumber]) {
         Self.delegateLogger.error(
             "Failed to advertise agent '\(sender.name, privacy: .public)': \(errorDict, privacy: .public)"
         )
+        // Bounded re-publish: mDNS publish can fail transiently (mDNSResponder
+        // not ready at cold launch, momentary collision beyond auto-rename).
+        let serviceName = sender.name
+        Task { @MainActor [weak self] in
+            await self?.retryPublish(serviceName: serviceName)
+        }
     }
 }

--- a/Packages/OsaurusCore/Networking/BonjourBrowser.swift
+++ b/Packages/OsaurusCore/Networking/BonjourBrowser.swift
@@ -6,6 +6,7 @@
 //  network, enabling the agent selector to list peers from other devices.
 //
 
+import Darwin
 import Foundation
 import os
 
@@ -33,6 +34,11 @@ public struct DiscoveredAgent: Identifiable, Equatable, Sendable {
     public let agentDescription: String
     public let address: String?
     public let host: String?
+    /// A numeric IP (preferring IPv4) parsed from the service's resolved
+    /// addresses. Used as a connection fallback when the mDNS `.local`
+    /// `host` is missing or cannot be resolved on the current network (some
+    /// enterprise/VPN setups block multicast `.local` resolution).
+    public let resolvedIP: String?
     public let port: Int
     /// Whether the peer advertised Secure Channel support (`osc=1` in its
     /// TXT record). Peers without it predate end-to-end encryption and will
@@ -42,6 +48,35 @@ public struct DiscoveredAgent: Identifiable, Equatable, Sendable {
 
     /// Internal key that matches the NetService name for lookup/removal.
     internal let serviceName: String
+
+    /// Best connectable host: the stable `.local` name when present,
+    /// otherwise the resolved numeric IP. `nil` only when neither resolved.
+    public var connectHost: String? {
+        if let host, !host.isEmpty { return host }
+        if let resolvedIP, !resolvedIP.isEmpty { return resolvedIP }
+        return nil
+    }
+
+    /// A short, human-verifiable rendering of the pinned crypto `address`
+    /// (e.g. `0x742d35…bD18`), shown at the pairing decision point so the
+    /// user verifies the cryptographic identity rather than only the
+    /// attacker-controllable display name. `nil` when no address is advertised.
+    public var addressFingerprint: String? {
+        guard let address, !address.isEmpty else { return nil }
+        let hex = address.hasPrefix("0x") ? String(address.dropFirst(2)) : address
+        guard hex.count > 12 else { return address }
+        return "0x\(hex.prefix(6))…\(hex.suffix(4))"
+    }
+
+    /// True when the peer claims Secure Channel support (`osc=1`) but
+    /// advertised no crypto address to pin. A genuine Osaurus peer always
+    /// advertises its address alongside `osc=1`; the inconsistent combination
+    /// is the signature of a spoofed advertisement (or a buggy peer), so the
+    /// pairing flow refuses it rather than silently skipping the server
+    /// identity check that the addressless branch would otherwise bypass.
+    public var isUnverifiableSecureChannelPeer: Bool {
+        supportsSecureChannel && (address ?? "").isEmpty
+    }
 }
 
 // MARK: - BonjourBrowser
@@ -63,6 +98,10 @@ public final class BonjourBrowser: NSObject, ObservableObject {
     @Published public private(set) var discoveredAgents: [DiscoveredAgent] = []
 
     private var core: BonjourBrowserCore?
+    /// Whether the background browse thread has been started. Browsing begins
+    /// lazily (see `startIfNeeded`) so the singleton can be constructed — e.g.
+    /// to subscribe to `$discoveredAgents` — without probing the LAN.
+    private var hasStarted = false
 
     /// Grace period before a `didRemove` actually drops an agent from the
     /// published list. mDNS TTL flaps (sleep/wake, Wi-Fi roam, cache expiry
@@ -74,7 +113,12 @@ public final class BonjourBrowser: NSObject, ObservableObject {
 
     private override init() {
         super.init()
-        let core = BonjourBrowserCore(
+        // The core is created but NOT started here. Merely constructing the
+        // singleton (every chat window subscribes to `$discoveredAgents`) must
+        // not begin an always-on mDNS browse or trigger the Local Network
+        // permission prompt for users who never use peer discovery. The browse
+        // starts the first time a discovery surface appears (`startIfNeeded`).
+        self.core = BonjourBrowserCore(
             serviceType: BonjourAdvertiser.serviceType,
             onResolved: { agent in
                 Task { @MainActor [weak self] in self?.upsert(agent) }
@@ -83,8 +127,19 @@ public final class BonjourBrowser: NSObject, ObservableObject {
                 Task { @MainActor [weak self] in self?.remove(serviceName: serviceName) }
             }
         )
-        self.core = core
-        core.start()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begin browsing for peers if it hasn't started yet. Idempotent and cheap
+    /// to call from `onAppear` / popover-open of any discovery surface (e.g.
+    /// the agent picker). Once started, the browse runs for the process
+    /// lifetime so an active discovered-agent chat keeps re-resolving across
+    /// network changes.
+    public func startIfNeeded() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        core?.start()
     }
 
     // MARK: - Private
@@ -123,7 +178,11 @@ public final class BonjourBrowser: NSObject, ObservableObject {
 /// touched only on that thread; resolved agents are delivered through the
 /// `@Sendable` callbacks. The browser lives for the process lifetime, so the
 /// thread and its run loop are never torn down.
-private final class BonjourBrowserCore: NSObject, @unchecked Sendable {
+///
+/// Module-internal (not `private`) so its pure static helpers
+/// (`firstResolvedIP`, `searchRetryDelay`) can be unit-tested via
+/// `@testable import`.
+final class BonjourBrowserCore: NSObject, @unchecked Sendable {
     private let serviceType: String
     private let onResolved: @Sendable (DiscoveredAgent) -> Void
     private let onRemoved: @Sendable (String) -> Void
@@ -134,6 +193,11 @@ private final class BonjourBrowserCore: NSObject, @unchecked Sendable {
     private var resolvingServices: [String: NetService] = [:]
     /// Service names whose first resolve failed and have one retry in flight.
     private var retriedResolves: Set<String> = []
+    /// Consecutive failed/aborted browse starts, reset by a successful
+    /// `willSearch`. Bounds the re-`searchForServices` backoff. Touched only on
+    /// the browser run-loop thread.
+    private var searchRetryCount = 0
+    static let maxSearchRetries = 5
 
     static let logger = Logger(subsystem: "com.osaurus", category: "bonjour")
 
@@ -192,11 +256,74 @@ private final class BonjourBrowserCore: NSObject, @unchecked Sendable {
             agentDescription: desc,
             address: addr,
             host: service.hostName,
+            resolvedIP: Self.firstResolvedIP(from: service.addresses),
             port: Int(service.port),
             supportsSecureChannel: osc,
             serviceName: service.name
         )
         onResolved(agent)
+    }
+
+    // MARK: - Address Parsing
+
+    /// Extract a numeric IP (preferring IPv4) from a service's resolved
+    /// `addresses`, used as a connection fallback when the `.local` hostname is
+    /// missing or unresolvable. Pure/static so it's unit-testable.
+    static func firstResolvedIP(from addresses: [Data]?) -> String? {
+        guard let addresses, !addresses.isEmpty else { return nil }
+        var ipv6Fallback: String?
+        for data in addresses {
+            let parsed: String? = data.withUnsafeBytes { raw in
+                guard let base = raw.baseAddress, raw.count >= MemoryLayout<sockaddr>.size else {
+                    return nil
+                }
+                let sa = base.assumingMemoryBound(to: sockaddr.self)
+                var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                let status = getnameinfo(
+                    sa,
+                    socklen_t(data.count),
+                    &host,
+                    socklen_t(host.count),
+                    nil,
+                    0,
+                    NI_NUMERICHOST
+                )
+                guard status == 0 else { return nil }
+                return String(cString: host)
+            }
+            guard let ip = parsed, !ip.isEmpty else { continue }
+            // Prefer IPv4 (routable on the LAN we discovered the peer on); keep
+            // the first IPv6 only as a fallback.
+            if ip.contains(".") { return ip }
+            if ipv6Fallback == nil { ipv6Fallback = ip }
+        }
+        return ipv6Fallback
+    }
+
+    // MARK: - Browse Restart
+
+    /// Backoff before the `attempt`-th browse restart (0-based): 1s, 2s, 4s, …
+    /// capped at 30s. Returns nil once the retry budget is exhausted.
+    static func searchRetryDelay(attempt: Int) -> TimeInterval? {
+        guard attempt < maxSearchRetries else { return nil }
+        return min(pow(2.0, Double(max(0, attempt))), 30.0)
+    }
+
+    /// Schedule a bounded re-`searchForServices` on the browser's run loop.
+    /// Called from the browse-failure delegate callbacks (same thread).
+    func scheduleSearchRetry() {
+        guard let delay = Self.searchRetryDelay(attempt: searchRetryCount) else {
+            Self.logger.error(
+                "Giving up Bonjour browse after \(Self.maxSearchRetries, privacy: .public) attempts"
+            )
+            return
+        }
+        searchRetryCount += 1
+        let timer = Timer(timeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self, let browser = self.browser else { return }
+            browser.searchForServices(ofType: self.serviceType, inDomain: "")
+        }
+        RunLoop.current.add(timer, forMode: .default)
     }
 }
 
@@ -207,11 +334,39 @@ private final class BonjourBrowserCore: NSObject, @unchecked Sendable {
 // `resolvingServices` only on that thread.
 
 extension BonjourBrowserCore: NetServiceBrowserDelegate {
+    func netServiceBrowserWillSearch(_ browser: NetServiceBrowser) {
+        // A successful (re)start re-arms the retry budget.
+        searchRetryCount = 0
+    }
+
+    func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didNotSearch errorDict: [String: NSNumber]
+    ) {
+        // The browse never started — most often a denied Local Network
+        // permission or mDNSResponder not yet ready. Surface it (silent
+        // zero-discovery is the worst outcome) and retry with bounded backoff.
+        Self.logger.error(
+            "Bonjour browse failed to start: \(errorDict, privacy: .public)"
+        )
+        scheduleSearchRetry()
+    }
+
+    func netServiceBrowserDidStopSearch(_ browser: NetServiceBrowser) {
+        // We never call `stop()` ourselves, so an unsolicited stop means the
+        // browse ended unexpectedly (e.g. mDNSResponder churn). Restart it
+        // under the same bounded backoff.
+        Self.logger.error("Bonjour browse stopped unexpectedly; restarting")
+        scheduleSearchRetry()
+    }
+
     func netServiceBrowser(
         _ browser: NetServiceBrowser,
         didFind service: NetService,
         moreComing: Bool
     ) {
+        // Finding a service proves the browse is healthy; re-arm the budget.
+        searchRetryCount = 0
         service.delegate = self
         resolvingServices[service.name] = service
         service.resolve(withTimeout: 5.0)

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateIdentityTests.swift
@@ -64,6 +64,7 @@ struct ChatWindowStateIdentityTests {
                 agentDescription: "A friendly remote helper",
                 address: "remote-addr",
                 host: "127.0.0.1",
+                resolvedIP: nil,
                 port: 1234,
                 supportsSecureChannel: true,
                 serviceName: "coco._osaurus._tcp."

--- a/Packages/OsaurusCore/Tests/Networking/BonjourTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/BonjourTests.swift
@@ -1,0 +1,198 @@
+//
+//  BonjourTests.swift
+//  OsaurusCoreTests
+//
+//  Covers the Bonjour audit remediation: live TXT-record updates vs republish,
+//  `osc`/address coupling in the advertised TXT, refusal of unverifiable
+//  (osc-without-address) peers at pairing, the `.local` → resolved-IP connect
+//  fallback, and the bounded browse/publish retry backoff.
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Advertised TXT record + republish decision
+
+@MainActor
+struct BonjourAdvertiserTXTTests {
+    @Test func txtRecord_omitsOscAndAddress_whenAddressless() {
+        let agent = Agent(name: "Local")
+        let fields = NetService.dictionary(fromTXTRecord: BonjourAdvertiser.txtRecord(for: agent))
+        // An addressless agent cannot complete a handshake, so it must NOT
+        // claim Secure Channel support.
+        #expect(fields["osc"] == nil)
+        #expect(fields["address"] == nil)
+        #expect(fields["id"] != nil)
+        #expect(fields["name"].flatMap { String(data: $0, encoding: .utf8) } == "Local")
+    }
+
+    @Test func txtRecord_includesOscAndAddress_whenAddressPresent() {
+        let agent = Agent(name: "Local", agentAddress: "0xABCDEF")
+        let fields = NetService.dictionary(fromTXTRecord: BonjourAdvertiser.txtRecord(for: agent))
+        #expect(fields["osc"].flatMap { String(data: $0, encoding: .utf8) } == "1")
+        #expect(fields["address"].flatMap { String(data: $0, encoding: .utf8) } == "0xABCDEF")
+    }
+
+    @Test func advertisementAction_publishesWhenNewOrNameChanged() {
+        let txt = Data("a".utf8)
+        #expect(
+            BonjourAdvertiser.advertisementAction(
+                hasService: false,
+                requestedName: nil,
+                publishedTXT: nil,
+                newName: "N",
+                newTXT: txt
+            ) == .publish
+        )
+        #expect(
+            BonjourAdvertiser.advertisementAction(
+                hasService: true,
+                requestedName: "Old",
+                publishedTXT: txt,
+                newName: "New",
+                newTXT: txt
+            ) == .publish
+        )
+    }
+
+    @Test func advertisementAction_updatesTXTWhenOnlyPayloadChanged() {
+        // The regression this guards: a description/address edit with an
+        // unchanged instance name must reach the wire (update in place) rather
+        // than be silently dropped.
+        #expect(
+            BonjourAdvertiser.advertisementAction(
+                hasService: true,
+                requestedName: "N",
+                publishedTXT: Data("old".utf8),
+                newName: "N",
+                newTXT: Data("new".utf8)
+            ) == .updateTXT
+        )
+    }
+
+    @Test func advertisementAction_noneWhenUnchanged() {
+        let txt = Data("same".utf8)
+        #expect(
+            BonjourAdvertiser.advertisementAction(
+                hasService: true,
+                requestedName: "N",
+                publishedTXT: txt,
+                newName: "N",
+                newTXT: txt
+            ) == .none
+        )
+    }
+
+    @Test func publishRetryDelay_backsOffAndCaps() {
+        #expect(BonjourAdvertiser.publishRetryDelay(attempt: 0) == 1)
+        #expect(BonjourAdvertiser.publishRetryDelay(attempt: 1) == 2)
+        #expect(BonjourAdvertiser.publishRetryDelay(attempt: 2) == 4)
+        #expect(BonjourAdvertiser.publishRetryDelay(attempt: 10) == 30)  // capped
+    }
+}
+
+// MARK: - DiscoveredAgent trust + connect helpers
+
+struct DiscoveredAgentTrustTests {
+    private func makeAgent(
+        address: String? = nil,
+        host: String? = "peer.local.",
+        resolvedIP: String? = nil,
+        osc: Bool = false
+    ) -> DiscoveredAgent {
+        DiscoveredAgent(
+            id: UUID(),
+            name: "Peer",
+            agentDescription: "",
+            address: address,
+            host: host,
+            resolvedIP: resolvedIP,
+            port: 1234,
+            supportsSecureChannel: osc,
+            serviceName: "peer._osaurus._tcp."
+        )
+    }
+
+    @Test func unverifiable_whenOscButNoAddress() {
+        #expect(makeAgent(address: nil, osc: true).isUnverifiableSecureChannelPeer)
+        #expect(makeAgent(address: "", osc: true).isUnverifiableSecureChannelPeer)
+    }
+
+    @Test func verifiable_whenOscWithAddress() {
+        #expect(makeAgent(address: "0xabc", osc: true).isUnverifiableSecureChannelPeer == false)
+    }
+
+    @Test func legacy_noOscNoAddress_isAllowed() {
+        // A genuine pre-Secure-Channel peer (plaintext) is not flagged.
+        #expect(makeAgent(address: nil, osc: false).isUnverifiableSecureChannelPeer == false)
+    }
+
+    @Test func addressFingerprint_shortensLongAddressButKeepsShortAsIs() {
+        let long = makeAgent(address: "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18")
+        let fp = try! #require(long.addressFingerprint)
+        #expect(fp.hasPrefix("0x"))
+        #expect(fp.contains("…"))
+        #expect(fp.count < long.address!.count)
+
+        #expect(makeAgent(address: "0x1234").addressFingerprint == "0x1234")
+        #expect(makeAgent(address: nil).addressFingerprint == nil)
+    }
+
+    @Test func connectHost_prefersHostThenResolvedIP() {
+        #expect(makeAgent(host: "mac.local.", resolvedIP: "10.0.0.5").connectHost == "mac.local.")
+        #expect(makeAgent(host: nil, resolvedIP: "10.0.0.5").connectHost == "10.0.0.5")
+        #expect(makeAgent(host: "", resolvedIP: "10.0.0.5").connectHost == "10.0.0.5")
+        #expect(makeAgent(host: nil, resolvedIP: nil).connectHost == nil)
+    }
+}
+
+// MARK: - BonjourBrowserCore pure helpers
+
+struct BonjourBrowserCoreTests {
+    private func ipv4Data(_ ip: String) -> Data {
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = UInt16(1234).bigEndian
+        _ = ip.withCString { inet_pton(AF_INET, $0, &addr.sin_addr) }
+        return withUnsafeBytes(of: addr) { Data($0) }
+    }
+
+    private func ipv6Data(_ ip: String) -> Data {
+        var addr = sockaddr_in6()
+        addr.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+        addr.sin6_family = sa_family_t(AF_INET6)
+        addr.sin6_port = UInt16(1234).bigEndian
+        _ = ip.withCString { inet_pton(AF_INET6, $0, &addr.sin6_addr) }
+        return withUnsafeBytes(of: addr) { Data($0) }
+    }
+
+    @Test func firstResolvedIP_returnsIPv4() {
+        #expect(BonjourBrowserCore.firstResolvedIP(from: [ipv4Data("192.168.1.42")]) == "192.168.1.42")
+    }
+
+    @Test func firstResolvedIP_prefersIPv4OverIPv6() {
+        let ip = BonjourBrowserCore.firstResolvedIP(from: [ipv6Data("2001:db8::1"), ipv4Data("10.0.0.5")])
+        #expect(ip == "10.0.0.5")
+    }
+
+    @Test func firstResolvedIP_fallsBackToIPv6() {
+        #expect(BonjourBrowserCore.firstResolvedIP(from: [ipv6Data("2001:db8::1")]) == "2001:db8::1")
+    }
+
+    @Test func firstResolvedIP_nilForEmptyOrNil() {
+        #expect(BonjourBrowserCore.firstResolvedIP(from: nil) == nil)
+        #expect(BonjourBrowserCore.firstResolvedIP(from: []) == nil)
+    }
+
+    @Test func searchRetryDelay_backsOffThenGivesUp() {
+        #expect(BonjourBrowserCore.searchRetryDelay(attempt: 0) == 1)
+        #expect(BonjourBrowserCore.searchRetryDelay(attempt: 1) == 2)
+        #expect(BonjourBrowserCore.searchRetryDelay(attempt: 4) == 16)
+        // Budget exhausted at maxSearchRetries.
+        #expect(BonjourBrowserCore.searchRetryDelay(attempt: BonjourBrowserCore.maxSearchRetries) == nil)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5145,7 +5145,16 @@ struct ChatView: View {
             .environment(\.theme, windowState.theme)
         }
         .sheet(item: $pendingDiscoveredAgent) { agent in
-            if agent.address != nil {
+            if agent.isUnverifiableSecureChannelPeer {
+                // Claims encryption (osc=1) but advertised no address to pin —
+                // an inconsistent advertisement (spoof, or a peer that needs to
+                // upgrade / assign an identity). Refuse rather than connect
+                // without any identity verification.
+                UnverifiablePeerSheet(agentName: agent.name) {
+                    pendingDiscoveredAgent = nil
+                }
+                .environment(\.theme, windowState.theme)
+            } else if agent.address != nil {
                 PairingSheet(agent: agent) { apiKey, isPermanent in
                     connectToDiscoveredAgent(agent, token: apiKey, isEphemeral: !isPermanent)
                     pendingDiscoveredAgent = nil
@@ -5222,8 +5231,11 @@ struct ChatView: View {
     }
 
     private func connectToDiscoveredAgent(_ agent: DiscoveredAgent, token: String, isEphemeral: Bool = true) {
-        // Strip trailing dot from mDNS hostnames (e.g. "device.local." -> "device.local")
-        let rawHost = agent.host ?? "localhost"
+        // Prefer the stable `.local` hostname, falling back to the resolved IP
+        // when it's missing (some networks block multicast `.local`
+        // resolution). Strip the trailing dot from mDNS hostnames
+        // (e.g. "device.local." -> "device.local").
+        let rawHost = agent.connectHost ?? "localhost"
         let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
         let manager = RemoteProviderManager.shared
 
@@ -6030,6 +6042,57 @@ extension ChatView {
     }
 }
 
+// MARK: - Unverifiable Peer Sheet
+
+/// Shown when a discovered peer claims Secure Channel support (`osc=1`) but
+/// advertised no crypto address to pin. We refuse the connection rather than
+/// proceed without any identity verification: a genuine, current Osaurus peer
+/// always advertises its address alongside `osc=1`, so this combination means
+/// either a spoofed advertisement or a peer that must upgrade / assign an
+/// identity. Refusal-only — there is no "connect anyway".
+private struct UnverifiablePeerSheet: View {
+    let agentName: String
+    let onClose: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.shield.fill")
+                        .font(theme.font(size: 16, weight: .semibold))
+                        .foregroundColor(theme.warningColor)
+                    Text("Can't verify \(agentName)", bundle: .module)
+                        .font(theme.font(size: 16, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                }
+
+                Text(
+                    "This agent advertised that it supports encryption but didn't include a verifiable identity, so it can't be paired securely. It may be impersonating another device, or the other device may need to update Osaurus.",
+                    bundle: .module
+                )
+                .font(theme.font(size: 13))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    onClose()
+                } label: {
+                    Text("Close", bundle: .module)
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 380)
+    }
+}
+
 // MARK: - Bonjour Token Sheet
 
 /// Sheet shown when the user selects a Bonjour-discovered remote agent.
@@ -6108,6 +6171,32 @@ private struct PairingSheet: View {
                 .font(theme.font(size: 13))
                 .foregroundColor(theme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Surface the cryptographic identity that pairing will pin and
+            // verify, so the user confirms *who* they're connecting to rather
+            // than trusting only the (unauthenticated) advertised display name.
+            if let fingerprint = agent.addressFingerprint {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.shield.fill")
+                        .font(theme.font(size: 13))
+                        .foregroundColor(theme.accentColor)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Verifying identity", bundle: .module)
+                            .font(theme.font(size: 11))
+                            .foregroundColor(theme.secondaryText)
+                        Text(fingerprint)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(theme.primaryText)
+                            .textSelection(.enabled)
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(theme.accentColor.opacity(0.08))
+                )
             }
 
             if let error = errorMessage {
@@ -6190,6 +6279,7 @@ private enum PairingClient {
         case denied
         case challengeFailed
         case identityMismatch
+        case unverifiablePeer
 
         var errorDescription: String? {
             switch self {
@@ -6201,11 +6291,23 @@ private enum PairingClient {
             case .challengeFailed: return "Could not obtain a pairing challenge from the remote device."
             case .identityMismatch:
                 return "The remote device could not prove it owns the discovered agent identity."
+            case .unverifiablePeer:
+                return
+                    "This agent claims to support encryption but didn't advertise a verifiable identity, so pairing was refused."
             }
         }
     }
 
     static func pair(with agent: DiscoveredAgent) async throws -> (apiKey: String, isPermanent: Bool) {
+        // Defense-in-depth: refuse a peer claiming Secure Channel support
+        // (osc=1) that advertised no address to pin. The address-gated
+        // verification below would otherwise be skipped entirely, leaving the
+        // server unauthenticated. (The sheet routing already diverts these to
+        // a refusal view; this guard fails closed if pair() is ever reached.)
+        guard !agent.isUnverifiableSecureChannelPeer else {
+            throw PairingError.unverifiablePeer
+        }
+
         let context = LAContext()
         context.touchIDAuthenticationAllowableReuseDuration = 300
 
@@ -6218,7 +6320,9 @@ private enum PairingClient {
 
         let connectorAddress = try PairingKey.deriveAddress(masterKey: masterKey)
 
-        let rawHost = agent.host ?? ""
+        // Prefer the `.local` hostname; fall back to the resolved IP when the
+        // peer advertised no hostname (or it can't be resolved on this network).
+        let rawHost = agent.connectHost ?? ""
         guard !rawHost.isEmpty else { throw PairingError.missingHost }
         let host = rawHost.hasSuffix(".") ? String(rawHost.dropLast()) : rawHost
 

--- a/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/SharedHeaderComponents.swift
@@ -422,6 +422,11 @@ struct AgentPill: View {
         }
         .onChange(of: isPopoverPresented) { _, presented in
             if presented {
+                // Lazily begin LAN peer discovery the moment the picker (the
+                // only surface that lists discovered agents) opens, so users
+                // who never open it don't trigger an always-on mDNS browse or
+                // the Local Network permission prompt. Idempotent.
+                BonjourBrowser.shared.startIfNeeded()
                 keyboard.start(
                     itemCount: menuItemCount,
                     initialIndex: initialHighlightIndex,


### PR DESCRIPTION
## Summary

Closes the gaps found in the Bonjour audit. The Secure Channel core (`SecureChannel.swift`) is **unchanged**; these fixes target the discovery/advertisement layer around it.

**Security**
- `BonjourAdvertiser.txtRecord`: advertise `osc=1` (Secure Channel support) **only** when the agent has a derived crypto address. Addressless agents no longer falsely claim encryption (they fail closed at run time, and the browser previously mislabeled them `supportsSecureChannel = true`).
- Pairing UI: the pairing sheet now surfaces the pinned crypto **fingerprint** (e.g. `0x742d35…bD18`) so the user verifies the cryptographic identity, not just the spoofable display name.
- Refuse `osc=1` peers that advertise **no** address (an inconsistent/spoofed advert) via a dedicated refusal sheet, with a fail-closed guard in `PairingClient.pair` instead of silently skipping server identity verification.

**Reliability**
- Propagate **live TXT updates**: `setTXTRecord` on the live `NetService` when only the payload changes (instance name unchanged), so `description`/`address` edits actually reach the wire. Stop/republish only on a real name change.
- Handle browse `didNotSearch`/`didStopSearch` and publish `didNotPublish` with logging and **bounded exponential backoff** (covers denied Local Network permission and mDNSResponder drops).

**Discoverability / privacy**
- Start the mDNS browse **lazily** when the agent picker opens, instead of always-on at launch — avoids the Local Network permission prompt and resource use for users who never use peer discovery.
- Fall back to a resolved **IP** (`service.addresses`, IPv4-preferred) when the `.local` hostname is missing or unresolvable on the current network.

**Out of scope (by design):** `local.`-only LAN domain, and cleartext TXT broadcast inherent to mDNS. The optional `NWListener`/`NWBrowser` migration was evaluated and deferred (the legacy path is now correct and tested; a rewrite isn't warranted for this remediation).

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` compiles clean.
- [x] New `Tests/Networking/BonjourTests.swift`: TXT republish decision matrix, `osc`/address coupling, unverifiable-peer predicate, fingerprint/`connectHost`, IPv4/IPv6 parsing, and retry backoff.
- [x] Blast-radius suite green (Bonjour, Pairing, Secure Channel, discovery, chat identity): **71 tests / 17 suites passed**.
- [ ] Manual: edit an advertised agent's description → confirm peers see the update without a name change.
- [ ] Manual: open the agent picker on a second device → confirm discovery starts lazily and the pairing sheet shows the fingerprint.

Made with [Cursor](https://cursor.com)