### PR TITLE
Keep Computer Use model loop on device

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseModelPrivacy.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseModelPrivacy.swift
@@ -1,0 +1,42 @@
+//
+//  ComputerUseModelPrivacy.swift
+//  OsaurusCore -- Computer Use
+//
+//  Privacy boundary for the nested computer-use model loop. The loop prompt
+//  carries AX-derived screen state (`AgentView`) and, after escalation, may
+//  carry screenshots. Until there is a consented, redacted remote projection
+//  for that whole prompt, the sub-agent itself must run on-device.
+//
+
+import Foundation
+
+enum ComputerUseModelPrivacy {
+    typealias InstalledModelResolver = @Sendable (String) -> Bool
+
+    static func isOnDeviceModel(
+        _ modelId: String,
+        installedModelResolver: InstalledModelResolver = {
+            ModelManager.findInstalledModel(named: $0) != nil
+        }
+    ) -> Bool {
+        let id = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !id.isEmpty else { return false }
+        if id.caseInsensitiveCompare("default") == .orderedSame { return true }
+        if id.caseInsensitiveCompare(FoundationModelService.serviceId) == .orderedSame { return true }
+        return installedModelResolver(id)
+    }
+
+    static func remoteModelFailureEnvelope(modelId: String, tool: String) -> String {
+        ToolEnvelope.failure(
+            kind: .unavailable,
+            message: remoteModelFailureMessage(modelId: modelId),
+            tool: tool,
+            retryable: false
+        )
+    }
+
+    static func remoteModelFailureMessage(modelId: String) -> String {
+        "Computer Use is local-only for screen privacy. The selected model '\(modelId)' appears to be remote, and the computer-use sub-agent would need AX-derived screen state to decide each step. "
+            + "Select an on-device Foundation or installed MLX model, then try again."
+    }
+}

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -131,6 +131,14 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             defaultModel: { AgentManager.shared.effectiveModel(for: agentId) }
         )
         let modelId = resolved.model
+        let modelIsLocal = await MainActor.run {
+            ComputerUseModelPrivacy.isOnDeviceModel(modelId)
+        }
+        guard modelIsLocal else {
+            throw SubagentError.unavailable(
+                ComputerUseModelPrivacy.remoteModelFailureMessage(modelId: modelId)
+            )
+        }
         // Snapshot the run rules from the RESOLVED model in a second main-actor
         // hop: the agent's autonomy ceiling, a snapshot of the user policy, and
         // the vision context (image support + local-vs-cloud posture +
@@ -141,7 +149,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             let policy = ComputerUsePolicyStore.load()
             let vision = VisionContext(
                 modelAcceptsImages: ComputerUseTool.modelAcceptsImages(modelId),
-                modelIsLocal: ModelManager.findInstalledModel(named: modelId) != nil,
+                modelIsLocal: modelIsLocal,
                 cloudConsent: CloudVisionConsent.shared.isGranted,
                 cloudScrubMode: CloudVisionConsent.shared.scrubMode
             )

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopTests.swift
@@ -49,3 +49,43 @@ final class ComputerUsePolicySummaryTests: XCTestCase {
         XCTAssertFalse(summary.contains("capped at"))
     }
 }
+
+final class ComputerUseModelPrivacyTests: XCTestCase {
+    func testAllowsFoundationAliasesAndInstalledMLXModels() {
+        let installed: ComputerUseModelPrivacy.InstalledModelResolver = { model in
+            model == "local-qwen" || model == "org/local-qwen"
+        }
+
+        XCTAssertTrue(
+            ComputerUseModelPrivacy.isOnDeviceModel("default", installedModelResolver: installed)
+        )
+        XCTAssertTrue(
+            ComputerUseModelPrivacy.isOnDeviceModel("foundation", installedModelResolver: installed)
+        )
+        XCTAssertTrue(
+            ComputerUseModelPrivacy.isOnDeviceModel("local-qwen", installedModelResolver: installed)
+        )
+        XCTAssertTrue(
+            ComputerUseModelPrivacy.isOnDeviceModel("org/local-qwen", installedModelResolver: installed)
+        )
+    }
+
+    func testBlocksRemoteProviderPrefixedModelsForAXPrivacy() {
+        let installed: ComputerUseModelPrivacy.InstalledModelResolver = { _ in false }
+
+        XCTAssertFalse(
+            ComputerUseModelPrivacy.isOnDeviceModel("openai/gpt-4o", installedModelResolver: installed)
+        )
+        XCTAssertFalse(
+            ComputerUseModelPrivacy.isOnDeviceModel("osaurus-router/gemma-4", installedModelResolver: installed)
+        )
+
+        let envelope = ComputerUseModelPrivacy.remoteModelFailureEnvelope(
+            modelId: "openai/gpt-4o",
+            tool: ComputerUseTool.toolName
+        )
+        XCTAssertTrue(envelope.contains("local-only"))
+        XCTAssertTrue(envelope.contains("AX-derived screen state"))
+        XCTAssertTrue(envelope.contains(ComputerUseTool.toolName))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an explicit model-privacy policy for the built-in Computer Use sub-agent.
- Blocks remote/provider-prefixed model ids for AX-derived screen state.
- Covers local Foundation/MLX allowance and remote failure envelope behavior.

## Why
The maintainer direction makes the in-core loop the Computer Use source of truth. This PR makes that loop local-first by construction so private screen state does not silently leave the Mac.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-computer-use-pr-validation swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUse`