### PR TITLE
Handle ambiguous Computer Use targets explicitly

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -694,8 +694,10 @@ public enum ComputerUseLoop {
                     let destResolution = TargetResolver.resolve(action.to, view: view, snapshot: snapshot)
                     switch destResolution {
                     case .resolved(_, let element, _):
+                        metrics.recordResolveAttempt(success: true)
                         destinationElement = element
                     case .ambiguous(let reason, let candidates):
+                        metrics.recordResolveAttempt(success: false)
                         metrics.ambiguousTargets += 1
                         toolResult =
                             "Couldn't resolve the drag destination: \(reason)\n"
@@ -703,6 +705,7 @@ public enum ComputerUseLoop {
                             + "\nRetry with one exact destination `mark`."
                         advancedStep = false
                     case .reobserve(let reason), .deadEnd(let reason):
+                        metrics.recordResolveAttempt(success: false)
                         toolResult = "Couldn't resolve the drag destination: \(reason)"
                         advancedStep = false
                     }

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -602,16 +602,27 @@ public enum ComputerUseLoop {
 
                 // Resolve the element for element-addressed verbs.
                 var resolvedElement: CUElement? = nil
+                var resolutionEvidence: TargetResolutionEvidence?
                 if requiresTarget(action.verb) || action.target != nil {
                     let resolution = TargetResolver.resolve(action.target, view: view, snapshot: snapshot)
                     switch resolution {
-                    case .resolved(_, let element):
+                    case .resolved(_, let element, let evidence):
                         resolvedElement = element
+                        resolutionEvidence = evidence
                         metrics.recordResolveAttempt(success: true)
                         consecutiveReobserve = 0
                         lastReobserveTargetKey = nil
                         // Resolved against the AX tree — no pixels needed; drop back to ax.
                         currentTier = .ax
+                    case .ambiguous(let reason, let candidates):
+                        metrics.recordResolveAttempt(success: false)
+                        metrics.ambiguousTargets += 1
+                        consecutiveReobserve = 0
+                        lastReobserveTargetKey = nil
+                        toolResult =
+                            "Ambiguous target: \(reason)\n"
+                            + renderResolutionCandidates(candidates)
+                            + "\nRetry with one exact `mark`."
                     case .reobserve(let reason):
                         metrics.recordResolveAttempt(success: false)
                         let key = targetKey(action.target)
@@ -682,8 +693,15 @@ public enum ComputerUseLoop {
                 if action.verb == .drag {
                     let destResolution = TargetResolver.resolve(action.to, view: view, snapshot: snapshot)
                     switch destResolution {
-                    case .resolved(_, let element):
+                    case .resolved(_, let element, _):
                         destinationElement = element
+                    case .ambiguous(let reason, let candidates):
+                        metrics.ambiguousTargets += 1
+                        toolResult =
+                            "Couldn't resolve the drag destination: \(reason)\n"
+                            + renderResolutionCandidates(candidates)
+                            + "\nRetry with one exact destination `mark`."
+                        advancedStep = false
                     case .reobserve(let reason), .deadEnd(let reason):
                         toolResult = "Couldn't resolve the drag destination: \(reason)"
                         advancedStep = false
@@ -724,6 +742,7 @@ public enum ComputerUseLoop {
                         action: action,
                         element: resolvedElement,
                         destinationElement: destinationElement,
+                        resolutionEvidence: resolutionEvidence,
                         pid: pid,
                         driver: driver,
                         availability: availability,
@@ -1034,6 +1053,7 @@ public enum ComputerUseLoop {
         action: AgentAction,
         element: CUElement?,
         destinationElement: CUElement? = nil,
+        resolutionEvidence: TargetResolutionEvidence? = nil,
         pid: Int32,
         driver: MacDriver,
         availability: MacDriverAvailability,
@@ -1214,6 +1234,9 @@ public enum ComputerUseLoop {
         if let delta = result.delta?.focusedElement {
             out += " Focus moved to \(delta.role)" + (delta.label.map { " \"\($0)\"" } ?? "") + "."
         }
+        if let resolutionEvidence {
+            out += " Target resolved by \(describeResolutionEvidence(resolutionEvidence))."
+        }
         switch result.routeUsed {
         case .hidFallback:
             out += " (input used the HID fallback, which moved the cursor)"
@@ -1388,6 +1411,30 @@ public enum ComputerUseLoop {
         if let mark = target.mark { return "mark:\(mark)" }
         if let d = target.describe { return "desc:\(d.lowercased())" }
         return "<empty>"
+    }
+
+    private static func renderResolutionCandidates(_ candidates: [TargetResolutionCandidate]) -> String {
+        guard !candidates.isEmpty else { return "Candidates: none." }
+        let lines = candidates.map { candidate in
+            "- mark \(candidate.mark): \(describe(candidate)) "
+                + "(confidence \(formatConfidence(candidate.confidence)), \(candidate.reason))"
+        }
+        return "Candidates:\n" + lines.joined(separator: "\n")
+    }
+
+    private static func describeResolutionEvidence(_ evidence: TargetResolutionEvidence) -> String {
+        "\(evidence.strategy.rawValue) confidence \(formatConfidence(evidence.confidence))"
+    }
+
+    private static func formatConfidence(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+
+    private static func describe(_ candidate: TargetResolutionCandidate) -> String {
+        var s = candidate.role
+        if let label = candidate.label, !label.isEmpty { s += " \"\(label)\"" }
+        if let value = candidate.value, !value.isEmpty { s += " value=\"\(value)\"" }
+        return s
     }
 
     private static func describe(_ element: CUElement) -> String {

--- a/Packages/OsaurusCore/ComputerUse/Resolver/TargetResolver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Resolver/TargetResolver.swift
@@ -189,11 +189,13 @@ public enum TargetResolver {
         }
 
         if matches.count > 1 {
-            let marks = matches.prefix(6).map { "\($0.item.mark)" }.joined(separator: ", ")
+            let candidates = Array(matches.prefix(6))
+            let marks = candidates.map { "\($0.item.mark)" }.joined(separator: ", ")
+            let capNote = matches.count > candidates.count ? " Showing top \(candidates.count)." : ""
             return .ambiguous(
-                reason: "\"\(describe)\" matches \(matches.count) elements (marks \(marks)). "
+                reason: "\"\(describe)\" matches \(matches.count) elements (marks \(marks)).\(capNote) "
                     + "Pick one by `mark`.",
-                candidates: matches.prefix(6).map {
+                candidates: candidates.map {
                     candidate(from: $0.item, confidence: $0.confidence, reason: $0.reason)
                 }
             )

--- a/Packages/OsaurusCore/ComputerUse/Resolver/TargetResolver.swift
+++ b/Packages/OsaurusCore/ComputerUse/Resolver/TargetResolver.swift
@@ -9,8 +9,9 @@
 //
 //  Three outcomes, mirroring the spec:
 //    - resolved:  a confident unique element.
+//    - ambiguous: multiple visible candidates; the model should choose a mark.
 //    - reobserve: the target probably exists but this view can't pin it
-//                 (out-of-range mark, ambiguous/zero describe match). A
+//                 (out-of-range mark, stale mark, zero describe match). A
 //                 fresh capture may help; the loop re-perceives and retries.
 //    - deadEnd:   the target is unusable as given (empty), or repeated
 //                 reobserve attempts still can't resolve it (decided by the
@@ -19,8 +20,55 @@
 
 import Foundation
 
+public enum TargetResolutionStrategy: String, Sendable, Equatable, Codable {
+    case mark
+    case exactLabel
+    case exactValue
+    case uniqueDescribe
+}
+
+public struct TargetResolutionEvidence: Sendable, Equatable, Codable {
+    public let strategy: TargetResolutionStrategy
+    /// 0...1 resolver confidence. This is a deterministic resolver score, not
+    /// a model probability.
+    public let confidence: Double
+    public let matchedMarks: [Int]
+
+    public init(strategy: TargetResolutionStrategy, confidence: Double, matchedMarks: [Int]) {
+        self.strategy = strategy
+        self.confidence = confidence
+        self.matchedMarks = matchedMarks
+    }
+}
+
+public struct TargetResolutionCandidate: Sendable, Equatable, Codable {
+    public let mark: Int
+    public let role: String
+    public let label: String?
+    public let value: String?
+    public let confidence: Double
+    public let reason: String
+
+    public init(
+        mark: Int,
+        role: String,
+        label: String?,
+        value: String?,
+        confidence: Double,
+        reason: String
+    ) {
+        self.mark = mark
+        self.role = role
+        self.label = label
+        self.value = value
+        self.confidence = confidence
+        self.reason = reason
+    }
+}
+
 public enum TargetResolution: Sendable, Equatable {
-    case resolved(elementId: String, element: CUElement)
+    case resolved(elementId: String, element: CUElement, evidence: TargetResolutionEvidence)
+    case ambiguous(reason: String, candidates: [TargetResolutionCandidate])
     case reobserve(reason: String)
     case deadEnd(reason: String)
 }
@@ -43,7 +91,15 @@ public enum TargetResolver {
         if let mark = target.mark {
             if let item = view.item(mark: mark) {
                 if let element = element(for: item.elementId, in: snapshot) {
-                    return .resolved(elementId: element.id, element: element)
+                    return .resolved(
+                        elementId: element.id,
+                        element: element,
+                        evidence: TargetResolutionEvidence(
+                            strategy: .mark,
+                            confidence: 1.0,
+                            matchedMarks: [mark]
+                        )
+                    )
                 }
                 // Mark exists in the view but the snapshot no longer has the id:
                 // the view is stale relative to the live tree.
@@ -80,34 +136,66 @@ public enum TargetResolver {
             return .reobserve(reason: "Empty describe. Re-observing.")
         }
 
-        // Exact label match wins outright (handles duplicate substrings like
-        // "Save" vs "Save As").
+        // Exact label match wins outright when unique (handles duplicate
+        // substrings like "Save" vs "Save As"). Duplicate exact labels are
+        // ambiguous and require the model to choose a mark.
         let exact = view.items.filter { ($0.label?.lowercased() == needle) }
-        if exact.count == 1, let item = exact.first,
-            let element = element(for: item.elementId, in: snapshot)
-        {
-            return .resolved(elementId: element.id, element: element)
+        if exact.count == 1, let item = exact.first {
+            guard let element = element(for: item.elementId, in: snapshot) else {
+                return .reobserve(reason: "The exact match for \"\(describe)\" went stale. Re-observing.")
+            }
+            return .resolved(
+                elementId: element.id,
+                element: element,
+                evidence: TargetResolutionEvidence(
+                    strategy: .exactLabel,
+                    confidence: 0.98,
+                    matchedMarks: [item.mark]
+                )
+            )
+        }
+        if exact.count > 1 {
+            return .ambiguous(
+                reason: "\"\(describe)\" exactly matches \(exact.count) elements. Pick one by `mark`.",
+                candidates: exact.map {
+                    candidate(from: $0, confidence: 0.98, reason: "exact label")
+                }
+            )
         }
 
-        // Substring over label/value/role.
-        let matches = view.items.filter { item in
-            if let label = item.label?.lowercased(), label.contains(needle) { return true }
-            if let value = item.value?.lowercased(), value.contains(needle) { return true }
-            if item.role.lowercased().contains(needle) { return true }
-            return false
-        }
+        // Conservative scored matching over label/value/role. A single match
+        // resolves with evidence; multiple matches stay ambiguous rather than
+        // guessing by score.
+        let matches = view.items.compactMap { scoredCandidate(for: $0, needle: needle) }
+            .sorted {
+                if $0.confidence == $1.confidence { return $0.item.mark < $1.item.mark }
+                return $0.confidence > $1.confidence
+            }
 
-        if matches.count == 1, let item = matches.first,
-            let element = element(for: item.elementId, in: snapshot)
-        {
-            return .resolved(elementId: element.id, element: element)
+        if matches.count == 1, let match = matches.first {
+            let item = match.item
+            guard let element = element(for: item.elementId, in: snapshot) else {
+                return .reobserve(reason: "The match for \"\(describe)\" went stale. Re-observing.")
+            }
+            return .resolved(
+                elementId: element.id,
+                element: element,
+                evidence: TargetResolutionEvidence(
+                    strategy: match.strategy,
+                    confidence: match.confidence,
+                    matchedMarks: [item.mark]
+                )
+            )
         }
 
         if matches.count > 1 {
-            let marks = matches.prefix(6).map { "\($0.mark)" }.joined(separator: ", ")
-            return .reobserve(
+            let marks = matches.prefix(6).map { "\($0.item.mark)" }.joined(separator: ", ")
+            return .ambiguous(
                 reason: "\"\(describe)\" matches \(matches.count) elements (marks \(marks)). "
-                    + "Pick one by `mark`."
+                    + "Pick one by `mark`.",
+                candidates: matches.prefix(6).map {
+                    candidate(from: $0.item, confidence: $0.confidence, reason: $0.reason)
+                }
             )
         }
 
@@ -123,5 +211,46 @@ public enum TargetResolver {
 
     private static func element(for id: String, in snapshot: CUSnapshot) -> CUElement? {
         snapshot.elements.first { $0.id == id }
+    }
+
+    private struct ScoredCandidate {
+        let item: AgentViewItem
+        let confidence: Double
+        let strategy: TargetResolutionStrategy
+        let reason: String
+    }
+
+    private static func scoredCandidate(for item: AgentViewItem, needle: String) -> ScoredCandidate? {
+        if let value = item.value?.lowercased(), value == needle {
+            return ScoredCandidate(item: item, confidence: 0.92, strategy: .exactValue, reason: "exact value")
+        }
+        if let label = item.label?.lowercased(), label.hasPrefix(needle) {
+            return ScoredCandidate(item: item, confidence: 0.82, strategy: .uniqueDescribe, reason: "label prefix")
+        }
+        if let label = item.label?.lowercased(), label.contains(needle) {
+            return ScoredCandidate(item: item, confidence: 0.72, strategy: .uniqueDescribe, reason: "label contains")
+        }
+        if let value = item.value?.lowercased(), value.contains(needle) {
+            return ScoredCandidate(item: item, confidence: 0.62, strategy: .uniqueDescribe, reason: "value contains")
+        }
+        if item.role.lowercased().contains(needle) {
+            return ScoredCandidate(item: item, confidence: 0.42, strategy: .uniqueDescribe, reason: "role contains")
+        }
+        return nil
+    }
+
+    private static func candidate(
+        from item: AgentViewItem,
+        confidence: Double,
+        reason: String
+    ) -> TargetResolutionCandidate {
+        TargetResolutionCandidate(
+            mark: item.mark,
+            role: item.role,
+            label: item.label,
+            value: item.value,
+            confidence: confidence,
+            reason: reason
+        )
     }
 }

--- a/Packages/OsaurusCore/ComputerUse/Telemetry/AxResolvableSweep.swift
+++ b/Packages/OsaurusCore/ComputerUse/Telemetry/AxResolvableSweep.swift
@@ -31,12 +31,14 @@ public struct AxProbe: Sendable {
 public struct AxSweepResult: Sendable, Equatable {
     public let total: Int
     public let resolved: Int
+    public let ambiguous: Int
     public let reobserve: Int
     public let deadEnd: Int
 
-    public init(total: Int, resolved: Int, reobserve: Int, deadEnd: Int) {
+    public init(total: Int, resolved: Int, ambiguous: Int = 0, reobserve: Int, deadEnd: Int) {
         self.total = total
         self.resolved = resolved
+        self.ambiguous = ambiguous
         self.reobserve = reobserve
         self.deadEnd = deadEnd
     }
@@ -54,6 +56,7 @@ public enum AxResolvableSweep {
     /// against that view.
     public static func run(driver: MacDriver, probes: [AxProbe]) async -> AxSweepResult {
         var resolved = 0
+        var ambiguous = 0
         var reobserve = 0
         var deadEnd = 0
         var total = 0
@@ -65,6 +68,7 @@ public enum AxResolvableSweep {
                 total += 1
                 switch TargetResolver.resolve(target, view: view, snapshot: snapshot) {
                 case .resolved: resolved += 1
+                case .ambiguous: ambiguous += 1
                 case .reobserve: reobserve += 1
                 case .deadEnd: deadEnd += 1
                 }
@@ -74,6 +78,7 @@ public enum AxResolvableSweep {
         return AxSweepResult(
             total: total,
             resolved: resolved,
+            ambiguous: ambiguous,
             reobserve: reobserve,
             deadEnd: deadEnd
         )

--- a/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
+++ b/Packages/OsaurusCore/ComputerUse/Telemetry/ComputerUseRunMetrics.swift
@@ -28,6 +28,9 @@ public struct ComputerUseRunMetrics: Sendable, Equatable {
     public var blocked = 0
     /// Dead-end terminations encountered (resolution gave out).
     public var deadEnds = 0
+    /// Ambiguous target descriptions that were returned to the model as
+    /// candidate marks instead of being retried through more perception.
+    public var ambiguousTargets = 0
     /// Actions executed and how many the verify step saw land (view changed).
     public var actsAttempted = 0
     public var verifyChanged = 0

--- a/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/ComputerUseEvidencePackTests.swift
@@ -208,7 +208,11 @@ final class ComputerUseEvidencePackTests: XCTestCase {
             modelId: "scripted-browser-form",
             driver: driver,
             gate: ComputerUseGate(policy: AutonomyPolicy(globalPreset: .trusted)),
-            feed: ComputerUseFeed(toolCallId: "evidence-browser-form", goal: "Fill out the form"),
+            feed: SubagentFeed(
+                toolCallId: "evidence-browser-form",
+                kindId: "computer_use",
+                title: "Fill out the form"
+            ),
             interrupt: InterruptToken(),
             confirm: { preview in
                 await confirmationRecorder.record(preview)

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -167,6 +167,51 @@ final class ComputerUseLoopRunTests: XCTestCase {
         XCTAssertTrue(clicks.isEmpty, "An unresolved target must never reach the driver")
     }
 
+    func testAmbiguousDescribeReturnsCandidateMarksWithoutEscalating() async {
+        let d = driver([
+            el("reply-all", "button", "Reply all"),
+            el("reply-sender", "button", "Reply sender"),
+        ])
+        let provider: AgentStepProvider = { input in
+            if input.lastToolResult?.localizedCaseInsensitiveContains("ambiguous target") ?? false {
+                return ModelActionCall(
+                    id: "pick-mark",
+                    arguments: AgentAction(
+                        verb: .click,
+                        target: AgentTarget(mark: 2),
+                        note: "click reply sender"
+                    ).argumentsJSON()
+                )
+            }
+            if input.lastToolResult?.localizedCaseInsensitiveContains("action succeeded") ?? false {
+                return ModelActionCall(
+                    id: "done",
+                    arguments: AgentAction(verb: .done, reason: "resolved ambiguity").argumentsJSON()
+                )
+            }
+            return ModelActionCall(
+                id: "ambiguous",
+                arguments: AgentAction(
+                    verb: .click,
+                    target: AgentTarget(describe: "reply"),
+                    note: "ambiguous reply"
+                ).argumentsJSON()
+            )
+        }
+
+        let result = await run(d, provider: provider, limits: RunLimits(maxSteps: 6, wallClockSeconds: 30))
+
+        XCTAssertTrue(result.outcome.isSuccess, "Expected recovery via mark; got \(result.outcome)")
+        XCTAssertEqual(result.metrics.ambiguousTargets, 1)
+        XCTAssertEqual(result.metrics.maxTier, .ax, "Ambiguity should ask for a mark, not escalate capture")
+        let clicks = await d.elementActions
+        XCTAssertEqual(clicks.count, 1, "Only the disambiguated click should reach the driver")
+        guard case let .click(id, _, _) = clicks.first else {
+            return XCTFail("Expected a click; got \(clicks)")
+        }
+        XCTAssertEqual(id, "reply-sender")
+    }
+
     // MARK: - Cancellation
 
     func testInterruptTerminatesAsInterrupted() async {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -203,6 +203,8 @@ final class ComputerUseLoopRunTests: XCTestCase {
 
         XCTAssertTrue(result.outcome.isSuccess, "Expected recovery via mark; got \(result.outcome)")
         XCTAssertEqual(result.metrics.ambiguousTargets, 1)
+        XCTAssertEqual(result.metrics.targetResolveAttempts, 2)
+        XCTAssertEqual(result.metrics.targetResolveSuccesses, 1)
         XCTAssertEqual(result.metrics.maxTier, .ax, "Ambiguity should ask for a mark, not escalate capture")
         let clicks = await d.elementActions
         XCTAssertEqual(clicks.count, 1, "Only the disambiguated click should reach the driver")
@@ -365,6 +367,30 @@ final class ComputerUseLoopRunTests: XCTestCase {
         }
         let coords = await d.coordinateActions
         XCTAssertTrue(coords.isEmpty, "An unresolved drag destination must never reach the driver")
+    }
+
+    func testDragWithAmbiguousDestinationRecordsFailedResolutionAndDoesNotDrive() async {
+        let d = driver([
+            el("card", "cell", "Card"),
+            el("trash-left", "button", "Trash"),
+            el("trash-right", "button", "Trash"),
+        ])
+        let result = await run(
+            d,
+            provider: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .drag, target: AgentTarget(mark: 1), to: AgentTarget(describe: "Trash")),
+                AgentAction(verb: .giveUp, reason: "ambiguous destination"),
+            ]),
+            limits: RunLimits(maxSteps: 10, wallClockSeconds: 30)
+        )
+        guard case .gaveUp = result.outcome else {
+            return XCTFail("Expected gaveUp after ambiguous destination feedback; got \(result.outcome)")
+        }
+        XCTAssertEqual(result.metrics.ambiguousTargets, 1)
+        XCTAssertEqual(result.metrics.targetResolveAttempts, 2)
+        XCTAssertEqual(result.metrics.targetResolveSuccesses, 1)
+        let coords = await d.coordinateActions
+        XCTAssertTrue(coords.isEmpty, "An ambiguous drag destination must never reach the driver")
     }
 
     // MARK: - Loop robustness (Phase 3)

--- a/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Perception/PerceptionTests.swift
@@ -206,21 +206,40 @@ final class ComputerUseRunMetricsTests: XCTestCase {
 
 final class AxResolvableSweepTests: XCTestCase {
     func testSweepTalliesResolutionOutcomes() async {
-        let driver = MockMacDriver.demo()  // pid 4242: Search textfield + Go button
+        let pid: Int32 = 4242
+        let snapshot = CUSnapshot(
+            snapshotId: 1,
+            pid: pid,
+            app: "Demo",
+            focusedWindow: "Main",
+            tier: .ax,
+            truncated: false,
+            windows: [CUWindowSummary(id: 1, title: "Main", focused: true, x: 0, y: 0, w: 800, h: 600)],
+            elements: [
+                CUElement(id: "go", role: "button", label: "Go"),
+                CUElement(id: "search", role: "textfield", label: "Search"),
+                CUElement(id: "reply-all", role: "button", label: "Reply all"),
+                CUElement(id: "reply-sender", role: "button", label: "Reply sender"),
+            ],
+            image: nil
+        )
+        let driver = MockMacDriver(snapshots: [pid: [snapshot]])
         let probe = AxProbe(
-            pid: 4242,
+            pid: pid,
             targets: [
                 AgentTarget(describe: "Go"),  // exact label → resolved
                 AgentTarget(describe: "Search"),  // exact label → resolved
+                AgentTarget(describe: "reply"),  // multiple matches → ambiguous
                 AgentTarget(describe: "zzzzz"),  // no match → reobserve
             ]
         )
         let result = await AxResolvableSweep.run(driver: driver, probes: [probe])
-        XCTAssertEqual(result.total, 3)
+        XCTAssertEqual(result.total, 4)
         XCTAssertEqual(result.resolved, 2)
+        XCTAssertEqual(result.ambiguous, 1)
         XCTAssertEqual(result.reobserve, 1)
         XCTAssertEqual(result.deadEnd, 0)
-        XCTAssertEqual(result.resolvableRate, 2.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(result.resolvableRate, 0.5, accuracy: 0.0001)
     }
 
     func testEmptySweepHasZeroRate() async {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Resolver/TargetResolverTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Resolver/TargetResolverTests.swift
@@ -5,8 +5,9 @@
 //  The one place mark→id resolution + staleness handling lives. These cover
 //  the three outcomes the loop's retry/escalation policy keys off:
 //   • resolved   — a confident unique element (by mark, then describe),
+//   • ambiguous  — multiple visible candidates; the model must choose a mark,
 //   • reobserve  — probably exists but this view can't pin it (out-of-range
-//                  mark, stale mark, ambiguous/zero describe), and
+//                  mark, stale mark, zero describe), and
 //   • deadEnd    — unusable as given (empty target).
 //
 //  Pure + model-free: build a view/snapshot in memory and resolve against it.
@@ -43,17 +44,31 @@ final class TargetResolverTests: XCTestCase {
     private func assertResolved(
         _ res: TargetResolution,
         id expected: String,
+        strategy: TargetResolutionStrategy? = nil,
+        minimumConfidence: Double? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        guard case .resolved(let elementId, _) = res else {
+        guard case .resolved(let elementId, _, let evidence) = res else {
             return XCTFail("Expected resolved \(expected); got \(res)", file: file, line: line)
         }
         XCTAssertEqual(elementId, expected, file: file, line: line)
+        if let strategy {
+            XCTAssertEqual(evidence.strategy, strategy, file: file, line: line)
+        }
+        if let minimumConfidence {
+            XCTAssertGreaterThanOrEqual(evidence.confidence, minimumConfidence, file: file, line: line)
+        }
+        XCTAssertFalse(evidence.matchedMarks.isEmpty, file: file, line: line)
     }
 
     private func reobserveReason(_ res: TargetResolution) -> String? {
         if case .reobserve(let r) = res { return r }
+        return nil
+    }
+
+    private func ambiguousCandidates(_ res: TargetResolution) -> [TargetResolutionCandidate]? {
+        if case .ambiguous(_, let candidates) = res { return candidates }
         return nil
     }
 
@@ -66,8 +81,18 @@ final class TargetResolverTests: XCTestCase {
 
     func testResolvesByMark() {
         let (view, snap) = make([el("a", "button", "Go"), el("b", "textfield", "Search")])
-        assertResolved(TargetResolver.resolve(AgentTarget(mark: 1), view: view, snapshot: snap), id: "a")
-        assertResolved(TargetResolver.resolve(AgentTarget(mark: 2), view: view, snapshot: snap), id: "b")
+        assertResolved(
+            TargetResolver.resolve(AgentTarget(mark: 1), view: view, snapshot: snap),
+            id: "a",
+            strategy: .mark,
+            minimumConfidence: 1.0
+        )
+        assertResolved(
+            TargetResolver.resolve(AgentTarget(mark: 2), view: view, snapshot: snap),
+            id: "b",
+            strategy: .mark,
+            minimumConfidence: 1.0
+        )
     }
 
     func testOutOfRangeMarkReobserves() {
@@ -115,7 +140,9 @@ final class TargetResolverTests: XCTestCase {
         let (view, snap) = make([el("a", "button", "Go"), el("b", "textfield", "Search")])
         assertResolved(
             TargetResolver.resolve(AgentTarget(describe: "Search"), view: view, snapshot: snap),
-            id: "b"
+            id: "b",
+            strategy: .exactLabel,
+            minimumConfidence: 0.95
         )
     }
 
@@ -124,20 +151,34 @@ final class TargetResolverTests: XCTestCase {
         let (view, snap) = make([el("a", "button", "Save"), el("b", "button", "Save As")])
         assertResolved(
             TargetResolver.resolve(AgentTarget(describe: "Save"), view: view, snapshot: snap),
-            id: "a"
+            id: "a",
+            strategy: .exactLabel
         )
     }
 
-    func testAmbiguousDescribeReobserves() {
+    func testAmbiguousDescribeReturnsCandidates() {
         let (view, snap) = make([
             el("a", "button", "Reply to all"),
             el("b", "button", "Reply to sender"),
         ])
-        let reason = reobserveReason(
-            TargetResolver.resolve(AgentTarget(describe: "reply"), view: view, snapshot: snap)
+        let result = TargetResolver.resolve(AgentTarget(describe: "reply"), view: view, snapshot: snap)
+        guard case .ambiguous(let reason, let candidates) = result else {
+            return XCTFail("Expected ambiguity; got \(result)")
+        }
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("matches 2"), "got: \(reason)")
+        XCTAssertEqual(candidates.map(\.mark), [1, 2])
+        XCTAssertTrue(candidates.allSatisfy { $0.confidence > 0 })
+    }
+
+    func testDuplicateExactLabelsAreAmbiguous() {
+        let (view, snap) = make([
+            el("a", "button", "Delete"),
+            el("b", "button", "Delete"),
+        ])
+        let candidates = ambiguousCandidates(
+            TargetResolver.resolve(AgentTarget(describe: "Delete"), view: view, snapshot: snap)
         )
-        XCTAssertNotNil(reason)
-        XCTAssertTrue(reason?.localizedCaseInsensitiveContains("matches 2") ?? false, "got: \(reason ?? "nil")")
+        XCTAssertEqual(candidates?.map(\.mark), [1, 2])
     }
 
     func testZeroMatchDescribeReobserves() {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Resolver/TargetResolverTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Resolver/TargetResolverTests.swift
@@ -156,6 +156,35 @@ final class TargetResolverTests: XCTestCase {
         )
     }
 
+    func testExactValueResolvesWithEvidence() {
+        let (view, snap) = make([el("a", "textfield", "Status", value: "Submitted")])
+        assertResolved(
+            TargetResolver.resolve(AgentTarget(describe: "Submitted"), view: view, snapshot: snap),
+            id: "a",
+            strategy: .exactValue,
+            minimumConfidence: 0.9
+        )
+    }
+
+    func testStaleScoredMatchReobserves() {
+        let (view, _) = make([el("a", "textfield", "Status", value: "Submitted")])
+        let liveSnap = CUSnapshot(
+            snapshotId: 2,
+            pid: 1,
+            app: "App",
+            focusedWindow: nil,
+            tier: .ax,
+            truncated: false,
+            windows: [],
+            elements: [el("z", "textfield", "Other", value: "Submitted")],
+            image: nil
+        )
+        let reason = reobserveReason(
+            TargetResolver.resolve(AgentTarget(describe: "Submitted"), view: view, snapshot: liveSnap)
+        )
+        XCTAssertTrue(reason?.localizedCaseInsensitiveContains("went stale") ?? false, "got: \(reason ?? "nil")")
+    }
+
     func testAmbiguousDescribeReturnsCandidates() {
         let (view, snap) = make([
             el("a", "button", "Reply to all"),
@@ -168,6 +197,21 @@ final class TargetResolverTests: XCTestCase {
         XCTAssertTrue(reason.localizedCaseInsensitiveContains("matches 2"), "got: \(reason)")
         XCTAssertEqual(candidates.map(\.mark), [1, 2])
         XCTAssertTrue(candidates.allSatisfy { $0.confidence > 0 })
+    }
+
+    func testAmbiguousDescribeCapsCandidatesAndNamesTopList() {
+        let elements = (1 ... 7).map { index in
+            el("reply-\(index)", "button", "Reply option \(index)")
+        }
+        let (view, snap) = make(elements)
+        let result = TargetResolver.resolve(AgentTarget(describe: "reply"), view: view, snapshot: snap)
+        guard case .ambiguous(let reason, let candidates) = result else {
+            return XCTFail("Expected ambiguity; got \(result)")
+        }
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("matches 7"), "got: \(reason)")
+        XCTAssertTrue(reason.localizedCaseInsensitiveContains("top 6"), "got: \(reason)")
+        XCTAssertEqual(candidates.count, 6)
+        XCTAssertEqual(candidates.map(\.mark), [1, 2, 3, 4, 5, 6])
     }
 
     func testDuplicateExactLabelsAreAmbiguous() {


### PR DESCRIPTION
## Summary
- Adds richer target-resolution confidence and candidate reporting.
- Avoids silently acting when multiple plausible UI targets match.
- Adds loop, resolver, and telemetry coverage for ambiguous target cases.

## Why
A fast local Computer Use loop should be decisive only when the harness has evidence. Ambiguity should become an explicit model/user-facing state, not a risky click.

## Validation
- `git diff --check`
- `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test-pr1668 swift test --package-path Packages/OsaurusCore --filter 'ComputerUseEvidencePackTests|TargetResolverTests|ComputerUseLoopRunTests'` — 44 tests passed\n- `swift test --package-path Packages/OsaurusEvals --filter 'ComputerUseLoopEvalTests'` — 10 tests passed\n- GitHub CI on `5d4ddde7`: test-core, test-cli, swiftlint, shellcheck, and release drafter all passed\n