### PR TITLE
Report truthful Computer Use text input routes

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Driver/Mac/ElementCache.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/Mac/ElementCache.swift
@@ -29,15 +29,25 @@ struct ElementActionResult: Codable {
     let cancelled: Bool?
     /// A small "what changed" record for successful actions on a known pid.
     let delta: FocusDelta?
+    /// Lower-level input transport when the action synthesized events.
+    let routeUsed: InputRoute?
+    /// High-level text-edit path when the action changed text.
+    let textInputRoute: CUTextInputRoute?
 
-    static func ok(delta: FocusDelta? = nil) -> ElementActionResult {
+    static func ok(
+        delta: FocusDelta? = nil,
+        routeUsed: InputRoute? = nil,
+        textInputRoute: CUTextInputRoute? = nil
+    ) -> ElementActionResult {
         return ElementActionResult(
             success: true,
             error: nil,
             stale: nil,
             removed: nil,
             cancelled: nil,
-            delta: delta
+            delta: delta,
+            routeUsed: routeUsed,
+            textInputRoute: textInputRoute
         )
     }
 
@@ -48,7 +58,9 @@ struct ElementActionResult: Codable {
             stale: nil,
             removed: nil,
             cancelled: nil,
-            delta: nil
+            delta: nil,
+            routeUsed: nil,
+            textInputRoute: nil
         )
     }
 
@@ -62,7 +74,9 @@ struct ElementActionResult: Codable {
             stale: true,
             removed: nil,
             cancelled: nil,
-            delta: nil
+            delta: nil,
+            routeUsed: nil,
+            textInputRoute: nil
         )
     }
 
@@ -76,7 +90,9 @@ struct ElementActionResult: Codable {
             stale: nil,
             removed: true,
             cancelled: nil,
-            delta: nil
+            delta: nil,
+            routeUsed: nil,
+            textInputRoute: nil
         )
     }
 
@@ -137,7 +153,7 @@ final class ElementInteraction: @unchecked Sendable {
             let center = CGPoint(x: frame.midX, y: frame.midY)
             let result = driver.click(pid: element.pid, point: center)
             if result.success {
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(delta: computeFocusDelta(pid: element.pid), routeUsed: driver.lastRoute)
             }
             return .fail(result.error ?? "Click failed")
         }
@@ -151,7 +167,7 @@ final class ElementInteraction: @unchecked Sendable {
             let center = CGPoint(x: frame.midX, y: frame.midY)
             let result = driver.doubleClick(pid: element.pid, point: center)
             if result.success {
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(delta: computeFocusDelta(pid: element.pid), routeUsed: driver.lastRoute)
             }
             return .fail(result.error ?? "Double click failed")
         }
@@ -186,7 +202,7 @@ final class ElementInteraction: @unchecked Sendable {
                 // Heads-up: Chromium coerces synthetic right-clicks on web content
                 // to left-clicks at the renderer-IPC boundary. AXShowMenu above is
                 // the only reliable right-click path for those targets.
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(delta: computeFocusDelta(pid: element.pid), routeUsed: driver.lastRoute)
             }
             return .fail(result.error ?? "Right click failed")
         }
@@ -218,7 +234,7 @@ final class ElementInteraction: @unchecked Sendable {
                 value as CFTypeRef
             )
             if result == .success {
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(delta: computeFocusDelta(pid: element.pid), textInputRoute: .axValue)
             }
             return .fail(
                 "Failed to set element value. Element may not be editable. "
@@ -239,7 +255,7 @@ final class ElementInteraction: @unchecked Sendable {
                 "" as CFTypeRef
             )
             if result == .success {
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(delta: computeFocusDelta(pid: element.pid), textInputRoute: .axValue)
             }
             // Fallback: focus, select all, delete — routed per-pid so other
             // apps don't see the Cmd+A.
@@ -253,7 +269,11 @@ final class ElementInteraction: @unchecked Sendable {
             }
             let del = driver.pressKey(pid: element.pid, keyCode: delCode, modifiers: [])
             if del.success {
-                return .ok(delta: computeFocusDelta(pid: element.pid))
+                return .ok(
+                    delta: computeFocusDelta(pid: element.pid),
+                    routeUsed: driver.lastRoute,
+                    textInputRoute: .elementFocusedKeyboard
+                )
             }
             return .fail(del.error ?? "Failed to clear field")
         }

--- a/Packages/OsaurusCore/ComputerUse/Driver/MacDriver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/MacDriver.swift
@@ -324,6 +324,20 @@ public struct CUFocusDelta: Sendable, Equatable, Codable {
     }
 }
 
+/// The high-level path used for text edits. This is intentionally separate
+/// from `InputRoute`: AX value writes do not synthesize keyboard events, while
+/// keyboard-based edits still carry their lower-level transport in `routeUsed`.
+public enum CUTextInputRoute: String, Codable, Sendable, CaseIterable, Hashable {
+    /// `AXValue` was set directly on the resolved element.
+    case axValue
+    /// The resolved element was focused first, then keyboard input was sent.
+    case elementFocusedKeyboard
+    /// Keyboard input was sent to the pid's current focus without an element id.
+    case pidFocusedKeyboard
+    /// Keyboard input was posted through the HID tap without a pid target.
+    case hidKeyboard
+}
+
 /// Result of an element/coordinate action. `stale`/`removed` tell the harness
 /// to re-observe rather than abandon the goal.
 public struct CUActionResult: Sendable, Equatable, Codable {
@@ -338,6 +352,10 @@ public struct CUActionResult: Sendable, Equatable, Codable {
     /// cursor warped (`hidFallback`) or a Chromium click likely missed
     /// (`perPid`), instead of the transport being invisible.
     public let routeUsed: InputRoute?
+    /// Text-edit path, when the action edited text. This distinguishes AX value
+    /// writes from focused keyboard input so verification evidence is honest
+    /// about what actually touched the app.
+    public let textInputRoute: CUTextInputRoute?
 
     public init(
         success: Bool,
@@ -345,7 +363,8 @@ public struct CUActionResult: Sendable, Equatable, Codable {
         stale: Bool = false,
         removed: Bool = false,
         delta: CUFocusDelta? = nil,
-        routeUsed: InputRoute? = nil
+        routeUsed: InputRoute? = nil,
+        textInputRoute: CUTextInputRoute? = nil
     ) {
         self.success = success
         self.error = error
@@ -353,10 +372,15 @@ public struct CUActionResult: Sendable, Equatable, Codable {
         self.removed = removed
         self.delta = delta
         self.routeUsed = routeUsed
+        self.textInputRoute = textInputRoute
     }
 
-    public static func ok(delta: CUFocusDelta? = nil, routeUsed: InputRoute? = nil) -> CUActionResult {
-        CUActionResult(success: true, delta: delta, routeUsed: routeUsed)
+    public static func ok(
+        delta: CUFocusDelta? = nil,
+        routeUsed: InputRoute? = nil,
+        textInputRoute: CUTextInputRoute? = nil
+    ) -> CUActionResult {
+        CUActionResult(success: true, delta: delta, routeUsed: routeUsed, textInputRoute: textInputRoute)
     }
 
     public static func failure(_ message: String) -> CUActionResult {

--- a/Packages/OsaurusCore/ComputerUse/Driver/NativeMacDriver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Driver/NativeMacDriver.swift
@@ -229,9 +229,11 @@ public struct NativeMacDriver: MacDriver {
                 }
                 if result.success {
                     let delta = resolvedPid.flatMap { computeFocusDelta(pid: $0) }
+                    let textRoute = textInputRoute(elementAddressed: id != nil, pidAddressed: resolvedPid != nil)
                     return CUActionResult.ok(
                         delta: delta.map(mapDelta),
-                        routeUsed: inputRoute(pidAddressed: resolvedPid != nil)
+                        routeUsed: inputRoute(pidAddressed: resolvedPid != nil),
+                        textInputRoute: textRoute
                     )
                 }
                 return .failure(result.error ?? "Type failed")
@@ -400,7 +402,9 @@ private func mapActionResult(_ r: ElementActionResult) -> CUActionResult {
         error: r.error,
         stale: r.stale ?? false,
         removed: r.removed ?? false,
-        delta: r.delta.map(mapDelta)
+        delta: r.delta.map(mapDelta),
+        routeUsed: r.routeUsed,
+        textInputRoute: r.textInputRoute
     )
 }
 
@@ -414,6 +418,13 @@ private func mapInputResult(_ r: InputResult, routeUsed: InputRoute? = nil) -> C
 /// warp the cursor.
 private func inputRoute(pidAddressed: Bool) -> InputRoute {
     pidAddressed ? BackgroundDriver.shared.lastRoute : .hidFallback
+}
+
+/// Text edit semantics are above the transport layer: a pid-addressed keyboard
+/// action can be either target-focused (`id != nil`) or current-focus only.
+private func textInputRoute(elementAddressed: Bool, pidAddressed: Bool) -> CUTextInputRoute {
+    if !pidAddressed { return .hidKeyboard }
+    return elementAddressed ? .elementFocusedKeyboard : .pidFocusedKeyboard
 }
 
 private func mapButton(_ b: CUMouseButton) -> MouseButton {

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -1166,6 +1166,10 @@ public enum ComputerUseLoop {
             }
         }
 
+        if let textInputRoute = result.textInputRoute {
+            metrics.recordTextInputRoute(textInputRoute)
+        }
+
         feed.emit(
             SubagentActivityEvent(
                 step: step,
@@ -1222,6 +1226,9 @@ public enum ComputerUseLoop {
             out += " (input used per-pid routing; a Chromium web-content target may not have received it)"
         case .skyLight, .none:
             break
+        }
+        if let textInputRoute = result.textInputRoute {
+            out += " " + describeTextInputRoute(textInputRoute)
         }
         out += view.hasChanges ? " The view changed." : " The view looks unchanged."
         out += "\n\nCurrent view:\n" + view.renderForModel()
@@ -1397,6 +1404,19 @@ public enum ComputerUseLoop {
         if let mark = target.mark { return "mark:\(mark)" }
         if let d = target.describe { return "desc:\(d.lowercased())" }
         return "<empty>"
+    }
+
+    private static func describeTextInputRoute(_ route: CUTextInputRoute) -> String {
+        switch route {
+        case .axValue:
+            return "(text edit used Accessibility value setting)"
+        case .elementFocusedKeyboard:
+            return "(text edit focused the target, then used keyboard input)"
+        case .pidFocusedKeyboard:
+            return "(text edit used pid-focused keyboard input)"
+        case .hidKeyboard:
+            return "(text edit used HID keyboard input, which may affect the frontmost app)"
+        }
     }
 
     private static func describe(_ element: CUElement) -> String {

--- a/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
+++ b/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
@@ -53,6 +53,9 @@ public struct ComputerUseRunMetrics: Sendable, Equatable {
     public var cloudVisionUsed = false
     /// Effect-class distribution of gated actions.
     public var effectCounts: [EffectClass: Int] = [:]
+    /// Text-input route distribution. This stays local/full-fidelity; shipped
+    /// telemetry deliberately avoids per-route action detail.
+    public var textInputRoutes: [CUTextInputRoute: Int] = [:]
 
     public init() {}
 
@@ -94,6 +97,10 @@ public struct ComputerUseRunMetrics: Sendable, Equatable {
 
     public mutating func recordEffect(_ effect: EffectClass) {
         effectCounts[effect, default: 0] += 1
+    }
+
+    public mutating func recordTextInputRoute(_ route: CUTextInputRoute) {
+        textInputRoutes[route, default: 0] += 1
     }
 
     public mutating func raiseTier(to tier: CaptureTier) {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Driver/MacDriverContractTests.swift
@@ -107,6 +107,20 @@ final class MockMacDriverContractTests: XCTestCase {
         XCTAssertEqual(recorded.count, 2)
     }
 
+    func testActionResultRoundTripsInputRouteMetadata() throws {
+        let result = CUActionResult.ok(
+            routeUsed: .skyLight,
+            textInputRoute: .elementFocusedKeyboard
+        )
+
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(CUActionResult.self, from: data)
+
+        XCTAssertEqual(decoded, result)
+        XCTAssertEqual(decoded.routeUsed, .skyLight)
+        XCTAssertEqual(decoded.textInputRoute, .elementFocusedKeyboard)
+    }
+
     func testFindFiltersByRoleAndText() async throws {
         let pid: Int32 = 7
         let snap = makeSnapshot(id: 3, pid: pid, labels: ["Sign in", "Cancel"], roles: ["button", "button"])

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
@@ -117,6 +117,46 @@ final class ComputerUseLoopActTests: XCTestCase {
         XCTAssertEqual(metrics.maxTier, .som)
     }
 
+    func testSetValueReportsAccessibilityValueRoute() async {
+        let pid: Int32 = 4242
+        let driver = MockMacDriver()
+        await driver.enqueueActionResults([
+            CUActionResult.ok(textInputRoute: .axValue)
+        ])
+
+        var currentTier: CaptureTier = .ax
+        var pendingFrame: CUImage?
+        var lastView: AgentView?
+        var lastSnapshot: CUSnapshot?
+        var metrics = ComputerUseRunMetrics()
+        let feed = ComputerUseFeed(toolCallId: "t", goal: "g")
+
+        let out = await ComputerUseLoop.act(
+            action: AgentAction(verb: .setValue, target: AgentTarget(mark: 13), text: "Jared"),
+            element: makeElement(),
+            pid: pid,
+            driver: driver,
+            availability: grantedAvailability(),
+            currentTier: &currentTier,
+            pendingFrameImage: &pendingFrame,
+            lastView: &lastView,
+            lastSnapshot: &lastSnapshot,
+            metrics: &metrics,
+            feed: feed,
+            step: 1
+        )
+
+        let actions = await driver.elementActions
+        guard case let .setValue(id, value)? = actions.first else {
+            return XCTFail("Expected set_value; got \(actions)")
+        }
+        XCTAssertEqual(id, "s1-13")
+        XCTAssertEqual(value, "Jared")
+        XCTAssertTrue(out.contains("Accessibility value setting"), "Route should be model-visible; got: \(out)")
+        XCTAssertEqual(metrics.textInputRoutes[.axValue], 1)
+        XCTAssertEqual(metrics.coordinateFallbacks, 0)
+    }
+
     func testSetValueRetriesViaCoordinateFocusWhenRefRemoved() async {
         let pid: Int32 = 4242
         let driver = MockMacDriver()
@@ -125,7 +165,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         await driver.enqueueActionResults([
             CUActionResult(success: false, error: "gone", removed: true),  // setValue
             CUActionResult.ok(),  // focus coordinate click
-            CUActionResult.ok(),  // typeText retry
+            CUActionResult.ok(routeUsed: .skyLight, textInputRoute: .pidFocusedKeyboard),  // typeText retry
         ])
 
         var currentTier: CaptureTier = .ax
@@ -162,6 +202,8 @@ final class ComputerUseLoopActTests: XCTestCase {
         XCTAssertEqual(text, "Jared")
         XCTAssertTrue(replace)
         XCTAssertEqual(metrics.coordinateFallbacks, 1)
+        XCTAssertEqual(metrics.textInputRoutes[.pidFocusedKeyboard], 1)
+        XCTAssertTrue(out.contains("pid-focused keyboard input"), "Retry route should be model-visible; got: \(out)")
         XCTAssertTrue(out.contains("Action succeeded"), "Fallback success should be reported; got: \(out)")
         XCTAssertEqual(currentTier, .ax, "A landed fallback means no need to escalate")
     }

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopActTests.swift
@@ -129,7 +129,7 @@ final class ComputerUseLoopActTests: XCTestCase {
         var lastView: AgentView?
         var lastSnapshot: CUSnapshot?
         var metrics = ComputerUseRunMetrics()
-        let feed = ComputerUseFeed(toolCallId: "t", goal: "g")
+        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "g")
 
         let out = await ComputerUseLoop.act(
             action: AgentAction(verb: .setValue, target: AgentTarget(mark: 13), text: "Jared"),

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
@@ -200,6 +200,17 @@ final class ComputerUseRunMetricsTests: XCTestCase {
         m.raiseTier(to: .vision)
         XCTAssertEqual(m.maxTier, .vision)
     }
+
+    func testTextInputRouteAccumulationStaysLocal() {
+        var m = ComputerUseRunMetrics()
+        m.recordTextInputRoute(.axValue)
+        m.recordTextInputRoute(.pidFocusedKeyboard)
+        m.recordTextInputRoute(.pidFocusedKeyboard)
+
+        XCTAssertEqual(m.textInputRoutes[.axValue], 1)
+        XCTAssertEqual(m.textInputRoutes[.pidFocusedKeyboard], 2)
+        XCTAssertNil(m.textInputRoutes[.hidKeyboard])
+    }
 }
 
 // MARK: - Ax-resolvable sweep

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
@@ -206,10 +206,11 @@ final class ComputerUseRunMetricsTests: XCTestCase {
         m.recordTextInputRoute(.axValue)
         m.recordTextInputRoute(.pidFocusedKeyboard)
         m.recordTextInputRoute(.pidFocusedKeyboard)
+        m.recordTextInputRoute(.hidKeyboard)
 
         XCTAssertEqual(m.textInputRoutes[.axValue], 1)
         XCTAssertEqual(m.textInputRoutes[.pidFocusedKeyboard], 2)
-        XCTAssertNil(m.textInputRoutes[.hidKeyboard])
+        XCTAssertEqual(m.textInputRoutes[.hidKeyboard], 1)
     }
 }
 


### PR DESCRIPTION
## Summary
- Tightens Computer Use input-route accounting so text-input routing is observable and local to the run.
- Extends coverage for HID keyboard route telemetry alongside paste/type routing.
- Preserves the existing driver contract while making action evidence more explicit.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter 'ComputerUseRunMetricsTests|MacDriverSnapshotIdTests|MacDriverKeyVocabularyTests|MacDriverCaptureModeTests|MockMacDriverContractTests|ComputerUseLoopActTests'` — 25 tests passed.
- `swift test --package-path Packages/OsaurusEvals --filter 'ComputerUseLoopEvalTests'` — 11 tests passed.
- `git diff --check` — passed.
- GitHub CI — green; merge state CLEAN.