### PR TITLE
Use public marks in Computer Use SOM screenshots

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Accessibility.swift
@@ -65,6 +65,33 @@ enum SnapshotIdFormat {
         else { return nil }
         return (snap, el)
     }
+
+    static func publicMark(from id: String) -> Int? {
+        guard let parsed = parse(id), parsed.element > 0 else { return nil }
+        return parsed.element
+    }
+
+    /// Canonical public marks for a snapshot-ordered id list. Valid positive
+    /// snapshot ids keep their encoded mark; malformed, zero, or duplicate ids
+    /// receive collision-free fallback marks that never steal a valid mark.
+    static func publicMarks(for ids: [String]) -> [Int] {
+        let reserved = Set(ids.compactMap(publicMark(from:)))
+        var used: Set<Int> = []
+        var nextFallback = 1
+        return ids.map { id in
+            if let parsed = publicMark(from: id), !used.contains(parsed) {
+                used.insert(parsed)
+                return parsed
+            }
+            while reserved.contains(nextFallback) || used.contains(nextFallback) {
+                nextFallback += 1
+            }
+            let fallback = nextFallback
+            used.insert(fallback)
+            nextFallback += 1
+            return fallback
+        }
+    }
 }
 
 // MARK: - Element Info
@@ -503,7 +530,9 @@ final class AccessibilityManager: @unchecked Sendable {
     }
 
     /// Returns elements from the most recent snapshot for a given pid.
-    /// Used by annotated screenshots.
+    /// Used by annotated screenshots. The production cache contains generated
+    /// snapshot ids, so public marks are derived from those ids by the overlay
+    /// renderer and display-order sorting happens after mark assignment.
     func mostRecentElements(for pid: Int32) -> [(id: String, frame: CGRect)] {
         lock.lock()
         let snapshotId: Int? =

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
@@ -102,9 +102,8 @@ func buildCapture(
         var opts = ScreenshotOptions()
         opts.pid = pid
         if let wid = windowId { opts.windowId = CGWindowID(wid) }
-        // SOM annotation reuses the existing element-id overlay; the agent
-        // gets both the numeric index in `elements[]` and the visual id label
-        // burned onto the image.
+        // SOM annotation burns the same public numeric mark shown in
+        // `elements[]` onto the image. Internal AX ids stay out of pixels.
         opts.annotate = (mode == .som)
         imageContent = await ScreenshotController.shared.capture(options: opts)
     }

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/CaptureMode.swift
@@ -17,10 +17,10 @@ import Foundation
 //             with rich AX trees.
 //   .vision — screenshot only, no AX tree. Smallest payload for
 //             vision-first VLMs that ground on pixels.
-//   .som    — set-of-mark: AX tree + screenshot, with element-id
+//   .som    — set-of-mark: AX tree + screenshot, with public mark
 //             numbers drawn on every actionable element. Default: lets
 //             pixel-grounded models reason visually while still using
-//             stable element ids for clicks.
+//             stable public marks for clicks.
 
 enum CaptureMode: String, Codable, Sendable {
     case ax
@@ -37,13 +37,13 @@ enum CaptureMode: String, Codable, Sendable {
 
 // MARK: - SOM Result
 //
-// `elementIndex` is the cua-style addressing layer: a stable integer per
-// element in display order, useful for vision-first agents that don't want to
-// parse `s7-42` ids.
+// `elementIndex` is the CUA-style public mark: a snapshot-scoped stable integer
+// derived from the snapshot id when available, useful for vision-first agents
+// that don't want to parse `s7-42` ids.
 
-/// One actionable element annotated with both its snapshot id and its
-/// SOM-mode index. The agent can use either to address the element in
-/// follow-up clicks.
+/// One actionable element annotated with its snapshot id and public SOM mark.
+/// The agent addresses the element by mark; the raw id is an internal resolver
+/// handle and must not be rendered into model text or screenshot pixels.
 struct SOMElementRef: Sendable {
     let elementIndex: Int
     let id: String
@@ -84,9 +84,10 @@ func buildCapture(
         return AccessibilityManager.shared.traverse(filter: filter)
     }
 
+    let publicMarks = SnapshotIdFormat.publicMarks(for: snapshot.elements.map(\.id))
     let elementRefs: [SOMElementRef] = snapshot.elements.enumerated().map { idx, info in
         SOMElementRef(
-            elementIndex: idx + 1,
+            elementIndex: publicMarks[idx],
             id: info.id,
             role: info.role,
             label: info.label,

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Screenshot.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Screenshot.swift
@@ -65,8 +65,8 @@ struct ScreenshotOptions: Decodable {
     /// If specified, save screenshot to this file path in addition to returning bytes.
     var savePath: String?
 
-    /// If true, overlay element IDs from the most recent snapshot (matched by pid).
-    /// Useful for vision-augmented agents to reference IDs straight from the image.
+    /// If true, overlay public marks from the most recent snapshot (matched by pid).
+    /// Useful for vision-augmented agents to reference `target.mark` from the image.
     /// Requires `pid` to be set, and that get_ui_elements has been called for that pid.
     var annotate: Bool?
 
@@ -451,16 +451,12 @@ struct SOMOverlayMark: Sendable, Equatable {
 }
 
 enum SOMOverlayRenderer {
-    /// Convert cached snapshot ids (`s<snapshot>-<element>`) into public marks.
-    /// Sorting by the encoded element number makes the overlay match
-    /// `AgentView`/`SOMResult` mark order even though the cache is dictionary
-    /// backed.
+    /// Convert cached snapshot ids (`s<snapshot>-<element>`) into the same
+    /// public marks used by `AgentView` and `SOMResult`.
     static func publicMarks(from elements: [(id: String, frame: CGRect)]) -> [SOMOverlayMark] {
-        elements.compactMap { element -> SOMOverlayMark? in
-            guard let parsed = SnapshotIdFormat.parse(element.id), parsed.element > 0 else {
-                return nil
-            }
-            return SOMOverlayMark(mark: parsed.element, frame: element.frame)
+        let marks = SnapshotIdFormat.publicMarks(for: elements.map(\.id))
+        return zip(elements, marks).map { element, mark in
+            SOMOverlayMark(mark: mark, frame: element.frame)
         }
         .sorted { lhs, rhs in lhs.mark < rhs.mark }
     }

--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/Screenshot.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/Screenshot.swift
@@ -4,7 +4,7 @@
 //
 //  Native macOS driver, brought in-core from osaurus-ai/osaurus-macos-use.
 //  Backgrounded window/display capture (works on occluded / off-Space windows)
-//  with optional element-id annotation overlay.
+//  with optional public-mark annotation overlay.
 //
 //  Refactored for in-core use: the original MCP `CallToolResult` content
 //  envelope was dropped in favor of a plain `CapturedImage` value the harness
@@ -169,7 +169,7 @@ final class ScreenshotController: @unchecked Sendable {
             return nil
         }
 
-        // Optionally annotate with element IDs before scaling so labels stay legible.
+        // Optionally annotate with public marks before scaling so labels stay legible.
         let annotatedImage: CGImage = {
             if options.annotate == true {
                 // When the caller passed a windowId, use that to compute the
@@ -183,9 +183,9 @@ final class ScreenshotController: @unchecked Sendable {
                     options.windowId.flatMap { captureBoundsForWindowId($0)?.origin }
                     ?? captureBoundsForPid(pid)?.origin
                 if let origin = captureOrigin,
-                    let overlaid = overlayElementIds(
+                    let overlaid = SOMOverlayRenderer.overlay(
                         on: cgImage,
-                        elements: elements,
+                        marks: SOMOverlayRenderer.publicMarks(from: elements),
                         captureOrigin: origin
                     )
                 {
@@ -443,81 +443,108 @@ final class ScreenshotController: @unchecked Sendable {
 
 // MARK: - Annotation Overlay
 
-/// Draws element-ID labels on top of `image` so vision-capable agents can
-/// reference IDs visually. `captureOrigin` is the screen-space origin of the
-/// capture so we can subtract it from each element's global AX coordinates.
-private func overlayElementIds(
-    on image: CGImage,
-    elements: [(id: String, frame: CGRect)],
-    captureOrigin: CGPoint
-) -> CGImage? {
-    let width = image.width
-    let height = image.height
-    guard width > 0, height > 0, !elements.isEmpty else { return image }
+/// Public mark plus frame, the only data the SOM overlay renderer is allowed
+/// to see. Labels, values, paths, and raw AX ids stay out of the pixel channel.
+struct SOMOverlayMark: Sendable, Equatable {
+    let mark: Int
+    let frame: CGRect
+}
 
-    guard
-        let context = CGContext(
-            data: nil,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: 0,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        )
-    else { return nil }
-
-    // Draw original image
-    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
-
-    // Set up colors: red boxes, white text on red
-    let boxStroke = CGColor(red: 1.0, green: 0.1, blue: 0.1, alpha: 0.95)
-    let labelFill = CGColor(red: 1.0, green: 0.1, blue: 0.1, alpha: 0.85)
-    context.setStrokeColor(boxStroke)
-    context.setLineWidth(1.5)
-
-    let nsContext = NSGraphicsContext(cgContext: context, flipped: false)
-    NSGraphicsContext.saveGraphicsState()
-    NSGraphicsContext.current = nsContext
-
-    let font = NSFont.boldSystemFont(ofSize: 11)
-    let textAttrs: [NSAttributedString.Key: Any] = [
-        .font: font,
-        .foregroundColor: NSColor.white,
-    ]
-
-    for element in elements {
-        let f = element.frame
-        // Convert global top-left coords to image-local coords.
-        // CGContext is bottom-left origin; flip y.
-        let localX = f.origin.x - captureOrigin.x
-        let localTopY = f.origin.y - captureOrigin.y
-        let bottomY = CGFloat(height) - localTopY - f.size.height
-        let rect = CGRect(x: localX, y: bottomY, width: f.size.width, height: f.size.height)
-        if rect.maxX <= 0 || rect.maxY <= 0 || rect.minX >= CGFloat(width)
-            || rect.minY >= CGFloat(height)
-        {
-            continue
+enum SOMOverlayRenderer {
+    /// Convert cached snapshot ids (`s<snapshot>-<element>`) into public marks.
+    /// Sorting by the encoded element number makes the overlay match
+    /// `AgentView`/`SOMResult` mark order even though the cache is dictionary
+    /// backed.
+    static func publicMarks(from elements: [(id: String, frame: CGRect)]) -> [SOMOverlayMark] {
+        elements.compactMap { element -> SOMOverlayMark? in
+            guard let parsed = SnapshotIdFormat.parse(element.id), parsed.element > 0 else {
+                return nil
+            }
+            return SOMOverlayMark(mark: parsed.element, frame: element.frame)
         }
-
-        context.stroke(rect)
-
-        // Draw a small label in the top-left of the element with the id
-        let labelText = element.id
-        let attributed = NSAttributedString(string: labelText, attributes: textAttrs)
-        let textSize = attributed.size()
-        let pad: CGFloat = 2
-        let labelRect = CGRect(
-            x: rect.minX,
-            y: rect.maxY - textSize.height - pad * 2,
-            width: textSize.width + pad * 2,
-            height: textSize.height + pad * 2
-        )
-        context.setFillColor(labelFill)
-        context.fill(labelRect)
-        attributed.draw(at: CGPoint(x: labelRect.minX + pad, y: labelRect.minY + pad))
+        .sorted { lhs, rhs in lhs.mark < rhs.mark }
     }
 
-    NSGraphicsContext.restoreGraphicsState()
-    return context.makeImage()
+    /// The exact label text burned into a SOM image. Keep this to the public
+    /// integer mark only: no AX id, label, value, role, or path.
+    static func label(for mark: Int) -> String {
+        "\(mark)"
+    }
+
+    /// Draws public mark labels on top of `image` so vision-capable agents can
+    /// reference `target.mark` visually. `captureOrigin` is the screen-space
+    /// origin of the capture so we can subtract it from each element's global
+    /// AX coordinates.
+    static func overlay(
+        on image: CGImage,
+        marks: [SOMOverlayMark],
+        captureOrigin: CGPoint
+    ) -> CGImage? {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0, !marks.isEmpty else { return image }
+
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else { return nil }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let boxStroke = CGColor(red: 1.0, green: 0.1, blue: 0.1, alpha: 0.95)
+        let labelFill = CGColor(red: 1.0, green: 0.1, blue: 0.1, alpha: 0.85)
+        context.setStrokeColor(boxStroke)
+        context.setLineWidth(1.5)
+
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: false)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = nsContext
+
+        let font = NSFont.boldSystemFont(ofSize: 11)
+        let textAttrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white,
+        ]
+
+        for mark in marks {
+            let f = mark.frame
+            // Convert global top-left coords to image-local coords.
+            // CGContext is bottom-left origin; flip y.
+            let localX = f.origin.x - captureOrigin.x
+            let localTopY = f.origin.y - captureOrigin.y
+            let bottomY = CGFloat(height) - localTopY - f.size.height
+            let rect = CGRect(x: localX, y: bottomY, width: f.size.width, height: f.size.height)
+            if rect.maxX <= 0 || rect.maxY <= 0 || rect.minX >= CGFloat(width)
+                || rect.minY >= CGFloat(height)
+            {
+                continue
+            }
+
+            context.stroke(rect)
+
+            let labelText = label(for: mark.mark)
+            let attributed = NSAttributedString(string: labelText, attributes: textAttrs)
+            let textSize = attributed.size()
+            let pad: CGFloat = 2
+            let labelRect = CGRect(
+                x: rect.minX,
+                y: rect.maxY - textSize.height - pad * 2,
+                width: textSize.width + pad * 2,
+                height: textSize.height + pad * 2
+            )
+            context.setFillColor(labelFill)
+            context.fill(labelRect)
+            attributed.draw(at: CGPoint(x: labelRect.minX + pad, y: labelRect.minY + pad))
+        }
+
+        NSGraphicsContext.restoreGraphicsState()
+        return context.makeImage()
+    }
 }

--- a/Packages/OsaurusCore/ComputerUse/Model/AgentAction.swift
+++ b/Packages/OsaurusCore/ComputerUse/Model/AgentAction.swift
@@ -80,7 +80,8 @@ public enum AgentVerb: String, Sendable, Codable, CaseIterable {
 /// to a natural-language `describe` the `TargetResolver` matches. At least
 /// one is required for element-addressed verbs.
 public struct AgentTarget: Sendable, Equatable {
-    /// 1-based index into the current `AgentView.items`.
+    /// Opaque public mark from the current `AgentView`, resolved with
+    /// `item(mark:)` rather than positional indexing.
     public let mark: Int?
     /// Natural-language fallback (role + label), matched when `mark` is
     /// absent or has gone stale.

--- a/Packages/OsaurusCore/ComputerUse/Model/AgentView.swift
+++ b/Packages/OsaurusCore/ComputerUse/Model/AgentView.swift
@@ -112,9 +112,11 @@ public struct AgentView: Sendable, Equatable {
         items.reserveCapacity(snapshot.elements.count)
         var consumed: [String: Int] = [:]  // how many of each key we've matched
 
+        let publicMarks = SnapshotIdFormat.publicMarks(for: snapshot.elements.map(\.id))
         for (index, element) in snapshot.elements.enumerated() {
             let key = matchKey(role: element.role, label: element.label)
             let visibleValue = visibleValue(for: element)
+            let mark = publicMarks[index]
             let changed: Bool
             if previous == nil {
                 changed = false
@@ -134,7 +136,7 @@ public struct AgentView: Sendable, Equatable {
 
             items.append(
                 AgentViewItem(
-                    mark: index + 1,
+                    mark: mark,
                     elementId: element.id,
                     role: element.role,
                     label: element.label,

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
@@ -30,6 +30,13 @@ final class MacDriverSnapshotIdTests: XCTestCase {
         XCTAssertNil(SnapshotIdFormat.parse("s7"))
         XCTAssertNil(SnapshotIdFormat.parse("sx-12"))
     }
+
+    func testPublicMarksUseParsedIdsWithCollisionFreeFallbacks() throws {
+        XCTAssertEqual(
+            SnapshotIdFormat.publicMarks(for: ["s9-2", "weird", "s9-2", "s9-0", "s9-1"]),
+            [2, 3, 4, 5, 1]
+        )
+    }
 }
 
 final class MacDriverKeyVocabularyTests: XCTestCase {
@@ -67,14 +74,96 @@ final class SOMOverlayRendererTests: XCTestCase {
     func testPublicMarksAreDerivedFromSnapshotIdsInMarkOrder() throws {
         let firstFrame = CGRect(x: 10, y: 20, width: 30, height: 40)
         let secondFrame = CGRect(x: 50, y: 60, width: 70, height: 80)
+        let fallbackFrame = CGRect(x: 1, y: 1, width: 1, height: 1)
         let marks = SOMOverlayRenderer.publicMarks(from: [
             (id: "s9-2", frame: secondFrame),
-            (id: "not-a-snapshot-id", frame: CGRect(x: 1, y: 1, width: 1, height: 1)),
+            (id: "not-a-snapshot-id", frame: fallbackFrame),
             (id: "s9-1", frame: firstFrame),
         ])
 
-        XCTAssertEqual(marks.map(\.mark), [1, 2])
-        XCTAssertEqual(marks.map(\.frame), [firstFrame, secondFrame])
+        XCTAssertEqual(marks.map(\.mark), [1, 2, 3])
+        XCTAssertEqual(marks.map(\.frame), [firstFrame, secondFrame, fallbackFrame])
+    }
+
+    func testOverlayMarksUseCanonicalFallbacksForMixedSnapshotIds() throws {
+        let firstFrame = CGRect(x: 10, y: 20, width: 30, height: 40)
+        let fallbackFrame = CGRect(x: 50, y: 60, width: 70, height: 80)
+        let duplicateFrame = CGRect(x: 90, y: 100, width: 30, height: 40)
+        let zeroFrame = CGRect(x: 130, y: 140, width: 30, height: 40)
+        let marks = SOMOverlayRenderer.publicMarks(from: [
+            (id: "s9-2", frame: firstFrame),
+            (id: "weird", frame: fallbackFrame),
+            (id: "s9-2", frame: duplicateFrame),
+            (id: "s9-0", frame: zeroFrame),
+        ])
+
+        XCTAssertEqual(marks.map(\.mark), [1, 2, 3, 4])
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: marks.map { (Int($0.frame.origin.x), $0.mark) }),
+            [
+                10: 2,
+                50: 1,
+                90: 3,
+                130: 4,
+            ]
+        )
+    }
+
+    func testOverlayMarksMatchRenderedAgentViewMarksForSameSnapshot() throws {
+        let snapshot = CUSnapshot(
+            snapshotId: 9,
+            pid: 4242,
+            app: "Mail",
+            focusedWindow: "Compose",
+            tier: .som,
+            truncated: false,
+            windows: [],
+            elements: [
+                CUElement(
+                    id: "s9-5",
+                    role: "textfield",
+                    label: "Subject",
+                    x: 50,
+                    y: 54,
+                    w: 240,
+                    h: 24
+                ),
+                CUElement(
+                    id: "s9-2",
+                    role: "button",
+                    label: "Send",
+                    x: 10,
+                    y: 20,
+                    w: 80,
+                    h: 24
+                ),
+            ],
+            image: nil
+        )
+        let view = AgentView.build(from: snapshot, previous: nil)
+        let overlayMarks = SOMOverlayRenderer.publicMarks(
+            from: snapshot.elements.map {
+                (
+                    id: $0.id,
+                    frame: CGRect(x: $0.x, y: $0.y, width: $0.w, height: $0.h)
+                )
+            }
+        )
+
+        XCTAssertEqual(Set(overlayMarks.map(\.mark)), Set(view.items.map(\.mark)))
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: overlayMarks.map { (Int($0.frame.origin.x), $0.mark) }),
+            [
+                10: 2,
+                50: 5,
+            ]
+        )
+        XCTAssertEqual(overlayMarks.map { SOMOverlayRenderer.label(for: $0.mark) }, ["2", "5"])
+        let renderedElements = view.renderForModel().split(separator: "\n")
+            .filter { $0.hasPrefix("  [") }
+            .map(String.init)
+        XCTAssertTrue(renderedElements.contains("  [2] button \"Send\""))
+        XCTAssertTrue(renderedElements.contains("  [5] textfield \"Subject\""))
     }
 
     func testOverlayLabelIsOnlyThePublicMark() throws {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
@@ -9,6 +9,7 @@
 //  exercised by the opt-in eval suite, not here.
 //
 
+import CoreGraphics
 import Foundation
 import XCTest
 
@@ -59,6 +60,65 @@ final class MacDriverCaptureModeTests: XCTestCase {
 
     func testCaptureTierMapsAllCases() throws {
         XCTAssertEqual(Set(CaptureTier.allCases), [.ax, .som, .vision])
+    }
+}
+
+final class SOMOverlayRendererTests: XCTestCase {
+    func testPublicMarksAreDerivedFromSnapshotIdsInMarkOrder() throws {
+        let firstFrame = CGRect(x: 10, y: 20, width: 30, height: 40)
+        let secondFrame = CGRect(x: 50, y: 60, width: 70, height: 80)
+        let marks = SOMOverlayRenderer.publicMarks(from: [
+            (id: "s9-2", frame: secondFrame),
+            (id: "not-a-snapshot-id", frame: CGRect(x: 1, y: 1, width: 1, height: 1)),
+            (id: "s9-1", frame: firstFrame),
+        ])
+
+        XCTAssertEqual(marks.map(\.mark), [1, 2])
+        XCTAssertEqual(marks.map(\.frame), [firstFrame, secondFrame])
+    }
+
+    func testOverlayLabelIsOnlyThePublicMark() throws {
+        let label = SOMOverlayRenderer.label(for: 42)
+        XCTAssertEqual(label, "42")
+        XCTAssertFalse(label.contains("s42"))
+        XCTAssertFalse(label.contains("-"))
+        XCTAssertFalse(label.localizedCaseInsensitiveContains("button"))
+    }
+
+    func testOverlayKeepsImageDimensions() throws {
+        let image = try makeSolidImage(width: 160, height: 120)
+        let overlaid = try XCTUnwrap(
+            SOMOverlayRenderer.overlay(
+                on: image,
+                marks: [
+                    SOMOverlayMark(
+                        mark: 1,
+                        frame: CGRect(x: 10, y: 10, width: 40, height: 30)
+                    )
+                ],
+                captureOrigin: .zero
+            )
+        )
+
+        XCTAssertEqual(overlaid.width, image.width)
+        XCTAssertEqual(overlaid.height, image.height)
+    }
+
+    private func makeSolidImage(width: Int, height: Int) throws -> CGImage {
+        let context = try XCTUnwrap(
+            CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        )
+        context.setFillColor(CGColor(gray: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try XCTUnwrap(context.makeImage())
     }
 }
 

--- a/Packages/OsaurusCore/Tests/ComputerUse/Model/AgentViewTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Model/AgentViewTests.swift
@@ -46,6 +46,31 @@ final class AgentViewTests: XCTestCase {
         XCTAssertEqual(view.items.map { $0.elementId }, ["a", "b", "c"])
     }
 
+    func testSnapshotIdMarksArePreservedWhenPresent() {
+        let view = AgentView.build(
+            from: snapshot([el("s9-2", "button", "A"), el("s9-5", "button", "B")]),
+            previous: nil
+        )
+        XCTAssertEqual(view.items.map { $0.mark }, [2, 5])
+        XCTAssertEqual(view.item(mark: 2)?.elementId, "s9-2")
+        XCTAssertEqual(view.item(mark: 5)?.elementId, "s9-5")
+        XCTAssertNil(view.item(mark: 1))
+    }
+
+    func testMixedSnapshotIdsKeepUniquePublicMarks() {
+        let view = AgentView.build(
+            from: snapshot([
+                el("s9-2", "button", "A"),
+                el("weird", "button", "B"),
+                el("s9-2", "button", "C"),
+                el("s9-1", "button", "D"),
+            ]),
+            previous: nil
+        )
+        XCTAssertEqual(view.items.map(\.mark), [2, 3, 4, 1])
+        XCTAssertEqual(Set(view.items.map(\.mark)).count, view.items.count)
+    }
+
     func testItemLookupByMark() {
         let view = AgentView.build(
             from: snapshot([el("a", "button", "A"), el("b", "button", "B")]),

--- a/docs/COMPUTER_USE.md
+++ b/docs/COMPUTER_USE.md
@@ -155,7 +155,7 @@ can't carry the step:
 | Tier | What it captures | Permission |
 |------|------------------|------------|
 | `ax` | Accessibility tree only, no pixels. Fastest. | Accessibility |
-| `som` | Set-of-mark: AX tree **+** screenshot with element-id numbers drawn on every actionable element. **Default capture mode.** | + Screen Recording |
+| `som` | Set-of-mark: AX tree **+** screenshot with public mark numbers drawn on every actionable element. **Default capture mode.** | + Screen Recording |
 | `vision` | Un-annotated screenshot for vision-first models that ground on pixels (the AX tree is still gathered for element ids). | + Screen Recording |
 
 `CaptureRouter` decides the next tier. In production it escalates when a target


### PR DESCRIPTION
## Summary
- Makes SOM screenshot overlays use public mark identifiers instead of leaking internal ids.
- Keeps the driver contract aligned with what the model-visible view can reference.
- Adds MacDriver contract coverage for the overlay shape.

## Why
The built-in loop should expose stable, auditable target handles to the model while keeping private implementation details inside the harness.

## Validation
- `git diff --check origin/main...HEAD`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-computer-use-pr-validation swift test --package-path Packages/OsaurusCore --quiet --filter ComputerUse`