### PR TITLE
Harden Computer Use secure field redaction

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
@@ -391,6 +391,11 @@ final class AccessibilityManager: @unchecked Sendable {
         let app = Self.axApp(pid)
 
         func readableLength(_ element: AXUIElement) -> Int {
+            if let role = axCopyAttribute(element, kAXRoleAttribute as String) as? String,
+                ComputerUseSecureFieldRedaction.isSecureRole(role)
+            {
+                return 0
+            }
             guard let value = axCopyAttribute(element, kAXValueAttribute as String) as? String
             else { return 0 }
             return value.trimmingCharacters(in: .whitespacesAndNewlines).count
@@ -555,6 +560,9 @@ final class AccessibilityManager: @unchecked Sendable {
         "colorwell",
         "searchfield",
         "securetextfield",
+        "securefield",
+        "passwordfield",
+        "password",
         "row",
         "cell",
         "outline",
@@ -809,14 +817,18 @@ final class AccessibilityManager: @unchecked Sendable {
             ?? nonEmpty(pairedTitleValue) ?? nonEmpty(help)
 
         let roleDescription = nonEmpty(getAttribute(element, kAXRoleDescriptionAttribute) as? String)
-        let value = stringifyValue(getAttribute(element, kAXValueAttribute))
+        let isSecureField = ComputerUseSecureFieldRedaction.isSecureRole(normalizedRole)
+        let value =
+            isSecureField
+            ? nil
+            : stringifyValue(getAttribute(element, kAXValueAttribute))
         let placeholder = nonEmpty(getAttribute(element, kAXPlaceholderValueAttribute) as? String)
         // Selection only exists on text-bearing roles; gate the extra AX read
         // to those so a 200-element traversal doesn't pay an IPC per button for
         // an attribute it can't have. Secure fields are excluded so a password
         // selection is never captured.
         let selectedText =
-            Self.textSelectionRoles.contains(normalizedRole)
+            !isSecureField && Self.textSelectionRoles.contains(normalizedRole)
             ? nonEmpty(getAttribute(element, kAXSelectedTextAttribute) as? String)
             : nil
 
@@ -1073,14 +1085,19 @@ func computeFocusDelta(pid: Int32) -> FocusDelta? {
         var valueRef: CFTypeRef?
         AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
         AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleRef)
-        AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
         let rawRole = (roleRef as? String) ?? "unknown"
         let role = AccessibilityManager.normalizeRole(rawRole)
         let label = (titleRef as? String).flatMap { $0.isEmpty ? nil : $0 }
-        let value: String? = {
-            if let s = valueRef as? String { return s.isEmpty ? nil : s }
-            return nil
-        }()
+        let value: String?
+        if ComputerUseSecureFieldRedaction.isSecureRole(role) {
+            value = nil
+        } else {
+            AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef)
+            value = {
+                if let s = valueRef as? String { return s.isEmpty ? nil : s }
+                return nil
+            }()
+        }
         focused = FocusedElementSummary(role: role, label: label, value: value)
     }
 
@@ -1162,7 +1179,7 @@ func computeFocusedContent(
 
     // Never read the contents (value/selection/viewport) of a secure field —
     // that's a password.
-    if role == "securetextfield" {
+    if ComputerUseSecureFieldRedaction.isSecureRole(role) {
         if role == "unknown", label == nil, placeholder == nil { return nil }
         return FocusedContentInfo(
             role: role,

--- a/Packages/OsaurusCore/ComputerUse/Model/AgentView.swift
+++ b/Packages/OsaurusCore/ComputerUse/Model/AgentView.swift
@@ -184,7 +184,7 @@ public struct AgentView: Sendable, Equatable {
     private static func visibleValue(for element: CUElement) -> String? {
         // Secure fields are never diffed by value; a change marker would reveal
         // that secret input changed even when the value itself is hidden.
-        CUSecureFieldRole.contains(element.role) ? nil : element.value
+        ComputerUseSecureFieldRedaction.value(role: element.role, element.value)
     }
 
     // MARK: Model rendering

--- a/Packages/OsaurusCore/ComputerUse/Model/SecureFieldRedaction.swift
+++ b/Packages/OsaurusCore/ComputerUse/Model/SecureFieldRedaction.swift
@@ -1,0 +1,34 @@
+//
+//  SecureFieldRedaction.swift
+//  OsaurusCore — Computer Use
+//
+//  Shared role guard for AX password fields. Native traversal should avoid
+//  reading their contents, and model-facing renderers should drop any secure
+//  value that reaches them through a mock or future capture path.
+//
+
+import Foundation
+
+enum ComputerUseSecureFieldRedaction {
+    static let roles: Set<String> = [
+        "securetextfield",
+        "axsecuretextfield",
+        "securefield",
+        "passwordfield",
+        "password",
+    ]
+
+    static func isSecureRole(_ role: String) -> Bool {
+        let lower = role.lowercased()
+        let normalized = lower.hasPrefix("ax") ? String(lower.dropFirst(2)) : lower
+        return roles.contains(lower) || roles.contains(normalized)
+    }
+
+    static func value(role: String, _ value: String?) -> String? {
+        isSecureRole(role) ? nil : value
+    }
+
+    static func selectedText(role: String, _ selectedText: String?) -> String? {
+        isSecureRole(role) ? nil : selectedText
+    }
+}

--- a/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
+++ b/Packages/OsaurusCore/ComputerUse/Perception/ScreenContextDistiller.swift
@@ -295,7 +295,7 @@ public struct ScreenContextDistiller: Sendable {
             // Secure fields: never surface value/selection/viewport even if the
             // driver somehow read one (it shouldn't). Defense-in-depth so a
             // password never reaches the model via screen context.
-            let isSecure = CUSecureFieldRole.contains(direct.role)
+            let isSecure = ComputerUseSecureFieldRedaction.isSecureRole(direct.role)
             let viewing = isSecure ? nil : contentValue(direct.viewport, limit: maxViewingChars)
             let value = isSecure ? nil : contentValue(direct.value, limit: maxValueChars)
             let selected = isSecure ? nil : contentValue(direct.selectedText, limit: maxValueChars)
@@ -316,7 +316,7 @@ public struct ScreenContextDistiller: Sendable {
             // Monaco's "editor is not accessible" label, a lone "/" viewport). For
             // an editor/input role, surface just the bare role — the user is
             // typing here, we simply can't read it — instead of dumping the junk.
-            if Self.rawInputRoles.contains(direct.role.lowercased()) {
+            if Self.isRawInputRole(direct.role) {
                 return ScreenContextSnapshot.FocusedElement(
                     role: friendlyRole(direct.role),
                     label: nil,
@@ -331,13 +331,14 @@ public struct ScreenContextDistiller: Sendable {
         guard let element = snapshot.elements.first(where: { $0.focused }) else { return nil }
         // Same secure-field guard on the breadth-limited traversal fallback: a
         // focused password field surfaces only its role/label, never its value.
-        let isSecure = CUSecureFieldRole.contains(element.role)
+        let isSecure = ComputerUseSecureFieldRedaction.isSecureRole(element.role)
         let value = isSecure ? nil : contentValue(element.value, limit: maxValueChars)
         let selected = isSecure ? nil : contentValue(element.selectedText, limit: maxValueChars)
         let label = labelValue(element.label, limit: maxItemChars)
         let placeholder = labelValue(element.placeholder, limit: maxItemChars)
         if value == nil, selected == nil, label == nil, placeholder == nil,
-            !Self.rawInputRoles.contains(element.role.lowercased()) {
+            !Self.isRawInputRole(element.role)
+        {
             return nil
         }
         return ScreenContextSnapshot.FocusedElement(
@@ -510,6 +511,10 @@ public struct ScreenContextDistiller: Sendable {
     ) -> (text: String, rank: ContentRank, weight: Int)? {
         let label = cleaned(element.label, limit: maxItemChars)
         let area = Self.clampedArea(element.w, element.h)
+        if ComputerUseSecureFieldRedaction.isSecureRole(element.role) {
+            guard let label else { return nil }
+            return ("\(label): (hidden)", .input, area)
+        }
         // "Large" = occupies a meaningful fraction of the focused window, the
         // signature of a document/editor body vs. a sidebar label.
         let isLarge = windowArea > 0 && area * 100 >= windowArea * 12
@@ -538,9 +543,6 @@ public struct ScreenContextDistiller: Sendable {
             guard let value = cleaned(element.value, limit: limit) else { return nil }
             if looksLikeBareToken(value) { return nil }
             return (label.map { "\($0): \(value)" } ?? value, .mainContent, area)
-        case "securetextfield":
-            guard let label else { return nil }
-            return ("\(label): (hidden)", .input, area)
         case "textfield", "searchfield", "combobox":
             // Non-focused inputs only matter when they already hold something.
             guard let value = cleaned(element.value, limit: maxValueChars) else { return nil }
@@ -627,8 +629,16 @@ public struct ScreenContextDistiller: Sendable {
     /// Raw (pre-`friendlyRole`) AX roles for text inputs / editors. Used to keep
     /// a "Focused field: <role>" line even when the content is unreadable.
     private static let rawInputRoles: Set<String> = [
-        "textfield", "textarea", "searchfield", "securetextfield", "combobox",
+        "textfield", "textarea", "searchfield", "combobox",
     ]
+
+    private static func isRawInputRole(_ role: String) -> Bool {
+        let lower = role.lowercased()
+        let normalized = lower.hasPrefix("ax") ? String(lower.dropFirst(2)) : lower
+        return rawInputRoles.contains(lower)
+            || rawInputRoles.contains(normalized)
+            || ComputerUseSecureFieldRedaction.isSecureRole(role)
+    }
 
     /// Characters that carry no signal alone: keyboard-shortcut glyphs plus the
     /// brackets/spaces that wrap them in hints like "(⌘J)". A string made only
@@ -892,11 +902,13 @@ public struct ScreenContextDistiller: Sendable {
     ]
 
     private func friendlyRole(_ role: String) -> String {
+        if ComputerUseSecureFieldRedaction.isSecureRole(role) {
+            return "secure field"
+        }
         switch role.lowercased() {
         case "textfield": return "text field"
         case "textarea": return "text area"
         case "searchfield": return "search field"
-        case "securetextfield": return "secure field"
         case "combobox": return "combo box"
         case "popupbutton": return "pop-up button"
         case "statictext", "staticrtext": return "text"

--- a/Packages/OsaurusCore/Tests/ComputerUse/Model/AgentViewTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Model/AgentViewTests.swift
@@ -158,6 +158,7 @@ final class AgentViewTests: XCTestCase {
             from: snapshot([
                 el("email", "textfield", "Email", value: "ops@example.com"),
                 el("password", "securetextfield", "Password", value: "p@ssw0rd-do-not-leak"),
+                el("token", "AXSecureTextField", "API token", value: "sk-secret"),
             ]),
             previous: nil
         )
@@ -167,7 +168,10 @@ final class AgentViewTests: XCTestCase {
         XCTAssertTrue(render.contains("ops@example.com"))
         XCTAssertTrue(render.contains("Password"))
         XCTAssertFalse(render.contains("p@ssw0rd-do-not-leak"))
+        XCTAssertTrue(render.contains("API token"))
+        XCTAssertFalse(render.contains("sk-secret"))
         XCTAssertNil(view.items.first(where: { $0.elementId == "password" })?.value)
+        XCTAssertNil(view.items.first(where: { $0.elementId == "token" })?.value)
     }
 
     func testSecureFieldValueChangeDoesNotRenderMarker() {
@@ -177,6 +181,22 @@ final class AgentViewTests: XCTestCase {
         )
         let next = AgentView.build(
             from: snapshot([el("password", "securetextfield", "Password", value: "new-secret")], id: 2),
+            previous: prev
+        )
+
+        XCTAssertFalse(next.hasChanges)
+        XCTAssertFalse(next.items.first?.changed ?? true)
+        XCTAssertFalse(next.renderForModel().contains("* ["))
+        XCTAssertFalse(next.renderForModel().contains("new-secret"))
+    }
+
+    func testSecureFieldAliasValueChangeDoesNotRenderMarker() {
+        let prev = AgentView.build(
+            from: snapshot([el("password", "securefield", "Password", value: "old-secret")]),
+            previous: nil
+        )
+        let next = AgentView.build(
+            from: snapshot([el("password", "securefield", "Password", value: "new-secret")], id: 2),
             previous: prev
         )
 

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/ScreenContextDistillerTests.swift
@@ -1130,6 +1130,7 @@ final class ScreenContextDistillerTests: XCTestCase {
         XCTAssertNil(snap.focusedElement?.value)
         XCTAssertNil(snap.focusedElement?.selectedText)
         XCTAssertFalse(snap.render().contains(secret))
+        XCTAssertEqual(snap.focusedElement?.role, "secure field")
         XCTAssertFalse(snap.sampledContents.contains { $0.contains(secret) })
     }
 }


### PR DESCRIPTION
## Summary
- Redacts secure-field values earlier in the built-in Computer Use perception path.
- Preserves non-sensitive Accessibility structure so `computer_use(goal:)` can still resolve targets.
- Adds focused coverage for AgentView redaction and screen-context distillation.

## Why
Computer Use is now the canonical in-core harness for macOS automation. This keeps sensitive text out of the high-fidelity local loop while retaining enough structure for fast target resolution.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-computer-use-pr-validation swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUse`