### PR TITLE
Gate dangerous launches and cross-window drags in Computer Use

### DIFF
--- a/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUseGateInspector.swift
+++ b/Packages/OsaurusCore/ComputerUse/Diagnostics/ComputerUseGateInspector.swift
@@ -129,7 +129,9 @@ enum ComputerUseGateInspector {
             app: appName,
             ceiling: input.ceiling
         )
-        let dangerousConfirm = effect >= .navigate && input.policy.requiresForcedConfirm(app: appName)
+        let dangerousConfirm =
+            effect >= .navigate
+            && input.policy.requiresForcedConfirm(app: appName, targetLabel: targetLabel)
         let finalDisposition: AutonomyDisposition?
         let decision: GateDecision
         let decisionText: String

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -1424,6 +1424,9 @@ public enum ComputerUseLoop {
             }
             return nil
         case (nil, nil):
+            // Real app-window elements inherit a window id from capture. A nil/nil
+            // pair is reserved for non-window surfaces such as menu-bar items, so
+            // it cannot prove a cross-window drag and is allowed only by that invariant.
             return nil
         default:
             return "Only one drag endpoint has a window id, so the loop cannot prove both endpoints are in "

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -693,7 +693,7 @@ public enum ComputerUseLoop {
                     if let reason = dragBoundaryViolation(start: resolvedElement, destination: destinationElement) {
                         metrics.blocked += 1
                         feed.emit(
-                            FeedEvent(
+                            SubagentActivityEvent(
                                 step: step + 1,
                                 kind: .blocked,
                                 title: "Blocked drag across boundary",

--- a/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
+++ b/Packages/OsaurusCore/ComputerUse/Loop/ComputerUseLoop.swift
@@ -690,6 +690,21 @@ public enum ComputerUseLoop {
                         advancedStep = false
                     }
                     if destinationElement == nil { break }
+                    if let reason = dragBoundaryViolation(start: resolvedElement, destination: destinationElement) {
+                        metrics.blocked += 1
+                        feed.emit(
+                            FeedEvent(
+                                step: step + 1,
+                                kind: .blocked,
+                                title: "Blocked drag across boundary",
+                                detail: reason,
+                                success: false
+                            )
+                        )
+                        toolResult = "Blocked drag: \(reason)"
+                        advancedStep = false
+                        break
+                    }
                 }
 
                 // Classify the real effect (verb baseline refined upward by the
@@ -1397,6 +1412,23 @@ public enum ComputerUseLoop {
         if let mark = target.mark { return "mark:\(mark)" }
         if let d = target.describe { return "desc:\(d.lowercased())" }
         return "<empty>"
+    }
+
+    private static func dragBoundaryViolation(start: CUElement?, destination: CUElement?) -> String? {
+        guard let start, let destination else { return nil }
+        switch (start.windowId, destination.windowId) {
+        case let (startWindow?, destinationWindow?):
+            guard startWindow == destinationWindow else {
+                return "Start mark is in window \(startWindow), but destination mark is in window "
+                    + "\(destinationWindow). Choose endpoints in the same window or ask the user to drag manually."
+            }
+            return nil
+        case (nil, nil):
+            return nil
+        default:
+            return "Only one drag endpoint has a window id, so the loop cannot prove both endpoints are in "
+                + "the same window. Re-observe or choose a safer same-window target."
+        }
     }
 
     private static func describe(_ element: CUElement) -> String {

--- a/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
@@ -304,6 +304,8 @@ public struct AutonomyPolicy: Codable, Sendable, Equatable {
         "disk utility", "com.apple.diskutility",
         "script editor", "com.apple.scripteditor",
         "automator", "com.apple.automator",
+        "shortcuts", "com.apple.shortcuts",
+        "docker", "orbstack", "utm", "virtualbox", "parallels",
         "1password", "bitwarden", "dashlane", "lastpass",
     ]
 

--- a/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/AutonomyPolicy.swift
@@ -309,13 +309,17 @@ public struct AutonomyPolicy: Codable, Sendable, Equatable {
         "1password", "bitwarden", "dashlane", "lastpass",
     ]
 
-    /// Whether driving `app` must always confirm because it's a sensitive app
-    /// (see `forcedConfirmAppNeedles`). `nil`/empty apps don't match — the
-    /// allowlist already rejects unknown apps under a restricted policy.
-    public func requiresForcedConfirm(app: String?) -> Bool {
-        guard let app else { return false }
-        let n = Self.normalize(app)
-        guard !n.isEmpty else { return false }
-        return Self.forcedConfirmAppNeedles.contains { n.contains($0) }
+    /// Whether driving `app` or a launch-like `targetLabel` must always confirm
+    /// because it references a sensitive app (see `forcedConfirmAppNeedles`).
+    /// Checking the target label covers launcher clicks from Dock, Spotlight, or
+    /// Finder, where the driven app is the launcher but the label names the app
+    /// being opened. `nil`/empty candidates do not match.
+    public func requiresForcedConfirm(app: String?, targetLabel: String? = nil) -> Bool {
+        [app, targetLabel].contains { candidate in
+            guard let candidate else { return false }
+            let n = Self.normalize(candidate)
+            guard !n.isEmpty else { return false }
+            return Self.forcedConfirmAppNeedles.contains { n.contains($0) }
+        }
     }
 }

--- a/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseGate.swift
+++ b/Packages/OsaurusCore/ComputerUse/Policy/ComputerUseGate.swift
@@ -50,7 +50,7 @@ public struct ComputerUseGate: ComputerUseGating {
         //    (often-empty) allowlist. Reads never reach here, so this only ever
         //    affects navigate/edit/consequential actions.
         var disposition = policy.disposition(for: effect, app: appName, ceiling: ceiling)
-        if effect >= .navigate, policy.requiresForcedConfirm(app: appName) {
+        if effect >= .navigate, policy.requiresForcedConfirm(app: appName, targetLabel: targetLabel) {
             disposition = AutonomyDisposition.strictest(disposition, .confirm)
         }
         switch disposition {

--- a/Packages/OsaurusCore/Tests/ComputerUse/Diagnostics/ComputerUseDiagnosticsTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Diagnostics/ComputerUseDiagnosticsTests.swift
@@ -220,6 +220,23 @@ final class ComputerUseGateInspectorTests: XCTestCase {
                 expectedCeilingContribution: nil
             ),
             ParityCase(
+                name: "dangerous launcher target",
+                input: ComputerUseGateInspectionInput(
+                    policy: AutonomyPolicy(globalPreset: .autonomous),
+                    appName: "Dock",
+                    verb: .click,
+                    targetLabel: "Terminal",
+                    targetRole: "AXButton"
+                ),
+                expectedEffect: .navigate,
+                expectedDecision: .confirm,
+                expectedFinalDisposition: .confirm,
+                expectedAllowlistAllowed: true,
+                expectedDangerousConfirm: true,
+                expectedPerAppContribution: nil,
+                expectedCeilingContribution: nil
+            ),
+            ParityCase(
                 name: "open app",
                 input: ComputerUseGateInspectionInput(
                     policy: AutonomyPolicy(globalPreset: .balanced, allowlist: ["mail"]),

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -24,13 +24,23 @@ final class ComputerUseLoopRunTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    private func el(_ id: String, _ role: String, _ label: String?, value: String? = nil) -> CUElement {
-        CUElement(id: id, role: role, label: label, value: value)
+    private func el(
+        _ id: String,
+        _ role: String,
+        _ label: String?,
+        value: String? = nil,
+        windowId: Int? = nil
+    ) -> CUElement {
+        CUElement(id: id, role: role, label: label, value: value, windowId: windowId)
     }
 
     /// A driver with one focused app (so `currentPid` is non-nil from the
     /// start) serving a single steady-state snapshot.
-    private func driver(_ elements: [CUElement], pid: Int32 = 4242) -> MockMacDriver {
+    private func driver(
+        _ elements: [CUElement],
+        pid: Int32 = 4242,
+        windows: [CUWindowSummary]? = nil
+    ) -> MockMacDriver {
         let snap = CUSnapshot(
             snapshotId: 1,
             pid: pid,
@@ -38,7 +48,7 @@ final class ComputerUseLoopRunTests: XCTestCase {
             focusedWindow: "Main",
             tier: .ax,
             truncated: false,
-            windows: [CUWindowSummary(id: 1, title: "Main", focused: true, x: 0, y: 0, w: 800, h: 600)],
+            windows: windows ?? [CUWindowSummary(id: 1, title: "Main", focused: true, x: 0, y: 0, w: 800, h: 600)],
             elements: elements,
             image: nil
         )
@@ -320,6 +330,35 @@ final class ComputerUseLoopRunTests: XCTestCase {
         }
         let coords = await d.coordinateActions
         XCTAssertTrue(coords.isEmpty, "An unresolved drag destination must never reach the driver")
+    }
+
+    func testDragAcrossWindowsIsBlockedBeforeDriver() async {
+        let windows = [
+            CUWindowSummary(id: 1, title: "Main", focused: true, x: 0, y: 0, w: 800, h: 600),
+            CUWindowSummary(id: 2, title: "Other", focused: false, x: 900, y: 0, w: 800, h: 600),
+        ]
+        let d = driver(
+            [
+                el("card", "cell", "Card", windowId: 1),
+                el("trash", "button", "Trash", windowId: 2),
+            ],
+            windows: windows
+        )
+        let result = await run(
+            d,
+            provider: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .drag, target: AgentTarget(mark: 1), to: AgentTarget(mark: 2), note: "cross"),
+                AgentAction(verb: .giveUp, reason: "blocked"),
+            ]),
+            limits: RunLimits(maxSteps: 10, wallClockSeconds: 30)
+        )
+
+        guard case .gaveUp = result.outcome else {
+            return XCTFail("Expected giveUp after blocked drag; got \(result.outcome)")
+        }
+        XCTAssertEqual(result.metrics.blocked, 1)
+        let coords = await d.coordinateActions
+        XCTAssertTrue(coords.isEmpty, "A cross-window drag must never reach the driver")
     }
 
     // MARK: - Loop robustness (Phase 3)

--- a/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Loop/ComputerUseLoopRunTests.swift
@@ -24,14 +24,23 @@ final class ComputerUseLoopRunTests: XCTestCase {
 
     // MARK: - Fixtures
 
+    private struct RunHarnessResult {
+        let result: ComputerUseRunResult
+        let feed: SubagentFeed
+    }
+
     private func el(
         _ id: String,
         _ role: String,
         _ label: String?,
         value: String? = nil,
-        windowId: Int? = nil
+        windowId: Int? = nil,
+        x: Int = 0,
+        y: Int = 0,
+        w: Int = 0,
+        h: Int = 0
     ) -> CUElement {
-        CUElement(id: id, role: role, label: label, value: value, windowId: windowId)
+        CUElement(id: id, role: role, label: label, value: value, windowId: windowId, x: x, y: y, w: w, h: h)
     }
 
     /// A driver with one focused app (so `currentPid` is non-nil from the
@@ -66,18 +75,38 @@ final class ComputerUseLoopRunTests: XCTestCase {
         interrupt: InterruptToken = InterruptToken(),
         limits: RunLimits = RunLimits(wallClockSeconds: 30)
     ) async -> ComputerUseRunResult {
-        await ComputerUseLoop.run(
+        await runWithFeed(
+            driver,
+            provider: provider,
+            gate: gate,
+            confirm: confirm,
+            interrupt: interrupt,
+            limits: limits
+        ).result
+    }
+
+    private func runWithFeed(
+        _ driver: MockMacDriver,
+        provider: @escaping AgentStepProvider,
+        gate: ComputerUseGating = HardwiredGate(),
+        confirm: @escaping @Sendable (ActionPreview) async -> Bool = { _ in true },
+        interrupt: InterruptToken = InterruptToken(),
+        limits: RunLimits = RunLimits(wallClockSeconds: 30)
+    ) async -> RunHarnessResult {
+        let feed = SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "test goal")
+        let result = await ComputerUseLoop.run(
             goal: "test goal",
             modelId: "test-model",
             driver: driver,
             gate: gate,
-            feed: SubagentFeed(toolCallId: "t", kindId: "computer_use", title: "test goal"),
+            feed: feed,
             interrupt: interrupt,
             confirm: confirm,
             limits: limits,
             sessionId: "cu-test",
             nextAction: provider
         )
+        return RunHarnessResult(result: result, feed: feed)
     }
 
     // MARK: - Terminal verbs
@@ -344,7 +373,7 @@ final class ComputerUseLoopRunTests: XCTestCase {
             ],
             windows: windows
         )
-        let result = await run(
+        let harness = await runWithFeed(
             d,
             provider: ComputerUseLoop.scriptedProvider([
                 AgentAction(verb: .drag, target: AgentTarget(mark: 1), to: AgentTarget(mark: 2), note: "cross"),
@@ -352,6 +381,7 @@ final class ComputerUseLoopRunTests: XCTestCase {
             ]),
             limits: RunLimits(maxSteps: 10, wallClockSeconds: 30)
         )
+        let result = harness.result
 
         guard case .gaveUp = result.outcome else {
             return XCTFail("Expected giveUp after blocked drag; got \(result.outcome)")
@@ -359,6 +389,59 @@ final class ComputerUseLoopRunTests: XCTestCase {
         XCTAssertEqual(result.metrics.blocked, 1)
         let coords = await d.coordinateActions
         XCTAssertTrue(coords.isEmpty, "A cross-window drag must never reach the driver")
+        let blocked = harness.feed.currentEvents().filter { $0.kind == .blocked }
+        XCTAssertEqual(blocked.last?.title, "Blocked drag across boundary")
+        XCTAssertEqual(blocked.last?.success, false)
+        XCTAssertTrue(blocked.last?.detail?.contains("destination mark is in window 2") == true)
+    }
+
+    func testDragWithinKnownWindowStillDrives() async {
+        let d = driver([
+            el("card", "cell", "Card", windowId: 1, x: 10, y: 20, w: 40, h: 20),
+            el("drop", "cell", "Drop", windowId: 1, x: 120, y: 20, w: 40, h: 20),
+        ])
+        let result = await run(
+            d,
+            provider: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .drag, target: AgentTarget(mark: 1), to: AgentTarget(mark: 2), note: "same window"),
+                AgentAction(verb: .done, reason: "dragged"),
+            ]),
+            limits: RunLimits(maxSteps: 10, wallClockSeconds: 30)
+        )
+
+        XCTAssertTrue(result.outcome.isSuccess)
+        XCTAssertEqual(result.metrics.blocked, 0)
+        let coords = await d.coordinateActions
+        XCTAssertEqual(coords.count, 1, "A same-window drag should still reach the driver")
+        guard case let .drag(fromX, fromY, toX, toY, pid)? = coords.first else {
+            return XCTFail("Expected coordinate drag; got \(coords)")
+        }
+        XCTAssertEqual(pid, 4242)
+        XCTAssertNotEqual(fromX, toX)
+        XCTAssertEqual(fromY, toY)
+    }
+
+    func testDragWithOnlyOneKnownWindowIdIsBlockedBeforeDriver() async {
+        let d = driver([
+            el("card", "cell", "Card", windowId: 1),
+            el("drop", "cell", "Drop"),
+        ])
+        let harness = await runWithFeed(
+            d,
+            provider: ComputerUseLoop.scriptedProvider([
+                AgentAction(verb: .drag, target: AgentTarget(mark: 1), to: AgentTarget(mark: 2), note: "mixed"),
+                AgentAction(verb: .giveUp, reason: "blocked"),
+            ]),
+            limits: RunLimits(maxSteps: 10, wallClockSeconds: 30)
+        )
+
+        guard case .gaveUp = harness.result.outcome else {
+            return XCTFail("Expected giveUp after unverifiable drag; got \(harness.result.outcome)")
+        }
+        XCTAssertEqual(harness.result.metrics.blocked, 1)
+        let coords = await d.coordinateActions
+        XCTAssertTrue(coords.isEmpty, "A drag with only one known window id must never reach the driver")
+        XCTAssertEqual(harness.feed.currentEvents().last(where: { $0.kind == .blocked })?.success, false)
     }
 
     // MARK: - Loop robustness (Phase 3)

--- a/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
@@ -150,7 +150,8 @@ final class DangerousAppGuardrailTests: XCTestCase {
         for app in [
             "Terminal.app", "com.apple.Terminal", "iTerm", "Ghostty",
             "System Settings", "com.apple.systempreferences",
-            "Keychain Access", "1Password", "Bitwarden",
+            "Keychain Access", "Shortcuts", "com.apple.shortcuts",
+            "Docker", "OrbStack", "UTM", "1Password", "Bitwarden",
         ] {
             let decision = await gate.evaluate(
                 action: click,
@@ -162,6 +163,30 @@ final class DangerousAppGuardrailTests: XCTestCase {
                 return XCTFail("\(app) should be guardrailed to confirm")
             }
         }
+    }
+
+    /// Launching a sensitive app is itself a navigate-class action and must
+    /// confirm under autonomous policy before the app is opened.
+    func testOpeningDangerousAppConfirmsEvenUnderAutonomous() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        let openTerminal = AgentAction(verb: .open, app: "com.apple.Terminal")
+        let effect = EffectClassifier.classify(
+            action: openTerminal,
+            appName: openTerminal.app,
+            recipeSignals: AppRecipes.signals(for: openTerminal.app)
+        )
+        XCTAssertEqual(effect, .navigate)
+
+        let decision = await gate.evaluate(
+            action: openTerminal,
+            effect: effect,
+            appName: openTerminal.app,
+            targetLabel: openTerminal.app
+        )
+        guard case .confirm(let preview) = decision else {
+            return XCTFail("opening Terminal should force a confirm under autonomous")
+        }
+        XCTAssertEqual(preview.appName, "com.apple.Terminal")
     }
 
     /// The guardrail only TIGHTENS: a read-only policy that denies edits still
@@ -310,6 +335,8 @@ final class AutonomyPolicyNormalizeTests: XCTestCase {
         let policy = AutonomyPolicy()
         XCTAssertTrue(policy.requiresForcedConfirm(app: "Terminal.app"))
         XCTAssertTrue(policy.requiresForcedConfirm(app: "com.apple.Terminal"))
+        XCTAssertTrue(policy.requiresForcedConfirm(app: "Shortcuts"))
+        XCTAssertTrue(policy.requiresForcedConfirm(app: "OrbStack"))
         XCTAssertFalse(policy.requiresForcedConfirm(app: "Notes"))
         XCTAssertFalse(policy.requiresForcedConfirm(app: nil))
         XCTAssertFalse(policy.requiresForcedConfirm(app: ""))

--- a/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
+++ b/Packages/OsaurusCore/Tests/ComputerUse/Policy/GateHardeningTests.swift
@@ -189,6 +189,24 @@ final class DangerousAppGuardrailTests: XCTestCase {
         XCTAssertEqual(preview.appName, "com.apple.Terminal")
     }
 
+    /// Launcher clicks are driven in Dock/Finder/Spotlight, but the target label
+    /// still names the sensitive app being opened.
+    func testClickingDangerousAppLauncherConfirmsEvenUnderAutonomous() async {
+        let gate = ComputerUseGate(policy: AutonomyPolicy(globalPreset: .autonomous))
+        let action = AgentAction(verb: .click, target: AgentTarget(describe: "Terminal"))
+        let decision = await gate.evaluate(
+            action: action,
+            effect: .navigate,
+            appName: "Dock",
+            targetLabel: "Terminal"
+        )
+        guard case .confirm(let preview) = decision else {
+            return XCTFail("clicking a Terminal launcher should force a confirm under autonomous")
+        }
+        XCTAssertEqual(preview.appName, "Dock")
+        XCTAssertEqual(preview.targetLabel, "Terminal")
+    }
+
     /// The guardrail only TIGHTENS: a read-only policy that denies edits still
     /// denies them in a dangerous app (a confirm floor can't loosen a deny).
     func testGuardrailCannotLoosenADeny() async {


### PR DESCRIPTION
## Summary
- Tightens Computer Use autonomy boundaries for dangerous app launches.
- Forces confirmation when a launcher target label names a sensitive app, even if the driven app is Dock, Finder, or Spotlight.
- Blocks cross-window drags before any driver action and pins the blocked feed event for the UI.

## Validation
- `swift test --package-path Packages/OsaurusCore --filter 'ComputerUseLoopRunTests|EffectClassifierHardeningTests|DangerousAppGuardrailTests|SoloCommitGatingTests|AutonomyPolicyNormalizeTests|ComputerUseGateInspectorTests'` — 48 tests passed.
- `swift test --package-path Packages/OsaurusEvals --filter 'ComputerUseLoopEvalTests'` — 11 tests passed.
- `git diff --check` — passed.
- GitHub CI — green; merge state CLEAN.